### PR TITLE
chore(gulp): Stop copying .cjs files to the dist folder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -157,10 +157,9 @@ var CONFIG = {
       cjs: {
         src: [
           'modules/**/*.md', '!modules/**/*.dart.md', 'modules/**/*.png',
-          'modules/**/*.cjs', 'modules/**/package.json'
+          'modules/**/package.json'
         ],
         pipes: {
-          '**/*.cjs': gulpPlugins.rename({extname: '.js'}),
           '**/*.js.md': gulpPlugins.rename(function(file) {
             file.basename = file.basename.substring(0, file.basename.lastIndexOf('.'));
           }),


### PR DESCRIPTION
They're already transpiled by the build/transpile.js.cjs task
