### PR TITLE
Remove invalid super() call

### DIFF
--- a/modules/angular2/src/change_detection/parser/ast.js
+++ b/modules/angular2/src/change_detection/parser/ast.js
@@ -418,7 +418,6 @@ export class TemplateBinding {
   name:string;
   expression:ASTWithSource;
   constructor(key:string, keyIsVar:boolean, name:string, expression:ASTWithSource) {
-    super();
     this.key = key;
     this.keyIsVar = keyIsVar;
     // only either name or expression will be filled.


### PR DESCRIPTION
Unless I'm missing something, this is invalid - no super without extending. Currently breaks #1060 
