### PR TITLE
feat(views): (de)hydration of views.

### DIFF
--- a/modules/change_detection/src/parser/context_with_variable_bindings.js
+++ b/modules/change_detection/src/parser/context_with_variable_bindings.js
@@ -1,8 +1,9 @@
 import {MapWrapper} from 'facade/collection';
+import {BaseException} from 'facade/lang';
 
 export class ContextWithVariableBindings {
   parent:any;
-  /// varBindings are read-only. updating/adding keys is not supported.
+  /// varBindings' keys are read-only. adding/removing keys is not supported.
   varBindings:Map;
 
   constructor(parent:any, varBindings:Map) {
@@ -16,5 +17,22 @@ export class ContextWithVariableBindings {
 
   get(name:string) {
     return MapWrapper.get(this.varBindings, name);
+  }
+
+  set(name:string, value) {
+    // TODO(rado): consider removing this check if we can guarantee this is not
+    // exposed to the public API.
+    if (this.hasBinding(name)) {
+      MapWrapper.set(this.varBindings, name, value);
+    } else {
+      throw new BaseException(
+        'VariableBindings do not support setting of new keys post-construction.');
+    }
+  }
+
+  clearValues() {
+    for (var [k, v] of MapWrapper.iterable(this.varBindings)) {
+      MapWrapper.set(this.varBindings, k, null);
+    }
   }
 }

--- a/modules/change_detection/test/parser/context_with_variable_bindings_spec.js
+++ b/modules/change_detection/test/parser/context_with_variable_bindings_spec.js
@@ -1,0 +1,42 @@
+import {ddescribe, describe, it, xit, iit, expect, beforeEach} from 'test_lib/test_lib';
+import {BaseException, isBlank, isPresent} from 'facade/lang';
+import {MapWrapper, ListWrapper} from 'facade/collection';
+import {ContextWithVariableBindings} from 'change_detection/parser/context_with_variable_bindings';
+
+export function main() {
+  describe('ContextWithVariableBindings', () => {
+    var locals;
+    beforeEach(() => {
+      locals = new ContextWithVariableBindings(null,
+          MapWrapper.createFromPairs([['key', 'value'], ['nullKey', null]]));
+    });
+
+    it('should support getting values', () => {
+      expect(locals.get('key')).toBe('value');
+
+      var notPresentValue = locals.get('notPresent');
+      expect(isPresent(notPresentValue)).toBe(false);
+    });
+
+    it('should support checking if key is persent', () => {
+      expect(locals.hasBinding('key')).toBe(true);
+      expect(locals.hasBinding('nullKey')).toBe(true);
+      expect(locals.hasBinding('notPresent')).toBe(false);
+    });
+
+    it('should support setting persent keys', () => {
+      locals.set('key', 'bar');
+      expect(locals.get('key')).toBe('bar');
+    });
+
+    it('should not support setting keys that are not present already', () => {
+      expect(() => locals.set('notPresent', 'bar')).toThrowError();
+    });
+
+    it('should clearValues', () => {
+      locals.clearValues();
+      expect(locals.get('key')).toBe(null);
+    });
+  })
+}
+

--- a/modules/core/src/application.js
+++ b/modules/core/src/application.js
@@ -54,7 +54,9 @@ export function documentDependentBindings(appComponentType) {
           // The light Dom of the app element is not considered part of
           // the angular application. Thus the context and lightDomInjector are
           // empty.
-          return appProtoView.instantiate(new Object(), injector, null, true);
+          var view = appProtoView.instantiate(null, true);
+          view.hydrate(injector, null, new Object());
+          return view;
         });
       }, [Compiler, Injector, appElementToken, appComponentAnnotatedTypeToken]),
 

--- a/modules/core/src/compiler/element_injector.js
+++ b/modules/core/src/compiler/element_injector.js
@@ -459,6 +459,10 @@ export class ElementInjector extends TreeNode {
     if (index == 9) return this._obj9;
     throw new OutOfBoundsAccess(index);
   }
+
+  hasInstances() {
+    return this._constructionCounter > 0;
+  }
 }
 
 class OutOfBoundsAccess extends Error {

--- a/modules/core/test/compiler/element_injector_spec.js
+++ b/modules/core/test/compiler/element_injector_spec.js
@@ -12,7 +12,7 @@ import {NgElement} from 'core/dom/element';
 //TODO: vsavkin: use a spy object
 class DummyView extends View {
   constructor() {
-    super(null, null, null, null, null, new ProtoRecordRange(), null);
+    super(null, null, null, null, null, null, new ProtoRecordRange());
   }
 }
 
@@ -147,6 +147,16 @@ export function main() {
       it("should be false otherwise", function () {
         var p = new ProtoElementInjector(null, 0, []);
         expect(p.hasBindings).toBeFalsy();
+      });
+    });
+
+    describe("hasInstances", function () {
+      it("should be false when no directives are instantiated", function () {
+        expect(injector([]).hasInstances()).toBe(false);
+      });
+
+      it("should be true when directives are instantiated", function () {
+        expect(injector([Directive]).hasInstances()).toBe(true);
       });
     });
 

--- a/modules/core/test/compiler/integration_spec.js
+++ b/modules/core/test/compiler/integration_spec.js
@@ -14,6 +14,7 @@ import {Decorator, Component, Template} from 'core/annotations/annotations';
 import {TemplateConfig} from 'core/annotations/template_config';
 
 import {ViewPort} from 'core/compiler/viewport';
+import {MapWrapper} from 'facade/collection';
 
 export function main() {
   describe('integration tests', function() {
@@ -27,7 +28,8 @@ export function main() {
       var view, ctx, cd;
       function createView(pv) {
         ctx = new MyComp();
-        view = pv.instantiate(ctx, new Injector([]), null);
+        view = pv.instantiate(null);
+        view.hydrate(new Injector([]), null, ctx);
         cd = new ChangeDetector(view.recordRange);
       }
 
@@ -79,7 +81,7 @@ export function main() {
       });
 
       it('should support template directives via `<template>` elements.', (done) => {
-        compiler.compile(MyComp, createElement('<div><template some-tmpl><copy-me>hello</copy-me></template></div>')).then((pv) => {
+        compiler.compile(MyComp, createElement('<div><template let-some-tmpl="greeting"><copy-me>{{greeting}}</copy-me></template></div>')).then((pv) => {
           createView(pv);
 
           cd.detectChanges();
@@ -88,13 +90,13 @@ export function main() {
           // 1 template + 2 copies.
           expect(childNodesOfWrapper.length).toBe(3);
           expect(childNodesOfWrapper[1].childNodes[0].nodeValue).toEqual('hello');
-          expect(childNodesOfWrapper[2].childNodes[0].nodeValue).toEqual('hello');
+          expect(childNodesOfWrapper[2].childNodes[0].nodeValue).toEqual('again');
           done();
         });
       });
 
       it('should support template directives via `template` attribute.', (done) => {
-        compiler.compile(MyComp, createElement('<div><copy-me template="some-tmpl">hello</copy-me></div>')).then((pv) => {
+        compiler.compile(MyComp, createElement('<div><copy-me template="some-tmpl #greeting">{{greeting}}</copy-me></div>')).then((pv) => {
           createView(pv);
 
           cd.detectChanges();
@@ -103,7 +105,7 @@ export function main() {
           // 1 template + 2 copies.
           expect(childNodesOfWrapper.length).toBe(3);
           expect(childNodesOfWrapper[1].childNodes[0].nodeValue).toEqual('hello');
-          expect(childNodesOfWrapper[2].childNodes[0].nodeValue).toEqual('hello');
+          expect(childNodesOfWrapper[2].childNodes[0].nodeValue).toEqual('again');
           done();
         });
       });
@@ -154,8 +156,8 @@ class ChildComp {
 })
 class SomeTemplate {
   constructor(viewPort: ViewPort) {
-    viewPort.create();
-    viewPort.create();
+    viewPort.create().setLocal('some-tmpl', 'hello');
+    viewPort.create().setLocal('some-tmpl', 'again');
   }
 }
 

--- a/modules/core/test/compiler/pipeline/element_binder_builder_spec.js
+++ b/modules/core/test/compiler/pipeline/element_binder_builder_spec.js
@@ -78,7 +78,8 @@ export function main() {
 
     function instantiateView(protoView) {
       evalContext = new Context();
-      view = protoView.instantiate(evalContext, new Injector([]), null);
+      view = protoView.instantiate(null);
+      view.hydrate(new Injector([]), null, evalContext);
       changeDetector = new ChangeDetector(view.recordRange);
     }
 

--- a/modules/core/test/compiler/viewport_spec.js
+++ b/modules/core/test/compiler/viewport_spec.js
@@ -14,13 +14,13 @@ function createElement(html) {
 }
 
 function createView(nodes) {
-  return new View(nodes, [], [], [], [], new ProtoRecordRange(), null);
+  return new View(null, nodes, [], [], [], [], new ProtoRecordRange());
 }
 
 export function main() {
   describe('viewport', () => {
     var viewPort, parentView, protoView, dom, customViewWithOneNode,
-    customViewWithTwoNodes, elementInjector;
+        customViewWithTwoNodes, elementInjector;
 
     beforeEach(() => {
       dom = createElement(`<div><stuff></stuff><div insert-after-me></div><stuff></stuff></div>`);
@@ -33,13 +33,13 @@ export function main() {
       customViewWithTwoNodes = createView([createElement('<div>one</div>'), createElement('<div>two</div>')]);
     });
 
-    describe('when detached', () => {
+    describe('when dehydrated', () => {
       it('should throw if create is called', () => {
         expect(() => viewPort.create()).toThrowError();
       });
     });
 
-    describe('when attached', () => {
+    describe('when hydrated', () => {
       function textInViewPort() {
         var out = '';
         // skipping starting filler, insert-me and final filler.
@@ -51,7 +51,7 @@ export function main() {
       }
 
       beforeEach(() => {
-        viewPort.attach(new Injector([]), null);
+        viewPort.hydrate(new Injector([]), null);
         var fillerView = createView([createElement('<filler>filler</filler>')]);
         viewPort.insert(fillerView);
       });
@@ -118,28 +118,29 @@ export function main() {
       var fancyView;
       beforeEach(() => {
         var parser = new Parser(new Lexer());
-        viewPort.attach(new Injector([]), null);
+        viewPort.hydrate(new Injector([]), null);
 
         var pv = new ProtoView(createElement('<div class="ng-binding">{{}}</div>'),
           new ProtoRecordRange());
         pv.bindElement(new ProtoElementInjector(null, 1, [SomeDirective]));
         pv.bindTextNode(0, parser.parseBinding('foo').ast);
-        fancyView = pv.instantiate(new Object(), null, null);
+        fancyView = pv.instantiate(null);
       });
 
-      it('attaching should update rootElementInjectors and parent RR', () => {
+      it('hydrating should update rootElementInjectors and parent RR', () => {
         viewPort.insert(fancyView);
         ListWrapper.forEach(fancyView.rootElementInjectors, (inj) =>
             expect(inj.parent).toBe(elementInjector));
         expect(parentView.recordRange.findFirstEnabledRecord()).not.toBe(null);
       });
 
-      it('detaching should update rootElementInjectors and parent RR', () => {
+      it('dehydrating should update rootElementInjectors and parent RR', () => {
         viewPort.insert(fancyView);
         viewPort.remove();
         ListWrapper.forEach(fancyView.rootElementInjectors, (inj) =>
             expect(inj.parent).toBe(null));
         expect(parentView.recordRange.findFirstEnabledRecord()).toBe(null);
+        expect(viewPort.length).toBe(0);
       });
     });
   });


### PR DESCRIPTION
Dehydrated views are views that are structurally fixed, but their
directive instances are purged and are not being dirty-checked.

During the hydration of a view, the context for watched expressions is set
(allowing for local bindings.)
