### PR TITLE
chore(bundle): avoid imports in "global" format

### DIFF
--- a/modules/angular2/angular2.js
+++ b/modules/angular2/angular2.js
@@ -1,6 +1,5 @@
 export * from './change_detection';
 export * from './core';
 export * from './annotations';
-export * from './template';
 export * from './directives';
 export * from './forms';


### PR DESCRIPTION
If an "empty" file (like angular2/template.js) is imported
it is auto-detected as the one using "global" format.
This is incorrect as the entire angular2 build output is in
the ES6 format. The fix consists of forcing the es6 format
for files where auto-detection fails.

Also see: https://github.com/systemjs/systemjs/wiki/Module-Format-Support
