### PR TITLE
feature(build): Include ts2dart transpile step in the Angular build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "gulp-sourcemaps": "1.3.*",
     "gulp-template": "^3.0.0",
     "gulp-traceur": "0.16.*",
+    "gulp-ts2dart": "^1.0.0",
     "gulp-webserver": "^0.8.7",
     "js-yaml": "^3.2.7",
     "karma": "^0.12.23",


### PR DESCRIPTION
This only transpiles one package to start with: di/.
It ensures that package transpiles without errors, so no one can
introduce non-TypeScript syntax.
Next step is to widen the task inputs to cover additional packages.

See design doc for the migration:
https://docs.google.com/document/d/14RJLhu6uuv7NchFkAb6PKzOOO0L7l3Z507eKWzkEUhQ/edit

A convenience task 'ts2dart' is added for developing ts2dart, and
it runs all of the angular code through the transpiler.
