### PR TITLE
chore: gulpifying the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Angular [![Build Status](https://travis-ci.org/angular/angular.svg?branch=master
 If you don't already have `npm`, get it by installing [node.js](http://nodejs.org/).
 
 1. `npm install`
-2. `npm install -g gulp karma karma-cli` (you might need to prefix this command with `sudo`)
+2. `npm install -g gulp` (you might need to prefix this command with `sudo`)
 3. `npm install -g protractor` (you might need to prefix this command with `sudo`)
 4. `webdriver-manager update`
 5. If you plan to use Dart:
@@ -41,8 +41,8 @@ If you don't already have `npm`, get it by installing [node.js](http://nodejs.or
 
 ### Unit tests
 
-1. `karma start karma-js.conf.js`: JS tests
-2. `karma start karma-dart.conf.js`: Dart tests
+1. `gulp test.js`: JS tests
+2. `gulp test.dart`: Dart tests
 
 Notes for transpiler tests:
 
@@ -94,7 +94,7 @@ Notes:
 If you need to debug the tests:
 
 - add a `debugger;` statement to the test you want to debug (oe the source code),
-- execute karma `node_modules/karma/bin/karma start karma-js.conf.js`,
+- execute karma `gulp test.js`,
 - press the top right "DEBUG" button,
 - open the dev tools and press F5,
 - the execution halt at the `debugger;` statement

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,8 @@ var pubbuild = require('./tools/build/pubbuild');
 var dartanalyzer = require('./tools/build/dartanalyzer');
 var jsserve = require('./tools/build/jsserve');
 var pubserve = require('./tools/build/pubserve');
+var karma = require('karma').server;
+var minimist = require('minimist');
 
 var DART_SDK = require('./tools/build/dartdetect')(gulp);
 // -----------------------
@@ -394,6 +396,31 @@ gulp.task('docs/serve', function() {
     .pipe(webserver({
       fallback: 'index.html'
     }));
+});
+
+// ------------------
+// tests
+function getBrowsersFromCLI() {
+  var args = minimist(process.argv.slice(2));
+  return [args.browsers?args.browsers:'DartiumWithWebPlatform']
+}
+gulp.task('test.js', function (done) {
+  karma.start({configFile: __dirname + '/karma-js.conf.js'}, done);
+});
+gulp.task('test.dart', function (done) {
+  karma.start({configFile: __dirname + '/karma-dart.conf.js'}, done);
+});
+gulp.task('test.js/ci', function (done) {
+  karma.start({configFile: __dirname + '/karma-js.conf.js', singleRun: true, reporters: ['dots'], browsers: getBrowsersFromCLI()}, done);
+});
+gulp.task('test.dart/ci', function (done) {
+  karma.start({configFile: __dirname + '/karma-dart.conf.js', singleRun: true, reporters: ['dots'], browsers: getBrowsersFromCLI()}, done);
+});
+gulp.task('ci', function(done) {
+  runSequence(
+    'test.js/ci',
+    'test.dart/ci'
+  );
 });
 
 // -----------------

--- a/scripts/ci/test_unit.sh
+++ b/scripts/ci/test_unit.sh
@@ -7,9 +7,4 @@ SCRIPT_DIR=$(dirname $0)
 source $SCRIPT_DIR/env_dart.sh
 cd $SCRIPT_DIR/../..
 
-./node_modules/karma/bin/karma start karma-js.conf \
-        --reporters=dots \
-        --browsers=$KARMA_BROWSERS --single-run
-./node_modules/karma/bin/karma start karma-dart.conf \
-        --reporters=dots \
-        --browsers=$KARMA_BROWSERS --single-run
+./node_modules/.bin/gulp ci --browsers=$KARMA_BROWSERS


### PR DESCRIPTION
This PR is a proposal to use gulp to run tests, avoiding the global karma install and shortening commands.

Notes:
- karma conf files were not touched, so it is still possible to debug tests directly in Webstorm
- the definition of the browser to be used in Travis is kept in .travis.yml file
