### PR TITLE
feat(dart/transform): Create a standalone di transformer

### DIFF
--- a/modules/angular2/pubspec.yaml
+++ b/modules/angular2/pubspec.yaml
@@ -15,5 +15,7 @@ dependencies:
   dart_style: '^0.1.3'
   html: '^0.12.0'
   stack_trace: '^1.1.1'
+transformers:
+  - angular2/src/transform/di_transformer
 dev_dependencies:
   guinness: "^0.1.17"

--- a/modules/angular2/src/core/compiler/private_component_loader.js
+++ b/modules/angular2/src/core/compiler/private_component_loader.js
@@ -1,5 +1,6 @@
 import {Compiler} from './compiler';
 import {ShadowDomStrategy} from './shadow_dom_strategy';
+import {Injectable} from 'angular2/di';
 import {EventManager} from 'angular2/src/render/dom/events/event_manager';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
 import {Component} from 'angular2/src/core/annotations/annotations';
@@ -7,6 +8,7 @@ import {PrivateComponentLocation} from './private_component_location';
 import {Type, stringify, BaseException} from 'angular2/src/facade/lang';
 
 
+@Injectable()
 export class PrivateComponentLoader {
   compiler:Compiler;
   shadowDomStrategy:ShadowDomStrategy;

--- a/modules/angular2/src/core/testability/testability.js
+++ b/modules/angular2/src/core/testability/testability.js
@@ -1,3 +1,4 @@
+import {Injectable} from 'angular2/di';
 import {DOM} from 'angular2/src/dom/dom_adapter';
 import {Map, MapWrapper, List, ListWrapper} from 'angular2/src/facade/collection';
 import {StringWrapper, isBlank, BaseException} from 'angular2/src/facade/lang';
@@ -9,6 +10,7 @@ import * as getTestabilityModule from 'angular2/src/core/testability/get_testabi
  * the browser and by services such as Protractor. Each bootstrapped Angular
  * application on the page will have an instance of Testability.
  */
+@Injectable()
 export class Testability {
   _pendingCount: number;
   _callbacks: List;
@@ -53,6 +55,7 @@ export class Testability {
   }
 }
 
+@Injectable()
 export class TestabilityRegistry {
   _applications: Map;
 

--- a/modules/angular2/src/transform/common/names.dart
+++ b/modules/angular2/src/transform/common/names.dart
@@ -7,3 +7,4 @@ const REGISTER_TYPE_METHOD_NAME = 'registerType';
 const REGISTER_GETTERS_METHOD_NAME = 'registerGetters';
 const REGISTER_SETTERS_METHOD_NAME = 'registerSetters';
 const REGISTER_METHODS_METHOD_NAME = 'registerMethods';
+const TRANSFORM_MODE = 'ngstatic';

--- a/modules/angular2/src/transform/common/options.dart
+++ b/modules/angular2/src/transform/common/options.dart
@@ -13,9 +13,14 @@ class TransformerOptions {
   /// application's [ReflectionCapabilities] are set.
   final String reflectionEntryPoint;
 
-  TransformerOptions._internal(this.entryPoint, this.reflectionEntryPoint);
+  /// The `BarbackMode#name` we are running in.
+  final String modeName;
 
-  factory TransformerOptions(String entryPoint, {String reflectionEntryPoint}) {
+  TransformerOptions._internal(
+      this.entryPoint, this.reflectionEntryPoint, this.modeName);
+
+  factory TransformerOptions(String entryPoint,
+      {String reflectionEntryPoint, String modeName: 'release'}) {
     if (entryPoint == null) {
       throw new ArgumentError.notNull(ENTRY_POINT_PARAM);
     } else if (entryPoint.isEmpty) {
@@ -24,6 +29,7 @@ class TransformerOptions {
     if (reflectionEntryPoint == null || entryPoint.isEmpty) {
       reflectionEntryPoint = entryPoint;
     }
-    return new TransformerOptions._internal(entryPoint, reflectionEntryPoint);
+    return new TransformerOptions._internal(
+        entryPoint, reflectionEntryPoint, modeName);
   }
 }

--- a/modules/angular2/src/transform/di_transformer.dart
+++ b/modules/angular2/src/transform/di_transformer.dart
@@ -1,0 +1,26 @@
+library angular2.src.transform.di_transformer;
+
+import 'package:barback/barback.dart';
+import 'package:dart_style/dart_style.dart';
+
+import 'directive_linker/transformer.dart';
+import 'directive_processor/transformer.dart';
+import 'bind_generator/transformer.dart';
+import 'reflection_remover/transformer.dart';
+import 'common/formatter.dart' as formatter;
+import 'common/options.dart';
+
+export 'common/options.dart';
+
+/// Removes the mirror-based initialization logic and replaces it with static
+/// logic.
+class DiTransformerGroup extends TransformerGroup {
+  DiTransformerGroup()
+      : super([[new DirectiveProcessor(null)], [new DirectiveLinker()]]) {
+    formatter.init(new DartFormatter());
+  }
+
+  factory DiTransformerGroup.asPlugin(BarbackSettings settings) {
+    return new DiTransformerGroup();
+  }
+}

--- a/modules/angular2/src/transform/directive_linker/transformer.dart
+++ b/modules/angular2/src/transform/directive_linker/transformer.dart
@@ -16,9 +16,7 @@ import 'linker.dart';
 /// `setupReflection` call the necessary `setupReflection` method in all
 /// dependencies.
 class DirectiveLinker extends Transformer {
-  final TransformerOptions options;
-
-  DirectiveLinker(this.options);
+  DirectiveLinker();
 
   @override
   bool isPrimary(AssetId id) => id.path.endsWith(DEPS_EXTENSION);
@@ -28,10 +26,11 @@ class DirectiveLinker extends Transformer {
     log.init(transform);
 
     try {
+      var reader = new AssetReader.fromTransform(transform);
       var assetId = transform.primaryInput.id;
-      var transformedCode =
-          await linkNgDeps(new AssetReader.fromTransform(transform), assetId);
-      var formattedCode = formatter.format(transformedCode, uri: assetId.path);
+      var assetPath = assetId.path;
+      var transformedCode = await linkNgDeps(reader, assetId);
+      var formattedCode = formatter.format(transformedCode, uri: assetPath);
       transform.addOutput(new Asset.fromString(assetId, formattedCode));
     } catch (ex, stackTrace) {
       log.logger.error('Linking ng directives failed.\n'

--- a/modules/angular2/src/transform/directive_processor/transformer.dart
+++ b/modules/angular2/src/transform/directive_processor/transformer.dart
@@ -32,14 +32,13 @@ class DirectiveProcessor extends Transformer {
     log.init(transform);
 
     try {
-      var assetCode = await transform.primaryInput.readAsString();
-      var ngDepsSrc = createNgDeps(assetCode, transform.primaryInput.id.path,
-          forceGenerate: transform.primaryInput.id.path == options.entryPoint);
+      var asset = transform.primaryInput;
+      var assetCode = await asset.readAsString();
+      var ngDepsSrc = createNgDeps(assetCode, asset.id.path);
       if (ngDepsSrc != null && ngDepsSrc.isNotEmpty) {
         var ngDepsAssetId =
             transform.primaryInput.id.changeExtension(DEPS_EXTENSION);
-        var exists = await transform.hasInput(ngDepsAssetId);
-        if (exists) {
+        if (await transform.hasInput(ngDepsAssetId)) {
           log.logger.error('Clobbering ${ngDepsAssetId}. '
               'This probably will not end well');
         }

--- a/modules/angular2/src/transform/directive_processor/visitors.dart
+++ b/modules/angular2/src/transform/directive_processor/visitors.dart
@@ -29,8 +29,13 @@ class _CtorTransformVisitor extends ToSourceVisitor with VisitorMixin {
       var suffix = type != null ? ', ' : '';
       visitNodeListWithSeparatorAndSuffix(metadata, ', ', suffix);
     }
-    if (_withParameterTypes) {
-      visitNodeWithSuffix(type, ' ');
+    var needCompileTimeConstants = !_withParameterNames;
+    if (_withParameterTypes && type != null) {
+      visitNodeWithSuffix(type.name, ' ');
+      if (!needCompileTimeConstants) {
+        // Types with arguments are not compile-time constants.
+        visitNodeWithSuffix(type.typeArguments, ' ');
+      }
     }
     if (_withParameterNames) {
       visitNode(name);

--- a/modules/angular2/src/transform/reflection_remover/rewriter.dart
+++ b/modules/angular2/src/transform/reflection_remover/rewriter.dart
@@ -81,7 +81,7 @@ class Rewriter {
 
   String _commentedNode(AstNode node) {
     // TODO(kegluneq): Return commented code once we generate all needed code.
-    return _code.substring(node.offset, node.end);
+    return '/*${_code.substring(node.offset, node.end)}*/';
   }
 }
 

--- a/modules/angular2/src/transform/transformer.dart
+++ b/modules/angular2/src/transform/transformer.dart
@@ -9,20 +9,27 @@ import 'bind_generator/transformer.dart';
 import 'reflection_remover/transformer.dart';
 import 'template_compiler/transformer.dart';
 import 'common/formatter.dart' as formatter;
+import 'common/names.dart';
 import 'common/options.dart';
 
 export 'common/options.dart';
 
 /// Replaces Angular 2 mirror use with generated code.
 class AngularTransformerGroup extends TransformerGroup {
-  AngularTransformerGroup(TransformerOptions options) : super([
-        [new DirectiveProcessor(options)],
-        [new DirectiveLinker()],
+  AngularTransformerGroup._(phases) : super(phases) {
+    formatter.init(new DartFormatter());
+  }
+
+  factory AngularTransformerGroup(TransformerOptions options) {
+    var phases = [[new DirectiveProcessor(options)], [new DirectiveLinker()]];
+    if (options.modeName == TRANSFORM_MODE) {
+      phases.addAll([
         [new BindGenerator(options)],
         [new TemplateComplier(options)],
         [new ReflectionRemover(options)]
-      ]) {
-    formatter.init(new DartFormatter());
+      ]);
+    }
+    return new AngularTransformerGroup._(phases);
   }
 
   factory AngularTransformerGroup.asPlugin(BarbackSettings settings) {
@@ -33,5 +40,6 @@ class AngularTransformerGroup extends TransformerGroup {
 TransformerOptions _parseOptions(BarbackSettings settings) {
   var config = settings.configuration;
   return new TransformerOptions(config[ENTRY_POINT_PARAM],
-      reflectionEntryPoint: config[REFLECTION_ENTRY_POINT_PARAM]);
+      reflectionEntryPoint: config[REFLECTION_ENTRY_POINT_PARAM],
+      modeName: settings.mode.name);
 }

--- a/modules/angular2/src/transform/transformer.dart
+++ b/modules/angular2/src/transform/transformer.dart
@@ -17,7 +17,7 @@ export 'common/options.dart';
 class AngularTransformerGroup extends TransformerGroup {
   AngularTransformerGroup(TransformerOptions options) : super([
         [new DirectiveProcessor(options)],
-        [new DirectiveLinker(options)],
+        [new DirectiveLinker()],
         [new BindGenerator(options)],
         [new TemplateComplier(options)],
         [new ReflectionRemover(options)]

--- a/modules/angular2/test/transform/bind_generator/basic_bind_files/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/bind_generator/basic_bind_files/bar.ng_deps.dart
@@ -1,4 +1,4 @@
-library bar;
+library bar.ng_deps.dart;
 
 import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';

--- a/modules/angular2/test/transform/bind_generator/basic_bind_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/bind_generator/basic_bind_files/expected/bar.ng_deps.dart
@@ -1,4 +1,4 @@
-library bar;
+library bar.ng_deps.dart;
 
 import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';

--- a/modules/angular2/test/transform/bind_generator/duplicate_bind_name_files/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/bind_generator/duplicate_bind_name_files/expected/soup.ng_deps.dart
@@ -1,4 +1,4 @@
-library dinner.soup;
+library dinner.soup.ng_deps.dart;
 
 import 'package:angular2/src/core/annotations/annotations.dart';
 import 'soup.dart';

--- a/modules/angular2/test/transform/bind_generator/duplicate_bind_name_files/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/bind_generator/duplicate_bind_name_files/soup.ng_deps.dart
@@ -1,4 +1,4 @@
-library dinner.soup;
+library dinner.soup.ng_deps.dart;
 
 import 'package:angular2/src/core/annotations/annotations.dart';
 import 'soup.dart';

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/bar.ng_deps.dart
@@ -1,4 +1,4 @@
-library bar;
+library bar.ng_deps.dart;
 
 import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/expected/bar.ng_deps.dart
@@ -1,4 +1,4 @@
-library bar;
+library bar.ng_deps.dart;
 
 import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/expected/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/expected/foo.ng_deps.dart
@@ -1,4 +1,4 @@
-library foo;
+library foo.ng_deps.dart;
 
 import 'foo.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/expected/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/expected/index.ng_deps.dart
@@ -1,4 +1,4 @@
-library web_foo;
+library web_foo.ng_deps.dart;
 
 import 'package:angular2/src/core/application.dart';
 import 'package:angular2/src/reflection/reflection_capabilities.dart';

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/foo.ng_deps.dart
@@ -1,4 +1,4 @@
-library foo;
+library foo.ng_deps.dart;
 
 import 'foo.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/index.ng_deps.dart
@@ -1,4 +1,4 @@
-library web_foo;
+library web_foo.ng_deps.dart;
 
 import 'package:angular2/src/core/application.dart';
 import 'package:angular2/src/reflection/reflection_capabilities.dart';

--- a/modules/angular2/test/transform/directive_linker/simple_files/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/bar.ng_deps.dart
@@ -1,4 +1,4 @@
-library bar;
+library bar.ng_deps.dart;
 
 import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';

--- a/modules/angular2/test/transform/directive_linker/simple_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/expected/bar.ng_deps.dart
@@ -1,4 +1,4 @@
-library bar;
+library bar.ng_deps.dart;
 
 import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';

--- a/modules/angular2/test/transform/directive_linker/simple_files/expected/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/expected/foo.ng_deps.dart
@@ -1,4 +1,4 @@
-library foo;
+library foo.ng_deps.dart;
 
 import 'foo.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';

--- a/modules/angular2/test/transform/directive_linker/simple_files/expected/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/expected/index.ng_deps.dart
@@ -1,4 +1,4 @@
-library web_foo;
+library web_foo.ng_deps.dart;
 
 import 'package:angular2/src/core/application.dart';
 import 'package:angular2/src/reflection/reflection_capabilities.dart';

--- a/modules/angular2/test/transform/directive_linker/simple_files/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/foo.ng_deps.dart
@@ -1,4 +1,4 @@
-library foo;
+library foo.ng_deps.dart;
 
 import 'foo.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';

--- a/modules/angular2/test/transform/directive_linker/simple_files/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/index.ng_deps.dart
@@ -1,4 +1,4 @@
-library web_foo;
+library web_foo.ng_deps.dart;
 
 import 'package:angular2/src/core/application.dart';
 import 'package:angular2/src/reflection/reflection_capabilities.dart';

--- a/modules/angular2/test/transform/directive_processor/parameter_metadata/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/parameter_metadata/expected/soup.ng_deps.dart
@@ -1,4 +1,4 @@
-library dinner.soup;
+library dinner.soup.ng_deps.dart;
 
 import 'soup.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';

--- a/modules/angular2/test/transform/integration/all_tests.dart
+++ b/modules/angular2/test/transform/integration/all_tests.dart
@@ -2,16 +2,17 @@ library angular2.test.transform.integration;
 
 import 'dart:io';
 import 'package:angular2/src/dom/html_adapter.dart';
+import 'package:angular2/src/transform/common/names.dart';
 import 'package:angular2/transformer.dart';
 import 'package:code_transformers/tests.dart';
 import 'package:dart_style/dart_style.dart';
-import 'package:guinness/guinness.dart';
 
 import '../common/read_file.dart';
 
 var formatter = new DartFormatter();
 var transform = new AngularTransformerGroup(new TransformerOptions(
-    'web/index.dart', reflectionEntryPoint: 'web/index.dart'));
+    'web/index.dart',
+    reflectionEntryPoint: 'web/index.dart', modeName: TRANSFORM_MODE));
 
 class IntegrationTestConfig {
   final String name;

--- a/modules/angular2/test/transform/integration/list_of_types_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/list_of_types_files/expected/bar.ng_deps.dart
@@ -1,8 +1,10 @@
-library bar;
+library bar.ng_deps.dart;
 
 import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 import 'foo.dart';
+import 'foo.ng_deps.dart' as i0;
+import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i1;
 
 bool _visited = false;
 void setupReflection(reflector) {
@@ -15,4 +17,6 @@ void setupReflection(reflector) {
       'annotations':
           const [const Component(componentServices: const [MyContext])]
     });
+  i0.setupReflection(reflector);
+  i1.setupReflection(reflector);
 }

--- a/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_deps.dart
@@ -1,7 +1,8 @@
-library bar;
+library bar.ng_deps.dart;
 
 import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
+import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i0;
 
 bool _visited = false;
 void setupReflection(reflector) {
@@ -13,4 +14,5 @@ void setupReflection(reflector) {
       'parameters': const [],
       'annotations': const [const Component(selector: '[soup]')]
     });
+  i0.setupReflection(reflector);
 }

--- a/modules/angular2/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
@@ -1,4 +1,4 @@
-library web_foo;
+library web_foo.ng_deps.dart;
 
 import 'index.dart';
 import 'package:angular2/src/core/application.dart';

--- a/modules/angular2/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
@@ -6,10 +6,15 @@ import 'package:angular2/src/reflection/reflection.dart';
 import 'package:angular2/src/reflection/reflection_capabilities.dart';
 import 'bar.dart';
 import 'bar.ng_deps.dart' as i0;
+import 'package:angular2/src/core/application.ng_deps.dart' as i1;
+import 'package:angular2/src/reflection/reflection_capabilities.ng_deps.dart'
+    as i2;
 
 bool _visited = false;
 void setupReflection(reflector) {
   if (_visited) return;
   _visited = true;
   i0.setupReflection(reflector);
+  i1.setupReflection(reflector);
+  i2.setupReflection(reflector);
 }

--- a/modules/angular2/test/transform/integration/synthetic_ctor_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/synthetic_ctor_files/expected/bar.ng_deps.dart
@@ -1,7 +1,8 @@
-library bar;
+library bar.ng_deps.dart;
 
 import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
+import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i0;
 
 bool _visited = false;
 void setupReflection(reflector) {
@@ -13,4 +14,5 @@ void setupReflection(reflector) {
       'parameters': const [],
       'annotations': const [const Component(selector: '[soup]')]
     });
+  i0.setupReflection(reflector);
 }

--- a/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
@@ -1,8 +1,10 @@
-library bar;
+library bar.ng_deps.dart;
 
 import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 import 'package:angular2/src/core/annotations/template.dart';
+import 'package:angular2/src/core/annotations/template.ng_deps.dart' as i0;
+import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i1;
 
 bool _visited = false;
 void setupReflection(reflector) {
@@ -17,4 +19,6 @@ void setupReflection(reflector) {
         const Template(inline: 'Salad')
       ]
     });
+  i0.setupReflection(reflector);
+  i1.setupReflection(reflector);
 }

--- a/modules/angular2/test/transform/integration/two_deps_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_deps_files/expected/bar.ng_deps.dart
@@ -1,8 +1,10 @@
-library bar;
+library bar.ng_deps.dart;
 
 import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 import 'foo.dart' as prefix;
+import 'foo.ng_deps.dart' as i0;
+import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i1;
 
 bool _visited = false;
 void setupReflection(reflector) {
@@ -16,4 +18,6 @@ void setupReflection(reflector) {
       'annotations':
           const [const Component(selector: prefix.preDefinedSelector)]
     });
+  i0.setupReflection(reflector);
+  i1.setupReflection(reflector);
 }

--- a/modules/angular2/test/transform/reflection_remover/reflection_remover_files/expected/index.dart
+++ b/modules/angular2/test/transform/reflection_remover/reflection_remover_files/expected/index.dart
@@ -13,10 +13,10 @@ library web_foo;
 
 import 'package:angular2/src/core/application.dart';
 import 'package:angular2/src/reflection/reflection.dart';
-import 'package:angular2/src/reflection/reflection_capabilities.dart';import 'index.ng_deps.dart' as ngStaticInit;
+/*import 'package:angular2/src/reflection/reflection_capabilities.dart';*/import 'index.ng_deps.dart' as ngStaticInit;
 
 void main() {
-  reflector.reflectionCapabilities = new ReflectionCapabilities();ngStaticInit.setupReflection(reflector);
+  /*reflector.reflectionCapabilities = new ReflectionCapabilities();*/ngStaticInit.setupReflection(reflector);
   bootstrap(MyComponent);
 }
 """;

--- a/modules/angular2/test/transform/template_compiler/inline_expression_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_expression_files/expected/hello.ng_deps.dart
@@ -1,4 +1,4 @@
-library examples.hello_world.index_common_dart;
+library examples.hello_world.index_common_dart.ng_deps.dart;
 
 import 'hello.dart';
 import 'package:angular2/angular2.dart'

--- a/modules/angular2/test/transform/template_compiler/inline_expression_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_expression_files/hello.ng_deps.dart
@@ -1,4 +1,4 @@
-library examples.hello_world.index_common_dart;
+library examples.hello_world.index_common_dart.ng_deps.dart;
 
 import 'hello.dart';
 import 'package:angular2/angular2.dart'

--- a/modules/angular2/test/transform/template_compiler/inline_method_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_method_files/expected/hello.ng_deps.dart
@@ -1,4 +1,4 @@
-library examples.hello_world.index_common_dart;
+library examples.hello_world.index_common_dart.ng_deps.dart;
 
 import 'hello.dart';
 import 'package:angular2/angular2.dart'

--- a/modules/angular2/test/transform/template_compiler/inline_method_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_method_files/hello.ng_deps.dart
@@ -1,4 +1,4 @@
-library examples.hello_world.index_common_dart;
+library examples.hello_world.index_common_dart.ng_deps.dart;
 
 import 'hello.dart';
 import 'package:angular2/angular2.dart'


### PR DESCRIPTION
- Run the `di` transformer on Angular codebase
- Generate `.ng_deps.dart` files indiscriminately for all `.dart` files.
- Remove import of `dart:mirrors` and use generated code exclusively

This successfully runs `hello_world`!
- Before `dart2js` size: 2.3M
- After `dart2js` size: 363K
- `index_static.dart.js` size: 334K

We may not actually want to merge this in to `master` quite yet (esp. given other in-flight PRs), but I wanted to make this available for hacking.
