### PR TITLE
feat(change_detection): update change detection benchmark

### DIFF
--- a/modules/benchmarks/e2e_test/change_detection_perf.es6
+++ b/modules/benchmarks/e2e_test/change_detection_perf.es6
@@ -6,13 +6,24 @@ describe('ng2 change detection benchmark', function () {
 
   afterEach(perfUtil.verifyNoBrowserErrors);
 
-  it('should log ng stats', function() {
+  it('should log ng stats (dynamic)', function() {
     perfUtil.runClickBenchmark({
       url: URL,
-      buttons: ['#ng2DetectChanges'],
-      id: 'ng2.changeDetection',
+      buttons: ['#ng2ChangeDetectionDynamic'],
+      id: 'ng2.changeDetection.dynamic',
       params: [{
-        name: 'iterations', value: 500000, scale: 'linear'
+        name: 'numberOfChecks', value: 900000, scale: 'linear'
+      }]
+    });
+  });
+
+  it('should log ng stats (jit)', function() {
+    perfUtil.runClickBenchmark({
+      url: URL,
+      buttons: ['#ng2ChangeDetectionJit'],
+      id: 'ng2.changeDetection.jit',
+      params: [{
+        name: 'numberOfChecks', value: 900000, scale: 'linear'
       }]
     });
   });
@@ -20,10 +31,10 @@ describe('ng2 change detection benchmark', function () {
   it('should log baseline stats', function() {
     perfUtil.runClickBenchmark({
       url: URL,
-      buttons: ['#baselineDetectChanges'],
+      buttons: ['#baselineChangeDetection'],
       id: 'baseline.changeDetection',
       params: [{
-        name: 'iterations', value: 500000, scale: 'linear'
+        name: 'numberOfChecks', value: 900000, scale: 'linear'
       }]
     });
   });

--- a/modules/benchmarks/src/change_detection/change_detection_benchmark.html
+++ b/modules/benchmarks/src/change_detection/change_detection_benchmark.html
@@ -5,15 +5,16 @@
 <h2>Params</h2>
 <form>
   Iterations:
-  <input type="number" name="iterations" placeholder="iterations" value="500000">
+  <input type="number" name="numberOfChecks" placeholder="numberOfChecks" value="900000">
   <br>
   <button>Apply</button>
 </form>
 
 <h2>Actions</h2>
 <p>
-<button id="ng2DetectChanges">Ng2 detect changes</button>
-<button id="baselineDetectChanges">baselineDetectChanges</button>
+<button id="ng2ChangeDetectionDynamic">Ng2 detect changes (dynamic)</button>
+<button id="ng2ChangeDetectionJit">Ng2 detect changes (jit)</button>
+<button id="baselineChangeDetection">baselineDetectChanges</button>
 </p>
 
 $SCRIPTS$


### PR DESCRIPTION
The current version of the benchmark is not very useful.
1. It creates 500 000 change detectors with one field read each. 
2. The baseline uses getters to run, which is slow (slower than the static change detection).

This PR rewrite the benchmark:
1. The baseline is static (and super fast).
2. We benchmark both the dynamic and static change detection.
