### PR TITLE
Add spec argument to the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ to the preprocessor and run the tests without exiting karma
 4. `protractor protractor-dart2js.conf.js`: Dart2JS e2e tests
 
 Angular specific command line options when running protractor:
-`protractor protractor-{js|dart2js}-conf.js --ng-help`
+  - `protractor protractor-{js|dart2js}-conf.js --ng-help`
+  - `protractor protractor-js.conf.js --spec tree`
 
 ### Performance tests
 

--- a/protractor-shared.js
+++ b/protractor-shared.js
@@ -21,6 +21,10 @@ var argv = require('yargs')
       'browsers': {
         describe: 'preconfigured browsers that should be used',
         default: 'ChromeDesktop'
+      },
+      'spec': {
+        describe: 'list module to test',
+        default: false
       }
     })
     .help('ng-help')
@@ -65,6 +69,23 @@ var BROWSER_CAPS = {
   }
 };
 
+var getBenchmarkFiles = function (benchmark, spec) {
+  var specFiles = [];
+  var perfFiles = [];
+  if (spec.length) {
+    spec.split(',').forEach(function (name) {
+      specFiles.push('dist/js/cjs/**/e2e_test/**/' + name + '_spec.js')
+    });
+    spec.split(',').forEach(function (name) {
+      perfFiles.push('dist/js/cjs/**/e2e_test/**/' + name + '_perf.js')
+    });
+  } else {
+    specFiles.push('dist/js/cjs/**/e2e_test/**/*_spec.js');
+    perfFiles.push('dist/js/cjs/**/e2e_test/**/*_perf.js');
+  }
+  return benchmark ? perfFiles : specFiles.concat(perfFiles);
+};
+
 var config = exports.config = {
   // Disable waiting for Angular as we don't have an integration layer yet...
   // TODO(tbosch): Implement a proper debugging API for Ng2.0, remove this here
@@ -80,12 +101,7 @@ var config = exports.config = {
     }
   },
 
-  specs: argv['benchmark'] ? [
-    'dist/js/cjs/**/e2e_test/**/*_perf.js'
-  ] : [
-    'dist/js/cjs/**/e2e_test/**/*_spec.js',
-    'dist/js/cjs/**/e2e_test/**/*_perf.js'
-  ],
+  specs: getBenchmarkFiles(argv['benchmark'], argv['spec']),
 
   exclude: [
     'dist/js/cjs/**/node_modules/**',


### PR DESCRIPTION
Allows to run a list of module test/perf.
Hi @tbosch, to run separate test/perf I found very useful have a command line argument to choose only the list of files I want run the test/perf.

Also can I ask if Benchpress will be an independent tool (so possible to installing by npm) before the ng-conf?

ThankYou
