### PR TITLE
chore(test): make it easier to run all JS and Dart tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "url": "https://github.com/angular/angular.git"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "npm run test-js && npm run test-dart",
+    "test-js": "./scripts/ci/test_js.sh",
+    "test-dart": "./scripts/ci/test_dart.sh",
     "postinstall": "./node_modules/.bin/bower install"
   },
   "dependencies": {

--- a/scripts/ci/test_dart.sh
+++ b/scripts/ci/test_dart.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 set -e
 
-MODE=$1
-
 echo =============================================================================
 # go to project dir
 SCRIPT_DIR=$(dirname $0)
 cd $SCRIPT_DIR/../..
 
-${SCRIPT_DIR}/build_$MODE.sh
-${SCRIPT_DIR}/test_$MODE.sh
+${SCRIPT_DIR}/test_unit_dart.sh
+${SCRIPT_DIR}/test_server_dart.sh
+${SCRIPT_DIR}/test_e2e_dart.sh

--- a/scripts/ci/test_e2e_dart.sh
+++ b/scripts/ci/test_e2e_dart.sh
@@ -21,4 +21,4 @@ trap killServer EXIT
 # wait for server to come up!
 sleep 10
 
-./node_modules/.bin/protractor protractor-dart2js.conf.js --browsers=$E2E_BROWSERS
+./node_modules/.bin/protractor protractor-dart2js.conf.js --browsers=${E2E_BROWSERS:-Dartium}

--- a/scripts/ci/test_e2e_js.sh
+++ b/scripts/ci/test_e2e_js.sh
@@ -21,4 +21,4 @@ trap killServer EXIT
 # wait for server to come up!
 sleep 10
 
-./node_modules/.bin/protractor protractor-js.conf.js --browsers=$E2E_BROWSERS
+./node_modules/.bin/protractor protractor-js.conf.js --browsers=${E2E_BROWSERS:-Dartium}

--- a/scripts/ci/test_js.sh
+++ b/scripts/ci/test_js.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 set -e
 
-MODE=$1
-
 echo =============================================================================
 # go to project dir
 SCRIPT_DIR=$(dirname $0)
 cd $SCRIPT_DIR/../..
 
-${SCRIPT_DIR}/build_$MODE.sh
-${SCRIPT_DIR}/test_$MODE.sh
+${SCRIPT_DIR}/test_unit_js.sh
+# ${SCRIPT_DIR}/test_server_js.sh # JS doesn't yet have server tests
+${SCRIPT_DIR}/test_e2e_js.sh


### PR DESCRIPTION
Performed a slight refactoring of CI scripts to make it easier for developers to run the **same** tests as those run on Travis. Defined `npm` scripts `test-js` and `test-dart`; also `npm test` now runs the whole lot.

(I will update the `DEVELOPER.md` once its PR #946 is accepted :) )
