### PR TITLE
chore: use load-plugins to make gulpfile shorter

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,24 +1,18 @@
 var benchpress = require('angular-benchpress/lib/cli');
-var clean = require('gulp-rimraf');
-var connect = require('gulp-connect');
-var ejs = require('gulp-ejs');
 var es = require('event-stream');
 var file2moduleName = require('./file2modulename');
 var fs = require('fs');
 var glob = require('glob');
 var gulp = require('gulp');
+var $ = require('gulp-load-plugins')();
 var merge = require('merge');
 var mergeStreams = require('event-stream').merge;
 var path = require('path');
 var Q = require('q');
 var readline = require('readline');
-var rename = require('gulp-rename');
 var runSequence = require('run-sequence');
-var shell = require('gulp-shell');
 var spawn = require('child_process').spawn;
 var through2 = require('through2');
-var watch = require('gulp-watch');
-var changed = require('gulp-changed');
 
 var js2es5Options = {
   sourceMaps: true,
@@ -87,7 +81,7 @@ var sourceTypeConfigs = {
 
 gulp.task('modules/clean', function() {
   return gulp.src('build', {read: false})
-      .pipe(clean());
+      .pipe($.rimraf());
 });
 
 gulp.task('modules/build.dart/src', function() {
@@ -97,7 +91,7 @@ gulp.task('modules/build.dart/src', function() {
 gulp.task('modules/build.dart/pubspec', function(done) {
   var outputDir = sourceTypeConfigs.dart.outputDir;
   return gulp.src('modules/*/pubspec.yaml')
-    .pipe(changed(outputDir)) // Only forward files that changed.
+    .pipe($.changed(outputDir)) // Only forward files that changed.
     .pipe(gulpDestWithForward(outputDir))
     .pipe(through2.obj(function(file, enc, done) {
       // After a `pubspec.yml` is copied, we run `pub install`.
@@ -130,19 +124,19 @@ function renameEs5ToJs(file) {
 
 function createModuleTask(sourceTypeConfig) {
   var transpile = gulp.src(sourceTypeConfig.transpileSrc)
-    .pipe(rename({extname: '.'+sourceTypeConfig.outputExt}))
-    .pipe(rename(renameSrcToLib))
+    .pipe($.rename({extname: '.'+sourceTypeConfig.outputExt}))
+    .pipe($.rename(renameSrcToLib))
     .pipe(gulpTraceur(sourceTypeConfig.compilerOptions, file2moduleName))
     .pipe(gulp.dest(sourceTypeConfig.outputDir));
   var copy = gulp.src(sourceTypeConfig.copySrc)
-    .pipe(rename(renameSrcToLib))
-    .pipe(rename(renameEs5ToJs))
+    .pipe($.rename(renameSrcToLib))
+    .pipe($.rename(renameEs5ToJs))
     .pipe(gulp.dest(sourceTypeConfig.outputDir));
   // TODO: provide the list of files to the template
   // automatically!
   var html = gulp.src(sourceTypeConfig.htmlSrc)
-    .pipe(rename(renameSrcToLib))
-    .pipe(ejs({
+    .pipe($.rename(renameSrcToLib))
+    .pipe($.ejs({
       type: sourceTypeConfig.outputExt
     }))
     .pipe(gulp.dest(sourceTypeConfig.outputDir));
@@ -261,7 +255,7 @@ gulp.task('benchmarks/build.js', function() {
 gulp.task('benchmarks/build.dart2js.dart', function () {
   return gulp.src([
     "build/dart/benchmarks/lib/**/benchmark.dart"
-  ]).pipe(shell(['dart2js --package-root="build/dart/benchmarks/packages" -o "<%= file.path %>.js" <%= file.path %>']));
+  ]).pipe($.shell(['dart2js --package-root="build/dart/benchmarks/packages" -o "<%= file.path %>.js" <%= file.path %>']));
 });
 
 gulp.task('benchmarks/create-bpconf.dart', function () {
@@ -299,7 +293,7 @@ gulp.task('benchmarks/build.dart', function() {
 // WEB SERVER
 
 gulp.task('serve', function() {
-  connect.server({
+  $.connect.server({
     root: [__dirname+'/build'],
     port: 8000,
     livereload: false,

--- a/package.json
+++ b/package.json
@@ -11,11 +11,6 @@
     "es6-module-loader": "^0.9.2",
     "systemjs": "^0.9.1",
     "angular-benchpress": "^0.1.3",
-    "gulp": "^3.8.8",
-    "gulp-changed": "^1.0.0",
-    "gulp-rename": "^1.2.0",
-    "gulp-watch": "^1.0.3",
-    "gulp-shell": "^0.2.10",
     "karma-cli": "^0.0.4",
     "karma": "^0.12.23",
     "karma-chrome-launcher": "^0.1.4",
@@ -29,7 +24,14 @@
     "gulp-rimraf": "^0.1.0",
     "run-sequence": "^0.3.6",
     "glob": "^4.0.6",
-    "gulp-ejs": "^0.3.1",
     "traceur": "0.0.74"
+  },
+  "devDependencies": {
+    "gulp": "^3.8.8",
+    "gulp-changed": "^1.0.0",
+    "gulp-rename": "^1.2.0",
+    "gulp-shell": "^0.2.10",
+    "gulp-load-plugins": "^0.7.1",
+    "gulp-ejs": "^0.3.1"
   }
 }


### PR DESCRIPTION
- remove unused `gulp-watch`
- add gulp-load-plugins
- move gulp and gulp-plugins to devDependencies
