### PR TITLE
fix(core): workaround for circular dependencies in nodejs

### DIFF
--- a/modules/angular2/src/core/compiler/view_container.js
+++ b/modules/angular2/src/core/compiler/view_container.js
@@ -1,25 +1,25 @@
-import {View, ProtoView} from './view';
+import * as viewModule from './view';
 import {DOM, Node, Element} from 'angular2/src/facade/dom';
 import {ListWrapper, MapWrapper, List} from 'angular2/src/facade/collection';
 import {BaseException} from 'angular2/src/facade/lang';
 import {Injector} from 'angular2/di';
-import {ElementInjector} from 'angular2/src/core/compiler/element_injector';
+import * as eiModule from 'angular2/src/core/compiler/element_injector';
 import {isPresent, isBlank} from 'angular2/src/facade/lang';
 import {EventManager} from 'angular2/src/core/events/event_manager';
 
 export class ViewContainer {
-  parentView: View;
+  parentView: viewModule.View;
   templateElement: Element;
-  defaultProtoView: ProtoView;
-  _views: List<View>;
+  defaultProtoView: viewModule.ProtoView;
+  _views: List<viewModule.View>;
   _lightDom: any;
   _eventManager: EventManager;
-  elementInjector: ElementInjector;
+  elementInjector: eiModule.ElementInjector;
   appInjector: Injector;
-  hostElementInjector: ElementInjector;
+  hostElementInjector: eiModule.ElementInjector;
 
-  constructor(parentView: View, templateElement: Element, defaultProtoView: ProtoView,
-      elementInjector: ElementInjector, eventManager: EventManager, lightDom = null) {
+  constructor(parentView: viewModule.View, templateElement: Element, defaultProtoView: viewModule.ProtoView,
+      elementInjector: eiModule.ElementInjector, eventManager: EventManager, lightDom = null) {
     this.parentView = parentView;
     this.templateElement = templateElement;
     this.defaultProtoView = defaultProtoView;
@@ -33,7 +33,7 @@ export class ViewContainer {
     this._eventManager = eventManager;
   }
 
-  hydrate(appInjector: Injector, hostElementInjector: ElementInjector) {
+  hydrate(appInjector: Injector, hostElementInjector: eiModule.ElementInjector) {
     this.appInjector = appInjector;
     this.hostElementInjector = hostElementInjector;
   }
@@ -50,7 +50,7 @@ export class ViewContainer {
     }
   }
 
-  get(index: number): View {
+  get(index: number): viewModule.View {
     return this._views[index];
   }
 
@@ -69,7 +69,7 @@ export class ViewContainer {
 
   // TODO(rado): profile and decide whether bounds checks should be added
   // to the methods below.
-  create(atIndex=-1): View {
+  create(atIndex=-1): viewModule.View {
     if (!this.hydrated()) throw new BaseException(
         'Cannot create views on a dehydrated ViewContainer');
     // TODO(rado): replace with viewFactory.
@@ -78,7 +78,7 @@ export class ViewContainer {
     return this.insert(newView, atIndex);
   }
 
-  insert(view, atIndex=-1): View {
+  insert(view, atIndex=-1): viewModule.View {
     if (atIndex == -1) atIndex = this._views.length;
     ListWrapper.insert(this._views, atIndex, view);
     if (isBlank(this._lightDom)) {
@@ -104,7 +104,7 @@ export class ViewContainer {
    * The method can be used together with insert to implement a view move, i.e.
    * moving the dom nodes while the directives in the view stay intact.
    */
-  detach(atIndex=-1): View {
+  detach(atIndex=-1): viewModule.View {
     if (atIndex == -1) atIndex = this._views.length - 1;
     var detachedView = this.get(atIndex);
     ListWrapper.removeAt(this._views, atIndex);

--- a/modules/angular2/src/core/compiler/view_pool.js
+++ b/modules/angular2/src/core/compiler/view_pool.js
@@ -1,19 +1,19 @@
 import {ListWrapper, MapWrapper, StringMapWrapper, List} from 'angular2/src/facade/collection';
-import {View} from './view';
+import * as viewModule from './view';
 
 export class ViewPool {
-  _views: List<View>;
+  _views: List<viewModule.View>;
   _capacity: number;
   constructor(capacity: number) {
     this._views = [];
     this._capacity = capacity;
   }
 
-  pop(): View {
+  pop(): viewModule.View {
     return ListWrapper.isEmpty(this._views) ? null : ListWrapper.removeLast(this._views);
   }
 
-  push(view: View) {
+  push(view: viewModule.View) {
     if (this._views.length < this._capacity) {
       ListWrapper.push(this._views, view);
     }

--- a/tools/transpiler/src/outputgeneration/DartParseTreeWriter.js
+++ b/tools/transpiler/src/outputgeneration/DartParseTreeWriter.js
@@ -16,6 +16,7 @@ import {
   OPEN_PAREN,
   OBJECT_PATTERN,
   OPEN_SQUARE,
+  PERIOD,
   SEMI_COLON,
   STAR,
   STATIC,
@@ -271,6 +272,11 @@ export class DartParseTreeWriter extends JavaScriptParseTreeWriter {
     } else {
       typeNameNode = typeAnnotation;
       args = [];
+    }
+
+    if (typeNameNode.moduleName && typeNameNode.moduleName.name && typeNameNode.moduleName.name.value) {
+      this.write_(typeNameNode.moduleName.name.value);
+      this.write_(PERIOD);
     }
 
     // TODO(vojta): Figure out why `typeNameNode` has different structure when used with a variable.


### PR DESCRIPTION
Implements the workaround proposed by @tbosch in #683 
Only 2 cases found so far ...

It doesn't remove circular dependencies and is not easily testable (until the main test suite can be run in nodejs).
But, on the bright side, it enables the compiler to run. 

Good enough to close #683 ?
