### PR TITLE
chore(example): adds example for zippy component

### DIFF
--- a/modules/examples/e2e_test/zippy_component/zippy_spec.dart
+++ b/modules/examples/e2e_test/zippy_component/zippy_spec.dart
@@ -1,0 +1,5 @@
+library examples.e2e_test.zippy_component.zippy_spec;
+
+main() {
+
+}

--- a/modules/examples/e2e_test/zippy_component/zippy_spec.ts
+++ b/modules/examples/e2e_test/zippy_component/zippy_spec.ts
@@ -1,0 +1,31 @@
+import {verifyNoBrowserErrors} from 'angular2/src/test_lib/e2e_util';
+
+describe('Zippy Component', function() {
+
+  afterEach(verifyNoBrowserErrors);
+
+  describe('dynamic reflection', function() {
+    var URL = 'examples/src/zippy_component/index.html';
+
+    beforeEach(function() { browser.get(URL); });
+
+    it('should change the zippy title depending on it\'s state', function() {
+      var zippyTitle = element(by.css('.zippy__title'));
+
+      expect(zippyTitle.getText()).toEqual('▾ Details');
+      zippyTitle.click();
+      expect(zippyTitle.getText()).toEqual('▸ Details');
+    });
+
+    it('should have zippy content', function() {
+      expect(element(by.css('.zippy__content')).getText()).toEqual('This is some content.');
+    });
+
+    it('should toggle when the zippy title is clicked', function() {
+      element(by.css('.zippy__title')).click();
+      expect(element(by.css('.zippy__content')).isDisplayed()).toEqual(false);
+      element(by.css('.zippy__title')).click();
+      expect(element(by.css('.zippy__content')).isDisplayed()).toEqual(true);
+    });
+  });
+});

--- a/modules/examples/src/zippy_component/index.html
+++ b/modules/examples/src/zippy_component/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <title>Zippy Angular 2.0</title>
+<body>
+  <zippy-app>
+    Loading...
+  </zippy-app>
+
+  $SCRIPTS$
+</body>
+</html>

--- a/modules/examples/src/zippy_component/index.ts
+++ b/modules/examples/src/zippy_component/index.ts
@@ -1,0 +1,27 @@
+import {bootstrap, Component, View, NgFor} from 'angular2/angular2';
+import {reflector} from 'angular2/src/reflection/reflection';
+import {ReflectionCapabilities} from 'angular2/src/reflection/reflection_capabilities';
+import {Zippy} from './zippy';
+
+@Component({selector: 'zippy-app'})
+@View({
+  template: `
+    <zippy (open)="pushLog('open')" (close)="pushLog('close')" title="Details">
+      This is some content.
+    </zippy>
+    <ul>
+      <li *ng-for="var log of logs">{{log}}</li>
+    </ul>
+  `,
+  directives: [Zippy, NgFor]
+})
+class ZippyApp {
+  logs: Array<string> = [];
+
+  pushLog(log: string) { this.logs.push(log); }
+}
+
+export function main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  bootstrap(ZippyApp);
+}

--- a/modules/examples/src/zippy_component/zippy.html
+++ b/modules/examples/src/zippy_component/zippy.html
@@ -1,0 +1,8 @@
+<div class="zippy">
+  <div (click)="toggle()" class="zippy__title">
+    {{ visible ? '&blacktriangledown;' : '&blacktriangleright;' }} {{title}}
+  </div>
+  <div [hidden]="!visible" class="zippy__content">
+    <content></content>
+  </div>
+</div>

--- a/modules/examples/src/zippy_component/zippy.ts
+++ b/modules/examples/src/zippy_component/zippy.ts
@@ -1,0 +1,24 @@
+import {Component, View, EventEmitter} from 'angular2/angular2';
+import {ObservableWrapper} from 'angular2/src/facade/async';
+
+@Component({
+  selector: 'zippy',
+  properties: ['title'],
+  events: ['openHandler: open', 'closeHandler: close']
+})
+@View({templateUrl: 'zippy.html'})
+export class Zippy {
+  visible: boolean = true;
+  title: string = '';
+  openHandler: EventEmitter = new EventEmitter();
+  closeHandler: EventEmitter = new EventEmitter();
+
+  toggle() {
+    this.visible = !this.visible;
+    if (this.visible) {
+      ObservableWrapper.callNext(this.openHandler, null);
+    } else {
+      ObservableWrapper.callNext(this.closeHandler, null);
+    }
+  }
+}

--- a/tools/broccoli/trees/browser_tree.ts
+++ b/tools/broccoli/trees/browser_tree.ts
@@ -46,6 +46,7 @@ const kServedPaths = [
   'examples/src/key_events',
   'examples/src/sourcemap',
   'examples/src/todo',
+  'examples/src/zippy_component',
   'examples/src/material/button',
   'examples/src/material/checkbox',
   'examples/src/material/dialog',


### PR DESCRIPTION
This commit adds a very simple zippy component implementation to the
`examples` collection.

Closes #696

ACTION:
- [x] add `open`/`close` event
- [x] add tests
