### PR TITLE
feat(Directives): add the ability to declaratively bind events

### DIFF
--- a/modules/angular2/src/core/annotations/annotations.js
+++ b/modules/angular2/src/core/annotations/annotations.js
@@ -8,16 +8,19 @@ export class Directive {
   lightDomServices:any; //List;
   implementsTypes:any; //List;
   lifecycle:any; //List
+  events:any; //List
   @CONST()
   constructor({
       selector,
       bind,
+      events,
       lightDomServices,
       implementsTypes,
       lifecycle
     }:{
       selector:string,
       bind:any,
+      events: any,
       lightDomServices:List,
       implementsTypes:List,
       lifecycle:List
@@ -27,6 +30,7 @@ export class Directive {
     this.lightDomServices = lightDomServices;
     this.implementsTypes = implementsTypes;
     this.bind = bind;
+    this.events = events;
     this.lifecycle = lifecycle;
   }
 
@@ -37,15 +41,14 @@ export class Directive {
 
 export class Component extends Directive {
   //TODO: vsavkin: uncomment it once the issue with defining fields in a sublass works
-  lightDomServices:any; //List;
   shadowDomServices:any; //List;
   componentServices:any; //List;
-  lifecycle:any; //List
 
 @CONST()
   constructor({
     selector,
     bind,
+    events,
     lightDomServices,
     shadowDomServices,
     componentServices,
@@ -54,6 +57,7 @@ export class Component extends Directive {
     }:{
       selector:String,
       bind:Object,
+      events:Object,
       lightDomServices:List,
       shadowDomServices:List,
       componentServices:List,
@@ -64,15 +68,14 @@ export class Component extends Directive {
     super({
       selector: selector,
       bind: bind,
+      events: events,
       lightDomServices: lightDomServices,
       implementsTypes: implementsTypes,
       lifecycle: lifecycle
     });
 
-    this.lightDomServices = lightDomServices;
     this.shadowDomServices = shadowDomServices;
     this.componentServices = componentServices;
-    this.lifecycle = lifecycle;
   }
 }
 
@@ -82,6 +85,7 @@ export class Decorator extends Directive {
   constructor({
       selector,
       bind,
+      events,
       lightDomServices,
       implementsTypes,
       lifecycle,
@@ -89,6 +93,7 @@ export class Decorator extends Directive {
     }:{
       selector:string,
       bind:any,
+      events:any,
       lightDomServices:List,
       implementsTypes:List,
       lifecycle:List,
@@ -99,6 +104,7 @@ export class Decorator extends Directive {
     super({
         selector: selector,
         bind: bind,
+        events: events,
         lightDomServices: lightDomServices,
         implementsTypes: implementsTypes,
         lifecycle: lifecycle
@@ -111,6 +117,7 @@ export class Viewport extends Directive {
   constructor({
       selector,
       bind,
+      events,
       lightDomServices,
       implementsTypes,
       lifecycle
@@ -125,6 +132,7 @@ export class Viewport extends Directive {
     super({
         selector: selector,
         bind: bind,
+        events: events,
         lightDomServices: lightDomServices,
         implementsTypes: implementsTypes,
         lifecycle: lifecycle

--- a/modules/angular2/src/core/compiler/element_binder.js
+++ b/modules/angular2/src/core/compiler/element_binder.js
@@ -1,6 +1,6 @@
 import {ProtoElementInjector} from './element_injector';
 import {DirectiveMetadata} from './directive_metadata';
-import {List, Map} from 'angular2/src/facade/collection';
+import {List, StringMap} from 'angular2/src/facade/collection';
 import {ProtoView} from './view';
 
 export class ElementBinder {
@@ -10,7 +10,7 @@ export class ElementBinder {
   textNodeIndices:List<int>;
   hasElementPropertyBindings:boolean;
   nestedProtoView: ProtoView;
-  events:Map;
+  events:StringMap;
   constructor(
     protoElementInjector: ProtoElementInjector, componentDirective:DirectiveMetadata,
     viewportDirective:DirectiveMetadata) {

--- a/modules/angular2/src/core/compiler/element_injector.js
+++ b/modules/angular2/src/core/compiler/element_injector.js
@@ -1,6 +1,6 @@
 import {FIELD, isPresent, isBlank, Type, int, BaseException} from 'angular2/src/facade/lang';
 import {Math} from 'angular2/src/facade/math';
-import {List, ListWrapper, MapWrapper, StringMap, StringMapWrapper} from 'angular2/src/facade/collection';
+import {List, ListWrapper, MapWrapper} from 'angular2/src/facade/collection';
 import {Injector, Key, Dependency, bind, Binding, NoProviderError, ProviderError, CyclicDependencyError} from 'angular2/di';
 import {Parent, Ancestor} from 'angular2/src/core/annotations/visibility';
 import {EventEmitter, PropertySetter} from 'angular2/src/core/annotations/di';
@@ -17,8 +17,6 @@ var _MAX_DIRECTIVE_CONSTRUCTION_COUNTER = 10;
 var MAX_DEPTH = Math.pow(2, 30) - 1;
 
 var _undefined = new Object();
-
-var _noop = function(_) {};
 
 var _staticKeys;
 
@@ -272,9 +270,8 @@ export class ProtoElementInjector  {
     }
   }
 
-  instantiate(parent:ElementInjector, host:ElementInjector, events,
-     reflector: Reflector):ElementInjector {
-    return new ElementInjector(this, parent, host, events, reflector);
+  instantiate(parent:ElementInjector, host:ElementInjector, reflector: Reflector):ElementInjector {
+    return new ElementInjector(this, parent, host, reflector);
   }
 
   directParent(): ProtoElementInjector {
@@ -327,11 +324,10 @@ export class ElementInjector extends TreeNode {
   _obj9:any;
   _preBuiltObjects;
   _constructionCounter;
-  _events:StringMap;
   _refelector: Reflector;
 
   constructor(proto:ProtoElementInjector, parent:ElementInjector, host:ElementInjector,
-    events: StringMap, reflector: Reflector) {
+    reflector: Reflector) {
     super(parent);
     if (isPresent(parent) && isPresent(host)) {
       throw new BaseException('Only either parent or host is allowed');
@@ -350,7 +346,6 @@ export class ElementInjector extends TreeNode {
     this._preBuiltObjects = null;
     this._lightDomAppInjector = null;
     this._shadowDomAppInjector = null;
-    this._events = events;
     this._obj0 = null;
     this._obj1 = null;
     this._obj2 = null;
@@ -515,13 +510,9 @@ export class ElementInjector extends TreeNode {
 
   _buildEventEmitter(dep) {
     var view = this._getPreBuiltObjectByKeyId(StaticKeys.instance().viewId);
-    if (isPresent(this._events)) {
-      var eventMap = StringMapWrapper.get(this._events, dep.eventEmitterName);
-      if (isPresent(eventMap)) {
-        return ProtoView.buildEventCallback(eventMap, view, this._proto.index);
-      }
-    }
-    return _noop;
+    return (event) => {
+      view.triggerEventHandlers(dep.eventEmitterName, event, this._proto.index);
+    };
   }
 
   _buildPropSetter(dep) {

--- a/modules/angular2/src/core/compiler/pipeline/compile_element.js
+++ b/modules/angular2/src/core/compiler/pipeline/compile_element.js
@@ -183,7 +183,7 @@ function getElementDescription(domElement):string {
 
   buf.add("<");
   buf.add(DOM.tagName(domElement).toLowerCase());
-  
+
   // show id and class first to ease element identification
   addDescriptionAttribute(buf, "id", MapWrapper.get(atts, "id"));
   addDescriptionAttribute(buf, "class", MapWrapper.get(atts, "class"));

--- a/modules/angular2/src/core/compiler/pipeline/element_binder_builder.js
+++ b/modules/angular2/src/core/compiler/pipeline/element_binder_builder.js
@@ -152,7 +152,9 @@ export class ElementBinderBuilder extends CompileStep {
       if (isPresent(current.eventBindings)) {
         this._bindEvents(protoView, current);
       }
-      this._bindDirectiveProperties(current.getAllDirectives(), current);
+      var directives = current.getAllDirectives();
+      this._bindDirectiveProperties(directives, current);
+      this._bindDirectiveEvents(directives, current);
     } else if (isPresent(parent)) {
       elementBinder = parent.inheritedElementBinder;
     }
@@ -197,6 +199,19 @@ export class ElementBinderBuilder extends CompileStep {
     MapWrapper.forEach(compileElement.eventBindings, (expression, eventName) => {
       protoView.bindEvent(eventName,  expression);
     });
+  }
+
+  _bindDirectiveEvents(directives: List<DirectiveMetadata>, compileElement: CompileElement) {
+    for (var directiveIndex = 0; directiveIndex < directives.length; directiveIndex++) {
+      var directive = directives[directiveIndex];
+      var annotation = directive.annotation;
+      if (isBlank(annotation.events)) continue;
+      var protoView = compileElement.inheritedProtoView;
+      StringMapWrapper.forEach(annotation.events, (action, eventName) => {
+        var expression = this._parser.parseAction(action, compileElement.elementDescription);
+        protoView.bindEvent(eventName, expression, directiveIndex);
+      });
+    }
   }
 
   _bindDirectiveProperties(directives: List<DirectiveMetadata>,

--- a/modules/angular2/test/core/compiler/view_container_spec.js
+++ b/modules/angular2/test/core/compiler/view_container_spec.js
@@ -72,7 +72,7 @@ export function main() {
       parentView = createView([dom.childNodes[0]]);
       protoView = new ProtoView(el('<div>hi</div>'), new DynamicProtoChangeDetector(null),
         new NativeShadowDomStrategy(null));
-      elementInjector = new ElementInjector(null, null, null, null, reflector);
+      elementInjector = new ElementInjector(null, null, null, reflector);
       viewContainer = new ViewContainer(parentView, insertionElement, protoView, elementInjector,
         null, reflector);
       customViewWithOneNode = createView([el('<div>single</div>')]);

--- a/modules/angular2/test/core/compiler/view_spec.js
+++ b/modules/angular2/test/core/compiler/view_spec.js
@@ -264,7 +264,7 @@ export function main() {
           pv.bindElement(testProtoElementInjector);
 
           var hostProtoInjector = new ProtoElementInjector(null, 0, []);
-          var hostInjector = hostProtoInjector.instantiate(null, null, null, reflector);
+          var hostInjector = hostProtoInjector.instantiate(null, null, reflector);
           var view;
           expect(() => view = pv.instantiate(hostInjector, null, reflector)).not.toThrow();
           expect(testProtoElementInjector.parentElementInjector).toBe(view.elementInjectors[0]);
@@ -279,7 +279,7 @@ export function main() {
           pv.bindElement(testProtoElementInjector);
 
           var hostProtoInjector = new ProtoElementInjector(null, 0, []);
-          var hostInjector = hostProtoInjector.instantiate(null, null, null, reflector);
+          var hostInjector = hostProtoInjector.instantiate(null, null, reflector);
           expect(() => pv.instantiate(hostInjector, null, reflector)).not.toThrow();
           expect(testProtoElementInjector.parentElementInjector).toBeNull();
           expect(testProtoElementInjector.hostElementInjector).toBe(hostInjector);
@@ -751,11 +751,10 @@ class TestProtoElementInjector extends ProtoElementInjector {
     super(parent, index, bindings, firstBindingIsComponent);
   }
 
-  instantiate(parent:ElementInjector, host:ElementInjector, events,
-              reflector: Reflector):ElementInjector {
+  instantiate(parent:ElementInjector, host:ElementInjector, reflector: Reflector):ElementInjector {
     this.parentElementInjector = parent;
     this.hostElementInjector = host;
-    return super.instantiate(parent, host, events, reflector);
+    return super.instantiate(parent, host, reflector);
   }
 }
 

--- a/modules/angular2/test/core/compiler/view_spec.js
+++ b/modules/angular2/test/core/compiler/view_spec.js
@@ -519,6 +519,20 @@ export function main() {
 
           expect(called).toEqual(1);
         });
+
+        it('should bind to directive events', () => {
+          var pv = new ProtoView(el('<div class="ng-binding"></div>'),
+            new DynamicProtoChangeDetector(null), null);
+          pv.bindElement(new ProtoElementInjector(null, 0, [SomeDirectiveWithEventHandler]));
+          pv.bindEvent('click', parser.parseAction('onEvent($event)', null), 0);
+          view = createView(pv, new EventManager([new DomEventsPlugin()], new FakeVmTurnZone()));
+
+          var directive = view.elementInjectors[0].get(SomeDirectiveWithEventHandler);
+          expect(directive.event).toEqual(null);
+
+          dispatchClick(view.nodes[0]);
+          expect(directive.event).toBe(dispatchedEvent);
+        });
       });
 
       describe('react to record changes', () => {
@@ -690,7 +704,6 @@ class SomeViewport {
   }
 }
 
-
 class AnotherDirective {
   prop:string;
   constructor() {
@@ -708,6 +721,17 @@ class EventEmitterDirective {
   }
 }
 
+class SomeDirectiveWithEventHandler {
+  event;
+
+  constructor() {
+    this.event = null;
+  }
+
+  onEvent(event) {
+    this.event = event;
+  }
+}
 
 class MyEvaluationContext {
   foo:string;

--- a/modules/benchmarks/src/element_injector/element_injector_benchmark.js
+++ b/modules/benchmarks/src/element_injector/element_injector_benchmark.js
@@ -33,11 +33,11 @@ export function main() {
 
   var bindings = [A, B, C];
   var proto = new ProtoElementInjector(null, 0, bindings);
-  var elementInjector = proto.instantiate(null, null, null, null);
+  var elementInjector = proto.instantiate(null, null, null);
 
   function instantiate () {
     for (var i = 0; i < iterations; ++i) {
-      var ei = proto.instantiate(null, null, null, null);
+      var ei = proto.instantiate(null, null, null);
       ei.instantiateDirectives(appInjector, null, null);
     }
   }


### PR DESCRIPTION
relates to #621 

Some remarks / questions on the implementation:
- the events map specified in the directive annotation maps events to callback, should we map event to actions instead to be more flexible:

``` js
// now
events: {
  'click': 'onClick' // the event is passed as the first & only parameter
}

// what about
events: {
  'click': 'onClick($events)',
  'focus': 'onFocus()',
  'custom': 'onCustom(prop + 3, null, "ng339")',
}
```
- with the current implemenation, it is not possible to declaratively bind to events emitted by the directive itself (via an `EventEmitter`), should this be considered ?

/cc @rkirov @mhevery

TODO:
- [x] squash after review
