### PR TITLE
feat(directives): autofocus decorator

### DIFF
--- a/modules/angular2/directives.js
+++ b/modules/angular2/directives.js
@@ -1,3 +1,4 @@
+export * from './src/directives/autofocus';
 export * from './src/directives/foreach';
 export * from './src/directives/if';
 export * from './src/directives/non_bindable';

--- a/modules/angular2/src/directives/autofocus.js
+++ b/modules/angular2/src/directives/autofocus.js
@@ -1,0 +1,33 @@
+import {Decorator} from 'angular2/src/core/annotations/annotations';
+import {NgElement} from 'angular2/src/core/dom/element';
+import {isBlank} from 'angular2/src/facade/lang';
+
+@Decorator({
+  selector: '[autofocus]',
+  bind: {
+    'autofocus': 'condition'
+  }
+})
+export class Autofocus {
+  element:NgElement;
+  prevCondition: boolean;
+
+  constructor(el: NgElement) {
+    this.element = el;
+    this.prevCondition = null;
+  }
+  set condition(newCondition) {
+    if (this.element.domElement.autofocus) {
+      this.element.domElement.focus();
+    }
+    else {
+      if (newCondition && (isBlank(this.prevCondition) || !this.prevCondition)) {
+        this.prevCondition = true;
+        this.element.domElement.focus();
+      } else {
+        this.prevCondition = false;
+      }
+    }
+    return newCondition;
+  }
+}


### PR DESCRIPTION
ng2 has the same problem in ng1. I also allowed a condition that wasn’t
in ng1. The code is more or less similar to if so we can start using
mixins or extend class for shared logic. I also need tests that I will
add depending on feedback etc

works: focused

``` html
<input autofocus />
```

works: focused

``` html
<input autofocus="false" />
```

works: focused

``` html
<input [autofocus]="true" />
```

works: not focused

``` html
<input [autofocus]="false" />
```
