### PR TITLE
Update build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ If you don't already have `npm`, get it by installing [node.js](http://nodejs.or
 2. `npm install -g gulp` (you might need to prefix this command with `sudo`)
 3. `npm install -g protractor` (you might need to prefix this command with `sudo`)
 4. `webdriver-manager update`
-5. If you plan to use Dart:
+5. `bower install`
+6. If you plan to use Dart:
   1. [Install the Dart SDK](https://www.dartlang.org/tools/sdk/) - Includes the `pub` command line tool. This repository requires `pub` in version `>=1.9.0-dev.8.0 <2.0.0`
   2. [Add the Dart SDK's `bin` directory to your system path](https://www.dartlang.org/tools/pub/installing.html)
   3. Get the pub packages you need: `pub get`
-6. `gulp build`
+7. `gulp build`
 
 ### Folder structure
 


### PR DESCRIPTION
Build will fail without polymer dependancy even if Dart SDK is not
installed.
