### PR TITLE
fix(build): Escape dollar signs in dart-transpiled string literals

### DIFF
--- a/tools/transpiler/src/outputgeneration/DartParseTreeWriter.js
+++ b/tools/transpiler/src/outputgeneration/DartParseTreeWriter.js
@@ -99,9 +99,15 @@ export class DartParseTreeWriter extends JavaScriptParseTreeWriter {
   }
 
   visitTemplateLiteralPortion(tree) {
-    this.writeRaw_(tree.value.toString().replace(/('|")/g, "\\$&"));
+    this.writeRaw_(tree.value.toString()
+      .replace(/('|")/g, "\\$&")
+      .replace(/([^\\])\$/g, "$1\\\$")
+      .replace(/^\$/, '\\\$'));
   }
 
+  visitLiteralExpression(tree) {
+    this.write_(('' + tree.literalToken).replace(/([^\\])\$/g, "$1\\\$"));
+  }
 
   // FUNCTIONS
   // - remove the "function" keyword
@@ -442,12 +448,6 @@ export class DartParseTreeWriter extends JavaScriptParseTreeWriter {
       this.write_('const');
     }
     super.visitArrayLiteralExpression(tree);
-  }
-
-  visitLiteralExpression(tree) {
-    // JavaScript regex doesn't support lookbehind so eat a char before
-    // dollar and then print it in the replacement
-    this.write_(('' + tree.literalToken).replace(/([^\\])\$/g, "$1\\\$"));
   }
 
   visitNewExpression(tree) {

--- a/tools/transpiler/src/outputgeneration/DartParseTreeWriter.js
+++ b/tools/transpiler/src/outputgeneration/DartParseTreeWriter.js
@@ -444,6 +444,12 @@ export class DartParseTreeWriter extends JavaScriptParseTreeWriter {
     super.visitArrayLiteralExpression(tree);
   }
 
+  visitLiteralExpression(tree) {
+    // JavaScript regex doesn't support lookbehind so eat a char before
+    // dollar and then print it in the replacement
+    this.write_(('' + tree.literalToken).replace(/([^\\])\$/g, "$1\\\$"));
+  }
+
   visitNewExpression(tree) {
     if (this.annotationContextCounter) {
       this.write_('const');

--- a/tools/transpiler/unittest/transpilertests.js
+++ b/tools/transpiler/unittest/transpilertests.js
@@ -1,3 +1,4 @@
+var assert = require("assert");
 var compiler = require('../index');
 
 // fixme: copied from top of gulpfile
@@ -15,13 +16,14 @@ describe('transpile to dart', function(){
   // https://github.com/angular/angular/issues/509
   it('should not interpolate inside old quotes', function(){
     var result = compiler.compile(OPTIONS, "test.js",
-      "var a = 1;" +
-      "var s1 = '${a}';" +
-      "var s2 = `${a}`;");
+      "var a:number = 1;" +
+      "var s1:string = '${a}';" +
+      "var s2:string = `${a}`;" +
+      "var s3:string = '\\${a}';");
     expect(result.js).toBe("library test;\n" +
-      "var a = 1;\n" +
-        // FIXME: this should escape the interpolation with backslash to fix the issue
-      "var s1 = '${a}';\n" +
-      "var s2 = '''${a}''';\n");
+      "num a = 1;\n" +
+      "String s1 = '\\${a}';\n" +
+      "String s2 = '''${a}''';\n" +
+      "String s3 = '\\${a}';\n");
   })
 });

--- a/tools/transpiler/unittest/transpilertests.js
+++ b/tools/transpiler/unittest/transpilertests.js
@@ -1,4 +1,3 @@
-var assert = require("assert");
 var compiler = require('../index');
 
 // fixme: copied from top of gulpfile
@@ -18,12 +17,32 @@ describe('transpile to dart', function(){
     var result = compiler.compile(OPTIONS, "test.js",
       "var a:number = 1;" +
       "var s1:string = '${a}';" +
-      "var s2:string = `${a}`;" +
-      "var s3:string = '\\${a}';");
+      "var s2:string = '\\${a}';" +
+      "var s3:string = '$a';");
     expect(result.js).toBe("library test;\n" +
       "num a = 1;\n" +
       "String s1 = '\\${a}';\n" +
-      "String s2 = '''${a}''';\n" +
-      "String s3 = '\\${a}';\n");
-  })
+      "String s2 = '\\${a}';\n" +
+      "String s3 = '\\$a';\n");
+  });
+
+  it('should not interpolate without curly braces', function() {
+    var result = compiler.compile(OPTIONS, "test.js",
+      "var a:number = 1;" +
+      "var s1:string = `$a`;" +
+      "var s2:string = `\\$a`;");
+    expect(result.js).toBe("library test;\n" +
+    "num a = 1;\n" +
+    "String s1 = '''\\$a''';\n" +
+    "String s2 = '''\\$a''';\n");
+  });
+
+  it('should interpolate inside template quotes', function() {
+    var result = compiler.compile(OPTIONS, "test.js",
+      "var a:number = 1;" +
+      "var s1:string = `${a}`;");
+    expect(result.js).toBe("library test;\n" +
+    "num a = 1;\n" +
+    "String s1 = '''${a}''';\n");
+  });
 });

--- a/tools/transpiler/unittest/transpilertests.js
+++ b/tools/transpiler/unittest/transpilertests.js
@@ -13,36 +13,38 @@ var OPTIONS = {
 describe('transpile to dart', function(){
 
   // https://github.com/angular/angular/issues/509
-  it('should not interpolate inside old quotes', function(){
-    var result = compiler.compile(OPTIONS, "test.js",
-      "var a:number = 1;" +
-      "var s1:string = '${a}';" +
-      "var s2:string = '\\${a}';" +
-      "var s3:string = '$a';");
-    expect(result.js).toBe("library test;\n" +
+  describe('string interpolation', function() {
+    it('should not interpolate inside old quotes', function(){
+      var result = compiler.compile(OPTIONS, "test.js",
+        "var a:number = 1;" +
+        "var s1:string = '${a}';" +
+        "var s2:string = '\\${a}';" +
+        "var s3:string = '$a';");
+      expect(result.js).toBe("library test;\n" +
       "num a = 1;\n" +
       "String s1 = '\\${a}';\n" +
       "String s2 = '\\${a}';\n" +
       "String s3 = '\\$a';\n");
-  });
+    });
 
-  it('should not interpolate without curly braces', function() {
-    var result = compiler.compile(OPTIONS, "test.js",
-      "var a:number = 1;" +
-      "var s1:string = `$a`;" +
-      "var s2:string = `\\$a`;");
-    expect(result.js).toBe("library test;\n" +
-    "num a = 1;\n" +
-    "String s1 = '''\\$a''';\n" +
-    "String s2 = '''\\$a''';\n");
-  });
+    it('should not interpolate without curly braces', function() {
+      var result = compiler.compile(OPTIONS, "test.js",
+        "var a:number = 1;" +
+        "var s1:string = `$a`;" +
+        "var s2:string = `\\$a`;");
+      expect(result.js).toBe("library test;\n" +
+      "num a = 1;\n" +
+      "String s1 = '''\\$a''';\n" +
+      "String s2 = '''\\$a''';\n");
+    });
 
-  it('should interpolate inside template quotes', function() {
-    var result = compiler.compile(OPTIONS, "test.js",
-      "var a:number = 1;" +
-      "var s1:string = `${a}`;");
-    expect(result.js).toBe("library test;\n" +
-    "num a = 1;\n" +
-    "String s1 = '''${a}''';\n");
+    it('should interpolate inside template quotes', function() {
+      var result = compiler.compile(OPTIONS, "test.js",
+        "var a:number = 1;" +
+        "var s1:string = `${a}`;");
+      expect(result.js).toBe("library test;\n" +
+      "num a = 1;\n" +
+      "String s1 = '''${a}''';\n");
+    });
   });
 });


### PR DESCRIPTION
Escape dollar signs in string literals - dart should not interpolate them.
Closes #509
