### PR TITLE
feat(transpiler): allow @CONST annotation on class

### DIFF
--- a/tools/transpiler/spec/classes_spec.js
+++ b/tools/transpiler/spec/classes_spec.js
@@ -21,6 +21,9 @@ class SubFoo extends Foo {
   }
 }
 
+@CONST
+class ConstClass {}
+
 class Const {
   @CONST
   constructor(a:number) {
@@ -60,6 +63,11 @@ export function main() {
       var subConst = new SubConst(1, 2);
       expect(subConst.a).toBe(1);
       expect(subConst.b).toBe(2);
+    });
+
+    it('@CONST on class without constructor should generate const constructor', function () {
+      var constClass = new ConstClass();
+      expect(constClass).not.toBe(null);
     });
 
     describe('inheritance', function() {


### PR DESCRIPTION
Added extra check for classes that define @CONST annotation without an explicit constructor to auto-create a const constructor for the class.  The @CONST annotation is moved from the class to the const constructor.

Fixes #99 
