### PR TITLE
feat(compiler): make directive bindings optional. Fixes #647

### DIFF
--- a/modules/angular2/src/core/compiler/pipeline/element_binder_builder.js
+++ b/modules/angular2/src/core/compiler/pipeline/element_binder_builder.js
@@ -204,22 +204,24 @@ export class ElementBinderBuilder extends CompileStep {
           var attributeValue = MapWrapper.get(compileElement.attrs(), elProp);
           if (isPresent(attributeValue)) {
             expression = _this._parser.wrapLiteralPrimitive(attributeValue, _this._compilationUnit);
-          } else {
-            throw new BaseException("No element binding found for property '" + elProp
-            + "' which is required by directive '" + stringify(directive.type) + "'");
           }
         }
-        var len = dirProp.length;
-        var dirBindingName = dirProp;
-        var isContentWatch = dirProp[len - 2] === '[' && dirProp[len - 1] === ']';
-        if (isContentWatch) dirBindingName = dirProp.substring(0, len - 2);
-        protoView.bindDirectiveProperty(
-          directiveIndex,
-          expression,
-          dirBindingName,
-          reflector.setter(dirBindingName),
-          isContentWatch
-        );
+
+        // Bindings are optional, so this binding only needs to be set up if an expression is given.
+        if (isPresent(expression)) {
+          var len = dirProp.length;
+          var dirBindingName = dirProp;
+          var isContentWatch = dirProp[len - 2] === '[' && dirProp[len - 1] === ']';
+          if (isContentWatch) dirBindingName = dirProp.substring(0, len - 2);
+
+          protoView.bindDirectiveProperty(
+            directiveIndex,
+            expression,
+            dirBindingName,
+            reflector.setter(dirBindingName),
+            isContentWatch
+          );
+        }
       });
     }
   }

--- a/modules/angular2/test/core/compiler/integration_spec.js
+++ b/modules/angular2/test/core/compiler/integration_spec.js
@@ -151,6 +151,20 @@ export function main() {
         });
       });
 
+      it('should support directives where a binding attribute is not given', function(done) {
+        tplResolver.setTemplate(MyComp,
+          new Template({
+            // No attribute "el-prop" specified.
+            inline: '<p my-dir></p>',
+            directives: [MyDir]
+          }));
+
+        compiler.compile(MyComp).then((pv) => {
+          createView(pv);
+          done();
+        });
+      });
+
       it('should support template directives via `<template>` elements.', (done) => {
         tplResolver.setTemplate(MyComp,
           new Template({

--- a/modules/angular2/test/core/compiler/pipeline/element_binder_builder_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/element_binder_builder_spec.js
@@ -430,11 +430,15 @@ export function main() {
 
     describe('errors', () => {
 
-      it('should throw if there is no element property bindings for a directive property binding', () => {
-        var pipeline = createPipeline({propertyBindings: MapWrapper.create(), directives: [SomeDecoratorDirectiveWithBinding]});
-        expect( () => {
-          pipeline.process(el('<div viewroot prop-binding directives>'));
-        }).toThrowError("No element binding found for property 'boundprop1' which is required by directive 'SomeDecoratorDirectiveWithBinding'");
+      it('should not throw any errors if there is no element property bindings for a directive ' +
+          'property binding', () => {
+        var pipeline = createPipeline({
+          propertyBindings: MapWrapper.create(),
+          directives: [SomeDecoratorDirectiveWithBinding]
+        });
+
+        // If processing throws an error, this test will fail.
+        pipeline.process(el('<div viewroot prop-binding directives>'));
       });
 
     });


### PR DESCRIPTION
Makes all directives bindings optional. A directive can still do its own enforcement of required bindings.
