### PR TITLE
Shadow DOM strategy with global styles

### DIFF
--- a/modules/angular2/src/core/compiler/pipeline/default_steps.js
+++ b/modules/angular2/src/core/compiler/pipeline/default_steps.js
@@ -12,7 +12,7 @@ import {ElementBinderBuilder} from './element_binder_builder';
 import {ResolveCss} from './resolve_css';
 import {ShimShadowDom} from './shim_shadow_dom';
 import {DirectiveMetadata} from 'angular2/src/core/compiler/directive_metadata';
-import {ShadowDomStrategy, EmulatedShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
+import {ShadowDomStrategy, EmulatedScopedShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
 
 /**
  * Default steps used for compiling a template.
@@ -39,7 +39,7 @@ export function createDefaultSteps(
     new ElementBinderBuilder(parser),
   ];
 
-  if (shadowDomStrategy instanceof EmulatedShadowDomStrategy) {
+  if (shadowDomStrategy instanceof EmulatedScopedShadowDomStrategy) {
     var step = new ShimShadowDom(compiledComponent, shadowDomStrategy);
     ListWrapper.push(steps, step);
   }

--- a/modules/angular2/src/core/compiler/style_inliner.js
+++ b/modules/angular2/src/core/compiler/style_inliner.js
@@ -118,11 +118,11 @@ export class StyleInliner {
 
 // Extracts the url from an import rule, supported formats:
 // - 'url' / "url",
-// - url('url') / url("url")
+// - url(url) / url('url') / url("url")
 function _extractUrl(importRule: string): string {
   var match = RegExpWrapper.firstMatch(_urlRe, importRule);
   if (isBlank(match)) return null;
-  return match[1];
+  return isPresent(match[1]) ? match[1] : match[2];
 }
 
 // Extracts the media query from an import rule.
@@ -140,5 +140,8 @@ function _wrapInMediaRule(css: string, query: string): string {
 }
 
 var _importRe = RegExpWrapper.create('@import\\s+([^;]+);');
-var _urlRe = RegExpWrapper.create('(?:url\\(\\s*)?[\'"]([^\'"]+)[\'"]');
+var _urlRe = RegExpWrapper.create(
+  'url\\(\\s*?[\'"]?([^\'")]+)[\'"]?|' + // url(url) or url('url') or url("url")
+  '[\'"]([^\'")]+)[\'"]'                 // "url" or 'url'
+);
 var _mediaQueryRe = RegExpWrapper.create('[\'"][^\'"]+[\'"]\\s*\\)?\\s*(.*)');

--- a/modules/angular2/src/core/compiler/style_url_resolver.js
+++ b/modules/angular2/src/core/compiler/style_url_resolver.js
@@ -34,6 +34,5 @@ export class StyleUrlResolver {
 }
 
 var _cssUrlRe = RegExpWrapper.create('(url\\()([^)]*)(\\))');
-// TODO(vicb): handle the media query part
-var _cssImportRe = RegExpWrapper.create('(@import[\\s]+(?!url\\())([^;]*)(;)');
+var _cssImportRe = RegExpWrapper.create('(@import[\\s]+(?!url\\())[\'"]([^\'"]*)[\'"](.*;)');
 var _quoteRe = RegExpWrapper.create('[\'"]');

--- a/modules/angular2/test/core/compiler/shadow_dom/shadow_dom_emulation_integration_spec.js
+++ b/modules/angular2/test/core/compiler/shadow_dom/shadow_dom_emulation_integration_spec.js
@@ -13,7 +13,9 @@ import {LifeCycle} from 'angular2/src/core/life_cycle/life_cycle';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
 import {ShadowDomStrategy,
         NativeShadowDomStrategy,
-        EmulatedShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
+        EmulatedScopedShadowDomStrategy,
+        EmulatedUnscopedShadowDomStrategy,
+} from 'angular2/src/core/compiler/shadow_dom_strategy';
 import {TemplateLoader} from 'angular2/src/core/compiler/template_loader';
 import {ComponentUrlMapper} from 'angular2/src/core/compiler/component_url_mapper';
 import {UrlResolver} from 'angular2/src/core/compiler/url_resolver';
@@ -35,7 +37,8 @@ export function main() {
 
     StringMapWrapper.forEach({
         "native" : new NativeShadowDomStrategy(styleUrlResolver),
-        "emulated" : new EmulatedShadowDomStrategy(styleInliner, styleUrlResolver, DOM.createElement('div'))
+        "scoped" : new EmulatedScopedShadowDomStrategy(styleInliner, styleUrlResolver, DOM.createElement('div')),
+        "unscoped" : new EmulatedUnscopedShadowDomStrategy(styleUrlResolver, DOM.createElement('div')),
       },
       (strategy, name) => {
 

--- a/modules/angular2/test/core/compiler/style_inliner_spec.js
+++ b/modules/angular2/test/core/compiler/style_inliner_spec.js
@@ -46,7 +46,7 @@ export function main() {
       });
 
       // TODO(vicb): fix the StyleInliner
-      xit('should support url([unquoted url]) in @import rules', (done) => {
+      it('should support url([unquoted url]) in @import rules', (done) => {
         xhr.reply('http://base/one.css', '.one {}');
         var css = '@import url(one.css);.main {}';
         var loadedCss = inliner.inlineImports(css, 'http://base');

--- a/modules/angular2/test/core/compiler/style_url_resolver_spec.js
+++ b/modules/angular2/test/core/compiler/style_url_resolver_spec.js
@@ -5,32 +5,67 @@ import {UrlResolver} from 'angular2/src/core/compiler/url_resolver';
 
 export function main() {
   describe('StyleUrlResolver', () => {
-    it('should resolve urls', () => {
+    it('should resolve "url()" urls', () => {
       var styleUrlResolver = new StyleUrlResolver(new FakeUrlResolver());
       var css = `
-      @import '1.css';
-      @import "2.css";
-      @import url('3.css');
-      @import url("4.css");
-      @import url(5.css);
-
       .foo {
         background-image: url("double.jpg");
         background-image: url('simple.jpg');
         background-image: url(noquote.jpg);
       }`;
       var expectedCss = `
-      @import 'base/1.css';
-      @import 'base/2.css';
-      @import url('base/3.css');
-      @import url('base/4.css');
-      @import url('base/5.css');
-
       .foo {
         background-image: url('base/double.jpg');
         background-image: url('base/simple.jpg');
         background-image: url('base/noquote.jpg');
       }`;
+
+      var resolvedCss = styleUrlResolver.resolveUrls(css, 'base');
+      expect(resolvedCss).toEqual(expectedCss);
+    });
+
+    it('should resolve "@import" urls', () => {
+      var styleUrlResolver = new StyleUrlResolver(new FakeUrlResolver());
+      var css = `
+      @import '1.css';
+      @import "2.css";
+      `;
+      var expectedCss = `
+      @import 'base/1.css';
+      @import 'base/2.css';
+      `;
+
+      var resolvedCss = styleUrlResolver.resolveUrls(css, 'base');
+      expect(resolvedCss).toEqual(expectedCss);
+    });
+
+    it('should resolve "@import url()" urls', () => {
+      var styleUrlResolver = new StyleUrlResolver(new FakeUrlResolver());
+      var css = `
+      @import url('3.css');
+      @import url("4.css");
+      @import url(5.css);
+      `;
+      var expectedCss = `
+      @import url('base/3.css');
+      @import url('base/4.css');
+      @import url('base/5.css');
+      `;
+
+      var resolvedCss = styleUrlResolver.resolveUrls(css, 'base');
+      expect(resolvedCss).toEqual(expectedCss);
+    });
+
+    it('should support media query in "@import"', () => {
+      var styleUrlResolver = new StyleUrlResolver(new FakeUrlResolver());
+      var css = `
+      @import 'print.css' print;
+      @import url(print.css) print;
+      `;
+      var expectedCss = `
+      @import 'base/print.css' print;
+      @import url('base/print.css') print;
+      `;
 
       var resolvedCss = styleUrlResolver.resolveUrls(css, 'base');
       expect(resolvedCss).toEqual(expectedCss);

--- a/modules/angular2/test/core/compiler/view_spec.js
+++ b/modules/angular2/test/core/compiler/view_spec.js
@@ -1,7 +1,7 @@
 import {describe, xit, it, expect, beforeEach, ddescribe, iit, el, proxy} from 'angular2/test_lib';
 import {ProtoView, ElementPropertyMemento, DirectivePropertyMemento} from 'angular2/src/core/compiler/view';
 import {ProtoElementInjector, ElementInjector, DirectiveBinding} from 'angular2/src/core/compiler/element_injector';
-import {EmulatedShadowDomStrategy, NativeShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
+import {EmulatedScopedShadowDomStrategy, NativeShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
 import {Component, Decorator, Viewport, Directive, onChange} from 'angular2/src/core/annotations/annotations';
 import {Lexer, Parser, DynamicProtoChangeDetector,
@@ -396,7 +396,7 @@ export function main() {
             new DynamicProtoChangeDetector(null), null);
 
           var pv = new ProtoView(el('<cmp class="ng-binding"></cmp>'),
-            new DynamicProtoChangeDetector(null), new EmulatedShadowDomStrategy(null, null, null));
+            new DynamicProtoChangeDetector(null), new EmulatedScopedShadowDomStrategy(null, null, null));
           var binder = pv.bindElement(new ProtoElementInjector(null, 0, [SomeComponent], true));
           binder.componentDirective = new DirectiveMetadataReader().read(SomeComponent);
           binder.nestedProtoView = subpv;


### PR DESCRIPTION
- The new strategy do not scope component styles but make them global,
- The former `EmulatedShadowStrategy` has been renamed to `EmulatedScopedShadowDomStrategy`. It does scope the styles.

We now have
- `EmulatedScopedShadowDomStrategy`,
- `EmulatedUnscopedShadowDomStrategy`,
- `NativeShadowDomStrategy`

I'm not really happy with the names, what about
- `ScopedShadowDomStrategy`,
- `UnscopedShadowDomStrategy`,
- `NativeShadowDomStrategy`

any better proposal is welcome !
