### PR TITLE
feat(elementBinder): introduce element binder.

### DIFF
--- a/modules/benchmarks/src/element_injector/instantiate_benchmark.js
+++ b/modules/benchmarks/src/element_injector/instantiate_benchmark.js
@@ -8,7 +8,7 @@ export function run () {
   var appInjector = new Injector([]);
 
   var bindings = [A, B, C];
-  var proto = new ProtoElementInjector(null, bindings, [], false);
+  var proto = new ProtoElementInjector(null, bindings);
   for (var i = 0; i < ITERATIONS; ++i) {
     var ei = proto.instantiate({view:null});
     ei.instantiateDirectives(appInjector);

--- a/modules/benchmarks/src/element_injector/instantiate_benchmark_codegen.js
+++ b/modules/benchmarks/src/element_injector/instantiate_benchmark_codegen.js
@@ -16,7 +16,7 @@ export function run () {
     ], false)];
 
 
-  var proto = new ProtoElementInjector(null, bindings, [], false);
+  var proto = new ProtoElementInjector(null, bindings);
   for (var i = 0; i < ITERATIONS; ++i) {
     var ei = proto.instantiate({view:null});
     ei.instantiateDirectives(appInjector);

--- a/modules/benchmarks/src/element_injector/instantiate_directive_benchmark.js
+++ b/modules/benchmarks/src/element_injector/instantiate_directive_benchmark.js
@@ -8,7 +8,7 @@ export function run () {
   var appInjector = new Injector([]);
 
   var bindings = [A, B, C];
-  var proto = new ProtoElementInjector(null, bindings, [], false);
+  var proto = new ProtoElementInjector(null, bindings);
   var ei = proto.instantiate({view:null});
 
   for (var i = 0; i < ITERATIONS; ++i) {

--- a/modules/core/src/compiler/element_binder.js
+++ b/modules/core/src/compiler/element_binder.js
@@ -1,0 +1,15 @@
+import {ProtoElementInjector} from './element_injector';
+import {FIELD} from 'facade/lang';
+import {List} from 'facade/collection';
+
+export class ElementBinder {
+  @FIELD('final protoElementInjector:ProtoElementInjector')
+  @FIELD('final textNodeIndices:List<int>')
+  @FIELD('final hasElementPropertyBindings:bool')
+  constructor(protoElementInjector: ProtoElementInjector,
+      textNodeIndices:List, hasElementPropertyBindings:boolean) {
+    this.protoElementInjector = protoElementInjector;  
+    this.textNodeIndices = textNodeIndices;
+    this.hasElementPropertyBindings = hasElementPropertyBindings;
+  }
+}

--- a/modules/core/src/compiler/element_injector.js
+++ b/modules/core/src/compiler/element_injector.js
@@ -146,10 +146,7 @@ export class ProtoElementInjector extends TreeNode {
   @FIELD('_key7:int')
   @FIELD('_key8:int')
   @FIELD('_key9:int')
-  @FIELD('textNodeIndices:List<int>')
-  @FIELD('hasElementPropertyBindings:bool')
-  constructor(parent:ProtoElementInjector, bindings:List, textNodeIndices:List,
-      hasElementPropertyBindings:boolean) {
+  constructor(parent:ProtoElementInjector, bindings:List) {
     super(parent);
 
     this._elementInjector = null;
@@ -180,9 +177,6 @@ export class ProtoElementInjector extends TreeNode {
     if (length > 10) {
       throw 'Maximum number of directives per element has been reached.';
     }
-
-    this.textNodeIndices = textNodeIndices;
-    this.hasElementPropertyBindings = hasElementPropertyBindings;
   }
 
   instantiate({view}):ElementInjector {

--- a/modules/core/test/compiler/element_injector_spec.js
+++ b/modules/core/test/compiler/element_injector_spec.js
@@ -70,7 +70,7 @@ export function main() {
     if (isBlank(appInjector)) appInjector = new Injector([]);
     if (isBlank(props)) props = {};
 
-    var proto = new ProtoElementInjector(null, bindings, [], false);
+    var proto = new ProtoElementInjector(null, bindings);
     var inj = proto.instantiate({view: props["view"]});
     inj.instantiateDirectives(appInjector);
     return inj;
@@ -79,12 +79,11 @@ export function main() {
   function parentChildInjectors(parentBindings, childBindings) {
     var inj = new Injector([]);
 
-    var protoParent = new ProtoElementInjector(null, parentBindings, [], false);
+    var protoParent = new ProtoElementInjector(null, parentBindings);
     var parent = protoParent.instantiate({view: null});
     parent.instantiateDirectives(inj);
 
-    var protoChild = new ProtoElementInjector(protoParent, childBindings, [],
-        false);
+    var protoChild = new ProtoElementInjector(protoParent, childBindings);
     var child = protoChild.instantiate({view: null});
     child.instantiateDirectives(inj);
 
@@ -94,9 +93,9 @@ export function main() {
   describe("ElementInjector", function () {
     describe("proto injectors", function () {
       it("should construct a proto tree", function () {
-        var p = new ProtoElementInjector(null, [], [], false);
-        var c1 = new ProtoElementInjector(p, [], [], false);
-        var c2 = new ProtoElementInjector(p, [], [], false);
+        var p = new ProtoElementInjector(null, []);
+        var c1 = new ProtoElementInjector(p, []);
+        var c2 = new ProtoElementInjector(p, []);
 
         expect(humanize(p, [
           [p, 'parent'],
@@ -108,9 +107,9 @@ export function main() {
 
     describe("instantiate", function () {
       it("should create an element injector", function () {
-        var protoParent = new ProtoElementInjector(null, [], [], false);
-        var protoChild1 = new ProtoElementInjector(protoParent, [], [], false);
-        var protoChild2 = new ProtoElementInjector(protoParent, [], [], false);
+        var protoParent = new ProtoElementInjector(null, []);
+        var protoChild1 = new ProtoElementInjector(protoParent, []);
+        var protoChild2 = new ProtoElementInjector(protoParent, []);
 
         var p = protoParent.instantiate({view: null});
         var c1 = protoChild1.instantiate({view: null});
@@ -126,12 +125,12 @@ export function main() {
 
     describe("hasBindings", function () {
       it("should be true when there are bindings", function () {
-        var p = new ProtoElementInjector(null, [Directive], [], false);
+        var p = new ProtoElementInjector(null, [Directive]);
         expect(p.hasBindings).toBeTruthy();
       });
 
       it("should be false otherwise", function () {
-        var p = new ProtoElementInjector(null, [], [], false);
+        var p = new ProtoElementInjector(null, []);
         expect(p.hasBindings).toBeFalsy();
       });
     });


### PR DESCRIPTION
It is a plain-old-data class to seperate the protoInjector from the
textNodes and elementBinding data.
