### PR TITLE
fix(build): build the broccoli tools with correct typescript version.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -550,13 +550,16 @@ gulp.task('build.tools', ['build/clean.tools'], function(done) {
 // private task to build tools
 gulp.task('!build.tools', function() {
   var tsResult = gulp.src(['tools/**/*.ts'])
-                     .pipe(sourcemaps.init())
-                     .pipe(tsc({target: 'ES5', module: 'commonjs', reporter: tsc.reporter.nullReporter()}))
-                     .on('error', function(error) {
-                        // gulp-typescript doesn't propagate errors from the src stream into the js stream so we are
-                        // forwarding the error into the merged stream
-                        mergedStream.emit('error', error);
-                     });
+      .pipe(sourcemaps.init())
+      .pipe(tsc({target: 'ES5', module: 'commonjs', reporter: tsc.reporter.nullReporter(),
+                 // Don't use the version of typescript that gulp-typescript depends on, we need 1.5
+                 // see https://github.com/ivogabe/gulp-typescript#typescript-version
+                 typescript: require('typescript')}))
+      .on('error', function(error) {
+        // gulp-typescript doesn't propagate errors from the src stream into the js stream so we are
+        // forwarding the error into the merged stream
+        mergedStream.emit('error', error);
+      });
 
   var destDir = gulp.dest('dist/tools/');
 


### PR DESCRIPTION
By default, gulp-typescript currently depends on typescript 1.4, which doesn't work for us.
For example, it doesn't allow `let` when emitting ES5, along with lots of other errors.
It so happens that npm sometimes makes this work, as seen by the warning
`npm WARN unmet dependency /Users/alexeagle/Projects/angular/node_modules/gulp-typescript requires typescript@'1.4.1' but will load
npm WARN unmet dependency /Users/alexeagle/Projects/angular/node_modules/typescript,
npm WARN unmet dependency which is version 1.5.0`
but when we update our node_modules in a certain way, we lose this setup and it breaks.

We should be explicit about using a different version of typescript than gulp-typescript depends on.
