### PR TITLE
feat(build): check circular depencies in Node.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var gulpPlugins = require('gulp-load-plugins')();
 var runSequence = require('run-sequence');
+var madge = require('madge');
 var merge = require('merge');
 var gulpTraceur = require('./tools/transpiler/gulp-traceur');
 
@@ -457,6 +458,25 @@ gulp.task('build/format.dart', rundartpackage(gulp, gulpPlugins, {
   args: CONFIG.formatDart.args
 }));
 
+// ------------
+// check circular dependencies in Node.js context
+gulp.task('build/checkCircularDependencies', function (done) {
+  var dependencyObject = madge(CONFIG.dest.js.dev.es6, {
+    format: 'es6',
+    paths: [CONFIG.dest.js.dev.es6],
+    extensions: ['.js', '.es6'],
+    onParseFile: function(data) {
+      data.src = data.src.replace(/import \* as/g, "//import * as");
+    }
+  });
+  var circularDependencies = dependencyObject.circular().getArray();
+  if (circularDependencies.length > 0) {
+    console.log(circularDependencies);
+    process.exit(1);
+  }
+  done();
+});
+
 // ------------------
 // web servers
 gulp.task('serve.js.dev', jsserve(gulp, gulpPlugins, {
@@ -623,6 +643,7 @@ gulp.task('build.dart', function(done) {
 gulp.task('build.js.dev', function(done) {
   runSequence(
     ['build/transpile.js.dev', 'build/html.js.dev', 'build/copy.js.dev', 'build/multicopy.js.dev.es6'],
+    'build/checkCircularDependencies',
     done
   );
 });

--- a/modules/angular2/src/core/compiler/element_binder.js
+++ b/modules/angular2/src/core/compiler/element_binder.js
@@ -2,7 +2,7 @@ import {int, isBlank, BaseException} from 'angular2/src/facade/lang';
 import {ProtoElementInjector} from './element_injector';
 import {DirectiveMetadata} from './directive_metadata';
 import {List, StringMap} from 'angular2/src/facade/collection';
-import {ProtoView} from './view';
+import * as viewModule from './view';
 
 export class ElementBinder {
   protoElementInjector:ProtoElementInjector;
@@ -10,7 +10,7 @@ export class ElementBinder {
   viewportDirective:DirectiveMetadata;
   textNodeIndices:List<int>;
   hasElementPropertyBindings:boolean;
-  nestedProtoView: ProtoView;
+  nestedProtoView: viewModule.ProtoView;
   events:StringMap;
   contentTagSelector:string;
   parent:ElementBinder;

--- a/modules/angular2/src/core/compiler/pipeline/compile_element.js
+++ b/modules/angular2/src/core/compiler/pipeline/compile_element.js
@@ -5,7 +5,7 @@ import {DirectiveMetadata} from '../directive_metadata';
 import {Decorator, Component, Viewport} from '../../annotations/annotations';
 import {ElementBinder} from '../element_binder';
 import {ProtoElementInjector} from '../element_injector';
-import {ProtoView} from '../view';
+import * as viewModule from '../view';
 import {dashCaseToCamelCase} from './util';
 
 import {AST} from 'angular2/change_detection';
@@ -33,7 +33,7 @@ export class CompileElement {
   _allDirectives:List<DirectiveMetadata>;
   isViewRoot:boolean;
   hasBindings:boolean;
-  inheritedProtoView:ProtoView;
+  inheritedProtoView:viewModule.ProtoView;
   inheritedProtoElementInjector:ProtoElementInjector;
   inheritedElementBinder:ElementBinder;
   distanceToParentInjector:int;

--- a/modules/angular2/src/core/compiler/pipeline/compile_step.js
+++ b/modules/angular2/src/core/compiler/pipeline/compile_step.js
@@ -1,10 +1,10 @@
 import {CompileElement} from './compile_element';
-import {CompileControl} from './compile_control';
+import * as ccModule from './compile_control';
 
 /**
  * One part of the compile process.
  * Is guaranteed to be called in depth first order
  */
 export class CompileStep {
-  process(parent:CompileElement, current:CompileElement, control:CompileControl) {}
+  process(parent:CompileElement, current:CompileElement, control:ccModule.CompileControl) {}
 }

--- a/modules/angular2/src/core/compiler/view_container.js
+++ b/modules/angular2/src/core/compiler/view_container.js
@@ -6,19 +6,19 @@ import {Injector} from 'angular2/di';
 import * as eiModule from 'angular2/src/core/compiler/element_injector';
 import {isPresent, isBlank} from 'angular2/src/facade/lang';
 import {EventManager} from 'angular2/src/core/events/event_manager';
-import * as ldModule from './shadow_dom_emulation/light_dom';
+import {LightDom} from './shadow_dom_emulation/light_dom';
 
 export class ViewContainer {
   parentView: viewModule.View;
   templateElement;
   defaultProtoView: viewModule.ProtoView;
   _views: List<viewModule.View>;
-  _lightDom: ldModule.LightDom;
+  _lightDom: LightDom;
   _eventManager: EventManager;
   elementInjector: eiModule.ElementInjector;
   appInjector: Injector;
   hostElementInjector: eiModule.ElementInjector;
-  hostLightDom: ldModule.LightDom;
+  hostLightDom: LightDom;
 
   constructor(parentView: viewModule.View,
               templateElement,
@@ -40,7 +40,7 @@ export class ViewContainer {
     this._eventManager = eventManager;
   }
 
-  hydrate(appInjector: Injector, hostElementInjector: eiModule.ElementInjector, hostLightDom: ldModule.LightDom) {
+  hydrate(appInjector: Injector, hostElementInjector: eiModule.ElementInjector, hostLightDom: LightDom) {
     this.appInjector = appInjector;
     this.hostElementInjector = hostElementInjector;
     this.hostLightDom = hostLightDom;

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "karma-dart": "^0.2.8",
     "karma-jasmine": "^0.2.2",
     "lodash": "^2.4.1",
+    "madge": "mlaval/madge#es6",
     "merge": "^1.2.0",
     "minimatch": "^2.0.1",
     "minimist": "1.1.x",


### PR DESCRIPTION
Introduces a new step in the build process which checks for circular dependencies to avoid issues in Node, as we saw in #931.
In fact, the check is done **after** removing all `import * as ...` since they are safe there.

It relies on [madge](https://github.com/pahen/madge) in which support of ES6 modules has been added: https://github.com/pahen/madge/pull/53.

The travis build is expected to fail here :)
