### PR TITLE
chore(build): update clang-format to 1.0.10

### DIFF
--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -3942,7 +3942,7 @@
           }
         },
         "clang-format": {
-          "version": "1.0.9"
+          "version": "1.0.10"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6085,9 +6085,9 @@
           }
         },
         "clang-format": {
-          "version": "1.0.9",
-          "from": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.9.tgz",
-          "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.9.tgz"
+          "version": "1.0.10",
+          "from": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.10.tgz"
         }
       }
     },


### PR DESCRIPTION
Fixes JS build failure on Windows
