### PR TITLE
feat(compiler): new semantics for `template` attributes and view variabl...

### DIFF
--- a/modules/change_detection/src/parser/ast.js
+++ b/modules/change_detection/src/parser/ast.js
@@ -111,7 +111,7 @@ export class KeyedAccess extends AST {
     this.obj = obj;
     this.key = key;
   }
-  
+
   eval(context) {
     var obj = this.obj.eval(context);
     var key = this.key.eval(context);
@@ -169,11 +169,11 @@ export class LiteralPrimitive extends AST {
   constructor(value) {
     this.value = value;
   }
-  
+
   eval(context) {
     return this.value;
   }
-  
+
   visit(visitor, args) {
     visitor.visitLiteralPrimitive(this, args);
   }
@@ -184,11 +184,11 @@ export class LiteralArray extends AST {
   constructor(expressions:List) {
     this.expressions = expressions;
   }
-  
+
   eval(context) {
     return ListWrapper.map(this.expressions, (e) => e.eval(context));
   }
-  
+
   visit(visitor, args) {
     visitor.visitLiteralArray(this, args);
   }
@@ -287,7 +287,7 @@ export class Assignment extends AST {
   eval(context) {
     return this.target.assign(context, this.value.eval(context));
   }
-  
+
   visit(visitor, args) {
     visitor.visitAssignment(this, args);
   }
@@ -333,6 +333,22 @@ export class FunctionCall extends AST {
 
   visit(visitor, args) {
     visitor.visitFunctionCall(this, args);
+  }
+}
+
+export class ASTWithSource {
+  constructor(ast:AST, source:string) {
+    this.source = source;
+    this.ast = ast;
+  }
+}
+
+export class TemplateBinding {
+  constructor(key:string, name:string, expression:ASTWithSource) {
+    this.key = key;
+    // only either name or expression will be filled.
+    this.name = name;
+    this.expression = expression;
   }
 }
 

--- a/modules/change_detection/src/parser/lexer.js
+++ b/modules/change_detection/src/parser/lexer.js
@@ -130,6 +130,7 @@ export const $CR        = 13;
 export const $SPACE     = 32;
 export const $BANG      = 33;
 export const $DQ        = 34;
+export const $HASH      = 35;
 export const $$         = 36;
 export const $PERCENT   = 37;
 export const $AMPERSAND = 38;
@@ -246,6 +247,8 @@ class _Scanner {
       case $SQ:
       case $DQ:
         return this.scanString();
+      case $HASH:
+        return this.scanOperator(start, StringWrapper.fromCharCode(peek));
       case $PLUS:
       case $MINUS:
       case $STAR:
@@ -459,7 +462,8 @@ var OPERATORS = SetWrapper.createFromList([
   '&',
   '|',
   '!',
-  '?'
+  '?',
+  '#'
 ]);
 
 

--- a/modules/change_detection/src/watch_group.js
+++ b/modules/change_detection/src/watch_group.js
@@ -310,6 +310,8 @@ class ProtoRecordCreator {
 
   visitAssignment(ast:Assignment, dest) {this.unsupported();}
 
+  visitTemplateBindings(ast, dest) {this.unsupported();}
+
   createRecordsFromAST(ast:AST, memento){
     ast.visit(this, memento);
   }

--- a/modules/change_detection/test/change_detector_spec.js
+++ b/modules/change_detection/test/change_detector_spec.js
@@ -18,7 +18,7 @@ import {Record} from 'change_detection/record';
 export function main() {
   function ast(exp:string) {
     var parser = new Parser(new Lexer(), new ClosureMap());
-    return parser.parseBinding(exp);
+    return parser.parseBinding(exp).ast;
   }
 
   function createChangeDetector(memo:string, exp:string, context = null, formatters = null) {

--- a/modules/change_detection/test/parser/lexer_spec.js
+++ b/modules/change_detection/test/parser/lexer_spec.js
@@ -237,6 +237,11 @@ export function main() {
         }).toThrowError("Lexer Error: Invalid unicode escape [\\u1''b] at column 2 in expression ['\\u1''bla']");
       });
 
+      it('should tokenize hash as operator', function() {
+        var tokens:List<Token> = lex("#");
+        expectOperatorToken(tokens[0], 0, '#');
+      });
+
     });
   });
 }

--- a/modules/core/src/compiler/pipeline/compile_element.js
+++ b/modules/core/src/compiler/pipeline/compile_element.js
@@ -6,6 +6,8 @@ import {Decorator} from '../../annotations/decorator';
 import {Component} from '../../annotations/component';
 import {Template} from '../../annotations/template';
 
+import {ASTWithSource} from 'change_detection/parser/ast';
+
 /**
  * Collects all data that is needed to process an element
  * in the compile process. Fields are filled
@@ -18,6 +20,7 @@ export class CompileElement {
     this._classList = null;
     this.textNodeBindings = null;
     this.propertyBindings = null;
+    this.variableBindings = null;
     this.decoratorDirectives = null;
     this.templateDirective = null;
     this.componentDirective = null;
@@ -60,18 +63,25 @@ export class CompileElement {
     return this._classList;
   }
 
-  addTextNodeBinding(indexInParent:int, expression:string) {
+  addTextNodeBinding(indexInParent:int, expression:ASTWithSource) {
     if (isBlank(this.textNodeBindings)) {
       this.textNodeBindings = MapWrapper.create();
     }
     MapWrapper.set(this.textNodeBindings, indexInParent, expression);
   }
 
-  addPropertyBinding(property:string, expression:string) {
+  addPropertyBinding(property:string, expression:ASTWithSource) {
     if (isBlank(this.propertyBindings)) {
       this.propertyBindings = MapWrapper.create();
     }
     MapWrapper.set(this.propertyBindings, property, expression);
+  }
+
+  addVariableBinding(contextName:string, templateName:string) {
+    if (isBlank(this.variableBindings)) {
+      this.variableBindings = MapWrapper.create();
+    }
+    MapWrapper.set(this.variableBindings, contextName, templateName);
   }
 
   addDirective(directive:AnnotatedType) {

--- a/modules/core/src/compiler/pipeline/default_steps.js
+++ b/modules/core/src/compiler/pipeline/default_steps.js
@@ -21,13 +21,13 @@ export function createDefaultSteps(
     directives: List<AnnotatedType>
   ) {
   return [
-    new PropertyBindingParser(),
-    new TextInterpolationParser(),
+    new ViewSplitter(parser),
+    new TextInterpolationParser(parser),
+    new PropertyBindingParser(parser),
     new DirectiveParser(directives),
-    new ViewSplitter(),
     new ElementBindingMarker(),
     new ProtoViewBuilder(),
     new ProtoElementInjectorBuilder(),
-    new ElementBinderBuilder(parser, closureMap)
+    new ElementBinderBuilder(closureMap)
   ];
 }

--- a/modules/core/src/compiler/pipeline/element_binding_marker.js
+++ b/modules/core/src/compiler/pipeline/element_binding_marker.js
@@ -18,6 +18,7 @@ const NG_BINDING_CLASS = 'ng-binding';
  * Reads:
  * - CompileElement#textNodeBindings
  * - CompileElement#propertyBindings
+ * - CompileElement#variableBindings
  * - CompileElement#decoratorDirectives
  * - CompileElement#componentDirective
  * - CompileElement#templateDirective
@@ -27,6 +28,7 @@ export class ElementBindingMarker extends CompileStep {
     var hasBindings =
       (isPresent(current.textNodeBindings) && MapWrapper.size(current.textNodeBindings)>0) ||
       (isPresent(current.propertyBindings) && MapWrapper.size(current.propertyBindings)>0) ||
+      (isPresent(current.variableBindings) && MapWrapper.size(current.variableBindings)>0) ||
       (isPresent(current.decoratorDirectives) && current.decoratorDirectives.length > 0) ||
       isPresent(current.templateDirective) ||
       isPresent(current.componentDirective);

--- a/modules/core/src/compiler/pipeline/property_binding_parser.js
+++ b/modules/core/src/compiler/pipeline/property_binding_parser.js
@@ -1,13 +1,18 @@
-import {isPresent, isBlank, RegExpWrapper} from 'facade/lang';
+import {isPresent, isBlank, RegExpWrapper, BaseException} from 'facade/lang';
 import {MapWrapper} from 'facade/collection';
+import {TemplateElement} from 'facade/dom';
+
+import {Parser} from 'change_detection/parser/parser';
+import {ExpressionWithSource} from 'change_detection/parser/ast';
 
 import {CompileStep} from './compile_step';
 import {CompileElement} from './compile_element';
 import {CompileControl} from './compile_control';
 
+import {interpolationToExpression} from './text_interpolation_parser';
+
 // TODO(tbosch): Cannot make this const/final right now because of the transpiler...
-var BIND_DASH_REGEXP = RegExpWrapper.create('bind-((?:[^-]|-(?!-))+)(?:--(.+))?');
-var PROP_BIND_REGEXP = RegExpWrapper.create('\\[([^|]+)(?:\\|(.+))?\\]');
+var BIND_NAME_REGEXP = RegExpWrapper.create('^(?:(?:(bind)|(let))-(.+))|\\[([^\\]]+)\\]');
 
 /**
  * Parses the property bindings on a single element.
@@ -16,15 +21,35 @@ var PROP_BIND_REGEXP = RegExpWrapper.create('\\[([^|]+)(?:\\|(.+))?\\]');
  * - CompileElement#propertyBindings
  */
 export class PropertyBindingParser extends CompileStep {
+  constructor(parser:Parser) {
+    this._parser = parser;
+  }
+
   process(parent:CompileElement, current:CompileElement, control:CompileControl) {
     var attrs = current.attrs();
     MapWrapper.forEach(attrs, (attrValue, attrName) => {
-      var parts = RegExpWrapper.firstMatch(BIND_DASH_REGEXP, attrName);
-      if (isBlank(parts)) {
-        parts = RegExpWrapper.firstMatch(PROP_BIND_REGEXP, attrName);
-      }
-      if (isPresent(parts)) {
-        current.addPropertyBinding(parts[1], attrValue);
+      var bindParts = RegExpWrapper.firstMatch(BIND_NAME_REGEXP, attrName);
+      if (isPresent(bindParts)) {
+        if (isPresent(bindParts[1])) {
+          // match: bind-prop
+          current.addPropertyBinding(bindParts[3], this._parser.parseBinding(attrValue));
+        } else if (isPresent(bindParts[2])) {
+          // match: let-prop
+          // Note: We assume that the ViewSplitter already did its work, i.e. template directive should
+          // only be present on <template> elements any more!
+          if (!(current.element instanceof TemplateElement)) {
+            throw new BaseException('let-* is only allowed on <template> elements!');
+          }
+          current.addVariableBinding(bindParts[3], attrValue);
+        } else if (isPresent(bindParts[4])) {
+          // match: [prop]
+          current.addPropertyBinding(bindParts[4], this._parser.parseBinding(attrValue));
+        }
+      } else {
+        var expression = interpolationToExpression(attrValue);
+        if (isPresent(expression)) {
+          current.addPropertyBinding(attrName, this._parser.parseBinding(expression));
+        }
       }
     });
   }

--- a/modules/core/src/compiler/pipeline/proto_view_builder.js
+++ b/modules/core/src/compiler/pipeline/proto_view_builder.js
@@ -1,5 +1,5 @@
 import {isPresent, BaseException} from 'facade/lang';
-import {ListWrapper} from 'facade/collection';
+import {ListWrapper, MapWrapper} from 'facade/collection';
 
 import {ProtoView} from '../view';
 import {ProtoWatchGroup} from 'change_detection/watch_group';
@@ -27,6 +27,11 @@ export class ProtoViewBuilder extends CompileStep {
           throw new BaseException('Only one nested view per element is allowed');
         }
         parent.inheritedElementBinder.nestedProtoView = inheritedProtoView;
+        if (isPresent(parent.variableBindings)) {
+          MapWrapper.forEach(parent.variableBindings, (mappedName, varName) => {
+            inheritedProtoView.bindVariable(varName, mappedName);
+          });
+        }
       }
     } else if (isPresent(parent)) {
       inheritedProtoView = parent.inheritedProtoView;

--- a/modules/core/src/compiler/pipeline/text_interpolation_parser.js
+++ b/modules/core/src/compiler/pipeline/text_interpolation_parser.js
@@ -1,6 +1,8 @@
 import {RegExpWrapper, StringWrapper, isPresent} from 'facade/lang';
 import {Node, DOM} from 'facade/dom';
 
+import {Parser} from 'change_detection/parser/parser';
+
 import {CompileStep} from './compile_step';
 import {CompileElement} from './compile_element';
 import {CompileControl} from './compile_control';
@@ -9,6 +11,34 @@ import {CompileControl} from './compile_control';
 var INTERPOLATION_REGEXP = RegExpWrapper.create('\\{\\{(.*?)\\}\\}');
 var QUOTE_REGEXP = RegExpWrapper.create("'");
 
+export function interpolationToExpression(value:string):string {
+  // TODO: add stringify formatter when we support formatters
+  var parts = StringWrapper.split(value, INTERPOLATION_REGEXP);
+  if (parts.length <= 1) {
+    return null;
+  }
+  var expression = '';
+  for (var i=0; i<parts.length; i++) {
+    var expressionPart = null;
+    if (i%2 === 0) {
+      // fixed string
+      if (parts[i].length > 0) {
+        expressionPart = "'" + StringWrapper.replaceAll(parts[i], QUOTE_REGEXP, "\\'") + "'";
+      }
+    } else {
+      // expression
+      expressionPart = "(" + parts[i] + ")";
+    }
+    if (isPresent(expressionPart)) {
+      if (expression.length > 0) {
+        expression += '+';
+      }
+      expression += expressionPart;
+    }
+  }
+  return expression;
+}
+
 /**
  * Parses interpolations in direct text child nodes of the current element.
  *
@@ -16,6 +46,10 @@ var QUOTE_REGEXP = RegExpWrapper.create("'");
  * - CompileElement#textNodeBindings
  */
 export class TextInterpolationParser extends CompileStep {
+  constructor(parser:Parser) {
+    this._parser = parser;
+  }
+
   process(parent:CompileElement, current:CompileElement, control:CompileControl) {
     var element = current.element;
     var childNodes = DOM.templateAwareRoot(element).childNodes;
@@ -28,30 +62,10 @@ export class TextInterpolationParser extends CompileStep {
   }
 
   _parseTextNode(pipelineElement, node, nodeIndex) {
-    // TODO: add stringify formatter when we support formatters
-    var parts = StringWrapper.split(node.nodeValue, INTERPOLATION_REGEXP);
-    if (parts.length > 1) {
-      var expression = '';
-      for (var i=0; i<parts.length; i++) {
-        var expressionPart = null;
-        if (i%2 === 0) {
-          // fixed string
-          if (parts[i].length > 0) {
-            expressionPart = "'" + StringWrapper.replaceAll(parts[i], QUOTE_REGEXP, "\\'") + "'";
-          }
-        } else {
-          // expression
-          expressionPart = "(" + parts[i] + ")";
-        }
-        if (isPresent(expressionPart)) {
-          if (expression.length > 0) {
-            expression += '+';
-          }
-          expression += expressionPart;
-        }
-      }
+    var expression = interpolationToExpression(node.nodeValue);
+    if (isPresent(expression)) {
       DOM.setText(node, ' ');
-      pipelineElement.addTextNodeBinding(nodeIndex, expression);
+      pipelineElement.addTextNodeBinding(nodeIndex, this._parser.parseBinding(expression));
     }
   }
 }

--- a/modules/core/src/compiler/view.js
+++ b/modules/core/src/compiler/view.js
@@ -78,6 +78,7 @@ export class ProtoView {
       protoWatchGroup:ProtoWatchGroup) {
     this.element = template;
     this.elementBinders = [];
+    this.variableBindings = MapWrapper.create();
     this.protoWatchGroup = protoWatchGroup;
     this.textNodesWithBindingCount = 0;
     this.elementsWithBindingCount = 0;
@@ -122,6 +123,10 @@ export class ProtoView {
         elements, binders, elementInjectors, shadowAppInjectors, view);
 
     return view;
+  }
+
+  bindVariable(contextName:string, templateName:string) {
+    MapWrapper.set(this.variableBindings, contextName, templateName);
   }
 
   bindElement(protoElementInjector:ProtoElementInjector,

--- a/modules/core/test/compiler/pipeline/element_binding_marker_spec.js
+++ b/modules/core/test/compiler/pipeline/element_binding_marker_spec.js
@@ -16,7 +16,7 @@ import {Component} from 'core/annotations/component';
 export function main() {
   describe('ElementBindingMarker', () => {
 
-    function createPipeline({textNodeBindings, propertyBindings, directives}={}) {
+    function createPipeline({textNodeBindings, propertyBindings, variableBindings, directives}={}) {
       var reflector = new Reflector();
       return new CompilePipeline([
         new MockStep((parent, current, control) => {
@@ -25,6 +25,9 @@ export function main() {
             }
             if (isPresent(propertyBindings)) {
               current.propertyBindings = propertyBindings;
+            }
+            if (isPresent(variableBindings)) {
+              current.variableBindings = variableBindings;
             }
             if (isPresent(directives)) {
               for (var i=0; i<directives.length; i++) {
@@ -50,6 +53,12 @@ export function main() {
     it('should mark elements with property bindings', () => {
       var propertyBindings = MapWrapper.createFromStringMap({'a': 'expr'});
       var results = createPipeline({propertyBindings: propertyBindings}).process(createElement('<div></div>'));
+      assertBinding(results[0], true);
+    });
+
+    it('should mark elements with variable bindings', () => {
+      var variableBindings = MapWrapper.createFromStringMap({'a': 'expr'});
+      var results = createPipeline({variableBindings: variableBindings}).process(createElement('<div></div>'));
       assertBinding(results[0], true);
     });
 

--- a/modules/core/test/compiler/pipeline/property_binding_parser_spec.js
+++ b/modules/core/test/compiler/pipeline/property_binding_parser_spec.js
@@ -4,20 +4,42 @@ import {CompilePipeline} from 'core/compiler/pipeline/compile_pipeline';
 import {DOM} from 'facade/dom';
 import {MapWrapper} from 'facade/collection';
 
+import {Parser} from 'change_detection/parser/parser';
+import {ClosureMap} from 'change_detection/parser/closure_map';
+import {Lexer} from 'change_detection/parser/lexer';
+
 export function main() {
   describe('PropertyBindingParser', () => {
     function createPipeline() {
-      return new CompilePipeline([new PropertyBindingParser()]);
+      return new CompilePipeline([new PropertyBindingParser(new Parser(new Lexer(), new ClosureMap()))]);
     }
 
     it('should detect [] syntax', () => {
       var results = createPipeline().process(createElement('<div [a]="b"></div>'));
-      expect(MapWrapper.get(results[0].propertyBindings, 'a')).toEqual('b');
+      expect(MapWrapper.get(results[0].propertyBindings, 'a').source).toEqual('b');
     });
 
     it('should detect bind- syntax', () => {
       var results = createPipeline().process(createElement('<div bind-a="b"></div>'));
-      expect(MapWrapper.get(results[0].propertyBindings, 'a')).toEqual('b');
+      expect(MapWrapper.get(results[0].propertyBindings, 'a').source).toEqual('b');
+    });
+
+    it('should detect interpolation syntax', () => {
+      // Note: we don't test all corner cases of interpolation as we assume shared functionality between text interpolation
+      // and attribute interpolation.
+      var results = createPipeline().process(createElement('<div a="{{b}}"></div>'));
+      expect(MapWrapper.get(results[0].propertyBindings, 'a').source).toEqual('(b)');
+    });
+
+    it('should detect let- syntax', () => {
+      var results = createPipeline().process(createElement('<template let-a="b"></template>'));
+      expect(MapWrapper.get(results[0].variableBindings, 'a')).toEqual('b');
+    });
+
+    it('should not allow let- syntax on non template elements', () => {
+      expect( () => {
+        createPipeline().process(createElement('<div let-a="b"></div>'))
+      }).toThrowError('let-* is only allowed on <template> elements!');
     });
   });
 }

--- a/modules/core/test/compiler/pipeline/text_interpolation_parser_spec.js
+++ b/modules/core/test/compiler/pipeline/text_interpolation_parser_spec.js
@@ -4,41 +4,45 @@ import {CompilePipeline} from 'core/compiler/pipeline/compile_pipeline';
 import {DOM} from 'facade/dom';
 import {MapWrapper} from 'facade/collection';
 
+import {Parser} from 'change_detection/parser/parser';
+import {ClosureMap} from 'change_detection/parser/closure_map';
+import {Lexer} from 'change_detection/parser/lexer';
+
 export function main() {
   describe('TextInterpolationParser', () => {
     function createPipeline() {
-      return new CompilePipeline([new TextInterpolationParser()]);
+      return new CompilePipeline([new TextInterpolationParser(new Parser(new Lexer(), new ClosureMap()))]);
     }
 
     it('should find text interpolation in normal elements', () => {
       var results = createPipeline().process(createElement('<div>{{expr1}}<span></span>{{expr2}}</div>'));
       var bindings = results[0].textNodeBindings;
-      expect(MapWrapper.get(bindings, 0)).toEqual("(expr1)");
-      expect(MapWrapper.get(bindings, 2)).toEqual("(expr2)");
+      expect(MapWrapper.get(bindings, 0).source).toEqual("(expr1)");
+      expect(MapWrapper.get(bindings, 2).source).toEqual("(expr2)");
     });
 
     it('should find text interpolation in template elements', () => {
       var results = createPipeline().process(createElement('<template>{{expr1}}<span></span>{{expr2}}</template>'));
       var bindings = results[0].textNodeBindings;
-      expect(MapWrapper.get(bindings, 0)).toEqual("(expr1)");
-      expect(MapWrapper.get(bindings, 2)).toEqual("(expr2)");
+      expect(MapWrapper.get(bindings, 0).source).toEqual("(expr1)");
+      expect(MapWrapper.get(bindings, 2).source).toEqual("(expr2)");
     });
 
     it('should allow multiple expressions', () => {
       var results = createPipeline().process(createElement('<div>{{expr1}}{{expr2}}</div>'));
       var bindings = results[0].textNodeBindings;
-      expect(MapWrapper.get(bindings, 0)).toEqual("(expr1)+(expr2)");
+      expect(MapWrapper.get(bindings, 0).source).toEqual("(expr1)+(expr2)");
     });
 
     it('should allow fixed text before, in between and after expressions', () => {
       var results = createPipeline().process(createElement('<div>a{{expr1}}b{{expr2}}c</div>'));
       var bindings = results[0].textNodeBindings;
-      expect(MapWrapper.get(bindings, 0)).toEqual("'a'+(expr1)+'b'+(expr2)+'c'");
+      expect(MapWrapper.get(bindings, 0).source).toEqual("'a'+(expr1)+'b'+(expr2)+'c'");
     });
 
     it('should escape quotes in fixed parts', () => {
       var results = createPipeline().process(createElement("<div>'\"a{{expr1}}</div>"));
-      expect(MapWrapper.get(results[0].textNodeBindings, 0)).toEqual("'\\'\"a'+(expr1)");
+      expect(MapWrapper.get(results[0].textNodeBindings, 0).source).toEqual("'\\'\"a'+(expr1)");
     });
   });
 }

--- a/modules/core/test/compiler/pipeline/view_splitter_spec.js
+++ b/modules/core/test/compiler/pipeline/view_splitter_spec.js
@@ -4,51 +4,35 @@ import {MapWrapper} from 'facade/collection';
 
 import {ViewSplitter} from 'core/compiler/pipeline/view_splitter';
 import {CompilePipeline} from 'core/compiler/pipeline/compile_pipeline';
-import {CompileElement} from 'core/compiler/pipeline/compile_element';
-import {CompileStep} from 'core/compiler/pipeline/compile_step'
-import {CompileControl} from 'core/compiler/pipeline/compile_control';
 import {DOM, TemplateElement} from 'facade/dom';
-import {Reflector} from 'core/compiler/reflector';
-import {Template} from 'core/annotations/template';
-import {Decorator} from 'core/annotations/decorator';
-import {Component} from 'core/annotations/component';
+
+import {Parser} from 'change_detection/parser/parser';
+import {ClosureMap} from 'change_detection/parser/closure_map';
+import {Lexer} from 'change_detection/parser/lexer';
 
 export function main() {
   describe('ViewSplitter', () => {
 
-    function createPipeline({textNodeBindings, propertyBindings, directives}={}) {
-      var reflector = new Reflector();
-      return new CompilePipeline([
-        new MockStep((parent, current, control) => {
-          if (isPresent(current.element.getAttribute('tmpl'))) {
-            current.addDirective(reflector.annotatedType(SomeTemplateDirective));
-            if (isPresent(textNodeBindings)) {
-              current.textNodeBindings = textNodeBindings;
-            }
-            if (isPresent(propertyBindings)) {
-              current.propertyBindings = propertyBindings;
-            }
-            if (isPresent(directives)) {
-              for (var i=0; i<directives.length; i++) {
-                current.addDirective(reflector.annotatedType(directives[i]));
-              }
-            }
-          }
-        }), new ViewSplitter()
-      ]);
+    function createPipeline() {
+      return new CompilePipeline([new ViewSplitter(new Parser(new Lexer(), new ClosureMap()))]);
     }
 
-    function commonTests(useTemplateElement) {
-      var rootElement;
-      beforeEach( () => {
-        if (useTemplateElement) {
-          rootElement = createElement('<div><span tmpl></span></div>');
-        } else {
-          rootElement = createElement('<div><span tmpl></span></div>');
-        }
-      });
+    it('should mark root elements as viewRoot', () => {
+      var rootElement = createElement('<div></div>');
+      var results = createPipeline().process(rootElement);
+      expect(results[0].isViewRoot).toBe(true);
+    });
+
+    it('should mark <template> elements as viewRoot', () => {
+      var rootElement = createElement('<div><template></template></div>');
+      var results = createPipeline().process(rootElement);
+      expect(results[1].isViewRoot).toBe(true);
+    });
+
+    describe('elements with template attribute', () => {
 
       it('should insert an empty <template> element', () => {
+        var rootElement = createElement('<div><div template></div></div>');
         var originalChild = rootElement.childNodes[0];
         var results = createPipeline().process(rootElement);
         expect(results[0].element).toBe(rootElement);
@@ -57,78 +41,28 @@ export function main() {
         expect(results[2].element).toBe(originalChild);
       });
 
-      it('should move the template directive to the new element', () => {
+      it('should mark the element as viewRoot', () => {
+        var rootElement = createElement('<div><div template></div></div>');
         var results = createPipeline().process(rootElement);
-        expect(results[1].templateDirective.type).toBe(SomeTemplateDirective);
-        expect(results[2].templateDirective).toBe(null);
-      });
-
-      it('should split the property bindings depending on the bindings on the directive', () => {
-        var propertyBindings = MapWrapper.createFromStringMap({
-          'templateBoundProp': 'a',
-          'nonBoundProp': 'c'
-        });
-        var results = createPipeline({propertyBindings: propertyBindings}).process(rootElement);
-        expect(MapWrapper.get(results[1].propertyBindings, 'templateBoundProp')).toEqual('a');
-        expect(MapWrapper.get(results[2].propertyBindings, 'nonBoundProp')).toEqual('c');
-      });
-
-      it('should keep the component, decorator directives and text node bindings on the original element', () => {
-        var textNodeBindings = MapWrapper.create();
-        MapWrapper.set(textNodeBindings, 0, 'someExpr');
-        var directives = [SomeDecoratorDirective, SomeComponentDirective];
-        var results = createPipeline({
-          textNodeBindings: textNodeBindings,
-          directives: directives
-        }).process(rootElement);
-        expect(results[1].componentDirective).toBe(null);
-        expect(results[1].decoratorDirectives).toBe(null);
-        expect(results[1].textNodeBindings).toBe(null);
-        expect(results[2].componentDirective.type).toEqual(SomeComponentDirective);
-        expect(results[2].decoratorDirectives[0].type).toEqual(SomeDecoratorDirective);
-        expect(results[2].textNodeBindings).toEqual(textNodeBindings);
-      });
-
-      it('should set the isViewRoot flag for the root and nested views', () => {
-        var results = createPipeline().process(rootElement);
-        expect(results[0].isViewRoot).toBe(true);
-        expect(results[1].isViewRoot).toBe(false);
         expect(results[2].isViewRoot).toBe(true);
       });
-    }
 
-    describe('template directive on normal element', () => {
-      commonTests(false);
-    });
+      it('should add property bindings from the template attribute', () => {
+        var rootElement = createElement('<div><div template="prop:expr"></div></div>');
+        var results = createPipeline().process(rootElement);
+        expect(MapWrapper.get(results[1].propertyBindings, 'prop').source).toEqual('expr');
+      });
 
-    describe('template directive on <template> element', () => {
-      commonTests(true);
+      it('should add variable mappings from the template attribute', () => {
+        var rootElement = createElement('<div><div template="varName #mapName"></div></div>');
+        var results = createPipeline().process(rootElement);
+        expect(results[1].variableBindings).toEqual(MapWrapper.createFromStringMap({'varName': 'mapName'}));
+      });
+
     });
 
   });
 }
-
-class MockStep extends CompileStep {
-  constructor(process) {
-    this.processClosure = process;
-  }
-  process(parent:CompileElement, current:CompileElement, control:CompileControl) {
-    this.processClosure(parent, current, control);
-  }
-}
-
-@Template({
-  bind: {
-    'templateBoundProp': 'dirProp'
-  }
-})
-class SomeTemplateDirective {}
-
-@Component()
-class SomeComponentDirective {}
-
-@Decorator()
-class SomeDecoratorDirective {}
 
 function createElement(html) {
   return DOM.createTemplate(html).content.firstChild;

--- a/modules/core/test/compiler/view_spec.js
+++ b/modules/core/test/compiler/view_spec.js
@@ -46,7 +46,7 @@ export function main() {
           it('should collect property bindings on the root element if it has the ng-binding class', () => {
             var pv = new ProtoView(templateAwareCreateElement('<div [prop]="a" class="ng-binding"></div>'), new ProtoWatchGroup());
             pv.bindElement(null);
-            pv.bindElementProperty('prop', parser.parseBinding('a'));
+            pv.bindElementProperty('prop', parser.parseBinding('a').ast);
 
             var view = pv.instantiate(null, null, null);
             expect(view.bindElements.length).toEqual(1);
@@ -57,7 +57,7 @@ export function main() {
             var pv = new ProtoView(templateAwareCreateElement('<div><span></span><span class="ng-binding"></span></div>'),
               new ProtoWatchGroup());
             pv.bindElement(null);
-            pv.bindElementProperty('a', parser.parseBinding('b'));
+            pv.bindElementProperty('a', parser.parseBinding('b').ast);
 
             var view = pv.instantiate(null, null, null);
             expect(view.bindElements.length).toEqual(1);
@@ -71,8 +71,8 @@ export function main() {
           it('should collect text nodes under the root element', () => {
             var pv = new ProtoView(templateAwareCreateElement('<div class="ng-binding">{{}}<span></span>{{}}</div>'), new ProtoWatchGroup());
             pv.bindElement(null);
-            pv.bindTextNode(0, parser.parseBinding('a'));
-            pv.bindTextNode(2, parser.parseBinding('b'));
+            pv.bindTextNode(0, parser.parseBinding('a').ast);
+            pv.bindTextNode(2, parser.parseBinding('b').ast);
 
             var view = pv.instantiate(null, null, null);
             expect(view.textNodes.length).toEqual(2);
@@ -84,7 +84,7 @@ export function main() {
             var pv = new ProtoView(templateAwareCreateElement('<div><span> </span><span class="ng-binding">{{}}</span></div>'),
               new ProtoWatchGroup());
             pv.bindElement(null);
-            pv.bindTextNode(0, parser.parseBinding('b'));
+            pv.bindTextNode(0, parser.parseBinding('b').ast);
 
             var view = pv.instantiate(null, null, null);
             expect(view.textNodes.length).toEqual(1);
@@ -176,7 +176,7 @@ export function main() {
         function createComponentWithSubPV(subProtoView) {
           var pv = new ProtoView(createElement('<cmp class="ng-binding"></cmp>'), new ProtoWatchGroup());
           var binder = pv.bindElement(new ProtoElementInjector(null, 0, [SomeComponent], true));
-          binder.componentDirective = someComponentDirective; 
+          binder.componentDirective = someComponentDirective;
           binder.nestedProtoView = subProtoView;
           return pv;
         }
@@ -239,7 +239,7 @@ export function main() {
           var pv = new ProtoView(createElement('<div class="ng-binding">{{}}</div>'),
             new ProtoWatchGroup());
           pv.bindElement(null);
-          pv.bindTextNode(0, parser.parseBinding('foo'));
+          pv.bindTextNode(0, parser.parseBinding('foo').ast);
           createView(pv);
 
           ctx.foo = 'buz';
@@ -251,7 +251,7 @@ export function main() {
           var pv = new ProtoView(createElement('<div class="ng-binding"></div>'),
             new ProtoWatchGroup());
           pv.bindElement(null);
-          pv.bindElementProperty('id', parser.parseBinding('foo'));
+          pv.bindElementProperty('id', parser.parseBinding('foo').ast);
           createView(pv);
 
           ctx.foo = 'buz';
@@ -263,7 +263,7 @@ export function main() {
           var pv = new ProtoView(createElement('<div class="ng-binding"></div>'),
             new ProtoWatchGroup());
           pv.bindElement(new ProtoElementInjector(null, 0, [SomeDirective]));
-          pv.bindDirectiveProperty( 0, parser.parseBinding('foo'), 'prop', closureMap.setter('prop'));
+          pv.bindDirectiveProperty( 0, parser.parseBinding('foo').ast, 'prop', closureMap.setter('prop'));
           createView(pv);
 
           ctx.foo = 'buz';


### PR DESCRIPTION
...es.
- Supports `<div template=“…”>`, including parsing the expressions within
  the attribute.
- Supports `<template let-ng-repeat=“rows”>`
- Adds attribute interpolation (was missing previously)
