### PR TITLE
fix(build): don’t read out chrome perflogs during e2e tests

### DIFF
--- a/modules/benchmarks/e2e_test/naive_infinite_scroll_perf.es6
+++ b/modules/benchmarks/e2e_test/naive_infinite_scroll_perf.es6
@@ -7,8 +7,7 @@ describe('ng2 naive infinite scroll benchmark', function () {
   afterEach(perfUtil.verifyNoBrowserErrors);
 
   [1, 2, 4].forEach(function(appSize) {
-    // TODO: reenable these tests when the are passing. See issue #1137
-    xit('should run scroll benchmark and collect stats for appSize = ' +
+    it('should run scroll benchmark and collect stats for appSize = ' +
         appSize, function(done) {
       perfUtil.runBenchmark({
         url: URL,

--- a/protractor-shared.js
+++ b/protractor-shared.js
@@ -135,7 +135,7 @@ var config = exports.config = {
     // During benchmarking, we need to open a new browser
     // for every benchmark, otherwise the numbers can get skewed
     // from other benchmarks (e.g. Chrome keeps JIT caches, ...)
-    if (argv['benchmark']) {
+    if (argv['benchmark'] && !argv['dryrun']) {
       var originalBrowser = browser;
       var _tmpBrowser;
       beforeEach(function() {
@@ -225,19 +225,21 @@ exports.createBenchpressRunner = function(options) {
       'lang': options.lang,
       'runId': runId
     }),
-    benchpress.MultiReporter.createBindings([
-      benchpress.ConsoleReporter,
-      benchpress.JsonFileReporter
-    ]),
     benchpress.JsonFileReporter.BINDINGS,
     benchpress.bind(benchpress.JsonFileReporter.PATH).toValue(resultsFolder)
   ];
   if (!argv['dryrun']) {
     bindings.push(benchpress.Validator.bindTo(benchpress.RegressionSlopeValidator));
     bindings.push(benchpress.bind(benchpress.RegressionSlopeValidator.SAMPLE_SIZE).toValue(argv['sample-size']));
+    bindings.push(benchpress.MultiReporter.createBindings([
+      benchpress.ConsoleReporter,
+      benchpress.JsonFileReporter
+    ]));
   } else {
     bindings.push(benchpress.Validator.bindTo(benchpress.SizeValidator));
     bindings.push(benchpress.bind(benchpress.SizeValidator.SAMPLE_SIZE).toValue(1));
+    bindings.push(benchpress.MultiReporter.createBindings([]));
+    bindings.push(benchpress.MultiMetric.createBindings([]));
   }
 
   global.benchpressRunner = new benchpress.Runner(bindings);


### PR DESCRIPTION
We do this as we are seeing flakes in Chrome with ECONNREFUSED.

Also reuses the same browser window.

Also reenables the infinite scroll benchmark

Closes #1137
