### PR TITLE
feat(transpiler): map type declarations to dart.

### DIFF
--- a/modules/change_detection/src/facade.dart
+++ b/modules/change_detection/src/facade.dart
@@ -12,3 +12,80 @@ class FieldGetterFactory {
     return (Object object) => instanceMirror.getField(symbol).reflectee;
   }
 }
+
+// These are here only because we have no way to annotate Dart's compile-time
+// export constant expressions. Keep in sync with facade.es6.
+// TODO(rado): move back to .js file when we decide how to handle Dart's const.
+
+// We use dirty checking aka no notification
+const MODE_MASK_NOTIFY = 0xFF00;
+// Encodes the state of dereference
+const MODE_MASK_STATE = 0x00FF;
+
+const MODE_PLUGIN_DIRTY_CHECK = 0x0000;
+const MODE_STATE_MARKER = 0x0000;
+
+/// _context[_protoRecord.propname] => _getter(_context)
+const MODE_STATE_PROPERTY = 0x0001;
+/// _context(_arguments)
+const MODE_STATE_INVOKE_CLOSURE = 0x0002;
+/// _getter(_context, _arguments)
+const MODE_STATE_INVOKE_METHOD = 0x0003;
+
+/// _context is Map => _previousValue is MapChangeRecord
+const MODE_STATE_MAP = 0x0004;
+/// _context is Array/List/Iterable => _previousValue = ListChangeRecord
+const MODE_STATE_LIST = 0x0005;
+
+const $EOF       = 0;
+const $TAB       = 9;
+const $LF        = 10;
+const $VTAB      = 11;
+const $FF        = 12;
+const $CR        = 13;
+const $SPACE     = 32;
+const $BANG      = 33;
+const $DQ        = 34;
+const $$         = 36;
+const $PERCENT   = 37;
+const $AMPERSAND = 38;
+const $SQ        = 39;
+const $LPAREN    = 40;
+const $RPAREN    = 41;
+const $STAR      = 42;
+const $PLUS      = 43;
+const $COMMA     = 44;
+const $MINUS     = 45;
+const $PERIOD    = 46;
+const $SLASH     = 47;
+const $COLON     = 58;
+const $SEMICOLON = 59;
+const $LT        = 60;
+const $EQ        = 61;
+const $GT        = 62;
+const $QUESTION  = 63;
+
+const $0 = 48;
+const $9 = 57;
+
+const $A = 65, $B = 66, $C = 67, $D = 68, $E = 69, $F = 70, $G = 71, $H = 72,
+      $I = 73, $J = 74, $K = 75, $L = 76, $M = 77, $N = 78, $O = 79, $P = 80,
+      $Q = 81, $R = 82, $S = 83, $T = 84, $U = 85, $V = 86, $W = 87, $X = 88,
+      $Y = 89, $Z = 90;
+
+const $LBRACKET  = 91;
+const $BACKSLASH = 92;
+const $RBRACKET  = 93;
+const $CARET     = 94;
+const $_         = 95;
+
+const $a =  97, $b =  98, $c =  99, $d = 100, $e = 101, $f = 102, $g = 103,
+      $h = 104, $i = 105, $j = 106, $k = 107, $l = 108, $m = 109, $n = 110,
+      $o = 111, $p = 112, $q = 113, $r = 114, $s = 115, $t = 116, $u = 117,
+      $v = 118, $w = 119, $x = 120, $y = 121, $z = 122;
+
+const $LBRACE = 123;
+const $BAR    = 124;
+const $RBRACE = 125;
+const $TILDE  = 126;
+const $NBSP   = 160;

--- a/modules/change_detection/src/facade.es6
+++ b/modules/change_detection/src/facade.es6
@@ -5,3 +5,80 @@ export class FieldGetterFactory {
     return new Function('o', 'return o["' + name + '"]');
   }
 }
+
+// These are here only because we have no way to annotate Dart's compile-time
+// constant expressions. Keep in sync with facade.dart.
+// TODO(rado): move back to .js file when we decide how to handle Dart's const.
+
+// We use dirty checking aka no notification
+export const MODE_MASK_NOTIFY = 0xFF00;
+// Encodes the state of dereference
+export const MODE_MASK_STATE = 0x00FF;
+
+export const MODE_PLUGIN_DIRTY_CHECK = 0x0000;
+export const MODE_STATE_MARKER = 0x0000;
+
+/// _context[_protoRecord.propname] => _getter(_context)
+export const MODE_STATE_PROPERTY = 0x0001;
+/// _context(_arguments)
+export const MODE_STATE_INVOKE_CLOSURE = 0x0002;
+/// _getter(_context, _arguments)
+export const MODE_STATE_INVOKE_METHOD = 0x0003;
+
+/// _context is Map => _previousValue is MapChangeRecord
+export const MODE_STATE_MAP = 0x0004;
+/// _context is Array/List/Iterable => _previousValue = ListChangeRecord
+export const MODE_STATE_LIST = 0x0005;
+
+export const $EOF       = 0;
+export const $TAB       = 9;
+export const $LF        = 10;
+export const $VTAB      = 11;
+export const $FF        = 12;
+export const $CR        = 13;
+export const $SPACE     = 32;
+export const $BANG      = 33;
+export const $DQ        = 34;
+export const $$         = 36;
+export const $PERCENT   = 37;
+export const $AMPERSAND = 38;
+export const $SQ        = 39;
+export const $LPAREN    = 40;
+export const $RPAREN    = 41;
+export const $STAR      = 42;
+export const $PLUS      = 43;
+export const $COMMA     = 44;
+export const $MINUS     = 45;
+export const $PERIOD    = 46;
+export const $SLASH     = 47;
+export const $COLON     = 58;
+export const $SEMICOLON = 59;
+export const $LT        = 60;
+export const $EQ        = 61;
+export const $GT        = 62;
+export const $QUESTION  = 63;
+
+export const $0 = 48;
+export const $9 = 57;
+
+export const $A = 65, $B = 66, $C = 67, $D = 68, $E = 69, $F = 70, $G = 71, $H = 72,
+      $I = 73, $J = 74, $K = 75, $L = 76, $M = 77, $N = 78, $O = 79, $P = 80,
+      $Q = 81, $R = 82, $S = 83, $T = 84, $U = 85, $V = 86, $W = 87, $X = 88,
+      $Y = 89, $Z = 90;
+
+export const $LBRACKET  = 91;
+export const $BACKSLASH = 92;
+export const $RBRACKET  = 93;
+export const $CARET     = 94;
+export const $_         = 95;
+
+export const $a =  97, $b =  98, $c =  99, $d = 100, $e = 101, $f = 102, $g = 103,
+      $h = 104, $i = 105, $j = 106, $k = 107, $l = 108, $m = 109, $n = 110,
+      $o = 111, $p = 112, $q = 113, $r = 114, $s = 115, $t = 116, $u = 117,
+      $v = 118, $w = 119, $x = 120, $y = 121, $z = 122;
+
+export const $LBRACE = 123;
+export const $BAR    = 124;
+export const $RBRACE = 125;
+export const $TILDE  = 126;
+export const $NBSP   = 160;

--- a/modules/change_detection/src/parser/scanner.js
+++ b/modules/change_detection/src/parser/scanner.js
@@ -1,5 +1,7 @@
 import {List, ListWrapper, SetWrapper} from "facade/collection";
 import {int, FIELD, NumberWrapper, StringJoiner, StringWrapper} from "facade/lang";
+import {
+MODE_MASK_NOTIFY, MODE_MASK_STATE, MODE_PLUGIN_DIRTY_CHECK, MODE_STATE_MARKER, MODE_STATE_PROPERTY, MODE_STATE_INVOKE_CLOSURE, MODE_STATE_INVOKE_METHOD, MODE_STATE_MAP, MODE_STATE_LIST, $EOF, $TAB, $LF, $VTAB, $FF, $CR, $SPACE, $BANG, $DQ, $$, $PERCENT, $AMPERSAND, $SQ, $LPAREN, $RPAREN, $STAR, $PLUS, $COMMA, $MINUS, $PERIOD, $SLASH, $COLON, $SEMICOLON, $LT, $EQ, $GT, $QUESTION, $0, $9, $A, $B, $C, $D, $E, $F, $G, $H, $I, $J, $K, $L, $M, $N, $O, $P, $Q, $R, $S, $T, $U, $V, $W, $X, $Y, $Z, $LBRACKET, $BACKSLASH, $RBRACKET, $CARET, $_, $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p, $q, $r, $s, $t, $u, $v, $w, $x, $y, $z, $LBRACE, $BAR, $RBRACE, $TILDE, $NBSP } from '../facade';
 
 // TODO(chirayu): Rewrite as consts when possible.
 export var TOKEN_TYPE_CHARACTER  = 1;
@@ -108,59 +110,6 @@ function newNumberToken(index:int, n:number):Token {
 
 
 var EOF:Token = new Token(-1, 0, 0, "");
-
-const $EOF       = 0;
-const $TAB       = 9;
-const $LF        = 10;
-const $VTAB      = 11;
-const $FF        = 12;
-const $CR        = 13;
-const $SPACE     = 32;
-const $BANG      = 33;
-const $DQ        = 34;
-const $$         = 36;
-const $PERCENT   = 37;
-const $AMPERSAND = 38;
-const $SQ        = 39;
-const $LPAREN    = 40;
-const $RPAREN    = 41;
-const $STAR      = 42;
-const $PLUS      = 43;
-const $COMMA     = 44;
-const $MINUS     = 45;
-const $PERIOD    = 46;
-const $SLASH     = 47;
-const $COLON     = 58;
-const $SEMICOLON = 59;
-const $LT        = 60;
-const $EQ        = 61;
-const $GT        = 62;
-const $QUESTION  = 63;
-
-const $0 = 48;
-const $9 = 57;
-
-const $A = 65, $B = 66, $C = 67, $D = 68, $E = 69, $F = 70, $G = 71, $H = 72,
-      $I = 73, $J = 74, $K = 75, $L = 76, $M = 77, $N = 78, $O = 79, $P = 80,
-      $Q = 81, $R = 82, $S = 83, $T = 84, $U = 85, $V = 86, $W = 87, $X = 88,
-      $Y = 89, $Z = 90;
-
-const $LBRACKET  = 91;
-const $BACKSLASH = 92;
-const $RBRACKET  = 93;
-const $CARET     = 94;
-const $_         = 95;
-
-const $a =  97, $b =  98, $c =  99, $d = 100, $e = 101, $f = 102, $g = 103,
-      $h = 104, $i = 105, $j = 106, $k = 107, $l = 108, $m = 109, $n = 110,
-      $o = 111, $p = 112, $q = 113, $r = 114, $s = 115, $t = 116, $u = 117,
-      $v = 118, $w = 119, $x = 120, $y = 121, $z = 122;
-
-const $LBRACE = 123;
-const $BAR    = 124;
-const $RBRACE = 125;
-const $TILDE  = 126;
-const $NBSP   = 160;
 
 
 export class ScannerError extends Error {

--- a/modules/change_detection/src/record.js
+++ b/modules/change_detection/src/record.js
@@ -1,6 +1,6 @@
 import {ProtoWatchGroup, WatchGroup} from './watch_group';
-import {FIELD} from 'facade/lang';
-import {FieldGetterFactory} from './facade';
+import {CONST, FIELD} from 'facade/lang';
+import { FieldGetterFactory, MODE_MASK_NOTIFY, MODE_MASK_STATE, MODE_PLUGIN_DIRTY_CHECK, MODE_STATE_MARKER, MODE_STATE_PROPERTY, MODE_STATE_INVOKE_CLOSURE, MODE_STATE_INVOKE_METHOD, MODE_STATE_MAP, MODE_STATE_LIST, $EOF, $TAB, $LF, $VTAB, $FF, $CR, $SPACE, $BANG, $DQ, $$, $PERCENT, $AMPERSAND, $SQ, $LPAREN, $RPAREN, $STAR, $PLUS, $COMMA, $MINUS, $PERIOD, $SLASH, $COLON, $SEMICOLON, $LT, $EQ, $GT, $QUESTION, $0, $9, $A, $B, $C, $D, $E, $F, $G, $H, $I, $J, $K, $L, $M, $N, $O, $P, $Q, $R, $S, $T, $U, $V, $W, $X, $Y, $Z, $LBRACKET, $BACKSLASH, $RBRACKET, $CARET, $_, $a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m, $n, $o, $p, $q, $r, $s, $t, $u, $v, $w, $x, $y, $z, $LBRACE, $BAR, $RBRACE, $TILDE, $NBSP } from './facade';
 
 /**
  * For now we are dropping expression coalescence. We can always add it later, but
@@ -142,26 +142,6 @@ export class Record {
 
 // The mode is divided into two parts. Which notification mechanism
 // to use and which dereference mode to execute.
-
-// We use dirty checking aka no notification
-const MODE_MASK_NOTIFY = 0xFF00;
-// Encodes the state of dereference
-const MODE_MASK_STATE = 0x00FF;
-
-const MODE_PLUGIN_DIRTY_CHECK = 0x0000;
-const MODE_STATE_MARKER = 0x0000;
-
-/// _context[_protoRecord.propname] => _getter(_context)
-const MODE_STATE_PROPERTY = 0x0001;
-/// _context(_arguments)
-const MODE_STATE_INVOKE_CLOSURE = 0x0002;
-/// _getter(_context, _arguments)
-const MODE_STATE_INVOKE_METHOD = 0x0003;
-
-/// _context is Map => _previousValue is MapChangeRecord
-const MODE_STATE_MAP = 0x0004;
-/// _context is Array/List/Iterable => _previousValue = ListChangeRecord
-const MODE_STATE_LIST = 0x0005;
 
 function isSame(a, b) {
   if (a === b) return true;

--- a/tools/transpiler/spec/var_declaration_spec.js
+++ b/tools/transpiler/spec/var_declaration_spec.js
@@ -1,0 +1,23 @@
+import {ddescribe, describe, it, expect} from 'test_lib/test_lib';
+
+export function main() {
+  describe('const declaration', function() {
+    it('should not break in dart', function() {
+      // const in dart denotes a compile-time constant, which the rvalue is not. 
+      // if transpilation changed const -> final for variable declarations, this
+      // should work as expected.
+      var id = (x) => x;
+
+      const a = id('');
+      const b:string= id('');
+      // We cannot check the semantics of const forbidding reassignment, because
+      // this is a compile-time error in traceur.
+
+      var c = id('');
+      var d:string = id('');
+
+      let e = id('');
+      let f:string = id('');
+    });
+  });
+}


### PR DESCRIPTION
ES6's const is Dart's final, so the type declarations are changed to
reflect that:

  untyped                   typed
var a -> var a;           var a:T -> T a;
let a -> var a;           let a:T -> T a;
const a -> final a;       const a:T -> final T a;

Still needed is support for Dart's const. Temporary moved all const
expressions to the .dart/.es6 specific files.
