### PR TITLE
Remove unused imports

### DIFF
--- a/modules/angular2/src/change_detection/dynamic_change_detector.js
+++ b/modules/angular2/src/change_detection/dynamic_change_detector.js
@@ -5,8 +5,6 @@ import {ContextWithVariableBindings} from './parser/context_with_variable_bindin
 import {AbstractChangeDetector} from './abstract_change_detector';
 import {ChangeDetectionUtil, SimpleChange, uninitialized} from './change_detection_util';
 
-import {ArrayChanges} from './array_changes';
-import {KeyValueChanges} from './keyvalue_changes';
 
 import {
   ProtoRecord,
@@ -23,7 +21,6 @@ import {
   ProtoChangeDetector
   } from './proto_change_detector';
 
-import {ChangeDetector, ChangeDispatcher} from './interfaces';
 import {ExpressionChangedAfterItHasBeenChecked, ChangeDetectionError} from './exceptions';
 
 export class DynamicChangeDetector extends AbstractChangeDetector {

--- a/modules/angular2/src/change_detection/proto_change_detector.js
+++ b/modules/angular2/src/change_detection/proto_change_detector.js
@@ -23,14 +23,11 @@ import {
   PrefixNot
   } from './parser/ast';
 
-import {ContextWithVariableBindings} from './parser/context_with_variable_bindings';
 import {ChangeRecord, ChangeDispatcher, ChangeDetector} from './interfaces';
 import {ChangeDetectionUtil} from './change_detection_util';
 import {DynamicChangeDetector} from './dynamic_change_detector';
 import {ChangeDetectorJITGenerator} from './change_detection_jit_generator';
 
-import {ArrayChanges} from './array_changes';
-import {KeyValueChanges} from './keyvalue_changes';
 import {coalesce} from './coalesce';
 
 export const RECORD_TYPE_SELF = 0;

--- a/modules/angular2/src/core/annotations/template.js
+++ b/modules/angular2/src/core/annotations/template.js
@@ -1,5 +1,4 @@
 import {ABSTRACT, CONST, Type} from 'angular2/src/facade/lang';
-import {List} from 'angular2/src/facade/collection';
 
 export class Template {
   url:any; //string;

--- a/modules/angular2/src/core/application.js
+++ b/modules/angular2/src/core/application.js
@@ -8,7 +8,6 @@ import {Parser, Lexer, ChangeDetection, dynamicChangeDetection, jitChangeDetecti
 import {TemplateLoader} from './compiler/template_loader';
 import {TemplateResolver} from './compiler/template_resolver';
 import {DirectiveMetadataReader} from './compiler/directive_metadata_reader';
-import {DirectiveMetadata} from './compiler/directive_metadata';
 import {List, ListWrapper} from 'angular2/src/facade/collection';
 import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
 import {VmTurnZone} from 'angular2/src/core/zone/vm_turn_zone';

--- a/modules/angular2/src/core/compiler/compiler.js
+++ b/modules/angular2/src/core/compiler/compiler.js
@@ -13,9 +13,7 @@ import {createDefaultSteps} from './pipeline/default_steps';
 import {TemplateLoader} from './template_loader';
 import {TemplateResolver} from './template_resolver';
 import {DirectiveMetadata} from './directive_metadata';
-import {Component} from '../annotations/annotations';
 import {Template} from '../annotations/template';
-import {Content} from './shadow_dom_emulation/content_tag';
 import {ShadowDomStrategy} from './shadow_dom_strategy';
 import {CompileStep} from './pipeline/compile_step';
 

--- a/modules/angular2/src/core/compiler/element_binder.js
+++ b/modules/angular2/src/core/compiler/element_binder.js
@@ -1,6 +1,4 @@
 import {ProtoElementInjector} from './element_injector';
-import {FIELD} from 'angular2/src/facade/lang';
-import {MapWrapper} from 'angular2/src/facade/collection';
 import {DirectiveMetadata} from './directive_metadata';
 import {List, Map} from 'angular2/src/facade/collection';
 import {ProtoView} from './view';

--- a/modules/angular2/src/core/compiler/pipeline/compile_control.js
+++ b/modules/angular2/src/core/compiler/pipeline/compile_control.js
@@ -1,6 +1,5 @@
 import {isBlank} from 'angular2/src/facade/lang';
 import {List, ListWrapper} from 'angular2/src/facade/collection';
-import {DOM, Element} from 'angular2/src/facade/dom';
 import {CompileElement} from './compile_element';
 import {CompileStep} from './compile_step';
 

--- a/modules/angular2/src/core/compiler/pipeline/compile_pipeline.js
+++ b/modules/angular2/src/core/compiler/pipeline/compile_pipeline.js
@@ -4,7 +4,6 @@ import {Element, Node, DOM} from 'angular2/src/facade/dom';
 import {CompileElement} from './compile_element';
 import {CompileControl} from './compile_control';
 import {CompileStep} from './compile_step';
-import {DirectiveMetadata} from '../directive_metadata';
 
 /**
  * CompilePipeline for executing CompileSteps recursively for

--- a/modules/angular2/src/core/compiler/pipeline/compile_step.js
+++ b/modules/angular2/src/core/compiler/pipeline/compile_step.js
@@ -1,6 +1,5 @@
 import {CompileElement} from './compile_element';
 import {CompileControl} from './compile_control';
-import {DirectiveMetadata} from '../directive_metadata';
 
 /**
  * One part of the compile process.

--- a/modules/angular2/src/core/compiler/pipeline/directive_parser.js
+++ b/modules/angular2/src/core/compiler/pipeline/directive_parser.js
@@ -9,7 +9,6 @@ import {Component, Viewport} from '../../annotations/annotations';
 import {CompileStep} from './compile_step';
 import {CompileElement} from './compile_element';
 import {CompileControl} from './compile_control';
-import {ShadowDomStrategy} from '../shadow_dom_strategy';
 
 /**
  * Parses the directives on a single element. Assumes ViewSplitter has already created

--- a/modules/angular2/src/core/compiler/pipeline/element_binder_builder.js
+++ b/modules/angular2/src/core/compiler/pipeline/element_binder_builder.js
@@ -6,11 +6,7 @@ import {reflector} from 'angular2/src/reflection/reflection';
 
 import {Parser, ProtoChangeDetector} from 'angular2/change_detection';
 
-import {Component, Directive} from '../../annotations/annotations';
 import {DirectiveMetadata} from '../directive_metadata';
-import {ProtoView, ElementPropertyMemento, DirectivePropertyMemento} from '../view';
-import {ProtoElementInjector} from '../element_injector';
-import {ElementBinder} from '../element_binder';
 
 import {CompileStep} from './compile_step';
 import {CompileElement} from './compile_element';

--- a/modules/angular2/src/core/compiler/pipeline/property_binding_parser.js
+++ b/modules/angular2/src/core/compiler/pipeline/property_binding_parser.js
@@ -1,6 +1,5 @@
 import {isPresent, isBlank, RegExpWrapper, BaseException} from 'angular2/src/facade/lang';
 import {MapWrapper} from 'angular2/src/facade/collection';
-import {TemplateElement} from 'angular2/src/facade/dom';
 
 import {Parser, AST, ExpressionWithSource} from 'angular2/change_detection';
 

--- a/modules/angular2/src/core/compiler/pipeline/proto_element_injector_builder.js
+++ b/modules/angular2/src/core/compiler/pipeline/proto_element_injector_builder.js
@@ -1,7 +1,6 @@
 import {isPresent, isBlank} from 'angular2/src/facade/lang';
 import {ListWrapper, MapWrapper} from 'angular2/src/facade/collection';
 
-import {Key} from 'angular2/di';
 import {ProtoElementInjector, ComponentKeyMetaData, DirectiveBinding} from '../element_injector';
 
 import {CompileStep} from './compile_step';

--- a/modules/angular2/src/core/compiler/shadow_dom_strategy.js
+++ b/modules/angular2/src/core/compiler/shadow_dom_strategy.js
@@ -4,7 +4,6 @@ import {List, ListWrapper} from 'angular2/src/facade/collection';
 import {View} from './view';
 import {Content} from './shadow_dom_emulation/content_tag';
 import {LightDom} from './shadow_dom_emulation/light_dom';
-import {DirectiveMetadata} from './directive_metadata';
 
 export class ShadowDomStrategy {
   attachTemplate(el:Element, view:View){}

--- a/modules/angular2/src/core/compiler/template_loader.js
+++ b/modules/angular2/src/core/compiler/template_loader.js
@@ -1,4 +1,3 @@
-import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
 import {isBlank, isPresent, BaseException, stringify} from 'angular2/src/facade/lang';
 import {DOM, Element} from 'angular2/src/facade/dom';
 import {StringMapWrapper} from 'angular2/src/facade/collection';

--- a/modules/angular2/src/core/compiler/view.js
+++ b/modules/angular2/src/core/compiler/view.js
@@ -12,7 +12,6 @@ import {FIELD, IMPLEMENTS, int, isPresent, isBlank, BaseException} from 'angular
 import {Injector} from 'angular2/di';
 import {NgElement} from 'angular2/src/core/dom/element';
 import {ViewContainer} from './view_container';
-import {Content} from './shadow_dom_emulation/content_tag';
 import {LightDom, DestinationLightDom} from './shadow_dom_emulation/light_dom';
 import {ShadowDomStrategy} from './shadow_dom_strategy';
 import {ViewPool} from './view_pool';

--- a/modules/angular2/src/directives/switch.js
+++ b/modules/angular2/src/directives/switch.js
@@ -1,7 +1,6 @@
 import {Decorator, Viewport} from 'angular2/src/core/annotations/annotations';
 import {ViewContainer} from 'angular2/src/core/compiler/view_container';
 import {NgElement} from 'angular2/src/core/dom/element';
-import {DOM} from 'angular2/src/facade/dom';
 import {isPresent, isBlank, normalizeBlank} from 'angular2/src/facade/lang';
 import {ListWrapper, List, MapWrapper, Map} from 'angular2/src/facade/collection';
 import {Parent} from 'angular2/src/core/annotations/visibility';

--- a/modules/angular2/src/test_lib/test_lib.dart
+++ b/modules/angular2/src/test_lib/test_lib.dart
@@ -6,7 +6,6 @@ import 'package:unittest/unittest.dart' hide expect;
 import 'dart:mirrors';
 import 'dart:async';
 import 'package:angular2/src/reflection/reflection.dart';
-import 'package:angular2/src/facade/dom.dart';
 import 'package:angular2/src/reflection/reflection_capabilities.dart';
 
 bool IS_DARTIUM = true;

--- a/modules/angular2/test/change_detection/change_detection_spec.js
+++ b/modules/angular2/test/change_detection/change_detection_spec.js
@@ -5,7 +5,6 @@ import {List, ListWrapper, MapWrapper, StringMapWrapper} from 'angular2/src/faca
 
 import {Parser} from 'angular2/src/change_detection/parser/parser';
 import {Lexer} from 'angular2/src/change_detection/parser/lexer';
-import {reflector} from 'angular2/src/reflection/reflection';
 import {arrayChangesAsString, kvChangesAsString} from './util';
 
 import {ChangeDispatcher, DynamicChangeDetector, ChangeDetectionError, ContextWithVariableBindings,
@@ -13,7 +12,6 @@ import {ChangeDispatcher, DynamicChangeDetector, ChangeDetectionError, ContextWi
 
 
 import {JitProtoChangeDetector, DynamicProtoChangeDetector} from 'angular2/src/change_detection/proto_change_detector';
-import {ChangeDetectionUtil} from 'angular2/src/change_detection/change_detection_util';
 
 
 export function main() {

--- a/modules/angular2/test/core/compiler/compiler_spec.js
+++ b/modules/angular2/test/core/compiler/compiler_spec.js
@@ -8,7 +8,6 @@ import {PromiseWrapper} from 'angular2/src/facade/async';
 import {Compiler, CompilerCache} from 'angular2/src/core/compiler/compiler';
 import {ProtoView} from 'angular2/src/core/compiler/view';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
-import {DirectiveMetadata} from 'angular2/src/core/compiler/directive_metadata';
 import {Component} from 'angular2/src/core/annotations/annotations';
 import {Template} from 'angular2/src/core/annotations/template';
 import {CompileElement} from 'angular2/src/core/compiler/pipeline/compile_element';

--- a/modules/angular2/test/core/compiler/directive_metadata_reader_spec.js
+++ b/modules/angular2/test/core/compiler/directive_metadata_reader_spec.js
@@ -1,11 +1,7 @@
 import {ddescribe, describe, it, iit, expect, beforeEach} from 'angular2/test_lib';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
 import {Decorator, Component, Viewport} from 'angular2/src/core/annotations/annotations';
-import {Template} from 'angular2/src/core/annotations/template';
 import {DirectiveMetadata} from 'angular2/src/core/compiler/directive_metadata';
-import {ShadowDomStrategy, NativeShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
-import {CONST} from 'angular2/src/facade/lang';
-import {If, Foreach} from 'angular2/directives';
 
 
 @Decorator({selector: 'someDecorator'})

--- a/modules/angular2/test/core/compiler/element_injector_spec.js
+++ b/modules/angular2/test/core/compiler/element_injector_spec.js
@@ -7,7 +7,6 @@ import {EventEmitter} from 'angular2/src/core/annotations/events';
 import {onDestroy} from 'angular2/src/core/annotations/annotations';
 import {Injector, Inject, bind} from 'angular2/di';
 import {View} from 'angular2/src/core/compiler/view';
-import {ProtoRecordRange} from 'angular2/change_detection';
 import {ViewContainer} from 'angular2/src/core/compiler/view_container';
 import {NgElement} from 'angular2/src/core/dom/element';
 import {LightDom, SourceLightDom, DestinationLightDom} from 'angular2/src/core/compiler/shadow_dom_emulation/light_dom';

--- a/modules/angular2/test/core/compiler/pipeline/directive_parser_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/directive_parser_spec.js
@@ -6,8 +6,6 @@ import {CompilePipeline} from 'angular2/src/core/compiler/pipeline/compile_pipel
 import {CompileStep} from 'angular2/src/core/compiler/pipeline/compile_step';
 import {CompileElement} from 'angular2/src/core/compiler/pipeline/compile_element';
 import {CompileControl} from 'angular2/src/core/compiler/pipeline/compile_control';
-import {DOM} from 'angular2/src/facade/dom';
-import {NativeShadowDomStrategy, ShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
 import {Component, Decorator, Viewport} from 'angular2/src/core/annotations/annotations';
 import {Template} from 'angular2/src/core/annotations/template';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';

--- a/modules/angular2/test/core/compiler/pipeline/property_binding_parser_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/property_binding_parser_spec.js
@@ -1,7 +1,6 @@
 import {describe, beforeEach, it, expect, iit, ddescribe, el} from 'angular2/test_lib';
 import {PropertyBindingParser} from 'angular2/src/core/compiler/pipeline/property_binding_parser';
 import {CompilePipeline} from 'angular2/src/core/compiler/pipeline/compile_pipeline';
-import {DOM} from 'angular2/src/facade/dom';
 import {MapWrapper} from 'angular2/src/facade/collection';
 import {CompileElement} from 'angular2/src/core/compiler/pipeline/compile_element';
 import {CompileStep} from 'angular2/src/core/compiler/pipeline/compile_step'

--- a/modules/angular2/test/core/compiler/shadow_dom/light_dom_spec.js
+++ b/modules/angular2/test/core/compiler/shadow_dom/light_dom_spec.js
@@ -3,12 +3,10 @@ import {IMPLEMENTS, isBlank} from 'angular2/src/facade/lang';
 import {ListWrapper, MapWrapper} from 'angular2/src/facade/collection';
 import {DOM} from 'angular2/src/facade/dom';
 import {Content} from 'angular2/src/core/compiler/shadow_dom_emulation/content_tag';
-import {NgElement} from 'angular2/src/core/dom/element';
 import {LightDom} from 'angular2/src/core/compiler/shadow_dom_emulation/light_dom';
 import {View} from 'angular2/src/core/compiler/view';
 import {ViewContainer} from 'angular2/src/core/compiler/view_container';
 import {ElementInjector} from 'angular2/src/core/compiler/element_injector';
-import {ProtoRecordRange} from 'angular2/change_detection';
 
 @proxy
 @IMPLEMENTS(ElementInjector)

--- a/modules/angular2/test/core/compiler/template_loader_spec.js
+++ b/modules/angular2/test/core/compiler/template_loader_spec.js
@@ -1,15 +1,11 @@
 import {describe, it, expect, beforeEach, ddescribe, iit, xit, el} from 'angular2/test_lib';
 
 import {TemplateLoader} from 'angular2/src/core/compiler/template_loader';
-import {TemplateResolver} from 'angular2/src/core/compiler/template_resolver';
-import {DirectiveMetadata} from 'angular2/src/core/compiler/directive_metadata';
 
-import {Component} from 'angular2/src/core/annotations/annotations';
 import {Template} from 'angular2/src/core/annotations/template';
 
 import {PromiseWrapper} from 'angular2/src/facade/async';
 import {Type, stringify, isPresent} from 'angular2/src/facade/lang';
-import {Map, MapWrapper} from 'angular2/src/facade/collection';
 
 import {XHRMock} from 'angular2/src/mock/xhr_mock';
 

--- a/modules/angular2/test/core/compiler/view_spec.js
+++ b/modules/angular2/test/core/compiler/view_spec.js
@@ -6,7 +6,6 @@ import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_meta
 import {Component, Decorator, Viewport, Directive, onChange} from 'angular2/src/core/annotations/annotations';
 import {Lexer, Parser, DynamicProtoChangeDetector,
   ChangeDetector} from 'angular2/change_detection';
-import {Template} from 'angular2/src/core/annotations/template';
 import {EventEmitter} from 'angular2/src/core/annotations/events';
 import {List, MapWrapper} from 'angular2/src/facade/collection';
 import {DOM, Element} from 'angular2/src/facade/dom';

--- a/modules/angular2/test/directives/foreach_spec.js
+++ b/modules/angular2/test/directives/foreach_spec.js
@@ -16,7 +16,6 @@ import {TemplateResolver} from 'angular2/src/core/compiler/template_resolver';
 import {Decorator, Component, Viewport} from 'angular2/src/core/annotations/annotations';
 import {Template} from 'angular2/src/core/annotations/template';
 
-import {ViewContainer} from 'angular2/src/core/compiler/view_container';
 import {Foreach} from 'angular2/src/directives/foreach';
 
 export function main() {

--- a/modules/angular2/test/forms/integration_spec.js
+++ b/modules/angular2/test/forms/integration_spec.js
@@ -10,7 +10,6 @@ import {TemplateResolver} from 'angular2/src/core/compiler/template_resolver';
 
 import {Injector} from 'angular2/di';
 
-import {DOM} from 'angular2/src/facade/dom';
 import {Map, MapWrapper} from 'angular2/src/facade/collection';
 import {Type, isPresent} from 'angular2/src/facade/lang';
 

--- a/modules/angular2/test/test_lib/test_lib_spec.js
+++ b/modules/angular2/test/test_lib/test_lib_spec.js
@@ -1,6 +1,5 @@
 import {describe, it, iit, ddescribe, expect, tick, async, SpyObject, beforeEach, proxy} from 'angular2/test_lib';
 import {MapWrapper, ListWrapper} from 'angular2/src/facade/collection';
-import {PromiseWrapper} from 'angular2/src/facade/async';
 import {IMPLEMENTS} from 'angular2/src/facade/lang';
 
 class TestObj {


### PR DESCRIPTION
This removes all hints from generated Dart code in the 'lib' dir

Will do a follow-up to cleanup test
