### PR TITLE
refactor(dart/transform): Minor renames

### DIFF
--- a/modules/angular2/src/transform/common/names.dart
+++ b/modules/angular2/src/transform/common/names.dart
@@ -1,6 +1,6 @@
 library angular2.transform.common.names;
 
-const SETUP_METHOD_NAME = 'setupReflection';
+const SETUP_METHOD_NAME = 'initReflector';
 const REFLECTOR_VAR_NAME = 'reflector';
 const DEPS_EXTENSION = '.ng_deps.dart';
 const REGISTER_TYPE_METHOD_NAME = 'registerType';

--- a/modules/angular2/src/transform/template_compiler/transformer.dart
+++ b/modules/angular2/src/transform/template_compiler/transformer.dart
@@ -14,14 +14,14 @@ import 'generator.dart';
 
 /// [Transformer] responsible for detecting and processing Angular 2 templates.
 ///
-/// [TemplateComplier] uses the Angular 2 `Compiler` to process the templates,
+/// [TemplateCompiler] uses the Angular 2 `Compiler` to process the templates,
 /// extracting information about what reflection is necessary to render and
 /// use that template. It then generates code in place of those reflective
 /// accesses.
-class TemplateComplier extends Transformer {
+class TemplateCompiler extends Transformer {
   final TransformerOptions options;
 
-  TemplateComplier(this.options);
+  TemplateCompiler(this.options);
 
   @override
   bool isPrimary(AssetId id) => id.path.endsWith(DEPS_EXTENSION);

--- a/modules/angular2/src/transform/transformer.dart
+++ b/modules/angular2/src/transform/transformer.dart
@@ -25,7 +25,7 @@ class AngularTransformerGroup extends TransformerGroup {
     if (options.modeName == TRANSFORM_MODE) {
       phases.addAll([
         [new BindGenerator(options)],
-        [new TemplateComplier(options)],
+        [new TemplateCompiler(options)],
         [new ReflectionRemover(options)]
       ]);
     }

--- a/modules/angular2/test/transform/bind_generator/basic_bind_files/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/bind_generator/basic_bind_files/bar.ng_deps.dart
@@ -4,7 +4,7 @@ import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/bind_generator/basic_bind_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/bind_generator/basic_bind_files/expected/bar.ng_deps.dart
@@ -4,7 +4,7 @@ import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/bind_generator/duplicate_bind_name_files/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/bind_generator/duplicate_bind_name_files/expected/soup.ng_deps.dart
@@ -4,7 +4,7 @@ import 'package:angular2/src/core/annotations/annotations.dart';
 import 'soup.dart';
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/bind_generator/duplicate_bind_name_files/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/bind_generator/duplicate_bind_name_files/soup.ng_deps.dart
@@ -4,7 +4,7 @@ import 'package:angular2/src/core/annotations/annotations.dart';
 import 'soup.dart';
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/bar.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/src/core/annotations/annotations.dart';
 export 'foo.dart';
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/expected/bar.ng_deps.dart
@@ -7,7 +7,7 @@ import 'foo.ng_deps.dart' as i0;
 export 'foo.dart';
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector
@@ -16,5 +16,5 @@ void setupReflection(reflector) {
       'parameters': const [],
       'annotations': const [const Component(selector: '[soup]')]
     });
-  i0.setupReflection(reflector);
+  i0.initReflector(reflector);
 }

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/expected/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/expected/foo.ng_deps.dart
@@ -4,7 +4,7 @@ import 'foo.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/expected/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/expected/index.ng_deps.dart
@@ -6,8 +6,8 @@ import 'bar.dart';
 import 'bar.ng_deps.dart' as i0;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
-  i0.setupReflection(reflector);
+  i0.initReflector(reflector);
 }

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/foo.ng_deps.dart
@@ -4,7 +4,7 @@ import 'foo.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/index.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/src/reflection/reflection_capabilities.dart';
 import 'bar.dart';
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
 }

--- a/modules/angular2/test/transform/directive_linker/simple_files/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/bar.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/src/core/annotations/annotations.dart';
 import 'foo.dart' as dep;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/directive_linker/simple_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/expected/bar.ng_deps.dart
@@ -6,7 +6,7 @@ import 'foo.dart' as dep;
 import 'foo.ng_deps.dart' as i0;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector
@@ -18,5 +18,5 @@ void setupReflection(reflector) {
             selector: '[soup]', services: const [dep.DependencyComponent])
       ]
     });
-  i0.setupReflection(reflector);
+  i0.initReflector(reflector);
 }

--- a/modules/angular2/test/transform/directive_linker/simple_files/expected/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/expected/foo.ng_deps.dart
@@ -4,7 +4,7 @@ import 'foo.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/directive_linker/simple_files/expected/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/expected/index.ng_deps.dart
@@ -6,8 +6,8 @@ import 'bar.dart';
 import 'bar.ng_deps.dart' as i0;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
-  i0.setupReflection(reflector);
+  i0.initReflector(reflector);
 }

--- a/modules/angular2/test/transform/directive_linker/simple_files/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/foo.ng_deps.dart
@@ -4,7 +4,7 @@ import 'foo.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/directive_linker/simple_files/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/index.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/src/reflection/reflection_capabilities.dart';
 import 'bar.dart';
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
 }

--- a/modules/angular2/test/transform/directive_processor/parameter_metadata/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/parameter_metadata/expected/soup.ng_deps.dart
@@ -4,7 +4,7 @@ import 'soup.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/integration/list_of_types_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/list_of_types_files/expected/bar.ng_deps.dart
@@ -7,7 +7,7 @@ import 'foo.ng_deps.dart' as i0;
 import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i1;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector
@@ -17,6 +17,6 @@ void setupReflection(reflector) {
       'annotations':
           const [const Component(componentServices: const [MyContext])]
     });
-  i0.setupReflection(reflector);
-  i1.setupReflection(reflector);
+  i0.initReflector(reflector);
+  i1.initReflector(reflector);
 }

--- a/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/src/core/annotations/annotations.dart';
 import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i0;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector
@@ -14,5 +14,5 @@ void setupReflection(reflector) {
       'parameters': const [],
       'annotations': const [const Component(selector: '[soup]')]
     });
-  i0.setupReflection(reflector);
+  i0.initReflector(reflector);
 }

--- a/modules/angular2/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
@@ -11,10 +11,10 @@ import 'package:angular2/src/reflection/reflection_capabilities.ng_deps.dart'
     as i2;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
-  i0.setupReflection(reflector);
-  i1.setupReflection(reflector);
-  i2.setupReflection(reflector);
+  i0.initReflector(reflector);
+  i1.initReflector(reflector);
+  i2.initReflector(reflector);
 }

--- a/modules/angular2/test/transform/integration/synthetic_ctor_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/synthetic_ctor_files/expected/bar.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/src/core/annotations/annotations.dart';
 import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i0;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector
@@ -14,5 +14,5 @@ void setupReflection(reflector) {
       'parameters': const [],
       'annotations': const [const Component(selector: '[soup]')]
     });
-  i0.setupReflection(reflector);
+  i0.initReflector(reflector);
 }

--- a/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
@@ -7,7 +7,7 @@ import 'package:angular2/src/core/annotations/template.ng_deps.dart' as i0;
 import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i1;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector
@@ -19,6 +19,6 @@ void setupReflection(reflector) {
         const Template(inline: 'Salad')
       ]
     });
-  i0.setupReflection(reflector);
-  i1.setupReflection(reflector);
+  i0.initReflector(reflector);
+  i1.initReflector(reflector);
 }

--- a/modules/angular2/test/transform/integration/two_deps_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_deps_files/expected/bar.ng_deps.dart
@@ -7,7 +7,7 @@ import 'foo.ng_deps.dart' as i0;
 import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i1;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector
@@ -18,6 +18,6 @@ void setupReflection(reflector) {
       'annotations':
           const [const Component(selector: prefix.preDefinedSelector)]
     });
-  i0.setupReflection(reflector);
-  i1.setupReflection(reflector);
+  i0.initReflector(reflector);
+  i1.initReflector(reflector);
 }

--- a/modules/angular2/test/transform/reflection_remover/reflection_remover_files/README.md
+++ b/modules/angular2/test/transform/reflection_remover/reflection_remover_files/README.md
@@ -2,6 +2,6 @@ Tests that the reflection removal step:
  1. Comments out the import of reflection_capabilities.dart
  2. Comments out the instantiation of `ReflectionCapabilities`
  3. Adds the appropriate import.
- 4. Adds the call to `setupReflection`
+ 4. Adds the call to `initReflector`
  5. Does not change line numbers in the source.
  6. Makes minimal changes to source offsets.

--- a/modules/angular2/test/transform/reflection_remover/reflection_remover_files/expected/index.dart
+++ b/modules/angular2/test/transform/reflection_remover/reflection_remover_files/expected/index.dart
@@ -16,7 +16,7 @@ import 'package:angular2/src/reflection/reflection.dart';
 /*import 'package:angular2/src/reflection/reflection_capabilities.dart';*/import 'index.ng_deps.dart' as ngStaticInit;
 
 void main() {
-  /*reflector.reflectionCapabilities = new ReflectionCapabilities();*/ngStaticInit.setupReflection(reflector);
+  /*reflector.reflectionCapabilities = new ReflectionCapabilities();*/ngStaticInit.initReflector(reflector);
   bootstrap(MyComponent);
 }
 """;

--- a/modules/angular2/test/transform/template_compiler/inline_expression_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_expression_files/expected/hello.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, Template, NgElement;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/template_compiler/inline_expression_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_expression_files/hello.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, Template, NgElement;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/template_compiler/inline_method_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_method_files/expected/hello.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, Template, NgElement;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/template_compiler/inline_method_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_method_files/hello.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, Template, NgElement;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/template_compiler/url_expression_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/url_expression_files/expected/hello.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, Template, NgElement;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/template_compiler/url_expression_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/url_expression_files/hello.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, Template, NgElement;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/template_compiler/url_method_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/url_method_files/expected/hello.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, Template, NgElement;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector

--- a/modules/angular2/test/transform/template_compiler/url_method_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/url_method_files/hello.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, Template, NgElement;
 
 bool _visited = false;
-void setupReflection(reflector) {
+void initReflector(reflector) {
   if (_visited) return;
   _visited = true;
   reflector


### PR DESCRIPTION
- Rename `setupReflection` => `reflectorInit`
- Rename `TemplateComplier` => `TemplateCompiler`

Fixes #1180 
