### PR TITLE
style(dart/transform): Remove `src` from library directives

### DIFF
--- a/modules/angular2/src/transform/bind_generator/generator.dart
+++ b/modules/angular2/src/transform/bind_generator/generator.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.bind_generator.generator;
+library angular2.transform.bind_generator.generator;
 
 import 'dart:async';
 

--- a/modules/angular2/src/transform/bind_generator/transformer.dart
+++ b/modules/angular2/src/transform/bind_generator/transformer.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.bind_generator.transformer;
+library angular2.transform.bind_generator.transformer;
 
 import 'dart:async';
 import 'package:angular2/src/transform/common/asset_reader.dart';

--- a/modules/angular2/src/transform/bind_generator/visitor.dart
+++ b/modules/angular2/src/transform/bind_generator/visitor.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.bind_generator.visitor;
+library angular2.transform.bind_generator.visitor;
 
 import 'package:analyzer/analyzer.dart';
 import 'package:angular2/src/transform/common/logging.dart';

--- a/modules/angular2/src/transform/common/asset_reader.dart
+++ b/modules/angular2/src/transform/common/asset_reader.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.common.asset_reader;
+library angular2.transform.common.asset_reader;
 
 import 'dart:async';
 import 'dart:convert';

--- a/modules/angular2/src/transform/common/formatter.dart
+++ b/modules/angular2/src/transform/common/formatter.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.common.formatter;
+library angular2.transform.common.formatter;
 
 import 'package:dart_style/dart_style.dart';
 

--- a/modules/angular2/src/transform/common/logging.dart
+++ b/modules/angular2/src/transform/common/logging.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.common.logging;
+library angular2.transform.common.logging;
 
 import 'package:barback/barback.dart';
 import 'package:code_transformers/messages/build_logger.dart';

--- a/modules/angular2/src/transform/common/names.dart
+++ b/modules/angular2/src/transform/common/names.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.common.names;
+library angular2.transform.common.names;
 
 const SETUP_METHOD_NAME = 'setupReflection';
 const REFLECTOR_VAR_NAME = 'reflector';

--- a/modules/angular2/src/transform/common/ngdata.dart
+++ b/modules/angular2/src/transform/common/ngdata.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.common.ng_data;
+library angular2.transform.common.ng_data;
 
 import 'dart:convert';
 

--- a/modules/angular2/src/transform/common/options.dart
+++ b/modules/angular2/src/transform/common/options.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.common.options;
+library angular2.transform.common.options;
 
 const ENTRY_POINT_PARAM = 'entry_point';
 const REFLECTION_ENTRY_POINT_PARAM = 'reflection_entry_point';

--- a/modules/angular2/src/transform/common/parser.dart
+++ b/modules/angular2/src/transform/common/parser.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.common.parser;
+library angular2.transform.common.parser;
 
 import 'dart:async';
 

--- a/modules/angular2/src/transform/common/registered_type.dart
+++ b/modules/angular2/src/transform/common/registered_type.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.common.registered_type;
+library angular2.transform.common.registered_type;
 
 import 'package:analyzer/analyzer.dart';
 import 'package:angular2/src/transform/common/names.dart';

--- a/modules/angular2/src/transform/common/visitor_mixin.dart
+++ b/modules/angular2/src/transform/common/visitor_mixin.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.common;
+library angular2.transform.common;
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/src/generated/java_core.dart';

--- a/modules/angular2/src/transform/directive_linker/linker.dart
+++ b/modules/angular2/src/transform/directive_linker/linker.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.directive_linker.linker;
+library angular2.transform.directive_linker.linker;
 
 import 'dart:async';
 

--- a/modules/angular2/src/transform/directive_linker/transformer.dart
+++ b/modules/angular2/src/transform/directive_linker/transformer.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.directive_linker.transformer;
+library angular2.transform.directive_linker.transformer;
 
 import 'dart:async';
 

--- a/modules/angular2/src/transform/directive_processor/rewriter.dart
+++ b/modules/angular2/src/transform/directive_processor/rewriter.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.directive_processor;
+library angular2.transform.directive_processor;
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/src/generated/java_core.dart';

--- a/modules/angular2/src/transform/directive_processor/transformer.dart
+++ b/modules/angular2/src/transform/directive_processor/transformer.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.directive_processor.transformer;
+library angular2.transform.directive_processor.transformer;
 
 import 'dart:async';
 

--- a/modules/angular2/src/transform/directive_processor/visitors.dart
+++ b/modules/angular2/src/transform/directive_processor/visitors.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.directive_processor;
+library angular2.transform.directive_processor;
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/src/generated/java_core.dart';

--- a/modules/angular2/src/transform/in_progress/annotation_processor.dart
+++ b/modules/angular2/src/transform/in_progress/annotation_processor.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform;
+library angular2.transform;
 
 import 'dart:collection' show Queue;
 import 'package:analyzer/src/generated/ast.dart';

--- a/modules/angular2/src/transform/in_progress/codegen.dart
+++ b/modules/angular2/src/transform/in_progress/codegen.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform;
+library angular2.transform;
 
 import 'package:analyzer/src/generated/ast.dart';
 import 'package:analyzer/src/generated/element.dart';
@@ -55,7 +55,7 @@ abstract class DirectiveRegistry {
 const setupReflectionMethodName = 'setupReflection';
 
 const _libraryDeclaration = '''
-library angular2.src.transform.generated;
+library  angular2.transform.generated;
 ''';
 
 const _reflectorImport = '''

--- a/modules/angular2/src/transform/in_progress/find_bootstrap.dart
+++ b/modules/angular2/src/transform/in_progress/find_bootstrap.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform;
+library angular2.transform;
 
 import 'package:analyzer/src/generated/ast.dart';
 import 'package:analyzer/src/generated/element.dart';

--- a/modules/angular2/src/transform/in_progress/find_reflection_capabilities.dart
+++ b/modules/angular2/src/transform/in_progress/find_reflection_capabilities.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform;
+library angular2.transform;
 
 import 'package:analyzer/src/generated/ast.dart';
 import 'package:analyzer/src/generated/element.dart';

--- a/modules/angular2/src/transform/in_progress/resolvers.dart
+++ b/modules/angular2/src/transform/in_progress/resolvers.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform;
+library angular2.transform;
 
 import 'package:barback/barback.dart';
 import 'package:analyzer/src/generated/element.dart';

--- a/modules/angular2/src/transform/in_progress/traversal.dart
+++ b/modules/angular2/src/transform/in_progress/traversal.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform;
+library angular2.transform;
 
 import 'package:analyzer/src/generated/ast.dart';
 import 'package:analyzer/src/generated/element.dart';

--- a/modules/angular2/src/transform/reflection_remover/ast_tester.dart
+++ b/modules/angular2/src/transform/reflection_remover/ast_tester.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.reflection_remover.ast_tester;
+library angular2.transform.reflection_remover.ast_tester;
 
 import 'package:analyzer/src/generated/ast.dart';
 import 'package:analyzer/src/generated/element.dart';

--- a/modules/angular2/src/transform/reflection_remover/codegen.dart
+++ b/modules/angular2/src/transform/reflection_remover/codegen.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.reflection_remover.codegen;
+library angular2.transform.reflection_remover.codegen;
 
 import 'package:analyzer/src/generated/ast.dart';
 import 'package:barback/barback.dart';

--- a/modules/angular2/src/transform/reflection_remover/remove_reflection_capabilities.dart
+++ b/modules/angular2/src/transform/reflection_remover/remove_reflection_capabilities.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.reflection_remover.remove_reflection_capabilities;
+library angular2.transform.reflection_remover.remove_reflection_capabilities;
 
 import 'package:analyzer/analyzer.dart';
 

--- a/modules/angular2/src/transform/reflection_remover/rewriter.dart
+++ b/modules/angular2/src/transform/reflection_remover/rewriter.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.reflection_remover.rewriter;
+library angular2.transform.reflection_remover.rewriter;
 
 import 'package:analyzer/src/generated/ast.dart';
 import 'package:angular2/src/transform/common/logging.dart';

--- a/modules/angular2/src/transform/reflection_remover/transformer.dart
+++ b/modules/angular2/src/transform/reflection_remover/transformer.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.reflection_remover.transformer;
+library angular2.transform.reflection_remover.transformer;
 
 import 'dart:async';
 import 'package:angular2/src/transform/common/logging.dart' as log;

--- a/modules/angular2/src/transform/template_compiler/generator.dart
+++ b/modules/angular2/src/transform/template_compiler/generator.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.template_compiler.generator;
+library angular2.transform.template_compiler.generator;
 
 import 'dart:async';
 

--- a/modules/angular2/src/transform/template_compiler/recording_reflection_capabilities.dart
+++ b/modules/angular2/src/transform/template_compiler/recording_reflection_capabilities.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.template_compiler.recording_reflection_capabilities;
+library angular2.transform.template_compiler.recording_reflection_capabilities;
 
 import 'package:angular2/src/reflection/reflection_capabilities.dart';
 import 'package:angular2/src/reflection/types.dart';

--- a/modules/angular2/src/transform/template_compiler/transformer.dart
+++ b/modules/angular2/src/transform/template_compiler/transformer.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform.template_compiler.transformer;
+library angular2.transform.template_compiler.transformer;
 
 import 'dart:async';
 

--- a/modules/angular2/src/transform/transformer.dart
+++ b/modules/angular2/src/transform/transformer.dart
@@ -1,4 +1,4 @@
-library angular2.src.transform;
+library angular2.transform;
 
 import 'package:barback/barback.dart';
 import 'package:dart_style/dart_style.dart';

--- a/modules/angular2/test/transform/template_compiler/inline_expression_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_expression_files/expected/hello.ng_deps.dart
@@ -1,4 +1,4 @@
-library examples.src.hello_world.index_common_dart;
+library examples.hello_world.index_common_dart;
 
 import 'hello.dart';
 import 'package:angular2/angular2.dart'

--- a/modules/angular2/test/transform/template_compiler/inline_expression_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_expression_files/hello.ng_deps.dart
@@ -1,4 +1,4 @@
-library examples.src.hello_world.index_common_dart;
+library examples.hello_world.index_common_dart;
 
 import 'hello.dart';
 import 'package:angular2/angular2.dart'

--- a/modules/angular2/test/transform/template_compiler/inline_method_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_method_files/expected/hello.ng_deps.dart
@@ -1,4 +1,4 @@
-library examples.src.hello_world.index_common_dart;
+library examples.hello_world.index_common_dart;
 
 import 'hello.dart';
 import 'package:angular2/angular2.dart'

--- a/modules/angular2/test/transform/template_compiler/inline_method_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_method_files/hello.ng_deps.dart
@@ -1,4 +1,4 @@
-library examples.src.hello_world.index_common_dart;
+library examples.hello_world.index_common_dart;
 
 import 'hello.dart';
 import 'package:angular2/angular2.dart'


### PR DESCRIPTION
Conform to Angular 2 style by removing `src` from library directives.
[Completed with](https://xkcd.com/208/):

```
find -name "*.dart" | xargs sed -i -e 's!library\(.*\)src\.\(.*\)!library\1\2!'
```

Closes #1005
