### PR TITLE
refactor(views): clean up creating views in place and extract view_hydra...

### DIFF
--- a/modules/angular2/src/core/application.js
+++ b/modules/angular2/src/core/application.js
@@ -29,11 +29,13 @@ import {StyleInliner} from 'angular2/src/render/dom/shadow_dom/style_inliner';
 import {ComponentRef, DynamicComponentLoader} from 'angular2/src/core/compiler/dynamic_component_loader';
 import {TestabilityRegistry, Testability} from 'angular2/src/core/testability/testability';
 import {ViewFactory, VIEW_POOL_CAPACITY} from 'angular2/src/core/compiler/view_factory';
+import {AppViewHydrator} from 'angular2/src/core/compiler/view_hydrator';
 import {ProtoViewFactory} from 'angular2/src/core/compiler/proto_view_factory';
 import {Renderer} from 'angular2/src/render/api';
 import {DirectDomRenderer} from 'angular2/src/render/dom/direct_dom_renderer';
 import * as rc from 'angular2/src/render/dom/compiler/compiler';
 import * as rvf from 'angular2/src/render/dom/view/view_factory';
+import * as rvh from 'angular2/src/render/dom/view/view_hydrator';
 
 import {
   appComponentRefToken,
@@ -98,14 +100,16 @@ function _injectorBindings(appComponentType): List<Binding> {
         [rvf.VIEW_POOL_CAPACITY, EventManager, ShadowDomStrategy]
       ),
       bind(rvf.VIEW_POOL_CAPACITY).toValue(10000),
+      rvh.RenderViewHydrator,
       ProtoViewFactory,
       // TODO(tbosch): We need an explicit factory here, as
       // we are getting errors in dart2js with mirrors...
       bind(ViewFactory).toFactory(
-        (capacity) => new ViewFactory(capacity),
-        [VIEW_POOL_CAPACITY]
+        (capacity, renderer) => new ViewFactory(capacity, renderer),
+        [VIEW_POOL_CAPACITY, Renderer]
       ),
       bind(VIEW_POOL_CAPACITY).toValue(10000),
+      AppViewHydrator,
       Compiler,
       CompilerCache,
       TemplateResolver,

--- a/modules/angular2/src/core/compiler/compiler.js
+++ b/modules/angular2/src/core/compiler/compiler.js
@@ -81,11 +81,11 @@ export class Compiler {
     return DirectiveBinding.createFromType(meta.type, meta.annotation);
   }
 
-  // Create a rootView as if the compiler encountered <rootcmp></rootcmp>.
+  // Create a hostView as if the compiler encountered <hostcmp></hostcmp>.
   // Used for bootstrapping.
-  compileRoot(elementOrSelector, componentTypeOrBinding:any):Promise<AppProtoView> {
-    return this._renderer.createRootProtoView(elementOrSelector, 'root').then( (rootRenderPv) => {
-      return this._compileNestedProtoViews(null, rootRenderPv, [this._bindDirective(componentTypeOrBinding)], true);
+  compileInHost(componentTypeOrBinding:any):Promise<AppProtoView> {
+    return this._renderer.createHostProtoView('host').then( (hostRenderPv) => {
+      return this._compileNestedProtoViews(null, hostRenderPv, [this._bindDirective(componentTypeOrBinding)], true);
     });
   }
 

--- a/modules/angular2/src/core/compiler/dynamic_component_loader.js
+++ b/modules/angular2/src/core/compiler/dynamic_component_loader.js
@@ -2,12 +2,11 @@ import {Key, Injector, Injectable, ResolvedBinding} from 'angular2/di'
 import {Compiler} from './compiler';
 import {DirectiveMetadataReader} from './directive_metadata_reader';
 import {Type, BaseException, stringify, isPresent} from 'angular2/src/facade/lang';
-import {List} from 'angular2/src/facade/collection';
 import {Promise} from 'angular2/src/facade/async';
 import {Component} from 'angular2/src/core/annotations/annotations';
 import {ViewFactory} from 'angular2/src/core/compiler/view_factory';
-import {Renderer} from 'angular2/src/render/api';
-import {ElementRef} from './element_injector';
+import {AppViewHydrator} from 'angular2/src/core/compiler/view_hydrator';
+import {ElementRef, DirectiveBinding} from './element_injector';
 import {AppView} from './view';
 
 /**
@@ -43,13 +42,15 @@ export class ComponentRef {
 export class DynamicComponentLoader {
   _compiler:Compiler;
   _viewFactory:ViewFactory;
+  _viewHydrator:AppViewHydrator;
   _directiveMetadataReader:DirectiveMetadataReader;
 
   constructor(compiler:Compiler, directiveMetadataReader:DirectiveMetadataReader,
-              renderer:Renderer, viewFactory:ViewFactory) {
+              viewFactory:ViewFactory, viewHydrator:AppViewHydrator) {
     this._compiler = compiler;
     this._directiveMetadataReader = directiveMetadataReader;
-    this._viewFactory = viewFactory
+    this._viewFactory = viewFactory;
+    this._viewHydrator = viewHydrator;
   }
 
   /**
@@ -58,59 +59,42 @@ export class DynamicComponentLoader {
    */
   loadIntoExistingLocation(type:Type, location:ElementRef, injector:Injector = null):Promise<ComponentRef> {
     this._assertTypeIsComponent(type);
+    var annotation = this._directiveMetadataReader.read(type).annotation;
+    var componentBinding = DirectiveBinding.createFromType(type, annotation);
 
-    var directiveMetadata = this._directiveMetadataReader.read(type);
-
-    var inj = this._componentAppInjector(location, injector, directiveMetadata.resolvedInjectables);
-
-    var hostEi = location.elementInjector;
-    var hostView = location.hostView;
     return this._compiler.compile(type).then(componentProtoView => {
-      var component = hostEi.dynamicallyCreateComponent(type, directiveMetadata.annotation, inj);
-      var componentView = this._instantiateAndHydrateView(componentProtoView, injector, hostEi, component);
-
-      //TODO(vsavkin): do not use component child views as we need to clear the dynamically created views
-      //same problem exists on the render side
-      hostView.setDynamicComponentChildView(location.boundElementIndex, componentView);
+      var componentView = this._viewFactory.getView(componentProtoView);
+      var hostView = location.hostView;
+      this._viewHydrator.hydrateDynamicComponentView(
+        hostView, location.boundElementIndex, componentView, componentBinding, injector);
 
       // TODO(vsavkin): return a component ref that dehydrates the component view and removes it
       // from the component child views
-      return new ComponentRef(location, component, componentView);
+      // See ViewFactory.returnView
+      // See AppViewHydrator.dehydrateDynamicComponentView
+      return new ComponentRef(location, location.elementInjector.getDynamicallyLoadedComponent(), componentView);
     });
   }
 
   /**
    * Loads a component as a child of the View given by the provided ElementRef. The loaded
    * component receives injection normally as a hosted view.
-   *
-   * TODO(vsavkin, jelbourn): remove protoViewFactory after render layer exists.
    */
   loadIntoNewLocation(elementOrSelector:any, type:Type, location:ElementRef,
                       injector:Injector = null):Promise<ComponentRef> {
     this._assertTypeIsComponent(type);
 
-    var inj = this._componentAppInjector(location, injector, null);
-
-    //TODO(tbosch) this should always be a selector
-    return  this._compiler.compileRoot(elementOrSelector, type).then(pv => {
-      var hostView = this._instantiateAndHydrateView(pv, inj, null, new Object());
+    return  this._compiler.compileInHost(type).then(hostProtoView => {
+      var hostView = this._viewFactory.getView(hostProtoView);
+      this._viewHydrator.hydrateInPlaceHostView(null, elementOrSelector, hostView, injector);
 
       // TODO(vsavkin): return a component ref that dehydrates the host view
+      // See ViewFactory.returnView
+      // See AppViewHydrator.dehydrateInPlaceHostView
       var newLocation = new ElementRef(hostView.elementInjectors[0]);
       var component = hostView.elementInjectors[0].getComponent();
       return new ComponentRef(newLocation, component, hostView.componentChildViews[0]);
     });
-  }
-
-  _componentAppInjector(location, injector:Injector, resolvedBindings:List<ResolvedBinding>) {
-    var inj = isPresent(injector) ? injector : location.injector;
-    return isPresent(resolvedBindings) ? inj.createChildFromResolved(resolvedBindings) : inj;
-  }
-
-  _instantiateAndHydrateView(protoView, injector, hostElementInjector, context) {
-    var componentView = this._viewFactory.getView(protoView);
-    componentView.hydrate(injector, hostElementInjector, context, null);
-    return componentView;
   }
 
   /** Asserts that the type being dynamically instantiated is a Component. */

--- a/modules/angular2/src/core/compiler/element_injector.js
+++ b/modules/angular2/src/core/compiler/element_injector.js
@@ -575,9 +575,9 @@ export class ElementInjector extends TreeNode {
     if (isPresent(p._keyId9)) this._getDirectiveByKeyId(p._keyId9);
   }
 
-  dynamicallyCreateComponent(componentType:Type, annotation:Directive, injector:Injector) {
+  dynamicallyCreateComponent(directiveBinding, injector:Injector) {
     this._shadowDomAppInjector = injector;
-    this._dynamicallyCreatedComponentBinding = DirectiveBinding.createFromType(componentType, annotation);
+    this._dynamicallyCreatedComponentBinding = directiveBinding;
     this._dynamicallyCreatedComponent = this._new(this._dynamicallyCreatedComponentBinding);
     return this._dynamicallyCreatedComponent;
   }
@@ -708,7 +708,7 @@ export class ElementInjector extends TreeNode {
 
   _buildPropSetter(dep) {
     var view = this._getPreBuiltObjectByKeyId(StaticKeys.instance().viewId);
-    var renderer = view.proto.renderer;
+    var renderer = view.renderer;
     var index = this._proto.index;
     return function(v) {
       renderer.setElementProperty(view.render, index, dep.propSetterName, v);

--- a/modules/angular2/src/core/compiler/proto_view_factory.js
+++ b/modules/angular2/src/core/compiler/proto_view_factory.js
@@ -13,11 +13,9 @@ import {ProtoElementInjector, DirectiveBinding} from './element_injector';
 @Injectable()
 export class ProtoViewFactory {
   _changeDetection:ChangeDetection;
-  _renderer:renderApi.Renderer;
 
-  constructor(changeDetection:ChangeDetection, renderer:renderApi.Renderer) {
+  constructor(changeDetection:ChangeDetection) {
     this._changeDetection = changeDetection;
-    this._renderer = renderer;
   }
 
   createProtoView(componentBinding:DirectiveBinding, renderProtoView: renderApi.ProtoViewDto, directives:List<DirectiveBinding>):AppProtoView {
@@ -30,7 +28,7 @@ export class ProtoViewFactory {
         'dummy', componentAnnotation.changeDetection
       );
     }
-    var protoView = new AppProtoView(this._renderer, renderProtoView.render, protoChangeDetector);
+    var protoView = new AppProtoView(renderProtoView.render, protoChangeDetector);
 
     for (var i=0; i<renderProtoView.elementBinders.length; i++) {
       var renderElementBinder = renderProtoView.elementBinders[i];

--- a/modules/angular2/src/core/compiler/view_hydrator.js
+++ b/modules/angular2/src/core/compiler/view_hydrator.js
@@ -1,0 +1,284 @@
+import {Injectable, Inject, OpaqueToken, Injector} from 'angular2/di';
+import {ListWrapper, MapWrapper, Map, StringMapWrapper, List} from 'angular2/src/facade/collection';
+import * as eli from './element_injector';
+import {isPresent, isBlank, BaseException} from 'angular2/src/facade/lang';
+import * as vcModule from './view_container';
+import * as viewModule from './view';
+import {BindingPropagationConfig, Locals} from 'angular2/change_detection';
+
+import * as renderApi from 'angular2/src/render/api';
+
+/**
+ * A dehydrated view is a state of the view that allows it to be moved around
+ * the view tree, without incurring the cost of recreating the underlying
+ * injectors and watch records.
+ *
+ * A dehydrated view has the following properties:
+ *
+ * - all element injectors are empty.
+ * - all appInjectors are released.
+ * - all viewcontainers are empty.
+ * - all context locals are set to null.
+ * - the view context is null.
+ *
+ * A call to hydrate/dehydrate is called whenever a view is attached/detached,
+ * but it does not do the attach/detach itself.
+ */
+@Injectable()
+export class AppViewHydrator {
+  _renderer:renderApi.Renderer;
+
+  constructor(renderer:renderApi.Renderer) {
+    this._renderer = renderer;
+  }
+
+  hydrateDynamicComponentView(hostView:viewModule.AppView, boundElementIndex:number,
+      componentView:viewModule.AppView, componentDirective:eli.DirectiveBinding, injector:Injector) {
+    var binder = hostView.proto.elementBinders[boundElementIndex];
+    if (!binder.hasDynamicComponent()) {
+      throw new BaseException(`There is no dynamic component directive at element ${boundElementIndex}`);
+    }
+    if (isPresent(hostView.componentChildViews[boundElementIndex])) {
+      throw new BaseException(`There already is a bound component at element ${boundElementIndex}`);
+    }
+    var hostElementInjector = hostView.elementInjectors[boundElementIndex];
+    if (isBlank(injector)) {
+      // TODO: We should have another way of accesing the app injector at hostView place.
+      injector = new eli.ElementRef(hostElementInjector).injector;
+    }
+
+    // shadowDomAppInjector
+    var shadowDomAppInjector = this._createShadowDomAppInjector(componentDirective, injector);
+    // Needed to make rtts-assert happy in unit tests...
+    if (isBlank(shadowDomAppInjector)) {
+      shadowDomAppInjector = null;
+    }
+    // create component instance
+    var component = hostElementInjector.dynamicallyCreateComponent(componentDirective, shadowDomAppInjector);
+
+    // componentView
+    hostView.componentChildViews[boundElementIndex] = componentView;
+    hostView.changeDetector.addShadowDomChild(componentView.changeDetector);
+
+    // render views
+    var renderViewRefs = this._renderer.createDynamicComponentView(hostView.render, boundElementIndex, componentView.proto.render);
+
+    this._viewHydrateRecurse(
+      componentView, renderViewRefs, 0, shadowDomAppInjector, hostElementInjector, component, null
+    );
+  }
+
+  dehydrateDynamicComponentView(parentView:viewModule.AppView, boundElementIndex:number) {
+    throw new BaseException('Not yet implemented!');
+    // Something along these lines:
+    // var binder = parentView.proto.elementBinders[boundElementIndex];
+    // if (!binder.hasDynamicComponent()) {
+    //   throw new BaseException(`There is no dynamic component directive at element ${boundElementIndex}`);
+    // }
+    // var componentView = parentView.componentChildViews[boundElementIndex];
+    // if (isBlank(componentView)) {
+    //   throw new BaseException(`There is no bound component at element ${boundElementIndex}`);
+    // }
+    // this._viewDehydrateRecurse(componentView);
+    // parentView.changeDetector.removeShadowDomChild(componentView.changeDetector);
+    // this._renderer.destroyDynamicComponentChildView(parentView.render, boundElementIndex);
+    // parentView.componentChildViews[boundElementIndex] = null;
+  }
+
+  hydrateInPlaceHostView(parentView:viewModule.AppView, hostElementSelector, hostView:viewModule.AppView, injector:Injector) {
+    var parentRenderViewRef = null;
+    if (isPresent(parentView)) {
+      // Needed for user views
+      throw new BaseException('Not yet supported');
+    }
+    var binder = hostView.proto.elementBinders[0];
+    var shadowDomAppInjector = this._createShadowDomAppInjector(binder.componentDirective, injector);
+
+    // render views
+    var renderViewRefs = this._renderer.createInPlaceHostView(parentRenderViewRef, hostElementSelector, hostView.proto.render);
+
+    this._viewHydrateRecurse(
+      hostView, renderViewRefs, 0, shadowDomAppInjector, null, new Object(), null
+    );
+  }
+
+  dehydrateInPlaceHostView(parentView:viewModule.AppView, hostView:viewModule.AppView) {
+    var parentRenderViewRef = null;
+    if (isPresent(parentView)) {
+      // Needed for user views
+      throw new BaseException('Not yet supported');
+    }
+    var render = hostView.render;
+    this._viewDehydrateRecurse(hostView);
+    this._renderer.destroyInPlaceHostView(parentRenderViewRef, render);
+  }
+
+  hydrateViewInViewContainer(viewContainer:vcModule.ViewContainer, atIndex:number, view:viewModule.AppView) {
+    if (!viewContainer.hydrated()) throw new BaseException(
+        'Cannot create views on a dehydrated ViewContainer');
+    var renderViewRefs = this._renderer.createViewInContainer(viewContainer.render, atIndex, view.proto.render);
+    viewContainer.parentView.changeDetector.addChild(view.changeDetector);
+    this._viewHydrateRecurse(view, renderViewRefs, 0, viewContainer.appInjector, viewContainer.hostElementInjector,
+      viewContainer.parentView.context, viewContainer.parentView.locals);
+  }
+
+  dehydrateViewInViewContainer(viewContainer:vcModule.ViewContainer, atIndex:number, view:viewModule.AppView) {
+    view.changeDetector.remove();
+    this._viewDehydrateRecurse(view);
+    this._renderer.destroyViewInContainer(viewContainer.render, atIndex);
+  }
+
+  _viewHydrateRecurse(
+      view:viewModule.AppView,
+      renderComponentViewRefs:List<renderApi.ViewRef>,
+      renderComponentIndex:number,
+      appInjector: Injector, hostElementInjector: eli.ElementInjector,
+      context: Object, locals:Locals):number {
+    if (view.hydrated()) throw new BaseException('The view is already hydrated.');
+
+    view.render = renderComponentViewRefs[renderComponentIndex++];
+
+    view.context = context;
+    view.locals.parent = locals;
+
+    // viewContainers
+    for (var i = 0; i < view.viewContainers.length; i++) {
+      var vc = view.viewContainers[i];
+      if (isPresent(vc)) {
+        this._viewContainerHydrateRecurse(vc, new renderApi.ViewContainerRef(view.render, i), appInjector, hostElementInjector);
+      }
+    }
+
+    var binders = view.proto.elementBinders;
+    for (var i = 0; i < binders.length; ++i) {
+      var componentDirective = binders[i].componentDirective;
+      var shadowDomAppInjector = null;
+
+      // shadowDomAppInjector
+      if (isPresent(componentDirective)) {
+        shadowDomAppInjector = this._createShadowDomAppInjector(componentDirective, appInjector);
+      } else {
+        shadowDomAppInjector = null;
+      }
+
+      // elementInjectors
+      var elementInjector = view.elementInjectors[i];
+      if (isPresent(elementInjector)) {
+        elementInjector.instantiateDirectives(appInjector, hostElementInjector, shadowDomAppInjector, view.preBuiltObjects[i]);
+
+        // The exporting of $implicit is a special case. Since multiple elements will all export
+        // the different values as $implicit, directly assign $implicit bindings to the variable
+        // name.
+        var exportImplicitName = elementInjector.getExportImplicitName();
+        if (elementInjector.isExportingComponent()) {
+          view.locals.set(exportImplicitName, elementInjector.getComponent());
+        } else if (elementInjector.isExportingElement()) {
+          view.locals.set(exportImplicitName, elementInjector.getNgElement());
+        }
+      }
+
+      if (binders[i].hasStaticComponent()) {
+        renderComponentIndex = this._viewHydrateRecurse(
+          view.componentChildViews[i],
+          renderComponentViewRefs,
+          renderComponentIndex,
+          shadowDomAppInjector,
+          elementInjector,
+          elementInjector.getComponent(),
+          null
+        );
+      }
+    }
+    view.changeDetector.hydrate(view.context, view.locals, view);
+    view.renderer.setEventDispatcher(view.render, view);
+    return renderComponentIndex;
+  }
+
+  /**
+   * This should only be called by View or ViewContainer.
+   */
+  _viewDehydrateRecurse(view:viewModule.AppView) {
+    // Note: preserve the opposite order of the hydration process.
+
+    // componentChildViews
+    for (var i = 0; i < view.componentChildViews.length; i++) {
+      var componentView = view.componentChildViews[i];
+      if (isPresent(componentView)) {
+        this._viewDehydrateRecurse(componentView);
+        var binder = view.proto.elementBinders[i];
+        if (binder.hasDynamicComponent()) {
+          view.componentChildViews[i] = null;
+          view.changeDetector.removeShadowDomChild(componentView.changeDetector);
+        }
+      }
+    }
+
+    // elementInjectors
+    for (var i = 0; i < view.elementInjectors.length; i++) {
+      if (isPresent(view.elementInjectors[i])) {
+        view.elementInjectors[i].clearDirectives();
+      }
+    }
+
+    // viewContainers
+    if (isPresent(view.viewContainers)) {
+      for (var i = 0; i < view.viewContainers.length; i++) {
+        var vc = view.viewContainers[i];
+        if (isPresent(vc)) {
+          this._viewContainerDehydrateRecurse(vc);
+        }
+      }
+    }
+
+    view.render = null;
+
+    if (isPresent(view.locals)) {
+      view.locals.clearValues();
+    }
+    view.context = null;
+    view.changeDetector.dehydrate();
+  }
+
+  _createShadowDomAppInjector(componentDirective, appInjector) {
+    var shadowDomAppInjector = null;
+
+    // shadowDomAppInjector
+    var injectables = componentDirective.resolvedInjectables;
+    if (isPresent(injectables)) {
+      shadowDomAppInjector = appInjector.createChildFromResolved(injectables);
+    } else {
+      shadowDomAppInjector = appInjector;
+    }
+    return shadowDomAppInjector;
+  }
+
+  /**
+   * This should only be called by View or ViewContainer.
+   */
+  _viewContainerHydrateRecurse(viewContainer:vcModule.ViewContainer, render:renderApi.ViewContainerRef, appInjector: Injector, hostElementInjector: eli.ElementInjector) {
+    viewContainer.viewHydrator = this;
+    viewContainer.render = render;
+    viewContainer.appInjector = appInjector;
+    viewContainer.hostElementInjector = hostElementInjector;
+  }
+
+  /**
+   * This should only be called by View or ViewContainer.
+   */
+  _viewContainerDehydrateRecurse(viewContainer:vcModule.ViewContainer) {
+    for (var i=0; i<viewContainer.length; i++) {
+      var view = viewContainer.get(i);
+      view.changeDetector.remove();
+      this._viewDehydrateRecurse(view);
+    }
+    // Note: We don't call clear here,
+    // as we don't want to change the render side
+    // as the render side does its own recursion.
+    viewContainer.internalClearWithoutRender();
+    viewContainer.viewHydrator = null;
+    viewContainer.appInjector = null;
+    viewContainer.hostElementInjector = null;
+    viewContainer.render = null;
+  }
+
+}

--- a/modules/angular2/src/render/dom/direct_dom_renderer.js
+++ b/modules/angular2/src/render/dom/direct_dom_renderer.js
@@ -1,15 +1,17 @@
 import {Injectable} from 'angular2/di';
 import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
 import {List, ListWrapper} from 'angular2/src/facade/collection';
-import {isBlank, isPresent} from 'angular2/src/facade/lang';
+import {isBlank, isPresent, BaseException} from 'angular2/src/facade/lang';
 
 import * as api from '../api';
 import {RenderView} from './view/view';
 import {RenderProtoView} from './view/proto_view';
 import {ViewFactory} from './view/view_factory';
+import {RenderViewHydrator} from './view/view_hydrator';
 import {Compiler} from './compiler/compiler';
 import {ShadowDomStrategy} from './shadow_dom/shadow_dom_strategy';
 import {ProtoViewBuilder} from './view/proto_view_builder';
+import {DOM} from 'angular2/src/dom/dom_adapter';
 
 function _resolveViewContainer(vc:api.ViewContainerRef) {
   return _resolveView(vc.view).viewContainers[vc.elementIndex];
@@ -65,14 +67,27 @@ export class DirectDomViewRef extends api.ViewRef {
 export class DirectDomRenderer extends api.Renderer {
   _compiler: Compiler;
   _viewFactory: ViewFactory;
+  _viewHydrator: RenderViewHydrator;
   _shadowDomStrategy: ShadowDomStrategy;
 
   constructor(
-      compiler: Compiler, viewFactory: ViewFactory, shadowDomStrategy: ShadowDomStrategy) {
+      compiler: Compiler, viewFactory: ViewFactory, viewHydrator: RenderViewHydrator, shadowDomStrategy: ShadowDomStrategy) {
     super();
     this._compiler = compiler;
     this._viewFactory = viewFactory;
+    this._viewHydrator = viewHydrator;
     this._shadowDomStrategy = shadowDomStrategy;
+  }
+
+  createHostProtoView(componentId):Promise<api.ProtoViewDto> {
+    var rootElement = DOM.createElement('div');
+    var hostProtoViewBuilder = new ProtoViewBuilder(rootElement);
+    var elBinder = hostProtoViewBuilder.bindElement(rootElement, 'root element');
+    elBinder.setComponentId(componentId);
+    elBinder.bindDirective(0);
+
+    this._shadowDomStrategy.processElement(null, componentId, rootElement);
+    return PromiseWrapper.resolve(hostProtoViewBuilder.build());
   }
 
   compile(template:api.ViewDefinition):Promise<api.ProtoViewDto> {
@@ -87,29 +102,22 @@ export class DirectDomRenderer extends api.Renderer {
     );
   }
 
-  createRootProtoView(selectorOrElement, componentId):Promise<api.ProtoViewDto> {
-    var element = selectorOrElement; // TODO: select the element if it is not a real element...
-    var rootProtoViewBuilder = new ProtoViewBuilder(element);
-    rootProtoViewBuilder.setIsRootView(true);
-    var elBinder = rootProtoViewBuilder.bindElement(element, 'root element');
-    elBinder.setComponentId(componentId);
-    elBinder.bindDirective(0);
-
-    this._shadowDomStrategy.processElement(null, componentId, element);
-    return PromiseWrapper.resolve(rootProtoViewBuilder.build());
+  createViewInContainer(vcRef:api.ViewContainerRef, atIndex:number, protoViewRef:api.ProtoViewRef):List<api.ViewRef> {
+    var view = this._viewFactory.getView(_resolveProtoView(protoViewRef));
+    var vc = _resolveViewContainer(vcRef);
+    this._viewHydrator.hydrateViewInViewContainer(vc, view);
+    vc.insert(view, atIndex);
+    return _collectComponentChildViewRefs(view);
   }
 
-  createView(protoViewRef:api.ProtoViewRef):List<api.ViewRef> {
-    return _collectComponentChildViewRefs(
-      this._viewFactory.getView(_resolveProtoView(protoViewRef))
-    );
+  destroyViewInContainer(vcRef:api.ViewContainerRef, atIndex:number):void {
+    var vc = _resolveViewContainer(vcRef);
+    var view = vc.detach(atIndex);
+    this._viewHydrator.dehydrateViewInViewContainer(vc, view);
+    this._viewFactory.returnView(view);
   }
 
-  destroyView(viewRef:api.ViewRef) {
-    this._viewFactory.returnView(_resolveView(viewRef));
-  }
-
-  insertViewIntoContainer(vcRef:api.ViewContainerRef, viewRef:api.ViewRef, atIndex=-1):void {
+  insertViewIntoContainer(vcRef:api.ViewContainerRef, atIndex=-1, viewRef:api.ViewRef):void {
     _resolveViewContainer(vcRef).insert(_resolveView(viewRef), atIndex);
   }
 
@@ -117,16 +125,39 @@ export class DirectDomRenderer extends api.Renderer {
     _resolveViewContainer(vcRef).detach(atIndex);
   }
 
-  setElementProperty(viewRef:api.ViewRef, elementIndex:number, propertyName:string, propertyValue:any):void {
-    _resolveView(viewRef).setElementProperty(elementIndex, propertyName, propertyValue);
+  createDynamicComponentView(hostViewRef:api.ViewRef, elementIndex:number, componentViewRef:api.ProtoViewRef):List<api.ViewRef> {
+    var hostView = _resolveView(hostViewRef);
+    var componentView = this._viewFactory.getView(_resolveProtoView(componentViewRef));
+    this._viewHydrator.hydrateDynamicComponentView(hostView, elementIndex, componentView);
+    return _collectComponentChildViewRefs(componentView);
   }
 
-  setDynamicComponentView(viewRef:api.ViewRef, elementIndex:number, nestedViewRef:api.ViewRef):void {
-    _resolveView(viewRef).setComponentView(
-      this._shadowDomStrategy,
-      elementIndex,
-      _resolveView(nestedViewRef)
-    );
+  destroyDynamicComponentView(hostViewRef:api.ViewRef, elementIndex:number):void {
+    throw new BaseException('Not supported yet');
+    // Something along these lines:
+    // var hostView = _resolveView(hostViewRef);
+    // var componentView = hostView.childComponentViews[elementIndex];
+    // this._viewHydrator.dehydrateDynamicComponentView(hostView, componentView);
+  }
+
+  createInPlaceHostView(parentViewRef:api.ViewRef, hostElementSelector, hostProtoViewRef:api.ProtoViewRef):List<api.ViewRef> {
+    var parentView = _resolveView(parentViewRef);
+    var hostView = this._viewFactory.createInPlaceHostView(hostElementSelector, _resolveProtoView(hostProtoViewRef));
+    this._viewHydrator.hydrateInPlaceHostView(parentView, hostView);
+    return _collectComponentChildViewRefs(hostView);
+  }
+
+  /**
+   * Destroys the given host view in the given parent view.
+   */
+  destroyInPlaceHostView(parentViewRef:api.ViewRef, hostViewRef:api.ViewRef):void {
+    var parentView = _resolveView(parentViewRef);
+    var hostView = _resolveView(hostViewRef);
+    this._viewHydrator.dehydrateInPlaceHostView(parentView, hostView);
+  }
+
+  setElementProperty(viewRef:api.ViewRef, elementIndex:number, propertyName:string, propertyValue:any):void {
+    _resolveView(viewRef).setElementProperty(elementIndex, propertyName, propertyValue);
   }
 
   setText(viewRef:api.ViewRef, textNodeIndex:number, text:string):void {

--- a/modules/angular2/src/render/dom/view/proto_view.js
+++ b/modules/angular2/src/render/dom/view/proto_view.js
@@ -10,18 +10,15 @@ export class RenderProtoView {
   element;
   elementBinders:List<ElementBinder>;
   isTemplateElement:boolean;
-  isRootView:boolean;
   rootBindingOffset:int;
 
   constructor({
     elementBinders,
-    element,
-    isRootView
+    element
   }) {
     this.element = element;
     this.elementBinders = elementBinders;
     this.isTemplateElement = DOM.isTemplateElement(this.element);
-    this.isRootView = isRootView;
     this.rootBindingOffset = (isPresent(this.element) && DOM.hasClass(this.element, NG_BINDING_CLASS)) ? 1 : 0;
   }
 

--- a/modules/angular2/src/render/dom/view/proto_view_builder.js
+++ b/modules/angular2/src/render/dom/view/proto_view_builder.js
@@ -25,7 +25,6 @@ export class ProtoViewBuilder {
   constructor(rootElement) {
     this.rootElement = rootElement;
     this.elements = [];
-    this.isRootView = false;
     this.variableBindings = MapWrapper.create();
   }
 
@@ -44,10 +43,6 @@ export class ProtoViewBuilder {
     // When this occurs, a lookup keyed by "index" must occur to find if there is a var referencing
     // it.
     MapWrapper.set(this.variableBindings, value, name);
-  }
-
-  setIsRootView(value) {
-    this.isRootView = value;
   }
 
   build():api.ProtoViewDto {
@@ -95,8 +90,7 @@ export class ProtoViewBuilder {
     return new api.ProtoViewDto({
       render: new directDomRenderer.DirectDomProtoViewRef(new RenderProtoView({
         element: this.rootElement,
-        elementBinders: renderElementBinders,
-        isRootView: this.isRootView
+        elementBinders: renderElementBinders
       })),
       elementBinders: apiElementBinders,
       variableBindings: this.variableBindings
@@ -257,9 +251,9 @@ export class EventBuilder extends AstTransformer {
     var result = new api.EventBinding(fullName, new ASTWithSource(adjustedAst, source.source, ''));
     var event = new Event(name, target, fullName);
     if (isBlank(target)) {
-      ListWrapper.push(this.localEvents, event);  
+      ListWrapper.push(this.localEvents, event);
     } else {
-      ListWrapper.push(this.globalEvents, event);  
+      ListWrapper.push(this.globalEvents, event);
     }
     return result;
   }

--- a/modules/angular2/src/render/dom/view/view.js
+++ b/modules/angular2/src/render/dom/view/view.js
@@ -6,9 +6,6 @@ import {ViewContainer} from './view_container';
 import {RenderProtoView} from './proto_view';
 import {LightDom} from '../shadow_dom/light_dom';
 import {Content} from '../shadow_dom/content_tag';
-import {EventManager} from 'angular2/src/render/dom/events/event_manager';
-
-import {ShadowDomStrategy} from '../shadow_dom/shadow_dom_strategy';
 
 // import {EventDispatcher} from '../../api';
 
@@ -30,14 +27,13 @@ export class RenderView {
   contentTags: List<Content>;
   lightDoms: List<LightDom>;
   proto: RenderProtoView;
-  eventManager: EventManager;
-  _hydrated: boolean;
+  hydrated: boolean;
   _eventDispatcher: any/*EventDispatcher*/;
-  _eventHandlerRemovers: List<Function>;
+  eventHandlerRemovers: List<Function>;
 
   constructor(
       proto:RenderProtoView, rootNodes:List,
-      boundTextNodes: List, boundElements:List, viewContainers:List, contentTags:List, eventManager: EventManager) {
+      boundTextNodes: List, boundElements:List, viewContainers:List, contentTags:List) {
     this.proto = proto;
     this.rootNodes = rootNodes;
     this.boundTextNodes = boundTextNodes;
@@ -45,15 +41,10 @@ export class RenderView {
     this.viewContainers = viewContainers;
     this.contentTags = contentTags;
     this.lightDoms = ListWrapper.createFixedSize(boundElements.length);
-    this.eventManager = eventManager;
     ListWrapper.fill(this.lightDoms, null);
     this.componentChildViews = ListWrapper.createFixedSize(boundElements.length);
-    this._hydrated = false;
-    this._eventHandlerRemovers = null;
-  }
-
-  hydrated() {
-    return this._hydrated;
+    this.hydrated = false;
+    this.eventHandlerRemovers = null;
   }
 
   setElementProperty(elementIndex:number, propertyName:string, value:any) {
@@ -65,136 +56,8 @@ export class RenderView {
     DOM.setText(this.boundTextNodes[textIndex], value);
   }
 
-  setComponentView(strategy: ShadowDomStrategy,
-      elementIndex:number, childView:RenderView) {
-    var element = this.boundElements[elementIndex];
-    var lightDom = strategy.constructLightDom(this, childView, element);
-    strategy.attachTemplate(element, childView);
-    this.lightDoms[elementIndex] = lightDom;
-    this.componentChildViews[elementIndex] = childView;
-    if (this._hydrated) {
-      childView.hydrate(lightDom);
-      if (isPresent(lightDom)) {
-        lightDom.redistribute();
-      }
-    }
-  }
-
   getViewContainer(index:number):ViewContainer {
     return this.viewContainers[index];
-  }
-
-  _getDestLightDom(binderIndex) {
-    var binder = this.proto.elementBinders[binderIndex];
-    var destLightDom = null;
-    if (binder.parentIndex !== -1 && binder.distanceToParent === 1) {
-      destLightDom = this.lightDoms[binder.parentIndex];
-    }
-    return destLightDom;
-  }
-
-  /**
-   * A dehydrated view is a state of the view that allows it to be moved around
-   * the view tree.
-   *
-   * A dehydrated view has the following properties:
-   *
-   * - all viewcontainers are empty.
-   *
-   * A call to hydrate/dehydrate does not attach/detach the view from the view
-   * tree.
-   */
-  hydrate(hostLightDom: LightDom) {
-    if (this._hydrated) throw new BaseException('The view is already hydrated.');
-    this._hydrated = true;
-
-    // viewContainers and content tags
-    for (var i = 0; i < this.viewContainers.length; i++) {
-      var vc = this.viewContainers[i];
-      var destLightDom = this._getDestLightDom(i);
-      if (isPresent(vc)) {
-        vc.hydrate(destLightDom, hostLightDom);
-      }
-      var ct = this.contentTags[i];
-      if (isPresent(ct)) {
-        ct.hydrate(destLightDom);
-      }
-    }
-
-    // componentChildViews
-    for (var i = 0; i < this.componentChildViews.length; i++) {
-      var cv = this.componentChildViews[i];
-      if (isPresent(cv)) {
-        cv.hydrate(this.lightDoms[i]);
-      }
-    }
-
-    for (var i = 0; i < this.lightDoms.length; ++i) {
-      var lightDom = this.lightDoms[i];
-      if (isPresent(lightDom)) {
-        lightDom.redistribute();
-      }
-    }
-
-    //add global events
-    this._eventHandlerRemovers = ListWrapper.create();
-    var binders = this.proto.elementBinders;
-    for (var binderIdx = 0; binderIdx < binders.length; binderIdx++) {
-      var binder = binders[binderIdx];
-      if (isPresent(binder.globalEvents)) {
-        for (var i = 0; i < binder.globalEvents.length; i++) {
-          var globalEvent = binder.globalEvents[i];
-          var remover = this._createGlobalEventListener(binderIdx, globalEvent.name, globalEvent.target, globalEvent.fullName);
-          ListWrapper.push(this._eventHandlerRemovers, remover);
-        }
-      }
-    }
-  }
-
-  _createGlobalEventListener(elementIndex, eventName, eventTarget, fullName): Function {
-    return this.eventManager.addGlobalEventListener(eventTarget, eventName, (event) => {
-      this.dispatchEvent(elementIndex, fullName, event);
-    });
-  }
-
-  dehydrate() {
-    // Note: preserve the opposite order of the hydration process.
-
-    // componentChildViews
-    for (var i = 0; i < this.componentChildViews.length; i++) {
-      var cv = this.componentChildViews[i];
-      if (isPresent(cv)) {
-        cv.dehydrate();
-        if (this.proto.elementBinders[i].hasDynamicComponent()) {
-          ViewContainer.removeViewNodes(cv);
-          this.lightDoms[i] = null;
-          this.componentChildViews[i] = null;
-        }
-      }
-    }
-
-    // viewContainers and content tags
-    if (isPresent(this.viewContainers)) {
-      for (var i = 0; i < this.viewContainers.length; i++) {
-        var vc = this.viewContainers[i];
-        if (isPresent(vc)) {
-          vc.dehydrate();
-        }
-        var ct = this.contentTags[i];
-        if (isPresent(ct)) {
-          ct.dehydrate();
-        }
-      }
-    }
-
-    //remove global events
-    for (var i = 0; i < this._eventHandlerRemovers.length; i++) {
-      this._eventHandlerRemovers[i]();
-    }
-
-    this._eventHandlerRemovers = null;
-    this._eventDispatcher = null;
-    this._hydrated = false;
   }
 
   setEventDispatcher(dispatcher:any/*EventDispatcher*/) {

--- a/modules/angular2/src/render/dom/view/view_container.js
+++ b/modules/angular2/src/render/dom/view/view_container.js
@@ -4,88 +4,64 @@ import {DOM} from 'angular2/src/dom/dom_adapter';
 
 import * as viewModule from './view';
 import * as ldModule from '../shadow_dom/light_dom';
-import * as vfModule from './view_factory';
 
 export class ViewContainer {
-  _viewFactory: vfModule.ViewFactory;
   templateElement;
-  _views: List<viewModule.RenderView>;
-  _lightDom: ldModule.LightDom;
-  _hostLightDom: ldModule.LightDom;
-  _hydrated: boolean;
+  views: List<viewModule.RenderView>;
+  lightDom: ldModule.LightDom;
+  hostLightDom: ldModule.LightDom;
+  hydrated: boolean;
 
-  constructor(viewFactory: vfModule.ViewFactory,
-              templateElement) {
-    this._viewFactory = viewFactory;
+  constructor(templateElement) {
     this.templateElement = templateElement;
 
     // The order in this list matches the DOM order.
-    this._views = [];
-    this._hostLightDom = null;
-    this._hydrated = false;
-  }
-
-  hydrate(destLightDom: ldModule.LightDom, hostLightDom: ldModule.LightDom) {
-    this._hydrated = true;
-    this._hostLightDom = hostLightDom;
-    this._lightDom = destLightDom;
-  }
-
-  dehydrate() {
-    if (isBlank(this._lightDom)) {
-      for (var i = this._views.length - 1; i >= 0; i--) {
-        var view = this._views[i];
-        ViewContainer.removeViewNodes(view);
-        this._viewFactory.returnView(view);
-      }
-      this._views = [];
-    } else {
-      for (var i=0; i<this._views.length; i++) {
-        var view = this._views[i];
-        this._viewFactory.returnView(view);
-      }
-      this._views = [];
-      this._lightDom.redistribute();
-    }
-
-    this._hostLightDom = null;
-    this._lightDom = null;
-    this._hydrated = false;
+    this.views = [];
+    this.hostLightDom = null;
+    this.hydrated = false;
   }
 
   get(index: number): viewModule.RenderView {
-    return this._views[index];
+    return this.views[index];
   }
 
   size() {
-    return this._views.length;
+    return this.views.length;
   }
 
   _siblingToInsertAfter(index: number) {
     if (index == 0) return this.templateElement;
-    return ListWrapper.last(this._views[index - 1].rootNodes);
+    return ListWrapper.last(this.views[index - 1].rootNodes);
   }
 
   _checkHydrated() {
-    if (!this._hydrated) throw new BaseException(
+    if (!this.hydrated) throw new BaseException(
         'Cannot change dehydrated ViewContainer');
   }
 
-  insert(view, atIndex=-1): viewModule.RenderView {
-    if (!view.hydrated()) {
-      view.hydrate(this._hostLightDom);
+  clear() {
+    this._checkHydrated();
+    for (var i=this.views.length-1; i>=0; i--) {
+      this.detach(i);
     }
-    if (atIndex == -1) atIndex = this._views.length;
-    ListWrapper.insert(this._views, atIndex, view);
+    if (isPresent(this.lightDom)) {
+      this.lightDom.redistribute();
+    }
+  }
 
-    if (isBlank(this._lightDom)) {
+  insert(view, atIndex=-1): viewModule.RenderView {
+    this._checkHydrated();
+    if (atIndex == -1) atIndex = this.views.length;
+    ListWrapper.insert(this.views, atIndex, view);
+
+    if (isBlank(this.lightDom)) {
       ViewContainer.moveViewNodesAfterSibling(this._siblingToInsertAfter(atIndex), view);
     } else {
-      this._lightDom.redistribute();
+      this.lightDom.redistribute();
     }
     // new content tags might have appeared, we need to redistribute.
-    if (isPresent(this._hostLightDom)) {
-      this._hostLightDom.redistribute();
+    if (isPresent(this.hostLightDom)) {
+      this.hostLightDom.redistribute();
     }
     return view;
   }
@@ -97,31 +73,30 @@ export class ViewContainer {
   detach(atIndex:number) {
     this._checkHydrated();
     var detachedView = this.get(atIndex);
-    ListWrapper.removeAt(this._views, atIndex);
-    if (isBlank(this._lightDom)) {
+    ListWrapper.removeAt(this.views, atIndex);
+    if (isBlank(this.lightDom)) {
       ViewContainer.removeViewNodes(detachedView);
     } else {
-      this._lightDom.redistribute();
+      this.lightDom.redistribute();
     }
     // content tags might have disappeared we need to do redistribution.
-    if (isPresent(this._hostLightDom)) {
-      this._hostLightDom.redistribute();
+    if (isPresent(this.hostLightDom)) {
+      this.hostLightDom.redistribute();
     }
     return detachedView;
   }
 
   contentTagContainers() {
-    return this._views;
+    return this.views;
   }
 
   nodes():List {
     var r = [];
-    for (var i = 0; i < this._views.length; ++i) {
-      r = ListWrapper.concat(r, this._views[i].rootNodes);
+    for (var i = 0; i < this.views.length; ++i) {
+      r = ListWrapper.concat(r, this.views[i].rootNodes);
     }
     return r;
   }
-
 
   static moveViewNodesAfterSibling(sibling, view) {
     for (var i = view.rootNodes.length - 1; i >= 0; --i) {

--- a/modules/angular2/src/render/dom/view/view_hydrator.js
+++ b/modules/angular2/src/render/dom/view/view_hydrator.js
@@ -1,0 +1,192 @@
+import {Injectable} from 'angular2/di';
+import {int, isPresent, isBlank, BaseException} from 'angular2/src/facade/lang';
+import {ListWrapper, MapWrapper, Map, StringMapWrapper, List} from 'angular2/src/facade/collection';
+
+import * as ldModule from '../shadow_dom/light_dom';
+import {EventManager} from '../events/event_manager';
+import {ViewFactory} from './view_factory';
+import * as vcModule from './view_container';
+import * as viewModule from './view';
+
+/**
+ * A dehydrated view is a state of the view that allows it to be moved around
+ * the view tree.
+ *
+ * A dehydrated view has the following properties:
+ *
+ * - all viewcontainers are empty.
+ *
+ * A call to hydrate/dehydrate is called whenever a view is attached/detached,
+ * but it does not do the attach/detach itself.
+ */
+@Injectable()
+export class RenderViewHydrator {
+  _eventManager:EventManager;
+  _viewFactory:ViewFactory;
+
+  constructor(eventManager:EventManager, viewFactory:ViewFactory) {
+    this._eventManager = eventManager;
+    this._viewFactory = viewFactory;
+  }
+
+  hydrateDynamicComponentView(hostView:viewModule.RenderView, boundElementIndex:number, componentView:viewModule.RenderView) {
+    this._viewFactory.setComponentView(hostView, boundElementIndex, componentView);
+    var lightDom = hostView.lightDoms[boundElementIndex];
+    this._viewHydrateRecurse(componentView, lightDom);
+    if (isPresent(lightDom)) {
+      lightDom.redistribute();
+    }
+  }
+
+  dehydrateDynamicComponentView(parentView:viewModule.RenderView, boundElementIndex:number) {
+    throw new BaseException('Not supported yet');
+    // Something along these lines:
+    // var componentView = parentView.componentChildViews[boundElementIndex];
+    // vcModule.ViewContainer.removeViewNodes(componentView);
+    // parentView.componentChildViews[boundElementIndex] = null;
+    // parentView.lightDoms[boundElementIndex] = null;
+    // this._viewDehydrateRecurse(componentView);
+  }
+
+  hydrateInPlaceHostView(parentView:viewModule.RenderView, hostView:viewModule.RenderView) {
+    if (isPresent(parentView)) {
+      throw new BaseException('Not supported yet');
+    }
+    this._viewHydrateRecurse(hostView, null);
+  }
+
+  dehydrateInPlaceHostView(parentView:viewModule.RenderView, hostView:viewModule.RenderView) {
+    if (isPresent(parentView)) {
+      throw new BaseException('Not supported yet');
+    }
+    this._viewDehydrateRecurse(hostView);
+  }
+
+  hydrateViewInViewContainer(viewContainer:vcModule.ViewContainer, view:viewModule.RenderView) {
+    this._viewHydrateRecurse(view, viewContainer.hostLightDom);
+  }
+
+  dehydrateViewInViewContainer(viewContainer:vcModule.ViewContainer, view:viewModule.RenderView) {
+    this._viewDehydrateRecurse(view);
+  }
+
+  _getViewDestLightDom(view, binderIndex) {
+    var binder = view.proto.elementBinders[binderIndex];
+    var destLightDom = null;
+    if (binder.parentIndex !== -1 && binder.distanceToParent === 1) {
+      destLightDom = view.lightDoms[binder.parentIndex];
+    }
+    return destLightDom;
+  }
+
+  _viewHydrateRecurse(view, hostLightDom: ldModule.LightDom) {
+    if (view.hydrated) throw new BaseException('The view is already hydrated.');
+    view.hydrated = true;
+
+    // viewContainers and content tags
+    for (var i = 0; i < view.viewContainers.length; i++) {
+      var vc = view.viewContainers[i];
+      var destLightDom = this._getViewDestLightDom(view, i);
+      if (isPresent(vc)) {
+        this._viewContainerHydrateRecurse(vc, destLightDom, hostLightDom);
+      }
+      var ct = view.contentTags[i];
+      if (isPresent(ct)) {
+        ct.hydrate(destLightDom);
+      }
+    }
+
+    // componentChildViews
+    for (var i = 0; i < view.componentChildViews.length; i++) {
+      var cv = view.componentChildViews[i];
+      if (isPresent(cv)) {
+        this._viewHydrateRecurse(cv, view.lightDoms[i]);
+      }
+    }
+
+    for (var i = 0; i < view.lightDoms.length; ++i) {
+      var lightDom = view.lightDoms[i];
+      if (isPresent(lightDom)) {
+        lightDom.redistribute();
+      }
+    }
+
+    //add global events
+    view.eventHandlerRemovers = ListWrapper.create();
+    var binders = view.proto.elementBinders;
+    for (var binderIdx = 0; binderIdx < binders.length; binderIdx++) {
+      var binder = binders[binderIdx];
+      if (isPresent(binder.globalEvents)) {
+        for (var i = 0; i < binder.globalEvents.length; i++) {
+          var globalEvent = binder.globalEvents[i];
+          var remover = this._createGlobalEventListener(view, binderIdx, globalEvent.name, globalEvent.target, globalEvent.fullName);
+          ListWrapper.push(view.eventHandlerRemovers, remover);
+        }
+      }
+    }
+  }
+
+  _createGlobalEventListener(view, elementIndex, eventName, eventTarget, fullName): Function {
+    return this._eventManager.addGlobalEventListener(eventTarget, eventName, (event) => {
+      view.dispatchEvent(elementIndex, fullName, event);
+    });
+  }
+
+  _viewDehydrateRecurse(view) {
+    // Note: preserve the opposite order of the hydration process.
+
+    // componentChildViews
+    for (var i = 0; i < view.componentChildViews.length; i++) {
+      var cv = view.componentChildViews[i];
+      if (isPresent(cv)) {
+        this._viewDehydrateRecurse(cv);
+        if (view.proto.elementBinders[i].hasDynamicComponent()) {
+          vcModule.ViewContainer.removeViewNodes(cv);
+          view.lightDoms[i] = null;
+          view.componentChildViews[i] = null;
+        }
+      }
+    }
+
+    // viewContainers and content tags
+    if (isPresent(view.viewContainers)) {
+      for (var i = 0; i < view.viewContainers.length; i++) {
+        var vc = view.viewContainers[i];
+        if (isPresent(vc)) {
+          this._viewContainerDehydrateRecurse(vc);
+        }
+        var ct = view.contentTags[i];
+        if (isPresent(ct)) {
+          ct.dehydrate();
+        }
+      }
+    }
+
+    //remove global events
+    for (var i = 0; i < view.eventHandlerRemovers.length; i++) {
+      view.eventHandlerRemovers[i]();
+    }
+
+    view.eventHandlerRemovers = null;
+    view.setEventDispatcher(null);
+    view.hydrated = false;
+  }
+
+  _viewContainerHydrateRecurse(viewContainer, destLightDom: ldModule.LightDom, hostLightDom: ldModule.LightDom) {
+    viewContainer.hydrated = true;
+    viewContainer.hostLightDom = hostLightDom;
+    viewContainer.lightDom = destLightDom;
+  }
+
+  _viewContainerDehydrateRecurse(viewContainer) {
+    for (var i=0; i<viewContainer.views.length; i++) {
+      this._viewDehydrateRecurse(viewContainer.views[i]);
+    }
+    viewContainer.clear();
+
+    viewContainer.hostLightDom = null;
+    viewContainer.lightDom = null;
+    viewContainer.hydrated = false;
+  }
+
+}

--- a/modules/angular2/src/test_lib/test_injector.js
+++ b/modules/angular2/src/test_lib/test_injector.js
@@ -35,11 +35,13 @@ import {List, ListWrapper} from 'angular2/src/facade/collection';
 import {FunctionWrapper} from 'angular2/src/facade/lang';
 
 import {ViewFactory, VIEW_POOL_CAPACITY} from 'angular2/src/core/compiler/view_factory';
+import {AppViewHydrator} from 'angular2/src/core/compiler/view_hydrator';
 import {ProtoViewFactory} from 'angular2/src/core/compiler/proto_view_factory';
 import {Renderer} from 'angular2/src/render/api';
 import {DirectDomRenderer} from 'angular2/src/render/dom/direct_dom_renderer';
 import * as rc from 'angular2/src/render/dom/compiler/compiler';
 import * as rvf from 'angular2/src/render/dom/view/view_factory';
+import * as rvh from 'angular2/src/render/dom/view/view_hydrator';
 
 /**
  * Returns the root injector bindings.
@@ -79,9 +81,11 @@ function _getAppBindings() {
     bind(Renderer).toClass(DirectDomRenderer),
     bind(rc.Compiler).toClass(rc.DefaultCompiler),
     rvf.ViewFactory,
+    rvh.RenderViewHydrator,
     bind(rvf.VIEW_POOL_CAPACITY).toValue(500),
     ProtoViewFactory,
     ViewFactory,
+    AppViewHydrator,
     bind(VIEW_POOL_CAPACITY).toValue(500),
     Compiler,
     CompilerCache,

--- a/modules/angular2/test/core/compiler/compiler_spec.js
+++ b/modules/angular2/test/core/compiler/compiler_spec.js
@@ -361,7 +361,7 @@ export function main() {
       });
     }));
 
-    it('should create root proto views', inject([AsyncTestCompleter], (async) => {
+    it('should create host proto views', inject([AsyncTestCompleter], (async) => {
       tplResolver.setView(MainComponent, new View({template: '<div></div>'}));
       var rootProtoView = createProtoView([
         createComponentElementBinder(reader, MainComponent)
@@ -373,7 +373,7 @@ export function main() {
         ],
         [rootProtoView, mainProtoView]
       );
-      compiler.compileRoot(null, MainComponent).then( (protoView) => {
+      compiler.compileInHost(MainComponent).then( (protoView) => {
         expect(protoView).toBe(rootProtoView);
         expect(rootProtoView.elementBinders[0].nestedProtoView).toBe(mainProtoView);
         async.done();
@@ -388,7 +388,7 @@ function createDirectiveBinding(reader, type) {
 }
 
 function createProtoView(elementBinders = null) {
-  var pv = new AppProtoView(null, null, null);
+  var pv = new AppProtoView(null, null);
   if (isBlank(elementBinders)) {
     elementBinders = [];
   }
@@ -497,7 +497,7 @@ class FakeRenderer extends renderApi.Renderer {
     return PromiseWrapper.resolve(ListWrapper.removeAt(this._results, 0));
   }
 
-  createRootProtoView(elementOrSelector, componentId):Promise<renderApi.ProtoViewDto> {
+  createHostProtoView(componentId):Promise<renderApi.ProtoViewDto> {
     return PromiseWrapper.resolve(
       createRenderProtoView([createRenderComponentElementBinder(0)])
     );
@@ -545,7 +545,7 @@ class FakeProtoViewFactory extends ProtoViewFactory {
   _results:List;
 
   constructor(results) {
-    super(null, null);
+    super(null);
     this.requests = [];
     this._results = results;
   }

--- a/modules/angular2/test/core/compiler/element_injector_spec.js
+++ b/modules/angular2/test/core/compiler/element_injector_spec.js
@@ -614,7 +614,7 @@ export function main() {
       });
 
       it('should return viewContainer', function () {
-        var viewContainer = new ViewContainer(null, null, null, null);
+        var viewContainer = new ViewContainer(null, null, null, null, null);
         var inj = injector([], null, null, new PreBuiltObjects(null, null, viewContainer, null));
 
         expect(inj.get(ViewContainer)).toEqual(viewContainer);
@@ -631,21 +631,21 @@ export function main() {
     describe("dynamicallyCreateComponent", () => {
       it("should create a component dynamically", () => {
         var inj = injector([]);
-        inj.dynamicallyCreateComponent(SimpleDirective, null, null);
+        inj.dynamicallyCreateComponent(DirectiveBinding.createFromType(SimpleDirective, null), null);
         expect(inj.getDynamicallyLoadedComponent()).toBeAnInstanceOf(SimpleDirective);
         expect(inj.get(SimpleDirective)).toBeAnInstanceOf(SimpleDirective);
       });
 
       it("should inject parent dependencies into the dynamically-loaded component", () => {
         var inj = parentChildInjectors([SimpleDirective], []);
-        inj.dynamicallyCreateComponent(NeedDirectiveFromAncestor, null, null);
+        inj.dynamicallyCreateComponent(DirectiveBinding.createFromType(NeedDirectiveFromAncestor, null), null);
         expect(inj.getDynamicallyLoadedComponent()).toBeAnInstanceOf(NeedDirectiveFromAncestor);
         expect(inj.getDynamicallyLoadedComponent().dependency).toBeAnInstanceOf(SimpleDirective);
       });
 
       it("should not inject the proxy component into the children of the dynamically-loaded component", () => {
         var injWithDynamicallyLoadedComponent = injector([SimpleDirective]);
-        injWithDynamicallyLoadedComponent.dynamicallyCreateComponent(SomeOtherDirective, null, null);
+        injWithDynamicallyLoadedComponent.dynamicallyCreateComponent(DirectiveBinding.createFromType(SomeOtherDirective, null), null);
 
         var shadowDomProtoInjector = new ProtoElementInjector(null, 0, [NeedDirectiveFromAncestor], false);
         var shadowDomInj = shadowDomProtoInjector.instantiate(null);
@@ -658,14 +658,14 @@ export function main() {
       it("should not inject the dynamically-loaded component into directives on the same element", () => {
         var proto = new ProtoElementInjector(null, 0, [NeedsDirective], false);
         var inj = proto.instantiate(null);
-        inj.dynamicallyCreateComponent(SimpleDirective, null, null);
+        inj.dynamicallyCreateComponent(DirectiveBinding.createFromType(SimpleDirective, null), null);
 
         expect(() => inj.instantiateDirectives(null, null, null, null)).toThrowError();
       });
 
       it("should inject the dynamically-loaded component into the children of the dynamically-loaded component", () => {
         var injWithDynamicallyLoadedComponent = injector([]);
-        injWithDynamicallyLoadedComponent.dynamicallyCreateComponent(SimpleDirective, null, null);
+        injWithDynamicallyLoadedComponent.dynamicallyCreateComponent(DirectiveBinding.createFromType(SimpleDirective, null), null);
 
         var shadowDomProtoInjector = new ProtoElementInjector(null, 0, [NeedDirectiveFromAncestor], false);
         var shadowDomInjector = shadowDomProtoInjector.instantiate(null);
@@ -678,8 +678,10 @@ export function main() {
       it("should remove the dynamically-loaded component when dehydrating", () => {
         var inj = injector([]);
         inj.dynamicallyCreateComponent(
-          DirectiveWithDestroy,
-          new DummyDirective({lifecycle: [onDestroy]}),
+          DirectiveBinding.createFromType(
+            DirectiveWithDestroy,
+            new DummyDirective({lifecycle: [onDestroy]})
+          ),
           null);
         var dir = inj.getDynamicallyLoadedComponent();
 
@@ -696,7 +698,7 @@ export function main() {
       it("should inject services of the dynamically-loaded component", () => {
         var inj = injector([]);
         var appInjector = Injector.resolveAndCreate([bind("service").toValue("Service")]);
-        inj.dynamicallyCreateComponent(NeedsService, null, appInjector);
+        inj.dynamicallyCreateComponent(DirectiveBinding.createFromType(NeedsService, null), appInjector);
         expect(inj.getDynamicallyLoadedComponent().service).toEqual("Service");
       });
     });
@@ -706,13 +708,13 @@ export function main() {
       function createpreBuildObject(eventName, eventHandler) {
         var handlers = StringMapWrapper.create();
         StringMapWrapper.set(handlers, eventName, eventHandler);
-        var pv = new AppProtoView(null, null, null);
+        var pv = new AppProtoView(null, null);
         pv.bindElement(null, 0, null, null, null);
         var eventBindings = ListWrapper.create();
         ListWrapper.push(eventBindings, new EventBinding(eventName, new Parser(new Lexer()).parseAction('handler()', '')));
         pv.bindEvent(eventBindings);
 
-        var view = new AppView(pv, MapWrapper.create());
+        var view = new AppView(null, pv, MapWrapper.create());
         view.context = new ContextWithHandler(eventHandler);
         return new PreBuiltObjects(view, null, null, null);
       }
@@ -751,8 +753,8 @@ export function main() {
 
       beforeEach( () => {
         renderer = new FakeRenderer();
-        var protoView = new AppProtoView(renderer, null, null);
-        view = new AppView(protoView, MapWrapper.create());
+        var protoView = new AppProtoView(null, null);
+        view = new AppView(renderer, protoView, MapWrapper.create());
         view.render = new ViewRef();
       });
 

--- a/modules/angular2/test/core/compiler/integration_spec.js
+++ b/modules/angular2/test/core/compiler/integration_spec.js
@@ -300,7 +300,6 @@ export function main() {
         }));
 
         tb.createView(MyComp, {context: ctx}).then((view) => {
-
           view.detectChanges();
 
           var childNodesOfWrapper = view.rootNodes[0].childNodes;
@@ -582,7 +581,7 @@ export function main() {
             dispatchEvent(DOM.getGlobalEventTarget("document"), 'domEvent');
             expect(listener.eventType).toEqual('document_domEvent');
 
-            view.rawView.dehydrate();
+            view.destroy();
             listener = injector.get(DecoratorListeningDomEvent);
             dispatchEvent(DOM.getGlobalEventTarget("body"), 'domEvent');
             expect(listener.eventType).toEqual('');

--- a/modules/angular2/test/core/compiler/view_factory_spec.js
+++ b/modules/angular2/test/core/compiler/view_factory_spec.js
@@ -16,6 +16,7 @@ import {
 } from 'angular2/test_lib';
 import {IMPLEMENTS, isBlank} from 'angular2/src/facade/lang';
 import {ViewFactory} from 'angular2/src/core/compiler/view_factory';
+import {Renderer, ViewRef} from 'angular2/src/render/api';
 import {AppProtoView, AppView} from 'angular2/src/core/compiler/view';
 import {DirectiveBinding, ElementInjector} from 'angular2/src/core/compiler/element_injector';
 import {DirectiveMetadataReader} from 'angular2/src/core/compiler/directive_metadata_reader';
@@ -26,13 +27,15 @@ import {ChangeDetector, ProtoChangeDetector} from 'angular2/change_detection';
 export function main() {
   describe('AppViewFactory', () => {
     var reader;
+    var renderer;
 
     beforeEach( () => {
+      renderer = new SpyRenderer();
       reader = new DirectiveMetadataReader();
     });
 
     function createViewFactory({capacity}):ViewFactory {
-      return new ViewFactory(capacity);
+      return new ViewFactory(capacity, renderer);
     }
 
     function createProtoChangeDetector() {
@@ -47,7 +50,7 @@ export function main() {
       if (isBlank(binders)) {
         binders = [];
       }
-      var pv = new AppProtoView(null, null, createProtoChangeDetector());
+      var pv = new AppProtoView(null, createProtoChangeDetector());
       pv.elementBinders = binders;
       return pv;
     }
@@ -153,6 +156,13 @@ export function main() {
 
 @Component({ selector: 'someComponent' })
 class SomeComponent {}
+
+@proxy
+@IMPLEMENTS(Renderer)
+class SpyRenderer extends SpyObject {
+  constructor(){super(Renderer);}
+  noSuchMethod(m){return super.noSuchMethod(m)}
+}
 
 @proxy
 @IMPLEMENTS(ChangeDetector)

--- a/modules/angular2/test/render/dom/integration_testbed.js
+++ b/modules/angular2/test/render/dom/integration_testbed.js
@@ -15,6 +15,7 @@ import {EventManager, EventManagerPlugin} from 'angular2/src/render/dom/events/e
 import {VmTurnZone} from 'angular2/src/core/zone/vm_turn_zone';
 import {StyleUrlResolver} from 'angular2/src/render/dom/shadow_dom/style_url_resolver';
 import {ViewFactory} from 'angular2/src/render/dom/view/view_factory';
+import {RenderViewHydrator} from 'angular2/src/render/dom/view/view_hydrator';
 
 export class IntegrationTestbed {
   renderer;
@@ -45,11 +46,12 @@ export class IntegrationTestbed {
     this.eventPlugin = new FakeEventManagerPlugin();
     var eventManager = new EventManager([this.eventPlugin], new FakeVmTurnZone());
     var viewFactory = new ViewFactory(viewCacheCapacity, eventManager, shadowDomStrategy);
-    this.renderer = new DirectDomRenderer(compiler, viewFactory, shadowDomStrategy);
+    var viewHydrator = new RenderViewHydrator(eventManager, viewFactory);
+    this.renderer = new DirectDomRenderer(compiler, viewFactory, viewHydrator, shadowDomStrategy);
   }
 
-  compileRoot(rootEl, componentId):Promise<ProtoViewDto> {
-    return this.renderer.createRootProtoView(rootEl, componentId).then( (rootProtoView) => {
+  compileRoot(componentId):Promise<ProtoViewDto> {
+    return this.renderer.createHostProtoView(componentId).then( (rootProtoView) => {
       return this._compileNestedProtoViews(rootProtoView, [
         new DirectiveMetadata({
           type: DirectiveMetadata.COMPONENT_TYPE,

--- a/modules/angular2/test/render/dom/shadow_dom/emulated_scoped_shadow_dom_strategy_spec.js
+++ b/modules/angular2/test/render/dom/shadow_dom/emulated_scoped_shadow_dom_strategy_spec.js
@@ -31,7 +31,7 @@ import {StyleInliner} from 'angular2/src/render/dom/shadow_dom/style_inliner';
 import {RenderView} from 'angular2/src/render/dom/view/view';
 
 export function main() {
-  describe('EmulatedScoped', () => {
+  describe('EmulatedScopedShadowDomStrategy', () => {
     var xhr, styleHost, strategy;
 
     beforeEach(() => {
@@ -47,7 +47,7 @@ export function main() {
     it('should attach the view nodes as child of the host element', () => {
       var host = el('<div><span>original content</span></div>');
       var nodes = el('<div>view</div>');
-      var view = new RenderView(null, [nodes], [], [], [], [], null);
+      var view = new RenderView(null, [nodes], [], [], [], []);
 
       strategy.attachTemplate(host, view);
       var firstChild = DOM.firstChild(host);

--- a/modules/angular2/test/render/dom/shadow_dom/emulated_unscoped_shadow_dom_strategy_spec.js
+++ b/modules/angular2/test/render/dom/shadow_dom/emulated_unscoped_shadow_dom_strategy_spec.js
@@ -28,7 +28,7 @@ import {RenderView} from 'angular2/src/render/dom/view/view';
 export function main() {
   var strategy;
 
-  describe('EmulatedUnscoped', () => {
+  describe('EmulatedUnscopedShadowDomStrategy', () => {
     var styleHost;
 
     beforeEach(() => {
@@ -42,7 +42,7 @@ export function main() {
     it('should attach the view nodes as child of the host element', () => {
       var host = el('<div><span>original content</span></div>');
       var nodes = el('<div>view</div>');
-      var view = new RenderView(null, [nodes], [], [], [], [], null);
+      var view = new RenderView(null, [nodes], [], [], [], []);
 
       strategy.attachTemplate(host, view);
       var firstChild = DOM.firstChild(host);

--- a/modules/angular2/test/render/dom/shadow_dom/native_shadow_dom_strategy_spec.js
+++ b/modules/angular2/test/render/dom/shadow_dom/native_shadow_dom_strategy_spec.js
@@ -35,7 +35,7 @@ export function main() {
     it('should attach the view nodes to the shadow root', () => {
       var host = el('<div><span>original content</span></div>');
       var nodes = el('<div>view</div>');
-      var view = new RenderView(null, [nodes], [], [], [], [], null);
+      var view = new RenderView(null, [nodes], [], [], [], []);
 
       strategy.attachTemplate(host, view);
       var shadowRoot = DOM.getShadowRoot(host);

--- a/modules/angular2/test/render/dom/shadow_dom_emulation_integration_spec.js
+++ b/modules/angular2/test/render/dom/shadow_dom_emulation_integration_spec.js
@@ -60,7 +60,7 @@ export function main() {
             templates: ListWrapper.concat(templates, componentTemplates)
           });
           renderer = testbed.renderer;
-          compileRoot = (rootEl, componentId) => testbed.compileRoot(rootEl, componentId);
+          compileRoot = (rootEl) => testbed.compileRoot(rootEl);
           compile = (componentId) => testbed.compile(componentId);
         }
 
@@ -78,8 +78,8 @@ export function main() {
               directives: [simple]
             })]
           });
-          compileRoot(rootEl, 'main').then( (pv) => {
-            renderer.createView(pv.render);
+          compileRoot('main').then( (pv) => {
+            renderer.createInPlaceHostView(null, rootEl, pv.render);
 
             expect(rootEl).toHaveText('SIMPLE(A)');
 
@@ -97,11 +97,10 @@ export function main() {
               directives: [dynamicComponent]
             })]
           });
-          compileRoot(rootEl, 'main').then( (rootPv) => {
+          compileRoot('main').then( (rootPv) => {
             compile('simple').then( (simplePv) => {
-              var views = renderer.createView(rootPv.render);
-              var simpleViews = renderer.createView(simplePv.render);
-              renderer.setDynamicComponentView(views[1], 0, simpleViews[0]);
+              var views = renderer.createInPlaceHostView(null, rootEl, rootPv.render);
+              renderer.createDynamicComponentView(views[1], 0, simplePv.render);
 
               expect(rootEl).toHaveText('SIMPLE(A)');
 
@@ -122,8 +121,8 @@ export function main() {
               directives: [multipleContentTagsComponent]
             })]
           });
-          compileRoot(rootEl, 'main').then( (pv) => {
-            renderer.createView(pv.render);
+          compileRoot('main').then( (pv) => {
+            renderer.createInPlaceHostView(null, rootEl, pv.render);
 
             expect(rootEl).toHaveText('(A, BC)');
 
@@ -142,8 +141,8 @@ export function main() {
               directives: [multipleContentTagsComponent]
             })]
           });
-          compileRoot(rootEl, 'main').then( (pv) => {
-            renderer.createView(pv.render);
+          compileRoot('main').then( (pv) => {
+            renderer.createInPlaceHostView(null, rootEl, pv.render);
 
             expect(rootEl).toHaveText('(, BAC)');
 
@@ -162,20 +161,18 @@ export function main() {
               directives: [multipleContentTagsComponent, manualViewportDirective]
             })]
           });
-          compileRoot(rootEl, 'main').then( (pv) => {
-            var viewRefs = renderer.createView(pv.render);
+          compileRoot('main').then( (pv) => {
+            var viewRefs = renderer.createInPlaceHostView(null, rootEl, pv.render);
             var vcRef = new ViewContainerRef(viewRefs[1], 1);
             var vcProtoViewRef = pv.elementBinders[0].nestedProtoView
               .elementBinders[1].nestedProtoView.render;
-            var childViewRef = renderer.createView(vcProtoViewRef)[0];
-
             expect(rootEl).toHaveText('(, B)');
 
-            renderer.insertViewIntoContainer(vcRef, childViewRef);
+            renderer.createViewInContainer(vcRef, 0, vcProtoViewRef)[0];
 
             expect(rootEl).toHaveText('(, AB)');
 
-            renderer.detachViewFromContainer(vcRef, 0);
+            renderer.destroyViewInContainer(vcRef, 0);
 
             expect(rootEl).toHaveText('(, B)');
 
@@ -194,20 +191,18 @@ export function main() {
               directives: [multipleContentTagsComponent, manualViewportDirective]
             })]
           });
-          compileRoot(rootEl, 'main').then( (pv) => {
-            var viewRefs = renderer.createView(pv.render);
+          compileRoot('main').then( (pv) => {
+            var viewRefs = renderer.createInPlaceHostView(null, rootEl, pv.render);
             var vcRef = new ViewContainerRef(viewRefs[1], 1);
             var vcProtoViewRef = pv.elementBinders[0].nestedProtoView
               .elementBinders[1].nestedProtoView.render;
-            var childViewRef = renderer.createView(vcProtoViewRef)[0];
-
             expect(rootEl).toHaveText('(, B)');
 
-            renderer.insertViewIntoContainer(vcRef, childViewRef);
+            renderer.createViewInContainer(vcRef, 0, vcProtoViewRef)[0];
 
             expect(rootEl).toHaveText('(A, B)');
 
-            renderer.detachViewFromContainer(vcRef, 0);
+            renderer.destroyViewInContainer(vcRef, 0);
 
             expect(rootEl).toHaveText('(, B)');
 
@@ -226,8 +221,8 @@ export function main() {
               directives: [outerWithIndirectNestedComponent]
             })]
           });
-          compileRoot(rootEl, 'main').then( (pv) => {
-            renderer.createView(pv.render);
+          compileRoot('main').then( (pv) => {
+            renderer.createInPlaceHostView(null, rootEl, pv.render);
 
             expect(rootEl).toHaveText('OUTER(SIMPLE(AB))');
 
@@ -247,16 +242,14 @@ export function main() {
               directives: [outerComponent, manualViewportDirective]
             })]
           });
-          compileRoot(rootEl, 'main').then( (pv) => {
-            var viewRefs = renderer.createView(pv.render);
+          compileRoot('main').then( (pv) => {
+            var viewRefs = renderer.createInPlaceHostView(null, rootEl, pv.render);
             var vcRef = new ViewContainerRef(viewRefs[1], 1);
             var vcProtoViewRef = pv.elementBinders[0].nestedProtoView
               .elementBinders[1].nestedProtoView.render;
-            var childViewRef = renderer.createView(vcProtoViewRef)[0];
-
             expect(rootEl).toHaveText('OUTER(INNER(INNERINNER(,BC)))');
 
-            renderer.insertViewIntoContainer(vcRef, childViewRef);
+            renderer.createViewInContainer(vcRef, 0, vcProtoViewRef)[0];
 
             expect(rootEl).toHaveText('OUTER(INNER(INNERINNER(A,BC)))');
             async.done();
@@ -275,21 +268,20 @@ export function main() {
               directives: [conditionalContentComponent]
             })]
           });
-          compileRoot(rootEl, 'main').then( (pv) => {
-            var viewRefs = renderer.createView(pv.render);
+          compileRoot('main').then( (pv) => {
+            var viewRefs = renderer.createInPlaceHostView(null, rootEl, pv.render);
             var vcRef = new ViewContainerRef(viewRefs[2], 0);
             var vcProtoViewRef = pv.elementBinders[0].nestedProtoView
               .elementBinders[0].nestedProtoView
               .elementBinders[0].nestedProtoView.render;
-            var childViewRef = renderer.createView(vcProtoViewRef)[0];
 
             expect(rootEl).toHaveText('(, ABC)');
 
-            renderer.insertViewIntoContainer(vcRef, childViewRef);
+            renderer.createViewInContainer(vcRef, 0, vcProtoViewRef)[0];
 
             expect(rootEl).toHaveText('(A, BC)');
 
-            renderer.detachViewFromContainer(vcRef, 0);
+            renderer.destroyViewInContainer(vcRef, 0);
 
             expect(rootEl).toHaveText('(, ABC)');
 

--- a/modules/angular2/test/render/dom/view/view_factory_spec.js
+++ b/modules/angular2/test/render/dom/view/view_factory_spec.js
@@ -42,7 +42,6 @@ export function main() {
       }
       return new RenderProtoView({
         element: rootEl,
-        isRootView: false,
         elementBinders: binders
       });
     }

--- a/modules/benchmarks/src/compiler/compiler_benchmark.js
+++ b/modules/benchmarks/src/compiler/compiler_benchmark.js
@@ -72,6 +72,7 @@ export function main() {
       new Parser(new Lexer()), shadowDomStrategy, new TemplateLoader(null, urlResolver)
     ),
     null,
+    null,
     shadowDomStrategy
   );
   var compiler = new Compiler(
@@ -81,7 +82,7 @@ export function main() {
     new ComponentUrlMapper(),
     urlResolver,
     renderer,
-    new ProtoViewFactory(dynamicChangeDetection, renderer)
+    new ProtoViewFactory(dynamicChangeDetection)
   );
   var templateNoBindings = createTemplateHtml('templateNoBindings', count);
   var templateWithBindings = createTemplateHtml('templateWithBindings', count);


### PR DESCRIPTION
...tor

Major changes:
- `compiler.compileRoot(el, type)`
  -> `compiler.compileInHost(type) + viewHydrator.hydrateHostViewInPlace(el, view)`
- move all `hydrate`/`dehydrate` methods out of `View` and `ViewContainer` into
  a standalone class `view_hydrator` as private methods and provide new public
  methods dedicated to the individual use cases.

Note: This PR does not change the current functionality, only moves it
into different places.

See design discussion in #1351, in preparation for imperative views.
