### PR TITLE
chore(build): update to TypeScript @head

### DIFF
--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -8716,7 +8716,7 @@
       }
     },
     "ts2dart": {
-      "version": "0.4.2",
+      "version": "0.4.8",
       "dependencies": {
         "source-map": {
           "version": "0.4.2",
@@ -9508,8 +9508,8 @@
       }
     },
     "typescript": {
-      "version": "1.5.0",
-      "resolved": "git://github.com/alexeagle/TypeScript#5d006dcd185eec3fa919c8670fbaa451d7912f66"
+      "version": "1.5.0-beta",
+      "resolved": "git://github.com/alexeagle/TypeScript#cddc1867c44b6bed9095dc30f0b0f552cbc003a9"
     },
     "vinyl": {
       "version": "0.4.6",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13451,9 +13451,9 @@
       }
     },
     "ts2dart": {
-      "version": "0.4.2",
-      "from": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.4.2.tgz",
-      "resolved": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.4.2.tgz",
+      "version": "0.4.8",
+      "from": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.4.8.tgz",
+      "resolved": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.4.8.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.4.2",
@@ -14693,9 +14693,9 @@
       }
     },
     "typescript": {
-      "version": "1.5.0",
+      "version": "1.5.0-beta",
       "from": "git://github.com/alexeagle/TypeScript#error_is_class",
-      "resolved": "git://github.com/alexeagle/TypeScript#5d006dcd185eec3fa919c8670fbaa451d7912f66"
+      "resolved": "git://github.com/alexeagle/TypeScript#cddc1867c44b6bed9095dc30f0b0f552cbc003a9"
     },
     "vinyl": {
       "version": "0.4.6",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "temp": "^0.8.1",
     "ternary-stream": "^1.2.3",
     "through2": "^0.6.1",
-    "ts2dart": "^0.4.2",
+    "ts2dart": "^0.4.8",
     "tsd": "^0.5.7",
     "typescript": "alexeagle/TypeScript#error_is_class",
     "vinyl": "^0.4.6",


### PR DESCRIPTION
We need to pick up some bugfixes for decorator emit. This still has our patch to make Error a class.
