### PR TITLE
[rtts_assert]: ease debugging ♥♥♥

### DIFF
--- a/modules/rtts_assert/src/rtts_assert.es6
+++ b/modules/rtts_assert/src/rtts_assert.es6
@@ -74,7 +74,15 @@ function assertArgumentTypes(...params) {
   }
 }
 
-function prettyPrint(value) {
+function prettyPrint(value, depth) {
+  if (typeof(depth) === 'undefined') {
+    depth = 0;
+  }
+
+  if (depth++ > 3) {
+    return '[...]';
+  }
+
   if (typeof value === 'undefined') {
     return 'undefined';
   }
@@ -96,12 +104,17 @@ function prettyPrint(value) {
       return value.__assertName;
     }
 
-    if (value.map) {
-      return '[' + value.map(prettyPrint).join(', ') + ']';
+    if (value.map && typeof value.map === 'function') {
+      return '[' + value.map((v) => prettyPrint(v, depth)).join(', ') + ']';
     }
 
     var properties = Object.keys(value);
-    return '{' + properties.map((p) => p + ': ' + prettyPrint(value[p])).join(', ') + '}';
+    var suffix = '}';
+    if (properties.length > 20) {
+      properties.length = 20;
+      suffix = ', ... }';
+    }
+    return '{' + properties.map((p) => p + ': ' + prettyPrint(value[p], depth)).join(', ') + suffix;
   }
 
   return value.__assertName || value.name || value.toString();

--- a/modules/rtts_assert/test/rtts_assert_spec.es6
+++ b/modules/rtts_assert/test/rtts_assert_spec.es6
@@ -14,6 +14,33 @@
 
 export function main() {
 
+describe('prettyPrint', () => {
+  class Type {};
+
+  it('should limit the number of printed properties', () => {
+    var o = {};
+    for (var i = 0; i < 100; i++) {
+      o['p_' + i] = i;
+    }
+    try {
+      assert.type(o, Type);
+      throw 'fail!';
+    } catch (e) {
+      expect(e.message.indexOf('p_0')).toBeGreaterThan(-1);
+      expect(e.message.indexOf('...')).toBeGreaterThan(-1);
+      expect(e.message.indexOf('p_20')).toBe(-1);
+    }
+  });
+
+  it('should limit the depth of printed properties', () => {
+    var o = {l1: {l2: {l3: {l4: {l5: {l6: 'deep'}}}}}};
+
+    expect(() => {
+      assert.type(o, Type);
+    }).toThrowError('Expected an instance of Type, got {l1: {l2: {l3: {l4: [...]}}}}!');
+  });
+});
+
 // ## Basic Type Check
 // By default, `instanceof` is used to check the type.
 //


### PR DESCRIPTION
`prettyPrint()` sometimes has recursion that makes the stack trace useless.

Before:

```
RangeError: Maximum call stack size exceeded
    at http://localhost:9876/base/modules/rtts_assert/src/rtts_assert.js:73:44
    at Array.map (native)
    at prettyPrint (http://localhost:9876/base/modules/rtts_assert/src/rtts_assert.js:73:31)
    at http://localhost:9876/base/modules/rtts_assert/src/rtts_assert.js:74:27
    at Array.map (native)
    at prettyPrint (http://localhost:9876/base/modules/rtts_assert/src/rtts_assert.js:73:31)
    at http://localhost:9876/base/modules/rtts_assert/src/rtts_assert.js:74:27
    at Array.map (native)
    at prettyPrint (http://localhost:9876/base/modules/rtts_assert/src/rtts_assert.js:73:31)
    at http://localhost:9876/base/modules/rtts_assert/src/rtts_assert.js:74:27
```

After:

```
LOG: 'Error: Invalid arguments given!
  - 1st argument has to be an instance of Function, got {onautocompleteerror: null, onautocomplete: null, onwaiting: null, onvolumechange: null, ontoggle: null, ontimeupdate: null, onsuspend: null, onsubmit: null, onstalled: null, onshow: null, onselect: null, onseeking: null, onseeked: null, onscroll: null, onresize: null, onreset: null, onratechange: null, onprogress: null, onplaying: null, onplay: null, ... }
  - 2nd argument has to be an instance of HTMLElement, got HelloRootCmp
```
