### PR TITLE
chore: show dart2js package warnings for angular2, benchmarks, examples

### DIFF
--- a/modules/angular2/pubspec.yaml
+++ b/modules/angular2/pubspec.yaml
@@ -17,7 +17,10 @@ dependencies:
   logging: '>=0.9.0 <0.11.0'
   source_span: '^1.0.0'
   stack_trace: '^1.1.1'
-transformers:
-  - angular2
 dev_dependencies:
   guinness: "^0.1.17"
+transformers:
+- angular2
+- $dart2js:
+    commandLineOptions:
+    - --show-package-warnings

--- a/modules/benchmarks/pubspec.yaml
+++ b/modules/benchmarks/pubspec.yaml
@@ -25,4 +25,8 @@ transformers:
         - web/src/tree/tree_benchmark.dart
 - $dart2js:
     minify: false
-    commandLineOptions: ['--dump-info', '--trust-type-annotations', '--trust-primitives']
+    commandLineOptions:
+    - --dump-info
+    - --trust-type-annotations
+    - --trust-primitives
+    - --show-package-warnings

--- a/modules/benchmarks_external/pubspec.yaml
+++ b/modules/benchmarks_external/pubspec.yaml
@@ -12,3 +12,6 @@ transformers:
     html_files:
       - web/src/naive_infinite_scroll/scroll_area.html
       - web/src/naive_infinite_scroll/scroll_item.html
+- $dart2js:
+    commandLineOptions:
+    - --show-package-warnings

--- a/modules/examples/pubspec.yaml
+++ b/modules/examples/pubspec.yaml
@@ -15,11 +15,13 @@ dev_dependencies:
   benchpress:
     path: ../benchpress
 transformers:
-  - angular2:
-      entry_points: web/src/hello_world/index_common.dart
-      reflection_entry_points: web/src/hello_world/index.dart
-  - $dart2js:
-      minify: false
-      #commandLineOptions: [--trust-type-annotations, --trust-primitives, --dump-info]
-      #commandLineOptions: [--trust-type-annotations, --dump-info]
-      commandLineOptions: [--dump-info]
+- angular2:
+    entry_points: web/src/hello_world/index_common.dart
+    reflection_entry_points: web/src/hello_world/index.dart
+- $dart2js:
+    minify: false
+    commandLineOptions:
+    - --dump-info
+    - --show-package-warnings
+    #- --trust-type-annotations
+    #- --trust-primitives


### PR DESCRIPTION
There are a LOT of warnings and errors being printed during dart2js
