### PR TITLE
Remove Directive and Binding Mementos

### DIFF
--- a/modules/angular2/change_detection.js
+++ b/modules/angular2/change_detection.js
@@ -9,8 +9,12 @@ export {ExpressionChangedAfterItHasBeenChecked, ChangeDetectionError}
     from './src/change_detection/exceptions';
 export {ProtoChangeDetector, ChangeDispatcher, ChangeDetector, ChangeDetection} from './src/change_detection/interfaces';
 export {CHECK_ONCE, CHECK_ALWAYS, DETACHED, CHECKED, ON_PUSH, DEFAULT} from './src/change_detection/constants';
-export {DynamicProtoChangeDetector, JitProtoChangeDetector, BindingRecord}
+export {DynamicProtoChangeDetector, JitProtoChangeDetector}
     from './src/change_detection/proto_change_detector';
+export {BindingRecord}
+    from './src/change_detection/binding_record';
+export {DirectiveRecord}
+    from './src/change_detection/directive_record';
 export {DynamicChangeDetector}
     from './src/change_detection/dynamic_change_detector';
 export {BindingPropagationConfig}

--- a/modules/angular2/src/change_detection/binding_record.js
+++ b/modules/angular2/src/change_detection/binding_record.js
@@ -1,0 +1,58 @@
+import {isPresent, isBlank} from 'angular2/src/facade/lang';
+import {SetterFn} from 'angular2/src/reflection/types';
+import {AST} from './parser/ast';
+import {DirectiveRecord} from './directive_record';
+
+const DIRECTIVE="directive";
+const ELEMENT="element";
+const TEXT_NODE="textNode";
+
+export class BindingRecord {
+  mode:string;
+  ast:AST;
+
+  elementIndex:number;
+  propertyName:string;
+  setter:SetterFn;
+
+  directiveRecord:DirectiveRecord;
+
+  constructor(mode:string, ast:AST, elementIndex:number, propertyName:string, setter:SetterFn, directiveRecord:DirectiveRecord) {
+    this.mode = mode;
+    this.ast = ast;
+
+    this.elementIndex = elementIndex;
+    this.propertyName = propertyName;
+    this.setter = setter;
+
+    this.directiveRecord = directiveRecord;
+  }
+
+  callOnChange() {
+    return isPresent(this.directiveRecord) && this.directiveRecord.callOnChange;
+  }
+
+  isDirective() {
+    return this.mode === DIRECTIVE;
+  }
+
+  isElement() {
+    return this.mode === ELEMENT;
+  }
+
+  isTextNode() {
+    return this.mode === TEXT_NODE;
+  }
+
+  static createForDirective(ast:AST, propertyName:string, setter:SetterFn, directiveRecord:DirectiveRecord) {
+    return new BindingRecord(DIRECTIVE, ast, 0, propertyName, setter, directiveRecord);
+  }
+
+  static createForElement(ast:AST, elementIndex:number, propertyName:string) {
+    return new BindingRecord(ELEMENT, ast, elementIndex, propertyName, null, null);
+  }
+
+  static createForTextNode(ast:AST, elementIndex:number) {
+    return new BindingRecord(TEXT_NODE, ast, elementIndex, null, null, null);
+  }
+}

--- a/modules/angular2/src/change_detection/change_detection_util.js
+++ b/modules/angular2/src/change_detection/change_detection_util.js
@@ -125,11 +125,11 @@ export class ChangeDetectionUtil {
     return _simpleChange(previousValue, currentValue);
   }
 
-  static addChange(changes, bindingMemento, change){
+  static addChange(changes, propertyName:string, change){
     if (isBlank(changes)) {
       changes = {};
     }
-    changes[bindingMemento.propertyName] = change;
+    changes[propertyName] = change;
     return changes;
   }
 }

--- a/modules/angular2/src/change_detection/coalesce.js
+++ b/modules/angular2/src/change_detection/coalesce.js
@@ -46,8 +46,7 @@ function _selfRecord(r:ProtoRecord, contextIndex:number, selfIndex:number):Proto
     r.fixedArgs,
     contextIndex,
     selfIndex,
-    r.bindingMemento,
-    r.directiveMemento,
+    r.bindingRecord,
     r.expressionAsString,
     r.lastInBinding,
     r.lastInDirective
@@ -74,8 +73,7 @@ function _replaceIndices(r:ProtoRecord, selfIndex:number, indexMap:Map) {
     r.fixedArgs,
     contextIndex,
     selfIndex,
-    r.bindingMemento,
-    r.directiveMemento,
+    r.bindingRecord,
     r.expressionAsString,
     r.lastInBinding,
     r.lastInDirective

--- a/modules/angular2/src/change_detection/directive_record.js
+++ b/modules/angular2/src/change_detection/directive_record.js
@@ -1,0 +1,19 @@
+export class DirectiveRecord {
+  elementIndex:number;
+  directiveIndex:number;
+  callOnAllChangesDone:boolean;
+  callOnChange:boolean;
+
+  constructor(elementIndex:number, directiveIndex:number, 
+              callOnAllChangesDone:boolean,
+              callOnChange:boolean) {
+    this.elementIndex = elementIndex;
+    this.directiveIndex = directiveIndex;
+    this.callOnAllChangesDone = callOnAllChangesDone;
+    this.callOnChange = callOnChange;
+  }
+
+  get name() {
+    return `${this.elementIndex}_${this.directiveIndex}`;
+  }
+}

--- a/modules/angular2/src/change_detection/interfaces.js
+++ b/modules/angular2/src/change_detection/interfaces.js
@@ -1,11 +1,10 @@
 import {List} from 'angular2/src/facade/collection';
 import {Locals} from './parser/locals';
-import {AST} from './parser/ast';
 import {DEFAULT} from './constants';
+import {BindingRecord} from './binding_record';
 
 export class ProtoChangeDetector  {
-  addAst(ast:AST, bindingMemento:any, directiveMemento:any = null){}
-  instantiate(dispatcher:any, bindingRecords:List, variableBindings:List, directiveMementos:List):ChangeDetector{
+  instantiate(dispatcher:any, bindingRecords:List, variableBindings:List, directiveRecords:List):ChangeDetector{
     return null;
   }
 }
@@ -17,7 +16,7 @@ export class ChangeDetection {
 }
 
 export class ChangeDispatcher {
-  invokeMementoFor(memento:any, value) {}
+  notifyOnBinding(bindingRecord:BindingRecord, value:any) {}
 }
 
 export class ChangeDetector {

--- a/modules/angular2/src/change_detection/proto_change_detector.js
+++ b/modules/angular2/src/change_detection/proto_change_detector.js
@@ -27,6 +27,7 @@ import {ChangeDetectionUtil} from './change_detection_util';
 import {DynamicChangeDetector} from './dynamic_change_detector';
 import {ChangeDetectorJITGenerator} from './change_detection_jit_generator';
 import {PipeRegistry} from './pipes/pipe_registry';
+import {BindingRecord} from './binding_record';
 
 import {coalesce} from './coalesce';
 
@@ -45,18 +46,6 @@ import {
   RECORD_TYPE_INTERPOLATE
   } from './proto_record';
 
-export class BindingRecord {
-  ast:AST;
-  bindingMemento:any;
-  directiveMemento:any;
-
-  constructor(ast:AST, bindingMemento:any, directiveMemento:any) {
-    this.ast = ast;
-    this.bindingMemento = bindingMemento;
-    this.directiveMemento = directiveMemento;
-  }
-}
-
 export class DynamicProtoChangeDetector extends ProtoChangeDetector {
   _pipeRegistry:PipeRegistry;
   _records:List<ProtoRecord>;
@@ -68,17 +57,17 @@ export class DynamicProtoChangeDetector extends ProtoChangeDetector {
     this._changeControlStrategy = changeControlStrategy;
   }
 
-  instantiate(dispatcher:any, bindingRecords:List, variableBindings:List, directiveMementos:List) {
+  instantiate(dispatcher:any, bindingRecords:List, variableBindings:List, directiveRecords:List) {
     this._createRecordsIfNecessary(bindingRecords, variableBindings);
     return new DynamicChangeDetector(this._changeControlStrategy, dispatcher,
-      this._pipeRegistry, this._records, directiveMementos);
+      this._pipeRegistry, this._records, directiveRecords);
   }
 
   _createRecordsIfNecessary(bindingRecords:List, variableBindings:List) {
     if (isBlank(this._records)) {
       var recordBuilder = new ProtoRecordBuilder();
-      ListWrapper.forEach(bindingRecords, (r) => {
-        recordBuilder.addAst(r.ast, r.bindingMemento, r.directiveMemento, variableBindings);
+      ListWrapper.forEach(bindingRecords, (b) => {
+        recordBuilder.addAst(b, variableBindings);
       });
       this._records = coalesce(recordBuilder.records);
     }
@@ -98,22 +87,22 @@ export class JitProtoChangeDetector extends ProtoChangeDetector {
     this._changeControlStrategy = changeControlStrategy;
   }
 
-  instantiate(dispatcher:any, bindingRecords:List, variableBindings:List, directiveMementos:List) {
-    this._createFactoryIfNecessary(bindingRecords, variableBindings, directiveMementos);
+  instantiate(dispatcher:any, bindingRecords:List, variableBindings:List, directiveRecords:List) {
+    this._createFactoryIfNecessary(bindingRecords, variableBindings, directiveRecords);
     return this._factory(dispatcher, this._pipeRegistry);
   }
 
-  _createFactoryIfNecessary(bindingRecords:List, variableBindings:List, directiveMementos:List) {
+  _createFactoryIfNecessary(bindingRecords:List, variableBindings:List, directiveRecords:List) {
     if (isBlank(this._factory)) {
       var recordBuilder = new ProtoRecordBuilder();
-      ListWrapper.forEach(bindingRecords, (r) => {
-        recordBuilder.addAst(r.ast, r.bindingMemento, r.directiveMemento, variableBindings);
+      ListWrapper.forEach(bindingRecords, (b) => {
+        recordBuilder.addAst(b, variableBindings);
       });
       var c = _jitProtoChangeDetectorClassCounter++;
       var records = coalesce(recordBuilder.records);
       var typeName = `ChangeDetector${c}`;
       this._factory = new ChangeDetectorJITGenerator(typeName, this._changeControlStrategy, records,
-        directiveMementos).generate();
+        directiveRecords).generate();
     }
   }
 }
@@ -125,13 +114,13 @@ class ProtoRecordBuilder {
     this.records = [];
   }
 
-  addAst(ast:AST, bindingMemento:any, directiveMemento:any = null, variableBindings:List = null) {
+  addAst(b:BindingRecord, variableBindings:List = null) {
     var last = ListWrapper.last(this.records);
-    if (isPresent(last) && last.directiveMemento == directiveMemento) {
+    if (isPresent(last) && last.bindingRecord.directiveRecord == b.directiveRecord) {
       last.lastInDirective = false;
     }
 
-    var pr = _ConvertAstIntoProtoRecords.convert(ast, bindingMemento, directiveMemento, this.records.length, variableBindings);
+    var pr = _ConvertAstIntoProtoRecords.convert(b, this.records.length, variableBindings);
     if (! ListWrapper.isEmpty(pr)) {
       var last = ListWrapper.last(pr);
       last.lastInBinding = true;
@@ -144,24 +133,22 @@ class ProtoRecordBuilder {
 
 class _ConvertAstIntoProtoRecords {
   protoRecords:List;
-  bindingMemento:any;
-  directiveMemento:any;
+  bindingRecord:BindingRecord;
   variableBindings:List;
   contextIndex:number;
   expressionAsString:string;
 
-  constructor(bindingMemento:any, directiveMemento:any, contextIndex:number, expressionAsString:string, variableBindings:List) {
+  constructor(bindingRecord:BindingRecord, contextIndex:number, expressionAsString:string, variableBindings:List) {
     this.protoRecords = [];
-    this.bindingMemento = bindingMemento;
-    this.directiveMemento = directiveMemento;
+    this.bindingRecord = bindingRecord;
     this.contextIndex = contextIndex;
     this.expressionAsString = expressionAsString;
     this.variableBindings = variableBindings;
   }
 
-  static convert(ast:AST, bindingMemento:any, directiveMemento:any, contextIndex:number, variableBindings:List) {
-    var c = new _ConvertAstIntoProtoRecords(bindingMemento, directiveMemento, contextIndex, ast.toString(), variableBindings);
-    ast.visit(c);
+  static convert(b:BindingRecord, contextIndex:number, variableBindings:List) {
+    var c = new _ConvertAstIntoProtoRecords(b, contextIndex, b.ast.toString(), variableBindings);
+    b.ast.visit(c);
     return c.protoRecords;
   }
 
@@ -262,7 +249,7 @@ class _ConvertAstIntoProtoRecords {
     var selfIndex = ++ this.contextIndex;
     ListWrapper.push(this.protoRecords,
       new ProtoRecord(type, name, funcOrValue, args, fixedArgs, context, selfIndex,
-        this.bindingMemento, this.directiveMemento, this.expressionAsString, false, false));
+        this.bindingRecord, this.expressionAsString, false, false));
     return selfIndex;
   }
 }

--- a/modules/angular2/src/change_detection/proto_record.js
+++ b/modules/angular2/src/change_detection/proto_record.js
@@ -1,4 +1,5 @@
 import {List} from 'angular2/src/facade/collection';
+import {BindingRecord} from './binding_record';
 
 export const RECORD_TYPE_SELF = 0;
 export const RECORD_TYPE_CONST = 1;
@@ -20,8 +21,7 @@ export class ProtoRecord {
   fixedArgs:List;
   contextIndex:number;
   selfIndex:number;
-  bindingMemento:any;
-  directiveMemento:any;
+  bindingRecord:BindingRecord;
   lastInBinding:boolean;
   lastInDirective:boolean;
   expressionAsString:string;
@@ -33,8 +33,7 @@ export class ProtoRecord {
               fixedArgs:List,
               contextIndex:number,
               selfIndex:number,
-              bindingMemento:any,
-              directiveMemento:any,
+              bindingRecord:BindingRecord,
               expressionAsString:string,
               lastInBinding:boolean,
               lastInDirective:boolean) {
@@ -46,8 +45,7 @@ export class ProtoRecord {
     this.fixedArgs = fixedArgs;
     this.contextIndex = contextIndex;
     this.selfIndex = selfIndex;
-    this.bindingMemento = bindingMemento;
-    this.directiveMemento = directiveMemento;
+    this.bindingRecord = bindingRecord;
     this.lastInBinding = lastInBinding;
     this.lastInDirective = lastInDirective;
     this.expressionAsString = expressionAsString;

--- a/modules/angular2/src/core/compiler/view.js
+++ b/modules/angular2/src/core/compiler/view.js
@@ -465,12 +465,6 @@ export class DirectiveBindingMemento {
     this.propertyName = propertyName;
     this.setter = setter;
   }
-
-  invoke(currentValue:any, elementInjectors:List<ElementInjector>) {
-    var elementInjector:ElementInjector = elementInjectors[this._elementInjectorIndex];
-    var directive = elementInjector.getDirectiveAtIndex(this._directiveIndex);
-    this.setter(directive, currentValue);
-  }
 }
 
 class DirectiveMemento {

--- a/modules/angular2/src/core/compiler/view_factory.js
+++ b/modules/angular2/src/core/compiler/view_factory.js
@@ -48,8 +48,8 @@ export class ViewFactory {
 
   _createView(protoView:viewModule.ProtoView): viewModule.View {
     var view = new viewModule.View(protoView, protoView.protoLocals);
-    var changeDetector = protoView.protoChangeDetector.instantiate(view, protoView.bindingRecords,
-      protoView.getVariableBindings(), protoView.getDirectiveMementos());
+    var changeDetector = protoView.protoChangeDetector.instantiate(view, protoView.bindings,
+      protoView.getVariableBindings(), protoView.getdirectiveRecords());
 
     var binders = protoView.elementBinders;
     var elementInjectors = ListWrapper.createFixedSize(binders.length);

--- a/modules/angular2/test/change_detection/coalesce_spec.js
+++ b/modules/angular2/test/change_detection/coalesce_spec.js
@@ -6,7 +6,7 @@ import {RECORD_TYPE_SELF, ProtoRecord} from 'angular2/src/change_detection/proto
 export function main() {
   function r(funcOrValue, args, contextIndex, selfIndex, lastInBinding = false) {
     return new ProtoRecord(99,  "name", funcOrValue, args, null, contextIndex, selfIndex,
-      null, null, null, lastInBinding, false);
+      null, null, lastInBinding, false);
   }
 
   describe("change detection - coalesce", () => {
@@ -74,7 +74,7 @@ export function main() {
       expect(rs[1]).toEqual(new ProtoRecord(
         RECORD_TYPE_SELF, "self", null,
         [], null, 1, 2,
-        null, null, null,
+        null, null,
         true, false)
       );
     });

--- a/modules/benchmarks/src/change_detection/change_detection_benchmark.js
+++ b/modules/benchmarks/src/change_detection/change_detection_benchmark.js
@@ -11,7 +11,8 @@ import {
   ChangeDetection,
   dynamicChangeDetection,
   jitChangeDetection,
-  BindingRecord
+  BindingRecord,
+  DirectiveRecord
 } from 'angular2/change_detection';
 
 
@@ -188,26 +189,26 @@ function setUpChangeDetection(changeDetection:ChangeDetection, iterations, objec
   var parentProto = changeDetection.createProtoChangeDetector('parent');
   var parentCd = parentProto.instantiate(dispatcher, [], [], []);
 
-  var targetObj = new Obj();
   var proto = changeDetection.createProtoChangeDetector("proto");
 
-  var directiveMemento = new FakeDirectiveMemento("target", targetObj);
-  var bindingRecords = [
-    new BindingRecord(parser.parseBinding('field0', null), new FakeBindingMemento(reflector.setter("field0"), "field0"), directiveMemento),
-    new BindingRecord(parser.parseBinding('field1', null), new FakeBindingMemento(reflector.setter("field1"), "field1"), directiveMemento),
-    new BindingRecord(parser.parseBinding('field2', null), new FakeBindingMemento(reflector.setter("field2"), "field2"), directiveMemento),
-    new BindingRecord(parser.parseBinding('field3', null), new FakeBindingMemento(reflector.setter("field3"), "field3"), directiveMemento),
-    new BindingRecord(parser.parseBinding('field4', null), new FakeBindingMemento(reflector.setter("field4"), "field4"), directiveMemento),
-    new BindingRecord(parser.parseBinding('field5', null), new FakeBindingMemento(reflector.setter("field5"), "field5"), directiveMemento),
-    new BindingRecord(parser.parseBinding('field6', null), new FakeBindingMemento(reflector.setter("field6"), "field6"), directiveMemento),
-    new BindingRecord(parser.parseBinding('field7', null), new FakeBindingMemento(reflector.setter("field7"), "field7"), directiveMemento),
-    new BindingRecord(parser.parseBinding('field8', null), new FakeBindingMemento(reflector.setter("field8"), "field8"), directiveMemento),
-    new BindingRecord(parser.parseBinding('field9', null), new FakeBindingMemento(reflector.setter("field9"), "field9"), directiveMemento)
+  var directiveRecord = new DirectiveRecord(0, 0, false, false);
+  var bindings = [
+    BindingRecord.createForDirective(parser.parseBinding('field0', null), "field0", reflector.setter("field0"), directiveRecord),
+    BindingRecord.createForDirective(parser.parseBinding('field1', null), "field1", reflector.setter("field1"), directiveRecord),
+    BindingRecord.createForDirective(parser.parseBinding('field2', null), "field2", reflector.setter("field2"), directiveRecord),
+    BindingRecord.createForDirective(parser.parseBinding('field3', null), "field3", reflector.setter("field3"), directiveRecord),
+    BindingRecord.createForDirective(parser.parseBinding('field4', null), "field4", reflector.setter("field4"), directiveRecord),
+    BindingRecord.createForDirective(parser.parseBinding('field5', null), "field5", reflector.setter("field5"), directiveRecord),
+    BindingRecord.createForDirective(parser.parseBinding('field6', null), "field6", reflector.setter("field6"), directiveRecord),
+    BindingRecord.createForDirective(parser.parseBinding('field7', null), "field7", reflector.setter("field7"), directiveRecord),
+    BindingRecord.createForDirective(parser.parseBinding('field8', null), "field8", reflector.setter("field8"), directiveRecord),
+    BindingRecord.createForDirective(parser.parseBinding('field9', null), "field9", reflector.setter("field9"), directiveRecord)
   ];
 
+  var targetObj = new Obj();
   for (var i = 0; i < iterations; ++i) {
-    var cd = proto.instantiate(dispatcher, bindingRecords, [], [directiveMemento]);
-    cd.hydrate(object, null, null);
+    var cd = proto.instantiate(dispatcher, bindings, [], [directiveRecord]);
+    cd.hydrate(object, null, new FakeDirectives(targetObj));
     parentCd.addChild(cd);
   }
   return parentCd;
@@ -298,36 +299,20 @@ export function main () {
   }
 }
 
-class FakeBindingMemento {
-  setter:Function;
-  propertyName:string;
-
-  constructor(setter:Function, propertyName:string) {
-    this.setter = setter;
-    this.propertyName = propertyName;
-  }
-}
-
-class FakeDirectiveMemento {
+class FakeDirectives {
   targetObj:Obj;
-  name:string;
-  callOnChange:boolean;
-  callOnAllChangesDone:boolean;
 
-  constructor(name, targetObj) {
+  constructor(targetObj) {
     this.targetObj = targetObj;
-    this.name = name;
-    this.callOnChange = false;
-    this.callOnAllChangesDone = false;
   }
 
-  directive(dirs) {
+  directive(record) {
     return this.targetObj;
   }
 }
 
 class DummyDispatcher extends ChangeDispatcher {
-  invokeMementoFor(bindingMemento, newValue) {
+  notifyOnBinding(bindingRecord, newValue) {
     throw "Should not be used";
   }
 }


### PR DESCRIPTION
A ProtoView instantiates a ChangeDetector as follows:
- It creates a list of BindingRecord
- Every binding records has a binding memento and a directive memento
- It passes this list to change detection to create a proto change detector

The original idea was to have mementos completely opaque to change detection. But this disallows a lot of optimizations (monomorphic setters). So in practice they are not opaque. This PR merges binding records and mementos and moves them from the view to the change detection module. As a result, we create fewer objects, and the code is easier to reason about.
