### PR TITLE
Added link to the developer channel for the Dart SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you don't already have `npm`, get it by installing [node.js](http://nodejs.or
 3. `npm install -g protractor` (you might need to prefix this command with `sudo`)
 4. `webdriver-manager update`
 5. If you plan to use Dart:
-  1. [Install the Dart SDK](https://www.dartlang.org/tools/sdk/) - Includes the `pub` command line tool. This repository requires `pub` in version `>=1.9.0-dev.8.0 <2.0.0`
+  1. [Install the Dart SDK](https://www.dartlang.org/tools/sdk/) - Includes the `pub` command line tool. This repository requires `pub` in version `>=1.9.0-dev.8.0 <2.0.0` [(In the developer channel)](https://www.dartlang.org/tools/download-archive/)
   2. [Add the Dart SDK's `bin` directory to your system path](https://www.dartlang.org/tools/pub/installing.html)
   3. Get the pub packages you need: `pub get`
 6. `gulp build`


### PR DESCRIPTION
There is not an easy way to navigate to the version of the Dart SDK.  Just one small step to aid in getting people to try out angular2.
