### PR TITLE
feat(test_lib): change test_lib.dart to structurally compare objects

### DIFF
--- a/modules/change_detection/pubspec.yaml
+++ b/modules/change_detection/pubspec.yaml
@@ -7,4 +7,4 @@ dependencies:
 dev_dependencies:
   test_lib:
     path: ../test_lib
-  guinness: ">=0.1.5 <0.2.0"
+  guinness: ">=0.1.16 <0.2.0"

--- a/modules/core/pubspec.yaml
+++ b/modules/core/pubspec.yaml
@@ -11,4 +11,4 @@ dependencies:
 dev_dependencies:
   test_lib:
     path: ../test_lib
-  guinness: ">=0.1.5 <0.2.0"
+  guinness: ">=0.1.16 <0.2.0"

--- a/modules/di/pubspec.yaml
+++ b/modules/di/pubspec.yaml
@@ -7,4 +7,4 @@ dependencies:
 dev_dependencies:
   test_lib:
     path: ../test_lib
-  guinness: ">=0.1.5 <0.2.0"
+  guinness: ">=0.1.16 <0.2.0"

--- a/modules/examples/pubspec.yaml
+++ b/modules/examples/pubspec.yaml
@@ -7,4 +7,4 @@ dependencies:
 dev_dependencies:
   test_lib:
     path: ../test_lib
-  guinness: ">=0.1.5 <0.2.0"
+  guinness: ">=0.1.16 <0.2.0"

--- a/modules/facade/pubspec.yaml
+++ b/modules/facade/pubspec.yaml
@@ -4,4 +4,4 @@ environment:
 dev_dependencies:
   test_lib:
     path: ../test_lib
-  guinness: ">=0.1.5 <0.2.0"
+  guinness: ">=0.1.16 <0.2.0"

--- a/modules/test_lib/pubspec.yaml
+++ b/modules/test_lib/pubspec.yaml
@@ -3,4 +3,4 @@ environment:
   sdk: '>=1.4.0'
 dependencies:
 dev_dependencies:
-  guinness: ">=0.1.5 <0.2.0"
+  guinness: ">=0.1.16 <0.2.0"

--- a/modules/test_lib/src/test_lib.dart
+++ b/modules/test_lib/src/test_lib.dart
@@ -15,9 +15,18 @@ Expect expect(actual, [matcher]) {
 class Expect extends gns.Expect {
   Expect(actual) : super(actual);
 
+  NotExpect get not => new NotExpect(actual);
+
+  void toEqual(expected) => toHaveSameProps(expected);
   void toThrowError([message=""]) => this.toThrowWith(message: message);
   void toBePromise() => _expect(actual is Future, equals(true));
   Function get _expect => gns.guinness.matchers.expect;
+}
+
+class NotExpect extends gns.NotExpect {
+  NotExpect(actual) : super(actual);
+
+  void toEqual(expected) => toHaveSameProps(expected);
 }
 
 it(name, fn) {

--- a/modules/test_lib/test/test_lib_spec.js
+++ b/modules/test_lib/test/test_lib_spec.js
@@ -1,0 +1,22 @@
+import {describe, it, iit, expect} from 'test_lib/test_lib';
+
+class TestObj {
+  constructor(prop) {
+    this.prop = prop;
+  }
+}
+
+export function main() {
+  describe("test_lib", function () {
+    describe("equality", function () {
+      it("should structurally compare objects", function () {
+        var expected = new TestObj(new TestObj({"one" : [1,2]}));
+        var actual = new TestObj(new TestObj({"one" : [1,2]}));
+        var falseActual = new TestObj(new TestObj({"one" : [1,3]}));
+
+        expect(actual).toEqual(expected);
+        expect(falseActual).not.toEqual(expected);
+      });
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
     path: build/dart/change_detection
 
 dev_dependencies:
-  guinness: ">=0.1.5 <0.2.0"
+  guinness: ">=0.1.16 <0.2.0"


### PR DESCRIPTION
Make `toEqual` behave the same way in JS and Dart.

```
        var expected = new TestObj(new TestObj({"one" : [1,2]}));
        var actual = new TestObj(new TestObj({"one" : [1,2]}));

        expect(actual).toEqual(expected);
```
