### PR TITLE
chore: support last dev build of Dart at 1.10.0-dev.1.10

### DIFF
--- a/modules/angular2/pubspec.yaml
+++ b/modules/angular2/pubspec.yaml
@@ -7,7 +7,7 @@ authors:
 description: Angular 2 for Dart - a web framework for modern web apps
 homepage: <%= packageJson.homepage %>
 environment:
-  sdk: '>=1.10.0 <2.0.0'
+  sdk: '>=1.10.0-dev.1.10 <2.0.0'
 dependencies:
   analyzer: '>=0.24.4 <0.26.0'
   barback: '^0.15.2+2'

--- a/modules/angular2_material/pubspec.yaml
+++ b/modules/angular2_material/pubspec.yaml
@@ -7,7 +7,7 @@ authors:
 description: Google material design components for Angular 2
 homepage: <%= packageJson.homepage %>
 environment:
-  sdk: '>=1.10.0 <2.0.0'
+  sdk: '>=1.10.0-dev.1.10 <2.0.0'
 dependencies:
   angular2: '^<%= packageJson.version %>'
   browser: '^0.10.0'

--- a/modules/benchmarks/pubspec.yaml
+++ b/modules/benchmarks/pubspec.yaml
@@ -7,7 +7,7 @@ authors:
 description: Angular2 benchmarks
 homepage: <%= packageJson.homepage %>
 environment:
-  sdk: '>=1.10.0 <2.0.0'
+  sdk: '>=1.10.0-dev.1.10 <2.0.0'
 dependencies:
   angular2: '^<%= packageJson.version %>'
   browser: '^0.10.0'

--- a/modules/benchpress/pubspec.yaml
+++ b/modules/benchpress/pubspec.yaml
@@ -7,7 +7,7 @@ authors:
 description: Benchpress - a framework for e2e performance tests
 homepage: <%= packageJson.homepage %>
 environment:
-  sdk: '>=1.10.0 <2.0.0'
+  sdk: '>=1.10.0-dev.1.10 <2.0.0'
 dependencies:
   stack_trace: '^1.1.1'
   angular2: '^<%= packageJson.version %>'

--- a/modules/examples/pubspec.yaml
+++ b/modules/examples/pubspec.yaml
@@ -1,6 +1,6 @@
 name: examples
 environment:
-  sdk: '>=1.10.0 <2.0.0'
+  sdk: '>=1.10.0-dev.1.10 <2.0.0'
 dependencies:
   angular2: '^<%= packageJson.version %>'
   angular2_material: '^<%= packageJson.version %>'


### PR DESCRIPTION
Can revert once 1.11 is available
