### PR TITLE
Format Dart code right after transform

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -527,11 +527,11 @@ gulp.task('build.dart', function(done) {
   runSequence(
     ['build/deps.js.dart2js', 'build/transpile.dart', 'build/html.dart'],
     'tests/transform.dart',
+    'build/format.dart',
     'build/pubspec.dart',
     'build/multicopy.dart',
     'build/pubbuild.dart',
     'build/analyze.dart',
-    'build/format.dart',
     done
   );
 });


### PR DESCRIPTION
Much easier to diagnose errors with pub build, analyzer, etc with formatted code

CC @yjbanov 
