### PR TITLE
Rename Future into Promise

### DIFF
--- a/modules/core/src/compiler/compiler.js
+++ b/modules/core/src/compiler/compiler.js
@@ -1,5 +1,5 @@
 import {Type} from 'facade/lang';
-import {Future} from 'facade/async';
+import {Promise} from 'facade/async';
 import {Element} from 'facade/dom';
 //import {ProtoView} from './view';
 import {TemplateLoader} from './template_loader';
@@ -13,14 +13,14 @@ export class Compiler {
   }
 
   /**
-   * # Why future?
+   * # Why promise?
    *   - compilation will load templates. Instantiating views before templates are loaded will
    *     complicate the Directive code. BENEFIT: view instantiation become synchrnous.
    * # Why result that is independent of injector?
    *   - don't know about injector in deserialization
    *   - compile does not need the injector, only the ViewFactory does
    */
-  compile(component:Type, element:Element/* = null*/):Future/*<ProtoView>*/ {
+  compile(component:Type, element:Element/* = null*/):Promise/*<ProtoView>*/ {
     return null;
   }
 

--- a/modules/core/src/compiler/template_loader.js
+++ b/modules/core/src/compiler/template_loader.js
@@ -1,11 +1,11 @@
-import {Future} from 'facade/async';
+import {Promise} from 'facade/async';
 //import {Document} from 'facade/dom';
 
 export class TemplateLoader {
 
   constructor() {}
 
-  load(url:String):Future/*<Document>*/ {
+  load(url:String):Promise/*<Document>*/ {
     return null;
   }
 }

--- a/modules/di/src/annotations.js
+++ b/modules/di/src/annotations.js
@@ -7,7 +7,7 @@ export class Inject {
   }
 }
 
-export class InjectFuture {
+export class InjectPromise {
   @CONST()
   constructor(token) {
     this.token = token;

--- a/modules/di/src/binding.js
+++ b/modules/di/src/binding.js
@@ -5,21 +5,21 @@ import {Key} from './key';
 
 export class Dependency {
   @FIELD('final key:Key')
-  @FIELD('final asFuture:bool')
+  @FIELD('final asPromise:bool')
   @FIELD('final lazy:bool')
-  constructor(key:Key, asFuture:boolean, lazy:boolean) {
+  constructor(key:Key, asPromise:boolean, lazy:boolean) {
     this.key = key;
-    this.asFuture = asFuture;
+    this.asPromise = asPromise;
     this.lazy = lazy;
   }
 }
 
 export class Binding {
-  constructor(key:Key, factory:Function, dependencies:List, providedAsFuture:boolean) {
+  constructor(key:Key, factory:Function, dependencies:List, providedAsPromise:boolean) {
     this.key = key;
     this.factory = factory;
     this.dependencies = dependencies;
-    this.providedAsFuture = providedAsFuture;
+    this.providedAsPromise = providedAsPromise;
   }
 }
 

--- a/modules/di/src/exceptions.js
+++ b/modules/di/src/exceptions.js
@@ -43,7 +43,7 @@ export class AsyncBindingError extends ProviderError {
     super(key, function (keys:List) {
       var first = stringify(ListWrapper.first(keys).token);
       return `Cannot instantiate ${first} synchronously. ` +
-        `It is provided as a future!${constructResolvingPath(keys)}`;
+        `It is provided as a promise!${constructResolvingPath(keys)}`;
     });
   }
 }

--- a/modules/di/src/reflector.dart
+++ b/modules/di/src/reflector.dart
@@ -1,7 +1,7 @@
 library facade.di.reflector;
 
 import 'dart:mirrors';
-import 'annotations.dart' show Inject, InjectFuture, InjectLazy;
+import 'annotations.dart' show Inject, InjectPromise, InjectLazy;
 import 'key.dart' show Key;
 import 'binding.dart' show Dependency;
 import 'exceptions.dart' show NoAnnotationError;
@@ -34,14 +34,14 @@ class Reflector {
       final metadata = p.metadata.map((m) => m.reflectee);
 
       var inject = metadata.firstWhere((m) => m is Inject, orElse: () => null);
-      var injectFuture = metadata.firstWhere((m) => m is InjectFuture, orElse: () => null);
+      var injectPromise = metadata.firstWhere((m) => m is InjectPromise, orElse: () => null);
       var injectLazy = metadata.firstWhere((m) => m is InjectLazy, orElse: () => null);
 
       if (inject != null) {
         return new Dependency(Key.get(inject.token), false, false);
 
-      } else if (injectFuture != null) {
-        return new Dependency(Key.get(injectFuture.token), true, false);
+      } else if (injectPromise != null) {
+        return new Dependency(Key.get(injectPromise.token), true, false);
 
       } else if (injectLazy != null) {
         return new Dependency(Key.get(injectLazy.token), false, true);

--- a/modules/di/src/reflector.es6
+++ b/modules/di/src/reflector.es6
@@ -1,6 +1,6 @@
 import {Type, isPresent} from 'facade/lang';
 import {List} from 'facade/collection';
-import {Inject, InjectFuture, InjectLazy} from './annotations';
+import {Inject, InjectPromise, InjectLazy} from './annotations';
 import {Key} from './key';
 import {Dependency} from './binding';
 import {NoAnnotationError} from './exceptions';
@@ -31,7 +31,7 @@ class Reflector {
       } else if (paramAnnotation instanceof Inject) {
         return this._createDependency(paramAnnotation.token, false, false);
 
-      } else if (paramAnnotation instanceof InjectFuture) {
+      } else if (paramAnnotation instanceof InjectPromise) {
         return this._createDependency(paramAnnotation.token, true, false);
 
       } else if (paramAnnotation instanceof InjectLazy) {
@@ -46,8 +46,8 @@ class Reflector {
     }
   }
 
-  _createDependency(token, asFuture, lazy):Dependency {
-    return new Dependency(Key.get(token), asFuture, lazy);
+  _createDependency(token, asPromise, lazy):Dependency {
+    return new Dependency(Key.get(token), asPromise, lazy);
   }
 }
 

--- a/modules/facade/src/async.dart
+++ b/modules/facade/src/async.dart
@@ -3,20 +3,20 @@ library angular.core.facade.async;
 import 'dart:async';
 export 'dart:async' show Future;
 
-class FutureWrapper {
-  static Future value(obj) {
+class PromiseWrapper {
+  static Future resolve(obj) {
     return new Future.value(obj);
   }
 
-  static Future error(obj) {
+  static Future reject(obj) {
     return new Future.error(obj);
   }
 
-  static Future wait(List<Future> futures){
-    return Future.wait(futures);
+  static Future all(List<Future> promises){
+    return Future.wait(promises);
   }
 
-  static Future catchError(Future future, Function onError){
-    return future.catchError(onError);
+  static Future then(Future promise, Function success, Function onError){
+    return promise.then(success, onError: onError);
   }
 }

--- a/modules/facade/src/async.es6
+++ b/modules/facade/src/async.es6
@@ -1,20 +1,20 @@
-export var Future = Promise;
+export var Promise = window.Promise;
 
-export class FutureWrapper {
-  static value(obj):Future {
-    return Future.resolve(obj);
+export class PromiseWrapper {
+  static resolve(obj):Promise {
+    return Promise.resolve(obj);
   }
 
-  static error(obj):Future {
-    return Future.reject(obj);
+  static reject(obj):Promise {
+    return Promise.reject(obj);
   }
 
-  static wait(futures):Future {
-    if (futures.length == 0) return Future.resolve([]);
-    return Future.all(futures);
+  static all(promises):Promise {
+    if (promises.length == 0) return Promise.resolve([]);
+    return Promise.all(promises);
   }
 
-  static catchError(future:Future, onError:Function):Future {
-    return future.catch(onError);
+  static then(promise:Promise, success:Function, rejection:Function):Promise {
+    return promise.then(success, rejection);
   }
 }

--- a/modules/test_lib/src/test_lib.dart
+++ b/modules/test_lib/src/test_lib.dart
@@ -16,7 +16,7 @@ class Expect extends gns.Expect {
   Expect(actual) : super(actual);
 
   void toThrowError(message) => this.toThrowWith(message: message);
-  void toBeFuture() => _expect(actual is Future, equals(true));
+  void toBePromise() => _expect(actual is Future, equals(true));
   Function get _expect => gns.guinness.matchers.expect;
 }
 

--- a/modules/test_lib/src/test_lib.es6
+++ b/modules/test_lib/src/test_lib.es6
@@ -19,14 +19,14 @@ window.print = function(msg) {
 
 window.beforeEach(function() {
   jasmine.addMatchers({
-    toBeFuture: function() {
+    toBePromise: function() {
       return {
         compare: function (actual, expectedClass) {
           var pass = typeof actual === 'object' && typeof actual.then === 'function';
           return {
             pass: pass,
             get message() {
-              return 'Expected ' + actual + ' to be a future';
+              return 'Expected ' + actual + ' to be a promise';
             }
           };
         }

--- a/tools/transpiler/src/outputgeneration/DartParseTreeWriter.js
+++ b/tools/transpiler/src/outputgeneration/DartParseTreeWriter.js
@@ -19,6 +19,8 @@ import {
 } from 'traceur/src/syntax/TokenType';
 
 import {ParseTreeWriter as JavaScriptParseTreeWriter, ObjectLiteralExpression} from 'traceur/src/outputgeneration/ParseTreeWriter';
+import {ImportedBinding, BindingIdentifier} from 'traceur/src/syntax/trees/ParseTrees';
+import {IdentifierToken} from 'traceur/src/syntax/IdentifierToken';
 
 export class DartParseTreeWriter extends JavaScriptParseTreeWriter {
   constructor(moduleName, outputPath) {
@@ -183,6 +185,7 @@ export class DartParseTreeWriter extends JavaScriptParseTreeWriter {
       case 'number': return 'num';
       case 'boolean': return 'bool';
       case 'string': return 'String';
+      case 'Promise': return 'Future';
       default: return typeName;
     }
   }
@@ -307,6 +310,18 @@ export class DartParseTreeWriter extends JavaScriptParseTreeWriter {
       throw new Error('"as" syntax not supported');
     }
     this.visitAny(tree.binding);
+  }
+
+  visitImportedBinding(tree) {
+    if (tree.binding && tree.binding.identifierToken) {
+      var b = tree.binding;
+      var t = b.identifierToken;
+      var token = new IdentifierToken(t.location, this.normalizeType_(t.value));
+      var binding = new BindingIdentifier(b.location, token);
+      super.visitImportedBinding(new ImportedBinding(tree.location, binding));
+    } else {
+      super.visitImportedBinding(tree);
+    }
   }
 
   visitImportSpecifierSet(tree) {


### PR DESCRIPTION
This PR renames Future into Promise, and here is why:

Dart and JS use different names for a few important primitives: Array/List, Promise/Future, boolean/bool, string/String. And we are inconsistent in choosing the names.

JS
1. We use boolean over bool
2. We use string over String

Dart
1. We use List over Array
2. We use Future over Promise

It is not about just types. StringWrapper uses JS names, and ListWrapper uses Dart names.

I think since we are using a flavor of ES6, and there are many more JS programmers, we should use the JS names. 

So  `Wrapper.operation(receiver, obj);` should be implemented in ES6: `receiver.operation(obj);`.

This is open for discussion.
