### PR TITLE
fix(di): allow injecting event emitter fns without specifying type annotation

### DIFF
--- a/modules/angular2/src/core/annotations/di.js
+++ b/modules/angular2/src/core/annotations/di.js
@@ -12,6 +12,10 @@ export class EventEmitter extends DependencyAnnotation {
     super();
     this.eventName = eventName;
   }
+
+  get token() {
+    return Function;
+  }
 }
 
 /**
@@ -24,6 +28,10 @@ export class PropertySetter extends DependencyAnnotation {
   constructor(propName) {
     super();
     this.propName = propName;
+  }
+
+  get token() {
+    return Function;
   }
 }
 

--- a/modules/angular2/src/di/annotations.js
+++ b/modules/angular2/src/di/annotations.js
@@ -107,6 +107,10 @@ export class DependencyAnnotation {
   @CONST()
   constructor() {
   }
+
+  get token() {
+    return null;
+  }
 }
 
 /**

--- a/modules/angular2/src/di/binding.js
+++ b/modules/angular2/src/di/binding.js
@@ -135,7 +135,11 @@ function _extractToken(typeOrFunc, annotations) {
       optional = true;
 
     } else if (paramAnnotation instanceof DependencyAnnotation) {
+      if (isPresent(paramAnnotation.token)) {
+       token = paramAnnotation.token;
+      }
       ListWrapper.push(depProps, paramAnnotation);
+
     } else if (paramAnnotation.name === "string") {
       token = paramAnnotation;
     }


### PR DESCRIPTION
Fixes #965

@vsavkin I'm not sure this is the best possible fix but I guess you are the most familiar with this part of the code, so would be great if you could review this one.

The basic problem was that without a type annotation binding couldn't figure out a token for `DependencyAnnotation`s while it seems that `ElementInjector` doesn't care that much about the token itself but is more interested in dependency properties. In this respect any token would do. 
