### PR TITLE
feat(examples): adds static dart hello world example.

### DIFF
--- a/modules/core/src/application.js
+++ b/modules/core/src/application.js
@@ -4,7 +4,6 @@ import {DOM, Element} from 'facade/dom';
 import {Compiler} from './compiler/compiler';
 import {ProtoView} from './compiler/view';
 import {Reflector, reflector} from 'reflection/reflection';
-import {ReflectionCapabilities} from 'reflection/reflection_capabilities';
 import {Parser} from 'change_detection/parser/parser';
 import {Lexer} from 'change_detection/parser/lexer';
 import {ChangeDetector} from 'change_detection/change_detector';
@@ -74,8 +73,6 @@ function _injectorBindings(appComponentType) {
 // Multiple calls to this method are allowed. Each application would only share
 // _rootInjector, which is not user-configurable by design, thus safe to share.
 export function bootstrap(appComponentType: Type, bindings=null) {
-  reflector.reflectionCapabilities = new ReflectionCapabilities();
-
   // TODO(rado): prepopulate template cache, so applications with only
   // index.html and main.js are possible.
   if (isBlank(_rootInjector)) _rootInjector = new Injector(_rootBindings);

--- a/modules/examples/pubspec.yaml
+++ b/modules/examples/pubspec.yaml
@@ -4,6 +4,8 @@ environment:
 dependencies:
   facade:
     path: ../facade
+  reflection:
+    path: ../reflection
   core:
     path: ../core
   browser: '>=0.10.0 <0.11.0'
@@ -11,3 +13,6 @@ dev_dependencies:
   test_lib:
     path: ../test_lib
   guinness: ">=0.1.16 <0.2.0"
+transformers:
+  - $dart2js:
+      minify: true

--- a/modules/examples/src/hello_world/static_app.js
+++ b/modules/examples/src/hello_world/static_app.js
@@ -1,0 +1,82 @@
+import *  as app from './app';
+
+import {Component, Decorator, TemplateConfig, NgElement} from 'core/core';
+import {Parser} from 'change_detection/parser/parser';
+import {Lexer} from 'change_detection/parser/lexer';
+
+import {Compiler} from 'core/compiler/compiler';
+import {DirectiveMetadataReader} from 'core/compiler/directive_metadata_reader';
+import {TemplateLoader} from 'core/compiler/template_loader';
+
+import {reflector} from 'reflection/reflection';
+
+function setup() {
+  reflector.registerType(app.HelloCmp, {
+    "factory": (service) => new app.HelloCmp(service),
+    "parameters": [[app.GreetingService]],
+    "annotations" : [new Component({
+      selector: 'hello-app',
+      componentServices: [app.GreetingService],
+      template: new TemplateConfig({
+        directives: [app.RedDec],
+        inline: `{{greeting}} <span red>world</span>!`})
+    })]
+  });
+
+  reflector.registerType(app.RedDec, {
+    "factory": (el) => new app.RedDec(el),
+    "parameters": [[NgElement]],
+    "annotations" : [new Decorator({selector: '[red]'})]
+  });
+
+  reflector.registerType(app.GreetingService, {
+    "factory": () => new app.GreetingService(),
+    "parameters": [],
+    "annotations": []
+  });
+
+  reflector.registerType(Compiler, {
+    "factory": (templateLoader, reader, parser) => new Compiler(templateLoader, reader, parser),
+    "parameters": [[TemplateLoader], [DirectiveMetadataReader], [Parser]],
+    "annotations": []
+  });
+
+
+  reflector.registerType(Parser, {
+    "factory": (lexer) => new Parser(lexer),
+    "parameters": [[Lexer]],
+    "annotations": []
+  });
+
+  reflector.registerType(TemplateLoader, {
+    "factory": () => new TemplateLoader(),
+    "parameters": [],
+    "annotations": []
+  });
+
+  reflector.registerType(DirectiveMetadataReader, {
+    "factory": () => new DirectiveMetadataReader(),
+    "parameters": [],
+    "annotations": []
+  });
+
+  reflector.registerType(Lexer, {
+    "factory": () => new Lexer(),
+    "parameters": [],
+    "annotations": []
+  });
+
+
+  reflector.registerGetters({
+    "greeting": (a) => a.greeting
+  });
+
+  reflector.registerSetters({
+    "greeting": (a,v) => a.greeting = v
+  });
+}
+
+export function main() {
+  setup();
+  app.main();
+}

--- a/modules/examples/web/index_static.html
+++ b/modules/examples/web/index_static.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Hello Angular 2.0 (Dart Static)</title>
+    <script type="application/dart" src="main_static.dart"></script>
+    <script src="packages/browser/dart.js"></script>
+  </head>
+  <body>
+    <hello-app>
+      Loading...
+    </hello-app>
+  </body>
+</html>
+
+<!-- to run do:
+  1) gulp build
+  2) gulp examples/pub.serve
+  3) open localhost:8080/index_static.html in dartium or chrome.
+  TODO(rado): merge with JS's index.html in ../src/hello_world/
+-->

--- a/modules/examples/web/main.dart
+++ b/modules/examples/web/main.dart
@@ -1,4 +1,11 @@
-import 'packages/examples/hello_world/app.dart' as HelloWorldApp;
+import 'package:examples/hello_world/app.dart' as HelloWorldApp;
+import 'package:reflection/reflection_capabilities.dart';
+import 'package:reflection/reflection.dart';
 
 // TODO(rado): templatize and make reusable for all examples.
-main() => HelloWorldApp.main();
+main() {
+  // enable mirrors and reflection.
+  // see static_app.js for an example of a static app.
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  HelloWorldApp.main();
+}

--- a/modules/examples/web/main_static.dart
+++ b/modules/examples/web/main_static.dart
@@ -1,0 +1,4 @@
+import 'packages/examples/hello_world/static_app.dart' as HelloWorldApp;
+
+// TODO(rado): templatize and make reusable for all examples.
+main() => HelloWorldApp.main();


### PR DESCRIPTION
Use gulp examples/pub.serve to start up the server and go to
http://localhost:8080/index_static.html to see the static app.
