### PR TITLE
feat(events): add support for global events

### DIFF
--- a/modules/angular2/src/core/annotations/annotations.js
+++ b/modules/angular2/src/core/annotations/annotations.js
@@ -367,6 +367,8 @@ export class Directive extends Injectable {
    * - `event1`: the DOM event that the directive listens to.
    * - `statement`: the statement to execute when the event occurs.
    *
+   * To listen to global events, a target must be added to the event name.
+   * The target can be `window`, `document` or `body`.
    *
    * When writing a directive event binding, you can also refer to the following local variables:
    * - `$event`: Current event object which triggered the event.
@@ -380,6 +382,7 @@ export class Directive extends Injectable {
    * @Directive({
    *   hostListeners: {
    *     'event1': 'onMethod1(arguments)',
+   *     'target:event2': 'onMethod2(arguments)',
    *     ...
    *   }
    * }
@@ -387,18 +390,21 @@ export class Directive extends Injectable {
    *
    * ## Basic Event Binding:
    *
-   * Suppose you want to write a directive that triggers on `change` hostListeners in the DOM. You would define the event
-   * binding as follows:
+   * Suppose you want to write a directive that triggers on `change` events in the DOM and on `resize` events in window.
+   * You would define the event binding as follows:
    *
    * ```
    * @Decorator({
    *   selector: 'input',
    *   hostListeners: {
-   *     'change': 'onChange($event)'
+   *     'change': 'onChange($event)',
+   *     'window:resize': 'onResize($event)'
    *   }
    * })
    * class InputDecorator {
    *   onChange(event:Event) {
+   *   }
+   *   onResize(event:Event) {
    *   }
    * }
    * ```

--- a/modules/angular2/src/core/compiler/proto_view_factory.js
+++ b/modules/angular2/src/core/compiler/proto_view_factory.js
@@ -118,9 +118,7 @@ export class ProtoViewFactory {
       protoView.bindElementProperty(astWithSource.ast, propertyName);
     });
     // events
-    MapWrapper.forEach(renderElementBinder.eventBindings, (astWithSource, eventName) => {
-      protoView.bindEvent(eventName, astWithSource.ast, -1);
-    });
+    protoView.bindEvent(renderElementBinder.eventBindings, -1);
     // variables
     // The view's locals needs to have a full set of variable names at construction time
     // in order to prevent new variables from being set later in the lifecycle. Since we don't want
@@ -143,9 +141,7 @@ export class ProtoViewFactory {
         protoView.bindDirectiveProperty(i, astWithSource.ast, propertyName, setter);
       });
       // directive events
-      MapWrapper.forEach(renderDirectiveMetadata.eventBindings, (astWithSource, eventName) => {
-        protoView.bindEvent(eventName, astWithSource.ast, i);
-      });
+      protoView.bindEvent(renderDirectiveMetadata.eventBindings, i);
     }
   }
 

--- a/modules/angular2/src/core/compiler/view.js
+++ b/modules/angular2/src/core/compiler/view.js
@@ -272,7 +272,7 @@ export class AppView {
       var elBinder = this.proto.elementBinders[elementIndex];
       if (isBlank(elBinder.hostListeners)) return;
       var eventMap = elBinder.hostListeners[eventName];
-      if (isBlank(eventName)) return;
+      if (isBlank(eventMap)) return;
       MapWrapper.forEach(eventMap, (expr, directiveIndex) => {
         var context;
         if (directiveIndex === -1) {
@@ -407,19 +407,23 @@ export class AppProtoView {
    * @param {int} directiveIndex The directive index in the binder or -1 when the event is not bound
    *                             to a directive
    */
-  bindEvent(eventName:string, expression:AST, directiveIndex: int = -1) {
+  bindEvent(eventBindings: List<renderApi.EventBinding>, directiveIndex: int = -1) {
     var elBinder = this.elementBinders[this.elementBinders.length - 1];
     var events = elBinder.hostListeners;
     if (isBlank(events)) {
       events = StringMapWrapper.create();
       elBinder.hostListeners = events;
     }
-    var event = StringMapWrapper.get(events, eventName);
-    if (isBlank(event)) {
-      event = MapWrapper.create();
-      StringMapWrapper.set(events, eventName, event);
+    for (var i = 0; i < eventBindings.length; i++) {
+      var eventBinding = eventBindings[i];
+      var eventName = eventBinding.fullName;
+      var event = StringMapWrapper.get(events, eventName);
+      if (isBlank(event)) {
+        event = MapWrapper.create();
+        StringMapWrapper.set(events, eventName, event);
+      }
+      MapWrapper.set(event, directiveIndex, eventBinding.source);
     }
-    MapWrapper.set(event, directiveIndex, expression);
   }
 
   /**

--- a/modules/angular2/src/dom/browser_adapter.dart
+++ b/modules/angular2/src/dom/browser_adapter.dart
@@ -119,6 +119,12 @@ class BrowserDomAdapter extends GenericBrowserDomAdapter {
     // addEventListener misses zones so we use element.on.
     element.on[event].listen(callback);
   }
+  Function onAndCancel(EventTarget element, String event, callback(arg)) {
+    // due to https://code.google.com/p/dart/issues/detail?id=17406
+    // addEventListener misses zones so we use element.on.
+    var subscription = element.on[event].listen(callback);
+    return subscription.cancel;
+  }
   void dispatchEvent(EventTarget el, Event evt) {
     el.dispatchEvent(evt);
   }
@@ -287,5 +293,14 @@ class BrowserDomAdapter extends GenericBrowserDomAdapter {
   String getEventKey(KeyboardEvent event) {
     int keyCode = event.keyCode;
     return _keyCodeToKeyMap.containsKey(keyCode) ? _keyCodeToKeyMap[keyCode] : 'Unidentified';
+  }
+  getGlobalEventTarget(String target) {
+    if (target == "window") {
+      return window;
+    } else if (target == "document") {
+      return document;
+    } else if (target == "body") {
+      return document.body;
+    }
   }
 }

--- a/modules/angular2/src/dom/browser_adapter.es6
+++ b/modules/angular2/src/dom/browser_adapter.es6
@@ -73,6 +73,12 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   on(el, evt, listener) {
     el.addEventListener(evt, listener, false);
   }
+  onAndCancel(el, evt, listener): Function {
+    el.addEventListener(evt, listener, false);
+    //Needed to follow Dart's subscription semantic, until fix of
+    //https://code.google.com/p/dart/issues/detail?id=17406
+    return () => {el.removeEventListener(evt, listener, false);};
+  }
   dispatchEvent(el, evt) {
     el.dispatchEvent(evt);
   }
@@ -352,5 +358,14 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
       key = _keyMap[key];
     }
     return key;
+  }
+  getGlobalEventTarget(target:string) {
+    if (target == "window") {
+      return window;
+    } else if (target == "document") {
+      return document;
+    } else if (target == "body") {
+      return document.body;
+    }
   }
 }

--- a/modules/angular2/src/dom/dom_adapter.js
+++ b/modules/angular2/src/dom/dom_adapter.js
@@ -39,6 +39,9 @@ export class DomAdapter {
   on(el, evt, listener) {
     throw _abstract();
   }
+  onAndCancel(el, evt, listener): Function {
+    throw _abstract();
+  }
   dispatchEvent(el, evt) {
     throw _abstract();
   }
@@ -271,6 +274,9 @@ export class DomAdapter {
     throw _abstract();
   }
   supportsNativeShadowDOM(): boolean {
+    throw _abstract();
+  }
+  getGlobalEventTarget(target:string) {
     throw _abstract();
   }
 }

--- a/modules/angular2/src/dom/html_adapter.dart
+++ b/modules/angular2/src/dom/html_adapter.dart
@@ -29,6 +29,9 @@ class Html5LibDomAdapter implements DomAdapter {
   on(el, evt, listener) {
     throw 'not implemented';
   }
+  Function onAndCancel(el, evt, listener) {
+    throw 'not implemented';
+  }
   dispatchEvent(el, evt) {
     throw 'not implemented';
   }

--- a/modules/angular2/src/dom/parse5_adapter.cjs
+++ b/modules/angular2/src/dom/parse5_adapter.cjs
@@ -86,6 +86,9 @@ export class Parse5DomAdapter extends DomAdapter {
   on(el, evt, listener) {
     //Do nothing, in order to not break forms integration tests
   }
+  onAndCancel(el, evt, listener): Function {
+    //Do nothing, in order to not break forms integration tests
+  }
   dispatchEvent(el, evt) {
     throw _notImplemented('dispatchEvent');
   }

--- a/modules/angular2/src/mock/vm_turn_zone_mock.js
+++ b/modules/angular2/src/mock/vm_turn_zone_mock.js
@@ -10,6 +10,6 @@ export class MockVmTurnZone extends VmTurnZone {
   }
 
   runOutsideAngular(fn) {
-    fn();
+    return fn();
   }
 }

--- a/modules/angular2/src/render/api.js
+++ b/modules/angular2/src/render/api.js
@@ -15,6 +15,16 @@ import {ASTWithSource} from 'angular2/change_detection';
  * - render compiler is not on the critical path as
  *   its output will be stored in precompiled templates.
  */
+export class EventBinding {
+  fullName: string; // name/target:name, e.g "click", "window:resize"
+  source: ASTWithSource;  
+
+  constructor(fullName :string, source: ASTWithSource) {
+    this.fullName = fullName;
+    this.source = source;
+  }
+}
+
 export class ElementBinder {
   index:number;
   parentIndex:number;
@@ -26,7 +36,7 @@ export class ElementBinder {
   // Note: this contains a preprocessed AST
   // that replaced the values that should be extracted from the element
   // with a local name
-  eventBindings: Map<string, ASTWithSource>;
+  eventBindings: List<EventBinding>;
   textBindings: List<ASTWithSource>;
   readAttributes: Map<string, string>;
 
@@ -57,7 +67,7 @@ export class DirectiveBinder {
   // Note: this contains a preprocessed AST
   // that replaced the values that should be extracted from the element
   // with a local name
-  eventBindings: Map<string, ASTWithSource>;
+  eventBindings: List<EventBinding>;
   constructor({
     directiveIndex, propertyBindings, eventBindings
   }) {

--- a/modules/angular2/src/render/dom/compiler/directive_parser.js
+++ b/modules/angular2/src/render/dom/compiler/directive_parser.js
@@ -1,4 +1,4 @@
-import {isPresent, isBlank, BaseException, assertionsEnabled, RegExpWrapper} from 'angular2/src/facade/lang';
+import {isPresent, isBlank, BaseException, assertionsEnabled, RegExpWrapper, StringWrapper} from 'angular2/src/facade/lang';
 import {List, MapWrapper, ListWrapper} from 'angular2/src/facade/collection';
 import {DOM} from 'angular2/src/dom/dom_adapter';
 import {Parser} from 'angular2/change_detection';
@@ -10,7 +10,7 @@ import {CompileElement} from './compile_element';
 import {CompileControl} from './compile_control';
 
 import {DirectiveMetadata} from '../../api';
-import {dashCaseToCamelCase, camelCaseToDashCase} from '../util';
+import {dashCaseToCamelCase, camelCaseToDashCase, EVENT_TARGET_SEPARATOR} from '../util';
 
 /**
  * Parses the directives on a single element. Assumes ViewSplitter has already created
@@ -132,7 +132,13 @@ export class DirectiveParser extends CompileStep {
 
   _bindDirectiveEvent(eventName, action, compileElement, directiveBinder) {
     var ast = this._parser.parseAction(action, compileElement.elementDescription);
-    directiveBinder.bindEvent(eventName, ast);
+    if (StringWrapper.contains(eventName, EVENT_TARGET_SEPARATOR)) {
+      var parts = eventName.split(EVENT_TARGET_SEPARATOR);
+      directiveBinder.bindEvent(parts[1], ast, parts[0]);
+    } else {
+      directiveBinder.bindEvent(eventName, ast);
+    }
+    
   }
 
   _splitBindConfig(bindConfig:string) {

--- a/modules/angular2/src/render/dom/util.js
+++ b/modules/angular2/src/render/dom/util.js
@@ -3,6 +3,8 @@ import {StringWrapper, RegExpWrapper, isPresent} from 'angular2/src/facade/lang'
 export const NG_BINDING_CLASS_SELECTOR = '.ng-binding';
 export const NG_BINDING_CLASS = 'ng-binding';
 
+export const EVENT_TARGET_SEPARATOR = ':';
+
 var CAMEL_CASE_REGEXP = RegExpWrapper.create('([A-Z])');
 var DASH_CASE_REGEXP = RegExpWrapper.create('-([a-z])');
 

--- a/modules/angular2/src/render/dom/view/element_binder.js
+++ b/modules/angular2/src/render/dom/view/element_binder.js
@@ -8,7 +8,8 @@ export class ElementBinder {
   textNodeIndices: List<number>;
   nestedProtoView: protoViewModule.RenderProtoView;
   eventLocals: AST;
-  eventNames: List<string>;
+  localEvents: List<Event>;
+  globalEvents: List<Event>;
   componentId: string;
   parentIndex:number;
   distanceToParent:number;
@@ -20,7 +21,8 @@ export class ElementBinder {
     nestedProtoView,
     componentId,
     eventLocals,
-    eventNames,
+    localEvents,
+    globalEvents,
     parentIndex,
     distanceToParent,
     propertySetters
@@ -30,9 +32,22 @@ export class ElementBinder {
     this.nestedProtoView = nestedProtoView;
     this.componentId = componentId;
     this.eventLocals = eventLocals;
-    this.eventNames = eventNames;
+    this.localEvents = localEvents;
+    this.globalEvents = globalEvents;
     this.parentIndex = parentIndex;
     this.distanceToParent = distanceToParent;
     this.propertySetters = propertySetters;
+  }
+}
+
+export class Event {
+  name: string;
+  target: string;
+  fullName: string;
+
+  constructor(name: string, target: string, fullName: string) {
+    this.name = name;
+    this.target = target;
+    this.fullName = fullName;
   }
 }

--- a/modules/angular2/src/render/dom/view/view_factory.js
+++ b/modules/angular2/src/render/dom/view/view_factory.js
@@ -125,7 +125,7 @@ export class ViewFactory {
 
     var view = new viewModule.RenderView(
       protoView, viewRootNodes,
-      boundTextNodes, boundElements, viewContainers, contentTags
+      boundTextNodes, boundElements, viewContainers, contentTags, this._eventManager
     );
 
     for (var binderIdx = 0; binderIdx < binders.length; binderIdx++) {
@@ -139,10 +139,10 @@ export class ViewFactory {
       }
 
       // events
-      if (isPresent(binder.eventLocals)) {
-        ListWrapper.forEach(binder.eventNames, (eventName) => {
-          this._createEventListener(view, element, binderIdx, eventName, binder.eventLocals);
-        });
+      if (isPresent(binder.eventLocals) && isPresent(binder.localEvents)) {
+        for (var i = 0; i < binder.localEvents.length; i++) {
+          this._createEventListener(view, element, binderIdx, binder.localEvents[i].name, binder.eventLocals);
+        }
       }
     }
 

--- a/modules/angular2/test/core/compiler/element_injector_spec.js
+++ b/modules/angular2/test/core/compiler/element_injector_spec.js
@@ -11,8 +11,7 @@ import {ViewContainer} from 'angular2/src/core/compiler/view_container';
 import {NgElement} from 'angular2/src/core/compiler/ng_element';
 import {Directive} from 'angular2/src/core/annotations/annotations';
 import {BindingPropagationConfig, Parser, Lexer} from 'angular2/change_detection';
-
-import {ViewRef, Renderer} from 'angular2/src/render/api';
+import {ViewRef, Renderer, EventBinding} from 'angular2/src/render/api';
 import {QueryList} from 'angular2/src/core/compiler/query_list';
 
 class DummyDirective extends Directive {
@@ -701,7 +700,9 @@ export function main() {
         StringMapWrapper.set(handlers, eventName, eventHandler);
         var pv = new AppProtoView(null, null, null);
         pv.bindElement(null, 0, null, null, null);
-        pv.bindEvent(eventName, new Parser(new Lexer()).parseAction('handler()', ''));
+        var eventBindings = ListWrapper.create();
+        ListWrapper.push(eventBindings, new EventBinding(eventName, new Parser(new Lexer()).parseAction('handler()', '')));
+        pv.bindEvent(eventBindings);
 
         var view = new AppView(pv, MapWrapper.create());
         view.context = new ContextWithHandler(eventHandler);

--- a/modules/angular2/test/render/dom/compiler/directive_parser_spec.js
+++ b/modules/angular2/test/render/dom/compiler/directive_parser_spec.js
@@ -23,7 +23,8 @@ export function main() {
         someDecorator,
         someDecoratorIgnoringChildren,
         someDecoratorWithProps,
-        someDecoratorWithEvents
+        someDecoratorWithEvents,
+        someDecoratorWithGlobalEvents
       ];
       parser = new Parser(new Lexer());
     });
@@ -130,8 +131,21 @@ export function main() {
         el('<div some-decor-events></div>')
       );
       var directiveBinding = results[0].directives[0];
-      expect(MapWrapper.get(directiveBinding.eventBindings, 'click').source)
-        .toEqual('doIt()');
+      expect(directiveBinding.eventBindings.length).toEqual(1);
+      var eventBinding = directiveBinding.eventBindings[0];
+      expect(eventBinding.fullName).toEqual('click');
+      expect(eventBinding.source.source).toEqual('doIt()');
+    });
+
+    it('should bind directive global events', () => {
+      var results = process(
+        el('<div some-decor-globalevents></div>')
+      );
+      var directiveBinding = results[0].directives[0];
+      expect(directiveBinding.eventBindings.length).toEqual(1);
+      var eventBinding = directiveBinding.eventBindings[0];
+      expect(eventBinding.fullName).toEqual('window:resize');
+      expect(eventBinding.source.source).toEqual('doItGlobal()');
     });
 
     describe('viewport directives', () => {
@@ -244,5 +258,12 @@ var someDecoratorWithEvents = new DirectiveMetadata({
   selector: '[some-decor-events]',
   hostListeners: MapWrapper.createFromStringMap({
     'click': 'doIt()'
+  })
+});
+
+var someDecoratorWithGlobalEvents = new DirectiveMetadata({
+  selector: '[some-decor-globalevents]',
+  hostListeners: MapWrapper.createFromStringMap({
+    'window:resize': 'doItGlobal()'
   })
 });

--- a/modules/angular2/test/render/dom/compiler/property_binding_parser_spec.js
+++ b/modules/angular2/test/render/dom/compiler/property_binding_parser_spec.js
@@ -96,10 +96,14 @@ export function main() {
 
     it('should detect () syntax', () => {
       var results = process(el('<div (click)="b()"></div>'));
-      expect(MapWrapper.get(results[0].eventBindings, 'click').source).toEqual('b()');
+      var eventBinding = results[0].eventBindings[0];
+      expect(eventBinding.source.source).toEqual('b()');
+      expect(eventBinding.fullName).toEqual('click');
       // "(click[])" is not an expected syntax and is only used to validate the regexp
       results = process(el('<div (click[])="b()"></div>'));
-      expect(MapWrapper.get(results[0].eventBindings, 'click[]').source).toEqual('b()');
+      eventBinding = results[0].eventBindings[0];
+      expect(eventBinding.source.source).toEqual('b()');
+      expect(eventBinding.fullName).toEqual('click[]');
     });
 
     it('should detect () syntax only if an attribute name starts and ends with ()', () => {
@@ -109,17 +113,23 @@ export function main() {
 
     it('should parse event handlers using () syntax as actions', () => {
       var results = process(el('<div (click)="foo=bar"></div>'));
-      expect(MapWrapper.get(results[0].eventBindings, 'click').source).toEqual('foo=bar');
+      var eventBinding = results[0].eventBindings[0];
+      expect(eventBinding.source.source).toEqual('foo=bar');
+      expect(eventBinding.fullName).toEqual('click');
     });
 
     it('should detect on- syntax', () => {
       var results = process(el('<div on-click="b()"></div>'));
-      expect(MapWrapper.get(results[0].eventBindings, 'click').source).toEqual('b()');
+      var eventBinding = results[0].eventBindings[0];
+      expect(eventBinding.source.source).toEqual('b()');
+      expect(eventBinding.fullName).toEqual('click');
     });
 
     it('should parse event handlers using on- syntax as actions', () => {
       var results = process(el('<div on-click="foo=bar"></div>'));
-      expect(MapWrapper.get(results[0].eventBindings, 'click').source).toEqual('foo=bar');
+      var eventBinding = results[0].eventBindings[0];
+      expect(eventBinding.source.source).toEqual('foo=bar');
+      expect(eventBinding.fullName).toEqual('click');
     });
 
     it('should store bound properties as temporal attributes', () => {

--- a/modules/angular2/test/render/dom/integration_testbed.js
+++ b/modules/angular2/test/render/dom/integration_testbed.js
@@ -173,6 +173,7 @@ export class FakeEventManagerPlugin extends EventManagerPlugin {
 
   addEventListener(element, eventName: string, handler: Function, shouldSupportBubble: boolean) {
     MapWrapper.set(this._eventHandlers, eventName, handler);
+    return () => {MapWrapper.delete(this._eventHandlers, eventName);}
   }
 }
 

--- a/modules/angular2/test/render/dom/shadow_dom/emulated_scoped_shadow_dom_strategy_spec.js
+++ b/modules/angular2/test/render/dom/shadow_dom/emulated_scoped_shadow_dom_strategy_spec.js
@@ -47,7 +47,7 @@ export function main() {
     it('should attach the view nodes as child of the host element', () => {
       var host = el('<div><span>original content</span></div>');
       var nodes = el('<div>view</div>');
-      var view = new RenderView(null, [nodes], [], [], [], []);
+      var view = new RenderView(null, [nodes], [], [], [], [], null);
 
       strategy.attachTemplate(host, view);
       var firstChild = DOM.firstChild(host);

--- a/modules/angular2/test/render/dom/shadow_dom/emulated_unscoped_shadow_dom_strategy_spec.js
+++ b/modules/angular2/test/render/dom/shadow_dom/emulated_unscoped_shadow_dom_strategy_spec.js
@@ -42,7 +42,7 @@ export function main() {
     it('should attach the view nodes as child of the host element', () => {
       var host = el('<div><span>original content</span></div>');
       var nodes = el('<div>view</div>');
-      var view = new RenderView(null, [nodes], [], [], [], []);
+      var view = new RenderView(null, [nodes], [], [], [], [], null);
 
       strategy.attachTemplate(host, view);
       var firstChild = DOM.firstChild(host);

--- a/modules/angular2/test/render/dom/shadow_dom/native_shadow_dom_strategy_spec.js
+++ b/modules/angular2/test/render/dom/shadow_dom/native_shadow_dom_strategy_spec.js
@@ -35,7 +35,7 @@ export function main() {
     it('should attach the view nodes to the shadow root', () => {
       var host = el('<div><span>original content</span></div>');
       var nodes = el('<div>view</div>');
-      var view = new RenderView(null, [nodes], [], [], [], []);
+      var view = new RenderView(null, [nodes], [], [], [], [], null);
 
       strategy.attachTemplate(host, view);
       var shadowRoot = DOM.getShadowRoot(host);

--- a/modules/angular2/test/render/dom/view/view_spec.js
+++ b/modules/angular2/test/render/dom/view/view_spec.js
@@ -2,6 +2,7 @@ import {describe, ddescribe, it, iit, xit, xdescribe, expect, beforeEach, el} fr
 
 import {ListWrapper} from 'angular2/src/facade/collection';
 
+import {RenderProtoView} from 'angular2/src/render/dom/view/proto_view';
 import {RenderView} from 'angular2/src/render/dom/view/view';
 import {ShadowDomStrategy} from 'angular2/src/render/dom/shadow_dom/shadow_dom_strategy';
 import {LightDom} from 'angular2/src/render/dom/shadow_dom/light_dom';
@@ -9,14 +10,15 @@ import {LightDom} from 'angular2/src/render/dom/shadow_dom/light_dom';
 export function main() {
 
   function createView() {
-    var proto = null;
+    var proto = new RenderProtoView({element: el('<div></div>'), isRootView: false, elementBinders: []});
     var rootNodes = [el('<div></div>')];
     var boundTextNodes = [];
     var boundElements = [el('<div></div>')];
     var viewContainers = [];
     var contentTags = [];
+    var eventManager = null;
     return new RenderView(proto, rootNodes,
-      boundTextNodes, boundElements, viewContainers, contentTags);
+      boundTextNodes, boundElements, viewContainers, contentTags, eventManager);
   }
 
   function createShadowDomStrategy(log) {


### PR DESCRIPTION
This is a first proposal to implement global event (see #1098). Knowing that the events system is not yet adapted to the new render architecture, it will require additional work later.

The proposed syntax adds a target to the event configuration. This target can be `window`, `document` or `body`. For example:

```
@Decorator({
  selector: '[foo]',
  events: {
    'click': 'onClick()',
    'window:resize': 'onResize()',
    'document:keypress': 'onKeypress()',
  }
})
```

With this solution, **the global event listeners are added during the view hydration, and removed during the view dehydration**.

To implement it:
- the `on` method of the DOM adapter now returns a function to cancel the listener (to follow the subscription mechanics of Dart). The `addEventListener` methods of the `EventManager` do the same.
- the events map in the `ElementBinder` is now a map of map, i.e. one map for each target ( @tbosch that would be an API change for the render layer).
