### PR TITLE
feat: add keyValDiff to default pipes

### DIFF
--- a/modules/angular2/change_detection.js
+++ b/modules/angular2/change_detection.js
@@ -19,6 +19,7 @@ import {ProtoChangeDetector, DynamicProtoChangeDetector, JitProtoChangeDetector}
     from './src/change_detection/proto_change_detector';
 import {PipeRegistry} from './src/change_detection/pipes/pipe_registry';
 import {ArrayChangesFactory} from './src/change_detection/pipes/array_changes';
+import {KeyValueChangesFactory} from './src/change_detection/pipes/keyvalue_changes';
 import {NullPipeFactory} from './src/change_detection/pipes/null_pipe';
 
 export class ChangeDetection {
@@ -31,6 +32,10 @@ export class ChangeDetection {
 export var defaultPipes = {
   "iterableDiff" : [
     new ArrayChangesFactory(),
+    new NullPipeFactory()
+  ],
+  "keyValDiff" : [
+    new KeyValueChangesFactory(),
     new NullPipeFactory()
   ]
 };

--- a/modules/angular2/src/change_detection/pipes/keyvalue_changes.js
+++ b/modules/angular2/src/change_detection/pipes/keyvalue_changes.js
@@ -1,8 +1,19 @@
 import {ListWrapper, MapWrapper, StringMapWrapper} from 'angular2/src/facade/collection';
-
 import {stringify, looseIdentical, isJsObject} from 'angular2/src/facade/lang';
 
-export class KeyValueChanges {
+import {NO_CHANGE, Pipe} from './pipe';
+
+export class KeyValueChangesFactory {
+  supports(obj):boolean {
+    return KeyValueChanges.supportsObj(obj);
+  }
+
+  create():Pipe {
+    return new KeyValueChanges();
+  }
+}
+
+export class KeyValueChanges extends Pipe {
   _records:Map;
 
   _mapHead:KVChangeRecord;
@@ -15,6 +26,7 @@ export class KeyValueChanges {
   _removalsTail:KVChangeRecord;
 
   constructor() {
+    super();
     this._records = MapWrapper.create();
     this._mapHead = null;
     this._previousMapHead = null;
@@ -26,12 +38,20 @@ export class KeyValueChanges {
     this._removalsTail = null;
   }
 
-  static supports(obj):boolean {
+  static supportsObj(obj):boolean {
     return obj instanceof Map || isJsObject(obj);
   }
 
-  supportsObj(obj):boolean {
-    return KeyValueChanges.supports(obj);
+  supports(obj):boolean {
+    return KeyValueChanges.supportsObj(obj);
+  }
+
+  transform(map){
+    if (this.check(map)) {
+      return this;
+    } else {
+      return NO_CHANGE;
+    }
   }
 
   get isDirty():boolean {

--- a/modules/angular2/test/change_detection/keyvalue_changes_spec.js
+++ b/modules/angular2/test/change_detection/keyvalue_changes_spec.js
@@ -131,10 +131,10 @@ export function main() {
       if (isJsObject({})) {
         describe('JsObject changes', () => {
           it('should support JS Object', () => {
-            expect(KeyValueChanges.supports({})).toBeTruthy();
-            expect(KeyValueChanges.supports("not supported")).toBeFalsy();
-            expect(KeyValueChanges.supports(0)).toBeFalsy();
-            expect(KeyValueChanges.supports(null)).toBeFalsy();
+            expect(KeyValueChanges.supportsObj({})).toBeTruthy();
+            expect(KeyValueChanges.supportsObj("not supported")).toBeFalsy();
+            expect(KeyValueChanges.supportsObj(0)).toBeFalsy();
+            expect(KeyValueChanges.supportsObj(null)).toBeFalsy();
           });
 
           it('should do basic object watching', () => {


### PR DESCRIPTION
I _presume_ I will need this to implement `[class]="{'foo': exp}"`

I'm not sure if the new keyValDiff should be added to default pipes, hence 2 commits. Happy to squash based on the review.
