### PR TITLE
chore(build): gulp test.unit.cjs broken the second run

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -684,6 +684,7 @@ gulp.task('test.unit.cjs/ci', function () {
 gulp.task('test.unit.cjs', ['build.js.cjs'], function () {
   //Run tests once
   runSequence('test.unit.cjs/ci', function() {});
+
   //Watcher to transpile file changed
   gulp.watch(CONFIG.transpile.src.js.concat(['modules/**/*.cjs']), function(event) {
     var relPath = path.relative(__dirname, event.path).replace(/\\/g, "/");
@@ -701,6 +702,7 @@ gulp.task('test.unit.cjs', ['build.js.cjs'], function () {
         delete require.cache[id];
       }
     }
+    global.assert = undefined;
     runSequence('test.unit.cjs/ci', function() {});
   });
 


### PR DESCRIPTION
This is a dirty workaround to make `gulp test.unit.cjs` work again as it used to.
Some clean up will be needed with the Broccoli and Typescript change to the build, i.e. re-enabling assertions for cjs tests.
