### PR TITLE
feat: introduce Title service

### DIFF
--- a/modules/angular2/src/dom/browser_adapter.dart
+++ b/modules/angular2/src/dom/browser_adapter.dart
@@ -173,6 +173,10 @@ class BrowserDomAdapter extends DomAdapter {
       document.implementation.createHtmlDocument('fakeTitle');
 
   HtmlDocument defaultDoc() => document;
+  String getTitle() => document.title;
+  void setTitle(String newTitle) {
+    document.title = newTitle;
+  }
   bool elementMatches(n, String selector) =>
       n is Element && n.matches(selector);
   bool isTemplateElement(Element el) =>

--- a/modules/angular2/src/dom/browser_adapter.es6
+++ b/modules/angular2/src/dom/browser_adapter.es6
@@ -215,6 +215,12 @@ export class BrowserDomAdapter extends DomAdapter {
   defaultDoc() {
     return document;
   }
+  getTitle() {
+    return document.title;
+  }
+  setTitle(newTitle:string) {
+    document.title = newTitle;
+  }
   elementMatches(n, selector:string):boolean {
     return n instanceof HTMLElement && n.matches(selector);
   }

--- a/modules/angular2/src/dom/dom_adapter.js
+++ b/modules/angular2/src/dom/dom_adapter.js
@@ -201,6 +201,12 @@ export class DomAdapter {
   defaultDoc() {
     throw _abstract();
   }
+  getTitle() {
+    throw _abstract();
+  }
+  setTitle(newTitle:string) {
+    throw _abstract();
+  }
   elementMatches(n, selector:string):boolean {
     throw _abstract();
   }

--- a/modules/angular2/src/services/title.js
+++ b/modules/angular2/src/services/title.js
@@ -1,0 +1,12 @@
+import {DOM} from 'angular2/src/dom/dom_adapter';
+
+export class Title {
+
+  getTitle():string {
+    return DOM.getTitle();
+  }
+
+  setTitle(newTitle:string) {
+    DOM.setTitle(newTitle);
+  }
+}

--- a/modules/angular2/test/services/title_spec.js
+++ b/modules/angular2/test/services/title_spec.js
@@ -1,0 +1,32 @@
+import {ddescribe, describe, it, iit, xit, expect, afterEach} from 'angular2/test_lib';
+import {DOM} from 'angular2/src/dom/dom_adapter';
+
+import {Title} from 'angular2/src/services/title';
+
+export function main() {
+
+  describe('title service', () => {
+    var initialTitle = DOM.getTitle();
+    var titleService = new Title();
+
+    afterEach(() => {
+      DOM.setTitle(initialTitle);
+    });
+
+    it('should allow reading initial title', () => {
+      expect(titleService.getTitle()).toEqual(initialTitle);
+    });
+
+    it('should set a title on the injected document', () => {
+      titleService.setTitle('test title');
+      expect(DOM.getTitle()).toEqual('test title');
+      expect(titleService.getTitle()).toEqual('test title');
+    });
+
+    it('should reset title to empty string if title not provided', () => {
+      titleService.setTitle(null);
+      expect(DOM.getTitle()).toEqual('');
+    });
+
+  });
+}


### PR DESCRIPTION
This is a new stab at #612

With the change from DOM facade to DOM adapters it doesn't seem possible / desirable to inject document instances so all the issues described in #827 is no longer relevant for this particular service.
