### PR TITLE
refactor(compiler): remove direct accesses to DOM

### DIFF
--- a/modules/angular2/src/core/compiler/shadow_dom_emulation/shadow_css.js
+++ b/modules/angular2/src/core/compiler/shadow_dom_emulation/shadow_css.js
@@ -523,28 +523,8 @@ var _polyfillHostRe = RegExpWrapper.create(_polyfillHost, 'im');
 var _colonHostRe = RegExpWrapper.create(':host', 'im');
 var _colonHostContextRe = RegExpWrapper.create(':host-context', 'im');
 
-function _cssTextToStyle(cssText: string) {
-  return DOM.createStyleElement(cssText);
-}
-
 function _cssToRules(cssText: string) {
-  var style = _cssTextToStyle(cssText);
-  DOM.appendChild(DOM.defaultDoc().head, style);
-  var rules = [];
-  if (isPresent(style.sheet)) {
-    // TODO(sorvell): Firefox throws when accessing the rules of a stylesheet
-    // with an @import
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=625013
-    try {
-      rules = style.sheet.cssRules;
-    } catch(e) {
-      //
-    }
-  } else {
-    // console.warn('sheet not found', style);
-  }
-  DOM.remove(style);
-  return rules;
+  return DOM.cssToRules(cssText);
 }
 
 function _withCssRules(cssText: string, callback: Function) {

--- a/modules/angular2/src/core/compiler/url_resolver.js
+++ b/modules/angular2/src/core/compiler/url_resolver.js
@@ -12,8 +12,8 @@ export class UrlResolver {
 
   resolve(baseUrl: string, url: string): string {
     if (isBlank(baseUrl)) {
-      UrlResolver.a.href = url;
-      return UrlResolver.a.href;
+      DOM.resolveAndSetHref(UrlResolver.a, url, null);
+      return DOM.getHref(UrlResolver.a);
     }
 
     if (isBlank(url) || url == '') return baseUrl;
@@ -28,8 +28,8 @@ export class UrlResolver {
       return url;
     }
 
-    UrlResolver.a.href = baseUrl + '/../' + url;
-    return UrlResolver.a.href;
+    DOM.resolveAndSetHref(UrlResolver.a, baseUrl, url);
+    return DOM.getHref(UrlResolver.a);
   }
 }
 

--- a/modules/angular2/src/dom/browser_adapter.dart
+++ b/modules/angular2/src/dom/browser_adapter.dart
@@ -2,7 +2,8 @@ library angular.core.facade.dom;
 
 import 'dart:html';
 import 'dart:js' show JsObject;
-import 'dom_adapter.dart' show setRootDomAdapter, DomAdapter;
+import 'dom_adapter.dart' show setRootDomAdapter;
+import 'generic_browser_adapter.dart' show GenericBrowserDomAdapter;
 import '../facade/browser.dart';
 
 // WARNING: Do not expose outside this class. Parsing HTML using this
@@ -13,7 +14,7 @@ class _IdentitySanitizer implements NodeTreeSanitizer {
 
 final _identitySanitizer = new _IdentitySanitizer();
 
-class BrowserDomAdapter extends DomAdapter {
+class BrowserDomAdapter extends GenericBrowserDomAdapter {
   static void makeCurrent() {
     setRootDomAdapter(new BrowserDomAdapter());
   }
@@ -196,4 +197,7 @@ class BrowserDomAdapter extends DomAdapter {
   bool isStyleRule(CssRule rule) => rule is CssStyleRule;
   bool isMediaRule(CssRule rule) => rule is CssMediaRule;
   bool isKeyframesRule(CssRule rule) => rule is CssKeyframesRule;
+  String getHref(AnchorElement element) {
+    return element.href;
+  }
 }

--- a/modules/angular2/src/dom/browser_adapter.es6
+++ b/modules/angular2/src/dom/browser_adapter.es6
@@ -1,6 +1,7 @@
 import {List, MapWrapper, ListWrapper} from 'angular2/src/facade/collection';
 import {isPresent} from 'angular2/src/facade/lang';
-import {DomAdapter, setRootDomAdapter} from './dom_adapter';
+import {setRootDomAdapter} from './dom_adapter';
+import {GenericBrowserDomAdapter} from './generic_browser_adapter';
 
 var _attrToPropMap = {
   'inner-html': 'innerHTML',
@@ -8,7 +9,7 @@ var _attrToPropMap = {
   'tabindex': 'tabIndex',
 };
 
-export class BrowserDomAdapter extends DomAdapter {
+export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   static makeCurrent() {
     setRootDomAdapter(new BrowserDomAdapter());
   }
@@ -263,5 +264,8 @@ export class BrowserDomAdapter extends DomAdapter {
   }
   isKeyframesRule(rule): boolean {
     return rule.type === CSSRule.KEYFRAMES_RULE;
+  }
+  getHref(el:Element): string {
+    return el.href;
   }
 }

--- a/modules/angular2/src/dom/dom_adapter.js
+++ b/modules/angular2/src/dom/dom_adapter.js
@@ -240,4 +240,13 @@ export class DomAdapter {
   isKeyframesRule(rule): boolean {
     throw _abstract();
   }
+  getHref(element): string {
+    throw _abstract();
+  }
+  resolveAndSetHref(element, baseUrl:string, href:string) {
+    throw _abstract();
+  }
+  cssToRules(css:string): List {
+    throw _abstract();
+  }
 }

--- a/modules/angular2/src/dom/generic_browser_adapter.js
+++ b/modules/angular2/src/dom/generic_browser_adapter.js
@@ -1,0 +1,37 @@
+import {ABSTRACT} from 'angular2/src/facade/lang';
+import {List, ListWrapper} from 'angular2/src/facade/collection';
+import {isPresent} from 'angular2/src/facade/lang';
+import {DomAdapter} from './dom_adapter';
+
+/**
+ * Provides DOM operations in any browser environment.
+ */
+@ABSTRACT()
+export class GenericBrowserDomAdapter extends DomAdapter {
+  resolveAndSetHref(el, baseUrl:string, href:string) {
+    el.href = href == null ? baseUrl : baseUrl + '/../' + href;
+  }
+  cssToRules(css:string): List {
+    var style = this.createStyleElement(css);
+    this.appendChild(this.defaultDoc().head, style);
+    var rules = ListWrapper.create();
+    if (isPresent(style.sheet)) {
+      // TODO(sorvell): Firefox throws when accessing the rules of a stylesheet
+      // with an @import
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=625013
+      try {
+        var rawRules = style.sheet.cssRules;
+        rules = ListWrapper.createFixedSize(rawRules.length);
+        for (var i=0; i<rawRules.length; i++) {
+          rules[i] = rawRules[i];
+        }
+      } catch(e) {
+        //
+      }
+    } else {
+      // console.warn('sheet not found', style);
+    }
+    this.remove(style);
+    return rules;
+  }
+}

--- a/modules/angular2/src/dom/html5lib_adapter.dart
+++ b/modules/angular2/src/dom/html5lib_adapter.dart
@@ -226,4 +226,13 @@ class Html5LibDomAdapter implements DomAdapter {
   bool isKeyframesRule(rule) {
     throw 'not implemented';
   }
+  String getHref(element) {
+    throw 'not implemented';
+  }
+  void resolveAndSetHref(element, baseUrl, href) {
+    throw 'not implemented';
+  }
+  List cssToRules(String css) {
+    throw 'not implemented';
+  }
 }


### PR DESCRIPTION
Needed to run all compiler tests with a DOM adapter.
