### PR TITLE
docs(README): correct path to JS example after dir structure reorg

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ They are all constructed via injection. For more information see the comments in
 source `modules/examples/src/hello_world/index.js`.
 
 You can build this example as either JS or Dart app:
-* (JS) `gulp serve.js.dev` and open `localhost:8000/examples/web/hello_world/` in Chrome.
+* (JS) `gulp serve.js.dev` and open `localhost:8000/examples/src/hello_world/` in Chrome.
 * (Dart) `gulp serve/examples.dart` and open `localhost:8080/hello_world` in Chrome (for dart2js) or Dartium (for Dart VM).
 
 ## Debug the transpiler


### PR DESCRIPTION
I'm not sure if we should correct the docs or the path itself, but yeh, current docs are not correct...
