### PR TITLE
feat(change_detector): add a way to inspect records and record ranges

### DIFF
--- a/modules/change_detection/src/parser/ast.js
+++ b/modules/change_detection/src/parser/ast.js
@@ -345,10 +345,12 @@ export class MethodCall extends AST {
   receiver:AST;
   fn:Function;
   args:List;
-  constructor(receiver:AST, fn:Function, args:List) {
+  name:string;
+  constructor(receiver:AST, name:string, fn:Function, args:List) {
     this.receiver = receiver;
     this.fn = fn;
     this.args = args;
+    this.name = name;
   }
 
   eval(context) {

--- a/modules/change_detection/src/parser/parser.js
+++ b/modules/change_detection/src/parser/parser.js
@@ -404,7 +404,7 @@ class _ParseAST {
       var args = this.parseCallArguments();
       this.expectCharacter($RPAREN);
       var fn = this.reflector.method(id);
-      return new MethodCall(receiver, fn, args);
+      return new MethodCall(receiver, id, fn, args);
 
     } else {
       var getter = this.reflector.getter(id);

--- a/modules/change_detection/src/record.js
+++ b/modules/change_detection/src/record.js
@@ -394,6 +394,82 @@ export class Record {
     }
     return record;
   }
+
+  inspect() {
+    return _inspect(this);
+  }
+
+  inspectRange() {
+    return this.recordRange.inspect();
+  }
+}
+
+function _inspect(record:Record) {
+  function mode() {
+    switch (record.getType()) {
+      case RECORD_TYPE_PROPERTY:
+        return "property";
+      case RECORD_TYPE_INVOKE_METHOD:
+        return "invoke_method";
+      case RECORD_TYPE_INVOKE_CLOSURE:
+        return "invoke_closure";
+      case RECORD_TYPE_INVOKE_PURE_FUNCTION:
+        return "pure_function";
+      case RECORD_TYPE_INVOKE_FORMATTER:
+        return "invoke_formatter";
+      case RECORD_TYPE_CONST:
+        return "const";
+      case RECORD_TYPE_KEY_VALUE:
+        return "key_value";
+      case RECORD_TYPE_ARRAY:
+        return "array";
+      case RECORD_TYPE_NULL:
+        return "null";
+      case RECORD_TYPE_MARKER:
+        return "marker";
+      default:
+        return "unexpected type!";
+    }
+  }
+
+  function disabled() {
+    return record.isDisabled() ? "disabled" : "enabled";
+  }
+
+  function description() {
+    var name = isPresent(record.protoRecord) ? record.protoRecord.name : "";
+    var exp = isPresent(record.protoRecord) ? record.protoRecord.expressionAsString : "";
+    var currValue = record.currentValue;
+    var context = record.context;
+
+    return `${mode()}, ${name}, ${disabled()} ` +
+      ` Current: ${currValue}, Context: ${context} in [${exp}]`;
+  }
+
+  if (isBlank(record)) return null;
+  if (!(record instanceof Record)) return record;
+
+  return new _RecordInspect(description(), record);
+}
+
+class _RecordInspect {
+  description:string;
+  record:Record;
+
+  constructor(description:string,record:Record) {
+    this.description = description;
+    this.record = record;
+  }
+
+  get next() {
+    return _inspect(this.record.next);
+  }
+  get nextEnabled() {
+    return _inspect(this.record.nextEnabled);
+  }
+  get dest() {
+    return _inspect(this.record.dest);
+  }
 }
 
 function isSame(a, b) {

--- a/modules/change_detection/test/record_range_spec.js
+++ b/modules/change_detection/test/record_range_spec.js
@@ -9,7 +9,8 @@ import {
   ChangeDetector,
   ProtoRecordRange,
   RecordRange,
-  ProtoRecord
+  ProtoRecord,
+  RECORD_TYPE_CONST
   } from 'change_detection/change_detector';
 
 import {Record} from 'change_detection/record';
@@ -335,6 +336,27 @@ export function main() {
         expect(enabledRecords(parent, recordNames)).toEqual([
           'record1', 'record2', 'record3', 'record4'
         ]);
+      });
+    });
+
+    describe("inspect", () => {
+      it("should return the description of the record", () => {
+        var proto = new ProtoRecord(null, RECORD_TYPE_CONST, 1, 0, "name", null, "group", "expression");
+        var record = new Record(null, proto, null);
+
+        var i = record.inspect();
+        expect(i.description).toContain("const, name, enabled");
+      });
+
+      it("should return the description of the records in the range", () => {
+        var proto = new ProtoRecord(null, RECORD_TYPE_CONST, 1, 0, "name", null, "group", "expression");
+        var record = new Record(null, proto, null);
+        var range = new RecordRange(null, null);
+        range.addRecord(record);
+
+        var i = range.inspect();;
+        expect(i.length).toEqual(1);
+        expect(i[0]).toContain("const, name, enabled");
       });
     });
   });


### PR DESCRIPTION
Due to the optimizations used in Record, troubleshooting change detection issues is difficult. This PR adds two functions: `record.inspect()` and `record.inspectRange()` to make it easier.
