### PR TITLE
chore(ts): introduce some TypeScript type declarations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ bower_components
 *.js.deps
 *.js.map
 
+# Or type definitions we mirror from github
+**/typings/**/*.d.ts
+
 # Include when developing application packages.
 pubspec.lock
 .c9

--- a/modules/angular2/tsd.json
+++ b/modules/angular2/tsd.json
@@ -1,0 +1,82 @@
+{
+  "version": "v4",
+  "repo": "angular/DefinitelyTyped",
+  "ref": "master",
+  "path": "typings",
+  "bundle": "typings/tsd.d.ts",
+  "installed": {
+    "es6-promise/es6-promise.d.ts": {
+      "commit": "be0b6b394f77a59e192ad7cfec18078706e44db5"
+    },
+    "hammerjs/hammerjs.d.ts": {
+      "commit": "be0b6b394f77a59e192ad7cfec18078706e44db5"
+    },
+    "jasmine/jasmine.d.ts": {
+      "commit": "055b3172e8eb374a75826710c4d08677872620d3"
+    },
+    "rx/rx.all.d.ts": {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.d.ts" : {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx-lite.d.ts" : {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.aggregates.d.ts" : {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.time.d.ts": {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.time-lite.d.ts": {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.async.d.ts" : {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.async-lite.d.ts" : {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.binding.d.ts" : {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.binding-lite.d.ts" : {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.coincidence.d.ts" : {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.coincidence-lite.d.ts" : {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.experimental.d.ts" : {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.joinpatterns.d.ts" : {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.virtualtime.d.ts" : {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.testing.d.ts": {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.backpressure.d.ts": {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+    "rx/rx.backpressure-lite.d.ts": {
+      "commit": "3882d337bb0808cde9fe4c08012508a48c135482"
+    },
+
+    "selenium-webdriver/selenium-webdriver.d.ts": {
+      "commit": "be0b6b394f77a59e192ad7cfec18078706e44db5"
+    },
+    "touch-events/touch-events.d.ts": {
+      "commit": "055b3172e8eb374a75826710c4d08677872620d3"
+    },
+    "zone/zone.d.ts": {
+      "commit": "055b3172e8eb374a75826710c4d08677872620d3"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "url": "https://github.com/angular/angular.git"
   },
   "scripts": {
+    "preinstall": "npm install tsd && tsd update --config modules/angular2/tsd.json",
     "postinstall": "webdriver-manager update && bower install && gulp pubget.dart",
     "test": "gulp test.all.js && gulp test.all.dart"
   },
@@ -56,6 +57,7 @@
     "gulp-template": "^3.0.0",
     "gulp-traceur": "0.17.*",
     "gulp-ts2dart": "^1.0.0",
+    "gulp-typescript": "ivogabe/gulp-typescript#3422fbff06532ccc57368f3b4c8801de8f72ef27",
     "gulp-webserver": "^0.8.7",
     "js-yaml": "^3.2.7",
     "karma": "^0.12.23",
@@ -77,6 +79,7 @@
     "temp": "^0.8.1",
     "ternary-stream": "^1.2.3",
     "through2": "^0.6.1",
+    "typescript": "Microsoft/TypeScript#cebe42b81fbeeaf68c8e228dda5e602ab94e151b",
     "vinyl": "^0.4.6",
     "yargs": "2.3.*"
   }


### PR DESCRIPTION
This uses tsd to fetch the typings from another git repo. I've forked the DefinitelyTyped repo because some typings we use are not available upstream.
