### PR TITLE
fix(build): use correct tsd command to get typings at requested versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/angular/angular.git"
   },
   "scripts": {
-    "postinstall": "webdriver-manager update && bower install && gulp pubget.dart && tsd update --config modules/angular2/tsd.json && tsd update --config tools/tsd.json",
+    "postinstall": "webdriver-manager update && bower install && gulp pubget.dart && tsd reinstall --config modules/angular2/tsd.json && tsd reinstall --config tools/tsd.json",
     "test": "gulp test.all.js && gulp test.all.dart"
   },
   "dependencies": {


### PR DESCRIPTION
From tsd docs:

Reinstall definitions

Reset the definitions to the commits listed in tsd.json:

$ tsd reinstall --save --overwrite
$ tsd reinstall -s -o
$ tsd reinstall -so
Update all definitions

Update everything in tsd.json to head version in the repository:

$ tsd update --save --overwrite
$ tsd update -s -o
$ tsd update -so
