### PR TITLE
Correct fixture for parsing .es6 files as TypeScript.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -323,6 +323,15 @@ gulp.task('build/transpile.js.prod.es5', function() {
   });
 });
 
+gulp.task('build/transpile.js.prod.es5.ts', function() {
+  return es5build({
+    src: CONFIG.dest.js.prod.es6 + '/angular2/src/facade/',
+    dest: CONFIG.dest.js.prod.es5,
+    modules: 'instantiate',
+    typescript: true
+  });
+});
+
 gulp.task('build/transpile.js.prod', function(done) {
   runSequence(
     'build/transpile.js.prod.es6',
@@ -361,11 +370,10 @@ gulp.task('build/format.dart.ts2dart', rundartpackage(gulp, gulpPlugins, {
   packageName: CONFIG.formatDart.packageName,
   args: ['dart_style:format', '-w', 'dist/dart.ts2dart']
 }));
-gulp.task('ts2dart', function(done) {
-  runSequence(
-    ['build/transpile.dart.ts2dart', 'build/format.dart.ts2dart'],
-    done
-  );
+
+// Temporary tasks for migration to TypeScript. Will likely fail.
+gulp.task('as2ts', function(done) {
+ runSequence('build/transpile.js.prod.es6', 'build/transpile.js.prod.es5.ts', done);
 });
 
 // ------------

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "gulp-template": "^3.0.0",
     "gulp-traceur": "0.16.*",
     "gulp-ts2dart": "^1.0.0",
+    "gulp-typescript": "^2.5.0",
     "gulp-webserver": "^0.8.7",
     "js-yaml": "^3.2.7",
     "karma": "^0.12.23",
@@ -77,6 +78,7 @@
     "temp": "^0.8.1",
     "ternary-stream": "^1.2.3",
     "through2": "^0.6.1",
+    "typescript": "mprobst/TypeScript#decorators_min",
     "vinyl": "^0.4.6",
     "yargs": "2.3.*"
   }

--- a/tools/build/es5build.js
+++ b/tools/build/es5build.js
@@ -6,6 +6,7 @@ var traceur = require('gulp-traceur');
 var rename = require('gulp-rename');
 var sourcemaps = require('gulp-sourcemaps');
 var through2 = require('through2');
+var ts = require('gulp-typescript');
 var fs = require('fs');
 var path = require('path');
 
@@ -47,7 +48,22 @@ if (!module.parent) {
 
 function run(config) {
   var src = ['!node_modules', '!node_modules/**', './**/*.es6'];
-  return gulp.src(src, {cwd: config.src})
+  var transpiler;
+  if (config.typescript) {
+    transpiler = ts({
+      target: 'ES5',
+      module: /*system.js*/'commonjs',
+      allowNonTsExtensions: true,
+      typescript: require('typescript')
+    }).js;
+  } else {
+    transpiler = traceur({
+      modules: config.modules,
+      sourceMaps: true
+    });
+  }
+
+  gulp.src(src, {cwd: config.src})
     .pipe(rename(function(file) {
       file.extname = file.extname.replace('.es6', '.js');
     }))
@@ -69,10 +85,7 @@ function run(config) {
         done();
       });
     }))
-    .pipe(traceur({
-      modules: config.modules,
-      sourceMaps: true
-    }))
+    .pipe(transpiler)
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest(config.dest));
 };


### PR DESCRIPTION
We don't intend for these to be transpiled to dart, so they don't need to conform to the TS subset that ts2dart supports. Instead, we should run these through the normal TypeScript compiler to discover the errors.
