### PR TITLE
feat(Change Detector): Add support for collection content watch

### DIFF
--- a/modules/change_detection/src/parser/ast.js
+++ b/modules/change_detection/src/parser/ast.js
@@ -29,6 +29,21 @@ export class EmptyExpr extends AST {
   }
 }
 
+export class Collection extends AST {
+  value:AST;
+  constructor(value:AST) {
+    this.value = value;
+  }
+
+  eval(context) {
+    return value.eval(context);
+  }
+
+  visit(visitor, args) {
+    visitor.visitCollection(this, args);
+  }
+}
+
 export class ImplicitReceiver extends AST {
   eval(context) {
     return context;
@@ -386,20 +401,21 @@ export class TemplateBinding {
 
 //INTERFACE
 export class AstVisitor {
-  visitChain(ast:Chain, args){}
-  visitImplicitReceiver(ast:ImplicitReceiver, args) {}
-  visitConditional(ast:Conditional, args) {}
   visitAccessMember(ast:AccessMember, args) {}
-  visitKeyedAccess(ast:KeyedAccess, args) {}
-  visitBinary(ast:Binary, args) {}
-  visitPrefixNot(ast:PrefixNot, args) {}
-  visitLiteralPrimitive(ast:LiteralPrimitive, args) {}
-  visitFormatter(ast:Formatter, args) {}
   visitAssignment(ast:Assignment, args) {}
+  visitBinary(ast:Binary, args) {}
+  visitChain(ast:Chain, args){}
+  visitCollection(ast:Collection, args) {}
+  visitConditional(ast:Conditional, args) {}
+  visitFormatter(ast:Formatter, args) {}
+  visitFunctionCall(ast:FunctionCall, args) {}
+  visitImplicitReceiver(ast:ImplicitReceiver, args) {}
+  visitKeyedAccess(ast:KeyedAccess, args) {}
   visitLiteralArray(ast:LiteralArray, args) {}
   visitLiteralMap(ast:LiteralMap, args) {}
+  visitLiteralPrimitive(ast:LiteralPrimitive, args) {}
   visitMethodCall(ast:MethodCall, args) {}
-  visitFunctionCall(ast:FunctionCall, args) {}
+  visitPrefixNot(ast:PrefixNot, args) {}
 }
 
 var _evalListCache = [[],[0],[0,0],[0,0,0],[0,0,0,0],[0,0,0,0,0]];

--- a/modules/change_detection/test/iterable.dart
+++ b/modules/change_detection/test/iterable.dart
@@ -1,0 +1,6 @@
+import 'dart:collection';
+
+class TestIterable extends IterableBase<int> {
+  List<int> list = [];
+  Iterator<int> get iterator => list.iterator;
+}

--- a/modules/change_detection/test/iterable.es6
+++ b/modules/change_detection/test/iterable.es6
@@ -1,0 +1,9 @@
+export class TestIterable {
+  constructor() {
+    this.list = [];
+  }
+
+  [Symbol.iterator]() {
+    return this.list[Symbol.iterator]();
+  }
+}

--- a/modules/change_detection/test/util.js
+++ b/modules/change_detection/test/util.js
@@ -1,0 +1,29 @@
+import {isBlank} from 'facade/lang';
+
+export function arrayChangesAsString({collection, previous, additions, moves, removals}) {
+  if (isBlank(collection)) collection = [];
+  if (isBlank(previous)) previous = [];
+  if (isBlank(additions)) additions = [];
+  if (isBlank(moves)) moves = [];
+  if (isBlank(removals)) removals = [];
+
+  return "collection: " + collection.join(', ') + "\n" +
+         "previous: " + previous.join(', ') + "\n" +
+         "additions: " + additions.join(', ') + "\n" +
+         "moves: " + moves.join(', ') + "\n" +
+         "removals: " + removals.join(', ') + "\n";
+}
+
+export function kvChangesAsString({map, previous, additions, changes, removals}) {
+  if (isBlank(map)) map = [];
+  if (isBlank(previous)) previous = [];
+  if (isBlank(additions)) additions = [];
+  if (isBlank(changes)) changes = [];
+  if (isBlank(removals)) removals = [];
+
+  return "map: " + map.join(', ') + "\n" +
+         "previous: " + previous.join(', ') + "\n" +
+         "additions: " + additions.join(', ') + "\n" +
+         "changes: " + changes.join(', ') + "\n" +
+         "removals: " + removals.join(', ') + "\n";
+}

--- a/modules/facade/src/collection.dart
+++ b/modules/facade/src/collection.dart
@@ -51,7 +51,7 @@ class ListWrapper {
   static filter(List list, fn) => list.where(fn).toList();
   static find(List list, fn) => list.firstWhere(fn, orElse:() => null);
   static any(List list, fn) => list.any(fn);
-  static forEach(list, fn) {
+  static forEach(list, Function fn) {
     list.forEach(fn);
   }
   static reduce(List list, Function fn, init) {
@@ -66,6 +66,15 @@ class ListWrapper {
   static void insert(List l, int index, value) { l.insert(index, value); }
   static void removeAt(List l, int index) { l.removeAt(index); }
   static void clear(List l) { l.clear(); }
+}
+
+bool isListLikeIterable(obj) => obj is Iterable;
+
+void iterateListLike(iter, Function fn) {
+  assert(iter is Iterable);
+  for (var item in iter) {
+    fn (item);
+  }
 }
 
 class SetWrapper {

--- a/modules/facade/src/lang.dart
+++ b/modules/facade/src/lang.dart
@@ -161,6 +161,11 @@ dynamic getMapKey(value) {
   return value.isNaN ? _NAN_KEY : value;
 }
 
-normalizeBlank(obj) {
+dynamic normalizeBlank(obj) {
   return isBlank(obj) ? null : obj;
 }
+
+bool isJsObject(o) {
+  return false;
+}
+

--- a/modules/facade/src/lang.es6
+++ b/modules/facade/src/lang.es6
@@ -202,3 +202,7 @@ export function getMapKey(value) {
 export function normalizeBlank(obj) {
   return isBlank(obj) ? null : obj;
 }
+
+export function isJsObject(o):boolean {
+  return o !== null && (typeof o === "function" || typeof o === "object");
+}


### PR DESCRIPTION
Add support for content watch (collections are normally watched by ref only).

Features in this PR:
- add content watch,
- add Iterable watch (like array watch),
- add JS Object watch (like map watch).
