### PR TITLE
Fixed example for EventEmitter

### DIFF
--- a/modules/angular2/src/core/annotations/annotations.js
+++ b/modules/angular2/src/core/annotations/annotations.js
@@ -120,7 +120,6 @@ import {DEFAULT} from 'angular2/change_detection';
  *
  * Here, the constructor declares a parameter, `someService`, and injects the `SomeService` type from the parent
  * component's injector.
- *
  * ```
  * @Decorator({ selector: '[my-directive]' })
  * class MyDirective {
@@ -372,17 +371,17 @@ export class Directive extends Injectable {
    *
    * ```
    * @Component({
-   *   events: ['status-change']
+   *   events: ['statusChange']
    * })
    * class TaskComponent {
    *   statusChange:EventEmitter;
    *
    *   constructor() {
-   *     this.complete = new EventEmitter();
+   *     this.statusChange = new EventEmitter();
    *   }
    *
    *   onComplete() {
-   *     this.statusChange.next("completed");
+   *     this.statusChange.next('completed');
    *   }
    * }
    * ```


### PR DESCRIPTION
I didn't get a full trace back for my evidence I got from making this example work. EventEmitter was instantiated and assigned to wrong property. Also the mapping should be done using the component property name as it will be obtained via accessor and exposed on the directive (as far as I understood).
