### PR TITLE
Check ON_PUSH detectors when their bindings change

### DIFF
--- a/modules/angular2/src/change_detection/abstract_change_detector.js
+++ b/modules/angular2/src/change_detection/abstract_change_detector.js
@@ -9,13 +9,13 @@ export class AbstractChangeDetector extends ChangeDetector {
   shadowDomChildren:List;
   parent:ChangeDetector;
   mode:string;
-  changeDetectorRef:ChangeDetectorRef;
+  ref:ChangeDetectorRef;
 
   constructor() {
     super();
     this.lightDomChildren = [];
     this.shadowDomChildren = [];
-    this.changeDetectorRef = new ChangeDetectorRef(this);
+    this.ref = new ChangeDetectorRef(this);
     this.mode = null;
   }
 
@@ -78,6 +78,10 @@ export class AbstractChangeDetector extends ChangeDetector {
     for(var i = 0; i < c.length; ++i) {
       c[i]._detectChanges(throwOnChange);
     }
+  }
+
+  markAsCheckOnce() {
+    this.mode = CHECK_ONCE;
   }
 
   markPathToRootAsCheckOnce() {

--- a/modules/angular2/src/change_detection/binding_record.js
+++ b/modules/angular2/src/change_detection/binding_record.js
@@ -32,6 +32,10 @@ export class BindingRecord {
     return isPresent(this.directiveRecord) && this.directiveRecord.callOnChange;
   }
 
+  isOnPushChangeDetection() {
+    return isPresent(this.directiveRecord) && this.directiveRecord.isOnPushChangeDetection();
+  }
+
   isDirective() {
     return this.mode === DIRECTIVE;
   }

--- a/modules/angular2/src/change_detection/directive_record.js
+++ b/modules/angular2/src/change_detection/directive_record.js
@@ -1,16 +1,24 @@
+import {ON_PUSH} from './constants';
+import {StringWrapper} from 'angular2/src/facade/lang';
+
 export class DirectiveRecord {
   elementIndex:number;
   directiveIndex:number;
   callOnAllChangesDone:boolean;
   callOnChange:boolean;
+  changeDetection:string;
 
   constructor(elementIndex:number, directiveIndex:number, 
-              callOnAllChangesDone:boolean,
-              callOnChange:boolean) {
+              callOnAllChangesDone:boolean, callOnChange:boolean, changeDetection:string) {
     this.elementIndex = elementIndex;
     this.directiveIndex = directiveIndex;
     this.callOnAllChangesDone = callOnAllChangesDone;
     this.callOnChange = callOnChange;
+    this.changeDetection = changeDetection;
+  }
+
+  isOnPushChangeDetection():boolean {
+    return StringWrapper.equals(this.changeDetection, ON_PUSH);
   }
 
   get name() {

--- a/modules/angular2/src/core/annotations/annotations.js
+++ b/modules/angular2/src/core/annotations/annotations.js
@@ -1,6 +1,7 @@
 import {ABSTRACT, CONST, normalizeBlank, isPresent} from 'angular2/src/facade/lang';
 import {ListWrapper, List} from 'angular2/src/facade/collection';
 import {Injectable} from 'angular2/di';
+import {DEFAULT} from 'angular2/change_detection';
 
 // type StringMap = {[idx: string]: string};
 
@@ -553,7 +554,7 @@ export class Component extends Directive {
     hostListeners,
     injectables,
     lifecycle,
-    changeDetection
+    changeDetection = DEFAULT
     }:{
       selector:string,
       properties:Object,

--- a/modules/angular2/src/core/compiler/element_injector.js
+++ b/modules/angular2/src/core/compiler/element_injector.js
@@ -8,7 +8,7 @@ import * as viewModule from 'angular2/src/core/compiler/view';
 import {ViewContainer} from 'angular2/src/core/compiler/view_container';
 import {NgElement} from 'angular2/src/core/compiler/ng_element';
 import {Directive, Component, onChange, onDestroy, onAllChangesDone} from 'angular2/src/core/annotations/annotations';
-import {ChangeDetectorRef} from 'angular2/change_detection';
+import {ChangeDetector, ChangeDetectorRef} from 'angular2/change_detection';
 import {QueryList} from './query_list';
 
 var _MAX_DIRECTIVE_CONSTRUCTION_COUNTER = 10;
@@ -277,6 +277,15 @@ export class DirectiveBinding extends ResolvedBinding {
     }
   }
 
+  get changeDetection() {
+    if (this.annotation instanceof Component) {
+      var c:Component = this.annotation;
+      return c.changeDetection;
+    } else {
+      return null;
+    }
+  }
+
   static createFromBinding(b:Binding, annotation:Directive):DirectiveBinding {
     var rb = b.resolve();
     var deps = ListWrapper.map(rb.dependencies, DirectiveDependency.createFrom);
@@ -298,13 +307,13 @@ export class PreBuiltObjects {
   view:viewModule.AppView;
   element:NgElement;
   viewContainer:ViewContainer;
-  changeDetectorRef:ChangeDetectorRef;
+  changeDetector:ChangeDetector;
   constructor(view, element:NgElement, viewContainer:ViewContainer,
-              changeDetectorRef:ChangeDetectorRef) {
+              changeDetector:ChangeDetector) {
     this.view = view;
     this.element = element;
     this.viewContainer = viewContainer;
-    this.changeDetectorRef = changeDetectorRef;
+    this.changeDetector = changeDetector;
   }
 }
 
@@ -603,6 +612,10 @@ export class ElementInjector extends TreeNode {
     return this._preBuiltObjects.element;
   }
 
+  getChangeDetector() {
+    return this._preBuiltObjects.changeDetector;
+  }
+
   getComponent() {
     if (this._proto._binding0IsComponent) {
       return this._obj0;
@@ -885,7 +898,7 @@ export class ElementInjector extends TreeNode {
     if (keyId === staticKeys.viewId) return this._preBuiltObjects.view;
     if (keyId === staticKeys.ngElementId) return this._preBuiltObjects.element;
     if (keyId === staticKeys.viewContainerId) return this._preBuiltObjects.viewContainer;
-    if (keyId === staticKeys.changeDetectorRefId) return this._preBuiltObjects.changeDetectorRef;
+    if (keyId === staticKeys.changeDetectorRefId) return this._preBuiltObjects.changeDetector.ref;
 
     //TODO add other objects as needed
     return _undefined;

--- a/modules/angular2/src/core/compiler/view.js
+++ b/modules/angular2/src/core/compiler/view.js
@@ -256,9 +256,14 @@ export class AppView {
     }
   }
 
-  directive(directive:DirectiveRecord) {
-    var elementInjector:ElementInjector = this.elementInjectors[directive.elementIndex];
+  getDirectiveFor(directive:DirectiveRecord) {
+    var elementInjector = this.elementInjectors[directive.elementIndex];
     return elementInjector.getDirectiveAtIndex(directive.directiveIndex);
+  }
+
+  getDetectorFor(directive:DirectiveRecord) {
+    var elementInjector = this.elementInjectors[directive.elementIndex];
+    return elementInjector.getChangeDetector();
   }
 
   setDynamicComponentChildView(boundElementIndex, view:AppView) {
@@ -458,9 +463,11 @@ export class AppProtoView {
 
     if (!MapWrapper.contains(this._directiveRecordsMap, id)) {
       var binding = protoElementInjector.getDirectiveBindingAtIndex(directiveIndex);
+      var changeDetection = binding.changeDetection;
+
       MapWrapper.set(this._directiveRecordsMap, id,
         new DirectiveRecord(elementInjectorIndex, directiveIndex,
-          binding.callOnAllChangesDone, binding.callOnChange));
+          binding.callOnAllChangesDone, binding.callOnChange, changeDetection));
     }
 
     return MapWrapper.get(this._directiveRecordsMap, id);

--- a/modules/angular2/src/core/compiler/view_factory.js
+++ b/modules/angular2/src/core/compiler/view_factory.js
@@ -5,7 +5,6 @@ import {isPresent, isBlank, BaseException} from 'angular2/src/facade/lang';
 import {NgElement} from 'angular2/src/core/compiler/ng_element';
 import * as vcModule from './view_container';
 import * as viewModule from './view';
-import {ChangeDetectorRef} from 'angular2/change_detection';
 
 // TODO(tbosch): Make this an OpaqueToken as soon as our transpiler supports this!
 export const VIEW_POOL_CAPACITY = 'ViewFactory.viewPoolCapacity';
@@ -77,13 +76,12 @@ export class ViewFactory {
       elementInjectors[binderIdx] = elementInjector;
 
       // componentChildViews
-      var changeDetectorRef = null;
+      var childChangeDetector = null;
       if (binder.hasStaticComponent()) {
         var childView = this._createView(binder.nestedProtoView);
-        changeDetector.addShadowDomChild(childView.changeDetector);
-
-        changeDetectorRef = new ChangeDetectorRef(childView.changeDetector);
-
+        childChangeDetector = childView.changeDetector;
+        changeDetector.addShadowDomChild(childChangeDetector);
+        
         componentChildViews[binderIdx] = childView;
       }
 
@@ -97,7 +95,7 @@ export class ViewFactory {
       // preBuiltObjects
       if (isPresent(elementInjector)) {
         preBuiltObjects[binderIdx] = new eli.PreBuiltObjects(view, new NgElement(view, binderIdx), viewContainer,
-          changeDetectorRef);
+          childChangeDetector);
       }
     }
 

--- a/modules/angular2/test/core/compiler/element_injector_spec.js
+++ b/modules/angular2/test/core/compiler/element_injector_spec.js
@@ -11,7 +11,7 @@ import {AppProtoView, AppView} from 'angular2/src/core/compiler/view';
 import {ViewContainer} from 'angular2/src/core/compiler/view_container';
 import {NgElement} from 'angular2/src/core/compiler/ng_element';
 import {Directive} from 'angular2/src/core/annotations/annotations';
-import {ChangeDetectorRef, Parser, Lexer} from 'angular2/change_detection';
+import {DynamicChangeDetector, ChangeDetectorRef, Parser, Lexer} from 'angular2/change_detection';
 import {ViewRef, Renderer, EventBinding} from 'angular2/src/render/api';
 import {QueryList} from 'angular2/src/core/compiler/query_list';
 
@@ -621,10 +621,10 @@ export function main() {
       });
 
       it('should return changeDetectorRef', function () {
-        var config = new ChangeDetectorRef(null);
-        var inj = injector([], null, null, new PreBuiltObjects(null, null, null, config));
+        var cd = new DynamicChangeDetector(null, null, null, [], []);
+        var inj = injector([], null, null, new PreBuiltObjects(null, null, null, cd));
 
-        expect(inj.get(ChangeDetectorRef)).toEqual(config);
+        expect(inj.get(ChangeDetectorRef)).toBe(cd.ref);
       });
     });
 

--- a/modules/benchmarks/src/change_detection/change_detection_benchmark.js
+++ b/modules/benchmarks/src/change_detection/change_detection_benchmark.js
@@ -12,7 +12,8 @@ import {
   dynamicChangeDetection,
   jitChangeDetection,
   BindingRecord,
-  DirectiveRecord
+  DirectiveRecord,
+  DEFAULT
 } from 'angular2/change_detection';
 
 
@@ -191,7 +192,7 @@ function setUpChangeDetection(changeDetection:ChangeDetection, iterations, objec
 
   var proto = changeDetection.createProtoChangeDetector("proto");
 
-  var directiveRecord = new DirectiveRecord(0, 0, false, false);
+  var directiveRecord = new DirectiveRecord(0, 0, false, false, DEFAULT);
   var bindings = [
     BindingRecord.createForDirective(parser.parseBinding('field0', null), "field0", reflector.setter("field0"), directiveRecord),
     BindingRecord.createForDirective(parser.parseBinding('field1', null), "field1", reflector.setter("field1"), directiveRecord),
@@ -306,7 +307,7 @@ class FakeDirectives {
     this.targetObj = targetObj;
   }
 
-  directive(record) {
+  getDirectiveFor(record) {
     return this.targetObj;
   }
 }


### PR DESCRIPTION
Please review only the second commit

Currently ON_PUSH just sets the mode to CHECK_ONCE during hydration. 

With this PR, ON_PUSH detectors will get checked after their bindings have gotten updated.
