### PR TITLE
docs(annotations): fix casing in view annotation

### DIFF
--- a/modules/angular2/src/core/annotations/view.js
+++ b/modules/angular2/src/core/annotations/view.js
@@ -36,14 +36,14 @@ export class View {
   /**
    * Specifies a template URL for an angular component.
    *
-   * NOTE: either `templateURL` or `template` should be used, but not both.
+   * NOTE: either `templateUrl` or `template` should be used, but not both.
    */
   templateUrl:string;
 
   /**
    * Specifies an inline template for an angular component.
    *
-   * NOTE: either `templateURL` or `template` should be used, but not both.
+   * NOTE: either `templateUurl` or `template` should be used, but not both.
    */
   template:string;
 


### PR DESCRIPTION
- Fix the casing to match key name exposed for `templateUrl` in `View`
  annotation
