### PR TITLE
fix(build): Require gulp-ts2dart at least at 1.0.6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "gulp-sourcemaps": "1.3.*",
     "gulp-template": "^3.0.0",
     "gulp-traceur": "0.17.*",
-    "gulp-ts2dart": "^1.0.0",
+    "gulp-ts2dart": "^1.0.6",
     "gulp-webserver": "^0.8.7",
     "js-yaml": "^3.2.7",
     "karma": "^0.12.23",


### PR DESCRIPTION
This fixes the build by pulling in a later version that correctly ignores the .es6 files.
