### PR TITLE
Update docs to fix variable typos

### DIFF
--- a/modules/angular2/docs/core/01_templates.md
+++ b/modules/angular2/docs/core/01_templates.md
@@ -378,7 +378,7 @@ of the templates occures. One such example is foreach.
 </form>
 <ul>
   <template foreach #person [in]="people" #i="index">
-    <li>{{i}}. {{item}}<li>
+    <li>{{i}}. {{person}}<li>
   </template>
 </ul>
 ```
@@ -394,7 +394,7 @@ syntax is prefferable.
 
 ```
 <ul>
-  <li template="foreach; #person; in=people; #i=index;">{{i}}. {{item}}<li>
+  <li template="foreach; #person; in=people; #i=index;">{{i}}. {{person}}<li>
 </ul>
 ```
 
@@ -404,7 +404,7 @@ which allows us to further shorten the text.
 
 ```
 <ul>
-  <li template="foreach #person in people #i=index">{{i}}. {{item}}<li>
+  <li template="foreach #person in people #i=index">{{i}}. {{person}}<li>
 </ul>
 ```
 
@@ -413,7 +413,7 @@ microsyntax for `foreach`.
 
 ```
 <ul>
-  <li template="foreach: var person in people; var i=index">{{i}}. {{item}}<li>
+  <li template="foreach: var person in people; var i=index">{{i}}. {{person}}<li>
 </ul>
 ```
 


### PR DESCRIPTION
It looks like the {{item}} variable in the examples should be {{person}}, as that is what has been exported (#person, etc). 

It seems like the docs aren't finalized, but the discrepancy might confuse people coming in to learn from them in the meantime.
