### PR TITLE
feat(benchmark): add a simple benchmark for the di module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Don’t commit the following directories created by pub.
 build/
+benchpress-build/
 packages/
 .buildlog
 node_modules

--- a/modules/benchmarks/src/di/benchmark.es5
+++ b/modules/benchmarks/src/di/benchmark.es5
@@ -1,0 +1,15 @@
+System.import('benchmarks/di/injector_get_benchmark').then(function (bm) {
+  window.benchmarkSteps.push({name: 'Injector.get (token)', fn: bm.run});
+}, console.log.bind(console));
+
+System.import('benchmarks/di/injector_get_by_key_benchmark').then(function (bm) {
+  window.benchmarkSteps.push({name: 'Injector.get (key)', fn: bm.run});
+}, console.log.bind(console));
+
+System.import('benchmarks/di/injector_get_child_benchmark').then(function (bm) {
+  window.benchmarkSteps.push({name: 'Injector.get (grand x 5 child)', fn: bm.run});
+}, console.log.bind(console));
+
+System.import('benchmarks/di/injector_instantiate_benchmark').then(function (bm) {
+  window.benchmarkSteps.push({name: 'Injector.instantiate', fn: bm.run});
+}, console.log.bind(console));

--- a/modules/benchmarks/src/di/bp.conf.es5
+++ b/modules/benchmarks/src/di/bp.conf.es5
@@ -1,0 +1,11 @@
+module.exports = function(config) {
+  config.set({
+    scripts: [
+      {src: '/js/traceur-runtime.js'},
+      {src: '/js/es6-module-loader-sans-promises.src.js'},
+      {src: '/js/extension-register.js'},
+      {src: 'register_system.js'},
+      {src: 'benchmark.js'}
+    ]
+  });
+};

--- a/modules/benchmarks/src/di/injector_get_benchmark.js
+++ b/modules/benchmarks/src/di/injector_get_benchmark.js
@@ -1,0 +1,43 @@
+import {Injector} from "di/di";
+
+var count = 0;
+
+export function run () {
+  var bindings = [A, B, C, D, E];
+  var injector = new Injector(bindings);
+
+  for (var i = 0; i < 20000; ++i) {
+    injector.get(D);
+    injector.get(E);
+  }
+}
+
+class A {
+  constructor() {
+    count++;
+  }
+}
+
+class B {
+  constructor(a:A) {
+    count++;
+  }
+}
+
+class C {
+  constructor(b:B) {
+    count++;
+  }
+}
+
+class D {
+  constructor(c:C, b:B) {
+    count++;
+  }
+}
+
+class E {
+  constructor(d:D, c:C) {
+    count++;
+  }
+}

--- a/modules/benchmarks/src/di/injector_get_by_key_benchmark.js
+++ b/modules/benchmarks/src/di/injector_get_by_key_benchmark.js
@@ -1,0 +1,46 @@
+import {Injector, Key} from "di/di";
+
+var count = 0;
+
+export function run () {
+  var bindings = [A, B, C, D, E];
+  var injector = new Injector(bindings);
+
+  var D_KEY = Key.get(D);
+  var E_KEY = Key.get(E);
+
+  for (var i = 0; i < 20000; ++i) {
+    injector.get(D_KEY);
+    injector.get(E_KEY);
+  }
+}
+
+class A {
+  constructor() {
+    count++;
+  }
+}
+
+class B {
+  constructor(a:A) {
+    count++;
+  }
+}
+
+class C {
+  constructor(b:B) {
+    count++;
+  }
+}
+
+class D {
+  constructor(c:C, b:B) {
+    count++;
+  }
+}
+
+class E {
+  constructor(d:D, c:C) {
+    count++;
+  }
+}

--- a/modules/benchmarks/src/di/injector_get_child_benchmark.js
+++ b/modules/benchmarks/src/di/injector_get_child_benchmark.js
@@ -1,0 +1,49 @@
+import {Injector, Key} from "di/di";
+
+var count = 0;
+
+export function run () {
+  var bindings = [A, B, C, D, E];
+  var injector = new Injector(bindings);
+  var childInjector = injector.
+    createChild([]).
+    createChild([]).
+    createChild([]).
+    createChild([]).
+    createChild([]);
+
+  for (var i = 0; i < 20000; ++i) {
+    childInjector.get(D);
+    childInjector.get(E);
+  }
+}
+
+class A {
+  constructor() {
+    count++;
+  }
+}
+
+class B {
+  constructor(a:A) {
+    count++;
+  }
+}
+
+class C {
+  constructor(b:B) {
+    count++;
+  }
+}
+
+class D {
+  constructor(c:C, b:B) {
+    count++;
+  }
+}
+
+class E {
+  constructor(d:D, c:C) {
+    count++;
+  }
+}

--- a/modules/benchmarks/src/di/injector_instantiate_benchmark.js
+++ b/modules/benchmarks/src/di/injector_instantiate_benchmark.js
@@ -1,0 +1,45 @@
+import {Injector, Key} from "di/di";
+
+var count = 0;
+
+export function run () {
+  var bindings = [A, B, C, D];
+  var injector = new Injector(bindings);
+
+  for (var i = 0; i < 1000; ++i) {
+    var child = injector.createChild([E]);
+    child.get(E);
+  }
+
+  console.log(count)
+}
+
+class A {
+  constructor() {
+    count++;
+  }
+}
+
+class B {
+  constructor(a:A) {
+    count++;
+  }
+}
+
+class C {
+  constructor(b:B) {
+    count++;
+  }
+}
+
+class D {
+  constructor(c:C, b:B) {
+    count++;
+  }
+}
+
+class E {
+  constructor(d:D, c:C) {
+    count++;
+  }
+}

--- a/modules/benchmarks/src/di/register_system.es5
+++ b/modules/benchmarks/src/di/register_system.es5
@@ -1,0 +1,10 @@
+System.paths = {
+  'core/*': '/js/core/lib/*.js',
+  'change_detection/*': '/js/change_detection/lib/*.js',
+  'facade/*': '/js/facade/lib/*.js',
+  'di/*': '/js/di/lib/*.js',
+  'rtts_assert/*': '/js/rtts_assert/lib/*.js',
+  'test_lib/*': '/js/test_lib/lib/*.js',
+  'benchmarks/*': '/js/benchmarks/lib/*.js'
+};
+register(System);

--- a/modules/di/src/injector.js
+++ b/modules/di/src/injector.js
@@ -45,7 +45,7 @@ export class Injector {
 
   _createListOfBindings(flattenBindings):List {
     var bindings = ListWrapper.createFixedSize(Key.numberOfKeys() + 1);
-    MapWrapper.forEach(flattenBindings, (keyId, v) => bindings[keyId] = v);
+    MapWrapper.forEach(flattenBindings, (v, keyId) => bindings[keyId] = v);
     return bindings;
   }
 

--- a/modules/di/src/key.js
+++ b/modules/di/src/key.js
@@ -1,5 +1,5 @@
 import {MapWrapper} from 'facade/collection';
-import {FIELD, int} from 'facade/lang';
+import {FIELD, int, isPresent} from 'facade/lang';
 
 var _allKeys = {};
 var _id:int = 0;
@@ -15,9 +15,8 @@ export class Key {
   static get(token) {
     if (token instanceof Key) return token;
 
-    if (MapWrapper.contains(_allKeys, token)) {
-      return MapWrapper.get(_allKeys, token)
-    }
+    var obj = MapWrapper.get(_allKeys, token);
+    if (isPresent(obj)) return obj;
 
     var newKey = new Key(token, ++_id);
     MapWrapper.set(_allKeys, token, newKey);

--- a/modules/di/src/key.js
+++ b/modules/di/src/key.js
@@ -1,7 +1,7 @@
-import {MapWrapper} from 'facade/collection';
+import {MapWrapper, Map} from 'facade/collection';
 import {FIELD, int, isPresent} from 'facade/lang';
 
-var _allKeys = {};
+var _allKeys = MapWrapper.create();
 var _id:int = 0;
 
 export class Key {
@@ -15,8 +15,9 @@ export class Key {
   static get(token) {
     if (token instanceof Key) return token;
 
-    var obj = MapWrapper.get(_allKeys, token);
-    if (isPresent(obj)) return obj;
+    if (MapWrapper.contains(_allKeys, token)) {
+      return MapWrapper.get(_allKeys, token);
+    }
 
     var newKey = new Key(token, ++_id);
     MapWrapper.set(_allKeys, token, newKey);

--- a/modules/facade/src/collection.dart
+++ b/modules/facade/src/collection.dart
@@ -9,7 +9,7 @@ class MapWrapper {
   static void set(m, k, v){ m[k] = v; }
   static contains(m, k) => m.containsKey(k);
   static forEach(m, fn) {
-    m.forEach(fn);
+    m.forEach((k,v) => fn(v,k));
   }
 }
 

--- a/modules/facade/src/collection.es6
+++ b/modules/facade/src/collection.es6
@@ -4,13 +4,11 @@ export var Set = window.Set;
 
 export class MapWrapper {
   static create():Map { return new Map(); }
-  static get(m, k) { return m[k]; }
-  static set(m, k, v) { m[k] = v; }
-  static contains(m, k) { return  m[k] != undefined; }
+  static get(m, k) { return m.get(k); }
+  static set(m, k, v) { m.set(k,v); }
+  static contains(m, k) { return  m.has(k); }
   static forEach(m, fn) {
-    for(var k in m) {
-      fn(k, m[k]);
-    }
+    m.forEach(fn);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "es6-module-loader": "^0.9.2",
     "systemjs": "^0.9.1",
+    "angular-benchpress": "^0.1.3",
     "gulp": "^3.8.8",
     "gulp-rename": "^1.2.0",
     "gulp-watch": "^1.0.3",
@@ -18,6 +19,7 @@
     "karma-chrome-launcher": "^0.1.4",
     "karma-dart": "^0.2.8",
     "karma-jasmine": "^0.2.2",
+    "merge": "^1.2.0",
     "q": "^1.0.1",
     "through2": "^0.6.1",
     "event-stream": "^3.1.5",


### PR DESCRIPTION
It adds the following tasks to the gulpfile:
1. `benchmarks/clean` // removes the compiled files
2. `benchmarks/build` // compiles all the files in `benchmarks` and creates a benchpress build
3. `benchmarks/run` // fires up a server

It also includes a very simple benchmark. It is not very useful and just serves as an example.

Extra notes:
1. Benchmarks run against the build folder. Right now everything is compiled with type checks enabled. We need to have another task (or maybe a flag) that compiles everything in production mode (without type checks).
