### PR TITLE
feat(Compiler): Make Compiler.buildRenderDirective() public and static.

### DIFF
--- a/modules/angular2/src/core/compiler/compiler.js
+++ b/modules/angular2/src/core/compiler/compiler.js
@@ -200,11 +200,11 @@ export class Compiler {
       componentId: stringify(component),
       absUrl: templateAbsUrl,
       template: view.template,
-      directives: ListWrapper.map(directives, this._buildRenderDirective)
+      directives: ListWrapper.map(directives, Compiler.buildRenderDirective)
     });
   }
 
-  _buildRenderDirective(directiveBinding) {
+  static buildRenderDirective(directiveBinding) {
     var ann = directiveBinding.annotation;
     var renderType;
     var compileChildren = true;


### PR DESCRIPTION
The new analysis task model (on which analyzer plugin will be based) works in a way that requires preparing all the information about a resolved file, class, method, etc at the time when we have this resolved entity. Afterwards this resolved AST might be flushed from heap to save memory.

So, we need to build DirectiveMetadata(s) as we go.
To reuse the existing Angular implementation we need to make the method Compiler.buildRenderDirective() public and static.
