### PR TITLE
perf(change detection): Assign this.locals in change detector ctor

### DIFF
--- a/modules/angular2/src/change_detection/change_detection_jit_generator.es6
+++ b/modules/angular2/src/change_detection/change_detection_jit_generator.es6
@@ -64,6 +64,7 @@ ${DISPATCHER_ACCESSOR} = dispatcher;
 ${PIPE_REGISTRY_ACCESSOR} = pipeRegistry;
 ${PROTOS_ACCESSOR} = protos;
 ${MEMENTOS_ACCESSOR} = directiveMementos;
+${LOCALS_ACCESSOR} = null;
 ${fieldsDefinitions}
 }
 


### PR DESCRIPTION
Set `this.locals = null;` in the ctor of generated change detector
classes to prevent the class "shape" from changing on `hydrate`.
