### PR TITLE
feat(benchmark): stop minifying code for easier debugging

### DIFF
--- a/modules/benchmarks/pubspec.yaml
+++ b/modules/benchmarks/pubspec.yaml
@@ -7,5 +7,5 @@ dependencies:
   browser: '>=0.10.0 <0.11.0'
 transformers:
 - $dart2js:
-#    minify: false
+    minify: false
     commandLineOptions: ['--dump-info', '--trust-type-annotations', '--trust-primitives']


### PR DESCRIPTION
fixes #805 

Unless there are good reasons for minifying the benchs, this is helpful for debugging (see related issue)
