### PR TITLE
refactor: update Dart package dependencies

### DIFF
--- a/modules/angular2/pubspec.yaml
+++ b/modules/angular2/pubspec.yaml
@@ -9,11 +9,11 @@ homepage: <%= packageJson.homepage %>
 environment:
   sdk: '>=1.9.0-dev.8.0'
 dependencies:
-  analyzer: '^0.22.4'
+  analyzer: '>=0.22.4 <0.25.0'
   barback: '^0.15.2+2'
   code_transformers: '^0.2.5'
   dart_style: '^0.1.3'
-  html5lib: '^0.12.0'
+  html: '^0.12.0'
   stack_trace: '^1.1.1'
 dev_dependencies:
   guinness: "^0.1.17"

--- a/modules/angular2/src/dom/html_adapter.dart
+++ b/modules/angular2/src/dom/html_adapter.dart
@@ -1,8 +1,8 @@
-library angular2.dom.html5adapter;
+library angular2.dom.htmlAdapter;
 
 import 'dom_adapter.dart';
-import 'package:html5lib/parser.dart' as parser;
-import 'package:html5lib/dom.dart';
+import 'package:html/parser.dart' as parser;
+import 'package:html/dom.dart';
 
 class Html5LibDomAdapter implements DomAdapter {
   static void makeCurrent() {

--- a/modules/angular2/src/transform/template_compiler/transformer.dart
+++ b/modules/angular2/src/transform/template_compiler/transformer.dart
@@ -2,7 +2,7 @@ library angular2.transform.template_compiler.transformer;
 
 import 'dart:async';
 
-import 'package:angular2/src/dom/html5lib_adapter.dart';
+import 'package:angular2/src/dom/html_adapter.dart';
 import 'package:angular2/src/transform/common/asset_reader.dart';
 import 'package:angular2/src/transform/common/formatter.dart';
 import 'package:angular2/src/transform/common/logging.dart' as log;

--- a/modules/angular2/test/core/compiler/compiler_html5lib.server.spec.dart
+++ b/modules/angular2/test/core/compiler/compiler_html5lib.server.spec.dart
@@ -1,6 +1,6 @@
 library angular2.compiler.html5lib_dom_adapter.test;
 
-import 'package:angular2/src/dom/html5lib_adapter.dart';
+import 'package:angular2/src/dom/html_adapter.dart';
 import 'package:angular2/src/test_lib/test_lib.dart' show testSetup;
 import 'compiler_common_tests.dart';
 

--- a/modules/angular2/test/dom/html5lib_adapter.server.spec.dart
+++ b/modules/angular2/test/dom/html5lib_adapter.server.spec.dart
@@ -2,7 +2,7 @@ library angular2.dom.html5lib_adapter.test;
 
 import 'package:guinness/guinness.dart';
 import 'package:unittest/unittest.dart' hide expect;
-import 'package:angular2/src/dom/html5lib_adapter.dart';
+import 'package:angular2/src/dom/html_adapter.dart';
 
 // A smoke-test of the adapter. It is primarily tested by the compiler.
 main() {

--- a/modules/angular2/test/transform/integration/all_tests.dart
+++ b/modules/angular2/test/transform/integration/all_tests.dart
@@ -1,7 +1,7 @@
 library angular2.test.transform.integration;
 
 import 'dart:io';
-import 'package:angular2/src/dom/html5lib_adapter.dart';
+import 'package:angular2/src/dom/html_adapter.dart';
 import 'package:angular2/transformer.dart';
 import 'package:code_transformers/tests.dart';
 import 'package:dart_style/dart_style.dart';

--- a/modules/angular2/test/transform/template_compiler/all_tests.dart
+++ b/modules/angular2/test/transform/template_compiler/all_tests.dart
@@ -1,7 +1,7 @@
 library angular2.test.transform.directive_processor.all_tests;
 
 import 'package:barback/barback.dart';
-import 'package:angular2/src/dom/html5lib_adapter.dart';
+import 'package:angular2/src/dom/html_adapter.dart';
 import 'package:angular2/src/transform/common/asset_reader.dart';
 import 'package:angular2/src/transform/common/formatter.dart';
 import 'package:angular2/src/transform/template_compiler/generator.dart';


### PR DESCRIPTION
Allow the latest version of analyzer and move from html5lib -> html package
