### PR TITLE
fixed markdown headings levels for Router docs

### DIFF
--- a/docs/angular.io-package/services/renderMarkdown.js
+++ b/docs/angular.io-package/services/renderMarkdown.js
@@ -11,9 +11,11 @@ var encoder = new Encoder('entity');
 
 /**
  * @dgService renderMarkdown
+ *
  * @description
  * Render the markdown in the given string as HTML.
  */
+
 module.exports = function renderMarkdown(trimIndentation) {
 
   var renderer = new marked.Renderer();
@@ -30,9 +32,7 @@ module.exports = function renderMarkdown(trimIndentation) {
       cssClasses.push(this.options.langPrefix + escape(lang, true));
     }
 
-    return 'pre(class="' + cssClasses.join(' ') + '")\n'
-            + indentString('code.\n', ' ', 2)
-            + trimmedCode;
+    return 'pre(class="' + cssClasses.join(' ') + '")\n' + indentString('code.\n', ' ', 2) + trimmedCode;
   };
 
   renderer.heading = function (text, level, raw) {

--- a/docs/angular.io-package/templates/class.template.html
+++ b/docs/angular.io-package/templates/class.template.html
@@ -38,7 +38,7 @@ p.location-badge.
         {$ member.name $}{$ paramList(member.params) | indent(4, true) | trim $}
     {% endif %}
     :markdown
-}
+
 {$ member.description | indent(6, true) | replace('## Example', '') | replace('# Example', '')  $}
 
 

--- a/modules/angular2/src/core/compiler/view_container_ref.js
+++ b/modules/angular2/src/core/compiler/view_container_ref.js
@@ -7,6 +7,9 @@ import * as avmModule from './view_manager';
 import {ElementRef} from './element_ref';
 import {ViewRef, ProtoViewRef, internalView} from './view_ref';
 
+/**
+ * @exportedAs angular2/core
+ */
 export class ViewContainerRef {
   _viewManager: avmModule.AppViewManager;
   _element: ElementRef;

--- a/modules/angular2/src/router/router.js
+++ b/modules/angular2/src/router/router.js
@@ -8,7 +8,7 @@ import {Instruction} from './instruction';
 import {RouterOutlet} from './router_outlet';
 
 /**
- * # Router
+ * ## Router
  * The router is responsible for mapping URLs to components.
  *
  * You can see the state of the router by inspecting the read-only field `router.navigating`.
@@ -65,7 +65,7 @@ export class Router {
   /**
    * Update the routing configuration and trigger a navigation.
    *
-   * # Usage
+   * ### Usage
    *
    * ```
    * router.config('/', SomeCmp);


### PR DESCRIPTION
@naomiblack please review and merge. Thanks. Fixes the large generated headings on the API router page:

issue: https://github.com/angular/angular.io/issues/55
