### PR TITLE
feat(events): adds support for injectable angular event emitters.

### DIFF
--- a/modules/benchmarks/src/element_injector/element_injector_benchmark.js
+++ b/modules/benchmarks/src/element_injector/element_injector_benchmark.js
@@ -31,11 +31,11 @@ export function main() {
 
   var bindings = [A, B, C];
   var proto = new ProtoElementInjector(null, 0, bindings);
-  var elementInjector = proto.instantiate(null,null);
+  var elementInjector = proto.instantiate(null,null, null);
 
   function instantiate () {
     for (var i = 0; i < iterations; ++i) {
-      var ei = proto.instantiate(null, null);
+      var ei = proto.instantiate(null, null, null);
       ei.instantiateDirectives(appInjector, null, null);
     }
   }

--- a/modules/core/src/annotations/events.js
+++ b/modules/core/src/annotations/events.js
@@ -1,0 +1,14 @@
+import {CONST} from 'facade/lang';
+import {DependencyAnnotation} from 'di/di';
+
+/**
+ * The directive can inject an emitter function that would emit events onto the
+ * directive host element.
+ */
+export class EventEmitter extends DependencyAnnotation {
+  eventName: string;
+  @CONST()
+  constructor(eventName) {
+    this.eventName = eventName;
+  }
+}

--- a/modules/core/test/compiler/viewport_spec.js
+++ b/modules/core/test/compiler/viewport_spec.js
@@ -69,7 +69,7 @@ export function main() {
       var insertionElement = dom.childNodes[1];
       parentView = createView([dom.childNodes[0]]);
       protoView = new ProtoView(el('<div>hi</div>'), new ProtoChangeDetector());
-      elementInjector = new ElementInjector(null, null, null);
+      elementInjector = new ElementInjector(null, null, null, null);
       viewPort = new ViewPort(parentView, insertionElement, protoView, elementInjector);
       customViewWithOneNode = createView([el('<div>single</div>')]);
       customViewWithTwoNodes = createView([el('<div>one</div>'), el('<div>two</div>')]);


### PR DESCRIPTION
Event emitters can be injected into Directives. Event emitters take over
browser events with the same name. Emitted events do not bubble. Event
emitters can be injected even if there is no corresponding callback in
the template.

```
Use as follows:
@Decorator(...)
class MyDec(@EventEmitter('click') clickEmitter) {
  ...
  fireClick() {
    var eventData = {...};
    this._clickEmitter(eventData);
  }
}
```
