### PR TITLE
feat(di:) add OpaqueToken to DI

### DIFF
--- a/modules/core/src/application.js
+++ b/modules/core/src/application.js
@@ -1,4 +1,4 @@
-import {Injector, bind} from 'di/di';
+import {Injector, bind, OpaqueToken} from 'di/di';
 import {Type, FIELD, isBlank, isPresent, BaseException} from 'facade/lang';
 import {DOM, Element} from 'facade/dom';
 import {Compiler} from './compiler/compiler';
@@ -21,11 +21,11 @@ var _rootBindings = [
   bind(Reflector).toValue(reflector), Compiler, TemplateLoader, DirectiveMetadataReader, Parser, Lexer
 ];
 
-export var appViewToken = new Object();
-export var appWatchGroupToken = new Object();
-export var appElementToken = new Object();
-export var appComponentAnnotatedTypeToken = new Object();
-export var appDocumentToken = new Object();
+export var appViewToken = new OpaqueToken('AppView');
+export var appRecordRangeToken = new OpaqueToken('AppRecordRange');
+export var appElementToken = new OpaqueToken('AppElement');
+export var appComponentAnnotatedTypeToken = new OpaqueToken('AppComponentAnnotatedType');
+export var appDocumentToken = new OpaqueToken('AppDocument');
 
 // Exported only for tests that need to overwrite default document binding.
 export function documentDependentBindings(appComponentType) {
@@ -59,10 +59,10 @@ export function documentDependentBindings(appComponentType) {
         });
       }, [Compiler, Injector, appElementToken, appComponentAnnotatedTypeToken]),
 
-      bind(appWatchGroupToken).toFactory((rootView) => rootView.recordRange,
+      bind(appRecordRangeToken).toFactory((rootView) => rootView.recordRange,
           [appViewToken]),
-      bind(ChangeDetector).toFactory((appWatchGroup) =>
-          new ChangeDetector(appWatchGroup), [appWatchGroupToken])
+      bind(ChangeDetector).toFactory((appRecordRange) =>
+          new ChangeDetector(appRecordRange), [appRecordRangeToken])
   ];
 }
 

--- a/modules/di/src/di.js
+++ b/modules/di/src/di.js
@@ -4,3 +4,4 @@ export * from './binding';
 export * from './key';
 export * from './module';
 export * from './exceptions';
+export * from './opaque_token';

--- a/modules/di/src/opaque_token.js
+++ b/modules/di/src/opaque_token.js
@@ -1,0 +1,11 @@
+export class OpaqueToken {
+  _desc:string;
+
+  constructor(desc:string){
+    this._desc = `Token(${desc})`;
+  }
+
+  toString() {
+    return this._desc;
+  }
+}


### PR DESCRIPTION
Using `new Object()` as a token causes cryptic errors. OpaqueToken class should be used instead.

Closes https://github.com/angular/angular/issues/223
