### PR TITLE
feat(package): introduce a catch-all package angular.

### DIFF
--- a/karma-dart.conf.js
+++ b/karma-dart.conf.js
@@ -42,6 +42,7 @@ module.exports = function(config) {
       '/packages/path': 'http://localhost:9877/base/packages/path',
 
       // Local dependencies, transpiled from the source.
+      '/packages/angular': 'http://localhost:9877/base/modules/angular/src',
       '/packages/core': 'http://localhost:9877/base/modules/core/src',
       '/packages/change_detection': 'http://localhost:9877/base/modules/change_detection/src',
       '/packages/reflection': 'http://localhost:9877/base/modules/reflection/src',

--- a/modules/angular/pubspec.yaml
+++ b/modules/angular/pubspec.yaml
@@ -1,0 +1,20 @@
+name: angular
+version: 2.0.0-alpha.1
+environment:
+  sdk: '>=1.4.0'
+dependencies:
+  stack_trace: '1.1.1'
+  change_detection:
+    path: ../change_detection
+  di:
+    path: ../di
+  facade:
+    path: ../facade
+  reflection:
+    path: ../reflection
+  directives:
+    path: ../directives
+dev_dependencies:
+  test_lib:
+    path: ../test_lib
+  guinness: ">=0.1.16 <0.2.0"

--- a/modules/angular/src/angular.js
+++ b/modules/angular/src/angular.js
@@ -1,0 +1,6 @@
+/**
+ * Define public API for Angular here.
+ */
+export * from 'change_detection/change_detection';
+export * from 'core/core';
+export * from 'directives/directives';

--- a/modules/benchmarks/pubspec.yaml
+++ b/modules/benchmarks/pubspec.yaml
@@ -2,6 +2,8 @@ name: benchmarks
 environment:
   sdk: '>=1.4.0'
 dependencies:
+  angular:
+    path: ../angular
   facade:
     path: ../facade
   di:

--- a/modules/benchmarks/src/tree/tree_benchmark.js
+++ b/modules/benchmarks/src/tree/tree_benchmark.js
@@ -1,6 +1,6 @@
 import {Parser, Lexer, ChangeDetector} from 'change_detection/change_detection';
 
-import {bootstrap, Component, Template, TemplateConfig, ViewPort, Compiler} from 'core/core';
+import {bootstrap, Component, Template, TemplateConfig, ViewPort, Compiler} from 'angular/angular';
 
 import {CompilerCache} from 'core/compiler/compiler';
 import {DirectiveMetadataReader} from 'core/compiler/directive_metadata_reader';

--- a/modules/core/src/core.js
+++ b/modules/core/src/core.js
@@ -1,17 +1,12 @@
-/**
- * Define public API for Angular here
- */
 export * from './annotations/annotations';
 export * from './compiler/interfaces';
 export * from './annotations/template_config';
 
 export * from './application';
 
-export * from 'change_detection/change_detection';
-
 export * from './compiler/compiler';
 export * from './compiler/template_loader';
 export * from './compiler/view';
 export * from './compiler/viewport';
 
-export * from 'core/dom/element';
+export * from './dom/element';

--- a/modules/directives/src/directives.js
+++ b/modules/directives/src/directives.js
@@ -1,0 +1,4 @@
+export * from './ng_if';
+export * from './ng_non_bindable';
+export * from './ng_repeat';
+export * from './ng_switch';

--- a/modules/examples/pubspec.yaml
+++ b/modules/examples/pubspec.yaml
@@ -2,6 +2,8 @@ name: examples
 environment:
   sdk: '>=1.4.0'
 dependencies:
+  angular:
+    path: ../angular
   facade:
     path: ../facade
   reflection:

--- a/modules/examples/src/hello_world/index_common.js
+++ b/modules/examples/src/hello_world/index_common.js
@@ -1,4 +1,4 @@
-import {bootstrap, Component, Decorator, TemplateConfig, NgElement} from 'core/core';
+import {bootstrap, Component, Decorator, TemplateConfig, NgElement} from 'angular/angular';
 
 // Angular 2.0 supports 3 basic types of directives:
 // - Component - the basic building blocks of Angular 2.0 apps. Backed by

--- a/modules/examples/src/hello_world/index_static.js
+++ b/modules/examples/src/hello_world/index_static.js
@@ -1,6 +1,6 @@
 import *  as app from './index_common';
 
-import {Component, Decorator, TemplateConfig, NgElement} from 'core/core';
+import {Component, Decorator, TemplateConfig, NgElement} from 'angular/angular';
 import {Lexer, Parser, ChangeDetector} from 'change_detection/change_detection';
 import {LifeCycle} from 'core/life_cycle/life_cycle';
 

--- a/test-main.js
+++ b/test-main.js
@@ -12,6 +12,9 @@ System.baseURL = '/base/modules/';
 
 // So that we can import packages like `core/foo`, instead of `core/src/foo`.
 System.paths = {
+  'angular/*': './angular/src/*.js',
+  'angular/test/*': './angular/test/*.js',
+
   'core/*': './core/src/*.js',
   'core/test/*': './core/test/*.js',
 

--- a/tools/build/snippets/runtime_paths.js
+++ b/tools/build/snippets/runtime_paths.js
@@ -1,4 +1,5 @@
 System.paths = {
+  'angular/*': '/angular/lib/*.js',
   'core/*': '/core/lib/*.js',
   'change_detection/*': '/change_detection/lib/*.js',
   'facade/*': '/facade/lib/*.js',


### PR DESCRIPTION
modules/angular has no implementation, but depends on all the pieces
that make angular - core, di, directives, etc. It is the package that
all client apps will depend on.
