### PR TITLE
fix(examples): Fix type registration in hello_world

### DIFF
--- a/modules/examples/src/hello_world/index_static.js
+++ b/modules/examples/src/hello_world/index_static.js
@@ -152,9 +152,9 @@ function setup() {
   });
 
   reflector.registerType(Content, {
-    "factory": (lightDom, el) => new Content(lightDom, el),
-    "parameters": [[DestinationLightDom], [NgElement]],
-    "annotations" : [new Decorator({selector: '[content]'})]
+    "factory": (lightDom, el, selector) => new Content(lightDom, el, selector),
+    "parameters": [[DestinationLightDom], [NgElement], [String]],
+    "annotations" : []
   });
 
   reflector.registerType(StyleInliner, {


### PR DESCRIPTION
Fixing `registerType` call for `Content` in index_static.js.
