### PR TITLE
test(di): Add a test for sync binding + resolved async dependency

### DIFF
--- a/modules/angular2/test/di/async_spec.js
+++ b/modules/angular2/test/di/async_spec.js
@@ -144,7 +144,7 @@ export function main() {
           .toThrowError('Cannot instantiate UserList synchronously. It is provided as a promise!');
       });
 
-      it('should throw when instantiating a sync binding with an dependency', function () {
+      it('should throw when instantiating a sync binding with an async dependency', function () {
         var injector = new Injector([
           bind(UserList).toAsyncFactory(fetchUsers),
           UserController
@@ -153,6 +153,19 @@ export function main() {
         expect(() => injector.get(UserController))
           .toThrowError('Cannot instantiate UserList synchronously. It is provided as a promise! (UserController -> UserList)');
       });
+
+      it('should not throw when instantiating a sync binding with a resolved async dependency',
+        inject([AsyncTestCompleter], (async) => {
+        var injector = new Injector([
+          bind(UserList).toAsyncFactory(fetchUsers),
+          UserController
+        ]);
+
+        injector.asyncGet(UserList).then(() => {
+          expect(() => { injector.get(UserController); }).not.toThrow();
+          async.done();
+        });
+      }));
 
       it('should resolve synchronously when an async dependency requested as a promise', function () {
         var injector = new Injector([


### PR DESCRIPTION
@vsavkin while discussing with @juliemr, we've noticed that pattern in application.js:

``` js
      bind(appViewToken).toAsyncFactory(...),

      bind(appChangeDetectorToken).toFactory((rootView) => rootView.changeDetector,
          [appViewToken]),
```

that's a sync binding but an async dependency.

It works because the Change Detector is instantiated only after the app view has been instantiated.

I think that's an important use case to capture in the unit tests.
