### PR TITLE
fix(change_detection): updated checkNoChange not to break next runs

### DIFF
--- a/modules/angular2/test/change_detection/change_detection_spec.js
+++ b/modules/angular2/test/change_detection/change_detection_spec.js
@@ -420,6 +420,22 @@ export function main() {
                 cd.checkNoChanges();
               }).toThrowError(new RegExp("Expression 'a in location' has changed after it was checked"));
             });
+
+            it("should not break the next run", () => {
+              var pcd = createProtoChangeDetector([
+                BindingRecord.createForElement(ast("a"), 0, "a")
+              ]);
+
+              var dispatcher = new TestDispatcher();
+              var cd = pcd.instantiate(dispatcher);
+              cd.hydrate(new TestData('value'), null, null);
+
+              expect(() => cd.checkNoChanges()).toThrow();
+
+              cd.detectChanges();
+
+              expect(dispatcher.loggedValues).toEqual(['value']);
+            });
           });
 
           //TODO vsavkin: implement it


### PR DESCRIPTION
checkNoChange currently mutates the state of the detector that it cannot be rerun. It should not matter that much in production, cause your app is broken. But it is inconvenient in tests.
