### PR TITLE
Update README for linguistic consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Follow the instructions given on the [Angular download page][download].
 
 ## Want to help?
 
-Want to file a bug, or contribute some code or improve documentation?  Excellent! Read up on our
+Want to file a bug, contribute some code, or improve documentation? Excellent! Read up on our
 guidelines for [contributing][contributing].
 
 
@@ -29,11 +29,11 @@ To see the examples, first build the project as described
 
 ### Hello World Example
 
-This example consists of three basic pieces - a component, a decorator and a
+This example consists of three basic pieces - a component, a decorator, and a
 service.  They are all constructed via injection. For more information see the
 comments in the source `modules/examples/src/hello_world/index.js`.
 
-You can build this example as either JS or Dart app:
+You can build this example as either a JS or a Dart app:
 
 * JS:
   * `$(npm bin)/gulp build.js.dev`, and


### PR DESCRIPTION
Remove unnecessary 'or' from line 21

Line 36 should follow the same linguistic structure as line 32 as far as putting 'a' before each list item.
