### PR TITLE
Add '$event' to event handler context

### DIFF
--- a/modules/change_detection/src/parser/ast.js
+++ b/modules/change_detection/src/parser/ast.js
@@ -335,8 +335,18 @@ export class MethodCall extends AST {
   }
 
   eval(context) {
-    var obj = this.receiver.eval(context);
-    return this.fn(obj, evalList(context, this.args));
+    var evaluatedContext = this.receiver.eval(context);
+    var evaluatedArgs = evalList(context, this.args);
+
+    while (evaluatedContext instanceof ContextWithVariableBindings) {
+      if (evaluatedContext.hasBinding(this.name)) {
+        var fn = evaluatedContext.get(this.name);
+        return FunctionWrapper.apply(fn, evaluatedArgs);
+      }
+      evaluatedContext = evaluatedContext.parent;
+    }
+
+    return this.fn(evaluatedContext, evaluatedArgs);
   }
 
   visit(visitor, args) {

--- a/modules/change_detection/test/parser/parser_spec.js
+++ b/modules/change_detection/test/parser/parser_spec.js
@@ -194,7 +194,7 @@ export function main() {
         });
 
         it("should fall back to a regular field read when ContextWithVariableBindings "+
-          "does not have the requested field", () => {
+           "does not have the requested field", () => {
           var locals = new ContextWithVariableBindings(td(999), MapWrapper.create());
           expectEval("a", locals).toEqual(999);
         });
@@ -210,6 +210,23 @@ export function main() {
 
         it('should throw when no method', () => {
           expectEvalError("blah()").toThrowError();
+        });
+
+        it('should evaluate a method from ContextWithVariableBindings', () => {
+          var context = new ContextWithVariableBindings(
+            td(0, 0, 'parent'),
+            MapWrapper.createFromPairs([['fn', () => 'child']])
+          );
+          expectEval("fn()", context).toEqual('child');
+        });
+
+        it('should fall back to the parent context when ContextWithVariableBindings does not ' +
+           'have the requested method', () => {
+          var context = new ContextWithVariableBindings(
+            td(0, 0, 'parent'),
+            MapWrapper.create()
+          );
+          expectEval("fn()", context).toEqual('parent');
         });
       });
 

--- a/modules/core/src/compiler/view.js
+++ b/modules/core/src/compiler/view.js
@@ -391,16 +391,18 @@ export class ProtoView {
   }
 
   static _addNativeEventListener(element: Element, eventName: string, expr, view: View) {
+    var locals = MapWrapper.create();
     DOM.on(element, eventName, (event) => {
       if (event.target === element) {
         // Most of the time the event will be fired only when the view is
         // in the live document.  However, in a rare circumstance the
         // view might get dehydrated, in between the event queuing up and
         // firing.
-        // TODO(rado): replace with
-        // expr.eval(new ContextWithVariableBindings(view.context, {'$event': event}));
-        // when eval with variable bindinds works.
-        if (view.hydrated()) expr.eval(view.context);
+        if (view.hydrated()) {
+          MapWrapper.set(locals, '\$event', event);
+          var context = new ContextWithVariableBindings(view.context, locals);
+          expr.eval(context);
+        }
       }
     });
   }

--- a/modules/core/test/compiler/view_spec.js
+++ b/modules/core/test/compiler/view_spec.js
@@ -404,24 +404,29 @@ export function main() {
       });
 
       describe('event handlers', () => {
-        var view, ctx, called;
+        var view, ctx, called, receivedEvent, dispatchedEvent;
 
         function createViewAndContext(protoView) {
           view = createView(protoView);
           ctx = view.context;
           called = 0;
-          ctx.callMe = () => called += 1;
+          receivedEvent = null;
+          ctx.callMe = (event) => {
+            called += 1;
+            receivedEvent = event;
+          }
         }
 
         function dispatchClick(el) {
-          DOM.dispatchEvent(el, DOM.createMouseEvent('click'));
+          dispatchedEvent = DOM.createMouseEvent('click');
+          DOM.dispatchEvent(el, dispatchedEvent);
         }
 
         function createProtoView() {
           var pv = new ProtoView(el('<div class="ng-binding"><div></div></div>'),
             new ProtoRecordRange());
           pv.bindElement(new TestProtoElementInjector(null, 0, []));
-          pv.bindEvent('click', parser.parseBinding('callMe()', null));
+          pv.bindEvent('click', parser.parseBinding('callMe(\$event)', null));
           return pv;
         }
 
@@ -431,6 +436,7 @@ export function main() {
           dispatchClick(view.nodes[0]);
 
           expect(called).toEqual(1);
+          expect(receivedEvent).toBe(dispatchedEvent);
         });
 
         it('should not fire on a bubbled native events', () => {
@@ -448,6 +454,7 @@ export function main() {
 
           view.dehydrate();
           dispatchClick(view.nodes[0]);
+          expect(called).toEqual(0);
         });
       });
 


### PR DESCRIPTION
A local context is created for the handler (`ContextWithVariableBindings`) and the event instance is assigned to `$event` on that context.

The first commit fixes an issue where a `ContextWithVariableBindings` would shadow any method calls on the parent context.
