### PR TITLE
Implement NgNonBindable directive

### DIFF
--- a/modules/core/src/annotations/annotations.js
+++ b/modules/core/src/annotations/annotations.js
@@ -74,6 +74,7 @@ export class Component extends Directive {
 }
 
 export class Decorator extends Directive {
+  compileChildren: boolean;
   @CONST()
   constructor({
       selector,

--- a/modules/core/src/annotations/annotations.js
+++ b/modules/core/src/annotations/annotations.js
@@ -80,14 +80,17 @@ export class Decorator extends Directive {
       selector,
       bind,
       lightDomServices,
-      implementsTypes
+      implementsTypes,
+      compileChildren = true
     }:{
       selector:string,
       bind:any,
       lightDomServices:List,
-      implementsTypes:List
+      implementsTypes:List,
+      compileChildren:boolean
     }={})
   {
+    this.compileChildren = compileChildren;
     super({
         selector: selector,
         bind: bind,

--- a/modules/core/src/compiler/pipeline/compile_element.js
+++ b/modules/core/src/compiler/pipeline/compile_element.js
@@ -32,6 +32,7 @@ export class CompileElement {
   inheritedProtoView:ProtoView;
   inheritedProtoElementInjector:ProtoElementInjector;
   inheritedElementBinder:ElementBinder;
+  compileChildren: boolean;
   constructor(element:Element) {
     this.element = element;
     this._attrs = null;
@@ -54,6 +55,7 @@ export class CompileElement {
     // inherited down to children if they don't have
     // an own elementBinder
     this.inheritedElementBinder = null;
+    this.compileChildren = true;
   }
 
   refreshAttrs() {

--- a/modules/core/src/compiler/pipeline/compile_element.js
+++ b/modules/core/src/compiler/pipeline/compile_element.js
@@ -119,6 +119,9 @@ export class CompileElement {
         this.decoratorDirectives = ListWrapper.create();
       }
       ListWrapper.push(this.decoratorDirectives, directive);
+      if (!annotation.compileChildren) {
+        this.compileChildren = false;
+      }
     } else if (annotation instanceof Template) {
       this.templateDirective = directive;
     } else if (annotation instanceof Component) {

--- a/modules/core/src/compiler/pipeline/compile_pipeline.js
+++ b/modules/core/src/compiler/pipeline/compile_pipeline.js
@@ -24,15 +24,18 @@ export class CompilePipeline {
 
   _process(results, parent:CompileElement, current:CompileElement) {
     var additionalChildren = this._control.internalProcess(results, 0, parent, current);
-    var node = DOM.templateAwareRoot(current.element).firstChild;
-    while (isPresent(node)) {
-      // compiliation can potentially move the node, so we need to store the
-      // next sibling before recursing.
-      var nextNode = DOM.nextSibling(node);
-      if (node.nodeType === Node.ELEMENT_NODE) {
-        this._process(results, current, new CompileElement(node));
+
+    if (current.compileChildren) {
+      var node = DOM.templateAwareRoot(current.element).firstChild;
+      while (isPresent(node)) {
+        // compiliation can potentially move the node, so we need to store the
+        // next sibling before recursing.
+        var nextNode = DOM.nextSibling(node);
+        if (node.nodeType === Node.ELEMENT_NODE) {
+          this._process(results, current, new CompileElement(node));
+        }
+        node = nextNode;
       }
-      node = nextNode;
     }
 
     if (isPresent(additionalChildren)) {

--- a/modules/core/src/compiler/pipeline/default_steps.js
+++ b/modules/core/src/compiler/pipeline/default_steps.js
@@ -23,9 +23,9 @@ export function createDefaultSteps(parser:Parser, compiledComponent: DirectiveMe
 
   return [
     new ViewSplitter(parser, compilationUnit),
-    new TextInterpolationParser(parser, compilationUnit),
     new PropertyBindingParser(parser, compilationUnit),
     new DirectiveParser(directives),
+    new TextInterpolationParser(parser, compilationUnit),
     new ElementBindingMarker(),
     new ProtoViewBuilder(),
     new ProtoElementInjectorBuilder(),

--- a/modules/core/src/compiler/pipeline/text_interpolation_parser.js
+++ b/modules/core/src/compiler/pipeline/text_interpolation_parser.js
@@ -54,6 +54,9 @@ export class TextInterpolationParser extends CompileStep {
   }
 
   process(parent:CompileElement, current:CompileElement, control:CompileControl) {
+    if (!current.compileChildren) {
+      return;
+    }
     var element = current.element;
     var childNodes = DOM.templateAwareRoot(element).childNodes;
     for (var i=0; i<childNodes.length; i++) {

--- a/modules/core/test/compiler/pipeline/directive_parser_spec.js
+++ b/modules/core/test/compiler/pipeline/directive_parser_spec.js
@@ -20,7 +20,14 @@ export function main() {
 
     beforeEach( () => {
       reader = new DirectiveMetadataReader();
-      directives = [SomeDecorator, SomeTemplate, SomeTemplate2, SomeComponent, SomeComponent2];
+      directives = [
+        SomeDecorator,
+        SomeDecoratorIgnoringChildren,
+        SomeTemplate,
+        SomeTemplate2,
+        SomeComponent,
+        SomeComponent2
+      ];
     });
 
     function createPipeline({propertyBindings, variableBindings}={}) {
@@ -141,6 +148,16 @@ export function main() {
         expect(results[0].decoratorDirectives).toEqual([reader.read(SomeDecorator)]);
       });
 
+      it('should compile children by default', () => {
+        var results = createPipeline().process(createElement('<div some-decor></div>'));
+        expect(results[0].compileChildren).toEqual(true);
+      });
+
+      it('should stop compiling children when specified in the decorator config', () => {
+        var results = createPipeline().process(createElement('<div some-decor-ignoring-children></div>'));
+        expect(results[0].compileChildren).toEqual(false);
+      });
+
       it('should detect them in variable bindings', () => {
         var pipeline = createPipeline({variableBindings: {
           'some-decor': 'someExpr'
@@ -175,6 +192,13 @@ class MockStep extends CompileStep {
   selector: '[some-decor]'
 })
 class SomeDecorator {}
+
+@Decorator({
+  selector: '[some-decor-ignoring-children]',
+  compileChildren: false
+})
+class SomeDecoratorIgnoringChildren {
+}
 
 @Template({
   selector: '[some-templ]'

--- a/modules/core/test/compiler/pipeline/pipeline_spec.js
+++ b/modules/core/test/compiler/pipeline/pipeline_spec.js
@@ -131,7 +131,7 @@ class MockStep extends CompileStep {
   }
 }
 
-class IgnoreChildrenStep extends CompileStep {
+export class IgnoreChildrenStep extends CompileStep {
   process(parent:CompileElement, current:CompileElement, control:CompileControl) {
     var attributeMap = DOM.attributeMap(current.element);
     if (MapWrapper.contains(attributeMap, 'ignore-children')) {

--- a/modules/core/test/compiler/pipeline/pipeline_spec.js
+++ b/modules/core/test/compiler/pipeline/pipeline_spec.js
@@ -118,16 +118,6 @@ class MockStep extends CompileStep {
   }
 }
 
-class LoggingStep extends CompileStep {
-  logs:List;
-  constructor(logs) {
-    this.logs = logs;
-  }
-  process(parent:CompileElement, current:CompileElement, control:CompileControl) {
-    ListWrapper.push(this.logs, {'parent':parent, 'current':current});
-  }
-}
-
 function logEntry(log, parent, current) {
   var parentId = '';
   if (isPresent(parent)) {

--- a/modules/directives/src/ng_non_bindable.js
+++ b/modules/directives/src/ng_non_bindable.js
@@ -1,0 +1,8 @@
+import {Decorator} from 'core/annotations/annotations';
+
+@Decorator({
+  selector: '[ng-non-bindable]',
+  compileChildren: false
+})
+export class NgNonBindable {
+}

--- a/modules/directives/src/ng_repeat.js
+++ b/modules/directives/src/ng_repeat.js
@@ -1,9 +1,9 @@
-import {Decorator, Component, Template} from 'core/annotations/annotations';
+import {Template} from 'core/annotations/annotations';
 import {OnChange} from 'core/compiler/interfaces';
 import {ViewPort} from 'core/compiler/viewport';
 import {View} from 'core/compiler/view';
 import {isPresent, isBlank} from 'facade/lang';
-import {ListWrapper, List} from 'facade/collection';
+import {ListWrapper} from 'facade/collection';
 
 @Template({
   selector: '[ng-repeat]',

--- a/modules/directives/test/ng_non_bindable_spec.js
+++ b/modules/directives/test/ng_non_bindable_spec.js
@@ -1,0 +1,89 @@
+import {describe, xit, it, expect, beforeEach, ddescribe, iit} from 'test_lib/test_lib';
+import {DOM} from 'facade/dom';
+import {Injector} from 'di/di';
+import {Lexer, Parser, ChangeDetector} from 'change_detection/change_detection';
+import {Compiler, CompilerCache} from 'core/compiler/compiler';
+import {DirectiveMetadataReader} from 'core/compiler/directive_metadata_reader';
+import {Decorator, Component} from 'core/annotations/annotations';
+import {TemplateConfig} from 'core/annotations/template_config';
+import {NgElement} from 'core/dom/element';
+import {NgNonBindable} from 'directives/ng_non_bindable';
+
+export function main() {
+  describe('ng-non-bindable', () => {
+    var view, cd, compiler, component;
+    beforeEach(() => {
+      compiler = new Compiler(null, new DirectiveMetadataReader(), new Parser(new Lexer()), new CompilerCache());
+    });
+
+    function createElement(html) {
+      return DOM.createTemplate(html).content.firstChild;
+    }
+
+    function createView(pv) {
+      component = new TestComponent();
+      view = pv.instantiate(null);
+      view.hydrate(new Injector([]), null, component);
+      cd = new ChangeDetector(view.recordRange);
+    }
+
+    function compileWithTemplate(template) {
+      return compiler.compile(TestComponent, createElement(template));
+    }
+
+    it('should not interpolate children', (done) => {
+      var template = '<div>{{text}}<span ng-non-bindable>{{text}}</span></div>';
+      compileWithTemplate(template).then((pv) => {
+        createView(pv);
+        cd.detectChanges();
+        expect(DOM.getText(view.nodes[0])).toEqual('foo{{text}}');
+        done();
+      });
+    });
+
+    it('should ignore directives on child nodes', (done) => {
+      var template = '<div ng-non-bindable><span id=child test-dec>{{text}}</span></div>';
+      compileWithTemplate(template).then((pv) => {
+        createView(pv);
+        cd.detectChanges();
+        var span = DOM.querySelector(view.nodes[0], '#child');
+        expect(DOM.hasClass(span, 'compiled')).toBeFalsy();
+        done();
+      });
+    });
+
+    it('should trigger directives on the same node', (done) => {
+      var template = '<div><span id=child ng-non-bindable test-dec>{{text}}</span></div>';
+      compileWithTemplate(template).then((pv) => {
+        createView(pv);
+        cd.detectChanges();
+        var span = DOM.querySelector(view.nodes[0], '#child');
+        expect(DOM.hasClass(span, 'compiled')).toBeTruthy();
+        done();
+      });
+    });
+  })
+}
+
+@Component({
+  selector: 'test-cmp',
+  template: new TemplateConfig({
+    inline: '',  // each test swaps with a custom template.
+    directives: [NgNonBindable, TestDecorator]
+  })
+})
+class TestComponent {
+  text: string;
+  constructor() {
+    this.text = 'foo';
+  }
+}
+
+@Decorator({
+  selector: '[test-dec]'
+})
+class TestDecorator {
+  constructor(el: NgElement) {
+    DOM.addClass(el.domElement, 'compiled');
+  }
+}


### PR DESCRIPTION
- Add a `compileChildren` config to `@Decorator`,
- Ignore interpolation and directives on child nodes,
- directives on the node with `ng-non-bindable` are considered.

Note: The `TextInterpolationParser` compiler step is move after the `DirectiveParser` step because interpolation should not happen when any decorator sets `compileChildren` to `false`
