### PR TITLE
fix(TemplateCompiler): fix a typo

### DIFF
--- a/modules/angular2/src/transform/template_compiler/transformer.dart
+++ b/modules/angular2/src/transform/template_compiler/transformer.dart
@@ -14,14 +14,14 @@ import 'generator.dart';
 
 /// [Transformer] responsible for detecting and processing Angular 2 templates.
 ///
-/// [TemplateComplier] uses the Angular 2 `Compiler` to process the templates,
+/// [TemplateCompiler] uses the Angular 2 `Compiler` to process the templates,
 /// extracting information about what reflection is necessary to render and
 /// use that template. It then generates code in place of those reflective
 /// accesses.
-class TemplateComplier extends Transformer {
+class TemplateCompiler extends Transformer {
   final TransformerOptions options;
 
-  TemplateComplier(this.options);
+  TemplateCompiler(this.options);
 
   @override
   bool isPrimary(AssetId id) => id.path.endsWith(DEPS_EXTENSION);

--- a/modules/angular2/src/transform/transformer.dart
+++ b/modules/angular2/src/transform/transformer.dart
@@ -19,7 +19,7 @@ class AngularTransformerGroup extends TransformerGroup {
         [new DirectiveProcessor(options)],
         [new DirectiveLinker(options)],
         [new BindGenerator(options)],
-        [new TemplateComplier(options)],
+        [new TemplateCompiler(options)],
         [new ReflectionRemover(options)]
       ]) {
     formatter.init(new DartFormatter());


### PR DESCRIPTION
@yjbanov @kegluneq more important would be to fix the [Travis error](https://travis-ci.org/angular/angular/jobs/56742691#L1561) - unless it is know and expected atm.

```
[Error from TemplateComplier on examples|web/src/todo/index.ng_deps.dart]:
Parsing ng templates failed.
Exception: not implemented
Stack Trace: #0      Html5LibDomAdapter.setAttribute (package:angular2/src/dom/html_adapter.dart:171:5)
#1      ViewSplitter._parseTemplateBindings (package:angular2/src/core/compiler/pipeline/view_splitter.dart:91:25)
```
