### PR TITLE
feat(dart/transform): Add the DirectiveMetadataReader

### DIFF
--- a/modules/angular2/src/transform/template_compiler/directive_metadata_reader.dart
+++ b/modules/angular2/src/transform/template_compiler/directive_metadata_reader.dart
@@ -1,0 +1,140 @@
+library angular2.transform.template_compiler.directive_metadata_reader;
+
+import 'package:analyzer/analyzer.dart';
+import 'package:angular2/src/render/api.dart';
+import 'package:angular2/src/transform/common/asset_reader.dart';
+import 'package:angular2/src/transform/common/logging.dart';
+import 'package:angular2/src/transform/common/names.dart';
+import 'package:angular2/src/transform/common/parser.dart';
+import 'package:angular2/src/transform/common/property_utils.dart' as prop;
+
+/// Reads [DirectiveMetadata] from the `attributes` of `t`.
+List<DirectiveMetadata> readDirectiveMetadata(RegisteredType t) {
+  var visitor = new _DirectiveMetadataVisitor();
+  t.annotations.accept(visitor);
+  return visitor.directiveMetadata;
+}
+
+num _getDirectiveType(String annotationName) {
+  // TODO(kegluneq): Detect subtypes & implementations of `Directive`s.
+  switch (annotationName) {
+    case 'Decorator':
+      return DirectiveMetadata.DECORATOR_TYPE;
+    case 'Component':
+      return DirectiveMetadata.COMPONENT_TYPE;
+    case 'Viewport':
+      return DirectiveMetadata.VIEWPORT_TYPE;
+    default:
+      return -1;
+  }
+}
+
+/// Visitor responsible for processing the `annotations` property of a
+/// [RegisterType] object and pulling out [DirectiveMetadata].
+class _DirectiveMetadataVisitor extends Object
+    with RecursiveAstVisitor<Object> {
+  DirectiveMetadata current;
+  final List<DirectiveMetadata> directiveMetadata = [];
+
+  @override
+  Object visitInstanceCreationExpression(InstanceCreationExpression node) {
+    var directiveType = _getDirectiveType('${node.constructorName.type.name}');
+    if (directiveType >= 0) {
+      current = new DirectiveMetadata(
+          type: directiveType,
+          compileChildren: false,
+          properties: {},
+          hostListeners: {},
+          setters: [],
+          readAttributes: []);
+      directiveMetadata.add(current);
+      super.visitInstanceCreationExpression(node);
+    }
+    // Annotation we do not recognize - no need to visit.
+    return null;
+  }
+
+  @override
+  Object visitNamedExpression(NamedExpression node) {
+    // TODO(kegluneq): Remove this limitation.
+    if (node.name is! Label || node.name.label is! SimpleIdentifier) {
+      logger.error(
+          'Angular 2 currently only supports simple identifiers in directives.'
+          ' Source: ${node}');
+      return null;
+    }
+    var keyString = '${node.name.label}';
+    // TODO(kegluneq): Populate the other values in [DirectiveMetadata] once
+    // they are specified as `hostAttributes` and `hostSetters`.
+    // See [https://github.com/angular/angular/issues/1244]
+    switch (keyString) {
+      case 'selector':
+        _populateSelector(node.expression);
+        break;
+      case 'compileChildren':
+        _populateCompileChildren(node.expression);
+        break;
+      case 'properties':
+        _populateProperties(node.expression);
+        break;
+      case 'hostListeners':
+        _populateHostListeners(node.expression);
+    }
+    return null;
+  }
+
+  String _expressionToString(Expression node, String nodeDescription) {
+    // TODO(kegluneq): Accept more options.
+    if (node is! SimpleStringLiteral) {
+      logger.error('Angular 2 currently only supports string literals '
+          'in $nodeDescription. Source: ${node}');
+      return null;
+    }
+    return stringLiteralToString(node);
+  }
+
+  void _populateSelector(Expression selectorValue) {
+    current.selector = _expressionToString(selectorValue, 'Directive#selector');
+  }
+
+  void _populateCompileChildren(Expression compileChildrenValue) {
+    if (compileChildrenValue is! BooleanLiteral) {
+      logger.error(
+          'Angular 2 currently only supports boolean literal values for '
+          'Decorator#compileChildren.'
+          ' Source: ${node}');
+      return;
+    }
+    current.compileChildren = compileChildrenValue.value;
+  }
+
+  void _populateProperties(Expression propertiesValue) {
+    if (propertiesValue is! MapLiteral) {
+      logger.error('Angular 2 currently only supports map literal values for '
+          'Directive#properties.'
+          ' Source: ${node}');
+      return;
+    }
+    for (MapLiteralEntry entry in propertiesValue.entries) {
+      var sKey = _expressionToString(entry.key, 'Directive#properties keys');
+      var sVal = _expressionToString(entry.value, 'Direcive#properties values');
+      current.properties[sKey] = sVal;
+    }
+  }
+
+  void _populateHostListeners(Expression hostListenersValue) {
+    if (hostListenersValue is! MapLiteral) {
+      logger.error('Angular 2 currently only supports map literal values for '
+          'Directive#hostListeners.'
+          ' Source: ${node}');
+      return;
+    }
+    for (MapLiteralEntry entry in hostListenersValue.entries) {
+      var sKey = _expressionToString(entry.key, 'Directive#hostListeners keys');
+      var sVal =
+          _expressionToString(entry.value, 'Directive#hostListeners values');
+      current.hostListeners[sKey] = sVal;
+      ;
+    }
+  }
+}

--- a/modules/angular2/src/transform/template_compiler/directive_metadata_reader.dart
+++ b/modules/angular2/src/transform/template_compiler/directive_metadata_reader.dart
@@ -134,7 +134,6 @@ class _DirectiveMetadataVisitor extends Object
       var sVal =
           _expressionToString(entry.value, 'Directive#hostListeners values');
       current.hostListeners[sKey] = sVal;
-      ;
     }
   }
 }

--- a/modules/angular2/src/transform/template_compiler/directive_metadata_reader.dart
+++ b/modules/angular2/src/transform/template_compiler/directive_metadata_reader.dart
@@ -2,11 +2,8 @@ library angular2.transform.template_compiler.directive_metadata_reader;
 
 import 'package:analyzer/analyzer.dart';
 import 'package:angular2/src/render/api.dart';
-import 'package:angular2/src/transform/common/asset_reader.dart';
 import 'package:angular2/src/transform/common/logging.dart';
-import 'package:angular2/src/transform/common/names.dart';
 import 'package:angular2/src/transform/common/parser.dart';
-import 'package:angular2/src/transform/common/property_utils.dart' as prop;
 
 /// Reads [DirectiveMetadata] from the `attributes` of `t`.
 List<DirectiveMetadata> readDirectiveMetadata(RegisteredType t) {
@@ -102,20 +99,20 @@ class _DirectiveMetadataVisitor extends Object
       logger.error(
           'Angular 2 currently only supports boolean literal values for '
           'Decorator#compileChildren.'
-          ' Source: ${node}');
+          ' Source: ${compileChildrenValue}');
       return;
     }
-    current.compileChildren = compileChildrenValue.value;
+    current.compileChildren = (compileChildrenValue as BooleanLiteral).value;
   }
 
   void _populateProperties(Expression propertiesValue) {
     if (propertiesValue is! MapLiteral) {
       logger.error('Angular 2 currently only supports map literal values for '
           'Directive#properties.'
-          ' Source: ${node}');
+          ' Source: ${propertiesValue}');
       return;
     }
-    for (MapLiteralEntry entry in propertiesValue.entries) {
+    for (MapLiteralEntry entry in (propertiesValue as MapLiteral).entries) {
       var sKey = _expressionToString(entry.key, 'Directive#properties keys');
       var sVal = _expressionToString(entry.value, 'Direcive#properties values');
       current.properties[sKey] = sVal;
@@ -126,10 +123,10 @@ class _DirectiveMetadataVisitor extends Object
     if (hostListenersValue is! MapLiteral) {
       logger.error('Angular 2 currently only supports map literal values for '
           'Directive#hostListeners.'
-          ' Source: ${node}');
+          ' Source: ${hostListenersValue}');
       return;
     }
-    for (MapLiteralEntry entry in hostListenersValue.entries) {
+    for (MapLiteralEntry entry in (hostListenersValue as MapLiteral).entries) {
       var sKey = _expressionToString(entry.key, 'Directive#hostListeners keys');
       var sVal =
           _expressionToString(entry.value, 'Directive#hostListeners values');

--- a/modules/angular2/test/transform/common/application.dart
+++ b/modules/angular2/test/transform/common/application.dart
@@ -8,7 +8,7 @@ import 'dart:async';
 /// Mocked out version of [bootstrap], defined in application.dart. Importing
 /// the actual file in tests causes issues with resolution due to its
 /// transitive dependencies.
-Future bootstrap(Type appComponentType, [List<Binding> bindings = null,
-    Function givenBootstrapErrorReporter = null]) {
+Future bootstrap(Type appComponentType,
+    [List bindings = null, Function givenBootstrapErrorReporter = null]) {
   return null;
 }

--- a/modules/angular2/test/transform/template_compiler/all_tests.dart
+++ b/modules/angular2/test/transform/template_compiler/all_tests.dart
@@ -1,7 +1,9 @@
 library angular2.test.transform.template_compiler.all_tests;
 
+import 'dart:async';
 import 'package:barback/barback.dart';
 import 'package:angular2/src/dom/html_adapter.dart';
+import 'package:angular2/src/render/api.dart';
 import 'package:angular2/src/transform/common/asset_reader.dart';
 import 'package:angular2/src/transform/common/parser.dart';
 import 'package:angular2/src/transform/template_compiler/directive_metadata_reader.dart';
@@ -52,44 +54,49 @@ void allTests() {
   });
 
   describe('DirectiveMetadataReader', () {
-    it('should parse simple expressions in inline templates', () async {
-      var inputPath =
-          'template_compiler/inline_expression_files/hello.ng_deps.dart';
+    Future<DirectiveMetadata> readSingleMetadata(inputPath) async {
       var ngDeps = await parser.parse(new AssetId('a', inputPath));
-
       var metadata = readDirectiveMetadata(ngDeps.registeredTypes.first);
-      expect(metadata.length).toEqual(2);
-      expect(metadata[0].selector).toEqual('hello-app');
+      expect(metadata.length).toEqual(1);
+      return metadata.first;
+    }
+
+    it('should parse selectors', () async {
+      var metadata = await readSingleMetadata(
+          'template_compiler/directive_metadata_files/selector.ng_deps.dart');
+      expect(metadata.selector).toEqual('hello-app');
     });
 
-    it('should parse simple methods in inline templates', () async {
-      var inputPath =
-      'template_compiler/inline_method_files/hello.ng_deps.dart';
-      var ngDeps = await parser.parse(new AssetId('a', inputPath));
+    it('should parse compile children values', () async {
+      var metadata = await readSingleMetadata('template_compiler/'
+          'directive_metadata_files/compile_children.ng_deps.dart');
+      expect(metadata.compileChildren).toBeTrue();
 
-      var metadata = readDirectiveMetadata(ngDeps.registeredTypes.first);
-      expect(metadata.length).toEqual(2);
-      expect(metadata[0].selector).toEqual('hello-app');
+      metadata = await readSingleMetadata(
+          'template_compiler/directive_metadata_files/selector.ng_deps.dart');
+      expect(metadata.compileChildren).toBeFalse();
     });
 
-    it('should parse simple expressions in linked templates.', () async {
-      var inputPath =
-      'template_compiler/url_expression_files/hello.ng_deps.dart';
-      var ngDeps = await parser.parse(new AssetId('a', inputPath));
-
-      var metadata = readDirectiveMetadata(ngDeps.registeredTypes.first);
-      expect(metadata.length).toEqual(2);
-      expect(metadata[0].selector).toEqual('hello-app');
+    it('should parse properties.', () async {
+      var metadata = await readSingleMetadata('template_compiler/'
+          'directive_metadata_files/properties.ng_deps.dart');
+      expect(metadata.properties).toBeNotNull();
+      expect(metadata.properties.length).toBe(2);
+      expect(metadata.properties).toContain('key1');
+      expect(metadata.properties['key1']).toEqual('val1');
+      expect(metadata.properties).toContain('key2');
+      expect(metadata.properties['key2']).toEqual('val2');
     });
 
-    it('should parse simple methods in linked templates.', () async {
-      var inputPath =
-      'template_compiler/url_method_files/hello.ng_deps.dart';
-      var ngDeps = await parser.parse(new AssetId('a', inputPath));
-
-      var metadata = readDirectiveMetadata(ngDeps.registeredTypes.first);
-      expect(metadata.length).toEqual(2);
-      expect(metadata[0].selector).toEqual('hello-app');
+    it('should parse host listeners.', () async {
+      var metadata = await readSingleMetadata('template_compiler/'
+          'directive_metadata_files/host_listeners.ng_deps.dart');
+      expect(metadata.hostListeners).toBeNotNull();
+      expect(metadata.hostListeners.length).toBe(2);
+      expect(metadata.hostListeners).toContain('change');
+      expect(metadata.hostListeners['change']).toEqual('onChange(\$event)');
+      expect(metadata.hostListeners).toContain('keyDown');
+      expect(metadata.hostListeners['keyDown']).toEqual('onKeyDown(\$event)');
     });
   });
 }

--- a/modules/angular2/test/transform/template_compiler/all_tests.dart
+++ b/modules/angular2/test/transform/template_compiler/all_tests.dart
@@ -3,6 +3,8 @@ library angular2.test.transform.template_compiler.all_tests;
 import 'package:barback/barback.dart';
 import 'package:angular2/src/dom/html_adapter.dart';
 import 'package:angular2/src/transform/common/asset_reader.dart';
+import 'package:angular2/src/transform/common/parser.dart';
+import 'package:angular2/src/transform/template_compiler/directive_metadata_reader.dart';
 import 'package:angular2/src/transform/template_compiler/generator.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:guinness/guinness.dart';
@@ -14,6 +16,7 @@ var formatter = new DartFormatter();
 void allTests() {
   Html5LibDomAdapter.makeCurrent();
   AssetReader reader = new TestAssetReader();
+  var parser = new Parser(reader);
 
   it('should parse simple expressions in inline templates.', () async {
     var inputPath =
@@ -46,6 +49,48 @@ void allTests() {
         'template_compiler/url_method_files/expected/hello.ng_deps.dart');
     var output = await processTemplates(reader, new AssetId('a', inputPath));
     _formatThenExpectEquals(output, expected);
+  });
+
+  describe('DirectiveMetadataReader', () {
+    it('should parse simple expressions in inline templates', () async {
+      var inputPath =
+          'template_compiler/inline_expression_files/hello.ng_deps.dart';
+      var ngDeps = await parser.parse(new AssetId('a', inputPath));
+
+      var metadata = readDirectiveMetadata(ngDeps.registeredTypes.first);
+      expect(metadata.length).toEqual(2);
+      expect(metadata[0].selector).toEqual('hello-app');
+    });
+
+    it('should parse simple methods in inline templates', () async {
+      var inputPath =
+      'template_compiler/inline_method_files/hello.ng_deps.dart';
+      var ngDeps = await parser.parse(new AssetId('a', inputPath));
+
+      var metadata = readDirectiveMetadata(ngDeps.registeredTypes.first);
+      expect(metadata.length).toEqual(2);
+      expect(metadata[0].selector).toEqual('hello-app');
+    });
+
+    it('should parse simple expressions in linked templates.', () async {
+      var inputPath =
+      'template_compiler/url_expression_files/hello.ng_deps.dart';
+      var ngDeps = await parser.parse(new AssetId('a', inputPath));
+
+      var metadata = readDirectiveMetadata(ngDeps.registeredTypes.first);
+      expect(metadata.length).toEqual(2);
+      expect(metadata[0].selector).toEqual('hello-app');
+    });
+
+    it('should parse simple methods in linked templates.', () async {
+      var inputPath =
+      'template_compiler/url_method_files/hello.ng_deps.dart';
+      var ngDeps = await parser.parse(new AssetId('a', inputPath));
+
+      var metadata = readDirectiveMetadata(ngDeps.registeredTypes.first);
+      expect(metadata.length).toEqual(2);
+      expect(metadata[0].selector).toEqual('hello-app');
+    });
   });
 }
 

--- a/modules/angular2/test/transform/template_compiler/directive_metadata_files/compile_children.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/directive_metadata_files/compile_children.ng_deps.dart
@@ -1,0 +1,17 @@
+library examples.hello_world.index_common_dart.ng_deps.dart;
+
+import 'hello.dart';
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Decorator, View, NgElement;
+
+bool _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(HelloCmp, {
+      'factory': () => new HelloCmp(),
+      'parameters': const [const []],
+      'annotations': const [const Decorator(compileChildren: true)]
+    });
+}

--- a/modules/angular2/test/transform/template_compiler/directive_metadata_files/compile_children.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/directive_metadata_files/compile_children.ng_deps.dart
@@ -1,8 +1,7 @@
 library examples.hello_world.index_common_dart.ng_deps.dart;
 
 import 'hello.dart';
-import 'package:angular2/angular2.dart'
-    show bootstrap, Component, Decorator, View, NgElement;
+import 'package:angular2/angular2.dart';
 
 bool _visited = false;
 void initReflector(reflector) {

--- a/modules/angular2/test/transform/template_compiler/directive_metadata_files/host_listeners.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/directive_metadata_files/host_listeners.ng_deps.dart
@@ -1,0 +1,23 @@
+library examples.hello_world.index_common_dart.ng_deps.dart;
+
+import 'hello.dart';
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Decorator, View, NgElement;
+
+bool _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(HelloCmp, {
+      'factory': () => new HelloCmp(),
+      'parameters': const [const []],
+      'annotations': const [
+        const Component(
+            hostListeners: const {
+          'change': 'onChange(\$event)',
+          'keyDown': 'onKeyDown(\$event)'
+        })
+      ]
+    });
+}

--- a/modules/angular2/test/transform/template_compiler/directive_metadata_files/properties.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/directive_metadata_files/properties.ng_deps.dart
@@ -1,0 +1,19 @@
+library examples.hello_world.index_common_dart.ng_deps.dart;
+
+import 'hello.dart';
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Decorator, View, NgElement;
+
+bool _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(HelloCmp, {
+      'factory': () => new HelloCmp(),
+      'parameters': const [const []],
+      'annotations': const [
+        const Component(properties: const {'key1': 'val1', 'key2': 'val2'})
+      ]
+    });
+}

--- a/modules/angular2/test/transform/template_compiler/directive_metadata_files/selector.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/directive_metadata_files/selector.ng_deps.dart
@@ -1,0 +1,17 @@
+library examples.hello_world.index_common_dart.ng_deps.dart;
+
+import 'hello.dart';
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Decorator, View, NgElement;
+
+bool _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(HelloCmp, {
+      'factory': () => new HelloCmp(),
+      'parameters': const [const []],
+      'annotations': const [const Component(selector: 'hello-app')]
+    });
+}

--- a/modules/angular2/test/transform/template_compiler/directive_metadata_files/too_many_directives.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/directive_metadata_files/too_many_directives.ng_deps.dart
@@ -1,0 +1,20 @@
+library examples.hello_world.index_common_dart.ng_deps.dart;
+
+import 'hello.dart';
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Decorator, View, NgElement;
+
+bool _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(HelloCmp, {
+      'factory': () => new HelloCmp(),
+      'parameters': const [const []],
+      'annotations': const [
+        const Component(selector: 'hello-app'),
+        const Component(selector: 'goodbye-app')
+      ]
+    });
+}


### PR DESCRIPTION
Add a class that parses and reads Directive metadata to prepare for
running the Render compiler in the Dart transformer.
