### PR TITLE
feat(application): move classes to the application level injector

### DIFF
--- a/modules/angular2/src/core/application.js
+++ b/modules/angular2/src/core/application.js
@@ -24,16 +24,6 @@ var _rootInjector: Injector;
 // Contains everything that is safe to share between applications.
 var _rootBindings = [
   bind(Reflector).toValue(reflector),
-  bind(ChangeDetection).toValue(dynamicChangeDetection),
-  Compiler,
-  CompilerCache,
-  TemplateLoader,
-  TemplateResolver,
-  DirectiveMetadataReader,
-  Parser,
-  Lexer,
-  bind(ShadowDomStrategy).toValue(new NativeShadowDomStrategy()),
-  bind(XHR).toValue(new XHRImpl()),
 ];
 
 export var appViewToken = new OpaqueToken('AppView');
@@ -87,6 +77,16 @@ function _injectorBindings(appComponentType): List<Binding> {
         var plugins = [new HammerGesturesPlugin()];
         return new EventManager(plugins, zone);
       }, [VmTurnZone]),
+      bind(ShadowDomStrategy).toValue(new NativeShadowDomStrategy()),
+      Compiler,
+      CompilerCache,
+      TemplateResolver,
+      bind(ChangeDetection).toValue(dynamicChangeDetection),
+      TemplateLoader,
+      DirectiveMetadataReader,
+      Parser,
+      Lexer,
+      bind(XHR).toValue(new XHRImpl()),
   ];
 }
 


### PR DESCRIPTION
fixes #649
- The ShadowDomStrategy and the TemplateResolver are moved from the root
  level to the application level injector so that the user can override
  them,
- The Compiler depends on them and needs to be moved at the application
  level,
- As the Compiler output depends on both the ShadowDomStrategy and the
  TemplateResolver, they are also moved at the application level.
