### PR TITLE
Change Detection: perf, fix, style

### DIFF
--- a/modules/benchmarks/src/change_detection/change_detection_benchmark.js
+++ b/modules/benchmarks/src/change_detection/change_detection_benchmark.js
@@ -8,7 +8,7 @@ import {benchmark, benchmarkStep} from 'benchpress/benchpress';
 import {
   ChangeDetector,
   ProtoRecordRange,
-  WatchGroupDispatcher,
+  ChangeDispatcher,
 } from 'change_detection/change_detector';
 
 
@@ -180,7 +180,7 @@ export function main () {
 }
 
 
-class DummyDispatcher extends WatchGroupDispatcher {
+class DummyDispatcher extends ChangeDispatcher {
   onRecordChange(record, context) {
   }
 }

--- a/modules/change_detection/src/change_detector.js
+++ b/modules/change_detection/src/change_detector.js
@@ -17,24 +17,23 @@ export class ChangeDetector {
     var count = 0;
     var updatedRecords = null;
     var record = this._rootRecordRange.findFirstEnabledRecord();
+    var currentRange, currentGroup;
 
     while (isPresent(record)) {
-      var currentRange = record.recordRange;
-      var currentGroup = record.groupMemento();
-
       if (record.check()) {
         count++;
         if (record.terminatesExpression()) {
+          currentRange = record.recordRange;
+          currentGroup = record.groupMemento();
           updatedRecords = this._addRecord(updatedRecords, record);
         }
       }
 
       if (isPresent(updatedRecords)) {
         var nextEnabled = record.nextEnabled;
-        var nextRange = isPresent(nextEnabled) ? nextEnabled.recordRange : null;
-        var nextGroup = isPresent(nextEnabled) ? nextEnabled.groupMemento() : null;
-
-        if (currentRange != nextRange || currentGroup != nextGroup) {
+        if (isBlank(nextEnabled) ||                       // we have reached the last enabled record
+            currentRange != nextEnabled.recordRange ||    // the next record is in a different range
+            currentGroup != nextEnabled.groupMemento()) { // the next record is in a different group
           currentRange.dispatcher.onRecordChange(currentGroup, updatedRecords);
           updatedRecords = null;
         }

--- a/modules/change_detection/src/record.js
+++ b/modules/change_detection/src/record.js
@@ -103,7 +103,7 @@ export class Record {
 
   // Opaque data which will be the target of notification.
   // If the object is instance of Record, then it it is directly processed
-  // Otherwise it is the context used by  WatchGroupDispatcher.
+  // Otherwise it is the context used by ChangeDispatcher.
   dest;
 
   constructor(recordRange:RecordRange, protoRecord:ProtoRecord, formatters:Map) {

--- a/modules/change_detection/src/record.js
+++ b/modules/change_detection/src/record.js
@@ -239,7 +239,6 @@ export class Record {
   }
 
   _updateDestination() {
-    // todo(vicb): compute this info only once in ctor ? (add a bit in mode not to grow the mem req)
     if (this.dest instanceof Record) {
       if (isPresent(this.protoRecord.dest.position)) {
         this.dest.updateArg(this.currentValue, this.protoRecord.dest.position);

--- a/modules/change_detection/src/record_range.js
+++ b/modules/change_detection/src/record_range.js
@@ -45,9 +45,10 @@ export class ProtoRecordRange {
    * Parses [ast] into [ProtoRecord]s and adds them to [ProtoRecordRange].
    *
    * @param ast The expression to watch
-   * @param expressionMemento an opaque object which will be passed to WatchGroupDispatcher on
+   * @param expressionMemento an opaque object which will be passed to ChangeDispatcher on
    *        detecting a change.
-   * @param content Wether to watch collection content (true) or reference (false, default)
+   * @param groupMemento
+   * @param content Whether to watch collection content (true) or reference (false, default)
    */
   addRecordsFromAST(ast:AST,
         expressionMemento,
@@ -65,7 +66,7 @@ export class ProtoRecordRange {
     this.recordCreator.createRecordsFromAST(ast, expressionMemento, groupMemento);
   }
 
-  // TODO(rado): the type annotation should be dispatcher:WatchGroupDispatcher.
+  // TODO(rado): the type annotation should be dispatcher:ChangeDispatcher.
   // but @Implements is not ready yet.
   instantiate(dispatcher, formatters:Map):RecordRange {
     var recordRange:RecordRange = new RecordRange(this, dispatcher);
@@ -98,11 +99,11 @@ export class ProtoRecordRange {
 
 export class RecordRange {
   protoRecordRange:ProtoRecordRange;
-  dispatcher:any; //WatchGroupDispatcher
+  dispatcher:any; //ChangeDispatcher
   headRecord:Record;
   tailRecord:Record;
   disabled:boolean;
-  // TODO(rado): the type annotation should be dispatcher:WatchGroupDispatcher.
+  // TODO(rado): the type annotation should be dispatcher:ChangeDispatcher.
   // but @Implements is not ready yet.
   constructor(protoRecordRange:ProtoRecordRange, dispatcher) {
     this.protoRecordRange = protoRecordRange;
@@ -296,8 +297,7 @@ function _linkEnabled(a:Record, b:Record) {
   b.prevEnabled = a;
 }
 
-export class WatchGroupDispatcher {
-  // The record holds the previous value at the time of the call
+export class ChangeDispatcher {
   onRecordChange(record:Record, context) {}
 }
 

--- a/modules/change_detection/src/record_range.js
+++ b/modules/change_detection/src/record_range.js
@@ -122,7 +122,7 @@ export class RecordRange {
     var lastRecord = this.tailRecord.prev;
 
     _link(lastRecord, record);
-    if (!lastRecord.disabled) {
+    if (!lastRecord.isDisabled()) {
       _linkEnabled(lastRecord, record);
     }
     _link(record, this.tailRecord);
@@ -210,8 +210,8 @@ export class RecordRange {
    */
   findFirstEnabledRecord() {
     var record = this.headRecord.next;
-    while (record !== this.tailRecord && record.disabled) {
-      if (record.isMarkerRecord && record.recordRange.disabled) {
+    while (record !== this.tailRecord && record.isDisabled()) {
+      if (record.isMarkerRecord() && record.recordRange.disabled) {
         record = record.recordRange.tailRecord.next;
       } else {
         record = record.next;
@@ -234,8 +234,8 @@ export class RecordRange {
    */
   findLastEnabledRecord() {
     var record = this.tailRecord.prev;
-    while (record !== this.headRecord && record.disabled) {
-      if (record.isMarkerRecord && record.recordRange.disabled) {
+    while (record !== this.headRecord && record.isDisabled()) {
+      if (record.isMarkerRecord() && record.recordRange.disabled) {
         record = record.recordRange.headRecord.prev;
       } else {
         record = record.prev;
@@ -256,7 +256,7 @@ export class RecordRange {
          record != null;
          record = record.next) {
 
-      if (record.isImplicitReceiver) {
+      if (record.isImplicitReceiver()) {
         this._setContextForRecord(context, record);
       }
     }

--- a/modules/change_detection/test/change_detector_spec.js
+++ b/modules/change_detection/test/change_detector_spec.js
@@ -11,7 +11,7 @@ import {
   ChangeDetector,
   ProtoRecordRange,
   RecordRange,
-  WatchGroupDispatcher,
+  ChangeDispatcher,
   ProtoRecord
 } from 'change_detection/change_detector';
 
@@ -480,7 +480,7 @@ class TestData {
   }
 }
 
-class TestDispatcher extends WatchGroupDispatcher {
+class TestDispatcher extends ChangeDispatcher {
   log:List;
   loggedValues:List;
   onChange:Function;

--- a/modules/change_detection/test/change_detector_spec.js
+++ b/modules/change_detection/test/change_detector_spec.js
@@ -417,7 +417,7 @@ export function main() {
           var prr = new ProtoRecordRange();
           prr.addRecordsFromAST(ast("a()"), "a", 1);
           prr.addRecordsFromAST(ast("b()"), "b", 2);
-          prr.addRecordsFromAST(ast("c()"), "b", 2);
+          prr.addRecordsFromAST(ast("c()"), "c", 2);
 
           var dispatcher = new TestDispatcher();
           var rr = prr.instantiate(dispatcher, null);

--- a/modules/change_detection/test/record_range_spec.js
+++ b/modules/change_detection/test/record_range_spec.js
@@ -212,8 +212,8 @@ export function main() {
         record2.disable();
         record3.disable();
 
-        expect(record2.disabled).toBeTruthy();
-        expect(record3.disabled).toBeTruthy();
+        expect(record2.isDisabled()).toBeTruthy();
+        expect(record3.isDisabled()).toBeTruthy();
 
         expect(enabledRecords(rr, recordNames)).toEqual(['record1', 'record4']);
       });

--- a/modules/change_detection/test/record_range_spec.js
+++ b/modules/change_detection/test/record_range_spec.js
@@ -9,7 +9,6 @@ import {
   ChangeDetector,
   ProtoRecordRange,
   RecordRange,
-  WatchGroupDispatcher,
   ProtoRecord
   } from 'change_detection/change_detector';
 

--- a/modules/core/src/compiler/view.js
+++ b/modules/core/src/compiler/view.js
@@ -1,6 +1,6 @@
 import {DOM, Element, Node, Text, DocumentFragment, TemplateElement} from 'facade/dom';
 import {ListWrapper, MapWrapper, StringMapWrapper, List} from 'facade/collection';
-import {ProtoRecordRange, RecordRange, WatchGroupDispatcher} from 'change_detection/record_range';
+import {ProtoRecordRange, RecordRange, ChangeDispatcher} from 'change_detection/record_range';
 import {Record} from 'change_detection/record';
 import {AST} from 'change_detection/parser/ast';
 
@@ -20,7 +20,7 @@ const NG_BINDING_CLASS = 'ng-binding';
 /**
  * Const of making objects: http://jsperf.com/instantiate-size-of-object
  */
-@IMPLEMENTS(WatchGroupDispatcher)
+@IMPLEMENTS(ChangeDispatcher)
 export class View {
   /// This list matches the _nodes list. It is sparse, since only Elements have ElementInjector
   rootElementInjectors:List<ElementInjector>;

--- a/modules/core/src/compiler/view.js
+++ b/modules/core/src/compiler/view.js
@@ -202,7 +202,7 @@ export class View {
     }
   }
 
-  _collectChanges(records:List) {
+  _collectChanges(records:List<Record>) {
     var changes = StringMapWrapper.create();
     for(var i = 0; i < records.length; ++i) {
       var record = records[i];


### PR DESCRIPTION
Edit: The 2 lasts commits are about improving perfs:
1. by using regular fns over getters/setters. The speed gain is impressive in FF, Chrome is a little bit slower but still much faster than FF,
2. by inlining `isPresent()` and `isBlank()` where there is no need to test for `undefined`

Note: benchpress results sometimes vary from a run to the next, especially with FF. 
