### PR TITLE
chore(build): make karma watch broccoli output for dart unit tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -321,31 +321,39 @@ function getBrowsersFromCLI() {
   return [args.browsers?args.browsers:'DartiumWithWebPlatform']
 }
 
-gulp.task('test.unit.js', ['build/clean.js'], function (neverDone) {
+gulp.task('test.unit.js', ['build/clean.js', 'broccoli.js.dev'], function (neverDone) {
 
   function buildAndTest() {
     runSequence(
       'broccoli.js.dev',
-      'test.unit.dev/karma-run'
+      'test.unit.js/karma-run'
     );
   }
 
   karma.server.start({configFile: __dirname + '/karma-js.conf.js'});
-  buildAndTest();
 
-  gulp.watch('modules/**', function() {
-    console.log('args', arguments);
-    buildAndTest();
-  });
+  gulp.watch('modules/**', buildAndTest);
 });
 
-gulp.task('test.unit.dev/karma-run', function(done) {
+gulp.task('test.unit.js/karma-run', function (done) {
   karma.runner.run({configFile: __dirname + '/karma-js.conf.js'}, done);
 });
 
+gulp.task('test.unit.dart', ['build/tree.dart'], function (done) {
+  function buildAndTest() {
+    runSequence(
+      'build/tree.dart',
+      'test.unit.dart/karma-run'
+    );
+  }
 
-gulp.task('test.unit.dart', function (done) {
-  karma.server.start({configFile: __dirname + '/karma-dart.conf.js'}, done);
+  karma.server.start({configFile: __dirname + '/karma-dart.conf.js'});
+
+  gulp.watch('modules/angular2/**', buildAndTest);
+});
+
+gulp.task('test.unit.dart/karma-run', function (done) {
+  karma.runner.run({configFile: __dirname + '/karma-dart.conf.js'}, done);
 });
 
 gulp.task('test.unit.js/ci', function (done) {
@@ -355,7 +363,7 @@ gulp.task('test.unit.js/ci', function (done) {
 
 gulp.task('test.unit.dart/ci', function (done) {
   karma.server.start({configFile: __dirname + '/karma-dart.conf.js',
-      singleRun: true, reporters: ['dots'], browsers: getBrowsersFromCLI()}, done);
+    singleRun: true, reporters: ['dots'], browsers: getBrowsersFromCLI()}, done);
 });
 
 

--- a/karma-dart.conf.js
+++ b/karma-dart.conf.js
@@ -11,14 +11,11 @@ module.exports = function(config) {
       // Init and configure guiness.
       {pattern: 'test-init.dart', included: true},
       // Unit test files needs to be included.
-      // Karma-dart generates `__adapter_unittest.dart` that imports these files.
-      {pattern: 'modules/*/test/**/*_spec.js', included: true},
-      {pattern: 'modules/*/test/**/*_spec.dart', included: true},
-      {pattern: 'tools/transpiler/spec/**/*_spec.js', included: true},
+      {pattern: 'dist/dart/**/*_spec.dart', included: true, watched: false},
 
-      // These files are not included, they are imported by the unit tests above.
-      {pattern: 'modules/**', included: false},
-      {pattern: 'tools/transpiler/spec/**/*', included: false},
+      // Karma-dart via the dart-unittest framework generates
+      // `__adapter_unittest.dart` that imports these files.
+      {pattern: 'dist/dart/**', included: false, watched: false},
 
       // Dependencies, installed with `pub install`.
       {pattern: 'packages/**/*.dart', included: false, watched: false},
@@ -27,49 +24,29 @@ module.exports = function(config) {
       {pattern: 'test-main.dart', included: true}
     ],
 
+    exclude: [
+      'dist/dart/**/packages/**',
+    ],
+
     karmaDartImports: {
       guinness: 'package:guinness/guinness_html.dart'
     },
 
-    // TODO(vojta): Remove the localhost:9877 from urls, once the proxy fix is merged:
-    // https://github.com/karma-runner/karma/pull/1207
-    //
     // Map packages to the correct urls where Karma serves them.
     proxies: {
       // Dependencies installed with `pub install`.
-      '/packages/unittest': 'http://localhost:9877/base/packages/unittest',
-      '/packages/guinness': 'http://localhost:9877/base/packages/guinness',
-      '/packages/matcher': 'http://localhost:9877/base/packages/matcher',
-      '/packages/stack_trace': 'http://localhost:9877/base/packages/stack_trace',
-      '/packages/collection': 'http://localhost:9877/base/packages/collection',
-      '/packages/path': 'http://localhost:9877/base/packages/path',
+      '/packages/unittest': '/base/packages/unittest',
+      '/packages/guinness': '/base/packages/guinness',
+      '/packages/matcher': '/base/packages/matcher',
+      '/packages/stack_trace': '/base/packages/stack_trace',
+      '/packages/collection': '/base/packages/collection',
+      '/packages/path': '/base/packages/path',
 
       // Local dependencies, transpiled from the source.
-      '/packages/angular': 'http://localhost:9877/base/modules/angular',
-      '/packages/benchpress': 'http://localhost:9877/base/modules/benchpress',
-      '/packages/core': 'http://localhost:9877/base/modules/core',
-      '/packages/change_detection': 'http://localhost:9877/base/modules/change_detection',
-      '/packages/reflection': 'http://localhost:9877/base/modules/reflection',
-      '/packages/router': 'http://localhost:9877/base/modules/router',
-      '/packages/di': 'http://localhost:9877/base/modules/di',
-      '/packages/directives': 'http://localhost:9877/base/modules/directives',
-      '/packages/facade': 'http://localhost:9877/base/modules/facade',
-      '/packages/forms': 'http://localhost:9877/base/modules/forms',
-      '/packages/test_lib': 'http://localhost:9877/base/modules/test_lib',
-      '/packages/mock': 'http://localhost:9877/base/modules/mock',
-    },
-
-    preprocessors: {
-      'modules/**/*.js': ['ts2dart'],
-      'modules/angular2/src/reflection/reflector.ts': ['ts2dart'],
-      'tools/**/*.js': ['ts2dart']
-    },
-
-    ts2dartPreprocessor: {
-      resolveModuleName: file2moduleName,
-      transformPath: function(fileName) {
-        return fileName.replace(/\.(js|ts)$/, '.dart');
-      }
+      '/packages/angular2': '/base/dist/dart/angular2/lib',
+      '/packages/angular2_material': '/base/dist/dart/angular2_material/lib',
+      '/packages/benchpress': '/base/dist/dart/benchpress/lib',
+      '/packages/examples': '/base/dist/dart/examples/lib'
     },
 
     customLaunchers: {
@@ -81,7 +58,4 @@ module.exports = function(config) {
 
     port: 9877
   });
-
-
-  config.plugins.push(require('./tools/transpiler/karma-ts2dart-preprocessor'));
 };

--- a/tools/broccoli/trees/dart_tree.ts
+++ b/tools/broccoli/trees/dart_tree.ts
@@ -144,5 +144,10 @@ module.exports = function makeDartTree(destinationPath) {
 
   var dartTree = mergeTrees([sourceTree, getTemplatedPubspecsTree(), getDocsTree()]);
 
+  // TODO(iminar): tree differ seems to have issues with trees created by mergeTrees, investigate!
+  //   ENOENT error is thrown while doing fs.readdirSync on inputRoot
+  //   in the meantime, we just do noop mv to create a new tree
+  dartTree = stew.mv(dartTree, '');
+
   return destCopy(dartTree, destinationPath);
 };


### PR DESCRIPTION
Previously, karma used a custom preprocessor. Instead, have karma
run built dart from the `dist` folder and use gulp and broccoli
to watch for changes.
