### PR TITLE
chore(README): warn that this repo is for Angular2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Angular [![Build Status](https://travis-ci.org/angular/angular.svg?branch=master)](https://travis-ci.org/angular/angular)
 =========
 
+This is the repository for the upcoming 2.0 version. If you're looking for the current oficial version of Angular you should go to [angular/angular.js](http://github.com/angular/angular.js)
+
 ## Build
 
 ### Prerequisites:


### PR DESCRIPTION
There are lots of issues being created regarding the 1.3 version in this repo.
Warning the users that this repo is for Angular 2.0 should avoid this confusion.
