### PR TITLE
chore(build): run forms tests in Node

### DIFF
--- a/modules/angular2/src/forms/directives.js
+++ b/modules/angular2/src/forms/directives.js
@@ -1,9 +1,11 @@
-import {View, Component, Decorator, Ancestor, onChange, ElementRef} from 'angular2/angular2';
+import {Decorator, onChange} from 'angular2/src/core/annotations/annotations';
+import {Ancestor} from 'angular2/src/core/annotations/visibility';
+import {ElementRef} from 'angular2/src/core/compiler/element_injector';
 import {Optional} from 'angular2/di';
 import {Renderer} from 'angular2/src/render/api';
-import {isBlank, isPresent, isString, CONST} from 'angular2/src/facade/lang';
-import {StringMapWrapper, ListWrapper} from 'angular2/src/facade/collection';
-import {ControlGroup, Control} from './model';
+import {isPresent, isString} from 'angular2/src/facade/lang';
+import {ListWrapper} from 'angular2/src/facade/collection';
+import {ControlGroup} from './model';
 import {Validators} from './validators';
 
 //export interface ControlValueAccessor {

--- a/modules/angular2/src/forms/validator_directives.js
+++ b/modules/angular2/src/forms/validator_directives.js
@@ -1,5 +1,4 @@
-import {Decorator} from 'angular2/angular2';
-
+import {Decorator} from 'angular2/src/core/annotations/annotations';
 import {Validators} from './validators';
 import {ControlDirective} from './directives';
 

--- a/tools/broccoli/trees/node_tree.ts
+++ b/tools/broccoli/trees/node_tree.ts
@@ -23,8 +23,7 @@ module.exports = function makeNodeTree(destinationPath) {
     exclude: [
       // the following code and tests are not compatible with CJS/node environment
       'angular2/src/core/zone/vm_turn_zone.es6',
-      'angular2/test/core/zone/**',
-      'angular2/test/forms/integration_spec.js'
+      'angular2/test/core/zone/**'
     ]
   });
 


### PR DESCRIPTION
It seems that the `import {...} from 'angular2/angular2';` are causing dependencies issues in Node.
