### PR TITLE
chore(readme): updates prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you don't already have `npm`, get it by installing [node.js](http://nodejs.or
 3. `npm install -g protractor` (you might need to prefix this command with `sudo`)
 4. `webdriver-manager update`
 5. If you plan to use Dart:
-  1. [Install the Dart SDK](https://www.dartlang.org/tools/sdk/)
+  1. [Install the Dart SDK](https://www.dartlang.org/tools/sdk/) - Includes the `pub` command line tool. This repository requires `pub` in version `>=1.4.0`
   2. [Add the Dart SDK's `bin` directory to your system path](https://www.dartlang.org/tools/pub/installing.html)
   3. Get the pub packages you need: `pub get`
 6. `gulp build`


### PR DESCRIPTION
Due to #670, this commit makes explicitly clear that version `>=1.4.0`
of the `pub` command line tool is required to run a local build with
`gulp build`.
