### PR TITLE
chore: source maps for Karma/Gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,7 @@ var through2 = require('through2');
 var watch = require('gulp-watch');
 
 var js2es5Options = {
+  sourceMaps: true,
   annotations: true, // parse annotations
   types: true, // parse types
   script: false, // parse as a module
@@ -36,6 +37,7 @@ var js2es5OptionsDev = merge(true, js2es5Options, {
 });
 
 var js2dartOptions = {
+  sourceMaps: true,
   annotations: true, // parse annotations
   types: true, // parse types
   script: false, // parse as a module

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,6 +53,7 @@ gulp.task('jsRuntime/build', function() {
   var traceurRuntime = gulp.src([
     gulpTraceur.RUNTIME_PATH,
     "node_modules/es6-module-loader/dist/es6-module-loader-sans-promises.src.js",
+    "node_modules/systemjs/dist/system.src.js",
     "node_modules/systemjs/lib/extension-register.js"
   ]).pipe(gulp.dest('build/js'));
   return traceurRuntime;

--- a/karma-dart.conf.js
+++ b/karma-dart.conf.js
@@ -57,6 +57,7 @@ module.exports = function(config) {
     traceurPreprocessor: {
       options: {
         outputLanguage: 'dart',
+        sourceMaps: true,
         script: false,
         modules: 'register',
         types: true,

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -15,6 +15,8 @@ module.exports = function(config) {
 
       'node_modules/traceur/bin/traceur-runtime.js',
       'node_modules/es6-module-loader/dist/es6-module-loader-sans-promises.src.js',
+      // Including systemjs because it defines `__eval`, which produces correct stack traces.
+      'node_modules/systemjs/dist/system.src.js',
       'node_modules/systemjs/lib/extension-register.js',
 
       'file2modulename.js',
@@ -31,6 +33,7 @@ module.exports = function(config) {
     traceurPreprocessor: {
       options: {
         outputLanguage: 'es5',
+        sourceMaps: true,
         script: false,
         modules: 'instantiate',
         types: true,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,1 @@
+karma-js.conf.js

--- a/modules/examples/src/todo/index.html
+++ b/modules/examples/src/todo/index.html
@@ -10,11 +10,11 @@
     <% } else { %>
     <script src="../../../traceur-runtime.js" type="text/javascript"></script>
     <script src="../../../rtts_assert/lib/rtts_assert.js" type="text/javascript"></script>
+    <script src="../../../es6-module-loader-sans-promises.src.js"></script>
+    <script src="../../../system.src.js"></script>
+    <script src="../../../extension-register.js"></script>
 
-    <script src="app.js" type="text/javascript"></script>
-    <script src="../../../facade/lib/dom.js" type="text/javascript"></script>
-
-    <script src="main.es5" type="text/javascript"></script>
+    <script src="main.js" type="text/javascript"></script>
     <% } %>
 </body>
 </html>

--- a/modules/examples/src/todo/main.es5
+++ b/modules/examples/src/todo/main.es5
@@ -1,1 +1,20 @@
-new (System.get("examples/todo/app").App)().run();
+register(System);
+
+System.baseURL = '../../../';
+
+// So that we can import packages like `core/foo`, instead of `core/src/foo`.
+System.paths = {
+  'core/*': './core/src/*.js',
+  'change_detection/*': './change_detection/src/*.js',
+  'facade/*': './facade/lib/*.js',
+  'di/*': './di/src/*.js',
+  'rtts_assert/*': './rtts_assert/lib/*.js',
+  'examples/*': './examples/lib/*.js'
+};
+
+
+System.import('examples/todo/app').then(function(m) {
+  (new m.App).run();
+}, function(e) {
+  console.error(e.stack || e);
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "systemjs": "^0.9.1",
     "angular-benchpress": "^0.1.3",
     "gulp": "^3.8.8",
+    "gulp-changed": "^1.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-watch": "^1.0.3",
     "gulp-shell": "^0.2.10",

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -8,6 +8,10 @@ SCRIPT_DIR=$(dirname $0)
 cd $SCRIPT_DIR/../..
 source ./scripts/env.sh
 
+# For some reason, this task fails on Travis when run as a part of the `gulp build`.
+# It runs `pub get` which fails to read the `pubspec.yml` (created earlier by the task).
+./node_modules/.bin/gulp modules/build.dart/pubspec
+
 ./node_modules/.bin/gulp build
 
 pub install

--- a/tools/transpiler/gulp-traceur.js
+++ b/tools/transpiler/gulp-traceur.js
@@ -1,6 +1,7 @@
 'use strict';
 var through = require('through2');
 var compiler = require('./index');
+var path = require('path');
 
 module.exports = gulpTraceur;
 gulpTraceur.RUNTIME_PATH = compiler.RUNTIME_PATH;
@@ -22,13 +23,26 @@ function gulpTraceur(options, resolveModuleName) {
     try {
       var originalFilePath = file.history[0];
       var moduleName = resolveModuleName ? resolveModuleName(file.relative) : null;
-      var compiled = compiler.compile(options, {
+      var result = compiler.compile(options, {
         inputPath: file.relative,
         outputPath: file.relative,
         moduleName: moduleName
       }, file.contents.toString());
-      file.contents = new Buffer(compiled);
-      this.push(file);
+
+      var transpiledContent = result.js;
+      var sourceMap = result.sourceMap;
+
+      if (sourceMap) {
+        var sourceMapFile = cloneFile(file, {
+          path: file.path.replace(/\.js$/, '.map'),
+          contents: JSON.stringify(sourceMap)
+        });
+
+        transpiledContent += '\n//# sourceMappingURL=./' + path.basename(sourceMapFile.path);
+        this.push(sourceMapFile);
+      }
+
+      this.push(cloneFile(file, {contents: transpiledContent}));
       done();
     } catch (errors) {
       if (errors.join) {
@@ -40,3 +54,8 @@ function gulpTraceur(options, resolveModuleName) {
     }
   });
 };
+
+function cloneFile(file, override) {
+  var File = file.constructor;
+  return new File({path: override.path || file.path, cwd: override.cwd || file.cwd, contents: new Buffer(override.contents || file.contents), base: override.base || file.base});
+}

--- a/tools/transpiler/index.js
+++ b/tools/transpiler/index.js
@@ -41,7 +41,19 @@ exports.compile = function compile(options, paths, source) {
     moduleName: moduleName
   });
   var CompilerCls = System.get('transpiler/src/compiler').Compiler;
-  return (new CompilerCls(localOptions)).compile(source, inputPath, outputPath);
+
+  var compiler = new CompilerCls(localOptions);
+  var result = {
+    js: compiler.compile(source, inputPath, outputPath),
+    sourceMap: null
+  };
+
+  var sourceMapString = compiler.getSourceMap();
+  if (sourceMapString) {
+    result.sourceMap = JSON.parse(sourceMapString);
+  }
+
+  return result;
 };
 
 // Transpile and evaluate the code in `src`.

--- a/tools/transpiler/karma-traceur-preprocessor.js
+++ b/tools/transpiler/karma-traceur-preprocessor.js
@@ -20,10 +20,23 @@ function createJs2DartPreprocessor(logger, basePath, config, emitter) {
       if (config.transformPath) {
         file.path = config.transformPath(file.originalPath);
       }
-      done(null, transpiler.compile(config.options, {
+
+      var result = transpiler.compile(config.options, {
         inputPath: file.originalPath,
+        outputPath: file.path,
         moduleName: moduleName
-      }, content));
+      }, content);
+
+      var transpiledContent = result.js;
+      var sourceMap = result.sourceMap;
+
+      if (sourceMap) {
+        transpiledContent += '\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,';
+        transpiledContent += new Buffer(JSON.stringify(sourceMap)).toString('base64') + '\n';
+        file.sourceMap = sourceMap;
+      }
+
+      done(null, transpiledContent);
     } catch (errors) {
       var errorString;
       if (errors.forEach) {


### PR DESCRIPTION
This changes the API of `tools/transpiler/index.js`. I believe it’s 
not used anywhere besides `gulp-traceur.js` and
`karma-traceur-preprocessor.js`. Instead of returning the transpiled
string, `compile()` returns a result object such as:

``` js
{
  js: ‘transpiled code’,
  sourceMap: null || {}
}
```

Closes #20
