### PR TITLE
refactor(Completer): rename complete() to resolve()

### DIFF
--- a/modules/angular2/src/core/application.js
+++ b/modules/angular2/src/core/application.js
@@ -125,7 +125,7 @@ export function bootstrap(appComponentType: Type, bindings: List<Binding>=null, 
         lc.registerWith(zone, rootView.changeDetector);
         lc.tick(); //the first tick that will bootstrap the app
 
-        bootstrapProcess.complete(appInjector);
+        bootstrapProcess.resolve(appInjector);
       },
 
       (err) => {

--- a/modules/angular2/src/core/compiler/xhr/xhr_impl.es6
+++ b/modules/angular2/src/core/compiler/xhr/xhr_impl.es6
@@ -11,7 +11,7 @@ export class XHRImpl extends XHR {
     xhr.onload = function() {
       var status = xhr.status;
       if (200 <= status && status <= 300) {
-        completer.complete(xhr.responseText);
+        completer.resolve(xhr.responseText);
       } else {
         completer.reject(`Failed to load ${url}`);
       }

--- a/modules/angular2/src/facade/async.dart
+++ b/modules/angular2/src/facade/async.dart
@@ -33,7 +33,7 @@ class _Completer {
 
   Future get promise => c.future;
 
-  void complete(v) {
+  void resolve(v) {
     c.complete(v);
   }
 

--- a/modules/angular2/src/facade/async.es6
+++ b/modules/angular2/src/facade/async.es6
@@ -32,7 +32,7 @@ export class PromiseWrapper {
 
     return {
       promise: p,
-      complete: resolve,
+      resolve: resolve,
       reject: reject
     };
   }

--- a/modules/angular2/src/mock/xhr_mock.js
+++ b/modules/angular2/src/mock/xhr_mock.js
@@ -90,7 +90,7 @@ class _PendingRequest {
     if (isBlank(response)) {
       this.completer.reject(`Failed to load ${this.url}`);
     } else {
-      this.completer.complete(response);
+      this.completer.resolve(response);
     }
   }
 

--- a/modules/angular2/test/core/zone/vm_turn_zone_spec.js
+++ b/modules/angular2/test/core/zone/vm_turn_zone_spec.js
@@ -54,8 +54,8 @@ export function main() {
           b.promise.then((_) => log.add('b then'));
         });
 
-        a.complete("a");
-        b.complete("b");
+        a.resolve("a");
+        b.resolve("b");
 
         PromiseWrapper.all([a.promise, b.promise]).then((_) => {
           expect(log.result()).toEqual('onTurnStart; run start; onTurnDone; onTurnStart; a then; onTurnDone; onTurnStart; b then; onTurnDone');
@@ -109,7 +109,7 @@ export function main() {
         zone.run(function () {
           PromiseWrapper.setTimeout(function () {
             PromiseWrapper.setTimeout(function () {
-              c.complete(null);
+              c.resolve(null);
               throw new BaseException('ccc');
             }, 0);
           }, 0);
@@ -130,7 +130,7 @@ export function main() {
         zone.run(function () {
           PromiseWrapper.resolve(null).then((_) => {
             return PromiseWrapper.resolve(null).then((__) => {
-              c.complete(null);
+              c.resolve(null);
               throw new BaseException("ddd");
             });
           });
@@ -152,7 +152,7 @@ export function main() {
         zone.run(function () {
           PromiseWrapper.setTimeout(function () {
             PromiseWrapper.setTimeout(function () {
-              c.complete(null);
+              c.resolve(null);
               throw new BaseException('ccc');
             }, 0);
           }, 0);

--- a/modules/benchpress/src/metric/perflog_metric.js
+++ b/modules/benchpress/src/metric/perflog_metric.js
@@ -65,7 +65,7 @@ export class PerflogMetric extends Metric {
       }
       var completer = PromiseWrapper.completer();
       this._setTimeout(
-        () => completer.complete(this._readUntilEndMark(markName, loopCount+1)),
+        () => completer.resolve(this._readUntilEndMark(markName, loopCount+1)),
         100
       );
       return completer.promise;

--- a/modules/benchpress/src/webdriver/selenium_webdriver_adapter.es6
+++ b/modules/benchpress/src/webdriver/selenium_webdriver_adapter.es6
@@ -21,7 +21,7 @@ export class SeleniumWebDriverAdapter extends WebDriverAdapter {
       // selenium-webdriver uses an own Node.js context,
       // so we need to convert data into objects of this context.
       // (e.g. otherwise instanceof checks of rtts_assert would fail)
-      (data) => completer.complete(convertToLocalProcess(data)),
+      (data) => completer.resolve(convertToLocalProcess(data)),
       completer.reject
     );
     return completer.promise;


### PR DESCRIPTION
- `resolve()` / `reject()` is the JS terminology,
- the current state is inconsistent: `PromiseWrapper.resolve()` / `PromiseWrapper.reject()` but `completer.complete()` / `completer.reject()`
