### PR TITLE
refactor(view): change view to pass all bindings to proto change detecto...

### DIFF
--- a/modules/angular2/change_detection.js
+++ b/modules/angular2/change_detection.js
@@ -7,7 +7,7 @@ export {ExpressionChangedAfterItHasBeenChecked, ChangeDetectionError}
     from './src/change_detection/exceptions';
 export {ChangeRecord, ChangeDispatcher, ChangeDetector,
     CHECK_ONCE, CHECK_ALWAYS, DETACHED, CHECKED} from './src/change_detection/interfaces';
-export {ProtoChangeDetector, DynamicProtoChangeDetector, JitProtoChangeDetector}
+export {ProtoChangeDetector, DynamicProtoChangeDetector, JitProtoChangeDetector, BindingRecord}
     from './src/change_detection/proto_change_detector';
 export {DynamicChangeDetector}
     from './src/change_detection/dynamic_change_detector';

--- a/modules/angular2/src/change_detection/proto_change_detector.js
+++ b/modules/angular2/src/change_detection/proto_change_detector.js
@@ -45,36 +45,44 @@ import {
 
 export class ProtoChangeDetector  {
   addAst(ast:AST, bindingMemento:any, directiveMemento:any = null){}
-  instantiate(dispatcher:any):ChangeDetector{
+  instantiate(dispatcher:any, bindingRecords:List):ChangeDetector{
     return null;
   }
 }
 
+export class BindingRecord {
+  ast:AST;
+  bindingMemento:any;
+  directiveMemento:any;
+
+  constructor(ast:AST, bindingMemento:any, directiveMemento:any) {
+    this.ast = ast;
+    this.bindingMemento = bindingMemento;
+    this.directiveMemento = directiveMemento;
+  }
+}
+
 export class DynamicProtoChangeDetector extends ProtoChangeDetector {
-  _records:List<ProtoRecord>;
-  _recordBuilder:ProtoRecordBuilder;
   _pipeRegistry:PipeRegistry;
+  _records:List<ProtoRecord>;
 
   constructor(pipeRegistry:PipeRegistry) {
     super();
     this._pipeRegistry = pipeRegistry;
-    this._records = null;
-    this._recordBuilder = new ProtoRecordBuilder();
   }
 
-  addAst(ast:AST, bindingMemento:any, directiveMemento:any = null) {
-    this._recordBuilder.addAst(ast, bindingMemento, directiveMemento);
-  }
-
-  instantiate(dispatcher:any) {
-    this._createRecordsIfNecessary();
+  instantiate(dispatcher:any, bindingRecords:List) {
+    this._createRecordsIfNecessary(bindingRecords);
     return new DynamicChangeDetector(dispatcher, this._pipeRegistry, this._records);
   }
 
-  _createRecordsIfNecessary() {
+  _createRecordsIfNecessary(bindingRecords:List) {
     if (isBlank(this._records)) {
-      var records = this._recordBuilder.records;
-      this._records = coalesce(records);
+      var recordBuilder = new ProtoRecordBuilder();
+      ListWrapper.forEach(bindingRecords, (r) => {
+        recordBuilder.addAst(r.ast, r.bindingMemento, r.directiveMemento);
+      });
+      this._records = coalesce(recordBuilder.records);
     }
   }
 }
@@ -82,29 +90,27 @@ export class DynamicProtoChangeDetector extends ProtoChangeDetector {
 var _jitProtoChangeDetectorClassCounter:number = 0;
 export class JitProtoChangeDetector extends ProtoChangeDetector {
   _factory:Function;
-  _recordBuilder:ProtoRecordBuilder;
   _pipeRegistry;
 
   constructor(pipeRegistry) {
     super();
     this._pipeRegistry = pipeRegistry;
     this._factory = null;
-    this._recordBuilder = new ProtoRecordBuilder();
   }
 
-  addAst(ast:AST, bindingMemento:any, directiveMemento:any = null) {
-    this._recordBuilder.addAst(ast, bindingMemento, directiveMemento);
-  }
-
-  instantiate(dispatcher:any) {
-    this._createFactoryIfNecessary();
+  instantiate(dispatcher:any, bindingRecords:List) {
+    this._createFactoryIfNecessary(bindingRecords);
     return this._factory(dispatcher, this._pipeRegistry);
   }
 
-  _createFactoryIfNecessary() {
+  _createFactoryIfNecessary(bindingRecords:List) {
     if (isBlank(this._factory)) {
+      var recordBuilder = new ProtoRecordBuilder();
+      ListWrapper.forEach(bindingRecords, (r) => {
+        recordBuilder.addAst(r.ast, r.bindingMemento, r.directiveMemento);
+      });
       var c = _jitProtoChangeDetectorClassCounter++;
-      var records = coalesce(this._recordBuilder.records);
+      var records = coalesce(recordBuilder.records);
       var typeName = `ChangeDetector${c}`;
       this._factory = new ChangeDetectorJITGenerator(typeName, records).generate();
     }

--- a/modules/angular2/test/core/compiler/element_injector_spec.js
+++ b/modules/angular2/test/core/compiler/element_injector_spec.js
@@ -12,7 +12,6 @@ import {NgElement} from 'angular2/src/core/dom/element';
 import {LightDom, DestinationLightDom} from 'angular2/src/core/compiler/shadow_dom_emulation/light_dom';
 import {Directive} from 'angular2/src/core/annotations/annotations';
 import {BindingPropagationConfig} from 'angular2/src/core/compiler/binding_propagation_config';
-import {DynamicProtoChangeDetector} from 'angular2/change_detection';
 
 @proxy
 @IMPLEMENTS(View)
@@ -476,7 +475,7 @@ export function main() {
         StringMapWrapper.set(handlers, 'click', (e, view) => { called = true;});
         var pv = new ProtoView(null, null, null);
         pv.eventHandlers = [handlers];
-        var view = new View(pv, null, new DynamicProtoChangeDetector(null), MapWrapper.create());
+        var view = new View(pv, null, MapWrapper.create());
         var preBuildObject = new PreBuiltObjects(view, null, null, null, null);
         var inj = injector([NeedsEventEmitter], null, null, preBuildObject);
         inj.get(NeedsEventEmitter).click();

--- a/modules/angular2/test/core/compiler/view_container_spec.js
+++ b/modules/angular2/test/core/compiler/view_container_spec.js
@@ -10,8 +10,9 @@ import {NativeShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_str
 import {DynamicProtoChangeDetector, ChangeDetector, Lexer, Parser} from 'angular2/change_detection';
 
 function createView(nodes) {
-  var view = new View(null, nodes, new DynamicProtoChangeDetector(null), MapWrapper.create());
-  view.init([], [], [], [], [], [], []);
+  var view = new View(null, nodes, MapWrapper.create());
+  var cd = new DynamicProtoChangeDetector(null).instantiate(view, []);
+  view.init(cd, [], [], [], [], [], [], []);
   return view;
 }
 

--- a/modules/benchmarks/src/change_detection/change_detection_benchmark.js
+++ b/modules/benchmarks/src/change_detection/change_detection_benchmark.js
@@ -10,7 +10,8 @@ import {
   ChangeDispatcher,
   ChangeDetection,
   dynamicChangeDetection,
-  jitChangeDetection
+  jitChangeDetection,
+  BindingRecord
 } from 'angular2/change_detection';
 
 
@@ -104,31 +105,28 @@ function setUpChangeDetection(changeDetection:ChangeDetection, iterations) {
   var parser = new Parser(new Lexer());
 
   var parentProto = changeDetection.createProtoChangeDetector('parent');
-  var parentCd = parentProto.instantiate(dispatcher);
+  var parentCd = parentProto.instantiate(dispatcher, []);
 
   var proto = changeDetection.createProtoChangeDetector("proto");
-  var astWithSource = [
-    parser.parseBinding('field0', null),
-    parser.parseBinding('field1', null),
-    parser.parseBinding('field2', null),
-    parser.parseBinding('field3', null),
-    parser.parseBinding('field4', null),
-    parser.parseBinding('field5', null),
-    parser.parseBinding('field6', null),
-    parser.parseBinding('field7', null),
-    parser.parseBinding('field8', null),
-    parser.parseBinding('field9', null)
+  var bindingRecords = [
+    new BindingRecord(parser.parseBinding('field0', null), "memo", 0),
+    new BindingRecord(parser.parseBinding('field1', null), "memo", 1),
+    new BindingRecord(parser.parseBinding('field2', null), "memo", 2),
+    new BindingRecord(parser.parseBinding('field3', null), "memo", 3),
+    new BindingRecord(parser.parseBinding('field4', null), "memo", 4),
+    new BindingRecord(parser.parseBinding('field5', null), "memo", 5),
+    new BindingRecord(parser.parseBinding('field6', null), "memo", 6),
+    new BindingRecord(parser.parseBinding('field7', null), "memo", 7),
+    new BindingRecord(parser.parseBinding('field8', null), "memo", 8),
+    new BindingRecord(parser.parseBinding('field9', null), "memo", 9)
   ];
-  for (var j = 0; j < 10; ++j) {
-    proto.addAst(astWithSource[j].ast, "memo", j);
-  }
 
   for (var i = 0; i < iterations; ++i) {
     var obj = new Obj();
     for (var j = 0; j < 10; ++j) {
       obj.setField(j, i);
     }
-    var cd = proto.instantiate(dispatcher);
+    var cd = proto.instantiate(dispatcher, bindingRecords);
     cd.hydrate(obj);
     parentCd.addChild(cd);
   }


### PR DESCRIPTION
...r at once

To be efficient we want to split locals from the component. One of the things required to do it is to process all bindings at once.
