### PR TITLE
chore: adds Windows support for build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,7 +102,8 @@ gulp.task('modules/build.dart/pubspec', function(done) {
     .pipe(through2.obj(function(file, enc, done) {
       if (file.previousContents.toString() !== file.contents.toString()) {
         console.log(file.path + ' changed, calling pub get');
-        var stream = spawn('pub', ['get'], {
+        var pubCmd = (process.platform === "win32" ? "pub.bat" : "pub");
+        var stream = spawn(pubCmd, ['get'], {
           stdio: [process.stdin, process.stdout, process.stderr],
           cwd: path.dirname(file.path)
         });
@@ -185,7 +186,8 @@ gulp.task('analyze/dartanalyzer', function(done) {
   }));
 
   function analyze(dirName, done) {
-    var stream = spawn('dartanalyzer', ['--fatal-warnings', tempFile], {
+    var dartanalyzerCmd = (process.platform === "win32" ? "dartanalyzer.bat" : "dartanalyzer");
+    var stream = spawn(dartanalyzerCmd, ['--fatal-warnings', tempFile], {
       // inherit stdin and stderr, but filter stdout
       stdio: [process.stdin, 'pipe', process.stderr],
       cwd: dirName

--- a/tools/transpiler/index.js
+++ b/tools/transpiler/index.js
@@ -61,8 +61,9 @@ function loadModule(filepath, transpile) {
   }
 
   if (transpile) {
-    var moduleName = filepath
+    var moduleName = path.normalize(filepath)
       .replace(__dirname, 'transpiler')
+      .replace(/\\/g, '/')
       .replace(/\.\w*$/, '');
     data = (new traceur.NodeCompiler(
       extend(SELF_COMPILE_OPTIONS, { moduleName: moduleName } )


### PR DESCRIPTION
With this PR, it possible to build the project on a Windows machine, and then to successfully run the JS and Dart test suites.
