### PR TITLE
[Question]: async tests in Dart vs JS

### DIFF
--- a/modules/angular2/test/facade/async_spec.js
+++ b/modules/angular2/test/facade/async_spec.js
@@ -1,0 +1,31 @@
+import {describe, it, expect, beforeEach, ddescribe, iit, xit, el} from 'angular2/test_lib';
+
+import {PromiseWrapper} from 'angular2/src/facade/async';
+
+export function main() {
+  ddescribe('PromiseWrapper', () => {
+    it('should report uncaught error in Promises', () => {
+      PromiseWrapper.reject('error');
+    });
+
+    it('should work in the same in JS and Dart', (done) => {
+      var rejected = PromiseWrapper.reject('error');
+
+      // rejected.then(function(_) { ... }); would produce the same result, ie fail in Dart only
+      PromiseWrapper.then(rejected,
+        function(_) { return 'resolved'; },
+        null
+      );
+
+      PromiseWrapper.then(rejected,
+        function(_) {
+          throw 'failure: error expected';
+        },
+        function(e) {
+          expect(e).toEqual('error');
+          done();
+        }
+      );
+    });
+ });
+}


### PR DESCRIPTION
While working on #861, I've notice this difference in JS vs Dart testing:
- Dart would throw for uncaught error in promise,
- JS would ignore them.

This PR has been created so that we try to make the behavior consistent between Dart & JS while refactoring the tests. **It is not intended to be merged as is**

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular/864)

<!-- Reviewable:end -->
