### PR TITLE
refactor(change_detection): call onChange from the change detector

### DIFF
--- a/modules/angular2/src/change_detection/change_detection_util.js
+++ b/modules/angular2/src/change_detection/change_detection_util.js
@@ -3,7 +3,6 @@ import {List, ListWrapper, MapWrapper, StringMapWrapper} from 'angular2/src/faca
 import {ProtoRecord} from './proto_record';
 import {ExpressionChangedAfterItHasBeenChecked} from './exceptions';
 import {NO_CHANGE} from './pipes/pipe';
-import {ChangeRecord, ChangeDetector} from './interfaces';
 import {CHECK_ALWAYS, CHECK_ONCE, CHECKED, DETACHED, ON_PUSH} from './constants';
 
 export var uninitialized = new Object();
@@ -40,31 +39,7 @@ var _simpleChanges = [
   new SimpleChange(null, null),
   new SimpleChange(null, null),
   new SimpleChange(null, null)
-]
-
-var _changeRecordsIndex = 0;
-var _changeRecords = [
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null),
-  new ChangeRecord(null, null)
-]
+];
 
 function _simpleChange(previousValue, currentValue) {
   var index = _simpleChangesIndex++ % 20;
@@ -73,16 +48,6 @@ function _simpleChange(previousValue, currentValue) {
   s.currentValue = currentValue;
   return s;
 }
-
-function _changeRecord(bindingMemento, change) {
-  var index = _changeRecordsIndex++ % 20;
-  var s = _changeRecords[index];
-  s.bindingMemento = bindingMemento;
-  s.change = change;
-  return s;
-}
-
-var _singleElementList = [null];
 
 export class ChangeDetectionUtil {
   static unitialized() {
@@ -152,33 +117,19 @@ export class ChangeDetectionUtil {
     throw new ExpressionChangedAfterItHasBeenChecked(proto, change);
   }
 
-  static simpleChange(previousValue:any, currentValue:any):SimpleChange {
-    return _simpleChange(previousValue, currentValue);
-  }
-
-  static changeRecord(memento:any, change:any):ChangeRecord {
-    return _changeRecord(memento, change);
-  }
-
-  static simpleChangeRecord(memento:any, previousValue:any, currentValue:any):ChangeRecord {
-    return _changeRecord(memento, _simpleChange(previousValue, currentValue));
-  }
-
   static changeDetectionMode(strategy:string) {
     return strategy == ON_PUSH ? CHECK_ONCE : CHECK_ALWAYS;
   }
 
-  static addRecord(updatedRecords:List, changeRecord:ChangeRecord):List {
-    if (isBlank(updatedRecords)) {
-      updatedRecords = _singleElementList;
-      updatedRecords[0] = changeRecord;
+  static simpleChange(previousValue:any, currentValue:any):SimpleChange {
+    return _simpleChange(previousValue, currentValue);
+  }
 
-    } else if (updatedRecords === _singleElementList) {
-      updatedRecords = [_singleElementList[0], changeRecord];
-
-    } else {
-      ListWrapper.push(updatedRecords, changeRecord);
+  static addChange(changes, bindingMemento, change){
+    if (isBlank(changes)) {
+      changes = {};
     }
-    return updatedRecords;
+    changes[bindingMemento.propertyName] = change;
+    return changes;
   }
 }

--- a/modules/angular2/test/core/compiler/view_spec.js
+++ b/modules/angular2/test/core/compiler/view_spec.js
@@ -7,11 +7,11 @@ import {Component, Decorator, Viewport, Directive, onChange, onAllChangesDone} f
 import {Lexer, Parser, DynamicProtoChangeDetector,
   ChangeDetector} from 'angular2/change_detection';
 import {EventEmitter} from 'angular2/src/core/annotations/di';
-import {List, MapWrapper} from 'angular2/src/facade/collection';
+import {List, MapWrapper, StringMapWrapper} from 'angular2/src/facade/collection';
 import {DOM} from 'angular2/src/dom/dom_adapter';
 import {int, IMPLEMENTS} from 'angular2/src/facade/lang';
 import {Injector} from 'angular2/di';
-import {View, PropertyUpdate} from 'angular2/src/core/compiler/view';
+import {View} from 'angular2/src/core/compiler/view';
 import {ViewContainer} from 'angular2/src/core/compiler/view_container';
 import {VmTurnZone} from 'angular2/src/core/zone/vm_turn_zone';
 import {EventManager, DomEventsPlugin} from 'angular2/src/render/dom/events/event_manager';
@@ -624,14 +624,13 @@ export function main() {
           ctx.b = 0;
           cd.detectChanges();
 
-          expect(directive.changes).toEqual({
-            "a" : PropertyUpdate.createWithoutPrevious(0),
-            "b" : PropertyUpdate.createWithoutPrevious(0)
-          });
+          expect(directive.changes["a"].currentValue).toEqual(0);
+          expect(directive.changes["b"].currentValue).toEqual(0);
 
           ctx.a = 100;
           cd.detectChanges();
-          expect(directive.changes).toEqual({"a" : new PropertyUpdate(100, 0)});
+          expect(directive.changes["a"].currentValue).toEqual(100);
+          expect(StringMapWrapper.contains(directive.changes, "b")).toBe(false);
         });
 
         it('should invoke the onAllChangesDone callback', () => {

--- a/modules/benchmarks/src/change_detection/change_detection_benchmark.js
+++ b/modules/benchmarks/src/change_detection/change_detection_benchmark.js
@@ -109,16 +109,16 @@ function setUpChangeDetection(changeDetection:ChangeDetection, iterations) {
 
   var proto = changeDetection.createProtoChangeDetector("proto");
   var bindingRecords = [
-    new BindingRecord(parser.parseBinding('field0', null), "memo", 0),
-    new BindingRecord(parser.parseBinding('field1', null), "memo", 1),
-    new BindingRecord(parser.parseBinding('field2', null), "memo", 2),
-    new BindingRecord(parser.parseBinding('field3', null), "memo", 3),
-    new BindingRecord(parser.parseBinding('field4', null), "memo", 4),
-    new BindingRecord(parser.parseBinding('field5', null), "memo", 5),
-    new BindingRecord(parser.parseBinding('field6', null), "memo", 6),
-    new BindingRecord(parser.parseBinding('field7', null), "memo", 7),
-    new BindingRecord(parser.parseBinding('field8', null), "memo", 8),
-    new BindingRecord(parser.parseBinding('field9', null), "memo", 9)
+    new BindingRecord(parser.parseBinding('field0', null), "memo", null),
+    new BindingRecord(parser.parseBinding('field1', null), "memo", null),
+    new BindingRecord(parser.parseBinding('field2', null), "memo", null),
+    new BindingRecord(parser.parseBinding('field3', null), "memo", null),
+    new BindingRecord(parser.parseBinding('field4', null), "memo", null),
+    new BindingRecord(parser.parseBinding('field5', null), "memo", null),
+    new BindingRecord(parser.parseBinding('field6', null), "memo", null),
+    new BindingRecord(parser.parseBinding('field7', null), "memo", null),
+    new BindingRecord(parser.parseBinding('field8', null), "memo", null),
+    new BindingRecord(parser.parseBinding('field9', null), "memo", null)
   ];
 
   for (var i = 0; i < iterations; ++i) {
@@ -215,6 +215,6 @@ export function main () {
 
 
 class DummyDispatcher extends ChangeDispatcher {
-  onRecordChange(record, context) {
+  invokeMementoFor(binding, newValue) {
   }
 }


### PR DESCRIPTION
Previously we would collect records before sending them to the dispatcher/view. The dispatcher would call setters and then, if necessary, would reduce the records into a map of changes. This means that setters and onChange calls were polymorphic. 

We want to change that. The first step is to make the dispatcher as dumb as possible, so we can move this logic into the detector. This PR does that.

Some notes:
- Now we invoke the setter right after we processed the binding.
- We collect changes if and only if the checked directive implements onChange
