### PR TITLE
Fix example for injecting same-element directive injection.

### DIFF
--- a/modules/angular2/src/core/annotations/annotations.js
+++ b/modules/angular2/src/core/annotations/annotations.js
@@ -134,7 +134,7 @@ import {Injectable} from 'angular2/di';
  * @Decorator({ selector: '[my-directive]' })
  * class MyDirective {
  *   constructor(dependency: Dependency) {
- *     expect(dependency.id).toEqual(2);
+ *     expect(dependency.id).toEqual(3);
  *   }
  * }
  * ```


### PR DESCRIPTION
Fixes the example to correspond with the corresponding text by making it expect the ID on the current element instead of the parent element.
