### PR TITLE
feat(RegExp): expose match indexes in Dart

### DIFF
--- a/modules/angular2/src/facade/lang.dart
+++ b/modules/angular2/src/facade/lang.dart
@@ -137,12 +137,22 @@ class RegExpWrapper {
 }
 
 class RegExpMatcherWrapper {
-  static Match next(Iterator<Match> matcher) {
+  static _JSLikeMatch next(Iterator<Match> matcher) {
     if (matcher.moveNext()) {
-      return matcher.current;
+      return new _JSLikeMatch(matcher.current);
     }
     return null;
   }
+}
+
+class _JSLikeMatch {
+  Match _m;
+
+  _JSLikeMatch(this._m);
+
+  String operator[](index) => _m[index];
+  int get index => _m.start;
+  int get length => _m.groupCount + 1;
 }
 
 class FunctionWrapper {

--- a/modules/angular2/test/facade/lang_spec.js
+++ b/modules/angular2/test/facade/lang_spec.js
@@ -1,0 +1,24 @@
+import {describe, it, expect, beforeEach, ddescribe, iit, xit, el} from 'angular2/test_lib';
+
+import {ListWrapper} from 'angular2/src/facade/collection';
+import {isPresent, RegExpWrapper, RegExpMatcherWrapper} from 'angular2/src/facade/lang';
+
+export function main() {
+  describe('RegExp', () => {
+    it('should expose the index for each match', () => {
+      var re = RegExpWrapper.create('(!)');
+      var matcher = RegExpWrapper.matcher(re, '0!23!567!!');
+      var indexes = [];
+      var m;
+
+      while (isPresent(m = RegExpMatcherWrapper.next(matcher))) {
+        ListWrapper.push(indexes, m.index);
+        expect(m[0]).toEqual('!');
+        expect(m[1]).toEqual('!');
+        expect(m.length).toBe(2);
+      }
+
+      expect(indexes).toEqual([1, 4, 8, 9]);
+    })
+ });
+}


### PR DESCRIPTION
This is something that will be needed to improve the CSS Inliner and not inline `@import` rules that are commented out.
