### PR TITLE
fix(compiler): clone templates before compiling them

### DIFF
--- a/modules/angular2/src/render/dom/compiler/template_loader.js
+++ b/modules/angular2/src/render/dom/compiler/template_loader.js
@@ -39,7 +39,9 @@ export class TemplateLoader {
         StringMapWrapper.set(this._htmlCache, url, promise);
       }
 
-      return promise;
+      // We need to clone the result as others might change it
+      // (e.g. the compiler).
+      return promise.then( (tplElement) => DOM.clone(tplElement) );
     }
 
     throw new BaseException('View should have either the url or template property set');

--- a/modules/angular2/test/render/dom/compiler/template_loader_spec.js
+++ b/modules/angular2/test/render/dom/compiler/template_loader_spec.js
@@ -45,17 +45,19 @@ export function main() {
       xhr.flush();
     }));
 
-    it('should cache template loaded through XHR', inject([AsyncTestCompleter], (async) => {
+    it('should cache template loaded through XHR but clone it as the compiler might change it', inject([AsyncTestCompleter], (async) => {
       var firstEl;
+      // we have only one xhr.expect, so there can only be one xhr call!
       xhr.expect('base/foo', 'xhr template');
       var template = new ViewDefinition({absUrl: 'base/foo'});
       loader.load(template)
         .then((el) => {
+          expect(DOM.content(el)).toHaveText('xhr template');
           firstEl = el;
           return loader.load(template);
         })
         .then((el) =>{
-          expect(el).toBe(firstEl);
+          expect(el).not.toBe(firstEl);
           expect(DOM.content(el)).toHaveText('xhr template');
           async.done();
         });


### PR DESCRIPTION
This is needed as the compiler changes templates during compilation
and we are caching templates in the `TemplateLoader`.

Closes #1058
