### PR TITLE
fix(location): dartium does not like pushState with null.

### DIFF
--- a/modules/angular2/src/router/location.js
+++ b/modules/angular2/src/router/location.js
@@ -36,7 +36,7 @@ export class Location {
 
   go(url:string) {
     url = this._stripBaseHref(url);
-    this._browserLocation.pushState(null, null, url);
+    this._browserLocation.pushState(null, '', url);
   }
 
   forward() {

--- a/modules/angular2/test/router/location_spec.js
+++ b/modules/angular2/test/router/location_spec.js
@@ -27,14 +27,14 @@ export function main() {
 
     it('should normalize urls on navigate', () => {
       location.go('/my/app/user/btford');
-      expect(browserLocation.spy('pushState')).toHaveBeenCalledWith(null, null, '/user/btford');
+      expect(browserLocation.spy('pushState')).toHaveBeenCalledWith(null, '', '/user/btford');
     });
 
     it('should remove index.html from base href', () => {
       browserLocation.baseHref = '/my/app/index.html';
       location = new Location(browserLocation);
       location.go('/my/app/user/btford');
-      expect(browserLocation.spy('pushState')).toHaveBeenCalledWith(null, null, '/user/btford');
+      expect(browserLocation.spy('pushState')).toHaveBeenCalledWith(null, '', '/user/btford');
     });
 
     it('should normalize urls on popstate', inject([AsyncTestCompleter], (async) => {


### PR DESCRIPTION
According to
https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history
the value of the title parameter is irrelevant anyways.
