### PR TITLE
fix(super): `super()` now means call the proto of the current function.

### DIFF
--- a/tools/transpiler/src/codegeneration/ClassTransformer.js
+++ b/tools/transpiler/src/codegeneration/ClassTransformer.js
@@ -127,7 +127,7 @@ export class ClassTransformer extends ParseTreeTransformer {
     // Add the field definitions to the beginning of the class.
     tree.elements = fields.concat(tree.elements);
 
-    return super(tree);
+    return super.transformClassDeclaration(tree);
   }
 
   /**

--- a/tools/transpiler/src/codegeneration/InstanceOfTransformer.js
+++ b/tools/transpiler/src/codegeneration/InstanceOfTransformer.js
@@ -14,7 +14,7 @@ export class InstanceOfTransformer extends ParseTreeTransformer {
    * @return {ParseTree}
    */
   transformBinaryExpression(tree) {
-    tree = super(tree);
+    tree = super.transformBinaryExpression(tree);
 
     if (tree.operator.type === INSTANCEOF) {
       return createBinaryExpression(tree.left, createOperatorToken('is'), tree.right);

--- a/tools/transpiler/src/compiler.js
+++ b/tools/transpiler/src/compiler.js
@@ -22,7 +22,7 @@ export class Compiler extends TraceurCompiler {
       this.throwIfErrors(errorReporter);
       return transformedTree;
     } else {
-      return super(tree, moduleName);
+      return super.transform(tree, moduleName);
     }
   }
 


### PR DESCRIPTION
See [traceur](https://github.com/google/traceur-
compiler/commit/6732e5eddf203ae02bcfb8faea837590bf32c061) for more details

The new semantic works with the Traceur version we use so that this could be merged right now.

(Sorry, for the mess deleting my branch, I had to do this to trigger Travis)
