### PR TITLE
feat(collection): Iterator and Iterable Wrapper

### DIFF
--- a/modules/angular2/src/facade/collection.dart
+++ b/modules/angular2/src/facade/collection.dart
@@ -162,6 +162,30 @@ void iterateListLike(iter, fn(item)) {
   }
 }
 
+class IteratorWrapper {
+  static Iterator iterator(iterable) {
+    return iterable.iterator;
+  }
+  static next(iterable) {
+    return iterable.moveNext();
+  }
+  static value(iterable) {
+    return iterable.current;
+  }
+}
+
+class IterableWrapper {
+  static Iterator iterator(iterable) {
+    return iterable.iterator;
+  }
+  static each(iterable, fn) {
+    assert(iterable is Iterable);
+    for (var item in iterable) {
+      fn(item);
+    }
+  }
+}
+
 class SetWrapper {
   static Set createFromList(List l) => new Set.from(l);
   static bool has(Set s, key) => s.contains(key);

--- a/modules/angular2/src/facade/collection.es6
+++ b/modules/angular2/src/facade/collection.es6
@@ -4,6 +4,7 @@ export var List = global.Array;
 export var Map = global.Map;
 export var Set = global.Set;
 export var StringMap = global.Object;
+//export var Iterator = global.Iterator;
 
 export class MapWrapper {
   static create():Map { return new Map(); }
@@ -217,6 +218,32 @@ export function iterateListLike(obj, fn:Function) {
     }
   }
 }
+
+export class IteratorWrapper {
+  static iterator(iterable) {
+    return iterable[Symbol.iterator]();
+  }
+  static next(iterable) {
+    return iterable.next();
+  }
+  static value(iterable) {
+    return iterable.value();
+  }
+}
+
+export class IterableWrapper {
+  static iterator(iterable) {
+    return iterable[Symbol.iterator]();
+  }
+  static each(iterable, fn) {
+    var iterator = IteratorWrapper.iterator(iterable);
+    var item;
+    while (!((item = IteratorWrapper.next(iterator)).done)) {
+      fn(IteratorWrapper.value(item));
+    }
+  }
+}
+
 
 export class SetWrapper {
   static createFromList(lst:List) { return new Set(lst); }


### PR DESCRIPTION
`IteratorWrapper` allows for perf wins when dealing with js vs dart, for example in the change detection we avoid `megamorphic` hits by avoiding helpers such as `iterateListLike` for arrays. 

``` es6
var index:int = 0;
var item;

// Perf: do not use iterateListLike
if (ListWrapper.isList(collection)) {
  var list = collection;
  this._length = collection.length;

  for (index; index < this._length; index++) {
    item = list[index];
    if (record === null || !looseIdentical(record.item, item)) {
      record = this._mismatch(record, item, index);
      mayBeDirty = true;
    } else if (mayBeDirty) {
      // TODO(misko): can we limit this to duplicates only?
      record = this._verifyReinsertion(record, item, index);
    }
    record = record._next;
  }
} else {
  var iterator = IteratorWrapper.iterator(obj);
  while (!((item = IteratorWrapper.next(iterator).done)) {
    if (record === null || !looseIdentical(record.item, IteratorWrapper.value(item))) {
      record = this._mismatch(record, IteratorWrapper.value(item), index);
      mayBeDirty = true;
    } else if (mayBeDirty) {
      // TODO(misko): can we limit this to duplicates only?
      record = this._verifyReinsertion(record, IteratorWrapper.value(item), index);
    }
    record = record._next;
    index++
  }
  this._length = index;
}
```

with one problem (how do you wrap `.done` for Dart)

`IteratorWrapper` and `IterableWrapper` both raise the question of how everything should be structured along with `.observer` coming into es7 we would need an `ObserverWrapper` that would act like rx.Observable but that would mean it needs to extend from an IterableWrapper base class 

here is my mvp of the wrapper in order to get more feedback
Javascript

``` es6
export class IteratorWrapper() {
  static iterator(iterable) {
    return iterable[Symbol.iterator]();
  }
  static next(iterable) {
    return iterable.next();
  }
  static value(iterable) {
    return iterable.value();
  }
}

export class IterableWrapper() {
  static iterator(iterable) {
    return iterable[Symbol.iterator]();
  }
  static each(iterable, fn) {
    var iterator = IteratorWrapper.iterator(iterable);
    var item;
    while (!((item = IteratorWrapper.next(iterator)).done)) {
      fn(IteratorWrapper.value(item));
    }
  }
}

```

Dart

``` dart
class IteratorWrapper {
  static Iterator iterator(iterable) {
    return iterable.iterator;
  }
  static next(iterable) {
    return iterable.moveNext();
  }
  static value(iterable) {
    return iterable.current;
  }
}

class IterableWrapper {
  static Iterator iterator(iterable) {
    return iterable.iterator;
  }
  static each(iterable, fn) {
    assert(iter is Iterable);
    for (var item in iter) {
      fn(item);
    }
  }
}
```

I am more than happen to extend `IterableWrapper` with all the methods from Dart [Dart Iterable](https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/dart:core.Iterable#id_Iterable-) 
