### PR TITLE
refactor(annotations): replace Module functions with plain lists.

### DIFF
--- a/modules/core/src/annotations/component.js
+++ b/modules/core/src/annotations/component.js
@@ -6,19 +6,19 @@ export class Component extends Directive {
   constructor({
       selector,
       bind,
-      lightDomServices,
-      implementsTypes,
       template,
-      elementServices,
-      componentServices
+      lightDomServices,
+      shadowDomServices,
+      componentServices,
+      implementsTypes
     }:{
       selector:String,
       bind:Object,
       template:TemplateConfig,
-      lightDomServices:DomServicesFunction,
-      shadowDomServices:DomServicesFunction,
-      componentServices:Array,
-      implementsTypes:Array<Type>
+      lightDomServices:List,
+      shadowDomServices:List,
+      componentServices:List,
+      implementsTypes:List
     }={})
   {
     super({
@@ -27,7 +27,8 @@ export class Component extends Directive {
         lightDomServices: lightDomServices,
         implementsTypes: implementsTypes});
     this.template = template;
-    this.elementServices = elementServices;
+    this.lightDomServices = lightDomServices;
+    this.shadowDomServices = shadowDomServices;
     this.componentServices = componentServices;
   }
 }
@@ -45,18 +46,11 @@ import 'package:angular/core.dart' as core;
     directives: const [CompA],
     formatters: const [Stringify]
   ),
-  componentServices: Example.componentServices,
-  elementServices: Example.elementServices,
+  componentServices: [...],
+  shadowDomServices: [...]
   implementsTypes: const [App]
 )
-class Example implements App {
-  static componentServices(Module m) {
-    m.bind();
-  }
-  static elementServices(ElementModule m) {
-    m.bind();
-  }
-}
+class Example implements App {}
 
 class CompA {}
 

--- a/modules/core/src/annotations/decorator.js
+++ b/modules/core/src/annotations/decorator.js
@@ -11,8 +11,8 @@ export class Decorator extends Directive {
     }:{
       selector:String,
       bind:Object,
-      lightDomServices:ElementServicesFunction,
-      implementsTypes:Array<Type>
+      lightDomServices:List,
+      implementsTypes:List
     }={})
   {
     super({

--- a/modules/core/src/annotations/directive.js
+++ b/modules/core/src/annotations/directive.js
@@ -1,6 +1,5 @@
-// import {Type} from 'facade/lang';
-// import {ElementServicesFunction} from './facade';
 import {ABSTRACT, CONST} from 'facade/lang';
+import {List} from 'facade/collection';
 
 
 @ABSTRACT()
@@ -14,8 +13,8 @@ export class Directive {
     }:{
       selector:String,
       bind:Object,
-      lightDomServices:ElementServicesFunction,
-      implementsTypes:Array<Type>
+      lightDomServices:List,
+      implementsTypes:List
     })
   {
     this.selector = selector;

--- a/modules/core/src/annotations/facade.dart
+++ b/modules/core/src/annotations/facade.dart
@@ -1,7 +1,0 @@
-library core.annotations.facade;
-
-import 'package:di/di.dart' show Module;
-import '../compiler/element_module.dart' show ElementModule;
-
-typedef DomServicesFunction(ElementModule m);
-typedef ComponentServicesFunction(Module m);

--- a/modules/core/src/annotations/facade.es6
+++ b/modules/core/src/annotations/facade.es6
@@ -1,2 +1,0 @@
-export var DomServicesFunction = Function;
-export var ComponentServicesFunction = Function;

--- a/modules/core/src/annotations/template.js
+++ b/modules/core/src/annotations/template.js
@@ -11,8 +11,8 @@ export class Template extends Directive {
     }:{
       selector:String,
       bind:Object,
-      lightDomServices:ElementServicesFunction,
-      implementsTypes:Array<Type>
+      lightDomServices:List,
+      implementsTypes:List
     }={})
   {
     super({


### PR DESCRIPTION
Remove shadowDomServices, since componentServices is used for that
purpose.
