### PR TITLE
fix(bundles): remove work-around rx.js module detection.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -824,7 +824,13 @@ var bundleConfig = {
   paths: {
     "*": "dist/js/prod/es6/*.es6",
     "rx/*": "node_modules/rx/*.js"
-  }
+  },
+  meta: {
+    // auto-detection fails to detect properly here - https://github.com/systemjs/builder/issues/123
+    'rx/dist/rx.all': {
+        format: 'cjs'
+      }
+    }
 };
 
 // production build
@@ -853,10 +859,13 @@ gulp.task('bundle.js.min', ['build.js.prod'], function() {
 
 // development build
 gulp.task('bundle.js.dev', ['build.js.dev'], function() {
-  return bundler.bundle(
-      merge(true, bundleConfig, {
+  var devBundleConfig = merge(true, bundleConfig);
+  devBundleConfig.paths =
+      merge(true, devBundleConfig.paths, {
        "*": "dist/js/dev/es6/*.es6"
-      }),
+      });
+  return bundler.bundle(
+      devBundleConfig,
       'angular2/angular2',
       './dist/build/angular2.dev.js',
       {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-modify": "0.0.4",
     "gulp-replace": "^0.5.3",
     "node-uuid": "1.4.x",
-    "rx": "2.4.6",
+    "rx": "2.5.1",
     "selenium-webdriver": "2.45.1",
     "systemjs": "^0.9.1",
     "traceur": "0.0.87",

--- a/tools/build/bundle.js
+++ b/tools/build/bundle.js
@@ -15,6 +15,5 @@ module.exports.bundle = function(buildConfig, moduleName, outputFile, outputConf
 module.exports.modify = function(srcs, concatName) {
   return gulp.src(srcs)
     .pipe(concat(concatName))
-    .pipe(replace('use strict', ''))  // remove after https://github.com/systemjs/builder/issues/123 is fixed.
     .pipe(replace('sourceMappingURL', 'sourceMappingURLDisabled'))  // TODO: add concat for sourceMaps
 }


### PR DESCRIPTION
Updates rx to the newest version, because a fix is needed.
