### PR TITLE
cleanup: remove toBool

### DIFF
--- a/modules/change_detection/src/record_range.js
+++ b/modules/change_detection/src/record_range.js
@@ -11,7 +11,7 @@ import {
   RECORD_TYPE_PROPERTY
 } from './record';
 
-import {FIELD, IMPLEMENTS, isBlank, isPresent, int, toBool, autoConvertAdd, BaseException,
+import {FIELD, IMPLEMENTS, isBlank, isPresent, int, autoConvertAdd, BaseException,
   NumberWrapper} from 'facade/lang';
 import {List, Map, ListWrapper, MapWrapper, StringMapWrapper} from 'facade/collection';
 import {ContextWithVariableBindings} from './parser/context_with_variable_bindings';

--- a/modules/facade/src/lang.dart
+++ b/modules/facade/src/lang.dart
@@ -27,11 +27,6 @@ class IMPLEMENTS {
 
 bool isPresent(obj) => obj != null;
 bool isBlank(obj) => obj == null;
-bool toBool(x) {
-  if (x is bool) return x;
-  if (x is num) return x != 0;
-  return false;
-}
 
 String stringify(obj) => obj.toString();
 

--- a/modules/facade/src/lang.es6
+++ b/modules/facade/src/lang.es6
@@ -27,10 +27,6 @@ export function isBlank(obj):boolean {
   return obj === undefined || obj === null;
 }
 
-export function toBool(obj) {
-  return !!obj;
-}
-
 export function stringify(token):string {
   if (typeof token === 'string') {
     return token;


### PR DESCRIPTION
Since we decided to use the semantics of the host language, toBool is no longer needed.
