### PR TITLE
chore(tests): update Protractor to 1.6.x and use Jasmine2 as framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash": "^2.4.1",
     "sprintf-js": "1.0.*",
     "q": "^1.0.1",
-    "protractor": "1.5.x",
+    "protractor": "1.6.x",
     "run-sequence": "^0.3.6",
     "through2": "^0.6.1"
   }

--- a/protractor-e2e-shared.js
+++ b/protractor-e2e-shared.js
@@ -5,6 +5,8 @@ var config = exports.config = {
 
   specs: ['dist/cjs/**/*_spec.js'],
 
+  framework: 'jasmine2',
+
   // Disable waiting for Angular as we don't have an integration layer yet...
   // TODO(tbosch): Implement a proper debugging API for Ng2.0, remove this here
   // and the sleeps in all tests.

--- a/protractor-perf-shared.js
+++ b/protractor-perf-shared.js
@@ -5,6 +5,8 @@ var config = exports.config = {
 
   specs: ['dist/cjs/**/*_perf.js'],
 
+  framework: 'jasmine2',
+
   params: {
     benchmark: {
       // size of the sample to take


### PR DESCRIPTION
There are no changes necessary in the current test code for the update to
Jasmine2 framework.
