### PR TITLE
feat(tooling): Add a .clang-format for automated JavaScript formatting.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+Language:        JavaScript
+BasedOnStyle:    Google
+ColumnLimit:     100


### PR DESCRIPTION
This mostly just allows 100 character long lines (Google style defaults to 80).
