### PR TITLE
Cyclic imports

### DIFF
--- a/file2modulename.js
+++ b/file2modulename.js
@@ -1,8 +1,5 @@
 function file2moduleName(filePath) {
   return filePath
-    // module name should not include non word characters (e.g. '-')
-    // -> important for Dart
-    .replace(/[^\w.\/]/g, '_')
     // module name should be relative to `modules` and `tools` folder
     .replace(/.*\/modules\//, '')
     .replace(/.*\/tools\//, '')

--- a/file2modulename.js
+++ b/file2modulename.js
@@ -9,7 +9,6 @@ function file2moduleName(filePath) {
     // module name should not include `src`, `test`, `lib`
     .replace(/\/src\//, '/')
     .replace(/\/lib\//, '/')
-    .replace(/\/test\//, '/')
     // module name should not have a suffix
     .replace(/\.\w*$/, '');
 }

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -8,12 +8,15 @@ module.exports = function(config) {
     frameworks: ['jasmine'],
 
     files: [
+      // Sources and specs.
+      // Loaded through the es6-module-loader, in `test-main.js`.
+      {pattern: 'modules/**', included: false},
+      {pattern: 'tools/transpiler/**', included: false},
+
       'node_modules/traceur/bin/traceur-runtime.js',
-      'modules/**/test_lib/**/*.es6',
-      'modules/**/*.js',
-      'modules/**/*.es6',
-      'tools/transpiler/spec/**/*.js',
-      'tools/transpiler/spec/**/*.es6',
+      'node_modules/es6-module-loader/dist/es6-module-loader-sans-promises.src.js',
+      'node_modules/systemjs/lib/extension-register.js',
+
       'file2modulename.js',
       'test-main.js'
     ],
@@ -29,7 +32,7 @@ module.exports = function(config) {
       options: {
         outputLanguage: 'es5',
         script: false,
-        modules: 'register',
+        modules: 'instantiate',
         types: true,
         typeAssertions: true,
         typeAssertionModule: 'rtts_assert/rtts_assert',
@@ -37,7 +40,7 @@ module.exports = function(config) {
       },
       resolveModuleName: file2moduleName,
       transformPath: function(fileName) {
-        return fileName.replace('.es6', '');
+        return fileName.replace(/\.es6$/, '.js');
       }
     },
 

--- a/modules/rtts_assert/test/rtts_assert_spec.es6
+++ b/modules/rtts_assert/test/rtts_assert_spec.es6
@@ -13,6 +13,7 @@
 import {assert} from 'rtts_assert/rtts_assert';
 
 
+export function main() {
 
 // ## Basic Type Check
 // By default, `instanceof` is used to check the type.
@@ -375,3 +376,5 @@ describe('Traceur', function() {
 // <center><small>
 // This documentation was generated from [assert.spec.js](https://github.com/vojtajina/assert/blob/master/test/assert.spec.js) using [Docco](http://jashkenas.github.io/docco/).
 // </small></center>
+
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "author": "Tobias Bosch <tbosch@google.com>",
   "license": "MIT",
   "dependencies": {
+    "es6-module-loader": "^0.9.2",
+    "systemjs": "^0.9.1",
     "gulp": "^3.8.8",
     "gulp-rename": "^1.2.0",
     "gulp-watch": "^1.0.3",

--- a/test-main.js
+++ b/test-main.js
@@ -1,11 +1,60 @@
-var TEST_REGEXP = /_spec.*/;
+// Use "register" extension from systemjs.
+// That's what Traceur outputs: `System.register()`.
+register(System);
 
-Object.keys(window.__karma__.files).forEach(function(path) {
-  if (TEST_REGEXP.test(path)) {
-    var moduleName = window.file2moduleName(path);
-    var mod = System.get(moduleName);
-    if (mod && mod.main) {
-      mod.main();
-    }
-  }
+
+// Cancel Karma's synchronous start,
+// we will call `__karma__.start()` later, once all the specs are loaded.
+__karma__.loaded = function() {};
+
+
+System.baseURL = '/base/modules/';
+
+// So that we can import packages like `core/foo`, instead of `core/src/foo`.
+System.paths = {
+  'core/*': './core/src/*.js',
+  'core/test/*': './core/test/*.js',
+
+  'change_detection/*': './change_detection/src/*.js',
+  'change_detection/test/*': './change_detection/test/*.js',
+
+  'facade/*': './facade/src/*.js',
+  'facade/test/*': './facade/test/*.js',
+
+  'di/*': './di/src/*.js',
+  'di/test/*': './di/test/*.js',
+
+  'rtts_assert/*': './rtts_assert/src/*.js',
+  'rtts_assert/test/*': './rtts_assert/test/*.js',
+
+  'test_lib/*': './test_lib/src/*.js',
+  'test_lib/test/*': './test_lib/test/*.js',
+
+  'transpiler/*': '../tools/transpiler/*.js'
+}
+
+
+// Import all the specs, execute their `main()` method and kick off Karma (Jasmine).
+Promise.all(
+  Object.keys(window.__karma__.files) // All files served by Karma.
+  .filter(onlySpecFiles)
+  .map(window.file2moduleName)        // Normalize paths to module names.
+  .map(function(path) {
+    return System.import(path).then(function(module) {
+      if (module.hasOwnProperty('main')) {
+        module.main()
+      } else {
+        throw new Error('Module ' + path + ' does not implement main() method.');
+      }
+    });
+  })).then(function() {
+  __karma__.start();
+}, function(error) {
+  console.error(error.stack || error)
+  __karma__.start();
 });
+
+
+function onlySpecFiles(path) {
+  return /_spec\.js$/.test(path);
+}

--- a/tools/transpiler/spec/a-0-subfolder/library_spec.js
+++ b/tools/transpiler/spec/a-0-subfolder/library_spec.js
@@ -1,3 +1,1 @@
-function main() {
-  assert(true);
-}
+export function main() {}

--- a/tools/transpiler/spec/cycle.js
+++ b/tools/transpiler/spec/cycle.js
@@ -1,0 +1,5 @@
+import {foo} from './cycle_spec';
+
+export function cycle() {
+  return foo;
+}

--- a/tools/transpiler/spec/cycle_spec.js
+++ b/tools/transpiler/spec/cycle_spec.js
@@ -1,0 +1,13 @@
+import {describe, it, expect} from 'test_lib/test_lib';
+import {cycle} from './cycle';
+
+export function main() {
+  describe('cycle', function() {
+    it('should work', function() {
+      expect(cycle()).toBe(true);
+    });
+  });
+}
+
+export var foo = true;
+

--- a/tools/transpiler/src/outputgeneration/DartParseTreeWriter.js
+++ b/tools/transpiler/src/outputgeneration/DartParseTreeWriter.js
@@ -20,7 +20,7 @@ import {ParseTreeWriter as JavaScriptParseTreeWriter, ObjectLiteralExpression} f
 export class DartParseTreeWriter extends JavaScriptParseTreeWriter {
   constructor(moduleName, outputPath) {
     super(outputPath);
-    this.libName = moduleName.replace(/\//g, '.');
+    this.libName = moduleName.replace(/\//g, '.').replace(/[^\w.\/]/g, '_');
   }
 
   // VARIABLES - types


### PR DESCRIPTION
This changes our setup to use [es6-module-loader](https://github.com/ModuleLoader/es6-module-loader) for loading files.

It also adds dependency on "systemjs" which is something like RequireJS implemented on the top of the ES6 module loader API. I hope we will be able to get rid off that dependency but we need to change Traceur to generate different output.

Next thing is to change annotations to make it work with cyclic dependencies.

The last commit is not supposed to be merged, it's just an example that the cycles work.
