### PR TITLE
fix(examples): hello-world app on Windows

### DIFF
--- a/file2modulename.js
+++ b/file2modulename.js
@@ -1,5 +1,5 @@
 function file2moduleName(filePath) {
-  return filePath
+  return filePath.replace(/\\/g, '/')
     // module name should be relative to `modules` and `tools` folder
     .replace(/.*\/modules\//, '')
     .replace(/.*\/tools\//, '')

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -330,7 +330,7 @@ gulp.task('serve', function() {
 });
 
 gulp.task('examples/pub.serve', function(done) {
-  spawn('pub', ['serve'], {cwd: 'build/dart/examples', stdio: 'inherit'})
+  spawn(PUB_CMD, ['serve'], {cwd: 'build/dart/examples', stdio: 'inherit'})
     .on('done', done);
 });
 


### PR DESCRIPTION
I missed the `file2modulename.js` part in PR #104 , and the right pub command should be used. This way, both JS and Dart hello-world examples work in a Windows environment.
