### PR TITLE
refactor(facade): remove dependency to rtts_assert

### DIFF
--- a/modules/angular2/src/facade/lang.es6
+++ b/modules/angular2/src/facade/lang.es6
@@ -1,5 +1,3 @@
-export {proxy} from 'rtts_assert/rtts_assert';
-
 var _global = typeof window === 'undefined' ? global : window;
 export {_global as global};
 

--- a/modules/angular2/src/test_lib/test_lib.es6
+++ b/modules/angular2/src/test_lib/test_lib.es6
@@ -1,5 +1,6 @@
 import {DOM} from 'angular2/src/facade/dom';
 
+export {proxy} from 'rtts_assert/rtts_assert';
 export var describe = window.describe;
 export var xdescribe = window.xdescribe;
 export var ddescribe = window.ddescribe;

--- a/modules/angular2/test/core/compiler/element_injector_spec.js
+++ b/modules/angular2/test/core/compiler/element_injector_spec.js
@@ -1,5 +1,5 @@
-import {describe, ddescribe, it, iit, xit, xdescribe, expect, beforeEach, SpyObject} from 'angular2/test_lib';
-import {isBlank, isPresent, FIELD, IMPLEMENTS, proxy} from 'angular2/src/facade/lang';
+import {describe, ddescribe, it, iit, xit, xdescribe, expect, beforeEach, SpyObject, proxy} from 'angular2/test_lib';
+import {isBlank, isPresent, FIELD, IMPLEMENTS} from 'angular2/src/facade/lang';
 import {ListWrapper, MapWrapper, List} from 'angular2/src/facade/collection';
 import {ProtoElementInjector, PreBuiltObjects, DirectiveBinding} from 'angular2/src/core/compiler/element_injector';
 import {Parent, Ancestor} from 'angular2/src/core/annotations/visibility';

--- a/modules/angular2/test/core/compiler/shadow_dom/content_tag_spec.js
+++ b/modules/angular2/test/core/compiler/shadow_dom/content_tag_spec.js
@@ -1,5 +1,5 @@
-import {describe, beforeEach, it, expect, ddescribe, iit, SpyObject, el} from 'angular2/test_lib';
-import {proxy, IMPLEMENTS} from 'angular2/src/facade/lang';
+import {describe, beforeEach, it, expect, ddescribe, iit, SpyObject, el, proxy} from 'angular2/test_lib';
+import {IMPLEMENTS} from 'angular2/src/facade/lang';
 import {DOM} from 'angular2/src/facade/dom';
 import {Content} from 'angular2/src/core/compiler/shadow_dom_emulation/content_tag';
 import {NgElement} from 'angular2/src/core/dom/element';

--- a/modules/angular2/test/core/compiler/shadow_dom/light_dom_spec.js
+++ b/modules/angular2/test/core/compiler/shadow_dom/light_dom_spec.js
@@ -1,5 +1,5 @@
-import {describe, beforeEach, it, expect, ddescribe, iit, SpyObject, el} from 'angular2/test_lib';
-import {proxy, IMPLEMENTS, isBlank} from 'angular2/src/facade/lang';
+import {describe, beforeEach, it, expect, ddescribe, iit, SpyObject, el, proxy} from 'angular2/test_lib';
+import {IMPLEMENTS, isBlank} from 'angular2/src/facade/lang';
 import {ListWrapper, MapWrapper} from 'angular2/src/facade/collection';
 import {DOM} from 'angular2/src/facade/dom';
 import {Content} from 'angular2/src/core/compiler/shadow_dom_emulation/content_tag';

--- a/modules/angular2/test/core/compiler/view_pool_spec.js
+++ b/modules/angular2/test/core/compiler/view_pool_spec.js
@@ -1,8 +1,8 @@
-import {describe, xit, it, expect, beforeEach, ddescribe, iit, el} from 'angular2/test_lib';
+import {describe, xit, it, expect, beforeEach, ddescribe, iit, el, proxy} from 'angular2/test_lib';
 
 import {View} from 'angular2/src/core/compiler/view';
 import {ViewPool} from 'angular2/src/core/compiler/view_pool';
-import {proxy, IMPLEMENTS} from 'angular2/src/facade/lang';
+import {IMPLEMENTS} from 'angular2/src/facade/lang';
 
 @proxy
 @IMPLEMENTS(View)

--- a/modules/angular2/test/core/compiler/view_spec.js
+++ b/modules/angular2/test/core/compiler/view_spec.js
@@ -1,4 +1,4 @@
-import {describe, xit, it, expect, beforeEach, ddescribe, iit, el} from 'angular2/test_lib';
+import {describe, xit, it, expect, beforeEach, ddescribe, iit, el, proxy} from 'angular2/test_lib';
 import {ProtoView, ElementPropertyMemento, DirectivePropertyMemento} from 'angular2/src/core/compiler/view';
 import {ProtoElementInjector, ElementInjector, DirectiveBinding} from 'angular2/src/core/compiler/element_injector';
 import {EmulatedShadowDomStrategy, NativeShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
@@ -10,7 +10,7 @@ import {TemplateConfig} from 'angular2/src/core/annotations/template_config';
 import {EventEmitter} from 'angular2/src/core/annotations/events';
 import {List, MapWrapper} from 'angular2/src/facade/collection';
 import {DOM, Element} from 'angular2/src/facade/dom';
-import {int, proxy, IMPLEMENTS} from 'angular2/src/facade/lang';
+import {int, IMPLEMENTS} from 'angular2/src/facade/lang';
 import {Injector} from 'angular2/di';
 import {View} from 'angular2/src/core/compiler/view';
 import {ViewPort} from 'angular2/src/core/compiler/viewport';

--- a/modules/angular2/test/core/compiler/viewport_spec.js
+++ b/modules/angular2/test/core/compiler/viewport_spec.js
@@ -1,7 +1,7 @@
-import {describe, xit, it, expect, beforeEach, ddescribe, iit, el} from 'angular2/test_lib';
+import {describe, xit, it, expect, beforeEach, ddescribe, iit, el, proxy} from 'angular2/test_lib';
 import {View, ProtoView} from 'angular2/src/core/compiler/view';
 import {ViewPort} from 'angular2/src/core/compiler/viewport';
-import {proxy, IMPLEMENTS} from 'angular2/src/facade/lang';
+import {IMPLEMENTS} from 'angular2/src/facade/lang';
 import {DOM, Node} from 'angular2/src/facade/dom';
 import {ListWrapper, MapWrapper} from 'angular2/src/facade/collection';
 import {Injector} from 'angular2/di';

--- a/modules/angular2/test/test_lib/test_lib_spec.js
+++ b/modules/angular2/test/test_lib/test_lib_spec.js
@@ -1,7 +1,7 @@
-import {describe, it, iit, ddescribe, expect, tick, async, SpyObject, beforeEach} from 'angular2/test_lib';
+import {describe, it, iit, ddescribe, expect, tick, async, SpyObject, beforeEach, proxy} from 'angular2/test_lib';
 import {MapWrapper, ListWrapper} from 'angular2/src/facade/collection';
 import {PromiseWrapper} from 'angular2/src/facade/async';
-import {IMPLEMENTS, proxy} from 'angular2/src/facade/lang';
+import {IMPLEMENTS} from 'angular2/src/facade/lang';
 
 class TestObj {
   prop;


### PR DESCRIPTION
Since the `proxy` is used only for tests, this dependency can be removed.
Ii seems that this is needed for a proper packaging.
