### PR TITLE
feat(dart/transform): Add DirectiveMetadata as/fromMap

### DIFF
--- a/modules/angular2/src/render/dom/convert.js
+++ b/modules/angular2/src/render/dom/convert.js
@@ -1,0 +1,47 @@
+import {ListWrapper, MapWrapper} from 'angular2/src/facade/collection';
+import {isPresent} from 'angular2/src/facade/lang';
+import {DirectiveMetadata} from 'angular2/src/render/api';
+
+/**
+ * Converts a [DirectiveMetadata] to a map representation. This creates a copy,
+ * that is, subsequent changes to `meta` will not be mirrored in the map.
+ */
+export function directiveMetadataToMap(meta: DirectiveMetadata): Map {
+  return MapWrapper.createFromPairs([
+    ['id', meta.id],
+    ['selector', meta.selector],
+    ['compileChildren', meta.compileChildren],
+    ['hostListeners', _cloneIfPresent(meta.hostListeners)],
+    ['hostProperties', _cloneIfPresent(meta.hostProperties)],
+    ['properties', _cloneIfPresent(meta.properties)],
+    ['readAttributes', _cloneIfPresent(meta.readAttributes)],
+    ['type', meta.type],
+    ['version', 1]
+  ]);
+}
+
+/**
+ * Converts a map representation of [DirectiveMetadata] into a
+ * [DirectiveMetadata] object. This creates a copy, that is, subsequent changes
+ * to `map` will not be mirrored in the [DirectiveMetadata] object.
+ */
+export function directiveMetadataFromMap(map: Map): DirectiveMetadata {
+  return new DirectiveMetadata({
+    id: MapWrapper.get(map, 'id'),
+    selector: MapWrapper.get(map, 'selector'),
+    compileChildren: MapWrapper.get(map, 'compileChildren'),
+    hostListeners: _cloneIfPresent(MapWrapper.get(map, 'hostListeners')),
+    hostProperties: _cloneIfPresent(MapWrapper.get(map, 'hostProperties')),
+    properties: _cloneIfPresent(MapWrapper.get(map, 'properties')),
+    readAttributes: _cloneIfPresent(MapWrapper.get(map, 'readAttributes')),
+    type: MapWrapper.get(map, 'type')
+  });
+}
+
+/**
+ * Clones the [List] or [Map] `o` if it is present.
+ */
+function _cloneIfPresent(o) {
+  if (!isPresent(o)) return null;
+  return ListWrapper.isList(o) ? ListWrapper.clone(o) : MapWrapper.clone(o);
+}

--- a/modules/angular2/test/render/dom/convert_spec.js
+++ b/modules/angular2/test/render/dom/convert_spec.js
@@ -1,0 +1,62 @@
+import {MapWrapper} from 'angular2/src/facade/collection';
+import {DirectiveMetadata} from 'angular2/src/render/api';
+import {directiveMetadataFromMap, directiveMetadataToMap} from
+    'angular2/src/render/dom/convert';
+import {describe, expect, it} from 'angular2/test_lib';
+
+export function main() {
+  describe('convert', () => {
+    it('directiveMetadataToMap', () => {
+      var someComponent = new DirectiveMetadata({
+        compileChildren: false,
+        hostListeners: MapWrapper.createFromPairs([['listenKey', 'listenVal']]),
+        hostProperties:
+            MapWrapper.createFromPairs([['hostPropKey', 'hostPropVal']]),
+        id: 'someComponent',
+        properties: MapWrapper.createFromPairs([['propKey', 'propVal']]),
+        readAttributes: ['read1', 'read2'],
+        selector: 'some-comp',
+        type: DirectiveMetadata.COMPONENT_TYPE
+      });
+      var map = directiveMetadataToMap(someComponent);
+      expect(MapWrapper.get(map, 'compileChildren')).toEqual(false);
+      expect(MapWrapper.get(map, 'hostListeners')).toEqual(
+          MapWrapper.createFromPairs([['listenKey', 'listenVal']]));
+      expect(MapWrapper.get(map, 'hostProperties')).toEqual(
+          MapWrapper.createFromPairs([['hostPropKey', 'hostPropVal']]));
+      expect(MapWrapper.get(map, 'id')).toEqual('someComponent');
+      expect(MapWrapper.get(map, 'properties')).toEqual(
+          MapWrapper.createFromPairs([['propKey', 'propVal']]));
+      expect(MapWrapper.get(map, 'readAttributes')).toEqual(['read1', 'read2']);
+      expect(MapWrapper.get(map, 'selector')).toEqual('some-comp');
+      expect(MapWrapper.get(map, 'type')).toEqual(
+          DirectiveMetadata.COMPONENT_TYPE);
+    });
+
+    it('mapToDirectiveMetadata', () => {
+      var map = MapWrapper.createFromPairs([
+        ['compileChildren', false],
+        ['hostListeners', MapWrapper.createFromPairs([['testKey', 'testVal']])],
+        ['hostProperties',
+            MapWrapper.createFromPairs([['hostPropKey', 'hostPropVal']])],
+        ['id', 'testId'],
+        ['properties', MapWrapper.createFromPairs([['propKey', 'propVal']])],
+        ['readAttributes', ['readTest1', 'readTest2']],
+        ['selector', 'testSelector'],
+        ['type', DirectiveMetadata.VIEWPORT_TYPE]
+      ]);
+      var meta = directiveMetadataFromMap(map);
+      expect(meta.compileChildren).toEqual(false);
+      expect(meta.hostListeners).toEqual(
+          MapWrapper.createFromPairs([['testKey', 'testVal']]));
+      expect(meta.hostProperties).toEqual(
+          MapWrapper.createFromPairs([['hostPropKey', 'hostPropVal']]));
+      expect(meta.id).toEqual('testId');
+      expect(meta.properties).toEqual(
+          MapWrapper.createFromPairs([['propKey', 'propVal']]));
+      expect(meta.readAttributes).toEqual(['readTest1', 'readTest2']);
+      expect(meta.selector).toEqual('testSelector');
+      expect(meta.type).toEqual(DirectiveMetadata.VIEWPORT_TYPE);
+    });
+  });
+}


### PR DESCRIPTION
Add utility methods to convert `render.dom.DirectiveMetadata` to and
from maps. This will allow saving and restoring `DirectiveMetadata` in
the Angular 2 Transformer.

We discussed adding this as a member on `DirectiveMetadata`. Since this
is not necessary for anything except the Transformer, we decided to put
it into a separate file to avoid shipping it with the Angular 2 core
code.
