### PR TITLE
feat(di): Add the `@Injectable` annotation

### DIFF
--- a/modules/angular2/di.js
+++ b/modules/angular2/di.js
@@ -1,4 +1,4 @@
-export {Inject, InjectPromise, InjectLazy, Optional, DependencyAnnotation} from './src/di/annotations';
+export {Inject, InjectPromise, InjectLazy, Injectable, Optional, DependencyAnnotation} from './src/di/annotations';
 export {Injector} from './src/di/injector';
 export {Binding, Dependency, bind} from './src/di/binding';
 export {Key, KeyRegistry} from './src/di/key';

--- a/modules/angular2/src/change_detection/parser/lexer.js
+++ b/modules/angular2/src/change_detection/parser/lexer.js
@@ -1,3 +1,4 @@
+import {Injectable} from 'angular2/di';
 import {List, ListWrapper, SetWrapper} from "angular2/src/facade/collection";
 import {int, NumberWrapper, StringJoiner, StringWrapper} from "angular2/src/facade/lang";
 
@@ -8,6 +9,7 @@ export const TOKEN_TYPE_STRING     = 4;
 export const TOKEN_TYPE_OPERATOR   = 5;
 export const TOKEN_TYPE_NUMBER     = 6;
 
+@Injectable()
 export class Lexer {
   text:string;
   tokenize(text:string):List {

--- a/modules/angular2/src/change_detection/parser/parser.js
+++ b/modules/angular2/src/change_detection/parser/parser.js
@@ -1,3 +1,4 @@
+import {Injectable} from 'angular2/di';
 import {int, isBlank, isPresent,  BaseException, StringWrapper, RegExpWrapper} from 'angular2/src/facade/lang';
 import {ListWrapper, List} from 'angular2/src/facade/collection';
 import {Lexer, EOF, Token, $PERIOD, $COLON, $SEMICOLON, $LBRACKET, $RBRACKET,
@@ -32,6 +33,7 @@ var _implicitReceiver = new ImplicitReceiver();
 var INTERPOLATION_REGEXP = RegExpWrapper.create('\\{\\{(.*?)\\}\\}');
 var QUOTE_REGEXP = RegExpWrapper.create("'");
 
+@Injectable()
 export class Parser {
   _lexer:Lexer;
   _reflector:Reflector;

--- a/modules/angular2/src/core/annotations/annotations.js
+++ b/modules/angular2/src/core/annotations/annotations.js
@@ -1,5 +1,6 @@
 import {ABSTRACT, CONST, normalizeBlank, isPresent} from 'angular2/src/facade/lang';
 import {ListWrapper, List} from 'angular2/src/facade/collection';
+import {Injectable} from 'angular2/di';
 
 // type StringMap = {[idx: string]: string};
 
@@ -10,7 +11,7 @@ import {ListWrapper, List} from 'angular2/src/facade/collection';
  * @publicModule angular2/angular2
  */
 @ABSTRACT()
-export class Directive {
+export class Directive extends Injectable {
   /**
    * The CSS selector that triggers the instantiation of a directive.
    *
@@ -189,6 +190,7 @@ export class Directive {
       lifecycle:List
     }={})
   {
+    super();
     this.selector = selector;
     this.bind = bind;
     this.events = events;

--- a/modules/angular2/src/core/compiler/compiler.js
+++ b/modules/angular2/src/core/compiler/compiler.js
@@ -1,3 +1,4 @@
+import {Injectable} from 'angular2/di';
 import {Type, isBlank, isPresent, BaseException, normalizeBlank, stringify} from 'angular2/src/facade/lang';
 import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
 import {List, ListWrapper, Map, MapWrapper} from 'angular2/src/facade/collection';
@@ -23,6 +24,7 @@ import {CssProcessor} from './css_processor';
  * Used to prevent duplicate work and resolve cyclic dependencies.
  * @publicModule angular2/angular2
  */
+@Injectable()
 export class CompilerCache {
   _cache:Map;
   constructor() {
@@ -49,6 +51,7 @@ export class CompilerCache {
  * the CompilePipeline and the CompileSteps.
  * @publicModule angular2/angular2
  */
+@Injectable()
 export class Compiler {
   _reader: DirectiveMetadataReader;
   _parser:Parser;

--- a/modules/angular2/src/core/compiler/component_url_mapper.js
+++ b/modules/angular2/src/core/compiler/component_url_mapper.js
@@ -1,6 +1,8 @@
+import {Injectable} from 'angular2/di';
 import {Type, isPresent} from 'angular2/src/facade/lang';
 import {Map, MapWrapper} from 'angular2/src/facade/collection';
 
+@Injectable()
 export class ComponentUrlMapper {
   // Returns the base URL to the component source file.
   // The returned URL could be:

--- a/modules/angular2/src/core/compiler/css_processor.js
+++ b/modules/angular2/src/core/compiler/css_processor.js
@@ -1,3 +1,4 @@
+import {Injectable} from 'angular2/di';
 import {DOM} from 'angular2/src/dom/dom_adapter';
 
 import {isPresent} from 'angular2/src/facade/lang';
@@ -15,6 +16,7 @@ import {DirectiveMetadata} from './directive_metadata';
  * - Apply any given transformers,
  * - Apply the shadow DOM strategy style step.
  */
+@Injectable()
 export class CssProcessor {
   _transformers: List<CssTransformer>;
 

--- a/modules/angular2/src/core/compiler/directive_metadata_reader.js
+++ b/modules/angular2/src/core/compiler/directive_metadata_reader.js
@@ -1,8 +1,10 @@
+import {Injectable} from 'angular2/di';
 import {Type, isPresent, BaseException, stringify} from 'angular2/src/facade/lang';
 import {Directive} from '../annotations/annotations';
 import {DirectiveMetadata} from './directive_metadata';
 import {reflector} from 'angular2/src/reflection/reflection';
 
+@Injectable()
 export class DirectiveMetadataReader {
   read(type:Type):DirectiveMetadata {
     var annotations = reflector.annotations(type);

--- a/modules/angular2/src/core/compiler/shadow_dom_emulation/content_tag.js
+++ b/modules/angular2/src/core/compiler/shadow_dom_emulation/content_tag.js
@@ -1,4 +1,5 @@
 import * as ldModule from './light_dom';
+import {Inject, Injectable} from 'angular2/di';
 import {DOM} from 'angular2/src/dom/dom_adapter';
 import {isPresent} from 'angular2/src/facade/lang';
 import {List, ListWrapper} from 'angular2/src/facade/collection';
@@ -13,6 +14,7 @@ class ContentStrategy {
  * It is used when the content tag is not a direct child of another component,
  * and thus does not affect redistribution.
  */
+@Injectable()
 class RenderedContent extends ContentStrategy {
   beginScript;
   endScript;

--- a/modules/angular2/src/core/compiler/shadow_dom_strategy.js
+++ b/modules/angular2/src/core/compiler/shadow_dom_strategy.js
@@ -1,3 +1,4 @@
+import {Injectable} from 'angular2/di';
 import {Type, isBlank, isPresent, int, StringWrapper, assertionsEnabled} from 'angular2/src/facade/lang';
 import {List, ListWrapper, MapWrapper, Map} from 'angular2/src/facade/collection';
 import {PromiseWrapper} from 'angular2/src/facade/async';
@@ -77,6 +78,7 @@ export class ShadowDomStrategy {
  * - styles are **not** scoped to their component and will apply to the whole document,
  * - you can **not** use shadow DOM specific selectors in the styles
  */
+@Injectable()
 export class EmulatedUnscopedShadowDomStrategy extends ShadowDomStrategy {
   _styleUrlResolver: StyleUrlResolver;
   _styleHost;
@@ -118,6 +120,7 @@ export class EmulatedUnscopedShadowDomStrategy extends ShadowDomStrategy {
  * - a common subset of shadow DOM selectors are supported,
  * - see `ShadowCss` for more information and limitations.
  */
+@Injectable()
 export class EmulatedScopedShadowDomStrategy extends EmulatedUnscopedShadowDomStrategy {
   _styleInliner: StyleInliner;
 
@@ -148,6 +151,7 @@ export class EmulatedScopedShadowDomStrategy extends EmulatedUnscopedShadowDomSt
  * The templates for the component are inserted in a Shadow Root created on the component element.
  * Hence they are strictly isolated.
  */
+@Injectable()
 export class NativeShadowDomStrategy extends ShadowDomStrategy {
   _styleUrlResolver: StyleUrlResolver;
 

--- a/modules/angular2/src/core/compiler/style_inliner.js
+++ b/modules/angular2/src/core/compiler/style_inliner.js
@@ -1,3 +1,4 @@
+import {Injectable} from 'angular2/di';
 import {XHR} from 'angular2/src/core/compiler/xhr/xhr';
 import {StyleUrlResolver} from 'angular2/src/core/compiler/style_url_resolver';
 import {UrlResolver} from 'angular2/src/core/compiler/url_resolver';
@@ -21,6 +22,7 @@ import {
  *
  * When an @import rules is inlined, it's url are rewritten.
  */
+@Injectable()
 export class StyleInliner {
   _xhr: XHR;
   _urlResolver: UrlResolver;

--- a/modules/angular2/src/core/compiler/style_url_resolver.js
+++ b/modules/angular2/src/core/compiler/style_url_resolver.js
@@ -1,12 +1,14 @@
 // Some of the code comes from WebComponents.JS
 // https://github.com/webcomponents/webcomponentsjs/blob/master/src/HTMLImports/path.js
 
+import {Injectable} from 'angular2/di';
 import {RegExp, RegExpWrapper, StringWrapper} from 'angular2/src/facade/lang';
 import {UrlResolver} from './url_resolver';
 
 /**
  * Rewrites URLs by resolving '@import' and 'url()' URLs from the given base URL.
  */
+@Injectable()
 export class StyleUrlResolver {
   _resolver: UrlResolver;
 

--- a/modules/angular2/src/core/compiler/template_loader.js
+++ b/modules/angular2/src/core/compiler/template_loader.js
@@ -1,3 +1,4 @@
+import {Injectable} from 'angular2/di';
 import {isBlank, isPresent, BaseException, stringify} from 'angular2/src/facade/lang';
 import {Map, MapWrapper, StringMapWrapper, StringMap} from 'angular2/src/facade/collection';
 import {DOM} from 'angular2/src/dom/dom_adapter';
@@ -12,6 +13,7 @@ import {UrlResolver} from './url_resolver';
  * Strategy to load component templates.
  * @publicModule angular2/angular2
  */
+@Injectable()
 export class TemplateLoader {
   _xhr: XHR;
   _htmlCache: StringMap;

--- a/modules/angular2/src/core/compiler/template_resolver.js
+++ b/modules/angular2/src/core/compiler/template_resolver.js
@@ -1,3 +1,4 @@
+import {Injectable} from 'angular2/di';
 import {Template} from 'angular2/src/core/annotations/template';
 
 import {Type, stringify, isBlank, BaseException} from 'angular2/src/facade/lang';
@@ -6,6 +7,7 @@ import {Map, MapWrapper, List, ListWrapper} from 'angular2/src/facade/collection
 import {reflector} from 'angular2/src/reflection/reflection';
 
 
+@Injectable()
 export class TemplateResolver {
   _cache: Map;
 

--- a/modules/angular2/src/core/compiler/url_resolver.js
+++ b/modules/angular2/src/core/compiler/url_resolver.js
@@ -1,6 +1,8 @@
+import {Injectable} from 'angular2/di';
 import {isPresent, isBlank, RegExpWrapper, BaseException} from 'angular2/src/facade/lang';
 import {DOM} from 'angular2/src/dom/dom_adapter';
 
+@Injectable()
 export class UrlResolver {
   static a;
 

--- a/modules/angular2/src/core/compiler/xhr/xhr_impl.dart
+++ b/modules/angular2/src/core/compiler/xhr/xhr_impl.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 import 'dart:html';
+import 'package:angular2/di.dart';
 import './xhr.dart' show XHR;
 
+@Injectable()
 class XHRImpl extends XHR {
   Future<String> get(String url) {
     return HttpRequest.request(url).then(

--- a/modules/angular2/src/core/compiler/xhr/xhr_impl.es6
+++ b/modules/angular2/src/core/compiler/xhr/xhr_impl.es6
@@ -1,6 +1,8 @@
+import {Injectable} from 'angular2/di';
 import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
 import {XHR} from './xhr';
 
+@Injectable()
 export class XHRImpl extends XHR {
   get(url: string): Promise<string> {
     var completer = PromiseWrapper.completer();

--- a/modules/angular2/src/core/exception_handler.js
+++ b/modules/angular2/src/core/exception_handler.js
@@ -1,6 +1,8 @@
+import {Injectable} from 'angular2/di';
 import {isPresent, print} from 'angular2/src/facade/lang';
 import {ListWrapper, isListLikeIterable} from 'angular2/src/facade/collection';
 
+@Injectable()
 export class ExceptionHandler {
   call(error, stackTrace = null, reason = null) {
     var longStackTrace = isListLikeIterable(stackTrace) ? ListWrapper.join(stackTrace, "\n\n") : stackTrace;

--- a/modules/angular2/src/core/life_cycle/life_cycle.js
+++ b/modules/angular2/src/core/life_cycle/life_cycle.js
@@ -1,8 +1,10 @@
+import {Injectable} from 'angular2/di';
 import {ChangeDetector} from 'angular2/change_detection';
 import {VmTurnZone} from 'angular2/src/core/zone/vm_turn_zone';
 import {ExceptionHandler} from 'angular2/src/core/exception_handler';
 import {isPresent} from 'angular2/src/facade/lang';
 
+@Injectable()
 export class LifeCycle {
   _errorHandler;
   _changeDetector:ChangeDetector;

--- a/modules/angular2/src/di/annotations.js
+++ b/modules/angular2/src/di/annotations.js
@@ -108,3 +108,22 @@ export class DependencyAnnotation {
   constructor() {
   }
 }
+
+/**
+ * A class annotation that marks a class as available to `Injector`s for
+ * creation.
+ *
+ * ```
+ * class NeedsService {
+ *   constructor(svc:UsefulService) {}
+ * }
+ *
+ * @Injectable
+ * class UsefulService {}
+ * ```
+ */
+export class Injectable {
+  @CONST()
+  constructor() {
+  }
+}

--- a/modules/examples/src/hello_world/index_common.js
+++ b/modules/examples/src/hello_world/index_common.js
@@ -1,4 +1,5 @@
 import {bootstrap, Component, Decorator, Template, NgElement} from 'angular2/angular2';
+import {Injectable} from 'angular2/di';
 
 // Angular 2.0 supports 3 basic types of directives:
 // - Component - the basic building blocks of Angular 2.0 apps. Backed by
@@ -52,7 +53,8 @@ class RedDec {
   }
 }
 
-// A service used by the HelloCmp component.
+// A service available to the Injector, used by the HelloCmp component.
+@Injectable()
 class GreetingService {
   greeting:string;
   constructor() {


### PR DESCRIPTION
- Add an annotation marking a class as available to `Injector`s.
- Mark `Compiler` and its dependencies as available to the `Injector`.
- Modify hello_world to use `@Injectable`.
