### PR TITLE
feat(change_detection): updated change detection to update directive dir...

### DIFF
--- a/modules/angular2/src/change_detection/change_detection_jit_generator.dart
+++ b/modules/angular2/src/change_detection/change_detection_jit_generator.dart
@@ -5,6 +5,6 @@ class ChangeDetectorJITGenerator {
   }
 
   generate() {
-    throw "Not supported in Dart";
+    throw "Jit Change Detection is not supported in Dart";
   }
 }

--- a/modules/angular2/src/change_detection/interfaces.js
+++ b/modules/angular2/src/change_detection/interfaces.js
@@ -1,16 +1,17 @@
 import {List} from 'angular2/src/facade/collection';
 import {Locals} from './parser/locals';
 import {AST} from './parser/ast';
+import {DEFAULT} from './constants';
 
 export class ProtoChangeDetector  {
   addAst(ast:AST, bindingMemento:any, directiveMemento:any = null){}
-  instantiate(dispatcher:any, bindingRecords:List, variableBindings:List, directiveMemento:List):ChangeDetector{
+  instantiate(dispatcher:any, bindingRecords:List, variableBindings:List, directiveMementos:List):ChangeDetector{
     return null;
   }
 }
 
 export class ChangeDetection {
-  createProtoChangeDetector(name:string, changeControlStrategy:string):ProtoChangeDetector{
+  createProtoChangeDetector(name:string, changeControlStrategy:string=DEFAULT):ProtoChangeDetector{
     return null;
   }
 }
@@ -35,7 +36,7 @@ export class ChangeRecord {
 }
 
 export class ChangeDispatcher {
-  onRecordChange(directiveMemento, records:List<ChangeRecord>) {}
+  invokeMementoFor(memento:any, value) {}
 }
 
 export class ChangeDetector {
@@ -45,7 +46,7 @@ export class ChangeDetector {
   addChild(cd:ChangeDetector) {}
   removeChild(cd:ChangeDetector) {}
   remove() {}
-  hydrate(context:any, locals:Locals) {}
+  hydrate(context:any, locals:Locals, directives:any) {}
   dehydrate() {}
   markPathToRootAsCheckOnce() {}
 

--- a/modules/benchmarks/e2e_test/tree_perf.es6
+++ b/modules/benchmarks/e2e_test/tree_perf.es6
@@ -17,10 +17,32 @@ describe('ng2 tree benchmark', function () {
     }).then(done, done.fail);
   });
 
+  it('should log the ng stats (update)', function(done) {
+    perfUtil.runClickBenchmark({
+      url: URL,
+      buttons: ['#ng2CreateDom'],
+      id: 'ng2.tree.update',
+      params: [{
+        name: 'depth', value: 9, scale: 'log2'
+      }]
+    }).then(done, done.fail);
+  });
+
   it('should log the baseline stats', function(done) {
     perfUtil.runClickBenchmark({
       url: URL,
       buttons: ['#baselineDestroyDom', '#baselineCreateDom'],
+      id: 'baseline.tree',
+      params: [{
+        name: 'depth', value: 9, scale: 'log2'
+      }]
+    }).then(done, done.fail);
+  });
+
+  it('should log the baseline stats (update)', function(done) {
+    perfUtil.runClickBenchmark({
+      url: URL,
+      buttons: ['#baselineCreateDom'],
       id: 'baseline.tree',
       params: [{
         name: 'depth', value: 9, scale: 'log2'

--- a/modules/benchmarks/src/change_detection/change_detection_benchmark.js
+++ b/modules/benchmarks/src/change_detection/change_detection_benchmark.js
@@ -185,27 +185,29 @@ function setUpChangeDetection(changeDetection:ChangeDetection, iterations, objec
   var dispatcher = new DummyDispatcher();
   var parser = new Parser(new Lexer());
 
-  var parentProto = changeDetection.createProtoChangeDetector('parent', null);
+  var parentProto = changeDetection.createProtoChangeDetector('parent');
   var parentCd = parentProto.instantiate(dispatcher, [], [], []);
 
   var targetObj = new Obj();
-  var proto = changeDetection.createProtoChangeDetector("proto", null);
+  var proto = changeDetection.createProtoChangeDetector("proto");
+
+  var directiveMemento = new FakeDirectiveMemento("target", targetObj);
   var bindingRecords = [
-    new BindingRecord(parser.parseBinding('field0', null), new FakeBindingMemento(targetObj, reflector.setter("field0")), null),
-    new BindingRecord(parser.parseBinding('field1', null), new FakeBindingMemento(targetObj, reflector.setter("field1")), null),
-    new BindingRecord(parser.parseBinding('field2', null), new FakeBindingMemento(targetObj, reflector.setter("field2")), null),
-    new BindingRecord(parser.parseBinding('field3', null), new FakeBindingMemento(targetObj, reflector.setter("field3")), null),
-    new BindingRecord(parser.parseBinding('field4', null), new FakeBindingMemento(targetObj, reflector.setter("field4")), null),
-    new BindingRecord(parser.parseBinding('field5', null), new FakeBindingMemento(targetObj, reflector.setter("field5")), null),
-    new BindingRecord(parser.parseBinding('field6', null), new FakeBindingMemento(targetObj, reflector.setter("field6")), null),
-    new BindingRecord(parser.parseBinding('field7', null), new FakeBindingMemento(targetObj, reflector.setter("field7")), null),
-    new BindingRecord(parser.parseBinding('field8', null), new FakeBindingMemento(targetObj, reflector.setter("field8")), null),
-    new BindingRecord(parser.parseBinding('field9', null), new FakeBindingMemento(targetObj, reflector.setter("field9")), null)
+    new BindingRecord(parser.parseBinding('field0', null), new FakeBindingMemento(reflector.setter("field0"), "field0"), directiveMemento),
+    new BindingRecord(parser.parseBinding('field1', null), new FakeBindingMemento(reflector.setter("field1"), "field1"), directiveMemento),
+    new BindingRecord(parser.parseBinding('field2', null), new FakeBindingMemento(reflector.setter("field2"), "field2"), directiveMemento),
+    new BindingRecord(parser.parseBinding('field3', null), new FakeBindingMemento(reflector.setter("field3"), "field3"), directiveMemento),
+    new BindingRecord(parser.parseBinding('field4', null), new FakeBindingMemento(reflector.setter("field4"), "field4"), directiveMemento),
+    new BindingRecord(parser.parseBinding('field5', null), new FakeBindingMemento(reflector.setter("field5"), "field5"), directiveMemento),
+    new BindingRecord(parser.parseBinding('field6', null), new FakeBindingMemento(reflector.setter("field6"), "field6"), directiveMemento),
+    new BindingRecord(parser.parseBinding('field7', null), new FakeBindingMemento(reflector.setter("field7"), "field7"), directiveMemento),
+    new BindingRecord(parser.parseBinding('field8', null), new FakeBindingMemento(reflector.setter("field8"), "field8"), directiveMemento),
+    new BindingRecord(parser.parseBinding('field9', null), new FakeBindingMemento(reflector.setter("field9"), "field9"), directiveMemento)
   ];
 
   for (var i = 0; i < iterations; ++i) {
-    var cd = proto.instantiate(dispatcher, bindingRecords, [], []);
-    cd.hydrate(object, null);
+    var cd = proto.instantiate(dispatcher, bindingRecords, [], [directiveMemento]);
+    cd.hydrate(object, null, null);
     parentCd.addChild(cd);
   }
   return parentCd;
@@ -298,17 +300,34 @@ export function main () {
 
 class FakeBindingMemento {
   setter:Function;
-  targetObj:Obj;
+  propertyName:string;
 
-  constructor(targetObj:Obj, setter:Function) {
-    this.targetObj = targetObj;
+  constructor(setter:Function, propertyName:string) {
     this.setter = setter;
+    this.propertyName = propertyName;
+  }
+}
+
+class FakeDirectiveMemento {
+  targetObj:Obj;
+  name:string;
+  callOnChange:boolean;
+  callOnAllChangesDone:boolean;
+
+  constructor(name, targetObj) {
+    this.targetObj = targetObj;
+    this.name = name;
+    this.callOnChange = false;
+    this.callOnAllChangesDone = false;
+  }
+
+  directive(dirs) {
+    return this.targetObj;
   }
 }
 
 class DummyDispatcher extends ChangeDispatcher {
   invokeMementoFor(bindingMemento, newValue) {
-    var obj = bindingMemento.targetObj;
-    bindingMemento.setter(obj, newValue);
+    throw "Should not be used";
   }
 }


### PR DESCRIPTION
...ectly, without the dispatcher

This PR makes updating directive properties monomorphic.
# Master:

Dynamic change detection: 
Reads: 85     Writes: 120

Jit:
Reads: 9      Writes: 19

Baseline:
Reads: 8      Writes: 12

Interestingly enough in Dart 120 becomes 180. Not sure why.
# With this change

Dynamic: 
Reads: 85     Writes: 120

Jit:
Reads: 9      Writes: 12

Baseline:
Reads: 8      Writes: 11

There is some cleanup required. I will do it as a separate PR after Tobias merges his changes.
