### PR TITLE
docs(di/injector): Fix documentation for toFactory and toAsyncFactory

### DIFF
--- a/modules/angular2/src/di/binding.js
+++ b/modules/angular2/src/di/binding.js
@@ -414,7 +414,7 @@ export class BindingBuilder {
    * ```javascript
    * var injector = Injector.resolveAndCreate([
    *   bind(Number).toFactory(() => { return 1+2; }}),
-   *   bind(String).toFactory((v) => { return "Value: " + v; }, [String] })
+   *   bind(String).toFactory((v) => { return "Value: " + v; }, [Number] })
    * ]);
    *
    * expect(injector.get(Number)).toEqual(3);
@@ -438,7 +438,7 @@ export class BindingBuilder {
    *   bind(Number).toAsyncFactory(() => {
    *     return new Promise((resolve) => resolve(1 + 2));
    *   }),
-   *   bind(String).toFactory((v) => { return "Value: " + v; }, [String])
+   *   bind(String).toFactory((v) => { return "Value: " + v; }, [Number])
    * ]);
    *
    * injector.asyncGet(Number).then((v) => expect(v).toBe(3));


### PR DESCRIPTION
The bound String classes should have a dependency on Number, not String.
