### PR TITLE
docs(application.js): ensure bootstrap promise,

### DIFF
--- a/modules/angular2/src/core/application.js
+++ b/modules/angular2/src/core/application.js
@@ -135,15 +135,15 @@ function _createVmZone(givenReporter:Function): VmTurnZone {
  * 
  * An application is bootstrapped inside an existing browser DOM, typically `index.html`. Unlike Angular 1, Angular 2
  * does not compile/process bindings in `index.html`. This is mainly for security reasons, as well as architectural
- * changes in Angular 2. This means that `index.html` can safely be processed using server-side binding technologies,
- * which may use double-curly `{{syntax}}` without collision from Angular 2 component double-curly `{{syntax}}`.
+ * changes in Angular 2. This means that `index.html` can safely be processed using server-side technologies such as bindings.
+ * (which may use double-curly `{{ syntax }}` without collision from Angular 2 component double-curly `{{ syntax }}`.)
  * 
  * We can use this script code:
  *     @Component({
  *        selector: 'my-app'   
  *     })
  *     @Template({
- *        inline: 'Hello {{name}}!'
+ *        inline: 'Hello {{ name }}!'
  *     })
  *     class MyApp {
  *       name:string;
@@ -154,7 +154,7 @@ function _createVmZone(givenReporter:Function): VmTurnZone {
  *     }
  * 
  *     main() {
- *       bootstrap(MyApp);
+ *       return bootstrap(MyApp);
  *     }
  * 
  * When the app developer invokes `bootstrap()` with the root component `MyApp` as its argument, Angular performs the 
@@ -188,7 +188,7 @@ function _createVmZone(givenReporter:Function): VmTurnZone {
  * 
  * If you need to bootstrap multiple applications that share common data, the applications must share a common 
  * change detection and zone. To do that, create a meta-component that lists the application components in its template.
- * By only  invoking the bootstrap()` method once with the meta-component as its argument, you ensure that only a single
+ * By only invoking the `bootstrap()` method once, with the meta-component as its argument, you ensure that only a single
  * change detection zone is created and therefore data can be shared across the applications.
  * 
  * 
@@ -210,7 +210,7 @@ function _createVmZone(givenReporter:Function): VmTurnZone {
  *   override default injection behavior.
  * - [errorReporter]: `function(exception:any, stackTrace:string)` a default error reporter for unhandled exceptions.
  * 
- * Returns the application`s private [Injector].
+ * Returns a [Promise] with the application`s private [Injector].
  */
 export function bootstrap(appComponentType: Type, 
                           componentServiceBindings: List<Binding>=null, 


### PR DESCRIPTION
so people using something like systemjs won't break the promise chain and at the same time shows that it's a promise

``` es6
Promise.all({
  app1: System.import('app1').then(module => module.main()),
  app2: System.import('app2').then(module => module.main()),
  app3: System.import('app3').then(module => module.main())
})
.then(function(injectors) {
  console.log('dem injectors', injectors);
});
```
