### PR TITLE
feat(view): replaced EventEmitter callback with EventEmitter observable

### DIFF
--- a/modules/angular2/angular2.js
+++ b/modules/angular2/angular2.js
@@ -3,3 +3,4 @@ export * from './core';
 export * from './annotations';
 export * from './directives';
 export * from './forms';
+export {Observable, EventEmitter} from 'angular2/src/facade/async';

--- a/modules/angular2/src/core/annotations/annotations.js
+++ b/modules/angular2/src/core/annotations/annotations.js
@@ -361,6 +361,30 @@ export class Directive extends Injectable {
   properties:any; //  StringMap
 
   /**
+   * Enumerates the set of emitted events.
+   *
+   * ## Syntax
+   *
+   * ```
+   * @Component({
+   *   events: ['status-change']
+   * })
+   * class TaskComponent {
+   *   statusChange:EventEmitter;
+   *
+   *   constructor() {
+   *     this.complete = new EventEmitter();
+   *   }
+   *
+   *   onComplete() {
+   *     this.statusChange.next("completed");
+   *   }
+   * }
+   * ```
+   */
+  events:List<string>;
+
+  /**
    * Specifies which DOM hostListeners a directive listens to.
    *
    * The `hostListeners` property defines a set of `event` to `method` key-value pairs:
@@ -426,11 +450,13 @@ export class Directive extends Injectable {
   constructor({
       selector,
       properties,
+      events,
       hostListeners,
       lifecycle
     }:{
       selector:string,
       properties:any,
+      events:List,
       hostListeners: any,
       lifecycle:List
     }={})
@@ -438,6 +464,7 @@ export class Directive extends Injectable {
     super();
     this.selector = selector;
     this.properties = properties;
+    this.events = events;
     this.hostListeners = hostListeners;
     this.lifecycle = lifecycle;
   }
@@ -551,6 +578,7 @@ export class Component extends Directive {
   constructor({
     selector,
     properties,
+    events,
     hostListeners,
     injectables,
     lifecycle,
@@ -558,6 +586,7 @@ export class Component extends Directive {
     }:{
       selector:string,
       properties:Object,
+      events:List,
       hostListeners:Object,
       injectables:List,
       lifecycle:List,
@@ -567,6 +596,7 @@ export class Component extends Directive {
     super({
       selector: selector,
       properties: properties,
+      events: events,
       hostListeners: hostListeners,
       lifecycle: lifecycle
     });
@@ -634,12 +664,14 @@ export class DynamicComponent extends Directive {
   constructor({
     selector,
     properties,
+    events,
     hostListeners,
     injectables,
     lifecycle
     }:{
       selector:string,
       properties:Object,
+      events:List,
       hostListeners:Object,
       injectables:List,
       lifecycle:List
@@ -647,6 +679,7 @@ export class DynamicComponent extends Directive {
     super({
       selector: selector,
       properties: properties,
+      events: events,
       hostListeners: hostListeners,
       lifecycle: lifecycle
     });
@@ -727,12 +760,14 @@ export class Decorator extends Directive {
   constructor({
       selector,
       properties,
+      events,
       hostListeners,
       lifecycle,
       compileChildren = true,
     }:{
       selector:string,
       properties:any,
+      events:List,
       hostListeners:any,
       lifecycle:List,
       compileChildren:boolean
@@ -741,6 +776,7 @@ export class Decorator extends Directive {
     super({
         selector: selector,
         properties: properties,
+        events: events,
         hostListeners: hostListeners,
         lifecycle: lifecycle
     });
@@ -846,17 +882,20 @@ export class Viewport extends Directive {
   constructor({
       selector,
       properties,
+      events,
       hostListeners,
       lifecycle
     }:{
       selector:string,
       properties:any,
+      events:List,
       lifecycle:List
     }={})
   {
     super({
         selector: selector,
         properties: properties,
+        events: events,
         hostListeners: hostListeners,
         lifecycle: lifecycle
     });

--- a/modules/angular2/src/core/annotations/di.js
+++ b/modules/angular2/src/core/annotations/di.js
@@ -2,33 +2,10 @@ import {CONST} from 'angular2/src/facade/lang';
 import {DependencyAnnotation} from 'angular2/di';
 
 /**
- * Specifies that a function for emitting events should be injected.
- *
- * NOTE: This is changing pre 1.0.
- * 
- * The directive can inject an emitter function that would emit events onto the directive host element.
- * 
- * @exportedAs angular2/annotations
- */
-export class EventEmitter extends DependencyAnnotation {
-  eventName: string;
-
-  @CONST()
-  constructor(eventName) {
-    super();
-    this.eventName = eventName;
-  }
-
-  get token() {
-    return Function;
-  }
-}
-
-/**
  * Specifies that a function for setting host properties should be injected.
  *
  * NOTE: This is changing pre 1.0.
- * 
+ *
  * The directive can inject a property setter that would allow setting this property on the host element.
  *
  * @exportedAs angular2/annotations

--- a/modules/angular2/src/facade/async.dart
+++ b/modules/angular2/src/facade/async.dart
@@ -37,26 +37,49 @@ class ObservableWrapper {
     return s.listen(onNext, onError: onError, onDone: onComplete, cancelOnError: true);
   }
 
-  static StreamController createController() {
-    return new StreamController.broadcast();
+  static void callNext(EventEmitter emitter, value) {
+    emitter.add(value);
   }
 
-  static Stream createObservable(StreamController controller) {
-    return controller.stream;
+  static void callThrow(EventEmitter emitter, error) {
+    emitter.addError(error);
   }
 
-  static void callNext(StreamController controller, value) {
-    controller.add(value);
-  }
-
-  static void callThrow(StreamController controller, error) {
-    controller.addError(error);
-  }
-
-  static void callReturn(StreamController controller) {
-    controller.close();
+  static void callReturn(EventEmitter emitter) {
+    emitter.close();
   }
 }
+
+class EventEmitter extends Stream {
+  StreamController<String> _controller;
+
+  EventEmitter() {
+    _controller = new StreamController.broadcast();
+  }
+
+  StreamSubscription listen(void onData(String line), {
+                              void onError(Error error),
+                              void onDone(),
+                              bool cancelOnError }) {
+    return _controller.stream.listen(onData,
+        onError: onError,
+        onDone: onDone,
+        cancelOnError: cancelOnError);
+  }
+
+  void add(value) {
+    _controller.add(value);
+  }
+
+  void addError(error) {
+    _controller.addError(error);
+  }
+
+  void close() {
+    _controller.close();
+  }
+}
+
 
 class _Completer {
   final Completer c;

--- a/modules/angular2/src/forms/model.js
+++ b/modules/angular2/src/forms/model.js
@@ -1,5 +1,5 @@
 import {isPresent} from 'angular2/src/facade/lang';
-import {Observable, ObservableController, ObservableWrapper} from 'angular2/src/facade/async';
+import {Observable, EventEmitter, ObservableWrapper} from 'angular2/src/facade/async';
 import {StringMap, StringMapWrapper, ListWrapper, List} from 'angular2/src/facade/collection';
 import {Validators} from './validators';
 
@@ -40,8 +40,7 @@ export class AbstractControl {
   _parent:any; /* ControlGroup | ControlArray */
   validator:Function;
 
-  valueChanges:Observable;
-  _valueChangesController:ObservableController;
+  _valueChanges:EventEmitter;
 
   constructor(validator:Function) {
     this.validator = validator;
@@ -72,6 +71,10 @@ export class AbstractControl {
     return ! this.pristine;
   }
 
+  get valueChanges():Observable {
+    return this._valueChanges;
+  }
+
   setParent(parent){
     this._parent = parent;
   }
@@ -95,16 +98,14 @@ export class Control extends AbstractControl {
   constructor(value:any, validator:Function = Validators.nullValidator) {
     super(validator);
     this._setValueErrorsStatus(value);
-
-    this._valueChangesController = ObservableWrapper.createController();
-    this.valueChanges = ObservableWrapper.createObservable(this._valueChangesController);
+    this._valueChanges = new EventEmitter();
   }
 
   updateValue(value:any):void {
     this._setValueErrorsStatus(value);
     this._pristine = false;
 
-    ObservableWrapper.callNext(this._valueChangesController, this._value);
+    ObservableWrapper.callNext(this._valueChanges, this._value);
 
     this._updateParent();
   }
@@ -137,8 +138,7 @@ export class ControlGroup extends AbstractControl {
     this.controls = controls;
     this._optionals = isPresent(optionals) ? optionals : {};
 
-    this._valueChangesController = ObservableWrapper.createController();
-    this.valueChanges = ObservableWrapper.createObservable(this._valueChangesController);
+    this._valueChanges = new EventEmitter();
 
     this._setParentForControls();
     this._setValueErrorsStatus();
@@ -169,7 +169,7 @@ export class ControlGroup extends AbstractControl {
     this._setValueErrorsStatus();
     this._pristine = false;
 
-    ObservableWrapper.callNext(this._valueChangesController, this._value);
+    ObservableWrapper.callNext(this._valueChanges, this._value);
 
     this._updateParent();
   }
@@ -222,8 +222,7 @@ export class ControlArray extends AbstractControl {
     super(validator);
     this.controls = controls;
 
-    this._valueChangesController = ObservableWrapper.createController();
-    this.valueChanges = ObservableWrapper.createObservable(this._valueChangesController);
+    this._valueChanges = new EventEmitter();
 
     this._setParentForControls();
     this._setValueErrorsStatus();
@@ -258,7 +257,7 @@ export class ControlArray extends AbstractControl {
     this._setValueErrorsStatus();
     this._pristine = false;
 
-    ObservableWrapper.callNext(this._valueChangesController, this._value);
+    ObservableWrapper.callNext(this._valueChanges, this._value);
 
     this._updateParent();
   }

--- a/modules/angular2/test/core/compiler/view_hydrator_spec.js
+++ b/modules/angular2/test/core/compiler/view_hydrator_spec.js
@@ -47,6 +47,7 @@ export function main() {
       var res = new SpyElementInjector();
       res.spy('isExportingComponent').andCallFake( () => false );
       res.spy('isExportingElement').andCallFake( () => false );
+      res.spy('getEventEmitterAccessors').andCallFake( () => [] );
       return res;
     }
 

--- a/modules/angular2/test/facade/async_spec.js
+++ b/modules/angular2/test/facade/async_spec.js
@@ -1,93 +1,57 @@
 import {describe, it, expect, beforeEach, ddescribe, iit, xit, el,
   SpyObject, AsyncTestCompleter, inject, IS_DARTIUM} from 'angular2/test_lib';
 
-import {ObservableWrapper, Observable, ObservableController, PromiseWrapper} from 'angular2/src/facade/async';
+import {ObservableWrapper, EventEmitter, PromiseWrapper} from 'angular2/src/facade/async';
 
 export function main() {
-  describe('Observable', () => {
-    var obs:Observable;
-    var controller:ObservableController;
-
+  describe('EventEmitter', () => {
+    var emitter:EventEmitter;
+    
     beforeEach(() => {
-      controller = ObservableWrapper.createController();
-      obs = ObservableWrapper.createObservable(controller);
+      emitter = new EventEmitter();
     });
 
     it("should call the next callback",  inject([AsyncTestCompleter], (async) => {
-      ObservableWrapper.subscribe(obs, (value) => {
+      ObservableWrapper.subscribe(emitter, (value) => {
         expect(value).toEqual(99);
         async.done();
       });
 
-      ObservableWrapper.callNext(controller, 99);
+      ObservableWrapper.callNext(emitter, 99);
     }));
 
     it("should call the throw callback", inject([AsyncTestCompleter], (async) => {
-      ObservableWrapper.subscribe(obs, (_) => {}, (error) => {
+      ObservableWrapper.subscribe(emitter, (_) => {}, (error) => {
         expect(error).toEqual("Boom");
         async.done();
       });
-      ObservableWrapper.callThrow(controller, "Boom");
+      ObservableWrapper.callThrow(emitter, "Boom");
+    }));
+
+    it("should work when no throw callback is provided", inject([AsyncTestCompleter], (async) => {
+      ObservableWrapper.subscribe(emitter, (_) => {}, (_) => {
+        async.done();
+      });
+      ObservableWrapper.callThrow(emitter, "Boom");
     }));
 
     it("should call the return callback", inject([AsyncTestCompleter], (async) => {
-      ObservableWrapper.subscribe(obs, (_) => {}, (_) => {}, () => {
+      ObservableWrapper.subscribe(emitter, (_) => {}, (_) => {}, () => {
         async.done();
       });
 
-      ObservableWrapper.callReturn(controller);
+      ObservableWrapper.callReturn(emitter);
     }));
 
     it("should subscribe to the wrapper asynchronously", () => {
       var called = false;
-      ObservableWrapper.subscribe(obs, (value) => {
+      ObservableWrapper.subscribe(emitter, (value) => {
         called = true;
       });
 
-      ObservableWrapper.callNext(controller, 99);
+      ObservableWrapper.callNext(emitter, 99);
       expect(called).toBe(false);
     });
-
-    if (!IS_DARTIUM) {
-      // See here: https://github.com/jhusain/observable-spec
-      describe("Generator", () => {
-        var generator;
-
-        beforeEach(() => {
-          generator = new SpyObject();
-          generator.spy("next");
-          generator.spy("throw");
-          generator.spy("return");
-        });
-
-        it("should call next on the given generator",  inject([AsyncTestCompleter], (async) => {
-          generator.spy("next").andCallFake((value) => {
-            expect(value).toEqual(99);
-            async.done();
-          });
-
-          ObservableWrapper.subscribe(obs, generator);
-          ObservableWrapper.callNext(controller, 99);
-        }));
-
-        it("should call throw on the given generator", inject([AsyncTestCompleter], (async) => {
-          generator.spy("throw").andCallFake((error) => {
-            expect(error).toEqual("Boom");
-            async.done();
-          });
-          ObservableWrapper.subscribe(obs, generator);
-          ObservableWrapper.callThrow(controller, "Boom");
-        }));
-
-        it("should call return on the given generator", inject([AsyncTestCompleter], (async) => {
-          generator.spy("return").andCallFake(() => {
-            async.done();
-          });
-          ObservableWrapper.subscribe(obs, generator);
-          ObservableWrapper.callReturn(controller);
-        }));
-      });
-    }
 
     //TODO: vsavkin: add tests cases
     //should call dispose on the subscription if generator returns {done:true}
@@ -95,5 +59,3 @@ export function main() {
     //should call dispose on the subscription on return
  });
 }
-
-//make sure rx observables are async

--- a/modules/angular2_material/src/components/radio/radio_button.js
+++ b/modules/angular2_material/src/components/radio/radio_button.js
@@ -1,11 +1,10 @@
-import {Component, View, Parent, Ancestor, Attribute, PropertySetter,
-    EventEmitter} from 'angular2/angular2';
+import {Component, View, Parent, Ancestor, Attribute, PropertySetter} from 'angular2/angular2';
 import {Optional} from 'angular2/src/di/annotations';
 import {MdRadioDispatcher} from 'angular2_material/src/components/radio/radio_dispatcher'
 import {MdTheme} from 'angular2_material/src/core/theme'
 import {onChange} from 'angular2/src/core/annotations/annotations';
 import {isPresent, StringWrapper} from 'angular2/src/facade/lang';
-// import {KeyCodes} from 'angular2_material/src/core/constants'
+import {ObservableWrapper, EventEmitter} from 'angular2/src/facade/async';
 import {Math} from 'angular2/src/facade/math';
 import {ListWrapper} from 'angular2/src/facade/collection';
 
@@ -177,6 +176,7 @@ export class MdRadioButton {
 @Component({
   selector: 'md-radio-group',
   lifecycle: [onChange],
+  events: ['change'],
   properties: {
     'disabled': 'disabled',
     'value': 'value'
@@ -212,6 +212,8 @@ export class MdRadioGroup {
   /** The ID of the selected radio button. */
   selectedRadioId: string;
 
+  change:EventEmitter;
+
   constructor(
       @Attribute('tabindex') tabindex: string,
       @Attribute('disabled') disabled: string,
@@ -219,11 +221,10 @@ export class MdRadioGroup {
       @PropertySetter('attr.role') roleSetter: Function,
       @PropertySetter('attr.aria-disabled') ariaDisabledSetter: Function,
       @PropertySetter('attr.aria-activedescendant') ariaActiveDescendantSetter: Function,
-      @EventEmitter('change') changeEmitter: Function,
       radioDispatcher: MdRadioDispatcher) {
     this.name_ = `md-radio-group-${_uniqueIdCounter++}`;
     this.radios_ = [];
-    this.changeEmitter = changeEmitter;
+    this.change = new EventEmitter();
     this.ariaActiveDescendantSetter = ariaActiveDescendantSetter;
     this.ariaDisabledSetter = ariaDisabledSetter;
     this.radioDispatcher = radioDispatcher;
@@ -277,7 +278,7 @@ export class MdRadioGroup {
     this.value = value;
     this.selectedRadioId = id;
     this.ariaActiveDescendantSetter(id);
-    this.changeEmitter();
+    ObservableWrapper.callNext(this.change, null);
   }
 
   /** Registers a child radio button with this group. */

--- a/modules/examples/src/forms/index.es6
+++ b/modules/examples/src/forms/index.es6
@@ -53,6 +53,7 @@ class HeaderFields {
 // This component is self-contained and can be tested in isolation.
 @Component({
   selector: 'survey-question',
+  events: ['destroy'],
   properties: {
     "question" : "question",
     "index" : "index"
@@ -100,16 +101,16 @@ class HeaderFields {
 class SurveyQuestion {
   question:ControlGroup;
   index:number;
-  onDelete:Function;
+  destroy:EventEmitter;
 
-  constructor(@EventEmitter("delete") onDelete:Function) {
-    this.onDelete = onDelete;
+  constructor() {
+    this.destroy = new EventEmitter();
   }
 
   deleteQuestion() {
     // Invoking an injected event emitter will fire an event,
     // which in this case will result in calling `deleteQuestion(i)`
-    this.onDelete();
+    this.destroy.next(null);
   }
 }
 
@@ -132,7 +133,7 @@ class SurveyQuestion {
           *for="var q of form.controls.questions.controls; var i=index"
           [question]="q"
           [index]="i + 1"
-          (delete)="deleteQuestion(i)">
+          (destroy)="destroyQuestion(i)">
       </survey-question>
 
       <button (click)="submitForm()">Submit</button>
@@ -175,14 +176,14 @@ class SurveyBuilder {
     // complex form interactions in a declarative fashion.
     //
     // We are disabling the responseLength control when the question type is checkbox.
-    newQuestion.controls.type.valueChanges.subscribe((v) =>
-      v == 'text' || v == 'textarea' ?
-        newQuestion.include('responseLength') : newQuestion.exclude('responseLength'));
+    newQuestion.controls.type.valueChanges.observer({
+      next: (v) => v == 'text' || v == 'textarea' ? newQuestion.include('responseLength') : newQuestion.exclude('responseLength')
+    });
 
     this.form.controls.questions.push(newQuestion);
   }
 
-  deleteQuestion(index:number) {
+  destroyQuestion(index:number) {
     this.form.controls.questions.removeAt(index);
   }
 


### PR DESCRIPTION
This PR replaces EventEmitter callbacks with EventEmitter observables. It also updates forms to use EventEmitter.

Background:
We already use observables in forms and http. Imo we should use the same type in all these places. The added EventEmitter type implements the Observable/Stream interface and also allows pushing value. 

A few things to note:
- EventEmitter uses sync subscription and async delivery. 
- EventEmitter is cold. This means that if you fire an event in the constructor of your component, before a listener got attached to it, it will not be received by anyone.
- The current implementation uses Rx/Dart Streams. This is temporary. We will either Rx3 or provide our own.

@mhevery @jeffbcross @yjbanov could you take a look?
