### PR TITLE
chore(install): cleanup

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,0 @@
-{
-  "directory": "bower_components/"
-}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "./node_modules/.bin/bower install"
+    "postinstall": "bower install"
   },
   "dependencies": {
     "es6-module-loader": "^0.9.2",


### PR DESCRIPTION
- `package.json`: explicit path to `node_modules/.bin` isn't needed
  since npm prepends it to `PATH`. See [nmp scripts
  doc](https://docs.npmjs.com/misc/scripts#path).
- `.bowerrc`: [Bower's default
  directory](http://bower.io/docs/config/#directory) is
  'bower_components', hence no need to explicitly set it to this value.
