### PR TITLE
docs(readme): add installation of pub as a pre-requisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 1. `npm install`
 2. `npm install -g gulp karma`
+3. [Install the Dart SDK](https://www.dartlang.org/tools/sdk/)
+4. [Add the Dart SDK's `bin` directory to your system path](https://www.dartlang.org/tools/pub/installing.html)
 3. `gulp build`
 4. `pub get`
 


### PR DESCRIPTION
I've never used dart before and as such didn't have pub set-up on my machine.  This caused the initial set-up to fail.

This adds one line instructing the user to install pub.
