### PR TITLE
fix(PropertyBindingParser): properly parse event bindings with assigements

### DIFF
--- a/modules/angular2/src/core/compiler/pipeline/property_binding_parser.js
+++ b/modules/angular2/src/core/compiler/pipeline/property_binding_parser.js
@@ -66,7 +66,7 @@ export class PropertyBindingParser extends CompileStep {
           MapWrapper.set(newAttrs, bindParts[5], attrValue);
         } else if (isPresent(bindParts[6])) {
           // match: (event)
-          current.addEventBinding(bindParts[6], this._parseBinding(attrValue, desc));
+          current.addEventBinding(bindParts[6], this._parseAction(attrValue, desc));
         }
       } else {
         var ast = this._parseInterpolation(attrValue, desc);

--- a/modules/angular2/test/core/compiler/pipeline/property_binding_parser_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/property_binding_parser_spec.js
@@ -68,12 +68,21 @@ export function main() {
       // "(click[])" is not an expected syntax and is only used to validate the regexp
       results = createPipeline().process(el('<div (click[])="b()"></div>'));
       expect(MapWrapper.get(results[0].eventBindings, 'click[]').source).toEqual('b()');
+    });
 
+    it('should parse event handlers using () syntax as actions', () => {
+      var results = createPipeline().process(el('<div (click)="foo=bar"></div>'));
+      expect(MapWrapper.get(results[0].eventBindings, 'click').source).toEqual('foo=bar');
     });
 
     it('should detect on- syntax', () => {
       var results = createPipeline().process(el('<div on-click="b()"></div>'));
       expect(MapWrapper.get(results[0].eventBindings, 'click').source).toEqual('b()');
+    });
+
+    it('should parse event handlers using on- syntax as actions', () => {
+      var results = createPipeline().process(el('<div on-click="foo=bar"></div>'));
+      expect(MapWrapper.get(results[0].eventBindings, 'click').source).toEqual('foo=bar');
     });
   });
 }


### PR DESCRIPTION
Fixes #981
