### PR TITLE
feat(AtScript): initialize class properties in Dart

### DIFF
--- a/tools/transpiler/spec/classes_spec.js
+++ b/tools/transpiler/spec/classes_spec.js
@@ -61,6 +61,11 @@ class WithFields {
   static id: number;
 }
 
+class WithInitializers {
+  static a = 'a';
+  b = 'b';
+}
+
 export function main() {
   describe('classes', function() {
     it('should work', function() {
@@ -107,6 +112,17 @@ export function main() {
         var obj = new WithFields();
         obj.name = 'Vojta';
         WithFields.id = 12;
+      });
+    });
+
+    describe('initializers', function() {
+      it('should support initialized static properties', () => {
+        expect(WithInitializers.a).toEqual('a');
+      });
+
+      it('should support initialized instance properties', () => {
+        var c = new WithInitializers();
+        expect(c.b).toEqual('b');
       });
     });
   });

--- a/tools/transpiler/src/outputgeneration/DartParseTreeWriter.js
+++ b/tools/transpiler/src/outputgeneration/DartParseTreeWriter.js
@@ -62,6 +62,14 @@ export class DartParseTreeWriter extends JavaScriptParseTreeWriter {
     this.writeSpace_();
 
     this.visitAny(tree.name);
+
+    if (tree.initializer) {
+      this.writeSpace_();
+      this.write_(EQUAL);
+      this.writeSpace_();
+      this.visitAny(tree.initializer);
+    }
+
     this.write_(SEMI_COLON);
   }
 


### PR DESCRIPTION
fixes #640 

/cc @yjbanov 

@tbosch properties initialization [works with Traceur](http://google.github.io/traceur-compiler/demo/repl.html#%2F%2F%20Options%3A%20--member-variables%20--script%20--source-maps%20%0Aclass%20C%20%7B%0A%20%20static%20a%20%3D%20'a'%3B%0A%20%20b%20%3D%20'b'%3B%0A%7D) any idea why it does not work when atscript compiles to JS ? It must be linked to one of the patch (see [Travis output](https://travis-ci.org/angular/angular/builds/50606794#L1090)).
