### PR TITLE
feat(build): enforce formatting of some files.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -508,9 +508,22 @@ gulp.task('build/format.dart', rundartpackage(gulp, gulpPlugins, {
   args: CONFIG.formatDart.args
 }));
 
+function doCheckFormat() {
+  return gulp.src(['Brocfile*.js', 'modules/**/*.ts', 'tools/**/*.ts', '!**/typings/**/*.d.ts'])
+    .pipe(format.checkFormat('file'));
+}
+
 gulp.task('check-format', function() {
-  return gulp.src(['Brocfile*.js', 'modules/**/*.ts', '!**/typings/**/*.d.ts'])
-      .pipe(format.checkFormat('file'));
+  return doCheckFormat().on('warning', function(e) {
+    console.log("NOTE: this will be promoted to an ERROR in the continuous build");
+  });
+});
+
+gulp.task('enforce-format', function() {
+  return doCheckFormat().on('warning', function(e) {
+    console.log("ERROR: Some files need formatting");
+    process.exit(1);
+  });
 });
 
 // ------------
@@ -755,6 +768,7 @@ gulp.task('build.js.dev', function(done) {
   runSequence(
     'broccoli.js.dev',
     'build/checkCircularDependencies',
+    'check-format',
     done
   );
 });

--- a/scripts/ci/build_js.sh
+++ b/scripts/ci/build_js.sh
@@ -8,4 +8,4 @@ SCRIPT_DIR=$(dirname $0)
 source $SCRIPT_DIR/env_dart.sh
 cd $SCRIPT_DIR/../..
 
-./node_modules/.bin/gulp build.js docs
+./node_modules/.bin/gulp enforce-format build.js docs

--- a/tools/broccoli/broccoli-writer.d.ts
+++ b/tools/broccoli/broccoli-writer.d.ts
@@ -1,8 +1,6 @@
 /// <reference path="../typings/es6-promise/es6-promise.d.ts" />
 
 
-declare class Writer {
-  write(readTree: (tree) => Promise<string>, destDir: string);
-}
+declare class Writer { write(readTree: (tree) => Promise<string>, destDir: string); }
 
 export = Writer;

--- a/tools/broccoli/traceur/index.ts
+++ b/tools/broccoli/traceur/index.ts
@@ -37,7 +37,7 @@ class TraceurFilter extends Writer {
                 // TODO: we should fix the sourceMappingURL written by Traceur instead of overriding
                 // (but we might switch to typescript first)
                 var mapFilepath = filepath.replace(/\.\w+$/, '') + this.destSourceMapExtension;
-                result.js = result.js + `\n//# sourceMappingURL=./${path.basename(mapFilepath)}`;
+                result.js = result.js + '\n  //# sourceMappingURL=./' + path.basename(mapFilepath);
 
                 var destFilepath = filepath.replace(/\.\w+$/, this.destExtension);
                 var destFile = path.join(destDir, destFilepath);

--- a/tools/broccoli/typescript/index.ts
+++ b/tools/broccoli/typescript/index.ts
@@ -22,34 +22,34 @@ class TSCompiler extends Writer {
     }
     options.target = (<any>ts).ScriptTarget[options.target];
     return readTree(this.inputTree)
-      .then(srcDir => {
-        var files = walkSync(srcDir)
-          .filter(filepath => path.extname(filepath).toLowerCase() === '.ts')
-          .map(filepath => path.resolve(srcDir, filepath));
+        .then(srcDir => {
+          var files = walkSync(srcDir)
+                          .filter(filepath => path.extname(filepath).toLowerCase() === '.ts')
+                          .map(filepath => path.resolve(srcDir, filepath));
 
-        if (files.length > 0) {
-          var program = ts.createProgram(files, options);
-          var emitResult = program.emit();
+          if (files.length > 0) {
+            var program = ts.createProgram(files, options);
+            var emitResult = program.emit();
 
-          var allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
+            var allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
 
-          var errMsg = '';
-          allDiagnostics.forEach(diagnostic => {
-            var message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
-            if (!diagnostic.file) {
-              errMsg += `\n${message}`;
-              return;
+            var errMsg = '';
+            allDiagnostics.forEach(diagnostic => {
+              var message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+              if (!diagnostic.file) {
+                errMsg += `\n${message}`;
+                return;
+              }
+              var {line, character} =
+                  diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+              errMsg += `\n${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`;
+            });
+
+            if (emitResult.emitSkipped) {
+              throw new Error(errMsg);
             }
-            var {line, character} =
-              diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
-            errMsg += `\n${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`;
-          });
-
-          if (emitResult.emitSkipped) {
-            throw new Error(errMsg);
           }
-        }
-      });
+        });
   }
 }
 module.exports = TSCompiler;


### PR DESCRIPTION
Our style guide includes formatting conventions. Instead of wasting time in reviewing PRs discussing things like indenting, and to avoid later deltas to fix bad formatting in earlier commits, we want to enforce these in the build.
The intent in this change is to fail the build as quickly as possible in travis, so those sending a PR immediately know they should run clang-format and update their commit. When running locally, we want users to know about formatting, but they may not want to act on it immediately, until they are done working. For this reason, it is only a warning outside of the continuous build.
This is done by having a check-format task which should run on most local builds, and an enforce-format task only run by travis.
