### PR TITLE
chore(karma): use ChromeCanary as the default for JS

### DIFF
--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -46,7 +46,7 @@ module.exports = function(config) {
         base: 'Dartium',
         flags: ['--enable-experimental-web-platform-features'] }
     },
-    browsers: ['DartiumWithWebPlatform'],
+    browsers: ['ChromeCanary'],
   });
 
   config.plugins.push(require('./tools/transpiler/karma-traceur-preprocessor'));


### PR DESCRIPTION
I'm leaving in the custom config for `DartiumWithWebPlatform` as is – in case you want to test the JS in Dartium.
