### PR TITLE
fix(dart/transform): Use `var` instead of `bool` in generated files

### DIFF
--- a/modules/angular2/src/transform/directive_processor/rewriter.dart
+++ b/modules/angular2/src/transform/directive_processor/rewriter.dart
@@ -91,7 +91,7 @@ class CreateNgDepsVisitor extends Object with SimpleAstVisitor<Object> {
 
   void _openFunctionWrapper() {
     _maybeWriteImport();
-    writer.print('bool _visited = false;'
+    writer.print('var _visited = false;'
         'void ${SETUP_METHOD_NAME}(${REFLECTOR_VAR_NAME}) {'
         'if (_visited) return; _visited = true;');
   }

--- a/modules/angular2/test/transform/bind_generator/basic_bind_files/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/bind_generator/basic_bind_files/bar.ng_deps.dart
@@ -3,7 +3,7 @@ library bar.ng_deps.dart;
 import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/bind_generator/basic_bind_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/bind_generator/basic_bind_files/expected/bar.ng_deps.dart
@@ -3,7 +3,7 @@ library bar.ng_deps.dart;
 import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/bind_generator/duplicate_bind_name_files/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/bind_generator/duplicate_bind_name_files/expected/soup.ng_deps.dart
@@ -3,7 +3,7 @@ library dinner.soup.ng_deps.dart;
 import 'package:angular2/src/core/annotations/annotations.dart';
 import 'soup.dart';
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/bind_generator/duplicate_bind_name_files/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/bind_generator/duplicate_bind_name_files/soup.ng_deps.dart
@@ -3,7 +3,7 @@ library dinner.soup.ng_deps.dart;
 import 'package:angular2/src/core/annotations/annotations.dart';
 import 'soup.dart';
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/bar.ng_deps.dart
@@ -4,7 +4,7 @@ import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 export 'foo.dart';
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/expected/bar.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/src/core/annotations/annotations.dart';
 export 'foo.dart';
 import 'foo.ng_deps.dart' as i0;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/expected/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/expected/foo.ng_deps.dart
@@ -3,7 +3,7 @@ library foo.ng_deps.dart;
 import 'foo.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/expected/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/expected/index.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/src/reflection/reflection_capabilities.dart';
 import 'bar.dart';
 import 'bar.ng_deps.dart' as i0;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/foo.ng_deps.dart
@@ -3,7 +3,7 @@ library foo.ng_deps.dart;
 import 'foo.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/index.ng_deps.dart
@@ -4,7 +4,7 @@ import 'package:angular2/src/core/application.dart';
 import 'package:angular2/src/reflection/reflection_capabilities.dart';
 import 'bar.dart';
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_linker/simple_files/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/bar.ng_deps.dart
@@ -4,7 +4,7 @@ import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 import 'foo.dart' as dep;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_linker/simple_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/expected/bar.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/src/core/annotations/annotations.dart';
 import 'foo.dart' as dep;
 import 'foo.ng_deps.dart' as i0;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_linker/simple_files/expected/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/expected/foo.ng_deps.dart
@@ -3,7 +3,7 @@ library foo.ng_deps.dart;
 import 'foo.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_linker/simple_files/expected/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/expected/index.ng_deps.dart
@@ -5,7 +5,7 @@ import 'package:angular2/src/reflection/reflection_capabilities.dart';
 import 'bar.dart';
 import 'bar.ng_deps.dart' as i0;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_linker/simple_files/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/foo.ng_deps.dart
@@ -3,7 +3,7 @@ library foo.ng_deps.dart;
 import 'foo.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_linker/simple_files/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/index.ng_deps.dart
@@ -4,7 +4,7 @@ import 'package:angular2/src/core/application.dart';
 import 'package:angular2/src/reflection/reflection_capabilities.dart';
 import 'bar.dart';
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_processor/custom_metadata/expected/chicken_soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/custom_metadata/expected/chicken_soup.ng_deps.dart
@@ -4,7 +4,7 @@ import 'chicken_soup.dart';
 import 'package:angular2/di.dart' show Injectable;
 import 'package:angular2/src/facade/lang.dart' show CONST;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_processor/custom_metadata/expected/split_pea_soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/custom_metadata/expected/split_pea_soup.ng_deps.dart
@@ -4,7 +4,7 @@ import 'split_pea_soup.dart';
 import 'package:angular2/di.dart' show Injectable;
 import 'package:angular2/src/facade/lang.dart' show CONST;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_processor/custom_metadata/expected/tortilla_soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/custom_metadata/expected/tortilla_soup.ng_deps.dart
@@ -4,7 +4,7 @@ import 'tortilla_soup.dart';
 import 'package:angular2/di.dart' show Injectable;
 import 'package:angular2/src/facade/lang.dart' show CONST;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/directive_processor/parameter_metadata/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/parameter_metadata/expected/soup.ng_deps.dart
@@ -3,7 +3,7 @@ library dinner.soup.ng_deps.dart;
 import 'soup.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/integration/list_of_types_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/list_of_types_files/expected/bar.ng_deps.dart
@@ -6,7 +6,7 @@ import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i0;
 import 'foo.dart';
 import 'foo.ng_deps.dart' as i1;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_deps.dart
@@ -4,7 +4,7 @@ import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i0;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
@@ -8,7 +8,7 @@ import 'index.ng_deps.dart' as ngStaticInit0;
 import 'bar.dart';
 import 'bar.ng_deps.dart' as i1;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/integration/synthetic_ctor_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/synthetic_ctor_files/expected/bar.ng_deps.dart
@@ -4,7 +4,7 @@ import 'bar.dart';
 import 'package:angular2/src/core/annotations/annotations.dart';
 import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i0;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
@@ -6,7 +6,7 @@ import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i0;
 import 'package:angular2/src/core/annotations/view.dart';
 import 'package:angular2/src/core/annotations/view.ng_deps.dart' as i1;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/integration/two_deps_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_deps_files/expected/bar.ng_deps.dart
@@ -6,7 +6,7 @@ import 'package:angular2/src/core/annotations/annotations.ng_deps.dart' as i0;
 import 'foo.dart' as prefix;
 import 'foo.ng_deps.dart' as i1;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/template_compiler/directive_metadata_files/compile_children.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/directive_metadata_files/compile_children.ng_deps.dart
@@ -3,7 +3,7 @@ library examples.hello_world.index_common_dart.ng_deps.dart;
 import 'hello.dart';
 import 'package:angular2/angular2.dart';
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/template_compiler/directive_metadata_files/host_listeners.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/directive_metadata_files/host_listeners.ng_deps.dart
@@ -4,7 +4,7 @@ import 'hello.dart';
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, View, NgElement;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/template_compiler/directive_metadata_files/properties.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/directive_metadata_files/properties.ng_deps.dart
@@ -4,7 +4,7 @@ import 'hello.dart';
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, View, NgElement;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/template_compiler/directive_metadata_files/selector.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/directive_metadata_files/selector.ng_deps.dart
@@ -4,7 +4,7 @@ import 'hello.dart';
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, View, NgElement;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/template_compiler/directive_metadata_files/too_many_directives.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/directive_metadata_files/too_many_directives.ng_deps.dart
@@ -4,7 +4,7 @@ import 'hello.dart';
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, View, NgElement;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/template_compiler/inline_expression_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_expression_files/expected/hello.ng_deps.dart
@@ -4,7 +4,7 @@ import 'hello.dart';
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, View, NgElement;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/template_compiler/inline_expression_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_expression_files/hello.ng_deps.dart
@@ -4,7 +4,7 @@ import 'hello.dart';
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, View, NgElement;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/template_compiler/inline_method_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_method_files/expected/hello.ng_deps.dart
@@ -4,7 +4,7 @@ import 'hello.dart';
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, View, NgElement;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/template_compiler/inline_method_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/inline_method_files/hello.ng_deps.dart
@@ -4,7 +4,7 @@ import 'hello.dart';
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, View, NgElement;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/template_compiler/url_expression_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/url_expression_files/expected/hello.ng_deps.dart
@@ -4,7 +4,7 @@ import 'hello.dart';
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, View, NgElement;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/template_compiler/url_expression_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/url_expression_files/hello.ng_deps.dart
@@ -4,7 +4,7 @@ import 'hello.dart';
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, View, NgElement;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/template_compiler/url_method_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/url_method_files/expected/hello.ng_deps.dart
@@ -4,7 +4,7 @@ import 'hello.dart';
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, View, NgElement;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;

--- a/modules/angular2/test/transform/template_compiler/url_method_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/url_method_files/hello.ng_deps.dart
@@ -4,7 +4,7 @@ import 'hello.dart';
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Decorator, View, NgElement;
 
-bool _visited = false;
+var _visited = false;
 void initReflector(reflector) {
   if (_visited) return;
   _visited = true;


### PR DESCRIPTION
If a source file hides `bool` (explicitly or implicitly via `show`), a
generated file using `bool` may not resolve.

Closes #1455
