### PR TITLE
refacor(lexer): remove unused ~/ operator

### DIFF
--- a/modules/angular2/src/change_detection/parser/lexer.js
+++ b/modules/angular2/src/change_detection/parser/lexer.js
@@ -179,7 +179,6 @@ const $a =  97, $b =  98, $c =  99, $d = 100, $e = 101, $f = 102, $g = 103,
 export const $LBRACE = 123;
 export const $BAR    = 124;
 export const $RBRACE = 125;
-const $TILDE  = 126;
 const $NBSP   = 160;
 
 
@@ -275,8 +274,6 @@ class _Scanner {
         return this.scanComplexOperator(start, $AMPERSAND, '&', '&');
       case $BAR:
         return this.scanComplexOperator(start, $BAR, '|', '|');
-      case $TILDE:
-        return this.scanComplexOperator(start, $SLASH, '~', '/');
       case $NBSP:
         while (isWhitespace(this.peek)) this.advance();
         return this.scanToken();
@@ -455,7 +452,6 @@ var OPERATORS = SetWrapper.createFromList([
   '-',
   '*',
   '/',
-  '~/',
   '%',
   '^',
   '=',
@@ -480,5 +476,5 @@ var KEYWORDS = SetWrapper.createFromList([
     'null',
     'undefined',
     'true',
-    'false',
+    'false'
 ]);


### PR DESCRIPTION
I'm not sure if we want to support the Dart's [~/ operator](https://www.dartlang.org/docs/dart-up-and-running/ch02.html#operators) (Divide, returning an integer result) but currently it is half-implemented (well, not implemented besides the lexer part, really, no tests etc.).

Opening a PR to either get rid of it or decide that we want to fully implement it.
