### PR TITLE
feat(dart/transform): Add debug transform parameters

### DIFF
--- a/modules/angular2/pubspec.yaml
+++ b/modules/angular2/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   code_transformers: '^0.2.5'
   dart_style: '^0.1.3'
   html: '^0.12.0'
+  logging: '>=0.9.0 <0.11.0'
   source_span: '^1.0.0'
   stack_trace: '^1.1.1'
 transformers:

--- a/modules/angular2/src/reflection/debug_reflection_capabilities.dart
+++ b/modules/angular2/src/reflection/debug_reflection_capabilities.dart
@@ -1,0 +1,55 @@
+library reflection.debug_reflection_capabilities;
+
+import 'package:logging/logging.dart';
+import 'package:stack_trace/stack_trace.dart';
+import 'types.dart';
+import 'reflection_capabilities.dart' as standard;
+
+class ReflectionCapabilities extends standard.ReflectionCapabilities {
+  final bool _verbose;
+  final Logger _log = new Logger('ReflectionCapabilities');
+
+  ReflectionCapabilities({bool verbose: false})
+      : _verbose = verbose,
+        super() {
+    Logger.root.level = _verbose ? Level.ALL : Level.INFO;
+    Logger.root.onRecord.listen((LogRecord rec) {
+      print('[${rec.loggerName}(${rec.level.name})]: ${rec.message}');
+    });
+  }
+
+  void _notify(String methodName, param) {
+    var trace = _verbose ? ' ${Trace.format(new Trace.current())}' : '';
+    _log.info('"$methodName" requested for "$param".$trace');
+  }
+
+  Function factory(Type type) {
+    _notify('factory', type);
+    return super.factory(type);
+  }
+
+  List<List> parameters(typeOrFunc) {
+    _notify('parameters', typeOrFunc);
+    return super.parameters(typeOrFunc);
+  }
+
+  List annotations(typeOrFunc) {
+    _notify('annotations', typeOrFunc);
+    return super.annotations(typeOrFunc);
+  }
+
+  GetterFn getter(String name) {
+    _notify('getter', name);
+    return super.getter(name);
+  }
+
+  SetterFn setter(String name) {
+    _notify('setter', name);
+    return super.setter(name);
+  }
+
+  MethodFn method(String name) {
+    _notify('method', name);
+    return super.method(name);
+  }
+}

--- a/modules/angular2/src/reflection/reflection.dart
+++ b/modules/angular2/src/reflection/reflection.dart
@@ -6,7 +6,7 @@ export 'reflector.dart';
 import 'package:angular2/src/facade/lang.dart';
 
 class NoReflectionCapabilities {
-  Function factory(Type type){
+  Function factory(Type type) {
     throw "Cannot find reflection information on ${stringify(type)}";
   }
 

--- a/modules/angular2/src/reflection/reflection_capabilities.dart
+++ b/modules/angular2/src/reflection/reflection_capabilities.dart
@@ -13,26 +13,43 @@ class ReflectionCapabilities {
     int length = ctor.parameters.length;
 
     switch (length) {
-      case 0: return () => create(name, []).reflectee;
-      case 1: return (a1) => create(name, [a1]).reflectee;
-      case 2: return (a1, a2) => create(name, [a1, a2]).reflectee;
-      case 3: return (a1, a2, a3) => create(name, [a1, a2, a3]).reflectee;
-      case 4: return (a1, a2, a3, a4) => create(name, [a1, a2, a3, a4]).reflectee;
-      case 5: return (a1, a2, a3, a4, a5) => create(name, [a1, a2, a3, a4, a5]).reflectee;
-      case 6: return (a1, a2, a3, a4, a5, a6) => create(name, [a1, a2, a3, a4, a5, a6]).reflectee;
-      case 7: return (a1, a2, a3, a4, a5, a6, a7) => create(name, [a1, a2, a3, a4, a5, a6, a7]).reflectee;
-      case 8: return (a1, a2, a3, a4, a5, a6, a7, a8) => create(name, [a1, a2, a3, a4, a5, a6, a7, a8]).reflectee;
-      case 9: return (a1, a2, a3, a4, a5, a6, a7, a8, a9) => create(name, [a1, a2, a3, a4, a5, a6, a7, a8, a9]).reflectee;
-      case 10: return (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) => create(name, [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10]).reflectee;
-    };
+      case 0:
+        return () => create(name, []).reflectee;
+      case 1:
+        return (a1) => create(name, [a1]).reflectee;
+      case 2:
+        return (a1, a2) => create(name, [a1, a2]).reflectee;
+      case 3:
+        return (a1, a2, a3) => create(name, [a1, a2, a3]).reflectee;
+      case 4:
+        return (a1, a2, a3, a4) => create(name, [a1, a2, a3, a4]).reflectee;
+      case 5:
+        return (a1, a2, a3, a4, a5) =>
+            create(name, [a1, a2, a3, a4, a5]).reflectee;
+      case 6:
+        return (a1, a2, a3, a4, a5, a6) =>
+            create(name, [a1, a2, a3, a4, a5, a6]).reflectee;
+      case 7:
+        return (a1, a2, a3, a4, a5, a6, a7) =>
+            create(name, [a1, a2, a3, a4, a5, a6, a7]).reflectee;
+      case 8:
+        return (a1, a2, a3, a4, a5, a6, a7, a8) =>
+            create(name, [a1, a2, a3, a4, a5, a6, a7, a8]).reflectee;
+      case 9:
+        return (a1, a2, a3, a4, a5, a6, a7, a8, a9) =>
+            create(name, [a1, a2, a3, a4, a5, a6, a7, a8, a9]).reflectee;
+      case 10:
+        return (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) =>
+            create(name, [a1, a2, a3, a4, a5, a6, a7, a8, a9, a10]).reflectee;
+    }
 
     throw "Factory cannot take more than 10 arguments";
   }
 
   List<List> parameters(typeOrFunc) {
-    final parameters = typeOrFunc is Type ?
-      _constructorParameters(typeOrFunc) :
-      _functionParameters(typeOrFunc);
+    final parameters = typeOrFunc is Type
+        ? _constructorParameters(typeOrFunc)
+        : _functionParameters(typeOrFunc);
     return parameters.map(_convertParameter).toList();
   }
 
@@ -44,9 +61,9 @@ class ReflectionCapabilities {
   }
 
   List annotations(typeOrFunc) {
-    final meta = typeOrFunc is Type ?
-      _constructorMetadata(typeOrFunc) :
-      _functionMetadata(typeOrFunc);
+    final meta = typeOrFunc is Type
+        ? _constructorMetadata(typeOrFunc)
+        : _functionMetadata(typeOrFunc);
 
     return meta.map((m) => m.reflectee).toList();
   }
@@ -58,12 +75,14 @@ class ReflectionCapabilities {
 
   SetterFn setter(String name) {
     var symbol = new Symbol(name);
-    return (receiver, value) => reflect(receiver).setField(symbol, value).reflectee;
+    return (receiver, value) =>
+        reflect(receiver).setField(symbol, value).reflectee;
   }
 
   MethodFn method(String name) {
     var symbol = new Symbol(name);
-    return (receiver, posArgs) => reflect(receiver).invoke(symbol, posArgs).reflectee;
+    return (receiver, posArgs) =>
+        reflect(receiver).invoke(symbol, posArgs).reflectee;
   }
 
   List _functionParameters(Function func) {

--- a/modules/angular2/src/transform/common/mirror_mode.dart
+++ b/modules/angular2/src/transform/common/mirror_mode.dart
@@ -1,0 +1,10 @@
+library angular2.transform.common.mirror_mode;
+
+/// Modes for mirror use.
+/// `none` is the default value and signifies that mirror use should be
+/// removed.
+/// `debug` allows the use of mirrors and logs a notice whenever they are
+/// accessed.
+/// `verbose` allows the use of mirrors and logs a stack trace whenever they
+/// are accessed.
+enum MirrorMode { debug, none, verbose }

--- a/modules/angular2/src/transform/common/names.dart
+++ b/modules/angular2/src/transform/common/names.dart
@@ -2,10 +2,10 @@ library angular2.transform.common.names;
 
 const SETUP_METHOD_NAME = 'initReflector';
 const REFLECTOR_VAR_NAME = 'reflector';
+const TRANSFORM_DYNAMIC_MODE = 'transform_dynamic';
 const DEPS_EXTENSION = '.ng_deps.dart';
 const REFLECTION_CAPABILITIES_NAME = 'ReflectionCapabilities';
 const REGISTER_TYPE_METHOD_NAME = 'registerType';
 const REGISTER_GETTERS_METHOD_NAME = 'registerGetters';
 const REGISTER_SETTERS_METHOD_NAME = 'registerSetters';
 const REGISTER_METHODS_METHOD_NAME = 'registerMethods';
-const TRANSFORM_MODE = 'ngstatic';

--- a/modules/angular2/src/transform/common/options.dart
+++ b/modules/angular2/src/transform/common/options.dart
@@ -1,5 +1,7 @@
 library angular2.transform.common.options;
 
+import 'mirror_mode.dart';
+
 const ENTRY_POINT_PARAM = 'entry_points';
 const REFLECTION_ENTRY_POINT_PARAM = 'reflection_entry_points';
 
@@ -15,15 +17,22 @@ class TransformerOptions {
   /// The `BarbackMode#name` we are running in.
   final String modeName;
 
-  TransformerOptions._internal(
-      this.entryPoints, this.reflectionEntryPoints, this.modeName);
+  /// The [MirrorMode] to use for the transformation.
+  final MirrorMode mirrorMode;
+
+  /// Whether to generate calls to our generated `initReflector` code
+  final bool initReflector;
+
+  TransformerOptions._internal(this.entryPoints, this.reflectionEntryPoints,
+      this.modeName, this.mirrorMode, this.initReflector);
 
   factory TransformerOptions(List<String> entryPoints,
-      {List<String> reflectionEntryPoints, String modeName: 'release'}) {
+      {List<String> reflectionEntryPoints, String modeName: 'release',
+      MirrorMode mirrorMode: MirrorMode.none, bool initReflector: true}) {
     if (reflectionEntryPoints == null || reflectionEntryPoints.isEmpty) {
       reflectionEntryPoints = entryPoints;
     }
-    return new TransformerOptions._internal(
-        entryPoints, reflectionEntryPoints, modeName);
+    return new TransformerOptions._internal(entryPoints, reflectionEntryPoints,
+        modeName, mirrorMode, initReflector);
   }
 }

--- a/modules/angular2/src/transform/common/options_reader.dart
+++ b/modules/angular2/src/transform/common/options_reader.dart
@@ -1,6 +1,7 @@
 library angular2.transform.common.options_reader;
 
 import 'package:barback/barback.dart';
+import 'mirror_mode.dart';
 import 'options.dart';
 
 TransformerOptions parseBarbackSettings(BarbackSettings settings) {
@@ -8,9 +9,27 @@ TransformerOptions parseBarbackSettings(BarbackSettings settings) {
   var entryPoints = _readFileList(config, ENTRY_POINT_PARAM);
   var reflectionEntryPoints =
       _readFileList(config, REFLECTION_ENTRY_POINT_PARAM);
+  var initReflector = !config.containsKey('init_reflector') ||
+      config['init_reflector'] != false;
+  String mirrorModeVal =
+      config.containsKey('mirror_mode') ? config['mirror_mode'] : '';
+  var mirrorMode = MirrorMode.none;
+  switch (mirrorModeVal) {
+    case 'debug':
+      mirrorMode = MirrorMode.debug;
+      break;
+    case 'verbose':
+      mirrorMode = MirrorMode.verbose;
+      break;
+    default:
+      mirrorMode = MirrorMode.none;
+      break;
+  }
   return new TransformerOptions(entryPoints,
       reflectionEntryPoints: reflectionEntryPoints,
-      modeName: settings.mode.name);
+      modeName: settings.mode.name,
+      mirrorMode: mirrorMode,
+      initReflector: initReflector);
 }
 
 /// Cribbed from the polymer project.

--- a/modules/angular2/src/transform/reflection_remover/remove_reflection_capabilities.dart
+++ b/modules/angular2/src/transform/reflection_remover/remove_reflection_capabilities.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'package:analyzer/analyzer.dart';
 import 'package:barback/barback.dart';
 import 'package:angular2/src/transform/common/asset_reader.dart';
+import 'package:angular2/src/transform/common/mirror_mode.dart';
 
 import 'codegen.dart';
 import 'rewriter.dart';
@@ -15,12 +16,15 @@ import 'rewriter.dart';
 /// This only searches the code in `reflectionEntryPoint`, not `part`s,
 /// `import`s, `export`s, etc.
 Future<String> removeReflectionCapabilities(AssetReader reader,
-    AssetId reflectionEntryPoint, Iterable<AssetId> newEntryPoints) async {
+    AssetId reflectionEntryPoint, Iterable<AssetId> newEntryPoints,
+    {MirrorMode mirrorMode: MirrorMode.none,
+    bool writeStaticInit: true}) async {
   var code = await reader.readAsString(reflectionEntryPoint);
   var reflectionEntryPointPath = reflectionEntryPoint.path;
   var newEntryPointPaths = newEntryPoints.map((id) => id.path);
 
   var codegen = new Codegen(reflectionEntryPointPath, newEntryPointPaths);
-  return new Rewriter(code, codegen)
+  return new Rewriter(code, codegen,
+          mirrorMode: mirrorMode, writeStaticInit: writeStaticInit)
       .rewrite(parseCompilationUnit(code, name: reflectionEntryPointPath));
 }

--- a/modules/angular2/src/transform/reflection_remover/transformer.dart
+++ b/modules/angular2/src/transform/reflection_remover/transformer.dart
@@ -3,6 +3,7 @@ library angular2.transform.reflection_remover.transformer;
 import 'dart:async';
 import 'package:angular2/src/transform/common/asset_reader.dart';
 import 'package:angular2/src/transform/common/logging.dart' as log;
+import 'package:angular2/src/transform/common/mirror_mode.dart';
 import 'package:angular2/src/transform/common/names.dart';
 import 'package:angular2/src/transform/common/options.dart';
 import 'package:barback/barback.dart';
@@ -38,8 +39,19 @@ class ReflectionRemover extends Transformer {
       });
       var reader = new AssetReader.fromTransform(transform);
 
+      var mirrorMode = options.mirrorMode;
+      var writeStaticInit = options.initReflector;
+      if (options.modeName == TRANSFORM_DYNAMIC_MODE) {
+        mirrorMode = MirrorMode.debug;
+        writeStaticInit = false;
+        log.logger.info('Running in "${options.modeName}", '
+            'mirrorMode: ${mirrorMode}, '
+            'writeStaticInit: ${writeStaticInit}.');
+      }
+
       var transformedCode = await removeReflectionCapabilities(
-          reader, transform.primaryInput.id, newEntryPoints);
+          reader, transform.primaryInput.id, newEntryPoints,
+          mirrorMode: mirrorMode, writeStaticInit: writeStaticInit);
       transform.addOutput(
           new Asset.fromString(transform.primaryInput.id, transformedCode));
     } catch (ex, stackTrace) {

--- a/modules/angular2/test/transform/integration/all_tests.dart
+++ b/modules/angular2/test/transform/integration/all_tests.dart
@@ -14,8 +14,7 @@ main() {
 
 var formatter = new DartFormatter();
 var transform = new AngularTransformerGroup(new TransformerOptions(
-    ['web/index.dart'],
-    reflectionEntryPoints: ['web/index.dart'], modeName: TRANSFORM_MODE));
+    ['web/index.dart'], reflectionEntryPoints: ['web/index.dart']));
 
 class IntegrationTestConfig {
   final String name;

--- a/modules/angular2/test/transform/reflection_remover/all_tests.dart
+++ b/modules/angular2/test/transform/reflection_remover/all_tests.dart
@@ -1,21 +1,46 @@
 library angular2.test.transform.reflection_remover;
 
 import 'package:analyzer/analyzer.dart';
+import 'package:angular2/src/transform/common/mirror_mode.dart';
 import 'package:angular2/src/transform/reflection_remover/codegen.dart';
 import 'package:angular2/src/transform/reflection_remover/rewriter.dart';
 import 'package:guinness/guinness.dart';
 
 import 'reflection_remover_files/expected/index.dart' as expected;
+import 'debug_mirrors_files/expected/index.dart' as debug_mirrors;
+import 'log_mirrors_files/expected/index.dart' as log_mirrors;
+import 'verbose_files/expected/index.dart' as verbose_mirrors;
 import '../common/read_file.dart';
 
 void allTests() {
   var codegen = new Codegen('web/index.dart', ['web/index.ng_deps.dart']);
+  var code = readFile('reflection_remover/index.dart');
 
-  it('should remove uses of mirrors & insert calls to generated code.', () {
-    var code =
-        readFile('reflection_remover/reflection_remover_files/index.dart');
+  it('should remove uses of mirrors & '
+      'insert calls to generated code by default.', () {
     var output =
         new Rewriter(code, codegen).rewrite(parseCompilationUnit(code));
     expect(output).toEqual(expected.code);
+  });
+
+  it('should replace uses of mirrors with the debug implementation & '
+      'insert calls to generated code in `MirrorMode.debug`.', () {
+    var output = new Rewriter(code, codegen, mirrorMode: MirrorMode.debug)
+        .rewrite(parseCompilationUnit(code));
+    expect(output).toEqual(debug_mirrors.code);
+  });
+
+  it('should replace uses of mirrors with the verbose implementation '
+      'in `MirrorMode.verbose`.', () {
+    var output = new Rewriter(code, codegen, mirrorMode: MirrorMode.verbose)
+        .rewrite(parseCompilationUnit(code));
+    expect(output).toEqual(verbose_mirrors.code);
+  });
+
+  it('should not initialize the reflector when `writeStaticInit` is `false`.',
+      () {
+    var output = new Rewriter(code, codegen, writeStaticInit: false)
+        .rewrite(parseCompilationUnit(code));
+    expect(output).toEqual(log_mirrors.code);
   });
 }

--- a/modules/angular2/test/transform/reflection_remover/debug_files/README.md
+++ b/modules/angular2/test/transform/reflection_remover/debug_files/README.md
@@ -1,0 +1,7 @@
+Tests that the reflection removal step:
+ 1. Comments out the import of reflection_capabilities.dart
+ 2. Comments out the instantiation of `ReflectionCapabilities`
+ 3. Adds the appropriate import.
+ 4. Adds the call to `initReflector`
+ 5. Does not change line numbers in the source.
+ 6. Makes minimal changes to source offsets.

--- a/modules/angular2/test/transform/reflection_remover/debug_files/expected/index.dart
+++ b/modules/angular2/test/transform/reflection_remover/debug_files/expected/index.dart
@@ -1,0 +1,22 @@
+library angular2.test.transform.debug_reflection_remover_files;
+
+// This file is intentionally formatted as a string to avoid having the
+// automatic transformer prettify it.
+//
+// This file represents transformed user code. Because this code will be
+// linked to output by a source map, we cannot change line numbers from the
+// original code and we therefore add our generated code on the same line as
+// those we are removing.
+
+var code = """
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+import 'package:angular2/src/reflection/debug_reflection_capabilities.dart';import 'index.ng_deps.dart' as ngStaticInit0;
+
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();ngStaticInit0.initReflector(reflector);
+  bootstrap(MyComponent);
+}
+""";

--- a/modules/angular2/test/transform/reflection_remover/debug_files/index.dart
+++ b/modules/angular2/test/transform/reflection_remover/debug_files/index.dart
@@ -1,0 +1,10 @@
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+import 'package:angular2/src/reflection/reflection_capabilities.dart';
+
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  bootstrap(MyComponent);
+}

--- a/modules/angular2/test/transform/reflection_remover/debug_mirrors_files/README.md
+++ b/modules/angular2/test/transform/reflection_remover/debug_mirrors_files/README.md
@@ -1,0 +1,7 @@
+Tests that the reflection removal step:
+ 1. Comments out the import of reflection_capabilities.dart
+ 2. Comments out the instantiation of `ReflectionCapabilities`
+ 3. Adds the appropriate import.
+ 4. Adds the call to `initReflector`
+ 5. Does not change line numbers in the source.
+ 6. Makes minimal changes to source offsets.

--- a/modules/angular2/test/transform/reflection_remover/debug_mirrors_files/expected/index.dart
+++ b/modules/angular2/test/transform/reflection_remover/debug_mirrors_files/expected/index.dart
@@ -1,0 +1,22 @@
+library angular2.test.transform.debug_reflection_remover_files;
+
+// This file is intentionally formatted as a string to avoid having the
+// automatic transformer prettify it.
+//
+// This file represents transformed user code. Because this code will be
+// linked to output by a source map, we cannot change line numbers from the
+// original code and we therefore add our generated code on the same line as
+// those we are removing.
+
+var code = """
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+import 'package:angular2/src/reflection/debug_reflection_capabilities.dart';import 'index.ng_deps.dart' as ngStaticInit0;
+
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();ngStaticInit0.initReflector(reflector);
+  bootstrap(MyComponent);
+}
+""";

--- a/modules/angular2/test/transform/reflection_remover/debug_mirrors_files/index.dart
+++ b/modules/angular2/test/transform/reflection_remover/debug_mirrors_files/index.dart
@@ -1,0 +1,10 @@
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+import 'package:angular2/src/reflection/reflection_capabilities.dart';
+
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  bootstrap(MyComponent);
+}

--- a/modules/angular2/test/transform/reflection_remover/index.dart
+++ b/modules/angular2/test/transform/reflection_remover/index.dart
@@ -1,0 +1,10 @@
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+import 'package:angular2/src/reflection/reflection_capabilities.dart';
+
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  bootstrap(MyComponent);
+}

--- a/modules/angular2/test/transform/reflection_remover/log_mirrors_files/README.md
+++ b/modules/angular2/test/transform/reflection_remover/log_mirrors_files/README.md
@@ -1,0 +1,7 @@
+Tests that the reflection removal step:
+ 1. Comments out the import of reflection_capabilities.dart
+ 2. Comments out the instantiation of `ReflectionCapabilities`
+ 3. Adds the appropriate import.
+ 4. Adds the call to `initReflector`
+ 5. Does not change line numbers in the source.
+ 6. Makes minimal changes to source offsets.

--- a/modules/angular2/test/transform/reflection_remover/log_mirrors_files/expected/index.dart
+++ b/modules/angular2/test/transform/reflection_remover/log_mirrors_files/expected/index.dart
@@ -1,0 +1,22 @@
+library angular2.test.transform.log_mirrors_files.expected;
+
+// This file is intentionally formatted as a string to avoid having the
+// automatic transformer prettify it.
+//
+// This file represents transformed user code. Because this code will be
+// linked to output by a source map, we cannot change line numbers from the
+// original code and we therefore add our generated code on the same line as
+// those we are removing.
+
+var code = """
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+/*import 'package:angular2/src/reflection/reflection_capabilities.dart';*/
+
+void main() {
+  /*reflector.reflectionCapabilities = new ReflectionCapabilities();*/
+  bootstrap(MyComponent);
+}
+""";

--- a/modules/angular2/test/transform/reflection_remover/log_mirrors_files/index.dart
+++ b/modules/angular2/test/transform/reflection_remover/log_mirrors_files/index.dart
@@ -1,0 +1,10 @@
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+import 'package:angular2/src/reflection/reflection_capabilities.dart';
+
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  bootstrap(MyComponent);
+}

--- a/modules/angular2/test/transform/reflection_remover/verbose_files/expected/index.dart
+++ b/modules/angular2/test/transform/reflection_remover/verbose_files/expected/index.dart
@@ -1,0 +1,22 @@
+library angular2.test.transform.debug_reflection_remover_files;
+
+// This file is intentionally formatted as a string to avoid having the
+// automatic transformer prettify it.
+//
+// This file represents transformed user code. Because this code will be
+// linked to output by a source map, we cannot change line numbers from the
+// original code and we therefore add our generated code on the same line as
+// those we are removing.
+
+var code = """
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+import 'package:angular2/src/reflection/debug_reflection_capabilities.dart';import 'index.ng_deps.dart' as ngStaticInit0;
+
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities(verbose: true);ngStaticInit0.initReflector(reflector);
+  bootstrap(MyComponent);
+}
+""";


### PR DESCRIPTION
Add two transform parameters to aid in debugging the transformer
- `mirror_mode`, with values {`debug`, `none`, and `verbose`}
- `init_reflector`, with values {`true`, `false`}

`mirror_mode`:
- `debug`: Allow reflective access, but log a message if it is used
- `none`: Remove reflective access, `throw` if it is used. Default value
- `verbose`: Allow reflective access, log a stack trace if it is used

`init_reflector`: Whether to generate calls to our generated
`initReflector` code.

These will be useful to reveal areas where the transformer is not generating
appropriate code and to quickly see where reflective accesses occur.

When the pub mode is `transform_dynamic`, we run in MirrorMode.debug
with `init_reflector = false`. This is used for testing purposes.
