### PR TITLE
chore(build): Add a tsconfig.json file

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.5.0",
+    "compilerOptions": {
+        "target": "es5",
+        "module": "commonjs",
+        "declaration": false,
+        "noImplicitAny": false,
+        "removeComments": true,
+        "noLib": false,
+        "outDir": "dist/js/cjs"
+    },
+    "filesGlob": [
+        "./**/*.ts",
+        "!./node_modules/**/*.ts"
+    ],
+}


### PR DESCRIPTION
This is simply to allow Atom editor's Typescript plugin to work without dropping tsconfig.json files and generated .js files in the
source directory.
