### PR TITLE
fix(DI): resolve dependencies from the requesting injector

### DIFF
--- a/modules/di/test/di/injector_spec.js
+++ b/modules/di/test/di/injector_spec.js
@@ -285,6 +285,28 @@ export function main() {
 
         expect(childCar).toBe(parentCar);
       });
+
+      it('should resolve dependencies', function () {
+        var parent = new Injector([Car])
+        var child = parent.createChild([
+          bind(Engine).toClass(TurboEngine)
+        ]);
+
+        var carFromChild = child.get(Car);
+
+        expect(carFromChild.engine).toBeAnInstanceOf(TurboEngine);
+      });
+
+      it('should resolve dependencies', function () {
+        var parent = new Injector([Car, Engine])
+        var child = parent.createChild([
+          bind(Engine).toClass(TurboEngine)
+        ]);
+
+        var carFromChild = child.get(Car);
+
+        expect(carFromChild.engine).toBeAnInstanceOf(TurboEngine);
+      });
     });
 
     describe("lazy", function () {


### PR DESCRIPTION
fixes #519 

@vsavkin could you please review this PR.

In order to solve 519, we need to propagate the "requestor" injector and use it each time we need to resolve dependencies.

I run the benchmarks twice after and before and haven't notice a measurable impact on perf.

Note: I need this fix for the `TemplateLoader` PR which makes the shadow DOM strategy global. The strategy is injected in the `Compiler` (both bindings are declared in the root bindings). This fix enables overriding the strategy at bootstrap time (in the application injector). Without the fix, the strategy would always be retrieved from the root injector and impossible to override.

/cc @vsavkin @vojtajina 
