### PR TITLE
chore(build): fix gulp-modify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fs-extra": "^0.18.0",
     "googleapis": "1.0.x",
     "gulp-insert": "^0.4.0",
-    "gulp-modify": "0.0.4",
+    "gulp-modify": "0.1.1",
     "gulp-replace": "^0.5.3",
     "node-uuid": "1.4.x",
     "rx": "2.5.1",


### PR DESCRIPTION
I couldn't do a clean build of the last master because `gulp-modify` does not exist in `0.0.4` version anymore : 

```
npm ERR! Valid install targets:
npm ERR! notarget ["0.0.1","0.0.2","0.0.3","0.0.5","0.1.0","0.1.1"]
```

Bumping the version to the latest release fixes the problem.
