### PR TITLE
Add support for assignment of component or element instance to vars and support for #name var shorthand.

### DIFF
--- a/modules/angular2/src/core/compiler/element_injector.js
+++ b/modules/angular2/src/core/compiler/element_injector.js
@@ -211,10 +211,22 @@ export class ProtoElementInjector  {
   index:int;
   view:View;
   distanceToParent:number;
+
+  /** Whether the element is exported as $implicit. */
+  exportElement:boolean;
+
+  /** Whether the component instance is exported as $implicit. */
+  exportComponent:boolean;
+
+  /** The variable name that will be set to $implicit for the element. */
+  exportImplicitName:string;
+
   constructor(parent:ProtoElementInjector, index:int, bindings:List, firstBindingIsComponent:boolean = false, distanceToParent:number = 0) {
     this.parent = parent;
     this.index = index;
     this.distanceToParent = distanceToParent;
+    this.exportComponent = false;
+    this.exportElement = false;
 
     this._binding0IsComponent = firstBindingIsComponent;
     this._binding0 = null; this._keyId0 = null;
@@ -405,6 +417,11 @@ export class ElementInjector extends TreeNode {
     return this._preBuiltObjects.element.domElement === el;
   }
 
+  /** Gets the NgElement associated with this ElementInjector */
+  getNgElement() {
+    return this._preBuiltObjects.element;
+  }
+
   getComponent() {
     if (this._proto._binding0IsComponent) {
       return this._obj0;
@@ -587,6 +604,21 @@ export class ElementInjector extends TreeNode {
 
   hasEventEmitter(eventName: string) {
     return this._proto.hasEventEmitter(eventName);
+  }
+
+  /** Gets whether this element is exporting a component instance as $implicit. */
+  isExportingComponent() {
+    return this._proto.exportComponent;
+  }
+
+  /** Gets whether this element is exporting its element as $implicit. */
+  isExportingElement() {
+    return this._proto.exportElement;
+  }
+
+  /** Get the name to which this element's $implicit is to be assigned. */
+  getExportImplicitName() {
+    return this._proto.exportImplicitName;
   }
 }
 

--- a/modules/angular2/src/core/compiler/pipeline/compile_element.js
+++ b/modules/angular2/src/core/compiler/pipeline/compile_element.js
@@ -106,11 +106,17 @@ export class CompileElement {
     MapWrapper.set(this.propertyBindings, property, expression);
   }
 
-  addVariableBinding(directiveName:string, templateName:string) {
+  addVariableBinding(variableName:string, variableValue:string) {
     if (isBlank(this.variableBindings)) {
       this.variableBindings = MapWrapper.create();
     }
-    MapWrapper.set(this.variableBindings, templateName, directiveName);
+
+    // Store the variable map from value to variable, reflecting how it will be used later by
+    // View. When a local is set to the view, a lookup for the variable name will take place keyed
+    // by the "value", or exported identifier. For example, ng-repeat sets a view local of "index".
+    // When this occurs, a lookup keyed by "index" must occur to find if there is a var referencing
+    // it.
+    MapWrapper.set(this.variableBindings, variableValue, variableName);
   }
 
   addEventBinding(eventName:string, expression:AST) {

--- a/modules/angular2/src/core/compiler/pipeline/property_binding_parser.js
+++ b/modules/angular2/src/core/compiler/pipeline/property_binding_parser.js
@@ -9,7 +9,16 @@ import {CompileElement} from './compile_element';
 import {CompileControl} from './compile_control';
 
 // TODO(tbosch): Cannot make this const/final right now because of the transpiler...
-var BIND_NAME_REGEXP = RegExpWrapper.create('^(?:(?:(bind)|(var)|(on))-(.+))|\\[([^\\]]+)\\]|\\(([^\\)]+)\\)');
+// Group 1 = "bind"
+// Group 2 = "var"
+// Group 3 = "on"
+// Group 4 = the identifier after "bind", "var", or "on"
+// Group 5 = idenitifer inside square braces
+// Group 6 = identifier inside parenthesis
+// Group 7 = "#"
+// Group 8 = identifier after "#"
+var BIND_NAME_REGEXP = RegExpWrapper.create(
+    '^(?:(?:(bind)|(var)|(on))-(.+))|\\[([^\\]]+)\\]|\\(([^\\)]+)\\)|(#)(.+)');
 
 /**
  * Parses the property bindings on a single element.
@@ -35,14 +44,12 @@ export class PropertyBindingParser extends CompileStep {
         if (isPresent(bindParts[1])) {
           // match: bind-prop
           current.addPropertyBinding(bindParts[4], this._parseBinding(attrValue));
-        } else if (isPresent(bindParts[2])) {
-          // match: let-prop
-          // Note: We assume that the ViewSplitter already did its work, i.e. template directive should
-          // only be present on <template> elements any more!
-          if (!(current.element instanceof TemplateElement)) {
-            throw new BaseException('var-* is only allowed on <template> elements!');
-          }
-          current.addVariableBinding(bindParts[4], attrValue);
+        } else if (isPresent(bindParts[2]) || isPresent(bindParts[7])) {
+          // match: var-name / var-name="iden" / #name / #name="iden"
+          var identifier = (isPresent(bindParts[4]) && bindParts[4] !== '') ?
+              bindParts[4] : bindParts[8];
+          var value = attrValue == '' ? '\$implicit' : attrValue;
+          current.addVariableBinding(identifier, value);
         } else if (isPresent(bindParts[3])) {
           // match: on-prop
           current.addEventBinding(bindParts[4], this._parseAction(attrValue));

--- a/modules/angular2/src/core/compiler/view.js
+++ b/modules/angular2/src/core/compiler/view.js
@@ -151,6 +151,16 @@ export class View {
       var elementInjector = this.elementInjectors[i];
       if (isPresent(elementInjector)) {
         elementInjector.instantiateDirectives(appInjector, shadowDomAppInjector, this.preBuiltObjects[i]);
+
+        // The exporting of $implicit is a special case. Since multiple elements will all export
+        // the different values as $implicit, directly assign $implicit bindings to the variable
+        // name.
+        var exportImplicitName = elementInjector.getExportImplicitName();
+        if (elementInjector.isExportingComponent()) {
+          this.context.set(exportImplicitName, elementInjector.getComponent());
+        } else if (elementInjector.isExportingElement()) {
+          this.context.set(exportImplicitName, elementInjector.getNgElement().domElement);
+        }
       }
 
       if (isPresent(componentDirective)) {

--- a/modules/angular2/test/core/compiler/integration_spec.js
+++ b/modules/angular2/test/core/compiler/integration_spec.js
@@ -133,6 +133,62 @@ export function main() {
           done();
         });
       });
+
+      it('should assign the component instance to a var-', (done) => {
+        compiler.compile(MyComp, el('<p><child-cmp var-alice></child-cmp></p>')).then((pv) => {
+          createView(pv);
+
+          expect(view.contextWithLocals).not.toBe(null);
+          expect(view.contextWithLocals.get('alice')).toBeAnInstanceOf(ChildComp);
+
+          done();
+        })
+      });
+
+      it('should assign two component instances each with a var-', (done) => {
+        var element = el('<p><child-cmp var-alice></child-cmp><child-cmp var-bob></p>');
+
+        compiler.compile(MyComp, element).then((pv) => {
+          createView(pv);
+
+          expect(view.contextWithLocals).not.toBe(null);
+          expect(view.contextWithLocals.get('alice')).toBeAnInstanceOf(ChildComp);
+          expect(view.contextWithLocals.get('bob')).toBeAnInstanceOf(ChildComp);
+          expect(view.contextWithLocals.get('alice')).not.toBe(view.contextWithLocals.get('bob'));
+
+          done();
+        })
+      });
+
+      it('should assign the component instance to a var- with shorthand syntax', (done) => {
+        compiler.compile(MyComp, el('<child-cmp #alice></child-cmp>')).then((pv) => {
+          createView(pv);
+
+          expect(view.contextWithLocals).not.toBe(null);
+          expect(view.contextWithLocals.get('alice')).toBeAnInstanceOf(ChildComp);
+
+          done();
+        })
+      });
+
+      it('should assign the element instance to a user-defined variable', (done) => {
+        // How is this supposed to work?
+        var element = el('<p></p>');
+        var div = el('<div var-alice></div>');
+        DOM.appendChild(div, el('<i>Hello</i>'));
+        DOM.appendChild(element, div);
+
+        compiler.compile(MyComp, element).then((pv) => {
+          createView(pv);
+          expect(view.contextWithLocals).not.toBe(null);
+
+          var value = view.contextWithLocals.get('alice');
+          expect(value).not.toBe(null);
+          expect(value.tagName).toEqual('DIV');
+
+          done();
+        })
+      });
     });
   });
 }

--- a/modules/angular2/test/core/compiler/pipeline/property_binding_parser_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/property_binding_parser_spec.js
@@ -34,10 +34,24 @@ export function main() {
       expect(MapWrapper.get(results[0].variableBindings, 'b')).toEqual('a');
     });
 
-    it('should not allow var- syntax on non template elements', () => {
-      expect( () => {
-        createPipeline().process(el('<div var-a="b"></div>'))
-      }).toThrowError('var-* is only allowed on <template> elements!');
+    it('should store variable binding for a non-template element', () => {
+      var results = createPipeline().process(el('<p var-george="washington"></p>'));
+      expect(MapWrapper.get(results[0].variableBindings, 'washington')).toEqual('george');
+    });
+
+    it('should store variable binding for a non-template element using shorthand syntax', () => {
+      var results = createPipeline().process(el('<p #george="washington"></p>'));
+      expect(MapWrapper.get(results[0].variableBindings, 'washington')).toEqual('george');
+    });
+
+    it('should store a variable binding with an implicit value', () => {
+      var results = createPipeline().process(el('<p var-george></p>'));
+      expect(MapWrapper.get(results[0].variableBindings, '\$implicit')).toEqual('george');
+    });
+
+    it('should store a variable binding with an implicit value using shorthand syntax', () => {
+      var results = createPipeline().process(el('<p #george></p>'));
+      expect(MapWrapper.get(results[0].variableBindings, '\$implicit')).toEqual('george');
     });
 
     it('should detect () syntax', () => {

--- a/modules/angular2/test/core/compiler/pipeline/proto_view_builder_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/proto_view_builder_spec.js
@@ -62,6 +62,21 @@ export function main() {
       }));
     });
 
+    it('should mark variables in the proto view context locals', () => {
+      var element = el('<div viewroot><p var-binding></p></div>');
+
+      var results = createPipeline({
+        'var1': 'map1',
+        'var2': 'map2'
+      }).process(element);
+
+      var protoView = results[0].inheritedProtoView;
+      expect(protoView.protoContextLocals).toEqual(MapWrapper.createFromStringMap({
+        'map2': null,
+        'map1': null
+      }));
+    });
+
     describe('errors', () => {
 
       it('should not allow multiple nested ProtoViews for the same parent element', () => {


### PR DESCRIPTION
Currently missing unit tests for View changes, as I'm not sure about the best way to test them in isolation.
Due to unfamiliarity with the codebase and the framework overall, I may have no considered some test cases.
