### PR TITLE
(docs) decorator events property

### DIFF
--- a/modules/angular2/docs/core/02_directives.md
+++ b/modules/angular2/docs/core/02_directives.md
@@ -70,7 +70,7 @@ Here is a trivial example of a tooltip decorator. The directive will log a toolt
   bind: {                // List which properties need to be bound
     text: 'tooltip'      //  - DOM element tooltip property should be 
   },                     //    mapped to the directive text property.
-  event: {               // List which events need to be mapped.
+  events: {               // List which events need to be mapped.
     mouseover: 'show'    //  - Invoke the show() method every time 
   }                      //    the mouseover event is fired.
 })


### PR DESCRIPTION
As from what i understand shouldn't the event property rather be events: https://github.com/angular/angular/blob/master/modules/angular2/src/core/annotations/annotations.js#L161
