### PR TITLE
chore: build the stable branch of Dart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ env:
   - ARCH=linux-x64
   matrix:
   - MODE=js DART_CHANNEL=dev
-# Dissabled until Dart v1.9 hits stable
-#  - MODE=dart DART_CHANNEL=stable
+  - MODE=dart DART_CHANNEL=stable
   - MODE=dart DART_CHANNEL=dev
 
 before_install:


### PR DESCRIPTION
Now that Dart 1.9 is stable
