### PR TITLE
Fix(proto_change_detector): ensure that a dotted property is parsed correctly

### DIFF
--- a/modules/angular2/src/change_detection/proto_change_detector.js
+++ b/modules/angular2/src/change_detection/proto_change_detector.js
@@ -171,7 +171,7 @@ class _ConvertAstIntoProtoRecords {
     var receiver = ast.receiver.visit(this);
     if (isPresent(this.variableBindings) && 
         ListWrapper.contains(this.variableBindings, ast.name) && 
-        (this.bindingRecord.propertyName === null || this.bindingRecord.propertyName.indexOf('.') === -1)) {
+        ast.receiver instanceof ImplicitReceiver) {
       return this._addRecord(RECORD_TYPE_LOCAL, ast.name, ast.name, [], null, receiver);
     } else {
       return this._addRecord(RECORD_TYPE_PROPERTY, ast.name, ast.getter, [], null, receiver);

--- a/modules/angular2/src/change_detection/proto_change_detector.js
+++ b/modules/angular2/src/change_detection/proto_change_detector.js
@@ -171,7 +171,7 @@ class _ConvertAstIntoProtoRecords {
     var receiver = ast.receiver.visit(this);
     if (isPresent(this.variableBindings) && 
         ListWrapper.contains(this.variableBindings, ast.name) && 
-        (!this.bindingRecord.propertyName || this.bindingRecord.propertyName.indexOf('.') === -1)) {
+        (this.bindingRecord.propertyName === null || this.bindingRecord.propertyName.indexOf('.') === -1)) {
       return this._addRecord(RECORD_TYPE_LOCAL, ast.name, ast.name, [], null, receiver);
     } else {
       return this._addRecord(RECORD_TYPE_PROPERTY, ast.name, ast.getter, [], null, receiver);

--- a/modules/angular2/src/change_detection/proto_change_detector.js
+++ b/modules/angular2/src/change_detection/proto_change_detector.js
@@ -169,7 +169,9 @@ class _ConvertAstIntoProtoRecords {
 
   visitAccessMember(ast:AccessMember) {
     var receiver = ast.receiver.visit(this);
-    if (isPresent(this.variableBindings) && ListWrapper.contains(this.variableBindings, ast.name)) {
+    if (isPresent(this.variableBindings) && 
+        ListWrapper.contains(this.variableBindings, ast.name) && 
+        (!this.bindingRecord.propertyName || this.bindingRecord.propertyName.indexOf('.') === -1)) {
       return this._addRecord(RECORD_TYPE_LOCAL, ast.name, ast.name, [], null, receiver);
     } else {
       return this._addRecord(RECORD_TYPE_PROPERTY, ast.name, ast.getter, [], null, receiver);

--- a/modules/angular2/test/change_detection/change_detection_spec.js
+++ b/modules/angular2/test/change_detection/change_detection_spec.js
@@ -474,11 +474,11 @@ export function main() {
               var address = new Address('Grenoble');
               var person = new Person('Victor', address);
               var locals = new Locals(null,
-                  MapWrapper.createFromPairs([["city", "Paris"]]));
+                  MapWrapper.createFromPairs([['city', 'MTV']]));
               expect(executeWatch('address.city', 'address.city', person, locals))
                 .toEqual(['address.city=Grenoble']);
               expect(executeWatch('city', 'city', person, locals))
-                .toEqual(['city=Paris']);
+                .toEqual(['city=MTV']);
             });
 
           });

--- a/modules/angular2/test/change_detection/change_detection_spec.js
+++ b/modules/angular2/test/change_detection/change_detection_spec.js
@@ -469,6 +469,18 @@ export function main() {
               expect(executeWatch('name', 'name', new Person("Jim"), locals))
                 .toEqual(['name=Jim']);
             });
+
+            it('should correctly handle nested properties', () => {
+              var address = new Address('Grenoble');
+              var person = new Person('Victor', address);
+              var locals = new Locals(null,
+                  MapWrapper.createFromPairs([["city", "Paris"]]));
+              expect(executeWatch('address.city', 'address.city', person, locals))
+                .toEqual(['address.city=Grenoble']);
+              expect(executeWatch('city', 'city', person, locals))
+                .toEqual(['city=Paris']);
+            });
+
           });
 
           describe("handle children", () => {


### PR DESCRIPTION
Previously there was a conflict when the name of an object property (address.city)
was the same as the name of a local variable (city), and it evaluated to the local
variable. Now it detects if a property has a dot and returns the local variable
only if the dot is missing.

No breaking changes, fix issue #1542
