### PR TITLE
feat: support bindings for the 'role' attribute

### DIFF
--- a/modules/angular2/src/core/compiler/pipeline/element_binder_builder.js
+++ b/modules/angular2/src/core/compiler/pipeline/element_binder_builder.js
@@ -1,4 +1,4 @@
-import {int, isPresent, isBlank, Type, BaseException, StringWrapper, RegExpWrapper, stringify} from 'angular2/src/facade/lang';
+import {int, isPresent, isBlank, Type, BaseException, StringWrapper, RegExpWrapper, isString, stringify} from 'angular2/src/facade/lang';
 import {Element, DOM} from 'angular2/src/facade/dom';
 import {ListWrapper, List, MapWrapper, StringMapWrapper} from 'angular2/src/facade/collection';
 
@@ -81,6 +81,18 @@ function styleSetterFactory(styleName:string, stylesuffix:string) {
   return setterFn;
 }
 
+const ROLE_ATTR = 'role';
+function roleSetter(element:Element, value) {
+  if (isString(value)) {
+    DOM.setAttribute(element, ROLE_ATTR, value);
+  } else {
+    DOM.removeAttribute(element, ROLE_ATTR);
+    if (isPresent(value)) {
+      throw new BaseException("Invalid role attribute, only string values are allowed, got '" + stringify(value) + "'");
+    }
+  }
+}
+
 /**
  * Creates the ElementBinders and adds watches to the
  * ProtoChangeDetector.
@@ -155,6 +167,8 @@ export class ElementBinderBuilder extends CompileStep {
 
       if (StringWrapper.startsWith(property, ARIA_PREFIX)) {
         setterFn = ariaSetterFactory(property);
+      } else if (StringWrapper.equals(property, ROLE_ATTR)) {
+        setterFn = roleSetter;
       } else if (StringWrapper.startsWith(property, CLASS_PREFIX)) {
         setterFn = classSetterFactory(StringWrapper.substring(property, CLASS_PREFIX.length));
       } else if (StringWrapper.startsWith(property, STYLE_PREFIX)) {

--- a/modules/angular2/test/core/compiler/pipeline/element_binder_builder_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/element_binder_builder_spec.js
@@ -241,6 +241,47 @@ export function main() {
       expect(DOM.getAttribute(view.nodes[0], 'aria-busy')).toEqual('false');
     });
 
+    it('should bind to ARIA role attribute', () => {
+      var propertyBindings = MapWrapper.createFromStringMap({
+        'role': 'prop1'
+      });
+      var pipeline = createPipeline({propertyBindings: propertyBindings});
+      var results = pipeline.process(el('<div viewroot prop-binding></div>'));
+      var pv = results[0].inheritedProtoView;
+
+      expect(pv.elementBinders[0].hasElementPropertyBindings).toBe(true);
+
+      instantiateView(pv);
+
+      evalContext.prop1 = 'alert';
+      changeDetector.detectChanges();
+      expect(DOM.getAttribute(view.nodes[0], 'role')).toEqual('alert');
+
+      evalContext.prop1 = 'alertdialog';
+      changeDetector.detectChanges();
+      expect(DOM.getAttribute(view.nodes[0], 'role')).toEqual('alertdialog');
+
+      evalContext.prop1 = null;
+      changeDetector.detectChanges();
+      expect(DOM.getAttribute(view.nodes[0], 'role')).toBeNull();
+    });
+
+    it('should throw for a non-string ARIA role', () => {
+      var propertyBindings = MapWrapper.createFromStringMap({
+        'role': 'prop1'
+      });
+      var pipeline = createPipeline({propertyBindings: propertyBindings});
+      var results = pipeline.process(el('<div viewroot prop-binding></div>'));
+      var pv = results[0].inheritedProtoView;
+
+      instantiateView(pv);
+
+      expect( () => {
+        evalContext.prop1 = 1; //invalid, non-string role
+        changeDetector.detectChanges();
+      }).toThrowError("Invalid role attribute, only string values are allowed, got '1'");
+    });
+
     it('should bind class with a dot', () => {
       var propertyBindings = MapWrapper.createFromStringMap({
         'class.bar': 'prop1',


### PR DESCRIPTION
This is initial support for binding to the ARIA's 'role' attribute. It is rather small but I'm not quite sure what should be behaviour for corner cases (ex.: null / falsy and non string values). I can see a couple of possibilities:
- null / falsy => remove the `role` attribute or let the default DOM's setter behaviour
- non-string => ignore vs. throw vs. let the default DOM's setter behaviour (it will throw in Dart)

Thoughts?

We are starting to get quite a number of those special-case bindings so I would like to make this behaviour a bit more generic (register special handlers) before adding support for other `aria-*` attributes. 

But yeh, if I could have feedback on the initial impl and corner cases handling this would be awesome.
