### PR TITLE
feat(dart/transform): Dedup getters, setters, & methods

### DIFF
--- a/modules/angular2/src/transform/template_compiler/directive_metadata_reader.dart
+++ b/modules/angular2/src/transform/template_compiler/directive_metadata_reader.dart
@@ -147,7 +147,8 @@ class _DirectiveMetadataVisitor extends Object
       return;
     }
     for (MapLiteralEntry entry in (hostPropertyValue as MapLiteral).entries) {
-      var sKey = _expressionToString(entry.key, 'Directive#hostProperties keys');
+      var sKey =
+          _expressionToString(entry.key, 'Directive#hostProperties keys');
       var sVal =
           _expressionToString(entry.value, 'Directive#hostProperties values');
       meta.hostProperties[sKey] = sVal;

--- a/modules/angular2/src/transform/template_compiler/generator.dart
+++ b/modules/angular2/src/transform/template_compiler/generator.dart
@@ -62,7 +62,8 @@ Future<String> processTemplates(AssetReader reader, AssetId entryPoint) async {
       '${code.substring(codeInjectIdx)}';
 }
 
-Iterable<String> _generateGetters(String typeName, List<String> getterNames) {
+Iterable<String> _generateGetters(
+    String typeName, Iterable<String> getterNames) {
   // TODO(kegluneq): Include `typeName` where possible.
   return getterNames.map((getterName) {
     if (!prop.isValid(getterName)) {
@@ -74,7 +75,8 @@ Iterable<String> _generateGetters(String typeName, List<String> getterNames) {
   });
 }
 
-Iterable<String> _generateSetters(String typeName, List<String> setterName) {
+Iterable<String> _generateSetters(
+    String typeName, Iterable<String> setterName) {
   return setterName.map((setterName) {
     if (!prop.isValid(setterName)) {
       // TODO(kegluenq): Eagerly throw here once #1295 is addressed.
@@ -86,7 +88,8 @@ Iterable<String> _generateSetters(String typeName, List<String> setterName) {
   });
 }
 
-Iterable<String> _generateMethods(String typeName, List<String> methodNames) {
+Iterable<String> _generateMethods(
+    String typeName, Iterable<String> methodNames) {
   return methodNames.map((methodName) {
     if (!prop.isValid(methodName)) {
       // TODO(kegluenq): Eagerly throw here once #1295 is addressed.

--- a/modules/angular2/src/transform/template_compiler/recording_reflection_capabilities.dart
+++ b/modules/angular2/src/transform/template_compiler/recording_reflection_capabilities.dart
@@ -8,11 +8,11 @@ import 'package:angular2/src/reflection/types.dart';
 /// reflectively accessed at runtime.
 class RecordingReflectionCapabilities implements ReflectionCapabilities {
   /// The names of all requested `getter`s.
-  final List<String> getterNames = <String>[];
+  final Set<String> getterNames = new Set<String>();
   /// The names of all requested `setter`s.
-  final List<String> setterNames = <String>[];
+  final Set<String> setterNames = new Set<String>();
   /// The names of all requested `method`s.
-  final List<String> methodNames = <String>[];
+  final Set<String> methodNames = new Set<String>();
 
   _notImplemented(String name) => throw 'Not implemented: $name';
 

--- a/modules/angular2/test/transform/template_compiler/all_tests.dart
+++ b/modules/angular2/test/transform/template_compiler/all_tests.dart
@@ -56,6 +56,14 @@ void allTests() {
     _formatThenExpectEquals(output, expected);
   });
 
+  it('should not generated duplicate getters/setters', () async {
+    var inputPath = 'template_compiler/duplicate_files/hello.ng_deps.dart';
+    var expected = readFile(
+        'template_compiler/duplicate_files/expected/hello.ng_deps.dart');
+    var output = await processTemplates(reader, new AssetId('a', inputPath));
+    _formatThenExpectEquals(output, expected);
+  });
+
   describe('DirectiveMetadataReader', () {
     Future<DirectiveMetadata> readMetadata(inputPath) async {
       var ngDeps = await parser.parse(new AssetId('a', inputPath));

--- a/modules/angular2/test/transform/template_compiler/duplicate_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/duplicate_files/expected/hello.ng_deps.dart
@@ -1,0 +1,22 @@
+library examples.hello_world.index_common_dart.ng_deps.dart;
+
+import 'hello.dart';
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Decorator, View, NgElement;
+
+var _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(HelloCmp, {
+      'factory': () => new HelloCmp(),
+      'parameters': const [const []],
+      'annotations': const [
+        const Component(selector: 'hello-app'),
+        const View(template: '{{greeting}}, {{greeting}}')
+      ]
+    })
+    ..registerGetters({'greeting': (o) => o.greeting})
+    ..registerSetters({'greeting': (o, v) => o.greeting = v});
+}

--- a/modules/angular2/test/transform/template_compiler/duplicate_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/duplicate_files/hello.ng_deps.dart
@@ -1,0 +1,20 @@
+library examples.hello_world.index_common_dart.ng_deps.dart;
+
+import 'hello.dart';
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Decorator, View, NgElement;
+
+var _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(HelloCmp, {
+      'factory': () => new HelloCmp(),
+      'parameters': const [const []],
+      'annotations': const [
+        const Component(selector: 'hello-app'),
+        const View(template: '{{greeting}}, {{greeting}}')
+      ]
+    });
+}


### PR DESCRIPTION
Dedup the getters, setters, and methods generated by the transformer
when compiling a template.

Run `dartformat` over the transform code.
