### PR TITLE
Replaced Children loop iteration for the firstChild method

### DIFF
--- a/modules/core/src/compiler/pipeline/compile_pipeline.js
+++ b/modules/core/src/compiler/pipeline/compile_pipeline.js
@@ -24,13 +24,12 @@ export class CompilePipeline {
 
   _process(results, parent:CompileElement, current:CompileElement) {
     var additionalChildren = this._control.internalProcess(results, 0, parent, current);
-
-    var childNodes = DOM.templateAwareRoot(current.element).childNodes;
-    for (var i=0; i<childNodes.length; i++) {
-      var node = childNodes[i];
-      if (node.nodeType === Node.ELEMENT_NODE) {
+    var node = DOM.templateAwareRoot(current.element).firstChild;
+    while (node){
+      if(node.nodeType === Node.ELEMENT_NODE) {
         this._process(results, current, new CompileElement(node));
       }
+      node = node.nextSibling;
     }
 
     if (isPresent(additionalChildren)) {


### PR DESCRIPTION
Replaced Children loop iteration for the firstChild method , such as requested on the issue 298 ---> https://github.com/angular/angular/issues/298
