### PR TITLE
fix(benchpress): only print the CV when it is meaningful

### DIFF
--- a/modules/benchpress/src/reporter/console_reporter.js
+++ b/modules/benchpress/src/reporter/console_reporter.js
@@ -83,10 +83,10 @@ export class ConsoleReporter extends Reporter {
         var sample = ListWrapper.map(validSample, (measureValues) => measureValues.values[metricName]);
         var mean = Statistic.calculateMean(sample);
         var cv = Statistic.calculateCoefficientOfVariation(sample, mean);
-        var formattedCv = NumberWrapper.isNaN(cv) ? 'NaN' : Math.floor(cv);
+        var formattedMean = ConsoleReporter._formatNum(mean)
         // Note: Don't use the unicode character for +- as it might cause
-        // hickups consoles...
-        return `${ConsoleReporter._formatNum(mean)}+-${formattedCv}%`;
+        // hickups for consoles...
+        return NumberWrapper.isNaN(cv) ? formattedMean : `${formattedMean}+-${Math.floor(cv)}%`;
       })
     );
     return PromiseWrapper.resolve(null);

--- a/modules/benchpress/test/reporter/console_reporter_spec.js
+++ b/modules/benchpress/test/reporter/console_reporter_spec.js
@@ -96,6 +96,22 @@ export function main() {
       ]);
     });
 
+    it('should print the coefficient of variation only when it is meaningful', () => {
+      createReporter({
+        columnWidth: 8,
+        metrics: { 'a': '', 'b': '' }
+      });
+      log = [];
+      reporter.reportSample([], [
+          mv(0, 0, { 'a': 3, 'b': 0 }),
+          mv(1, 1, { 'a': 5, 'b': 0 })
+      ]);
+      expect(log).toEqual([
+        '======== | ========',
+        '4.00+-25% |     0.00'
+      ]);
+    });
+
   });
 }
 


### PR DESCRIPTION
When the mean is 0, the coefficient of variation is calculated to be
NaN, which is not meaningful, so instead of printing "+-NaN%", just
don't print the CV at all.

Closes #908
