### PR TITLE
chore: update pubspec files

### DIFF
--- a/modules/angular2/pubspec.yaml
+++ b/modules/angular2/pubspec.yaml
@@ -7,9 +7,9 @@ authors:
 description: Angular 2 for Dart - a web framework for modern web apps
 homepage: <%= packageJson.homepage %>
 environment:
-  sdk: '>=1.9.0-dev.8.0'
+  sdk: '>=1.10.0 <2.0.0'
 dependencies:
-  analyzer: '^0.24.4'
+  analyzer: '>=0.24.4 <0.26.0'
   barback: '^0.15.2+2'
   code_transformers: '^0.2.8'
   dart_style: '^0.1.3'

--- a/modules/angular2_material/pubspec.yaml
+++ b/modules/angular2_material/pubspec.yaml
@@ -7,10 +7,10 @@ authors:
 description: Google material design components for Angular 2
 homepage: <%= packageJson.homepage %>
 environment:
-  sdk: '>=1.9.0-dev.8.0'
+  sdk: '>=1.10.0 <2.0.0'
 dependencies:
   angular2: '^<%= packageJson.version %>'
-  browser: '>=0.10.0 <0.11.0'
+  browser: '^0.10.0'
 dependency_overrides:
   angular2:
     path: ../angular2

--- a/modules/benchmarks/pubspec.yaml
+++ b/modules/benchmarks/pubspec.yaml
@@ -7,10 +7,10 @@ authors:
 description: Angular2 benchmarks
 homepage: <%= packageJson.homepage %>
 environment:
-  sdk: '>=1.9.0-dev.8.0'
+  sdk: '>=1.10.0 <2.0.0'
 dependencies:
   angular2: '^<%= packageJson.version %>'
-  browser: '>=0.10.0 <0.11.0'
+  browser: '^0.10.0'
 dependency_overrides:
   angular2:
     path: ../angular2

--- a/modules/benchpress/pubspec.yaml
+++ b/modules/benchpress/pubspec.yaml
@@ -7,13 +7,13 @@ authors:
 description: Benchpress - a framework for e2e performance tests
 homepage: <%= packageJson.homepage %>
 environment:
-  sdk: '>=1.9.0-dev.8.0'
+  sdk: '>=1.10.0 <2.0.0'
 dependencies:
   stack_trace: '^1.1.1'
   angular2: '^<%= packageJson.version %>'
   webdriver: '^0.9.0'
+dev_dependencies:
+  guinness: '^0.1.17'
 dependency_overrides:
   angular2:
     path: ../angular2
-dev_dependencies:
-  guinness: '^0.1.17'

--- a/modules/examples/pubspec.yaml
+++ b/modules/examples/pubspec.yaml
@@ -1,19 +1,19 @@
 name: examples
 environment:
-  sdk: '>=1.4.0'
+  sdk: '>=1.10.0 <2.0.0'
 dependencies:
   angular2: '^<%= packageJson.version %>'
   angular2_material: '^<%= packageJson.version %>'
-  browser: '>=0.10.0 <0.11.0'
+  browser: '^0.10.0'
+dev_dependencies:
+  guinness: '^0.1.17'
+  benchpress:
+    path: ../benchpress
 dependency_overrides:
   angular2:
     path: ../angular2
   angular2_material:
     path: ../angular2_material
-dev_dependencies:
-  guinness: ">=0.1.17 <0.2.0"
-  benchpress:
-    path: ../benchpress
 transformers:
 - angular2:
     entry_points:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,6 @@
 name: angular
 environment:
   sdk: '>=1.9.0 <2.0.0'
-dependencies:
-  stack_trace: '^1.1.1'
 dev_dependencies:
   guinness: '^0.1.17'
+  unittest: '^0.11.5+4'


### PR DESCRIPTION
Allow latest analyzer version
Add an upper constraint to the Dart SDK
