### PR TITLE
feat(transpiler): Transform template strings to triple quoted Dart strings

### DIFF
--- a/tools/transpiler/spec/lang_spec.js
+++ b/tools/transpiler/spec/lang_spec.js
@@ -5,5 +5,10 @@ export function main() {
     it('string interpolation', function() {
       expect(`${123}-'${456}"`).toEqual('123-\'456"');
     });
+
+    it('multiline string', function () {
+      expect(`1'
+2"`).toEqual('1\'\n2"');
+    });
   });
 }

--- a/tools/transpiler/src/outputgeneration/DartParseTreeWriter.js
+++ b/tools/transpiler/src/outputgeneration/DartParseTreeWriter.js
@@ -75,12 +75,11 @@ export class DartParseTreeWriter extends JavaScriptParseTreeWriter {
 
   visitTemplateLiteralExpression(tree) {
     if (tree.operand) {
-      this.visitAny(tree.operand);
-      this.writeSpace_();
+      throw new Error('tagged template strings are not supported');
     }
-    this.writeRaw_('"');
+    this.writeRaw_("'''");
     this.visitList(tree.elements);
-    this.writeRaw_('"');
+    this.writeRaw_("'''");
   }
 
   visitTemplateLiteralPortion(tree) {


### PR DESCRIPTION
Modified output of template strings to write triple quoted Dart strings to support multi-line strings since multi-line is supported by ES6 template strings.

Added error to reject tagged template strings since those aren't supported.

Closes #114
