### PR TITLE
Fixed small typo in example

### DIFF
--- a/modules/examples/src/todo/index.html
+++ b/modules/examples/src/todo/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <body>
-    <input type="test">
+    <input type="text">
     <ul></ul>
 
 


### PR DESCRIPTION
I recon `<input type="test">` should be `type="text"`...
