### PR TITLE
fix(dart/transform): Use updated package:analyzer

### DIFF
--- a/modules/angular2/pubspec.yaml
+++ b/modules/angular2/pubspec.yaml
@@ -9,7 +9,7 @@ homepage: <%= packageJson.homepage %>
 environment:
   sdk: '>=1.9.0-dev.8.0'
 dependencies:
-  analyzer: '^0.22.4'
+  analyzer: '^0.24.0'
   barback: '^0.15.2+2'
   code_transformers: '^0.2.5'
   dart_style: '^0.1.3'


### PR DESCRIPTION
Updates Angular 2 to use package:analyzer v0.24.0, which contains fixes
for the parsing of `async` and `await`.

Closes #950
