### PR TITLE
fix(PropertyBindingParser): detect bindings using full attribute name

### DIFF
--- a/modules/angular2/src/core/compiler/pipeline/property_binding_parser.js
+++ b/modules/angular2/src/core/compiler/pipeline/property_binding_parser.js
@@ -17,7 +17,7 @@ import {CompileControl} from './compile_control';
 // Group 7 = "#"
 // Group 8 = identifier after "#"
 var BIND_NAME_REGEXP = RegExpWrapper.create(
-    '^(?:(?:(bind)|(var)|(on))-(.+))|\\[([^\\]]+)\\]|\\(([^\\)]+)\\)|(#)(.+)');
+    '^(?:(?:(?:(bind)|(var)|(on))-(.+))|\\[([^\\]]+)\\]|\\(([^\\)]+)\\)|(#)(.+))$');
 
 /**
  * Parses the property bindings on a single element.

--- a/modules/angular2/test/core/compiler/pipeline/property_binding_parser_spec.js
+++ b/modules/angular2/test/core/compiler/pipeline/property_binding_parser_spec.js
@@ -25,9 +25,18 @@ export function main() {
       expect(MapWrapper.get(results[0].propertyBindings, 'a').source).toEqual('b');
     });
 
+    it('should detect [] syntax only if an attribute name starts and ends with []', () => {
+      expect(createPipeline().process(el('<div z[a]="b"></div>'))[0].propertyBindings).toBe(null);
+      expect(createPipeline().process(el('<div [a]v="b"></div>'))[0].propertyBindings).toBe(null);
+    });
+
     it('should detect bind- syntax', () => {
       var results = createPipeline().process(el('<div bind-a="b"></div>'));
       expect(MapWrapper.get(results[0].propertyBindings, 'a').source).toEqual('b');
+    });
+
+    it('should detect bind- syntax only if an attribute name starts with bind', () => {
+      expect(createPipeline().process(el('<div _bind-a="b"></div>'))[0].propertyBindings).toBe(null);
     });
 
     it('should detect interpolation syntax', () => {
@@ -62,12 +71,22 @@ export function main() {
       expect(MapWrapper.get(results[0].variableBindings, '\$implicit')).toEqual('george');
     });
 
+    it('should detect variable bindings only if an attribute name starts with #', () => {
+      var results = createPipeline().process(el('<p b#george></p>'));
+      expect(results[0].variableBindings).toBe(null);
+    });
+
     it('should detect () syntax', () => {
       var results = createPipeline().process(el('<div (click)="b()"></div>'));
       expect(MapWrapper.get(results[0].eventBindings, 'click').source).toEqual('b()');
       // "(click[])" is not an expected syntax and is only used to validate the regexp
       results = createPipeline().process(el('<div (click[])="b()"></div>'));
       expect(MapWrapper.get(results[0].eventBindings, 'click[]').source).toEqual('b()');
+    });
+
+    it('should detect () syntax only if an attribute name starts and ends with ()', () => {
+      expect(createPipeline().process(el('<div z(a)="b()"></div>'))[0].propertyBindings).toBe(null);
+      expect(createPipeline().process(el('<div (a)v="b()"></div>'))[0].propertyBindings).toBe(null);
     });
 
     it('should parse event handlers using () syntax as actions', () => {


### PR DESCRIPTION
Fixes #1001
