### PR TITLE
refactor(PipeRegistry): improve error messages

### DIFF
--- a/modules/angular2/src/change_detection/pipes/pipe_registry.js
+++ b/modules/angular2/src/change_detection/pipes/pipe_registry.js
@@ -15,14 +15,14 @@ export class PipeRegistry {
   get(type:string, obj, cdRef:ChangeDetectorRef):Pipe {
     var listOfConfigs = this.config[type];
     if (isBlank(listOfConfigs)) {
-      throw new BaseException(`Cannot find a pipe for type '${type}' object '${obj}'`);
+      throw new BaseException(`Cannot find '${type}' pipe supporting object '${obj}'`);
     }
 
     var matchingConfig = ListWrapper.find(listOfConfigs,
       (pipeConfig) => pipeConfig.supports(obj));
 
     if (isBlank(matchingConfig)) {
-      throw new BaseException(`Cannot find a pipe for type '${type}' object '${obj}'`);
+      throw new BaseException(`Cannot find '${type}' pipe supporting object '${obj}'`);
     }
 
     return matchingConfig.create(cdRef);

--- a/modules/angular2/test/change_detection/pipes/pipe_registry_spec.js
+++ b/modules/angular2/test/change_detection/pipes/pipe_registry_spec.js
@@ -22,7 +22,7 @@ export function main() {
     it("should throw when no matching type", () => {
       var r = new PipeRegistry({});
       expect(() => r.get("unknown", "some object", null)).toThrowError(
-        `Cannot find a pipe for type 'unknown' object 'some object'`
+        `Cannot find 'unknown' pipe supporting object 'some object'`
       );
     });
 
@@ -32,7 +32,7 @@ export function main() {
       });
 
       expect(() => r.get("type", "some object", null)).toThrowError(
-        `Cannot find a pipe for type 'type' object 'some object'`
+        `Cannot find 'type' pipe supporting object 'some object'`
       );
     });
   });


### PR DESCRIPTION
While investigating #1472 the error messages from the `PipeRegistry` were not immediately obvious. See this plunk: http://plnkr.co/edit/4qJgKzOSigfUyObSZsYy?p=preview

The issue here is that a given pipe can't handle objects of type string, but the error you are getting was: 

> Cannot find a pipe for type 'keyValDiff' object 'static-class' in [static-class in App]

After this change it would be:

> Cannot find pipe 'keyValDiff' supporting object 'static-class' in [static-class in App] 
