### PR TITLE
fix(TemplateResolver): better error message when bootstrapping non-Component

### DIFF
--- a/modules/angular2/src/core/compiler/template_resolver.js
+++ b/modules/angular2/src/core/compiler/template_resolver.js
@@ -33,6 +33,6 @@ export class TemplateResolver {
       }
     }
 
-    throw new BaseException(`No template found for ${stringify(component)}`);
+    throw new BaseException(`Only Components can be bootstrapped`);
   }
 }


### PR DESCRIPTION
Suggested error message

closes #951
