### PR TITLE
remove unused test method

### DIFF
--- a/modules/change_detection/test/parser/parser_spec.js
+++ b/modules/change_detection/test/parser/parser_spec.js
@@ -418,10 +418,6 @@ export function main() {
         });
       }
 
-      function names(templateBindings) {
-        return ListWrapper.map(templateBindings, (binding) => binding.name );
-      }
-
       function exprSources(templateBindings) {
         return ListWrapper.map(templateBindings,
           (binding) => isPresent(binding.expression) ? binding.expression.source : null );


### PR DESCRIPTION
came up when running Dart 1.9 analyzer
