### PR TITLE
fix(compiler): fix nextSibling iterator in compiler.

### DIFF
--- a/modules/core/src/compiler/pipeline/compile_pipeline.js
+++ b/modules/core/src/compiler/pipeline/compile_pipeline.js
@@ -25,11 +25,14 @@ export class CompilePipeline {
   _process(results, parent:CompileElement, current:CompileElement) {
     var additionalChildren = this._control.internalProcess(results, 0, parent, current);
     var node = DOM.templateAwareRoot(current.element).firstChild;
-    while (isPresent(node)){
-      if(node.nodeType === Node.ELEMENT_NODE) {
+    while (isPresent(node)) {
+      // compiliation can potentially move the node, so we need to store the
+      // next sibling before recursing.
+      var nextNode = DOM.nextSibling(node);
+      if (node.nodeType === Node.ELEMENT_NODE) {
         this._process(results, current, new CompileElement(node));
       }
-      node = DOM.nextSibling(node);
+      node = nextNode;
     }
 
     if (isPresent(additionalChildren)) {

--- a/modules/core/test/compiler/pipeline/view_splitter_spec.js
+++ b/modules/core/test/compiler/pipeline/view_splitter_spec.js
@@ -79,6 +79,13 @@ export function main() {
         expect(results[1].variableBindings).toBe(null);
       });
 
+      it('should iterate properly after a template dom modification', () => {
+        var rootElement = createElement('<div><div template></div><after></after></div>');
+        var results = createPipeline().process(rootElement);
+        // 1 root + 2 initial + 1 generated template elements
+        expect(results.length).toEqual(4);
+      });
+
     });
 
   });


### PR DESCRIPTION
Due to DOM manipulations happening during compilation, it is not correct
to call nextSibling after compilation steps.
