### PR TITLE
refactor(compiler): remove direct accesses to DOM in tests

### DIFF
--- a/modules/angular2/test/core/compiler/pipeline/element_binder_builder_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/element_binder_builder_spec.js
@@ -29,13 +29,13 @@ export function main() {
       return new CompilePipeline([
         new MockStep((parent, current, control) => {
             var hasBinding = false;
-            if (isPresent(current.element.getAttribute('text-binding'))) {
+            if (isPresent(DOM.getAttribute(current.element, 'text-binding'))) {
               MapWrapper.forEach(textNodeBindings, (v,k) => {
                 current.addTextNodeBinding(k, parser.parseBinding(v, null));
               });
               hasBinding = true;
             }
-            if (isPresent(current.element.getAttribute('prop-binding'))) {
+            if (isPresent(DOM.getAttribute(current.element, 'prop-binding'))) {
               if (isPresent(propertyBindings)) {
                 MapWrapper.forEach(propertyBindings, (v,k) => {
                   current.addPropertyBinding(k, parser.parseBinding(v, null));
@@ -43,13 +43,13 @@ export function main() {
               }
               hasBinding = true;
             }
-            if (isPresent(current.element.getAttribute('event-binding'))) {
+            if (isPresent(DOM.getAttribute(current.element, 'event-binding'))) {
               MapWrapper.forEach(eventBindings, (v,k) => {
                 current.addEventBinding(k, parser.parseAction(v, null));
               });
               hasBinding = true;
             }
-            if (isPresent(current.element.getAttribute('directives'))) {
+            if (isPresent(DOM.getAttribute(current.element, 'directives'))) {
               hasBinding = true;
               for (var i=0; i<directives.length; i++) {
                 var dirMetadata = reflector.read(directives[i]);
@@ -61,13 +61,13 @@ export function main() {
               DOM.addClass(current.element, 'ng-binding');
             }
             if (isPresent(protoElementInjector) &&
-                (isPresent(current.element.getAttribute('text-binding')) ||
-                 isPresent(current.element.getAttribute('prop-binding')) ||
-                 isPresent(current.element.getAttribute('directives')) ||
-                 isPresent(current.element.getAttribute('event-binding')))) {
+                (isPresent(DOM.getAttribute(current.element, 'text-binding')) ||
+                 isPresent(DOM.getAttribute(current.element, 'prop-binding')) ||
+                 isPresent(DOM.getAttribute(current.element, 'directives')) ||
+                 isPresent(DOM.getAttribute(current.element, 'event-binding')))) {
               current.inheritedProtoElementInjector = protoElementInjector;
             }
-            if (isPresent(current.element.getAttribute('viewroot'))) {
+            if (isPresent(DOM.getAttribute(current.element, 'viewroot'))) {
               current.isViewRoot = true;
               current.inheritedProtoView = new ProtoView(
                 current.element,
@@ -338,11 +338,11 @@ export function main() {
 
       evalContext.prop1 = 'red';
       changeDetector.detectChanges();
-      expect(view.nodes[0].style.color).toEqual('red');
+      expect(DOM.getStyle(view.nodes[0], 'color')).toEqual('red');
 
       evalContext.prop1 = 'blue';
       changeDetector.detectChanges();
-      expect(view.nodes[0].style.color).toEqual('blue');
+      expect(DOM.getStyle(view.nodes[0], 'color')).toEqual('blue');
     });
 
     it('should bind style with a dot and suffix', () => {

--- a/modules/angular2/test/core/compiler/pipeline/pipeline_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/pipeline_spec.js
@@ -105,7 +105,7 @@ export function main() {
         var newChild = new CompileElement(el('<div id="3"></div>'));
         var pipeline = new CompilePipeline([
           new MockStep((parent, current, control) => {
-            if (StringWrapper.equals(current.element.id, '1')) {
+            if (StringWrapper.equals(DOM.getAttribute(current.element, 'id'), '1')) {
               control.addChild(newChild);
             }
           }),
@@ -144,9 +144,9 @@ export class IgnoreChildrenStep extends CompileStep {
 function logEntry(log, parent, current) {
   var parentId = '';
   if (isPresent(parent)) {
-    parentId = parent.element.getAttribute('id')+'<';
+    parentId = DOM.getAttribute(parent.element, 'id') + '<';
   }
-  ListWrapper.push(log, parentId+current.element.getAttribute('id'));
+  ListWrapper.push(log, parentId + DOM.getAttribute(current.element, 'id'));
 }
 
 function createLoggerStep(log) {
@@ -158,7 +158,7 @@ function createLoggerStep(log) {
 function createWrapperStep(wrapperId, log) {
   var nextElementId = 0;
   return new MockStep((parent, current, control) => {
-    var parentCountStr = current.element.getAttribute(wrapperId);
+    var parentCountStr = DOM.getAttribute(current.element, wrapperId);
     if (isPresent(parentCountStr)) {
       var parentCount = NumberWrapper.parseInt(parentCountStr, 10);
       while (parentCount > 0) {

--- a/modules/angular2/test/core/compiler/pipeline/proto_element_injector_builder_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/proto_element_injector_builder_spec.js
@@ -1,5 +1,6 @@
 import {describe, beforeEach, it, expect, iit, ddescribe, el} from 'angular2/test_lib';
 import {isPresent, isBlank} from 'angular2/src/facade/lang';
+import {DOM} from 'angular2/src/dom/dom_adapter';
 import {List, ListWrapper, MapWrapper} from 'angular2/src/facade/collection';
 
 import {ProtoElementInjectorBuilder} from 'angular2/src/core/compiler/pipeline/proto_element_injector_builder';
@@ -33,11 +34,11 @@ export function main() {
       }
       var reader = new DirectiveMetadataReader();
       return new CompilePipeline([new MockStep((parent, current, control) => {
-        if (isPresent(current.element.getAttribute('viewroot'))) {
+        if (isPresent(DOM.getAttribute(current.element, 'viewroot'))) {
           current.isViewRoot = true;
         }
 
-        if (isPresent(current.element.getAttribute('directives'))) {
+        if (isPresent(DOM.getAttribute(current.element, 'directives'))) {
           for (var i=0; i<directives.length; i++) {
             var dirMetadata = reader.read(directives[i]);
             current.addDirective(dirMetadata);
@@ -45,7 +46,7 @@ export function main() {
         }
 
         // Check only for the hard-coded var- attribute from ELEMENT_WITH_VAR test element.
-        if (isPresent(current.element.getAttribute('var-name'))) {
+        if (isPresent(DOM.getAttribute(current.element, 'var-name'))) {
           current.variableBindings = MapWrapper.create();
           MapWrapper.set(current.variableBindings, '\$implicit', 'name');
         }

--- a/modules/angular2/test/core/compiler/pipeline/proto_view_builder_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/proto_view_builder_spec.js
@@ -1,5 +1,6 @@
 import {describe, beforeEach, it, expect, iit, ddescribe, el} from 'angular2/test_lib';
 import {isPresent} from 'angular2/src/facade/lang';
+import {DOM} from 'angular2/src/dom/dom_adapter';
 import {dynamicChangeDetection} from 'angular2/change_detection';
 import {ElementBinder} from 'angular2/src/core/compiler/element_binder';
 import {ProtoViewBuilder} from 'angular2/src/core/compiler/pipeline/proto_view_builder';
@@ -14,10 +15,10 @@ export function main() {
   describe('ProtoViewBuilder', () => {
     function createPipeline(variableBindings = null) {
       return new CompilePipeline([new MockStep((parent, current, control) => {
-        if (isPresent(current.element.getAttribute('viewroot'))) {
+        if (isPresent(DOM.getAttribute(current.element, 'viewroot'))) {
           current.isViewRoot = true;
         }
-        if (isPresent(current.element.getAttribute('var-binding'))) {
+        if (isPresent(DOM.getAttribute(current.element, 'var-binding'))) {
           current.variableBindings = MapWrapper.createFromStringMap(variableBindings);
         }
         current.inheritedElementBinder = new ElementBinder(null, null, null);

--- a/modules/angular2/test/core/compiler/pipeline/view_splitter_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/view_splitter_spec.js
@@ -25,6 +25,7 @@ export function main() {
       it('should move the content into a new <template> element and mark that as viewRoot', () => {
         var rootElement = el('<div><template if="true">a</template></div>');
         var results = createPipeline().process(rootElement);
+
         expect(DOM.getOuterHTML(results[1].element)).toEqual('<template if="true"></template>');
         expect(results[1].isViewRoot).toBe(false);
         expect(DOM.getOuterHTML(results[2].element)).toEqual('<template>a</template>');
@@ -60,7 +61,7 @@ export function main() {
 
       it('should work with top-level template node', () => {
         var rootElement = DOM.createTemplate('<div template>x</div>');
-        var originalChild = rootElement.content.childNodes[0];
+        var originalChild = DOM.content(rootElement).childNodes[0];
         var results = createPipeline().process(rootElement);
 
         expect(results[0].element).toBe(rootElement);
@@ -119,7 +120,7 @@ export function main() {
 
       it('should work with top-level template node', () => {
         var rootElement = DOM.createTemplate('<div *foo>x</div>');
-        var originalChild = rootElement.content.childNodes[0];
+        var originalChild = DOM.content(rootElement).childNodes[0];
         var results = createPipeline().process(rootElement);
 
         expect(results[0].element).toBe(rootElement);

--- a/modules/angular2/test/core/compiler/selector_spec.js
+++ b/modules/angular2/test/core/compiler/selector_spec.js
@@ -1,4 +1,5 @@
 import {describe, it, expect, beforeEach, ddescribe, iit, xit, el} from 'angular2/test_lib';
+import {DOM} from 'angular2/src/dom/dom_adapter';
 import {SelectorMatcher} from 'angular2/src/core/compiler/selector';
 import {CssSelector} from 'angular2/src/core/compiler/selector';
 import {List, ListWrapper, MapWrapper} from 'angular2/src/facade/collection';
@@ -70,7 +71,7 @@ export function main() {
 
       var elementSelector = new CssSelector();
       var element = el('<div attr></div>');
-      var empty = element.getAttribute('attr');
+      var empty = DOM.getAttribute(element, 'attr');
       elementSelector.addAttribute('some-decor', empty);
       matcher.match(elementSelector, selectableCollector);
       expect(matched).toEqual([s1,1]);

--- a/modules/angular2/test/core/compiler/template_loader_spec.js
+++ b/modules/angular2/test/core/compiler/template_loader_spec.js
@@ -1,4 +1,5 @@
 import {describe, it, expect, beforeEach, ddescribe, iit, xit, el} from 'angular2/test_lib';
+import {DOM} from 'angular2/src/dom/dom_adapter';
 import {TemplateLoader} from 'angular2/src/core/compiler/template_loader';
 import {UrlResolver} from 'angular2/src/core/compiler/url_resolver';
 
@@ -17,7 +18,7 @@ export function main() {
 
     it('should load inline templates synchronously', () => {
       var template = new Template({inline: 'inline template'});
-      expect(loader.load(template).content).toHaveText('inline template');
+      expect(DOM.content(loader.load(template))).toHaveText('inline template');
     });
 
     it('should load templates through XHR', (done) => {
@@ -25,7 +26,7 @@ export function main() {
       var template = new Template({url: '/foo'});
       loader.setBaseUrl(template, 'base');
       loader.load(template).then((el) => {
-        expect(el.content).toHaveText('xhr template');
+        expect(DOM.content(el)).toHaveText('xhr template');
         done();
       });
       xhr.flush();
@@ -43,7 +44,7 @@ export function main() {
         })
         .then((el) =>{
           expect(el).toBe(firstEl);
-          expect(el.content).toHaveText('xhr template');
+          expect(DOM.content(el)).toHaveText('xhr template');
           done();
         });
       xhr.flush();

--- a/modules/angular2/test/core/compiler/view_spec.js
+++ b/modules/angular2/test/core/compiler/view_spec.js
@@ -138,7 +138,7 @@ export function main() {
           var view = pv.instantiate(null, null, reflector);
           view.hydrate(null, null, null);
           expect(view.nodes.length).toBe(1);
-          expect(view.nodes[0].getAttribute('id')).toEqual('1');
+          expect(DOM.getAttribute(view.nodes[0], 'id')).toEqual('1');
         });
 
         describe('collect elements with property bindings', () => {


### PR DESCRIPTION
Needed to run all compiler tests with a DOM adapter.
