### PR TITLE
refactor(testability): rename function to get testability

### DIFF
--- a/modules/angular2/src/core/testability/get_testability.dart
+++ b/modules/angular2/src/core/testability/get_testability.dart
@@ -85,12 +85,9 @@ class PublicTestability implements _JsObjectProxyable {
 
 class GetTestability {
   static addToWindow(TestabilityRegistry registry) {
-    js.context['angular2'] = _jsify({
-      'getTestability': (Element elem) {
+    js.context['getAngularTestability'] = _jsify((Element elem) {
         Testability testability = registry.findTestabilityInTree(elem);
         return _jsify(new PublicTestability(testability));
-        },
-      'resumeBootstrap': ([arg]) {},
-    });
+      });
   }
 }

--- a/modules/angular2/src/core/testability/get_testability.es6
+++ b/modules/angular2/src/core/testability/get_testability.es6
@@ -19,20 +19,13 @@ class PublicTestability {
 
 export class GetTestability {
   static addToWindow(registry: TestabilityRegistry) {
-    if (!global.angular2) {
-      global.angular2 = {};
-    }
-    global.angular2.getTestability = function(elem): PublicTestability {
+    global.getAngularTestability = function(elem): PublicTestability {
       var testability = registry.findTestabilityInTree(elem);
 
       if (testability == null) {
         throw new Error('Could not find testability for element.');
       }
       return new PublicTestability(testability);
-    };
-    global.angular2.resumeBootstrap = function() {
-      // Intentionally left blank. This will allow Protractor to run
-      // against angular2 without turning off Angular synchronization.
     };
   }
 }


### PR DESCRIPTION
Previously, getting testability was `window.angular2.getTestability`
This was because the plan was to export the API to the window as
angular2. However, the decision was changed to make this just `angular`
in https://github.com/angular/angular/commit/3177576ad6889fd7cb592d27ff0cd5c0d85bd9d6

To decouple testability from the rest of the Angular API, just make it
one function, `window.getAngularTestability`.
