### PR TITLE
Refactoring

### DIFF
--- a/tools/js2dart/src/parser.js
+++ b/tools/js2dart/src/parser.js
@@ -9,6 +9,7 @@ export class Parser extends TraceurParser {
   constructor(file, errorReporter = new SyntaxErrorReporter()) {
     super(file, errorReporter);
   }
+
   parseTypeName_() {
     // Copy of original implementation
     var typeName = super.parseTypeName_();
@@ -24,6 +25,7 @@ export class Parser extends TraceurParser {
     }
     return typeName;
   }
+
   parseImportSpecifier_() {
     // Copy of original implementation
     var start = this.getTreeStartLocation_();
@@ -33,7 +35,7 @@ export class Parser extends TraceurParser {
     var name = this.eatIdName_();
     // Support for wraps keywoard
     if (this.peekToken_().value === WRAPS) {
-      var token = this.nextToken_();
+      token = this.nextToken_();
       var wrappedIdentifier = this.eatId_();
       // TODO: Save the fact that this is a wrapper type and
       // also the wrapped type
@@ -48,9 +50,10 @@ export class Parser extends TraceurParser {
     }
     return new ImportSpecifier(this.getTreeLocation_(start), binding, name);
   }
+
   parseObjectType_() {
    //TODO(misko): save the type information
-   this.eat_(OPEN_CURLY)
+   this.eat_(OPEN_CURLY);
    do {
      var identifier = this.eatId_();
      this.eat_(COLON);

--- a/tools/js2dart/src/parser.js
+++ b/tools/js2dart/src/parser.js
@@ -11,12 +11,7 @@ export class Parser extends TraceurParser {
   }
   parseTypeName_() {
     // Copy of original implementation
-    var start = this.getTreeStartLocation_();
-    var typeName = new TypeName(this.getTreeLocation_(start), null, this.eatId_());
-    while (this.eatIf_(PERIOD)) {
-      var memberName = this.eatIdName_();
-      typeName = new TypeName(this.getTreeLocation_(start), typeName, memberName);
-    }
+    var typeName = super.parseTypeName_();
     var next = this.peekType_();
     // Generics support
     if (this.eatIf_(OPEN_ANGLE)) {


### PR DESCRIPTION
In this PR I've tried to use as much of possible from the original Traceur code, overriding only where required.

Does this kind of changes make sense ?

Some related question: today there is only one `dart_class_transformer.js` that has all the transformations.

To be more compliant with the original Traceur code, it would probably makes sense to have a `DartTransformer` that would be the main entry point and every single transformation defined in a separate class & file. All those files should be hosted in a `codegeneration` folder.

I'm not sure if GH is the best place to discuss this kind of thing. Should we create a "js2dart" room in flowdock ?
