### PR TITLE
chore(traceur): update to 0.0.79

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "run-sequence": "^0.3.6",
     "systemjs": "^0.9.1",
     "through2": "^0.6.1",
-    "traceur": "0.0.74",
+    "traceur": "0.0.79",
     "which": "~1",
     "zone.js": "0.3.0"
   },

--- a/tools/transpiler/index.js
+++ b/tools/transpiler/index.js
@@ -15,6 +15,7 @@ var SELF_COMPILE_OPTIONS = {
 };
 
 var needsReload = true;
+var oldSystemGet = System.get;
 
 exports.reloadSources = function() {
   needsReload = true;
@@ -63,6 +64,16 @@ function reloadCompiler() {
   glob.sync(__dirname + '/src/**/*.js').forEach(function(fileName) {
     loadModule(fileName, true);
   });
+
+  // Traceur modules are register with the ".js" extension but we don't want
+  // to add it to all the import statements.
+  System.get = function get(normalizedName) {
+    var m = oldSystemGet.call(this, normalizedName);
+    if (!m && normalizedName.indexOf('traceur') == 0) {
+      m = oldSystemGet.call(this, normalizedName + '.js');
+    }
+    return m;
+  };
 }
 
 function loadModule(filepath, transpile) {


### PR DESCRIPTION
needs a little hack as traceur internal modules are registered with the ".js" extension
