### PR TITLE
chore(dgeni): set log level to 'warning'

### DIFF
--- a/docs/dgeni-package/index.js
+++ b/docs/dgeni-package/index.js
@@ -45,7 +45,7 @@ module.exports = new Package('angular', [jsdocPackage, nunjucksPackage])
 
 // Configure the log service
 .config(function(log) {
-  log.level = 'info';
+  log.level = 'warning';
 })
 
 


### PR DESCRIPTION
@petebacondarwin I would be nice to avoid cluttering the CI logs with info message, is this the right thing to do ?
