### PR TITLE
fix(spec): fix spec and perf files path in getBenchmarkFiles function

### DIFF
--- a/protractor-shared.js
+++ b/protractor-shared.js
@@ -104,8 +104,8 @@ var getBenchmarkFiles = function (benchmark, spec) {
   var perfFiles = [];
   if (spec.length) {
     spec.split(',').forEach(function (name) {
-      specFiles.push('dist/js/cjs/**/e2e_test/' + name)
-      perfFiles.push('dist/js/cjs/**/e2e_test/' + name)
+      specFiles.push('dist/js/cjs/**/e2e_test/' + name + '_spec.js');
+      perfFiles.push('dist/js/cjs/**/e2e_test/' + name + '_perf.js');
     });
   } else {
     specFiles.push('dist/js/cjs/**/e2e_test/**/*_spec.js');


### PR DESCRIPTION
By running

```
protractor protractor-js.conf.js --benchmark --spec largetable
```

was causing a file path error, after this PR fix everything start working again.
