### PR TITLE
BUG FIX: without specification, certain versions of bower install ./app/...

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}


### PR DESCRIPTION
...bower_components...

fixes bower to install in `./bower_components` so build does not fail on `gulp build.js`
