### PR TITLE
Multiple templates per Component

### DIFF
--- a/modules/angular2/core.js
+++ b/modules/angular2/core.js
@@ -1,7 +1,7 @@
 export * from './src/core/annotations/annotations';
 export * from './src/core/annotations/visibility';
 export * from './src/core/compiler/interfaces';
-export * from './src/core/annotations/template_config';
+export * from './src/core/annotations/template';
 export * from './src/core/application';
 
 export * from './src/core/compiler/compiler';

--- a/modules/angular2/src/core/annotations/annotations.js
+++ b/modules/angular2/src/core/annotations/annotations.js
@@ -1,6 +1,5 @@
 import {ABSTRACT, CONST, normalizeBlank, isPresent} from 'angular2/src/facade/lang';
 import {ListWrapper, List} from 'angular2/src/facade/collection';
-import {TemplateConfig} from './template_config';
 
 @ABSTRACT()
 export class Directive {
@@ -38,7 +37,6 @@ export class Directive {
 
 export class Component extends Directive {
   //TODO: vsavkin: uncomment it once the issue with defining fields in a sublass works
-  template:any; //TemplateConfig;
   lightDomServices:any; //List;
   shadowDomServices:any; //List;
   componentServices:any; //List;
@@ -48,7 +46,6 @@ export class Component extends Directive {
   constructor({
     selector,
     bind,
-    template,
     lightDomServices,
     shadowDomServices,
     componentServices,
@@ -57,7 +54,6 @@ export class Component extends Directive {
     }:{
       selector:String,
       bind:Object,
-      template:TemplateConfig,
       lightDomServices:List,
       shadowDomServices:List,
       componentServices:List,
@@ -73,7 +69,6 @@ export class Component extends Directive {
       lifecycle: lifecycle
     });
 
-    this.template = template;
     this.lightDomServices = lightDomServices;
     this.shadowDomServices = shadowDomServices;
     this.componentServices = componentServices;

--- a/modules/angular2/src/core/annotations/template.js
+++ b/modules/angular2/src/core/annotations/template.js
@@ -1,25 +1,31 @@
 import {ABSTRACT, CONST, Type} from 'angular2/src/facade/lang';
 import {List} from 'angular2/src/facade/collection';
 
-export class TemplateConfig {
+export class Template {
   url:any; //string;
   inline:any; //string;
   directives:any; //List<Type>;
   formatters:any; //List<Type>;
-  source:any;//List<TemplateConfig>;
+  source:any;//List<Template>;
+  locale:any; //string
+  device:any; //string
   @CONST()
   constructor({
       url,
       inline,
       directives,
       formatters,
-      source
+      source,
+      locale,
+      device
     }: {
       url: string,
       inline: string,
       directives: List<Type>,
       formatters: List<Type>,
-      source: List<TemplateConfig>
+      source: List<Template>,
+      locale: string,
+      device: string
     })
   {
     this.url = url;
@@ -27,5 +33,7 @@ export class TemplateConfig {
     this.directives = directives;
     this.formatters = formatters;
     this.source = source;
+    this.locale = locale;
+    this.device = device;
   }
 }

--- a/modules/angular2/src/core/application.js
+++ b/modules/angular2/src/core/application.js
@@ -6,6 +6,7 @@ import {ProtoView} from './compiler/view';
 import {Reflector, reflector} from 'angular2/src/reflection/reflection';
 import {Parser, Lexer, ChangeDetection, dynamicChangeDetection, jitChangeDetection} from 'angular2/change_detection';
 import {TemplateLoader} from './compiler/template_loader';
+import {TemplateResolver} from './compiler/template_resolver';
 import {DirectiveMetadataReader} from './compiler/directive_metadata_reader';
 import {DirectiveMetadata} from './compiler/directive_metadata';
 import {List, ListWrapper} from 'angular2/src/facade/collection';
@@ -28,6 +29,7 @@ var _rootBindings = [
   Compiler,
   CompilerCache,
   TemplateLoader,
+  TemplateResolver,
   DirectiveMetadataReader,
   Parser,
   Lexer,
@@ -62,7 +64,7 @@ function _injectorBindings(appComponentType): List<Binding> {
 
       bind(appViewToken).toAsyncFactory((changeDetection, compiler, injector, appElement,
         appComponentAnnotatedType, strategy, eventManager) => {
-        return compiler.compile(appComponentAnnotatedType.type, null).then(
+        return compiler.compile(appComponentAnnotatedType.type).then(
             (protoView) => {
           var appProtoView = ProtoView.createRootProtoView(protoView, appElement,
             appComponentAnnotatedType, changeDetection.createProtoChangeDetector('root'),

--- a/modules/angular2/src/core/compiler/directive_metadata.js
+++ b/modules/angular2/src/core/compiler/directive_metadata.js
@@ -1,7 +1,5 @@
 import {Type} from 'angular2/src/facade/lang';
 import {Directive} from 'angular2/src/core/annotations/annotations'
-import {List} from 'angular2/src/facade/collection'
-import {ShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
 
 /**
  * Combination of a type with the Directive annotation
@@ -9,13 +7,9 @@ import {ShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy'
 export class DirectiveMetadata {
   type:Type;
   annotation:Directive;
-  componentDirectives:List<Type>;
 
-  constructor(type:Type,
-              annotation:Directive,
-              componentDirectives:List<Type>) {
+  constructor(type:Type, annotation:Directive) {
     this.annotation = annotation;
     this.type = type;
-    this.componentDirectives = componentDirectives;
   }
 }

--- a/modules/angular2/src/core/compiler/directive_metadata_reader.js
+++ b/modules/angular2/src/core/compiler/directive_metadata_reader.js
@@ -1,9 +1,7 @@
 import {Type, isPresent, BaseException, stringify} from 'angular2/src/facade/lang';
-import {List, ListWrapper} from 'angular2/src/facade/collection';
-import {Directive, Component} from '../annotations/annotations';
+import {Directive} from '../annotations/annotations';
 import {DirectiveMetadata} from './directive_metadata';
 import {reflector} from 'angular2/src/reflection/reflection';
-import {ShadowDom, ShadowDomStrategy, ShadowDomNative} from './shadow_dom_strategy';
 
 export class DirectiveMetadataReader {
   read(type:Type):DirectiveMetadata {
@@ -12,39 +10,12 @@ export class DirectiveMetadataReader {
       for (var i=0; i<annotations.length; i++) {
         var annotation = annotations[i];
 
-        if (annotation instanceof Component) {
-          return new DirectiveMetadata(
-            type,
-            annotation,
-            this.componentDirectivesMetadata(annotation)
-          );
-        }
-
         if (annotation instanceof Directive) {
-          return new DirectiveMetadata(type, annotation, null);
+          return new DirectiveMetadata(type, annotation);
         }
       }
     }
     throw new BaseException(`No Directive annotation found on ${stringify(type)}`);
   }
 
-  componentDirectivesMetadata(annotation:Component):List<Type> {
-    var template = annotation.template;
-    var result:List<Type> = ListWrapper.create();
-    if (isPresent(template) && isPresent(template.directives)) {
-      this._buildList(result, template.directives);
-    }
-    return result;
-  }
-
-  _buildList(out:List<Type>, tree:List<any>) {
-    for (var i = 0; i < tree.length; i++) {
-      var item = tree[i];
-      if (ListWrapper.isList(item)) {
-        this._buildList(out, item);
-      } else {
-        ListWrapper.push(out, item);
-      }
-    }
-  }
 }

--- a/modules/angular2/src/core/compiler/template_loader.js
+++ b/modules/angular2/src/core/compiler/template_loader.js
@@ -1,14 +1,11 @@
 import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
 import {isBlank, isPresent, BaseException, stringify} from 'angular2/src/facade/lang';
-import {TemplateElement, DOM, Element} from 'angular2/src/facade/dom';
+import {DOM, Element} from 'angular2/src/facade/dom';
 import {StringMapWrapper} from 'angular2/src/facade/collection';
 
-import {TemplateConfig} from 'angular2/src/core/annotations/template_config';
-import {Component} from 'angular2/src/core/annotations/annotations';
-
-import {DirectiveMetadata} from 'angular2/src/core/compiler/directive_metadata';
-
 import {XHR} from './xhr/xhr';
+
+import {Template} from 'angular2/src/core/annotations/template';
 
 /**
  * Strategy to load component templates.
@@ -23,16 +20,13 @@ export class TemplateLoader {
   }
 
   // TODO(vicb): union type: return an Element or a Promise<Element>
-  load(cmpMetadata: DirectiveMetadata) {
-    var annotation:Component = cmpMetadata.annotation;
-    var tplConfig:TemplateConfig = annotation.template;
-
-    if (isPresent(tplConfig.inline)) {
-      return DOM.createTemplate(tplConfig.inline);
+  load(template: Template) {
+    if (isPresent(template.inline)) {
+      return DOM.createTemplate(template.inline);
     }
 
-    if (isPresent(tplConfig.url)) {
-      var url = tplConfig.url;
+    if (isPresent(template.url)) {
+      var url = template.url;
       var promise = StringMapWrapper.get(this._cache, url);
 
       if (isBlank(promise)) {
@@ -46,6 +40,6 @@ export class TemplateLoader {
       return promise;
     }
 
-    throw new BaseException(`No template configured for component ${stringify(cmpMetadata.type)}`);
+    throw new BaseException(`Templates should have either their url or inline property set`);
   }
 }

--- a/modules/angular2/src/core/compiler/template_resolver.js
+++ b/modules/angular2/src/core/compiler/template_resolver.js
@@ -1,0 +1,38 @@
+import {Template} from 'angular2/src/core/annotations/template';
+
+import {Type, stringify, isBlank, BaseException} from 'angular2/src/facade/lang';
+import {Map, MapWrapper, List, ListWrapper} from 'angular2/src/facade/collection';
+
+import {reflector} from 'angular2/src/reflection/reflection';
+
+
+export class TemplateResolver {
+  _cache: Map;
+
+  constructor() {
+    this._cache = MapWrapper.create();
+  }
+
+  resolve(component: Type): Template {
+    var template = MapWrapper.get(this._cache, component);
+
+    if (isBlank(template)) {
+      template = this._resolve(component);
+      MapWrapper.set(this._cache, component, template);
+    }
+
+    return template;
+  }
+
+  _resolve(component: Type) {
+    var annotations = reflector.annotations(component);
+    for (var i = 0; i < annotations.length; i++) {
+      var annotation = annotations[i];
+      if (annotation instanceof Template) {
+        return annotation;
+      }
+    }
+
+    throw new BaseException(`No template found for ${stringify(component)}`);
+  }
+}

--- a/modules/angular2/src/forms/directives.js
+++ b/modules/angular2/src/forms/directives.js
@@ -1,4 +1,4 @@
-import {TemplateConfig, Component, Decorator, NgElement, Ancestor, onChange} from 'angular2/core';
+import {Template, Component, Decorator, NgElement, Ancestor, onChange} from 'angular2/core';
 import {DOM} from 'angular2/src/facade/dom';
 import {isBlank, isPresent, CONST} from 'angular2/src/facade/lang';
 import {StringMapWrapper, ListWrapper} from 'angular2/src/facade/collection';
@@ -164,11 +164,9 @@ export class ControlGroupDirective extends ControlGroupDirectiveBase {
   selector: '[new-control-group]',
   bind: {
     'new-control-group' : 'initData'
-  },
-  template: new TemplateConfig({
-    inline: '<content>'
-  })
+  }
 })
+@Template({inline: '<content>'})
 export class NewControlGroupDirective extends ControlGroupDirectiveBase {
   _initData:any;
   _controlGroup:ControlGroup;

--- a/modules/angular2/test/core/application_spec.js
+++ b/modules/angular2/test/core/application_spec.js
@@ -6,16 +6,11 @@ import {DOM} from 'angular2/src/facade/dom';
 import {ListWrapper} from 'angular2/src/facade/collection';
 import {PromiseWrapper} from 'angular2/src/facade/async';
 import {bind, Inject} from 'angular2/di';
-import {TemplateConfig} from 'angular2/src/core/annotations/template_config';
+import {Template} from 'angular2/src/core/annotations/template';
 import {LifeCycle} from 'angular2/src/core/life_cycle/life_cycle';
 
-@Component({
-  selector: 'hello-app',
-  template: new TemplateConfig({
-    inline: '{{greeting}} world!',
-    directives: []
-  })
-})
+@Component({selector: 'hello-app'})
+@Template({inline: '{{greeting}} world!'})
 class HelloRootCmp {
   greeting:string;
   constructor() {
@@ -23,13 +18,8 @@ class HelloRootCmp {
   }
 }
 
-@Component({
-  selector: 'hello-app-2',
-  template: new TemplateConfig({
-    inline: '{{greeting}} world, again!',
-    directives: []
-  })
-})
+@Component({selector: 'hello-app-2'})
+@Template({inline: '{{greeting}} world, again!'})
 class HelloRootCmp2 {
   greeting:string;
   constructor() {
@@ -37,13 +27,8 @@ class HelloRootCmp2 {
   }
 }
 
-@Component({
-  selector: 'hello-app',
-  template: new TemplateConfig({
-    inline: '',
-    directives: []
-  })
-})
+@Component({selector: 'hello-app'})
+@Template({inline: ''})
 class HelloRootCmp3 {
   appBinding;
 
@@ -52,13 +37,8 @@ class HelloRootCmp3 {
   }
 }
 
-@Component({
-  selector: 'hello-app',
-  template: new TemplateConfig({
-    inline: '',
-    directives: []
-  })
-})
+@Component({selector: 'hello-app'})
+@Template({inline: ''})
 class HelloRootCmp4 {
   lc;
 

--- a/modules/angular2/test/core/compiler/directive_metadata_reader_spec.js
+++ b/modules/angular2/test/core/compiler/directive_metadata_reader_spec.js
@@ -1,42 +1,24 @@
 import {ddescribe, describe, it, iit, expect, beforeEach} from 'angular2/test_lib';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
-import {Decorator, Component} from 'angular2/src/core/annotations/annotations';
-import {TemplateConfig} from 'angular2/src/core/annotations/template_config';
+import {Decorator, Component, Viewport} from 'angular2/src/core/annotations/annotations';
+import {Template} from 'angular2/src/core/annotations/template';
 import {DirectiveMetadata} from 'angular2/src/core/compiler/directive_metadata';
 import {ShadowDomStrategy, NativeShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
 import {CONST} from 'angular2/src/facade/lang';
 import {If, Foreach} from 'angular2/directives';
 
 
-@Decorator({
-  selector: 'someSelector'
-})
-class SomeDirective {
-}
+@Decorator({selector: 'someDecorator'})
+class SomeDecorator {}
+
+@Component({selector: 'someComponent'})
+class SomeComponent {}
+
+@Viewport({selector: 'someViewport'})
+class SomeViewport {}
 
 class SomeDirectiveWithoutAnnotation {
 }
-
-@Component({
-  selector: 'withoutDirectives'
-})
-class ComponentWithoutDirectives {}
-
-@Component({
-  selector: 'withDirectives',
-  template: new TemplateConfig({
-    directives: [ComponentWithoutDirectives]
-  })
-})
-class ComponentWithDirectives {}
-
-@Component({
-  selector: 'withDirectivesTree',
-  template: new TemplateConfig({
-    directives: [[SomeDirective, [Foreach, If]], ComponentWithoutDirectives]
-  })
-})
-class ComponentWithDirectivesTree {}
 
 export function main() {
   describe("DirectiveMetadataReader", () => {
@@ -46,33 +28,28 @@ export function main() {
       reader = new DirectiveMetadataReader();
     });
 
-    it('should read out the annotation', () => {
-      var directiveMetadata = reader.read(SomeDirective);
+    it('should read out the Decorator annotation', () => {
+      var directiveMetadata = reader.read(SomeDecorator);
       expect(directiveMetadata).toEqual(
-        new DirectiveMetadata(SomeDirective, new Decorator({selector: 'someSelector'}), null));
+        new DirectiveMetadata(SomeDecorator, new Decorator({selector: 'someDecorator'})));
+    });
+
+    it('should read out the Viewport annotation', () => {
+      var directiveMetadata = reader.read(SomeViewport);
+      expect(directiveMetadata).toEqual(
+        new DirectiveMetadata(SomeViewport, new Viewport({selector: 'someViewport'})));
+    });
+
+    it('should read out the Component annotation', () => {
+      var directiveMetadata = reader.read(SomeComponent);
+      expect(directiveMetadata).toEqual(
+        new DirectiveMetadata(SomeComponent, new Component({selector: 'someComponent'})));
     });
 
     it('should throw if not matching annotation is found', () => {
       expect(() => {
         reader.read(SomeDirectiveWithoutAnnotation);
       }).toThrowError('No Directive annotation found on SomeDirectiveWithoutAnnotation');
-    });
-
-    describe("componentDirectives", () => {
-      it("should return an empty list when no directives specified", () => {
-        var cmp = reader.read(ComponentWithoutDirectives);
-        expect(cmp.componentDirectives).toEqual([]);
-      });
-
-      it("should return a list of directives specified in the template config", () => {
-        var cmp = reader.read(ComponentWithDirectives);
-        expect(cmp.componentDirectives).toEqual([ComponentWithoutDirectives]);
-      });
-
-      it("should return a list of directives specified in the template config as a tree", () => {
-        var cmp = reader.read(ComponentWithDirectivesTree);
-        expect(cmp.componentDirectives).toEqual([SomeDirective, Foreach, If, ComponentWithoutDirectives]);
-      });
     });
   });
 }

--- a/modules/angular2/test/core/compiler/pipeline/directive_parser_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/directive_parser_spec.js
@@ -9,7 +9,7 @@ import {CompileControl} from 'angular2/src/core/compiler/pipeline/compile_contro
 import {DOM} from 'angular2/src/facade/dom';
 import {NativeShadowDomStrategy, ShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
 import {Component, Decorator, Viewport} from 'angular2/src/core/annotations/annotations';
-import {TemplateConfig} from 'angular2/src/core/annotations/template_config';
+import {Template} from 'angular2/src/core/annotations/template';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
 import {Lexer, Parser} from 'angular2/change_detection';
 
@@ -235,19 +235,14 @@ class SomeViewport {}
 })
 class SomeViewport2 {}
 
-@Component({
-  selector: '[some-comp]'
-})
+@Component({selector: '[some-comp]'})
 class SomeComponent {}
 
-@Component({
-  selector: '[some-comp2]'
-})
+@Component({selector: '[some-comp2]'})
 class SomeComponent2 {}
 
-@Component({
-  template: new TemplateConfig({
+@Component()
+@Template({
     directives: [SomeDecorator, SomeViewport, SomeViewport2, SomeComponent, SomeComponent2]
-  })
 })
 class MyComp {}

--- a/modules/angular2/test/core/compiler/pipeline/element_binder_builder_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/element_binder_builder_spec.js
@@ -405,9 +405,7 @@ class SomeViewportDirectiveWithBinding {
 class SomeComponentDirective {
 }
 
-@Component({
-  bind: {'boundprop3': 'compProp'}
-})
+@Component({bind: {'boundprop3': 'compProp'}})
 class SomeComponentDirectiveWithBinding {
   compProp;
   constructor() {

--- a/modules/angular2/test/core/compiler/pipeline/shadow_dom_transformer_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/shadow_dom_transformer_spec.js
@@ -14,7 +14,7 @@ export function main() {
   describe('ShadowDomTransformer', () => {
     function createPipeline(selector, strategy:ShadowDomStrategy, styleHost) {
       var component = new Component({selector: selector});
-      var meta = new DirectiveMetadata(null, component, null);
+      var meta = new DirectiveMetadata(null, component);
       var transformer = new ShadowDomTransformer(meta, strategy, styleHost);
       transformer.clearCache();
       return new CompilePipeline([transformer]);

--- a/modules/angular2/test/core/compiler/view_spec.js
+++ b/modules/angular2/test/core/compiler/view_spec.js
@@ -6,7 +6,7 @@ import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_meta
 import {Component, Decorator, Viewport, Directive, onChange} from 'angular2/src/core/annotations/annotations';
 import {Lexer, Parser, DynamicProtoChangeDetector,
   ChangeDetector} from 'angular2/change_detection';
-import {TemplateConfig} from 'angular2/src/core/annotations/template_config';
+import {Template} from 'angular2/src/core/annotations/template';
 import {EventEmitter} from 'angular2/src/core/annotations/events';
 import {List, MapWrapper} from 'angular2/src/facade/collection';
 import {DOM, Element} from 'angular2/src/facade/dom';
@@ -649,9 +649,7 @@ class DirectiveImplementingOnChange {
 
 class SomeService {}
 
-@Component({
-  componentServices: [SomeService]
-})
+@Component({componentServices: [SomeService]})
 class SomeComponent {
   service: SomeService;
   constructor(service: SomeService) {

--- a/modules/angular2/test/directives/foreach_spec.js
+++ b/modules/angular2/test/directives/foreach_spec.js
@@ -1,6 +1,8 @@
 import {describe, xit, it, expect, beforeEach, ddescribe, iit, el} from 'angular2/test_lib';
 
 import {DOM} from 'angular2/src/facade/dom';
+import {Map, MapWrapper, ListWrapper} from 'angular2/src/facade/collection';
+import {Type, isPresent} from 'angular2/src/facade/lang';
 
 import {Injector} from 'angular2/di';
 import {Lexer, Parser, ChangeDetector, dynamicChangeDetection} from 'angular2/change_detection';
@@ -8,20 +10,23 @@ import {Lexer, Parser, ChangeDetector, dynamicChangeDetection} from 'angular2/ch
 import {Compiler, CompilerCache} from 'angular2/src/core/compiler/compiler';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
 import {NativeShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
+import {TemplateLoader} from 'angular2/src/core/compiler/template_loader';
+import {TemplateResolver} from 'angular2/src/core/compiler/template_resolver';
 
 import {Decorator, Component, Viewport} from 'angular2/src/core/annotations/annotations';
-import {TemplateConfig} from 'angular2/src/core/annotations/template_config';
+import {Template} from 'angular2/src/core/annotations/template';
 
 import {ViewContainer} from 'angular2/src/core/compiler/view_container';
-import {MapWrapper, ListWrapper} from 'angular2/src/facade/collection';
 import {Foreach} from 'angular2/src/directives/foreach';
 
 export function main() {
   describe('foreach', () => {
-    var view, cd, compiler, component;
+    var view, cd, compiler, component, tplResolver;
     beforeEach(() => {
-      compiler = new Compiler(dynamicChangeDetection, null, new DirectiveMetadataReader(),
-        new Parser(new Lexer()), new CompilerCache(), new NativeShadowDomStrategy());
+      tplResolver = new FakeTemplateResolver();
+      compiler = new Compiler(dynamicChangeDetection, new TemplateLoader(null),
+        new DirectiveMetadataReader(), new Parser(new Lexer()), new CompilerCache(),
+        new NativeShadowDomStrategy(), tplResolver);
     });
 
     function createView(pv) {
@@ -31,8 +36,13 @@ export function main() {
       cd = view.changeDetector;
     }
 
-    function compileWithTemplate(template) {
-      return compiler.compile(TestComponent, el(template));
+    function compileWithTemplate(html) {
+      var template = new Template({
+        inline: html,
+        directives: [Foreach]
+      });
+      tplResolver.setTemplate(TestComponent, template);
+      return compiler.compile(TestComponent);
     }
 
     var TEMPLATE = '<div><copy-me template="foreach #item in items">{{item.toString()}};</copy-me></div>';
@@ -217,17 +227,34 @@ class Foo {
   }
 }
 
-@Component({
-  selector: 'test-cmp',
-  template: new TemplateConfig({
-    inline: '',  // each test swaps with a custom template.
-    directives: [Foreach]
-  })
-})
+@Component({selector: 'test-cmp'})
 class TestComponent {
   items: any;
   item: any;
   constructor() {
     this.items = [1, 2];
+  }
+}
+
+class FakeTemplateResolver extends TemplateResolver {
+  _cmpTemplates: Map;
+
+  constructor() {
+    super();
+    this._cmpTemplates = MapWrapper.create();
+  }
+
+  setTemplate(component: Type, template: Template) {
+    MapWrapper.set(this._cmpTemplates, component, template);
+  }
+
+  resolve(component: Type): Template {
+    var override = MapWrapper.get(this._cmpTemplates, component);
+
+    if (isPresent(override)) {
+      return override;
+    }
+
+    return super.resolve(component);
   }
 }

--- a/modules/angular2/test/directives/non_bindable_spec.js
+++ b/modules/angular2/test/directives/non_bindable_spec.js
@@ -1,21 +1,27 @@
 import {describe, xit, it, expect, beforeEach, ddescribe, iit, el} from 'angular2/test_lib';
 import {DOM} from 'angular2/src/facade/dom';
+import {Map, MapWrapper} from 'angular2/src/facade/collection';
+import {Type, isPresent} from 'angular2/src/facade/lang';
 import {Injector} from 'angular2/di';
 import {Lexer, Parser, ChangeDetector, dynamicChangeDetection} from 'angular2/change_detection';
 import {Compiler, CompilerCache} from 'angular2/src/core/compiler/compiler';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
 import {NativeShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
 import {Decorator, Component} from 'angular2/src/core/annotations/annotations';
-import {TemplateConfig} from 'angular2/src/core/annotations/template_config';
+import {Template} from 'angular2/src/core/annotations/template';
+import {TemplateLoader} from 'angular2/src/core/compiler/template_loader';
+import {TemplateResolver} from 'angular2/src/core/compiler/template_resolver';
 import {NgElement} from 'angular2/src/core/dom/element';
 import {NonBindable} from 'angular2/src/directives/non_bindable';
 
 export function main() {
   describe('non-bindable', () => {
-    var view, cd, compiler, component;
+    var view, cd, compiler, component, tplResolver;
     beforeEach(() => {
-      compiler = new Compiler(dynamicChangeDetection,
-        null, new DirectiveMetadataReader(), new Parser(new Lexer()), new CompilerCache(), new NativeShadowDomStrategy());
+      tplResolver = new FakeTemplateResolver();
+      compiler = new Compiler(dynamicChangeDetection, new TemplateLoader(null),
+        new DirectiveMetadataReader(), new Parser(new Lexer()), new CompilerCache(),
+        new NativeShadowDomStrategy(), tplResolver);
     });
 
     function createView(pv) {
@@ -25,8 +31,13 @@ export function main() {
       cd = view.changeDetector;
     }
 
-    function compileWithTemplate(template) {
-      return compiler.compile(TestComponent, el(template));
+    function compileWithTemplate(html) {
+      var template = new Template({
+        inline: html,
+        directives: [NonBindable, TestDecorator]
+      });
+      tplResolver.setTemplate(TestComponent, template);
+      return compiler.compile(TestComponent);
     }
 
     it('should not interpolate children', (done) => {
@@ -63,13 +74,7 @@ export function main() {
   })
 }
 
-@Component({
-  selector: 'test-cmp',
-  template: new TemplateConfig({
-    inline: '',  // each test swaps with a custom template.
-    directives: [NonBindable, TestDecorator]
-  })
-})
+@Component({selector: 'test-cmp'})
 class TestComponent {
   text: string;
   constructor() {
@@ -83,5 +88,28 @@ class TestComponent {
 class TestDecorator {
   constructor(el: NgElement) {
     DOM.addClass(el.domElement, 'compiled');
+  }
+}
+
+class FakeTemplateResolver extends TemplateResolver {
+  _cmpTemplates: Map;
+
+  constructor() {
+    super();
+    this._cmpTemplates = MapWrapper.create();
+  }
+
+  setTemplate(component: Type, template: Template) {
+    MapWrapper.set(this._cmpTemplates, component, template);
+  }
+
+  resolve(component: Type): Template {
+    var override = MapWrapper.get(this._cmpTemplates, component);
+
+    if (isPresent(override)) {
+      return override;
+    }
+
+    return super.resolve(component);
   }
 }

--- a/modules/angular2/test/directives/switch_spec.js
+++ b/modules/angular2/test/directives/switch_spec.js
@@ -1,20 +1,26 @@
 import {describe, xit, it, expect, beforeEach, ddescribe, iit, el} from 'angular2/test_lib';
 import {DOM} from 'angular2/src/facade/dom';
+import {Map, MapWrapper} from 'angular2/src/facade/collection';
+import {Type, isPresent} from 'angular2/src/facade/lang';
 import {Injector} from 'angular2/di';
 import {Lexer, Parser, dynamicChangeDetection} from 'angular2/change_detection';
 import {Compiler, CompilerCache} from 'angular2/src/core/compiler/compiler';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
 import {NativeShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
 import {Component} from 'angular2/src/core/annotations/annotations';
-import {TemplateConfig} from 'angular2/src/core/annotations/template_config';
+import {Template} from 'angular2/src/core/annotations/template';
+import {TemplateLoader} from 'angular2/core';
+import {TemplateResolver} from 'angular2/src/core/compiler/template_resolver';
 import {Switch, SwitchWhen, SwitchDefault} from 'angular2/src/directives/switch';
 
 export function main() {
   describe('switch', () => {
-    var view, cd, compiler, component;
+    var view, cd, compiler, component, tplResolver;
     beforeEach(() => {
-      compiler = new Compiler(dynamicChangeDetection, null, new DirectiveMetadataReader(),
-        new Parser(new Lexer()), new CompilerCache(), new NativeShadowDomStrategy());
+      tplResolver = new FakeTemplateResolver();
+      compiler = new Compiler(dynamicChangeDetection, new TemplateLoader(null),
+        new DirectiveMetadataReader(), new Parser(new Lexer()), new CompilerCache(),
+        new NativeShadowDomStrategy(), tplResolver);
     });
 
     function createView(pv) {
@@ -24,8 +30,13 @@ export function main() {
       cd = view.changeDetector;
     }
 
-    function compileWithTemplate(template) {
-      return compiler.compile(TestComponent, el(template));
+    function compileWithTemplate(html) {
+      var template = new Template({
+        inline: html,
+        directives: [Switch, SwitchWhen, SwitchDefault]
+      });
+      tplResolver.setTemplate(TestComponent, template);
+      return compiler.compile(TestComponent);
     }
 
     describe('switch value changes', () => {
@@ -143,13 +154,7 @@ export function main() {
   });
 }
 
-@Component({
-  selector: 'test-cmp',
-  template: new TemplateConfig({
-    inline: '',  // each test swaps with a custom template.
-    directives: [Switch, SwitchWhen, SwitchDefault]
-  })
-})
+@Component({selector: 'test-cmp'})
 class TestComponent {
   switchValue: any;
   when1: any;
@@ -159,5 +164,28 @@ class TestComponent {
     this.switchValue = null;
     this.when1 = null;
     this.when2 = null;
+  }
+}
+
+class FakeTemplateResolver extends TemplateResolver {
+  _cmpTemplates: Map;
+
+  constructor() {
+    super();
+    this._cmpTemplates = MapWrapper.create();
+  }
+
+  setTemplate(component: Type, template: Template) {
+    MapWrapper.set(this._cmpTemplates, component, template);
+  }
+
+  resolve(component: Type): Template {
+    var override = MapWrapper.get(this._cmpTemplates, component);
+
+    if (isPresent(override)) {
+      return override;
+    }
+
+    return super.resolve(component);
   }
 }

--- a/modules/benchmarks/src/naive_infinite_scroll/app.js
+++ b/modules/benchmarks/src/naive_infinite_scroll/app.js
@@ -1,7 +1,7 @@
 import {int, isPresent} from 'angular2/src/facade/lang';
 import {reflector} from 'angular2/src/reflection/reflection';
 import {getIntParameter, bindAction} from 'angular2/src/test_lib/benchmark_util';
-import {bootstrap, Component, Viewport, TemplateConfig, ViewContainer, Compiler}
+import {bootstrap, Component, Viewport, Template, ViewContainer, Compiler}
     from 'angular2/angular2';
 import {PromiseWrapper} from 'angular2/src/facade/async';
 import {ListWrapper} from 'angular2/src/facade/collection';
@@ -83,26 +83,23 @@ export function setupReflectorForApp() {
     'factory': () => { return new App(); },
     'parameters': [],
     'annotations': [
-      new Component({
-        selector: 'scroll-app',
-        template: new TemplateConfig({
-          directives: [ScrollAreaComponent, If, Foreach],
-          inline: `
-            <div>
-              <div style="display: flex">
-                <scroll-area id="testArea"></scroll-area>
-                <div style="padding-left: 20px">
-                  <button id="run-btn">Run</button>
-                  <button id="reset-btn">Reset</button>
-                </div>
+      new Component({selector: 'scroll-app'}),
+      new Template({
+        directives: [ScrollAreaComponent, If, Foreach],
+        inline: `
+          <div>
+            <div style="display: flex">
+              <scroll-area id="testArea"></scroll-area>
+              <div style="padding-left: 20px">
+                <button id="run-btn">Run</button>
+                <button id="reset-btn">Reset</button>
               </div>
-              <div template="if scrollAreas.length > 0">
-                <p>Following tables are only here to add weight to the UI:</p>
-                <scroll-area template="foreach #scrollArea in scrollAreas"></scroll-area>
-              </div>
-            </div>`
-        })
-      })
-    ]
+            </div>
+            <div template="if scrollAreas.length > 0">
+              <p>Following tables are only here to add weight to the UI:</p>
+              <scroll-area template="foreach #scrollArea in scrollAreas"></scroll-area>
+            </div>
+          </div>`
+      })]
   });
 }

--- a/modules/benchmarks/src/naive_infinite_scroll/cells.js
+++ b/modules/benchmarks/src/naive_infinite_scroll/cells.js
@@ -1,7 +1,7 @@
 import {int} from 'angular2/src/facade/lang';
 import {reflector} from 'angular2/src/reflection/reflection';
 import {getIntParameter, bindAction} from 'angular2/src/test_lib/benchmark_util';
-import {bootstrap, Component, Viewport, TemplateConfig, ViewContainer, Compiler}
+import {bootstrap, Component, Viewport, Template, ViewContainer, Compiler}
     from 'angular2/angular2';
 import {PromiseWrapper} from 'angular2/src/facade/async';
 import {ListWrapper, MapWrapper} from 'angular2/src/facade/collection';
@@ -103,14 +103,14 @@ export function setupReflectorForCells() {
     'annotations': [
       new Component({
         selector: 'company-name',
-        template: new TemplateConfig({
-            directives: [],
-            inline: `<div [style]="style">{{company.name}}</div>`
-        }),
         bind: {
           'cell-width': 'width',
           'company': 'company'
         }
+      }),
+      new Template({
+          directives: [],
+          inline: `<div [style]="style">{{company.name}}</div>`
       })
     ]
   });
@@ -121,14 +121,14 @@ export function setupReflectorForCells() {
     'annotations': [
       new Component({
         selector: 'opportunity-name',
-        template: new TemplateConfig({
-            directives: [],
-            inline: `<div [style]="style">{{opportunity.name}}</div>`
-        }),
         bind: {
           'cell-width': 'width',
           'opportunity': 'opportunity'
         }
+      }),
+      new Template({
+          directives: [],
+          inline: `<div [style]="style">{{opportunity.name}}</div>`
       })
     ]
   });
@@ -139,14 +139,14 @@ export function setupReflectorForCells() {
     'annotations': [
       new Component({
         selector: 'offering-name',
-        template: new TemplateConfig({
-            directives: [],
-            inline: `<div [style]="style">{{offering.name}}</div>`
-        }),
         bind: {
           'cell-width': 'width',
           'offering': 'offering'
         }
+      }),
+      new Template({
+          directives: [],
+          inline: `<div [style]="style">{{offering.name}}</div>`
       })
     ]
   });
@@ -157,22 +157,22 @@ export function setupReflectorForCells() {
     'annotations': [
       new Component({
         selector: 'stage-buttons',
-        template: new TemplateConfig({
-            directives: [Foreach],
-            inline: `
-              <div [style]="style">
-                  <button template="foreach #stage in stages"
-                          [disabled]="stage.isDisabled"
-                          [style]="stage.style"
-                          on-click="setStage(stage)">
-                    {{stage.name}}
-                  </button>
-              </div>`
-        }),
         bind: {
           'cell-width': 'width',
           'offering': 'offering'
         }
+      }),
+      new Template({
+          directives: [Foreach],
+          inline: `
+            <div [style]="style">
+                <button template="foreach #stage in stages"
+                        [disabled]="stage.isDisabled"
+                        [style]="stage.style"
+                        on-click="setStage(stage)">
+                  {{stage.name}}
+                </button>
+            </div>`
       })
     ]
   });
@@ -183,19 +183,19 @@ export function setupReflectorForCells() {
     'annotations': [
       new Component({
         selector: 'account-cell',
-        template: new TemplateConfig({
-            directives: [],
-            inline: `
-              <div [style]="style">
-                <a href="/account/{{account.accountId}}">
-                  {{account.accountId}}
-                </a>
-              </div>`
-        }),
         bind: {
           'cell-width': 'width',
           'account': 'account'
         }
+      }),
+      new Template({
+          directives: [],
+          inline: `
+            <div [style]="style">
+              <a href="/account/{{account.accountId}}">
+                {{account.accountId}}
+              </a>
+            </div>`
       })
     ]
   });
@@ -206,14 +206,14 @@ export function setupReflectorForCells() {
     'annotations': [
       new Component({
         selector: 'formatted-cell',
-        template: new TemplateConfig({
-            directives: [],
-            inline: `<div [style]="style">{{formattedValue}}</div>`
-        }),
         bind: {
           'cell-width': 'width',
           'value': 'value'
         }
+      }),
+      new Template({
+          directives: [],
+          inline: `<div [style]="style">{{formattedValue}}</div>`
       })
     ]
   });

--- a/modules/benchmarks/src/naive_infinite_scroll/index.js
+++ b/modules/benchmarks/src/naive_infinite_scroll/index.js
@@ -4,13 +4,14 @@ import {MapWrapper} from 'angular2/src/facade/collection';
 
 import {Parser, Lexer, ChangeDetector, ChangeDetection}
     from 'angular2/change_detection';
-import {bootstrap, Component, Viewport, TemplateConfig, ViewContainer, Compiler}
+import {bootstrap, Component, Viewport, Template, ViewContainer, Compiler}
     from 'angular2/angular2';
 import {reflector} from 'angular2/src/reflection/reflection';
 import {CompilerCache} from 'angular2/src/core/compiler/compiler';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
 import {ShadowDomStrategy, NativeShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
 import {TemplateLoader} from 'angular2/src/core/compiler/template_loader';
+import {TemplateResolver} from 'angular2/src/core/compiler/template_resolver';
 import {LifeCycle} from 'angular2/src/core/life_cycle/life_cycle';
 import {XHR} from 'angular2/src/core/compiler/xhr/xhr';
 import {XHRImpl} from 'angular2/src/core/compiler/xhr/xhr_impl';
@@ -172,10 +173,12 @@ export function setupReflectorForAngular() {
   });
 
   reflector.registerType(Compiler, {
-    "factory": (changeDetection, templateLoader, reader, parser, compilerCache, shadowDomStrategy) =>
-      new Compiler(changeDetection, templateLoader, reader, parser, compilerCache, shadowDomStrategy),
+    "factory": (changeDetection, templateLoader, reader, parser, compilerCache, shadowDomStrategy,
+      resolver) =>
+      new Compiler(changeDetection, templateLoader, reader, parser, compilerCache, shadowDomStrategy,
+        resolver),
     "parameters": [[ChangeDetection], [TemplateLoader], [DirectiveMetadataReader], [Parser],
-                   [CompilerCache], [ShadowDomStrategy]],
+                   [CompilerCache], [ShadowDomStrategy], [TemplateResolver]],
     "annotations": []
   });
 
@@ -194,6 +197,12 @@ export function setupReflectorForAngular() {
   reflector.registerType(TemplateLoader, {
     "factory": (xhr) => new TemplateLoader(xhr),
     "parameters": [[XHR]],
+    "annotations": []
+  });
+
+  reflector.registerType(TemplateResolver, {
+    "factory": () => new TemplateResolver(),
+    "parameters": [],
     "annotations": []
   });
 

--- a/modules/benchmarks/src/naive_infinite_scroll/scroll_area.js
+++ b/modules/benchmarks/src/naive_infinite_scroll/scroll_area.js
@@ -1,7 +1,7 @@
 import {int, FINAL} from 'angular2/src/facade/lang';
 import {reflector} from 'angular2/src/reflection/reflection';
 import {getIntParameter, bindAction} from 'angular2/src/test_lib/benchmark_util';
-import {Component, Viewport, TemplateConfig, ViewContainer, Compiler}
+import {Component, Viewport, Template, ViewContainer, Compiler}
     from 'angular2/angular2';
 import {PromiseWrapper} from 'angular2/src/facade/async';
 import {ListWrapper, MapWrapper} from 'angular2/src/facade/collection';
@@ -67,23 +67,23 @@ export function setupReflectorForScrollArea() {
     'annotations': [
       new Component({
         selector: 'scroll-area',
-        template: new TemplateConfig({
-            directives: [ScrollItemComponent, Foreach],
-            inline: `
-              <div>
-                  <div id="scrollDiv"
-                       [style]="scrollDivStyle"
-                       on-scroll="onScroll($event)">
-                      <div id="padding"></div>
-                      <div id="inner">
-                          <scroll-item
-                              template="foreach #item in visibleItems"
-                              [offering]="item">
-                          </scroll-item>
-                      </div>
+      }),
+      new Template({
+        directives: [ScrollItemComponent, Foreach],
+        inline: `
+          <div>
+              <div id="scrollDiv"
+                   [style]="scrollDivStyle"
+                   on-scroll="onScroll($event)">
+                  <div id="padding"></div>
+                  <div id="inner">
+                      <scroll-item
+                          template="foreach #item in visibleItems"
+                          [offering]="item">
+                      </scroll-item>
                   </div>
-              </div>`
-        })
+              </div>
+          </div>`
       })
     ]
   });

--- a/modules/benchmarks/src/naive_infinite_scroll/scroll_item.js
+++ b/modules/benchmarks/src/naive_infinite_scroll/scroll_item.js
@@ -1,6 +1,6 @@
 import {int} from 'angular2/src/facade/lang';
 import {reflector} from 'angular2/src/reflection/reflection';
-import {Component, Viewport, TemplateConfig, ViewContainer, Compiler}
+import {Component, Viewport, Template, ViewContainer, Compiler}
     from 'angular2/angular2';
 import {PromiseWrapper} from 'angular2/src/facade/async';
 import {ListWrapper, MapWrapper} from 'angular2/src/facade/collection';
@@ -51,55 +51,55 @@ export function setupReflectorForScrollItem() {
     'annotations': [
       new Component({
         selector: 'scroll-item',
-        template: new TemplateConfig({
-          directives: [
-            CompanyNameComponent,
-            OpportunityNameComponent,
-            OfferingNameComponent,
-            StageButtonsComponent,
-            AccountCellComponent,
-            FormattedCellComponent
-          ],
-          inline: `
-            <div [style]="itemStyle">
-                <company-name [company]="offering.company"
-                              [cell-width]="companyNameWidth">
-                </company-name>
-                <opportunity-name [opportunity]="offering.opportunity"
-                                  [cell-width]="opportunityNameWidth">
-                </opportunity-name>
-                <offering-name [offering]="offering"
-                               [cell-width]="offeringNameWidth">
-                </offering-name>
-                <account-cell [account]="offering.account"
-                              [cell-width]="accountCellWidth">
-                </account-cell>
-                <formatted-cell [value]="offering.basePoints"
-                                [cell-width]="basePointsWidth">
-                </formatted-cell>
-                <formatted-cell [value]="offering.kickerPoints"
-                                [cell-width]="kickerPointsWidth">
-                </formatted-cell>
-                <stage-buttons [offering]="offering"
-                               [cell-width]="stageButtonsWidth">
-                </stage-buttons>
-                <formatted-cell [value]="offering.bundles"
-                                [cell-width]="bundlesWidth">
-                </formatted-cell>
-                <formatted-cell [value]="offering.dueDate"
-                                [cell-width]="dueDateWidth">
-                </formatted-cell>
-                <formatted-cell [value]="offering.endDate"
-                                [cell-width]="endDateWidth">
-                </formatted-cell>
-                <formatted-cell [value]="offering.aatStatus"
-                                [cell-width]="aatStatusWidth">
-                </formatted-cell>
-            </div>`
-        }),
         bind: {
           'offering': 'offering'
         }
+      }),
+      new Template({
+        directives: [
+          CompanyNameComponent,
+          OpportunityNameComponent,
+          OfferingNameComponent,
+          StageButtonsComponent,
+          AccountCellComponent,
+          FormattedCellComponent
+        ],
+        inline: `
+          <div [style]="itemStyle">
+              <company-name [company]="offering.company"
+                            [cell-width]="companyNameWidth">
+              </company-name>
+              <opportunity-name [opportunity]="offering.opportunity"
+                                [cell-width]="opportunityNameWidth">
+              </opportunity-name>
+              <offering-name [offering]="offering"
+                             [cell-width]="offeringNameWidth">
+              </offering-name>
+              <account-cell [account]="offering.account"
+                            [cell-width]="accountCellWidth">
+              </account-cell>
+              <formatted-cell [value]="offering.basePoints"
+                              [cell-width]="basePointsWidth">
+              </formatted-cell>
+              <formatted-cell [value]="offering.kickerPoints"
+                              [cell-width]="kickerPointsWidth">
+              </formatted-cell>
+              <stage-buttons [offering]="offering"
+                             [cell-width]="stageButtonsWidth">
+              </stage-buttons>
+              <formatted-cell [value]="offering.bundles"
+                              [cell-width]="bundlesWidth">
+              </formatted-cell>
+              <formatted-cell [value]="offering.dueDate"
+                              [cell-width]="dueDateWidth">
+              </formatted-cell>
+              <formatted-cell [value]="offering.endDate"
+                              [cell-width]="endDateWidth">
+              </formatted-cell>
+              <formatted-cell [value]="offering.aatStatus"
+                              [cell-width]="aatStatusWidth">
+              </formatted-cell>
+          </div>`
       })
     ]
   });

--- a/modules/benchmarks/src/tree/tree_benchmark.js
+++ b/modules/benchmarks/src/tree/tree_benchmark.js
@@ -1,11 +1,12 @@
 import {Parser, Lexer, ChangeDetector, ChangeDetection, jitChangeDetection}
   from 'angular2/change_detection';
 
-import {bootstrap, Component, Viewport, TemplateConfig, ViewContainer, Compiler} from 'angular2/angular2';
+import {bootstrap, Component, Viewport, Template, ViewContainer, Compiler} from 'angular2/angular2';
 
 import {CompilerCache} from 'angular2/src/core/compiler/compiler';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
 import {TemplateLoader} from 'angular2/src/core/compiler/template_loader';
+import {TemplateResolver} from 'angular2/src/core/compiler/template_resolver';
 import {ShadowDomStrategy, NativeShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
 import {LifeCycle} from 'angular2/src/core/life_cycle/life_cycle';
 
@@ -24,28 +25,26 @@ function setupReflector() {
   reflector.registerType(AppComponent, {
     'factory': () => new AppComponent(),
     'parameters': [],
-    'annotations' : [new Component({
-      selector: 'app',
-      template: new TemplateConfig({
+    'annotations' : [
+      new Component({selector: 'app'}),
+      new Template({
         directives: [TreeComponent],
         inline: `<tree [data]='initData'></tree>`
-      })
-    })]
+      })]
   });
 
   reflector.registerType(TreeComponent, {
     'factory': () => new TreeComponent(),
     'parameters': [],
-    'annotations' : [new Component({
-      selector: 'tree',
-      bind: {
-        'data': 'data'
-      },
-      template: new TemplateConfig({
-          directives: [TreeComponent, NgIf],
-          inline: `<span> {{data.value}} <span template='ng-if data.right != null'><tree [data]='data.right'></tree></span><span template='ng-if data.left != null'><tree [data]='data.left'></tree></span></span>`
-      })
-    })]
+    'annotations' : [
+      new Component({
+        selector: 'tree',
+        bind: {'data': 'data'}
+      }),
+      new Template({
+        directives: [TreeComponent, NgIf],
+        inline: `<span> {{data.value}} <span template='ng-if data.right != null'><tree [data]='data.right'></tree></span><span template='ng-if data.left != null'><tree [data]='data.left'></tree></span></span>`
+      })]
   });
 
   reflector.registerType(NgIf, {
@@ -60,9 +59,10 @@ function setupReflector() {
   });
 
   reflector.registerType(Compiler, {
-    'factory': (cd, templateLoader, reader, parser, compilerCache, strategy) => new Compiler(cd, templateLoader, reader, parser, compilerCache, strategy),
+    'factory': (cd, templateLoader, reader, parser, compilerCache, strategy, resolver) =>
+      new Compiler(cd, templateLoader, reader, parser, compilerCache, strategy, resolver),
     'parameters': [[ChangeDetection], [TemplateLoader], [DirectiveMetadataReader],
-                   [Parser], [CompilerCache], [ShadowDomStrategy]],
+                   [Parser], [CompilerCache], [ShadowDomStrategy], [TemplateResolver]],
     'annotations': []
   });
 
@@ -81,6 +81,12 @@ function setupReflector() {
   reflector.registerType(TemplateLoader, {
     'factory': (xhr) => new TemplateLoader(xhr),
     'parameters': [[XHR]],
+    'annotations': []
+  });
+
+  reflector.registerType(TemplateResolver, {
+    'factory': () => new TemplateResolver(),
+    'parameters': [],
     'annotations': []
   });
 

--- a/modules/examples/src/gestures/index.js
+++ b/modules/examples/src/gestures/index.js
@@ -1,13 +1,9 @@
-import {bootstrap, Component, TemplateConfig} from 'angular2/core';
+import {bootstrap, Component, Template} from 'angular2/core';
 import {reflector} from 'angular2/src/reflection/reflection';
 import {ReflectionCapabilities} from 'angular2/src/reflection/reflection_capabilities';
 
-@Component({
-  selector: 'gestures-app',
-  template: new TemplateConfig({
-    url: 'template.html'
-  })
-})
+@Component({selector: 'gestures-app'})
+@Template({url: 'template.html'})
 class GesturesCmp {
   swipeDirection: string;
   pinchScale: number;

--- a/modules/examples/src/hello_world/index_common.js
+++ b/modules/examples/src/hello_world/index_common.js
@@ -1,4 +1,4 @@
-import {bootstrap, Component, Decorator, TemplateConfig, NgElement} from 'angular2/angular2';
+import {bootstrap, Component, Decorator, Template, NgElement} from 'angular2/angular2';
 
 // Angular 2.0 supports 3 basic types of directives:
 // - Component - the basic building blocks of Angular 2.0 apps. Backed by
@@ -15,19 +15,19 @@ import {bootstrap, Component, Decorator, TemplateConfig, NgElement} from 'angula
   selector: 'hello-app',
   // These are services that would be created if a class in the component's
   // template tries to inject them.
-  componentServices: [GreetingService],
-  template: new TemplateConfig({
-    // The template for the component.
-    // Expressions in the template (like {{greeting}}) are evaluated in the
-    // context of the HelloCmp class below.
-    inline: `<div class="greeting">{{greeting}} <span red>world</span>!</div>
-             <button class="changeButton" (click)="changeGreeting()">change greeting</button>`,
-    // All directives used in the template need to be specified. This allows for
-    // modularity (RedDec can only be used in this template)
-    // and better tooling (the template can be invalidated if the attribute is
-    // misspelled).
-    directives: [RedDec]
-  })
+  componentServices: [GreetingService]
+})
+// The template for the component.
+@Template({
+  // Expressions in the template (like {{greeting}}) are evaluated in the
+  // context of the HelloCmp class below.
+  inline: `<div class="greeting">{{greeting}} <span red>world</span>!</div>
+           <button class="changeButton" (click)="changeGreeting()">change greeting</button>`,
+  // All directives used in the template need to be specified. This allows for
+  // modularity (RedDec can only be used in this template)
+  // and better tooling (the template can be invalidated if the attribute is
+  // misspelled).
+  directives: [RedDec]
 })
 class HelloCmp {
   greeting: string;

--- a/modules/examples/src/hello_world/index_static.js
+++ b/modules/examples/src/hello_world/index_static.js
@@ -1,6 +1,6 @@
 import *  as app from './index_common';
 
-import {Component, Decorator, TemplateConfig, NgElement} from 'angular2/angular2';
+import {Component, Decorator, Template, NgElement} from 'angular2/angular2';
 import {Lexer, Parser, ChangeDetection, ChangeDetector} from 'angular2/change_detection';
 import {LifeCycle} from 'angular2/src/core/life_cycle/life_cycle';
 
@@ -8,6 +8,7 @@ import {Compiler, CompilerCache} from 'angular2/src/core/compiler/compiler';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
 import {ShadowDomStrategy, NativeShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
 import {TemplateLoader} from 'angular2/src/core/compiler/template_loader';
+import {TemplateResolver} from 'angular2/src/core/compiler/template_resolver';
 import {XHR} from 'angular2/src/core/compiler/xhr/xhr';
 import {XHRImpl} from 'angular2/src/core/compiler/xhr/xhr_impl';
 
@@ -17,14 +18,16 @@ function setup() {
   reflector.registerType(app.HelloCmp, {
     "factory": (service) => new app.HelloCmp(service),
     "parameters": [[app.GreetingService]],
-    "annotations" : [new Component({
-      selector: 'hello-app',
-      componentServices: [app.GreetingService],
-      template: new TemplateConfig({
+    "annotations" : [
+      new Component({
+        selector: 'hello-app',
+        componentServices: [app.GreetingService]
+      }),
+      new Template({
         directives: [app.RedDec],
         inline: `<div class="greeting">{{greeting}} <span red>world</span>!</div>
-                 <button class="changeButton" (click)="changeGreeting()">change greeting</button>`})
-    })]
+                 <button class="changeButton" (click)="changeGreeting()">change greeting</button>`
+      })]
   });
 
   reflector.registerType(app.RedDec, {
@@ -40,10 +43,12 @@ function setup() {
   });
 
   reflector.registerType(Compiler, {
-    "factory": (changeDetection, templateLoader, reader, parser, compilerCache, shadowDomStrategy) =>
-      new Compiler(changeDetection, templateLoader, reader, parser, compilerCache, shadowDomStrategy),
+    "factory": (changeDetection, templateLoader, reader, parser, compilerCache, shadowDomStrategy,
+                resolver) =>
+      new Compiler(changeDetection, templateLoader, reader, parser, compilerCache, shadowDomStrategy,
+        resolver),
     "parameters": [[ChangeDetection], [TemplateLoader], [DirectiveMetadataReader], [Parser],
-                   [CompilerCache], [ShadowDomStrategy]],
+                   [CompilerCache], [ShadowDomStrategy], [TemplateResolver]],
     "annotations": []
   });
 
@@ -62,6 +67,12 @@ function setup() {
   reflector.registerType(TemplateLoader, {
     "factory": (xhr) => new TemplateLoader(xhr),
     "parameters": [[XHR]],
+    "annotations": []
+  });
+
+  reflector.registerType(TemplateResolver, {
+    "factory": () => new TemplateResolver(),
+    "parameters": [],
     "annotations": []
   });
 


### PR DESCRIPTION
Relates to #596, the first commit is PR #628 

This PR is a **work in progress**

Done:
- Rename `TemplateConfig` to `Template`
- Introduce a simple `TemplateResolver`, update the tests

ToDo:
- [x] move the template configuration from inside `@Component({template: ...})` to the `@Template` annotation to allow multiple templates per component,
- [x] update the resolver accordingly
