### PR TITLE
feat(dart/transform): Use the render Compiler and the DirectiveParser

### DIFF
--- a/modules/angular2/src/dom/html_adapter.dart
+++ b/modules/angular2/src/dom/html_adapter.dart
@@ -83,7 +83,16 @@ class Html5LibDomAdapter implements DomAdapter {
     throw 'not implemented';
   }
   String nodeName(node) {
-    throw 'not implemented';
+    switch (node.nodeType) {
+      case Node.ELEMENT_NODE:
+        return (node as Element).localName;
+      case Node.TEXT_NODE:
+        return '#text';
+      default:
+        throw 'not implemented for type ${node.nodeType}. '
+            'See http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-1950641247'
+            ' for node types definitions.';
+    }
   }
   String nodeValue(node) => node.data;
   String type(node) {
@@ -179,9 +188,8 @@ class Html5LibDomAdapter implements DomAdapter {
   getElementsByTagName(element, String name) {
     throw 'not implemented';
   }
-  List classList(element) {
-    throw 'not implemented';
-  }
+  List classList(element) => element.classes.toList();
+
   addClass(element, String classname) {
     element.classes.add(classname);
   }

--- a/modules/angular2/src/transform/common/directive_metadata_reader.dart
+++ b/modules/angular2/src/transform/common/directive_metadata_reader.dart
@@ -47,6 +47,7 @@ class _DirectiveMetadataVisitor extends Object
           properties: {},
           hostListeners: {},
           hostProperties: {},
+          hostAttributes: {},
           readAttributes: []);
       super.visitInstanceCreationExpression(node);
     }
@@ -79,6 +80,9 @@ class _DirectiveMetadataVisitor extends Object
         break;
       case 'hostProperties':
         _populateHostProperties(node.expression);
+        break;
+      case 'hostAttributes':
+        _populateHostAttributes(node.expression);
         break;
       case 'hostListeners':
         _populateHostListeners(node.expression);
@@ -153,6 +157,22 @@ class _DirectiveMetadataVisitor extends Object
       var sVal =
           _expressionToString(entry.value, 'Directive#hostProperties values');
       meta.hostProperties[sKey] = sVal;
+    }
+  }
+
+  void _populateHostAttributes(Expression hostAttributeValue) {
+    if (hostAttributeValue is! MapLiteral) {
+      logger.error('Angular 2 currently only supports map literal values for '
+          'Directive#hostAttributes.'
+          ' Source: ${hostAttributeValue}');
+      return;
+    }
+    for (MapLiteralEntry entry in (hostAttributeValue as MapLiteral).entries) {
+      var sKey =
+          _expressionToString(entry.key, 'Directive#hostAttributes keys');
+      var sVal =
+          _expressionToString(entry.value, 'Directive#hostAttributes values');
+      meta.hostAttributes[sKey] = sVal;
     }
   }
 }

--- a/modules/angular2/src/transform/common/directive_metadata_reader.dart
+++ b/modules/angular2/src/transform/common/directive_metadata_reader.dart
@@ -9,6 +9,9 @@ import 'parser.dart';
 DirectiveMetadata readDirectiveMetadata(RegisteredType t) {
   var visitor = new _DirectiveMetadataVisitor();
   t.annotations.accept(visitor);
+  if (visitor.meta != null) {
+    visitor.meta.id = '${t.typeName}';
+  }
   return visitor.meta;
 }
 

--- a/modules/angular2/src/transform/common/parser.dart
+++ b/modules/angular2/src/transform/common/parser.dart
@@ -68,13 +68,20 @@ class NgDeps {
   final List<ImportDirective> imports = [];
   final List<ExportDirective> exports = [];
   final List<RegisteredType> registeredTypes = [];
-  FunctionDeclaration setupMethod;
+  LibraryDirective lib = null;
+  FunctionDeclaration setupMethod = null;
 
   NgDeps(this.code);
 }
 
 class _ParseNgDepsVisitor extends Object with RecursiveAstVisitor<Object> {
   NgDeps ngDeps = null;
+
+  @override
+  Object visitLibraryDirective(LibraryDirective node) {
+    ngDeps.lib = node;
+    return null;
+  }
 
   @override
   Object visitImportDirective(ImportDirective node) {

--- a/modules/angular2/src/transform/directive_metadata_extractor/transformer.dart
+++ b/modules/angular2/src/transform/directive_metadata_extractor/transformer.dart
@@ -16,6 +16,8 @@ import 'extractor.dart';
 /// These files contain commented Json-formatted representations of all
 /// `Directive`s in the associated file.
 class DirectiveMetadataExtractor extends Transformer {
+  final _encoder = const JsonEncoder.withIndent('  ');
+
   DirectiveMetadataExtractor();
 
   @override
@@ -36,7 +38,7 @@ class DirectiveMetadataExtractor extends Transformer {
           jsonMap[k] = directiveMetadataToMap(v);
         });
         transform.addOutput(new Asset.fromString(
-            _outputAssetId(fromAssetId), JSON.encode(jsonMap)));
+            _outputAssetId(fromAssetId), _encoder.convert(jsonMap)));
       }
     } catch (ex, stackTrace) {
       log.logger.error('Extracting ng metadata failed.\n'

--- a/modules/angular2/src/transform/template_compiler/compile_step_factory.dart
+++ b/modules/angular2/src/transform/template_compiler/compile_step_factory.dart
@@ -6,6 +6,7 @@ import 'package:angular2/src/render/api.dart';
 import 'package:angular2/src/render/dom/compiler/compile_step.dart';
 import 'package:angular2/src/render/dom/compiler/compile_step_factory.dart'
     as base;
+import 'package:angular2/src/render/dom/compiler/directive_parser.dart';
 import 'package:angular2/src/render/dom/compiler/property_binding_parser.dart';
 import 'package:angular2/src/render/dom/compiler/text_interpolation_parser.dart';
 import 'package:angular2/src/render/dom/compiler/view_splitter.dart';
@@ -20,6 +21,7 @@ class CompileStepFactory implements base.CompileStepFactory {
     return [
       new ViewSplitter(_parser),
       new PropertyBindingParser(_parser),
+      new DirectiveParser(_parser, template.directives),
       new TextInterpolationParser(_parser)
     ];
   }

--- a/modules/angular2/src/transform/template_compiler/view_definition_creator.dart
+++ b/modules/angular2/src/transform/template_compiler/view_definition_creator.dart
@@ -1,0 +1,232 @@
+library angular2.transform.template_compiler.view_definition_creator;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:analyzer/analyzer.dart';
+import 'package:angular2/src/render/api.dart';
+import 'package:angular2/src/render/dom/convert.dart';
+import 'package:angular2/src/transform/common/asset_reader.dart';
+import 'package:angular2/src/transform/common/logging.dart';
+import 'package:angular2/src/transform/common/names.dart';
+import 'package:angular2/src/transform/common/parser.dart';
+import 'package:barback/barback.dart';
+import 'package:code_transformers/assets.dart';
+
+/// Creates [ViewDefinition] objects for all `View` `Directive`s defined in
+/// `entryPoint`.
+Future<ViewDefinitionResults> createViewDefinitions(
+    AssetReader reader, AssetId entryPoint) async {
+  return await new _ViewDefinitionCreator(reader, entryPoint).createViewDefs();
+}
+
+class ViewDefinitionResults {
+  final NgDeps ngDeps;
+  final Map<RegisteredType, ViewDefinition> viewDefinitions;
+  ViewDefinitionResults._(this.ngDeps, this.viewDefinitions);
+}
+
+String _getComponentId(AssetId assetId, String className) =>
+    '$assetId:$className';
+
+/// Creates [ViewDefinition] objects for all `View` `Directive`s defined in
+/// `entryPoint`.
+class _ViewDefinitionCreator {
+  final AssetReader reader;
+  final AssetId entryPoint;
+  final Future<NgDeps> ngDepsFuture;
+
+  _ViewDefinitionCreator(AssetReader reader, AssetId entryPoint)
+      : this.reader = reader,
+        this.entryPoint = entryPoint,
+        ngDepsFuture = new Parser(reader).parse(entryPoint);
+
+  Future<ViewDefinitionResults> createViewDefs() async {
+    var ngDeps = await ngDepsFuture;
+
+    var retVal = <RegisteredType, ViewDefinition>{};
+    var visitor = new _TemplateExtractVisitor(await _createMetadataMap());
+    ngDeps.registeredTypes.forEach((rType) {
+      visitor.reset();
+      rType.annotations.accept(visitor);
+      if (visitor.viewDef != null) {
+        var typeName = '${rType.typeName}';
+        if (visitor._metadataMap.containsKey(typeName)) {
+          visitor.viewDef.componentId = visitor._metadataMap[typeName].id;
+        } else {
+          logger.warning('Missing component "$typeName" in metadata map',
+              asset: entryPoint);
+          visitor.viewDef.componentId = _getComponentId(entryPoint, typeName);
+        }
+        retVal[rType] = visitor.viewDef;
+      }
+    });
+    return new ViewDefinitionResults._(ngDeps, retVal);
+  }
+
+  /// Creates a map from [AssetId] to import prefix for `.dart` libraries
+  /// imported by `entryPoint`, excluding any `.ng_deps.dart` files it imports.
+  /// Unprefixed imports have `null` as their value. `entryPoint` is included
+  /// in the map with no prefix.
+  Future<Map<AssetId, String>> _createImportAssetToPrefixMap() async {
+    // TODO(kegluneq): Support `part` directives.
+    var ngDeps = await ngDepsFuture;
+
+    var importAssetToPrefix = <AssetId, String>{};
+    // Include the `.ng_meta.dart` file associated with `entryPoint`.
+    importAssetToPrefix[new AssetId(
+        entryPoint.package, toMetaExtension(entryPoint.path))] = null;
+
+    for (ImportDirective node in ngDeps.imports) {
+      var uri = stringLiteralToString(node.uri);
+      if (uri.endsWith('.dart') && !uri.endsWith(DEPS_EXTENSION)) {
+        var prefix = node.prefix != null && node.prefix.name != null
+            ? '${node.prefix.name}'
+            : null;
+        importAssetToPrefix[
+            uriToAssetId(entryPoint, uri, logger, null /* span */)] = prefix;
+      }
+    }
+    return importAssetToPrefix;
+  }
+
+  /// Reads the `.ng_meta.json` files associated with all of `entryPoint`'s
+  /// imports and creates a map `Type` name, prefixed if appropriate to the
+  /// associated [DirectiveMetadata].
+  ///
+  /// For example, if in `entryPoint` we have:
+  ///
+  /// ```
+  /// import 'component.dart' as prefix;
+  /// ```
+  ///
+  /// and in 'component.dart' we have:
+  ///
+  /// ```
+  /// @Component(...)
+  /// class MyComponent {...}
+  /// ```
+  ///
+  /// This method will look for `component.ng_meta.json`to contain the
+  /// serialized [DirectiveMetadata] `MyComponent` and any other `Directive`s
+  /// declared in `component.dart`. We use this information to build a map:
+  ///
+  /// ```
+  /// {
+  ///   "prefix.MyComponent": [DirectiveMetadata for MyComponent],
+  ///   ...<any other entries>...
+  /// }
+  /// ```
+  Future<Map<String, DirectiveMetadata>> _createMetadataMap() async {
+    var importAssetToPrefix = await _createImportAssetToPrefixMap();
+
+    var retVal = <String, DirectiveMetadata>{};
+    for (var importAssetId in importAssetToPrefix.keys) {
+      var metaAssetId = new AssetId(
+          importAssetId.package, toMetaExtension(importAssetId.path));
+      if (await reader.hasInput(metaAssetId)) {
+        try {
+          var json = await reader.readAsString(metaAssetId);
+          var jsonMap = JSON.decode(json);
+          jsonMap.forEach((className, metaDataMap) {
+            var prefixStr = importAssetToPrefix[importAssetId];
+            var key = prefixStr != null ? '$prefixStr.$className' : className;
+            var value = directiveMetadataFromMap(metaDataMap)
+              ..id = _getComponentId(importAssetId, className);
+            retVal[key] = value;
+          });
+        } catch (ex, stackTrace) {
+          logger.warning('Failed to decode: $ex, $stackTrace',
+              asset: metaAssetId);
+        }
+      }
+    }
+    return retVal;
+  }
+}
+
+/// Visitor responsible for processing the `annotations` property of a
+/// {@link RegisterType} object and pulling out [ViewDefinition] information.
+class _TemplateExtractVisitor extends Object with RecursiveAstVisitor<Object> {
+  ViewDefinition viewDef = null;
+  final Map<String, DirectiveMetadata> _metadataMap;
+
+  _TemplateExtractVisitor(this._metadataMap);
+
+  void reset() {
+    viewDef = null;
+  }
+
+  /// These correspond to the annotations themselves.
+  @override
+  Object visitInstanceCreationExpression(InstanceCreationExpression node) {
+    if ('${node.constructorName.type}' == 'View') {
+      viewDef = new ViewDefinition(directives: <DirectiveMetadata>[]);
+      node.visitChildren(this);
+    }
+    return null;
+  }
+
+  /// These correspond to the annotation parameters.
+  @override
+  Object visitNamedExpression(NamedExpression node) {
+    // TODO(kegluneq): Remove this limitation.
+    if (node.name is! Label || node.name.label is! SimpleIdentifier) {
+      logger.error(
+          'Angular 2 currently only supports simple identifiers in directives.'
+          ' Source: ${node}');
+      return null;
+    }
+    var keyString = '${node.name.label}';
+    if (keyString == 'directives') {
+      _readDirectives(node.expression);
+    }
+    if (keyString == 'template' || keyString == 'templateUrl') {
+      if (node.expression is! SimpleStringLiteral) {
+        logger.error(
+            'Angular 2 currently only supports string literals in directives.'
+            ' Source: ${node}');
+        return null;
+      }
+      var valueString = stringLiteralToString(node.expression);
+      if (keyString == 'templateUrl') {
+        if (viewDef.absUrl != null) {
+          logger.error(
+              'Found multiple values for "templateUrl". Source: ${node}');
+        }
+        viewDef.absUrl = valueString;
+      } else {
+        // keyString == 'template'
+        if (viewDef.template != null) {
+          logger.error('Found multiple values for "template". Source: ${node}');
+        }
+        viewDef.template = valueString;
+      }
+    }
+    return null;
+  }
+
+  void _readDirectives(Expression node) {
+    if (node is! ListLiteral) {
+      logger.error(
+          'Angular 2 currently only supports list literals as values for'
+          ' "directives". Source: $node');
+      return;
+    }
+    var directiveList = (node as ListLiteral);
+    for (var node in directiveList.elements) {
+      if (node is! SimpleIdentifier && node is! PrefixedIdentifier) {
+        logger.error(
+            'Angular 2 currently only supports simple and prefixed identifiers '
+            'as values for "directives". Source: $node');
+        return;
+      }
+      var name = '$node';
+      if (_metadataMap.containsKey(name)) {
+        viewDef.directives.add(_metadataMap[name]);
+      } else {
+        logger.warning('Could not find Directive entry for $name');
+      }
+    }
+  }
+}

--- a/modules/angular2/src/transform/template_compiler/view_definition_creator.dart
+++ b/modules/angular2/src/transform/template_compiler/view_definition_creator.dart
@@ -29,6 +29,10 @@ class ViewDefinitionResults {
 String _getComponentId(AssetId assetId, String className) =>
     '$assetId:$className';
 
+// TODO(kegluenq): Improve this test.
+bool _isViewAnnotation(InstanceCreationExpression node) =>
+    '${node.constructorName.type}' == 'View';
+
 /// Creates [ViewDefinition] objects for all `View` `Directive`s defined in
 /// `entryPoint`.
 class _ViewDefinitionCreator {
@@ -147,7 +151,7 @@ class _ViewDefinitionCreator {
 }
 
 /// Visitor responsible for processing the `annotations` property of a
-/// {@link RegisterType} object and pulling out [ViewDefinition] information.
+/// [RegisterType] object and pulling out [ViewDefinition] information.
 class _TemplateExtractVisitor extends Object with RecursiveAstVisitor<Object> {
   ViewDefinition viewDef = null;
   final Map<String, DirectiveMetadata> _metadataMap;
@@ -161,7 +165,7 @@ class _TemplateExtractVisitor extends Object with RecursiveAstVisitor<Object> {
   /// These correspond to the annotations themselves.
   @override
   Object visitInstanceCreationExpression(InstanceCreationExpression node) {
-    if ('${node.constructorName.type}' == 'View') {
+    if (_isViewAnnotation(node)) {
       viewDef = new ViewDefinition(directives: <DirectiveMetadata>[]);
       node.visitChildren(this);
     }
@@ -183,6 +187,10 @@ class _TemplateExtractVisitor extends Object with RecursiveAstVisitor<Object> {
       _readDirectives(node.expression);
     }
     if (keyString == 'template' || keyString == 'templateUrl') {
+      // This could happen in a non-View annotation with a `template` or
+      // `templateUrl` property.
+      if (viewDef == null) return null;
+
       if (node.expression is! SimpleStringLiteral) {
         logger.error(
             'Angular 2 currently only supports string literals in directives.'
@@ -208,6 +216,10 @@ class _TemplateExtractVisitor extends Object with RecursiveAstVisitor<Object> {
   }
 
   void _readDirectives(Expression node) {
+    // This could happen in a non-View annotation with a `directives`
+    // parameter.
+    if (viewDef == null) return;
+
     if (node is! ListLiteral) {
       logger.error(
           'Angular 2 currently only supports list literals as values for'

--- a/modules/angular2/src/transform/template_compiler/view_definition_creator.dart
+++ b/modules/angular2/src/transform/template_compiler/view_definition_creator.dart
@@ -108,8 +108,9 @@ class _ViewDefinitionCreator {
   /// ```
   ///
   /// This method will look for `component.ng_meta.json`to contain the
-  /// serialized [DirectiveMetadata] `MyComponent` and any other `Directive`s
-  /// declared in `component.dart`. We use this information to build a map:
+  /// serialized [DirectiveMetadata] for `MyComponent` and any other
+  /// `Directive`s declared in `component.dart`. We use this information to
+  /// build a map:
   ///
   /// ```
   /// {

--- a/modules/angular2/test/transform/integration/all_tests.dart
+++ b/modules/angular2/test/transform/integration/all_tests.dart
@@ -57,6 +57,8 @@ void allTests() {
         outputs: {
       'a|web/bar.ng_deps.dart':
           'simple_annotation_files/expected/bar.ng_deps.dart',
+      'a|web/bar.ng_meta.json':
+          'simple_annotation_files/expected/bar.ng_meta.json',
       'a|web/index.ng_deps.dart':
           'simple_annotation_files/expected/index.ng_deps.dart'
     }),

--- a/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_meta.json
+++ b/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_meta.json
@@ -1,0 +1,1 @@
+{"MyComponent":{"id":"MyComponent","selector":"[soup]","compileChildren":true,"hostListeners":{},"hostProperties":{},"properties":{},"readAttributes":[],"type":1,"version":1}}

--- a/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_meta.json
+++ b/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_meta.json
@@ -1,1 +1,14 @@
-{"MyComponent":{"id":"MyComponent","selector":"[soup]","compileChildren":true,"hostListeners":{},"hostProperties":{},"hostAttributes":{},"properties":{},"readAttributes":[],"type":1,"version":1}}
+{
+  "MyComponent": {
+    "id": "MyComponent",
+    "selector": "[soup]",
+    "compileChildren": true,
+    "hostListeners": {},
+    "hostProperties": {},
+    "hostAttributes": {},
+    "properties": {},
+    "readAttributes": [],
+    "type": 1,
+    "version": 1
+  }
+}

--- a/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_meta.json
+++ b/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_meta.json
@@ -1,1 +1,1 @@
-{"MyComponent":{"id":"MyComponent","selector":"[soup]","compileChildren":true,"hostListeners":{},"hostProperties":{},"properties":{},"readAttributes":[],"type":1,"version":1}}
+{"MyComponent":{"id":"MyComponent","selector":"[soup]","compileChildren":true,"hostListeners":{},"hostProperties":{},"hostAttributes":{},"properties":{},"readAttributes":[],"type":1,"version":1}}

--- a/modules/angular2/test/transform/template_compiler/all_tests.dart
+++ b/modules/angular2/test/transform/template_compiler/all_tests.dart
@@ -58,6 +58,32 @@ void allTests() {
     var output = await processTemplates(reader, new AssetId('a', inputPath));
     _formatThenExpectEquals(output, expected);
   });
+
+  it('should parse `View` directives with a single dependency.', () async {
+    var inputPath = 'template_compiler/one_directive_files/hello.ng_deps.dart';
+    var expected = readFile(
+        'template_compiler/one_directive_files/expected/hello.ng_deps.dart');
+
+    var output = await processTemplates(reader, new AssetId('a', inputPath));
+    _formatThenExpectEquals(output, expected);
+  });
+
+  it('should parse `View` directives with a single prefixed dependency.',
+      () async {
+    var inputPath = 'template_compiler/with_prefix_files/hello.ng_deps.dart';
+    var expected = readFile(
+        'template_compiler/with_prefix_files/expected/hello.ng_deps.dart');
+
+    var output = await processTemplates(reader, new AssetId('a', inputPath));
+    _formatThenExpectEquals(output, expected);
+
+    inputPath = 'template_compiler/with_prefix_files/goodbye.ng_deps.dart';
+    expected = readFile(
+        'template_compiler/with_prefix_files/expected/goodbye.ng_deps.dart');
+
+    output = await processTemplates(reader, new AssetId('a', inputPath));
+    _formatThenExpectEquals(output, expected);
+  });
 }
 
 void _formatThenExpectEquals(String actual, String expected) {

--- a/modules/angular2/test/transform/template_compiler/duplicate_files/hello.ng_meta.json
+++ b/modules/angular2/test/transform/template_compiler/duplicate_files/hello.ng_meta.json
@@ -1,0 +1,14 @@
+{
+  "HelloCmp":
+  {
+    "id":"HelloCmp",
+    "selector":"hello-app",
+    "compileChildren":true,
+    "hostListeners":{},
+    "hostProperties":{},
+    "properties":{},
+    "readAttributes":[],
+    "type":1,
+    "version":1
+  }
+}

--- a/modules/angular2/test/transform/template_compiler/inline_expression_files/hello.ng_meta.json
+++ b/modules/angular2/test/transform/template_compiler/inline_expression_files/hello.ng_meta.json
@@ -1,0 +1,14 @@
+{
+  "HelloCmp":
+  {
+    "id":"HelloCmp",
+    "selector":"hello-app",
+    "compileChildren":true,
+    "hostListeners":{},
+    "hostProperties":{},
+    "properties":{},
+    "readAttributes":[],
+    "type":1,
+    "version":1
+  }
+}

--- a/modules/angular2/test/transform/template_compiler/inline_method_files/hello.ng_meta.json
+++ b/modules/angular2/test/transform/template_compiler/inline_method_files/hello.ng_meta.json
@@ -1,0 +1,14 @@
+{
+  "HelloCmp":
+  {
+    "id":"HelloCmp",
+    "selector":"hello-app",
+    "compileChildren":true,
+    "hostListeners":{},
+    "hostProperties":{},
+    "properties":{},
+    "readAttributes":[],
+    "type":1,
+    "version":1
+  }
+}

--- a/modules/angular2/test/transform/template_compiler/one_directive_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/one_directive_files/expected/hello.ng_deps.dart
@@ -1,0 +1,28 @@
+library examples.hello_world.index_common_dart.ng_deps.dart;
+
+import 'hello.dart';
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Directive, View, NgElement;
+
+var _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(HelloCmp, {
+      'factory': () => new HelloCmp(),
+      'parameters': const [const []],
+      'annotations': const [
+        const Component(selector: 'hello-app'),
+        const View(template: 'goodbye-app', directives: const [GoodbyeCmp])
+      ]
+    })
+    ..registerType(GoodbyeCmp, {
+      'factory': () => new GoodbyeCmp(),
+      'parameters': const [const []],
+      'annotations': const [
+        const Component(selector: 'goodbye-app'),
+        const View(template: 'Goodbye')
+      ]
+    });
+}

--- a/modules/angular2/test/transform/template_compiler/one_directive_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/one_directive_files/hello.ng_deps.dart
@@ -1,0 +1,28 @@
+library examples.hello_world.index_common_dart.ng_deps.dart;
+
+import 'hello.dart';
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Directive, View, NgElement;
+
+var _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(HelloCmp, {
+      'factory': () => new HelloCmp(),
+      'parameters': const [const []],
+      'annotations': const [
+        const Component(selector: 'hello-app'),
+        const View(template: 'goodbye-app', directives: const [GoodbyeCmp])
+      ]
+    })
+    ..registerType(GoodbyeCmp, {
+      'factory': () => new GoodbyeCmp(),
+      'parameters': const [const []],
+      'annotations': const [
+        const Component(selector: 'goodbye-app'),
+        const View(template: 'Goodbye')
+      ]
+    });
+}

--- a/modules/angular2/test/transform/template_compiler/one_directive_files/hello.ng_meta.json
+++ b/modules/angular2/test/transform/template_compiler/one_directive_files/hello.ng_meta.json
@@ -1,0 +1,25 @@
+{
+  "HelloCmp":
+  {
+    "id":"HelloCmp",
+    "selector":"hello-app",
+    "compileChildren":true,
+    "hostListeners":{},
+    "hostProperties":{},
+    "properties":{},
+    "readAttributes":[],
+    "type":1,
+    "version":1
+  },
+  "GoodbyeCmp":{
+    "id":"GoodbyeCmp",
+    "selector":"goodbye-app",
+    "compileChildren":true,
+    "hostListeners":{},
+    "hostProperties":{},
+    "properties":{},
+    "readAttributes":[],
+    "type":1,
+    "version":1
+  }
+}

--- a/modules/angular2/test/transform/template_compiler/url_expression_files/hello.ng_meta.json
+++ b/modules/angular2/test/transform/template_compiler/url_expression_files/hello.ng_meta.json
@@ -1,0 +1,14 @@
+{
+  "HelloCmp":
+  {
+    "id":"HelloCmp",
+    "selector":"hello-app",
+    "compileChildren":true,
+    "hostListeners":{},
+    "hostProperties":{},
+    "properties":{},
+    "readAttributes":[],
+    "type":1,
+    "version":1
+  }
+}

--- a/modules/angular2/test/transform/template_compiler/url_method_files/hello.ng_meta.json
+++ b/modules/angular2/test/transform/template_compiler/url_method_files/hello.ng_meta.json
@@ -1,0 +1,14 @@
+{
+  "HelloCmp":
+  {
+    "id":"HelloCmp",
+    "selector":"hello-app",
+    "compileChildren":true,
+    "hostListeners":{},
+    "hostProperties":{},
+    "properties":{},
+    "readAttributes":[],
+    "type":1,
+    "version":1
+  }
+}

--- a/modules/angular2/test/transform/template_compiler/with_prefix_files/expected/goodbye.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/with_prefix_files/expected/goodbye.ng_deps.dart
@@ -1,0 +1,22 @@
+library examples.hello_world.index_common_dart.ng_deps.dart;
+
+import 'goodbye.dart';
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Directive, View, NgElement;
+
+var _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(GoodbyeCmp, {
+      'factory': () => new GoodbyeCmp(),
+      'parameters': const [const []],
+      'annotations': const [
+        const Component(selector: 'goodbye-app'),
+        const View(template: 'Goodbye {{name}}')
+      ]
+    })
+    ..registerGetters({'name': (o) => o.name})
+    ..registerSetters({'name': (o, v) => o.name = v});
+}

--- a/modules/angular2/test/transform/template_compiler/with_prefix_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/with_prefix_files/expected/hello.ng_deps.dart
@@ -1,0 +1,24 @@
+library examples.hello_world.index_common_dart.ng_deps.dart;
+
+import 'hello.dart';
+import 'goodbye.dart' as prefix;
+import 'goodbye.ng_deps.dart' as i0;
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Directive, View, NgElement;
+
+var _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(HelloCmp, {
+      'factory': () => new HelloCmp(),
+      'parameters': const [const []],
+      'annotations': const [
+        const Component(selector: 'hello-app'),
+        const View(
+            template: 'goodbye-app', directives: const [prefix.GoodbyeCmp])
+      ]
+    });
+  i0.initReflector(reflector);
+}

--- a/modules/angular2/test/transform/template_compiler/with_prefix_files/goodbye.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/with_prefix_files/goodbye.ng_deps.dart
@@ -1,0 +1,20 @@
+library examples.hello_world.index_common_dart.ng_deps.dart;
+
+import 'goodbye.dart';
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Directive, View, NgElement;
+
+var _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(GoodbyeCmp, {
+      'factory': () => new GoodbyeCmp(),
+      'parameters': const [const []],
+      'annotations': const [
+        const Component(selector: 'goodbye-app'),
+        const View(template: 'Goodbye {{name}}')
+      ]
+    });
+}

--- a/modules/angular2/test/transform/template_compiler/with_prefix_files/goodbye.ng_meta.json
+++ b/modules/angular2/test/transform/template_compiler/with_prefix_files/goodbye.ng_meta.json
@@ -1,0 +1,13 @@
+{
+  "GoodbyeCmp":{
+    "id":"GoodbyeCmp",
+    "selector":"goodbye-app",
+    "compileChildren":true,
+    "hostListeners":{},
+    "hostProperties":{},
+    "properties":{},
+    "readAttributes":[],
+    "type":1,
+    "version":1
+  }
+}

--- a/modules/angular2/test/transform/template_compiler/with_prefix_files/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/template_compiler/with_prefix_files/hello.ng_deps.dart
@@ -1,0 +1,24 @@
+library examples.hello_world.index_common_dart.ng_deps.dart;
+
+import 'hello.dart';
+import 'goodbye.dart' as prefix;
+import 'goodbye.ng_deps.dart' as i0;
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Directive, View, NgElement;
+
+var _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(HelloCmp, {
+      'factory': () => new HelloCmp(),
+      'parameters': const [const []],
+      'annotations': const [
+        const Component(selector: 'hello-app'),
+        const View(
+            template: 'goodbye-app', directives: const [prefix.GoodbyeCmp])
+      ]
+    });
+  i0.initReflector(reflector);
+}

--- a/modules/angular2/test/transform/template_compiler/with_prefix_files/hello.ng_meta.json
+++ b/modules/angular2/test/transform/template_compiler/with_prefix_files/hello.ng_meta.json
@@ -1,0 +1,14 @@
+{
+  "HelloCmp":
+  {
+    "id":"HelloCmp",
+    "selector":"hello-app",
+    "compileChildren":true,
+    "hostListeners":{},
+    "hostProperties":{},
+    "properties":{},
+    "readAttributes":[],
+    "type":1,
+    "version":1
+  }
+}

--- a/tools/broccoli/trees/dart_tree.ts
+++ b/tools/broccoli/trees/dart_tree.ts
@@ -46,7 +46,7 @@ function getSourceTree() {
   var tsInputTree = modulesFunnel(['**/*.js', '**/*.ts', '**/*.dart'], ['rtts_assert/**/*']);
   var transpiled = ts2dart.transpile(tsInputTree);
   // Native sources, dart only examples, etc.
-  var dartSrcs = modulesFunnel(['**/*.dart']);
+  var dartSrcs = modulesFunnel(['**/*.dart', '**/*.ng_meta.json']);
   return mergeTrees([transpiled, dartSrcs]);
 }
 


### PR DESCRIPTION
Update the `TemplateCompile` step to use the full render `Compiler`.

Provide `DirectiveMetadata` for `ViewDefinition` objects and use it to
run the `DirectiveParser` step of the render compile pipeline.
