### PR TITLE
feat: support binding to camel-cased properties

### DIFF
--- a/modules/angular2/src/core/compiler/pipeline/directive_parser.js
+++ b/modules/angular2/src/core/compiler/pipeline/directive_parser.js
@@ -10,7 +10,8 @@ import {CompileStep} from './compile_step';
 import {CompileElement} from './compile_element';
 import {CompileControl} from './compile_control';
 
-import {isSpecialProperty} from './element_binder_builder';;
+import {isSpecialProperty} from './element_binder_builder';
+import {dashCaseToCamelCase} from './util';
 
 var PROPERTY_BINDING_REGEXP = RegExpWrapper.create('^ *([^\\s\\|]+)');
 
@@ -72,7 +73,7 @@ export class DirectiveParser extends CompileStep {
     // only be present on <template> elements any more!
     var isTemplateElement = DOM.isTemplateElement(current.element);
     var matchedProperties; // StringMap - used in dev mode to store all properties that have been matched
-    
+
     this._selectorMatcher.match(cssSelector, (selector, directive) => {
       matchedProperties = updateMatchedProperties(matchedProperties, selector, directive);
       checkDirectiveValidity(directive, current, isTemplateElement);
@@ -139,10 +140,10 @@ function checkMissingDirectives(current, matchedProperties, isTemplateElement) {
     if (isPresent(ppBindings)) {
       // check that each property corresponds to a real property or has been matched by a directive
       MapWrapper.forEach(ppBindings, (expression, prop) => {
-        if (!DOM.hasProperty(current.element, prop) && !isSpecialProperty(prop)) {
+        if (!DOM.hasProperty(current.element, dashCaseToCamelCase(prop)) && !isSpecialProperty(prop)) {
           if (!isPresent(matchedProperties) || !isPresent(StringMapWrapper.get(matchedProperties, prop))) {
             throw new BaseException(`Missing directive to handle '${prop}' in ${current.elementDescription}`);
-          } 
+          }
         }
       });
     }

--- a/modules/angular2/src/core/compiler/pipeline/element_binder_builder.js
+++ b/modules/angular2/src/core/compiler/pipeline/element_binder_builder.js
@@ -11,6 +11,7 @@ import {DirectiveMetadata} from '../directive_metadata';
 import {CompileStep} from './compile_step';
 import {CompileElement} from './compile_element';
 import {CompileControl} from './compile_control';
+import {dashCaseToCamelCase} from './util';
 
 var DOT_REGEXP = RegExpWrapper.create('\\.');
 
@@ -242,6 +243,6 @@ export class ElementBinderBuilder extends CompileStep {
 
   _resolvePropertyName(attrName:string) {
     var mappedPropName = StringMapWrapper.get(DOM.attrToPropMap, attrName);
-    return isPresent(mappedPropName) ? mappedPropName : attrName;
+    return isPresent(mappedPropName) ? mappedPropName : dashCaseToCamelCase(attrName);
   }
 }

--- a/modules/angular2/src/core/compiler/pipeline/util.js
+++ b/modules/angular2/src/core/compiler/pipeline/util.js
@@ -1,0 +1,9 @@
+import {StringWrapper, RegExpWrapper} from 'angular2/src/facade/lang';
+
+var CAMEL_CASE_REGEXP = RegExpWrapper.create('-([a-z])');
+
+export function dashCaseToCamelCase(input:string) {
+  return StringWrapper.replaceAllMapped(input, CAMEL_CASE_REGEXP, (m) => {
+    return m[1].toUpperCase();
+  });
+}

--- a/modules/angular2/test/core/compiler/integration_spec.js
+++ b/modules/angular2/test/core/compiler/integration_spec.js
@@ -123,6 +123,23 @@ export function main() {
         });
       });
 
+      it('should consume binding to camel-cased properties using dash-cased syntax in templates', (done) => {
+        tplResolver.setTemplate(MyComp, new Template({inline: '<input [read-only]="ctxBoolProp">'}));
+
+        compiler.compile(MyComp).then((pv) => {
+          createView(pv);
+
+          cd.detectChanges();
+          expect(view.nodes[0].readOnly).toBeFalsy();
+
+          ctx.ctxBoolProp = true;
+          cd.detectChanges();
+          expect(view.nodes[0].readOnly).toBeTruthy();
+
+          done();
+        });
+      });
+
       it('should consume binding to inner-html', (done) => {
         tplResolver.setTemplate(MyComp, new Template({inline: '<div inner-html="{{ctxProp}}"></div>'}));
 
@@ -532,9 +549,11 @@ class PushBasedComp {
 class MyComp {
   ctxProp:string;
   ctxNumProp;
+  ctxBoolProp;
   constructor() {
     this.ctxProp = 'initial value';
     this.ctxNumProp = 0;
+    this.ctxBoolProp = false;
   }
 }
 


### PR DESCRIPTION
This is the first stab at #866

While it works for properties, the bigger questions is about properties form that we want to have inside compiler's pipeline, see [my comment in 866](https://github.com/angular/angular/issues/866#issuecomment-78116266)
