### PR TITLE
fix(facade): `ListWrapper.sort()` should not return the list

### DIFF
--- a/modules/angular2/src/facade/collection.es6
+++ b/modules/angular2/src/facade/collection.es6
@@ -187,7 +187,6 @@ export class ListWrapper {
   }
   static sort(l:List, compareFn:Function) {
     l.sort(compareFn);
-    return l;
   }
 }
 


### PR DESCRIPTION
This is the semantics of the regular `Array.sort` in JS,
so the wrapper should imitate this.
