### PR TITLE
feat(query): adds initial implementation of the query api.

### DIFF
--- a/modules/angular2/src/core/annotations/di.js
+++ b/modules/angular2/src/core/annotations/di.js
@@ -54,3 +54,15 @@ export class Attribute extends DependencyAnnotation {
     return this;
   }
 }
+
+/**
+ * The directive can inject an query that would reflect a list of ancestor directives
+ */
+export class Query extends DependencyAnnotation {
+  directive;
+  @CONST()
+  constructor(directive) {
+    super();
+    this.directive = directive;
+  }
+}

--- a/modules/angular2/src/core/compiler/query_list.dart
+++ b/modules/angular2/src/core/compiler/query_list.dart
@@ -1,0 +1,47 @@
+library angular2.src.core.compiler.query_list;
+
+import 'package:angular2/src/core/annotations/annotations.dart';
+import 'dart:collection';
+
+/**
+ * Injectable Objects that contains a live list of child directives in the light Dom of a directive.
+ * The directives are kept in depth-first pre-order traversal of the DOM.
+ *
+ * In the future this class will implement an Observable interface.
+ * For now it uses a plain list of observable callbacks.
+ */
+class QueryList extends Object with IterableMixin<Directive> {
+  List<Directive> _results;
+  List _callbacks;
+  bool _dirty;
+
+  QueryList(): _results = [], _callbacks = [], _dirty = false;
+
+  Iterator<Directive> get iterator => _results.iterator;
+
+  reset(newList) {
+    _results = newList;
+    _dirty = true;
+  }
+
+  add(obj) {
+    _results.add(obj);
+    _dirty = true;
+  }
+
+  // TODO(rado): hook up with change detection after #995.
+  fireCallbacks() {
+    if (_dirty) {
+      _callbacks.forEach((c) => c());
+      _dirty = false;
+    }
+  }
+
+  onChange(callback) {
+    this._callbacks.add(callback);
+  }
+
+  removeCallback(callback) {
+    this._callbacks.remove(callback);
+  }
+}

--- a/modules/angular2/src/core/compiler/query_list.es6
+++ b/modules/angular2/src/core/compiler/query_list.es6
@@ -1,0 +1,51 @@
+import {List, MapWrapper, ListWrapper} from 'angular2/src/facade/collection';
+import {Directive} from 'angular2/src/core/annotations/annotations';
+
+/**
+ * Injectable Objects that contains a live list of child directives in the light Dom of a directive.
+ * The directives are kept in depth-first pre-order traversal of the DOM.
+ *
+ * In the future this class will implement an Observable interface.
+ * For now it uses a plain list of observable callbacks.
+ */
+export class QueryList {
+  _results: List<Directive>;
+  _callbacks;
+  _dirty;
+
+  constructor() {
+    this._results = [];
+    this._callbacks = [];
+    this._dirty = false;
+  }
+
+  [Symbol.iterator]() {
+    return this._results[Symbol.iterator]();
+  }
+
+  reset(newList) {
+    this._results = newList;
+    this._dirty = true;
+  }
+
+  add(obj) {
+    ListWrapper.push(this._results, obj);
+    this._dirty = true;
+  }
+
+  // TODO(rado): hook up with change detection after #995.
+  fireCallbacks() {
+    if (this._dirty) {
+      ListWrapper.forEach(this._callbacks, (c) => c());
+      this._dirty = false;
+    }
+  }
+
+  onChange(callback) {
+    ListWrapper.push(this._callbacks, callback);
+  }
+
+  removeCallback(callback) {
+    ListWrapper.remove(this._callbacks, callback);
+  }
+}

--- a/modules/angular2/src/core/compiler/view_container.js
+++ b/modules/angular2/src/core/compiler/view_container.js
@@ -75,6 +75,11 @@ export class ViewContainer {
     return this._views.length;
   }
 
+  _siblingInjectorToLinkAfter(index: number) {
+    if (index == 0) return null;
+    return ListWrapper.last(this._views[index - 1].rootElementInjectors)
+  }
+
   hydrated() {
     return isPresent(this.appInjector);
   }
@@ -106,7 +111,7 @@ export class ViewContainer {
     if (atIndex == -1) atIndex = this._views.length;
     ListWrapper.insert(this._views, atIndex, view);
     this.parentView.changeDetector.addChild(view.changeDetector);
-    this._linkElementInjectors(view);
+    this._linkElementInjectors(this._siblingInjectorToLinkAfter(atIndex), view);
 
     return view;
   }
@@ -133,15 +138,19 @@ export class ViewContainer {
     return detachedView;
   }
 
-  _linkElementInjectors(view) {
-    for (var i = 0; i < view.rootElementInjectors.length; ++i) {
-      view.rootElementInjectors[i].parent = this.elementInjector;
+  contentTagContainers() {
+    return this._views;
+  }
+
+  _linkElementInjectors(sibling, view) {
+    for (var i = view.rootElementInjectors.length - 1; i >= 0; i--) {
+      view.rootElementInjectors[i].linkAfter(this.elementInjector, sibling);
     }
   }
 
   _unlinkElementInjectors(view) {
     for (var i = 0; i < view.rootElementInjectors.length; ++i) {
-      view.rootElementInjectors[i].parent = null;
+      view.rootElementInjectors[i].unlink();
     }
   }
 }

--- a/modules/angular2/src/render/dom/view/view_container.js
+++ b/modules/angular2/src/render/dom/view/view_container.js
@@ -122,6 +122,7 @@ export class ViewContainer {
     return r;
   }
 
+
   static moveViewNodesAfterSibling(sibling, view) {
     for (var i = view.rootNodes.length - 1; i >= 0; --i) {
       DOM.insertAfter(sibling, view.rootNodes[i]);

--- a/modules/angular2/test/core/compiler/query_integration_spec.js
+++ b/modules/angular2/test/core/compiler/query_integration_spec.js
@@ -1,0 +1,122 @@
+import {
+  AsyncTestCompleter,
+  beforeEach,
+  ddescribe,
+  describe,
+  el,
+  expect,
+  iit,
+  inject,
+  IS_NODEJS,
+  it,
+  xit,
+  } from 'angular2/test_lib';
+
+import {TestBed} from 'angular2/src/test_lib/test_bed';
+
+import {QueryList} from 'angular2/src/core/compiler/query_list';
+import {Query} from 'angular2/src/core/annotations/di';
+
+import {Decorator, Component, Template, If, For} from 'angular2/angular2';
+
+import {BrowserDomAdapter} from 'angular2/src/dom/browser_adapter';
+
+export function main() {
+  BrowserDomAdapter.makeCurrent();
+  describe('Query API', () => {
+
+    it('should contain all directives in the light dom', inject([TestBed, AsyncTestCompleter], (tb, async) => {
+      var template =
+        '<div text="1"></div>' +
+        '<needs-query text="2"><div text="3"></div></needs-query>' +
+        '<div text="4"></div>';
+
+      tb.createView(MyComp, {html: template}).then((view) => {
+        view.detectChanges();
+        expect(view.rootNodes).toHaveText('2|3|');
+
+        async.done();
+      });
+    }));
+
+    it('should reflect dynamically inserted directives', inject([TestBed, AsyncTestCompleter], (tb, async) => {
+      var template =
+        '<div text="1"></div>' +
+        '<needs-query text="2"><div *if="shouldShow" [text]="\'3\'"></div></needs-query>' +
+        '<div text="4"></div>';
+
+      tb.createView(MyComp, {html: template}).then((view) => {
+
+        view.detectChanges();
+        expect(view.rootNodes).toHaveText('2|');
+
+        view.context.shouldShow = true;
+        view.detectChanges();
+        // TODO(rado): figure out why the second tick is necessary.
+        view.detectChanges();
+        expect(view.rootNodes).toHaveText('2|3|');
+
+        async.done();
+      });
+    }));
+
+    it('should reflect moved directives', inject([TestBed, AsyncTestCompleter], (tb, async) => {
+      var template =
+        '<div text="1"></div>' +
+        '<needs-query text="2"><div *for="var i of list" [text]="i"></div></needs-query>' +
+        '<div text="4"></div>';
+
+      tb.createView(MyComp, {html: template}).then((view) => {
+        view.detectChanges();
+        view.detectChanges();
+
+        expect(view.rootNodes).toHaveText('2|1d|2d|3d|');
+
+        view.context.list = ['3d', '2d'];
+        view.detectChanges();
+        view.detectChanges();
+        expect(view.rootNodes).toHaveText('2|3d|2d|');
+
+        async.done();
+      });
+    }));
+  });
+}
+
+@Component({selector: 'needs-query'})
+@Template({
+  directives: [For],
+  inline: '<div *for="var dir of query">{{dir.text}}|</div>'
+})
+class NeedsQuery {
+  query: QueryList;
+  constructor(@Query(TextDirective) query: QueryList) {
+    this.query = query;
+  }
+}
+
+var _constructiontext = 0;
+
+@Decorator({
+  selector: '[text]',
+  bind: {
+    'text': 'text'
+  }
+})
+class TextDirective {
+  text: string;
+  constructor() {}
+}
+
+@Component({selector: 'my-comp'})
+@Template({
+  directives: [NeedsQuery, TextDirective,  If, For]
+})
+class MyComp {
+  shouldShow: boolean;
+  list;
+  constructor() {
+    this.shouldShow = false;
+    this.list = ['1d', '2d', '3d'];
+  }
+}

--- a/modules/angular2/test/core/compiler/query_list_spec.js
+++ b/modules/angular2/test/core/compiler/query_list_spec.js
@@ -1,0 +1,69 @@
+import {describe, it, expect, beforeEach, ddescribe, iit, xit, el} from 'angular2/test_lib';
+
+import {List, MapWrapper, ListWrapper, iterateListLike} from 'angular2/src/facade/collection';
+import {QueryList} from 'angular2/src/core/compiler/query_list';
+
+
+export function main() {
+  describe('QueryList', () => {
+    var queryList, log;
+    beforeEach(() => {
+      queryList = new QueryList();
+      log = '';
+    });
+
+    function logAppend(item) {
+      log += (log.length == 0 ? '' : ', ') + item;
+    }
+
+    it('should support adding objects and iterating over them', () => {
+      queryList.add('one');
+      queryList.add('two');
+      iterateListLike(queryList, logAppend);
+      expect(log).toEqual('one, two');
+    });
+
+    it('should support resetting and iterating over the new objects', () => {
+      queryList.add('one');
+      queryList.add('two');
+      queryList.reset(['one again']);
+      queryList.add('two again');
+      iterateListLike(queryList, logAppend);
+      expect(log).toEqual('one again, two again');
+    });
+
+    describe('simple observable interface', () => {
+      it('should fire callbacks on change', () => {
+        var fires = 0;
+        queryList.onChange(() => {fires += 1;});
+
+        queryList.fireCallbacks();
+        expect(fires).toEqual(0);
+
+        queryList.add('one');
+
+        queryList.fireCallbacks();
+        expect(fires).toEqual(1);
+
+        queryList.fireCallbacks();
+        expect(fires).toEqual(1);
+      });
+
+      it('should support removing callbacks', () => {
+        var fires = 0;
+        var callback = () => fires += 1;
+        queryList.onChange(callback);
+
+        queryList.add('one');
+        queryList.fireCallbacks();
+        expect(fires).toEqual(1);
+
+        queryList.removeCallback(callback);
+
+        queryList.add('two');
+        queryList.fireCallbacks();
+        expect(fires).toEqual(1);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Queries allow a directive to inject a live list of directives of a given
type from its LightDom. The injected list is Iterable (in JS and Dart).
It will be Observable when Observables are support in JS, for now it
maintains a simple list of onChange callbacks API.

To support queries, element injectors now maintain a list of
child injectors in the correct DOM order (dynamically updated by
viewports).

For performance reasons we allow only 3 active queries in an injector
subtree. The feature adds no overhead to the application when not
used. Queries walk the injector tree only during dynamic view
addition/removal as triggered by viewport directives.

Closes #792
