### PR TITLE
chore(test): improve test.unit.cjs task

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -137,7 +137,7 @@ $(npm bin)/gulp clean
 
 1. `$(npm bin)/gulp test.unit.js`: JS tests in a browser; runs in **watch mode** (i.e. karma
   watches the test files for changes and re-runs tests when files are updated).
-2. `$(npm bin)/gulp test.unit.cjs`: JS tests in NodeJS (requires a build before)
+2. `$(npm bin)/gulp test.unit.cjs`: JS tests in NodeJS; runs in **watch mode**
 3. `$(npm bin)/gulp test.unit.dart`: Dart tests in Dartium; runs in **watch mode**.
 
 If you prefer running tests in "single-run" mode rather than watch mode use

--- a/scripts/ci/test_unit_js.sh
+++ b/scripts/ci/test_unit_js.sh
@@ -10,4 +10,4 @@ cd $SCRIPT_DIR/../..
 ./node_modules/.bin/gulp test.transpiler.unittest
 ./node_modules/.bin/gulp docs/test
 ./node_modules/.bin/gulp test.unit.js/ci --browsers=$KARMA_BROWSERS
-./node_modules/.bin/gulp test.unit.cjs
+./node_modules/.bin/gulp test.unit.cjs/ci

--- a/tools/transpiler/index.js
+++ b/tools/transpiler/index.js
@@ -23,9 +23,9 @@ exports.reloadSources = function() {
   needsReload = true;
 };
 
-exports.compile = function compile(options, paths, source) {
+exports.compile = function compile(options, paths, source, reloadTraceur) {
   if (needsReload) {
-    reloadCompiler();
+    reloadCompiler(reloadTraceur);
     needsReload = false;
   }
   var inputPath, outputPath, moduleName;
@@ -73,8 +73,10 @@ exports.init = function() {
 
 // Transpile and evaluate the code in `src`.
 // Use existing traceur to compile our sources.
-function reloadCompiler() {
-  loadModule(TRACEUR_PATH, false);
+function reloadCompiler(reloadTraceur) {
+  if (reloadTraceur) {
+    loadModule(TRACEUR_PATH, false);
+  }
   glob.sync(__dirname + '/src/**/*.js').forEach(function(fileName) {
     loadModule(fileName, true);
   });

--- a/tools/transpiler/karma-traceur-preprocessor.js
+++ b/tools/transpiler/karma-traceur-preprocessor.js
@@ -25,7 +25,7 @@ function createJs2DartPreprocessor(logger, basePath, config, emitter) {
         inputPath: file.originalPath,
         outputPath: file.path,
         moduleName: moduleName
-      }, content);
+      }, content, true);
 
       var transpiledContent = result.js;
       var sourceMap = result.sourceMap;


### PR DESCRIPTION
This PR creates a new gulp task to offer a Karma-like experience for Node.js tests.

Running this task will build the cjs distribution (`build.js.cjs` task), run the tests once and add some watchers: one to transpile files on change, and one to run the tests again after this transpilation.

I works but feels not that clean, any idea for improvement is welcome.
