### PR TITLE
feat(change_detection): change binding syntax to explicitly specify pipes

### DIFF
--- a/modules/angular2/change_detection.js
+++ b/modules/angular2/change_detection.js
@@ -18,8 +18,8 @@ export * from './src/change_detection/pipes/pipe';
 import {ProtoChangeDetector, DynamicProtoChangeDetector, JitProtoChangeDetector}
     from './src/change_detection/proto_change_detector';
 import {PipeRegistry} from './src/change_detection/pipes/pipe_registry';
-import {ArrayChanges} from './src/change_detection/pipes/array_changes';
-import {NullPipe} from './src/change_detection/pipes/null_pipe';
+import {ArrayChangesFactory} from './src/change_detection/pipes/array_changes';
+import {NullPipeFactory} from './src/change_detection/pipes/null_pipe';
 
 export class ChangeDetection {
   createProtoChangeDetector(name:string):ProtoChangeDetector{
@@ -29,15 +29,9 @@ export class ChangeDetection {
 }
 
 export var defaultPipes = {
-  "[]" : [
-    {
-      "supports" : ArrayChanges.supportsObj,
-      "pipe" : () => new ArrayChanges()
-    },
-    {
-      "supports" : NullPipe.supportsObj,
-      "pipe" : () => new NullPipe()
-    }
+  "iterableDiff" : [
+    new ArrayChangesFactory(),
+    new NullPipeFactory()
   ]
 };
 

--- a/modules/angular2/src/change_detection/dynamic_change_detector.js
+++ b/modules/angular2/src/change_detection/dynamic_change_detector.js
@@ -17,7 +17,7 @@ import {
   RECORD_TYPE_PRIMITIVE_OP,
   RECORD_TYPE_KEYED_ACCESS,
   RECORD_TYPE_INVOKE_FORMATTER,
-  RECORD_TYPE_STRUCTURAL_CHECK,
+  RECORD_TYPE_PIPE,
   RECORD_TYPE_INTERPOLATE
   } from './proto_record';
 
@@ -81,7 +81,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector {
 
   _check(proto:ProtoRecord) {
     try {
-      if (proto.mode == RECORD_TYPE_STRUCTURAL_CHECK) {
+      if (proto.mode == RECORD_TYPE_PIPE) {
         return this._pipeCheck(proto);
       } else {
         return this._referenceCheck(proto);
@@ -184,7 +184,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector {
     if (isPresent(storedPipe) && storedPipe.supports(context)) {
       return storedPipe;
     } else {
-      var pipe = this.pipeRegistry.get("[]", context);
+      var pipe = this.pipeRegistry.get(proto.name, context);
       this._writePipe(proto, pipe);
       return pipe;
     }

--- a/modules/angular2/src/change_detection/parser/ast.js
+++ b/modules/angular2/src/change_detection/parser/ast.js
@@ -33,22 +33,6 @@ export class EmptyExpr extends AST {
   }
 }
 
-export class Structural extends AST {
-  value:AST;
-  constructor(value:AST) {
-    super();
-    this.value = value;
-  }
-
-  eval(context) {
-    return value.eval(context);
-  }
-
-  visit(visitor) {
-    return visitor.visitStructural(this);
-  }
-}
-
 export class ImplicitReceiver extends AST {
   eval(context) {
     return context;
@@ -201,6 +185,20 @@ export class Formatter extends AST {
 
   visit(visitor) {
     return visitor.visitFormatter(this);
+  }
+}
+
+export class Pipe extends AST {
+  exp:AST;
+  name:string;
+  constructor(exp:AST, name:string) {
+    super();
+    this.exp = exp;
+    this.name = name;
+  }
+
+  visit(visitor) {
+    return visitor.visitPipe(this);
   }
 }
 
@@ -460,9 +458,9 @@ export class AstVisitor {
   visitAssignment(ast:Assignment) {}
   visitBinary(ast:Binary) {}
   visitChain(ast:Chain){}
-  visitStructural(ast:Structural) {}
   visitConditional(ast:Conditional) {}
   visitFormatter(ast:Formatter) {}
+  visitPipe(ast:Pipe) {}
   visitFunctionCall(ast:FunctionCall) {}
   visitImplicitReceiver(ast:ImplicitReceiver) {}
   visitKeyedAccess(ast:KeyedAccess) {}

--- a/modules/angular2/src/change_detection/parser/parser.js
+++ b/modules/angular2/src/change_detection/parser/parser.js
@@ -14,6 +14,7 @@ import {
   PrefixNot,
   Conditional,
   Formatter,
+  Pipe,
   Assignment,
   Chain,
   KeyedAccess,
@@ -50,6 +51,15 @@ export class Parser {
     var tokens = this._lexer.tokenize(input);
     var ast = new _ParseAST(input, location, tokens, this._reflector, false).parseChain();
     return new ASTWithSource(ast, input, location);
+  }
+
+  addPipes(bindingAst:ASTWithSource, pipes:List<String>):ASTWithSource {
+    if (ListWrapper.isEmpty(pipes)) return bindingAst;
+
+    var res = ListWrapper.reduce(pipes,
+      (result, currentPipeName) => new Pipe(result, currentPipeName),
+      bindingAst.ast);
+    return new ASTWithSource(res, bindingAst.source, bindingAst.location);
   }
 
   parseTemplateBindings(input:string, location:any):List<TemplateBinding> {

--- a/modules/angular2/src/change_detection/pipes/array_changes.js
+++ b/modules/angular2/src/change_detection/pipes/array_changes.js
@@ -16,6 +16,16 @@ import {
 
 import {NO_CHANGE, Pipe} from './pipe';
 
+export class ArrayChangesFactory {
+  supports(obj):boolean {
+    return ArrayChanges.supportsObj(obj);
+  }
+
+  create():Pipe {
+    return new ArrayChanges();
+  }
+}
+
 export class ArrayChanges extends Pipe {
   _collection;
   _length:int;

--- a/modules/angular2/src/change_detection/pipes/null_pipe.js
+++ b/modules/angular2/src/change_detection/pipes/null_pipe.js
@@ -1,6 +1,16 @@
 import {isBlank} from 'angular2/src/facade/lang';
 import {Pipe, NO_CHANGE} from './pipe';
 
+export class NullPipeFactory {
+  supports(obj):boolean {
+    return NullPipe.supportsObj(obj);
+  }
+
+  create():Pipe {
+    return new NullPipe();
+  }
+}
+
 export class NullPipe extends Pipe {
   called:boolean;
   constructor() {

--- a/modules/angular2/src/change_detection/pipes/pipe_registry.js
+++ b/modules/angular2/src/change_detection/pipes/pipe_registry.js
@@ -16,12 +16,12 @@ export class PipeRegistry {
     }
 
     var matchingConfig = ListWrapper.find(listOfConfigs,
-      (pipeConfig) => pipeConfig["supports"](obj));
+      (pipeConfig) => pipeConfig.supports(obj));
 
     if (isBlank(matchingConfig)) {
       throw new BaseException(`Cannot find a pipe for type '${type}' object '${obj}'`);
     }
 
-    return matchingConfig["pipe"]();
+    return matchingConfig.create();
   }
 }

--- a/modules/angular2/src/change_detection/proto_change_detector.js
+++ b/modules/angular2/src/change_detection/proto_change_detector.js
@@ -9,9 +9,9 @@ import {
   AstVisitor,
   Binary,
   Chain,
-  Structural,
   Conditional,
   Formatter,
+  Pipe,
   FunctionCall,
   ImplicitReceiver,
   Interpolation,
@@ -41,12 +41,12 @@ import {
   RECORD_TYPE_PRIMITIVE_OP,
   RECORD_TYPE_KEYED_ACCESS,
   RECORD_TYPE_INVOKE_FORMATTER,
-  RECORD_TYPE_STRUCTURAL_CHECK,
+  RECORD_TYPE_PIPE,
   RECORD_TYPE_INTERPOLATE
   } from './proto_record';
 
 export class ProtoChangeDetector  {
-  addAst(ast:AST, bindingMemento:any, directiveMemento:any = null, structural:boolean = false){}
+  addAst(ast:AST, bindingMemento:any, directiveMemento:any = null){}
   instantiate(dispatcher:any, formatters:Map):ChangeDetector{
     return null;
   }
@@ -64,8 +64,8 @@ export class DynamicProtoChangeDetector extends ProtoChangeDetector {
     this._recordBuilder = new ProtoRecordBuilder();
   }
 
-  addAst(ast:AST, bindingMemento:any, directiveMemento:any = null, structural:boolean = false) {
-    this._recordBuilder.addAst(ast, bindingMemento, directiveMemento, structural);
+  addAst(ast:AST, bindingMemento:any, directiveMemento:any = null) {
+    this._recordBuilder.addAst(ast, bindingMemento, directiveMemento);
   }
 
   instantiate(dispatcher:any, formatters:Map) {
@@ -95,8 +95,8 @@ export class JitProtoChangeDetector extends ProtoChangeDetector {
     this._recordBuilder = new ProtoRecordBuilder();
   }
 
-  addAst(ast:AST, bindingMemento:any, directiveMemento:any = null, structural:boolean = false) {
-    this._recordBuilder.addAst(ast, bindingMemento, directiveMemento, structural);
+  addAst(ast:AST, bindingMemento:any, directiveMemento:any = null) {
+    this._recordBuilder.addAst(ast, bindingMemento, directiveMemento);
   }
 
   instantiate(dispatcher:any, formatters:Map) {
@@ -121,9 +121,7 @@ class ProtoRecordBuilder {
     this.records = [];
   }
 
-  addAst(ast:AST, bindingMemento:any, directiveMemento:any = null, structural:boolean = false) {
-    if (structural) ast = new Structural(ast);
-
+  addAst(ast:AST, bindingMemento:any, directiveMemento:any = null) {
     var last = ListWrapper.last(this.records);
     if (isPresent(last) && last.directiveMemento == directiveMemento) {
       last.lastInDirective = false;
@@ -228,9 +226,9 @@ class _ConvertAstIntoProtoRecords {
       ChangeDetectionUtil.cond, [c,t,f], null, 0);
   }
 
-  visitStructural(ast:Structural) {
-    var value = ast.value.visit(this);
-    return this._addRecord(RECORD_TYPE_STRUCTURAL_CHECK, "structural", null, [], null, value);
+  visitPipe(ast:Pipe) {
+    var value = ast.exp.visit(this);
+    return this._addRecord(RECORD_TYPE_PIPE, ast.name, ast.name, [], null, value);
   }
 
   visitKeyedAccess(ast:KeyedAccess) {

--- a/modules/angular2/src/change_detection/proto_record.js
+++ b/modules/angular2/src/change_detection/proto_record.js
@@ -8,7 +8,7 @@ export const RECORD_TYPE_INVOKE_METHOD = 4;
 export const RECORD_TYPE_INVOKE_CLOSURE = 5;
 export const RECORD_TYPE_KEYED_ACCESS = 6;
 export const RECORD_TYPE_INVOKE_FORMATTER = 7;
-export const RECORD_TYPE_STRUCTURAL_CHECK = 8;
+export const RECORD_TYPE_PIPE = 8;
 export const RECORD_TYPE_INTERPOLATE = 9;
 
 export class ProtoRecord {

--- a/modules/angular2/src/core/compiler/view.js
+++ b/modules/angular2/src/core/compiler/view.js
@@ -511,8 +511,7 @@ export class ProtoView {
     directiveIndex:number,
     expression:AST,
     setterName:string,
-    setter:SetterFn,
-    isContentWatch: boolean) {
+    setter:SetterFn) {
 
     var bindingMemento = new DirectiveBindingMemento(
       this.elementBinders.length-1,
@@ -521,7 +520,7 @@ export class ProtoView {
       setter
     );
     var directiveMemento = DirectiveMemento.get(bindingMemento);
-    this.protoChangeDetector.addAst(expression, bindingMemento, directiveMemento, isContentWatch);
+    this.protoChangeDetector.addAst(expression, bindingMemento, directiveMemento);
   }
 
   // Create a rootView as if the compiler encountered <rootcmp></rootcmp>,

--- a/modules/angular2/src/directives/foreach.js
+++ b/modules/angular2/src/directives/foreach.js
@@ -7,7 +7,7 @@ import {ListWrapper} from 'angular2/src/facade/collection';
 @Viewport({
   selector: '[foreach][in]',
   bind: {
-    'iterableChanges[]': 'in'
+    'iterableChanges': 'in | iterableDiff'
   }
 })
 export class Foreach  {

--- a/modules/angular2/test/change_detection/parser/parser_spec.js
+++ b/modules/angular2/test/change_detection/parser/parser_spec.js
@@ -51,6 +51,10 @@ export function main() {
     return createParser().parseInterpolation(text, location);
   }
 
+  function addPipes(ast, pipes) {
+    return createParser().addPipes(ast, pipes);
+  }
+
   function expectEval(text, passedInContext = null) {
     var c = isBlank(passedInContext) ? td() : passedInContext;
     return expect(parseAction(text).eval(c));
@@ -541,6 +545,29 @@ export function main() {
         expect(ast.expressions.length).toEqual(2);
         expect(ast.expressions[0].name).toEqual('a');
         expect(ast.expressions[1].name).toEqual('b');
+      });
+    });
+
+    describe('addPipes', () => {
+      it('should return the given ast whe the list of pipes is empty', () => {
+        var ast = parseBinding("1 + 1", "Location");
+        var transformedAst = addPipes(ast, []);
+        expect(transformedAst).toBe(ast);
+      });
+
+      it('should append pipe ast nodes', () => {
+        var ast = parseBinding("1 + 1", "Location");
+        var transformedAst = addPipes(ast, ['one', 'two']);
+        expect(transformedAst.ast.name).toEqual("two");
+        expect(transformedAst.ast.exp.name).toEqual("one");
+        expect(transformedAst.ast.exp.exp.operation).toEqual("+");
+      });
+
+      it('should preserve location and source', () => {
+        var ast = parseBinding("1 + 1", "Location");
+        var transformedAst = addPipes(ast, ['one', 'two']);
+        expect(transformedAst.source).toEqual("1 + 1");
+        expect(transformedAst.location).toEqual("Location");
       });
     });
 

--- a/modules/angular2/test/change_detection/pipe_registry_spec.js
+++ b/modules/angular2/test/change_detection/pipe_registry_spec.js
@@ -11,8 +11,8 @@ export function main() {
     it("should return the first pipe supporting the data type", () => {
       var r = new PipeRegistry({
         "type": [
-          {"supports": (obj) => false, "pipe": () => firstPipe},
-          {"supports": (obj) => true, "pipe": () => secondPipe}
+          new PipeFactory(false, firstPipe),
+          new PipeFactory(true, secondPipe)
         ]
       });
 
@@ -36,4 +36,22 @@ export function main() {
       );
     });
   });
+}
+
+class PipeFactory {
+  shouldSupport:boolean;
+  pipe:any;
+
+  constructor(shouldSupport:boolean, pipe:any) {
+    this.shouldSupport = shouldSupport;
+    this.pipe = pipe;
+  }
+
+  supports(obj):boolean {
+    return this.shouldSupport;
+  }
+
+  create():Pipe {
+    return this.pipe;
+  }
 }

--- a/modules/angular2/test/core/compiler/view_spec.js
+++ b/modules/angular2/test/core/compiler/view_spec.js
@@ -548,7 +548,7 @@ export function main() {
           var pv = new ProtoView(el('<div class="ng-binding"></div>'),
             new DynamicProtoChangeDetector(null), null);
           pv.bindElement(new ProtoElementInjector(null, 0, [SomeDirective]));
-          pv.bindDirectiveProperty(0, parser.parseBinding('foo', null), 'prop', reflector.setter('prop'), false);
+          pv.bindDirectiveProperty(0, parser.parseBinding('foo', null), 'prop', reflector.setter('prop'));
           createViewAndChangeDetector(pv);
 
           ctx.foo = 'buz';
@@ -563,8 +563,8 @@ export function main() {
           pv.bindElement(new ProtoElementInjector(null, 0, [
             DirectiveBinding.createFromType(DirectiveImplementingOnChange, new Directive({lifecycle: [onChange]}))
           ]));
-          pv.bindDirectiveProperty( 0, parser.parseBinding('a', null), 'a', reflector.setter('a'), false);
-          pv.bindDirectiveProperty( 0, parser.parseBinding('b', null), 'b', reflector.setter('b'), false);
+          pv.bindDirectiveProperty( 0, parser.parseBinding('a', null), 'a', reflector.setter('a'));
+          pv.bindDirectiveProperty( 0, parser.parseBinding('b', null), 'b', reflector.setter('b'));
           createViewAndChangeDetector(pv);
 
           ctx.a = 100;
@@ -582,8 +582,8 @@ export function main() {
           pv.bindElement(new ProtoElementInjector(null, 0, [
             DirectiveBinding.createFromType(DirectiveImplementingOnChange, new Directive({lifecycle: [onChange]}))
           ]));
-          pv.bindDirectiveProperty( 0, parser.parseBinding('a', null), 'a', reflector.setter('a'), false);
-          pv.bindDirectiveProperty( 0, parser.parseBinding('b', null), 'b', reflector.setter('b'), false);
+          pv.bindDirectiveProperty( 0, parser.parseBinding('a', null), 'a', reflector.setter('a'));
+          pv.bindDirectiveProperty( 0, parser.parseBinding('b', null), 'b', reflector.setter('b'));
           createViewAndChangeDetector(pv);
 
           ctx.a = 0;

--- a/modules/benchmarks/src/change_detection/change_detection_benchmark.js
+++ b/modules/benchmarks/src/change_detection/change_detection_benchmark.js
@@ -119,7 +119,7 @@ function setUpChangeDetection(changeDetection:ChangeDetection, iterations) {
     parser.parseBinding('field9', null)
   ];
   for (var j = 0; j < 10; ++j) {
-    proto.addAst(astWithSource[j].ast, "memo", j, false);
+    proto.addAst(astWithSource[j].ast, "memo", j);
   }
 
   for (var i = 0; i < iterations; ++i) {

--- a/modules/benchmarks/src/naive_infinite_scroll/index.js
+++ b/modules/benchmarks/src/naive_infinite_scroll/index.js
@@ -169,7 +169,7 @@ export function setupReflectorForAngular() {
     'annotations' : [new Viewport({
       selector: '[foreach]',
       bind: {
-        'iterableChanges[]': 'in'
+        'iterableChanges': 'in | iterableDiff'
       }
     })]
   });


### PR DESCRIPTION
Now you can do the following:

```
@Viewport({
  selector: '[foreach][in]',
  bind: {
    'iterableChanges': 'in | iterableDiff'
  }
})
```

The next PR will remove the notion of transformers and add support for pipes to bindings.
