### PR TITLE
fix(bootstrap): change bootstrap not to create a separate injector for t...

### DIFF
--- a/modules/di/test/di/injector_spec.js
+++ b/modules/di/test/di/injector_spec.js
@@ -148,6 +148,16 @@ export function main() {
       expect(car).toBeAnInstanceOf(Car);
     });
 
+    it("should use the last binding "+
+      "when there are mutliple bindings for same token", function () {
+      var injector = new Injector([
+        bind(Engine).toClass(Engine),
+        bind(Engine).toClass(TurboEngine)
+      ]);
+
+      expect(injector.get(Engine)).toBeAnInstanceOf(TurboEngine);
+    });
+
     it('should use non-type tokens', function () {
       var injector = new Injector([
         bind('token').toValue('value')


### PR DESCRIPTION
...he provided bindings

Currently, we create a separate injector for the passed-in / root bindings. This injectors sits below the one creating the application component. This means that the applicaiton component cannot access the passed-in bindings.
