### PR TITLE
tests(e2e): upgrade Protractor to 1.7.0 and remove special cases for shadow dom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - LOGS_DIR=/tmp/angular-build/logs
   - ARCH=linux-x64
   matrix:
-  - MODE=js DART_CHANNEL=stable
+  - MODE=js DART_CHANNEL=dev
 # Dissabled until Dart v1.9 hits stable
 #  - MODE=dart DART_CHANNEL=stable
   - MODE=dart DART_CHANNEL=dev

--- a/modules/benchmarks/e2e_test/naive_infinite_scroll_perf.es6
+++ b/modules/benchmarks/e2e_test/naive_infinite_scroll_perf.es6
@@ -13,10 +13,8 @@ describe('ng2 naive infinite scroll benchmark', function () {
         url: URL,
         id: 'ng2.naive_infinite_scroll',
         work: function() {
-          browser.executeScript(
-              'document.querySelector("scroll-app /deep/ #reset-btn").click()');
-          browser.executeScript(
-              'document.querySelector("scroll-app /deep/ #run-btn").click()');
+          element(by.deepCss('#reset-btn')).click();
+          element(by.deepCss('#run-btn')).click();
           browser.wait(() => {
             return $('#done').getText().then(
               function() { return true; },

--- a/modules/benchmarks_external/e2e_test/naive_infinite_scroll_perf.es6
+++ b/modules/benchmarks_external/e2e_test/naive_infinite_scroll_perf.es6
@@ -13,10 +13,8 @@ describe('ng-dart1.x naive infinite scroll benchmark', function () {
         url: URL,
         id: 'ng1-dart1.x.naive_infinite_scroll',
         work: function() {
-          browser.executeScript(
-              'document.querySelector("scroll-app /deep/ #reset-btn").click()');
-          browser.executeScript(
-              'document.querySelector("scroll-app /deep/ #run-btn").click()');
+          element(by.deepCss('#reset-btn')).click();
+          element(by.deepCss('#run-btn')).click();
           var s = 1000;
           if (appSize > 4) {
             s = s + appSize * 100;

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "merge": "^1.2.0",
     "minimatch": "^2.0.1",
     "minimist": "1.1.x",
-    "protractor": "1.6.x",
+    "protractor": "1.7.x",
     "q": "^1.0.1",
     "run-sequence": "^0.3.6",
     "source-map": "^0.3.0",


### PR DESCRIPTION
With Protractor 1.7.0, which installs chromedriver 2.14, shadow DOM is supported.
