### PR TITLE
refactor(test_lib): remove IS_NODEJS

### DIFF
--- a/modules/angular2/src/dom/browser_adapter.es6
+++ b/modules/angular2/src/dom/browser_adapter.es6
@@ -234,7 +234,7 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     return node.nodeType === Node.TEXT_NODE;
   }
   isCommentNode(node:Node):boolean {
-    return node.nodeType === Node.TEXT_NODE;
+    return node.nodeType === Node.COMMENT_NODE;
   }
   isElementNode(node:Node):boolean {
     return node.nodeType === Node.ELEMENT_NODE;

--- a/modules/angular2/src/dom/dom_adapter.js
+++ b/modules/angular2/src/dom/dom_adapter.js
@@ -144,6 +144,9 @@ export class DomAdapter {
   getShadowRoot(el) {
     throw _abstract();
   }
+  getDistributedNodes(el) {
+    throw _abstract();
+  }
   clone(node) {
     throw _abstract();
   }
@@ -247,6 +250,12 @@ export class DomAdapter {
     throw _abstract();
   }
   cssToRules(css:string): List {
+    throw _abstract();
+  }
+  supportsDOMEvents(): boolean {
+    throw _abstract();
+  }
+  supportsNativeShadowDOM(): boolean {
     throw _abstract();
   }
 }

--- a/modules/angular2/src/dom/generic_browser_adapter.js
+++ b/modules/angular2/src/dom/generic_browser_adapter.js
@@ -1,6 +1,6 @@
 import {ABSTRACT} from 'angular2/src/facade/lang';
 import {List, ListWrapper} from 'angular2/src/facade/collection';
-import {isPresent} from 'angular2/src/facade/lang';
+import {isPresent, isFunction} from 'angular2/src/facade/lang';
 import {DomAdapter} from './dom_adapter';
 
 /**
@@ -8,6 +8,9 @@ import {DomAdapter} from './dom_adapter';
  */
 @ABSTRACT()
 export class GenericBrowserDomAdapter extends DomAdapter {
+  getDistributedNodes(el) {
+    return el.getDistributedNodes();
+  }
   resolveAndSetHref(el, baseUrl:string, href:string) {
     el.href = href == null ? baseUrl : baseUrl + '/../' + href;
   }
@@ -33,5 +36,11 @@ export class GenericBrowserDomAdapter extends DomAdapter {
     }
     this.remove(style);
     return rules;
+  }
+  supportsDOMEvents(): boolean {
+    return true;
+  }
+  supportsNativeShadowDOM(): boolean {
+    return isFunction(this.defaultDoc().body.createShadowRoot);
   }
 }

--- a/modules/angular2/src/dom/html5lib_adapter.dart
+++ b/modules/angular2/src/dom/html5lib_adapter.dart
@@ -235,4 +235,13 @@ class Html5LibDomAdapter implements DomAdapter {
   List cssToRules(String css) {
     throw 'not implemented';
   }
+  List getDistributedNodes(Node) {
+    throw 'not implemented';
+  }
+  bool supportsDOMEvents() {
+    throw 'not implemented';
+  }
+  bool supportsNativeShadowDOM() {
+    throw 'not implemented';
+  }
 }

--- a/modules/angular2/src/dom/parse5_adapter.cjs
+++ b/modules/angular2/src/dom/parse5_adapter.cjs
@@ -3,7 +3,7 @@ var parser = new parse5.Parser(parse5.TreeAdapters.htmlparser2);
 var serializer = new parse5.Serializer(parse5.TreeAdapters.htmlparser2);
 var treeAdapter = parser.treeAdapter;
 
-var cssParse = require('css-parse');
+var cssParse = require('css').parse;
 
 var url = require('url');
 
@@ -252,6 +252,9 @@ export class Parse5DomAdapter extends DomAdapter {
   getShadowRoot(el) {
     return el.shadowRoot;
   }
+  getDistributedNodes(el) {
+    throw _notImplemented('getDistributedNodes');
+  }
   clone(node) {
     var temp = treeAdapter.createElement("template", null, []);
     treeAdapter.appendChild(temp, node);
@@ -384,7 +387,7 @@ export class Parse5DomAdapter extends DomAdapter {
     return treeAdapter.isTextNode(node);
   }
   isCommentNode(node):boolean {
-    throw treeAdapter.isCommentNode(node);
+    return treeAdapter.isCommentNode(node);
   }
   isElementNode(node):boolean {
     return node ? treeAdapter.isElementNode(node) : false;
@@ -454,6 +457,12 @@ export class Parse5DomAdapter extends DomAdapter {
       rules = this._buildRules(parsedCSS.stylesheet.rules, css);
     }
     return rules;
+  }
+  supportsDOMEvents(): boolean {
+    return false;
+  }
+  supportsNativeShadowDOM(): boolean {
+    return false;
   }
 }
 

--- a/modules/angular2/src/facade/lang.dart
+++ b/modules/angular2/src/facade/lang.dart
@@ -24,6 +24,7 @@ class IMPLEMENTS {
 bool isPresent(obj) => obj != null;
 bool isBlank(obj) => obj == null;
 bool isString(obj) => obj is String;
+bool isFunction(obj) => obj is Function;
 
 String stringify(obj) => obj.toString();
 

--- a/modules/angular2/src/facade/lang.es6
+++ b/modules/angular2/src/facade/lang.es6
@@ -38,6 +38,10 @@ export function isString(obj):boolean {
   return typeof obj === "string";
 }
 
+export function isFunction(obj):boolean {
+  return typeof obj === "function";
+}
+
 export function stringify(token):string {
   if (typeof token === 'string') {
     return token;

--- a/modules/angular2/src/test_lib/test_lib.dart
+++ b/modules/angular2/src/test_lib/test_lib.dart
@@ -18,7 +18,6 @@ import './test_injector.dart';
 export './test_injector.dart' show inject;
 
 bool IS_DARTIUM = true;
-bool IS_NODEJS = false;
 
 List _testBindings = [];
 Injector _injector;
@@ -165,11 +164,11 @@ String elementText(n) {
   }
 
   if (DOM.isElementNode(n) && DOM.tagName(n) == 'CONTENT') {
-    return elementText(n.getDistributedNodes());
+    return elementText(DOM.getDistributedNodes(n));
   }
 
   if (DOM.hasShadowRoot(n)) {
-    return elementText(DOM.childNodesAsList(n.shadowRoot));
+    return elementText(DOM.childNodesAsList(DOM.getShadowRoot(n)));
   }
 
   if (hasNodes(n)) {

--- a/modules/angular2/src/test_lib/test_lib.es6
+++ b/modules/angular2/src/test_lib/test_lib.es6
@@ -14,7 +14,6 @@ export var afterEach = _global.afterEach;
 export var expect = _global.expect;
 
 export var IS_DARTIUM = false;
-export var IS_NODEJS = typeof window === 'undefined';
 
 export class AsyncTestCompleter {
   _done: Function;
@@ -293,23 +292,26 @@ export class SpyObject {
 
 function elementText(n) {
   var hasNodes = (n) => {var children = DOM.childNodes(n); return children && children.length > 0;}
-  if (!IS_NODEJS) {
-    if (n instanceof Comment)         return '';
 
-    if (n instanceof Array)           return n.map((nn) => elementText(nn)).join("");
-    if (n instanceof Element && DOM.tagName(n) == 'CONTENT')
-      return elementText(Array.prototype.slice.apply(n.getDistributedNodes()));
-    if (DOM.hasShadowRoot(n))             return elementText(DOM.childNodesAsList(n.shadowRoot));
-    if (hasNodes(n))                  return elementText(DOM.childNodesAsList(n));
-
-    return n.textContent;
-  } else {
-    if (n instanceof Array) {
-      return n.map((nn) => elementText(nn)).join("");
-    } else if (hasNodes(n)) {
-      return elementText(DOM.childNodesAsList(n));
-    } else {
-      return DOM.getText(n);
-    }
+  if (n instanceof Array) {
+    return n.map((nn) => elementText(nn)).join("");
   }
+
+  if (DOM.isCommentNode(n)) {
+    return '';
+  }
+
+  if (DOM.isElementNode(n) && DOM.tagName(n) == 'CONTENT') {
+    return elementText(Array.prototype.slice.apply(DOM.getDistributedNodes(n)));
+  }
+
+  if (DOM.hasShadowRoot(n)) {
+    return elementText(DOM.childNodesAsList(DOM.getShadowRoot(n)));
+  }
+
+  if (hasNodes(n)) {
+    return elementText(DOM.childNodesAsList(n));
+  }
+
+  return DOM.getText(n);
 }

--- a/modules/angular2/test/core/compiler/shadow_dom/shadow_css_spec.js
+++ b/modules/angular2/test/core/compiler/shadow_dom/shadow_css_spec.js
@@ -1,4 +1,4 @@
-import {describe, beforeEach, it, expect, ddescribe, iit, SpyObject, el, IS_NODEJS} from 'angular2/test_lib';
+import {describe, beforeEach, it, expect, ddescribe, iit, SpyObject, el} from 'angular2/test_lib';
 import {ShadowCss} from 'angular2/src/core/compiler/shadow_dom_emulation/shadow_css';
 
 import {RegExpWrapper, StringWrapper} from 'angular2/src/facade/lang';
@@ -91,16 +91,13 @@ export function main() {
       expect(StringWrapper.contains(css, '#menu > .bar {;background: blue;}')).toBeTruthy();
     });
 
-    if (!IS_NODEJS) {
-      //TODO: reactivate once CSS parser is fixed: https://github.com/reworkcss/css/issues/65
-      it('should support polyfill-rule', () => {
-        var css = s("polyfill-rule {content: ':host.foo .bar';background: blue;}", 'a', 'a-host');
-        expect(css).toEqual('[a-host].foo .bar {background: blue;}');
+    it('should support polyfill-rule', () => {
+      var css = s("polyfill-rule {content: ':host.foo .bar';background: blue;}", 'a', 'a-host');
+      expect(css).toEqual('[a-host].foo .bar {background: blue;}');
 
-        css = s('polyfill-rule {content: ":host.foo .bar";background: blue;}', 'a', 'a-host');
-        expect(css).toEqual('[a-host].foo .bar {background: blue;}');
-      });
-    }
+      css = s('polyfill-rule {content: ":host.foo .bar";background: blue;}', 'a', 'a-host');
+      expect(css).toEqual('[a-host].foo .bar {background: blue;}');
+    });
 
     it('should handle ::shadow', () => {
       var css = s('x::shadow > y {}', 'a');

--- a/modules/angular2/test/core/compiler/shadow_dom/shadow_dom_emulation_integration_spec.js
+++ b/modules/angular2/test/core/compiler/shadow_dom/shadow_dom_emulation_integration_spec.js
@@ -7,7 +7,6 @@ import {
   expect,
   iit,
   inject,
-  IS_NODEJS,
   it,
   xit,
 } from 'angular2/test_lib';
@@ -54,7 +53,7 @@ export function main() {
       "scoped" : new EmulatedScopedShadowDomStrategy(styleInliner, styleUrlResolver, DOM.createElement('div')),
       "unscoped" : new EmulatedUnscopedShadowDomStrategy(styleUrlResolver, DOM.createElement('div'))
     }
-    if (!IS_NODEJS) {
+    if (DOM.supportsNativeShadowDOM()) {
       StringMapWrapper.set(strategies, "native", new NativeShadowDomStrategy(styleUrlResolver));
     }
 

--- a/modules/angular2/test/core/compiler/view_spec.js
+++ b/modules/angular2/test/core/compiler/view_spec.js
@@ -1,4 +1,4 @@
-import {describe, xit, it, expect, beforeEach, ddescribe, iit, el, proxy, IS_NODEJS} from 'angular2/test_lib';
+import {describe, xit, it, expect, beforeEach, ddescribe, iit, el, proxy} from 'angular2/test_lib';
 import {ProtoView, ElementPropertyMemento, DirectivePropertyMemento} from 'angular2/src/core/compiler/view';
 import {ProtoElementInjector, ElementInjector, DirectiveBinding} from 'angular2/src/core/compiler/element_injector';
 import {EmulatedScopedShadowDomStrategy, NativeShadowDomStrategy} from 'angular2/src/core/compiler/shadow_dom_strategy';
@@ -444,7 +444,7 @@ export function main() {
         });
       });
 
-      if (!IS_NODEJS) {
+      if (DOM.supportsDOMEvents()) {
         describe('event handlers', () => {
           var view, ctx, called, receivedEvent, dispatchedEvent;
 

--- a/modules/angular2/test/forms/integration_spec.js
+++ b/modules/angular2/test/forms/integration_spec.js
@@ -11,9 +11,9 @@ import {
   inject,
   it,
   queryView,
-  xit,
-  IS_NODEJS
+  xit
 } from 'angular2/test_lib';
+import {DOM} from 'angular2/src/dom/dom_adapter';
 
 import {Lexer, Parser, ChangeDetector, dynamicChangeDetection} from 'angular2/change_detection';
 import {Compiler, CompilerCache} from 'angular2/src/core/compiler/compiler';
@@ -86,7 +86,7 @@ export function main() {
       });
     }));
 
-    if (!IS_NODEJS) {
+    if (DOM.supportsDOMEvents()) {
       it("should update the control group values on DOM change", inject([AsyncTestCompleter], (async) => {
         var form = new ControlGroup({
           "login": new Control("oldValue")
@@ -153,7 +153,7 @@ export function main() {
       });
     }));
 
-    if (!IS_NODEJS) {
+    if (DOM.supportsDOMEvents()) {
       describe("different control types", () => {
         it("should support type=checkbox", inject([AsyncTestCompleter], (async) => {
           var ctx = new MyComp(new ControlGroup({"checkbox": new Control(true)}));
@@ -261,7 +261,7 @@ export function main() {
         });
       }));
 
-      if (!IS_NODEJS) {
+      if (DOM.supportsDOMEvents()) {
         it("should update the control group values on DOM change", inject([AsyncTestCompleter], (async) => {
           var form = new ControlGroup({
             "nested": new ControlGroup({

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "angular": "1.3.5",
     "bower": "^1.3.12",
     "canonical-path": "0.0.2",
-    "css-parse": "2.0.0",
+    "css": "mlaval/css#issue65",
     "del": "~1",
     "dgeni": "^0.4.1",
     "dgeni-packages": "^0.10.11",


### PR DESCRIPTION
Following comments from @vsavkin , this PR gets rid of `IS_NODEJS` in tests.
