### PR TITLE
fix(docs): fix broken docs test after addition of .ts extension to dgeni

### DIFF
--- a/docs/dgeni-package/readers/atScript.spec.js
+++ b/docs/dgeni-package/readers/atScript.spec.js
@@ -33,7 +33,7 @@ describe('atScript file reader', function() {
 
 
   it('should provide a default pattern', function() {
-    expect(reader.defaultPattern).toEqual(/\.js|\.es6$/);
+    expect(reader.defaultPattern).toEqual(/\.js|\.es6|\.ts$/);
   });
 
 


### PR DESCRIPTION
regex.

Fixing test that wasn't updated after @petebacondarwin's change e30ad2ec2c7cf75c3bfc8823a305c967a1a507a4 earlier today.
