### PR TITLE
refactor(change_detection): removed global change detection objects so i...

### DIFF
--- a/modules/angular2/change_detection.js
+++ b/modules/angular2/change_detection.js
@@ -25,5 +25,5 @@ export {PipeRegistry} from './src/change_detection/pipes/pipe_registry';
 export {uninitialized} from './src/change_detection/change_detection_util';
 export {NO_CHANGE, Pipe} from './src/change_detection/pipes/pipe';
 export {
-  defaultPipes, DynamicChangeDetection, JitChangeDetection, dynamicChangeDetection, jitChangeDetection
+  defaultPipes, DynamicChangeDetection, JitChangeDetection, defaultPipeRegistry
 } from './src/change_detection/change_detection';

--- a/modules/angular2/src/change_detection/change_detection.js
+++ b/modules/angular2/src/change_detection/change_detection.js
@@ -5,6 +5,7 @@ import {KeyValueChangesFactory} from './pipes/keyvalue_changes';
 import {NullPipeFactory} from './pipes/null_pipe';
 import {DEFAULT} from './constants';
 import {ChangeDetection, ProtoChangeDetector} from './interfaces';
+import {Injectable} from 'angular2/di';
 
 export var defaultPipes = {
   "iterableDiff" : [
@@ -17,6 +18,10 @@ export var defaultPipes = {
   ]
 };
 
+/**
+ * @exportedAs angular2/change_detection
+ */
+@Injectable()
 export class DynamicChangeDetection extends ChangeDetection {
   registry:PipeRegistry;
 
@@ -30,6 +35,10 @@ export class DynamicChangeDetection extends ChangeDetection {
   }
 }
 
+/**
+ * @exportedAs angular2/change_detection
+ */
+@Injectable()
 export class JitChangeDetection extends ChangeDetection {
   registry:PipeRegistry;
 
@@ -43,18 +52,4 @@ export class JitChangeDetection extends ChangeDetection {
   }
 }
 
-var _registry = new PipeRegistry(defaultPipes);
-
-/**
- * Implements dynamic change detection. See: [ChangeDetection] for more details.
- *
- * @exportedAs angular2/change_detection
- */
-export var dynamicChangeDetection = new DynamicChangeDetection(_registry);
-
-/**
- * Implements just-in-time change detection. See: [ChangeDetection] for more details.
- *
- * @exportedAs angular2/change_detection
- */
-export var jitChangeDetection = new JitChangeDetection(_registry);
+export var defaultPipeRegistry = new PipeRegistry(defaultPipes);

--- a/modules/angular2/src/change_detection/pipes/pipe_registry.js
+++ b/modules/angular2/src/change_detection/pipes/pipe_registry.js
@@ -1,8 +1,10 @@
 import {List, ListWrapper} from 'angular2/src/facade/collection';
 import {isBlank, isPresent, BaseException, CONST} from 'angular2/src/facade/lang';
 import {Pipe} from './pipe';
+import {Injectable} from 'angular2/di';
 import {ChangeDetectorRef} from '../change_detector_ref';
 
+@Injectable()
 export class PipeRegistry {
   config;
 

--- a/modules/angular2/src/core/application.js
+++ b/modules/angular2/src/core/application.js
@@ -5,7 +5,7 @@ import {BrowserDomAdapter} from 'angular2/src/dom/browser_adapter';
 import {DOM} from 'angular2/src/dom/dom_adapter';
 import {Compiler, CompilerCache} from './compiler/compiler';
 import {Reflector, reflector} from 'angular2/src/reflection/reflection';
-import {Parser, Lexer, ChangeDetection, dynamicChangeDetection, jitChangeDetection} from 'angular2/change_detection';
+import {Parser, Lexer, ChangeDetection, DynamicChangeDetection, PipeRegistry, defaultPipeRegistry} from 'angular2/change_detection';
 import {ExceptionHandler} from './exception_handler';
 import {TemplateLoader} from 'angular2/src/render/dom/compiler/template_loader';
 import {TemplateResolver} from './compiler/template_resolver';
@@ -113,7 +113,8 @@ function _injectorBindings(appComponentType): List<Binding> {
       Compiler,
       CompilerCache,
       TemplateResolver,
-      bind(ChangeDetection).toValue(dynamicChangeDetection),
+      bind(PipeRegistry).toValue(defaultPipeRegistry),
+      bind(ChangeDetection).toClass(DynamicChangeDetection),
       TemplateLoader,
       DirectiveMetadataReader,
       Parser,

--- a/modules/angular2/src/test_lib/test_injector.js
+++ b/modules/angular2/src/test_lib/test_injector.js
@@ -2,7 +2,8 @@ import {bind} from 'angular2/di';
 
 import {Compiler, CompilerCache} from 'angular2/src/core/compiler/compiler';
 import {Reflector, reflector} from 'angular2/src/reflection/reflection';
-import {Parser, Lexer, ChangeDetection, dynamicChangeDetection} from 'angular2/change_detection';
+import {Parser, Lexer, ChangeDetection, DynamicChangeDetection,
+  PipeRegistry, defaultPipeRegistry} from 'angular2/change_detection';
 import {ExceptionHandler} from 'angular2/src/core/exception_handler';
 import {TemplateLoader} from 'angular2/src/render/dom/compiler/template_loader';
 import {TemplateResolver} from 'angular2/src/core/compiler/template_resolver';
@@ -90,7 +91,8 @@ function _getAppBindings() {
     Compiler,
     CompilerCache,
     bind(TemplateResolver).toClass(MockTemplateResolver),
-    bind(ChangeDetection).toValue(dynamicChangeDetection),
+    bind(PipeRegistry).toValue(defaultPipeRegistry),
+    bind(ChangeDetection).toClass(DynamicChangeDetection),
     TemplateLoader,
     DynamicComponentLoader,
     DirectiveMetadataReader,

--- a/modules/angular2/test/core/compiler/integration_spec.js
+++ b/modules/angular2/test/core/compiler/integration_spec.js
@@ -21,8 +21,8 @@ import {Type, isPresent, BaseException, assertionsEnabled, isJsObject, global} f
 import {PromiseWrapper, EventEmitter, ObservableWrapper} from 'angular2/src/facade/async';
 
 import {Injector, bind} from 'angular2/di';
-import {dynamicChangeDetection,
-  ChangeDetection, DynamicChangeDetection, Pipe, PipeRegistry, ChangeDetectorRef, ON_PUSH} from 'angular2/change_detection';
+import {PipeRegistry, defaultPipeRegistry,
+  ChangeDetection, DynamicChangeDetection, Pipe, ChangeDetectorRef, ON_PUSH} from 'angular2/change_detection';
 
 import {Decorator, Component, Viewport, DynamicComponent} from 'angular2/src/core/annotations/annotations';
 import {View} from 'angular2/src/core/annotations/view';

--- a/modules/benchmarks/src/change_detection/change_detection_benchmark.js
+++ b/modules/benchmarks/src/change_detection/change_detection_benchmark.js
@@ -9,8 +9,8 @@ import {
   Parser,
   ChangeDispatcher,
   ChangeDetection,
-  dynamicChangeDetection,
-  jitChangeDetection,
+  DynamicChangeDetection,
+  JitChangeDetection,
   BindingRecord,
   DirectiveRecord,
   DEFAULT
@@ -261,7 +261,7 @@ export function main () {
 
 
   // -- DYNAMIC
-  var ng2DynamicChangeDetector = setUpChangeDetection(dynamicChangeDetection, numberOfDetectors, object);
+  var ng2DynamicChangeDetector = setUpChangeDetection(new DynamicChangeDetection(null), numberOfDetectors, object);
 
   runChangeDetectionReads(ng2DynamicChangeDetector, 1); //warmup
 
@@ -281,7 +281,7 @@ export function main () {
   // -- JIT
   // Reenable when we have transformers for Dart
   if (isJsObject({})) {
-    var ng2JitChangeDetector = setUpChangeDetection(jitChangeDetection, numberOfDetectors, object);
+    var ng2JitChangeDetector = setUpChangeDetection(new JitChangeDetection(null), numberOfDetectors, object);
 
     runChangeDetectionReads(ng2JitChangeDetector, 1); //warmup
 

--- a/modules/benchmarks/src/compiler/compiler_benchmark.js
+++ b/modules/benchmarks/src/compiler/compiler_benchmark.js
@@ -6,7 +6,7 @@ import {MapWrapper} from 'angular2/src/facade/collection';
 import {DirectiveMetadata} from 'angular2/src/core/compiler/directive_metadata';
 import {NativeShadowDomStrategy} from 'angular2/src/render/dom/shadow_dom/native_shadow_dom_strategy';
 
-import {Parser, Lexer, ProtoRecordRange, dynamicChangeDetection} from 'angular2/change_detection';
+import {Parser, Lexer, ProtoRecordRange, DynamicChangeDetection} from 'angular2/change_detection';
 
 import {Compiler, CompilerCache} from 'angular2/src/core/compiler/compiler';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
@@ -82,7 +82,7 @@ export function main() {
     new ComponentUrlMapper(),
     urlResolver,
     renderer,
-    new ProtoViewFactory(dynamicChangeDetection)
+    new ProtoViewFactory(new DynamicChangeDetection(null))
   );
   var templateNoBindings = createTemplateHtml('templateNoBindings', count);
   var templateWithBindings = createTemplateHtml('templateWithBindings', count);

--- a/modules/examples/src/hello_world/index_static.js
+++ b/modules/examples/src/hello_world/index_static.js
@@ -1,7 +1,7 @@
 import *  as app from './index_common';
 
 import {Component, Decorator, View, NgElement} from 'angular2/angular2';
-import {Lexer, Parser, ChangeDetection, ChangeDetector} from 'angular2/change_detection';
+import {Lexer, Parser, ChangeDetection, ChangeDetector, PipeRegistry, DynamicChangeDetection} from 'angular2/change_detection';
 import {ExceptionHandler} from 'angular2/src/core/exception_handler';
 import {LifeCycle} from 'angular2/src/core/life_cycle/life_cycle';
 
@@ -245,6 +245,12 @@ function setup() {
   reflector.registerType(Testability, {
     "factory": () => new Testability(),
     "parameters": [],
+    "annotations": []
+  });
+
+  reflector.registerType(DynamicChangeDetection, {
+    "factory": (registry) => new DynamicChangeDetection(registry),
+    "parameters": [[PipeRegistry]],
     "annotations": []
   });
 


### PR DESCRIPTION
...t is possible to override pipe registry

Currently we do not allow overriding PipeRegistry, which several people complained about. This PR makes it possible.
