### PR TITLE
feat(change_detection): add support for pipes in the template

### DIFF
--- a/modules/angular2/change_detection.js
+++ b/modules/angular2/change_detection.js
@@ -35,19 +35,33 @@ export var defaultPipes = {
   ]
 };
 
-var _registry = new PipeRegistry(defaultPipes);
-
 export class DynamicChangeDetection extends ChangeDetection {
+  registry:PipeRegistry;
+
+  constructor(registry:PipeRegistry) {
+    super();
+    this.registry = registry;
+  }
+
   createProtoChangeDetector(name:string):ProtoChangeDetector{
-    return new DynamicProtoChangeDetector(_registry);
+    return new DynamicProtoChangeDetector(this.registry);
   }
 }
 
 export class JitChangeDetection extends ChangeDetection {
+  registry:PipeRegistry;
+
+  constructor(registry:PipeRegistry) {
+    super();
+    this.registry = registry;
+  }
+
   createProtoChangeDetector(name:string):ProtoChangeDetector{
-    return new JitProtoChangeDetector(_registry);
+    return new JitProtoChangeDetector(this.registry);
   }
 }
 
-export var dynamicChangeDetection = new DynamicChangeDetection();
-export var jitChangeDetection = new JitChangeDetection();
+var _registry = new PipeRegistry(defaultPipes);
+
+export var dynamicChangeDetection = new DynamicChangeDetection(_registry);
+export var jitChangeDetection = new JitChangeDetection(_registry);

--- a/modules/angular2/src/change_detection/dynamic_change_detector.js
+++ b/modules/angular2/src/change_detection/dynamic_change_detector.js
@@ -16,7 +16,6 @@ import {
   RECORD_TYPE_INVOKE_CLOSURE,
   RECORD_TYPE_PRIMITIVE_OP,
   RECORD_TYPE_KEYED_ACCESS,
-  RECORD_TYPE_INVOKE_FORMATTER,
   RECORD_TYPE_PIPE,
   RECORD_TYPE_INTERPOLATE
   } from './proto_record';
@@ -25,7 +24,6 @@ import {ExpressionChangedAfterItHasBeenChecked, ChangeDetectionError} from './ex
 
 export class DynamicChangeDetector extends AbstractChangeDetector {
   dispatcher:any;
-  formatters:Map;
   pipeRegistry;
 
   values:List;
@@ -35,10 +33,9 @@ export class DynamicChangeDetector extends AbstractChangeDetector {
 
   protos:List<ProtoRecord>;
 
-  constructor(dispatcher:any, formatters:Map, pipeRegistry:PipeRegistry, protoRecords:List<ProtoRecord>) {
+  constructor(dispatcher:any, pipeRegistry:PipeRegistry, protoRecords:List<ProtoRecord>) {
     super();
     this.dispatcher = dispatcher;
-    this.formatters = formatters;
     this.pipeRegistry = pipeRegistry;
 
     this.values = ListWrapper.createFixedSize(protoRecords.length + 1);
@@ -148,10 +145,6 @@ export class DynamicChangeDetector extends AbstractChangeDetector {
       case RECORD_TYPE_INTERPOLATE:
       case RECORD_TYPE_PRIMITIVE_OP:
         return FunctionWrapper.apply(proto.funcOrValue, this._readArgs(proto));
-
-      case RECORD_TYPE_INVOKE_FORMATTER:
-        var formatter = MapWrapper.get(this.formatters, proto.funcOrValue);
-        return FunctionWrapper.apply(formatter, this._readArgs(proto));
 
       default:
         throw new BaseException(`Unknown operation ${proto.mode}`);

--- a/modules/angular2/src/change_detection/parser/ast.js
+++ b/modules/angular2/src/change_detection/parser/ast.js
@@ -170,31 +170,15 @@ export class KeyedAccess extends AST {
   }
 }
 
-export class Formatter extends AST {
+export class Pipe extends AST {
   exp:AST;
   name:string;
   args:List<AST>;
-  allArgs:List<AST>;
   constructor(exp:AST, name:string, args:List) {
     super();
     this.exp = exp;
     this.name = name;
     this.args = args;
-    this.allArgs = ListWrapper.concat([exp], args);
-  }
-
-  visit(visitor) {
-    return visitor.visitFormatter(this);
-  }
-}
-
-export class Pipe extends AST {
-  exp:AST;
-  name:string;
-  constructor(exp:AST, name:string) {
-    super();
-    this.exp = exp;
-    this.name = name;
   }
 
   visit(visitor) {
@@ -459,7 +443,6 @@ export class AstVisitor {
   visitBinary(ast:Binary) {}
   visitChain(ast:Chain){}
   visitConditional(ast:Conditional) {}
-  visitFormatter(ast:Formatter) {}
   visitPipe(ast:Pipe) {}
   visitFunctionCall(ast:FunctionCall) {}
   visitImplicitReceiver(ast:ImplicitReceiver) {}

--- a/modules/angular2/src/change_detection/proto_change_detector.js
+++ b/modules/angular2/src/change_detection/proto_change_detector.js
@@ -10,7 +10,6 @@ import {
   Binary,
   Chain,
   Conditional,
-  Formatter,
   Pipe,
   FunctionCall,
   ImplicitReceiver,
@@ -40,14 +39,13 @@ import {
   RECORD_TYPE_INVOKE_CLOSURE,
   RECORD_TYPE_PRIMITIVE_OP,
   RECORD_TYPE_KEYED_ACCESS,
-  RECORD_TYPE_INVOKE_FORMATTER,
   RECORD_TYPE_PIPE,
   RECORD_TYPE_INTERPOLATE
   } from './proto_record';
 
 export class ProtoChangeDetector  {
   addAst(ast:AST, bindingMemento:any, directiveMemento:any = null){}
-  instantiate(dispatcher:any, formatters:Map):ChangeDetector{
+  instantiate(dispatcher:any):ChangeDetector{
     return null;
   }
 }
@@ -68,10 +66,9 @@ export class DynamicProtoChangeDetector extends ProtoChangeDetector {
     this._recordBuilder.addAst(ast, bindingMemento, directiveMemento);
   }
 
-  instantiate(dispatcher:any, formatters:Map) {
+  instantiate(dispatcher:any) {
     this._createRecordsIfNecessary();
-    return new DynamicChangeDetector(dispatcher, formatters,
-      this._pipeRegistry, this._records);
+    return new DynamicChangeDetector(dispatcher, this._pipeRegistry, this._records);
   }
 
   _createRecordsIfNecessary() {
@@ -99,9 +96,9 @@ export class JitProtoChangeDetector extends ProtoChangeDetector {
     this._recordBuilder.addAst(ast, bindingMemento, directiveMemento);
   }
 
-  instantiate(dispatcher:any, formatters:Map) {
+  instantiate(dispatcher:any) {
     this._createFactoryIfNecessary();
-    return this._factory(dispatcher, formatters, this._pipeRegistry);
+    return this._factory(dispatcher, this._pipeRegistry);
   }
 
   _createFactoryIfNecessary() {
@@ -176,10 +173,6 @@ class _ConvertAstIntoProtoRecords {
   visitAccessMember(ast:AccessMember) {
     var receiver = ast.receiver.visit(this);
     return this._addRecord(RECORD_TYPE_PROPERTY, ast.name, ast.getter, [], null, receiver);
-  }
-
-  visitFormatter(ast:Formatter) {
-    return this._addRecord(RECORD_TYPE_INVOKE_FORMATTER, ast.name, ast.name, this._visitAll(ast.allArgs), null, 0);
   }
 
   visitMethodCall(ast:MethodCall) {

--- a/modules/angular2/src/change_detection/proto_record.js
+++ b/modules/angular2/src/change_detection/proto_record.js
@@ -7,7 +7,6 @@ export const RECORD_TYPE_PROPERTY = 3;
 export const RECORD_TYPE_INVOKE_METHOD = 4;
 export const RECORD_TYPE_INVOKE_CLOSURE = 5;
 export const RECORD_TYPE_KEYED_ACCESS = 6;
-export const RECORD_TYPE_INVOKE_FORMATTER = 7;
 export const RECORD_TYPE_PIPE = 8;
 export const RECORD_TYPE_INTERPOLATE = 9;
 
@@ -54,7 +53,6 @@ export class ProtoRecord {
 
   isPureFunction():boolean {
     return this.mode === RECORD_TYPE_INTERPOLATE ||
-      this.mode === RECORD_TYPE_INVOKE_FORMATTER ||
       this.mode === RECORD_TYPE_PRIMITIVE_OP;
   }
 }

--- a/modules/angular2/src/core/compiler/view.js
+++ b/modules/angular2/src/core/compiler/view.js
@@ -19,8 +19,6 @@ import {EventManager} from 'angular2/src/core/events/event_manager';
 
 const NG_BINDING_CLASS = 'ng-binding';
 const NG_BINDING_CLASS_SELECTOR = '.ng-binding';
-// TODO(tbosch): Cannot use `const` because of Dart.
-var NO_FORMATTERS = MapWrapper.create();
 
 // TODO(rado): make this configurable/smarter.
 var VIEW_POOL_CAPACITY = 10000;
@@ -50,7 +48,7 @@ export class View {
   constructor(proto:ProtoView, nodes:List<Node>, protoChangeDetector:ProtoChangeDetector, protoContextLocals:Map) {
     this.proto = proto;
     this.nodes = nodes;
-    this.changeDetector = protoChangeDetector.instantiate(this, NO_FORMATTERS);
+    this.changeDetector = protoChangeDetector.instantiate(this);
     this.elementInjectors = null;
     this.rootElementInjectors = null;
     this.textNodes = null;

--- a/modules/angular2/test/change_detection/parser/parser_spec.js
+++ b/modules/angular2/test/change_detection/parser/parser_spec.js
@@ -5,7 +5,7 @@ import {MapWrapper, ListWrapper} from 'angular2/src/facade/collection';
 import {Parser} from 'angular2/src/change_detection/parser/parser';
 import {Lexer} from 'angular2/src/change_detection/parser/lexer';
 import {ContextWithVariableBindings} from 'angular2/src/change_detection/parser/context_with_variable_bindings';
-import {Formatter, LiteralPrimitive} from 'angular2/src/change_detection/parser/ast';
+import {Pipe, LiteralPrimitive} from 'angular2/src/change_detection/parser/ast';
 
 class TestData {
   a;
@@ -340,8 +340,8 @@ export function main() {
         });
       });
 
-      it("should error when using formatters", () => {
-        expectEvalError('x|blah').toThrowError(new RegExp('Cannot have a formatter'));
+      it("should error when using pipes", () => {
+        expectEvalError('x|blah').toThrowError(new RegExp('Cannot have a pipe'));
       });
 
       it('should pass exceptions', () => {
@@ -367,16 +367,16 @@ export function main() {
     });
 
     describe("parseBinding", () => {
-      describe("formatters", () => {
-        it("should parse formatters", () => {
+      describe("pipes", () => {
+        it("should parse pipes", () => {
           var exp = parseBinding("'Foo'|uppercase").ast;
-          expect(exp).toBeAnInstanceOf(Formatter);
+          expect(exp).toBeAnInstanceOf(Pipe);
           expect(exp.name).toEqual("uppercase");
         });
 
-        it("should parse formatters with args", () => {
+        it("should parse pipes with args", () => {
           var exp = parseBinding("1|increment:2").ast;
-          expect(exp).toBeAnInstanceOf(Formatter);
+          expect(exp).toBeAnInstanceOf(Pipe);
           expect(exp.name).toEqual("increment");
           expect(exp.args[0]).toBeAnInstanceOf(LiteralPrimitive);
         });

--- a/modules/benchmarks/src/change_detection/change_detection_benchmark.js
+++ b/modules/benchmarks/src/change_detection/change_detection_benchmark.js
@@ -103,7 +103,7 @@ function setUpChangeDetection(changeDetection:ChangeDetection, iterations) {
   var parser = new Parser(new Lexer());
 
   var parentProto = changeDetection.createProtoChangeDetector('parent');
-  var parentCd = parentProto.instantiate(dispatcher, MapWrapper.create());
+  var parentCd = parentProto.instantiate(dispatcher);
 
   var proto = changeDetection.createProtoChangeDetector("proto");
   var astWithSource = [
@@ -127,7 +127,7 @@ function setUpChangeDetection(changeDetection:ChangeDetection, iterations) {
     for (var j = 0; j < 10; ++j) {
       obj.setField(j, i);
     }
-    var cd = proto.instantiate(dispatcher,  null);
+    var cd = proto.instantiate(dispatcher);
     cd.setContext(obj);
     parentCd.addChild(cd);
   }


### PR DESCRIPTION
```
{{ exp | pipe1 | pipe2 }}
<web-component [prop]="exp | pipe1">
```

The coolest thing is the following:

```
<angular-component [prop]="exp | pipe1">
```

And AngularComponent is defined as follows

```
@Component({
  bind: {
    field: 'prop | pipe2;
  }
})
```

will combine the two pipes into: `exp | pipe1 | pipe2`
