### PR TITLE
perf(Change Detection): Remove a useless test

### DIFF
--- a/modules/change_detection/src/record.js
+++ b/modules/change_detection/src/record.js
@@ -240,9 +240,7 @@ export class Record {
 
   updateContext(value) {
     this.context = value;
-    if (!this.isMarkerRecord) {
-      this.recordRange.enableRecord(this);
-    }
+    this.recordRange.enableRecord(this);
   }
 
   get isMarkerRecord() {


### PR DESCRIPTION
Only "implicit receiver" records get their context updated (since #239)
