### PR TITLE
docs(promise_pipe.ts): correct "async" pipe

### DIFF
--- a/modules/angular2/src/change_detection/pipes/promise_pipe.ts
+++ b/modules/angular2/src/change_detection/pipes/promise_pipe.ts
@@ -23,7 +23,7 @@ export var __esModule = true;
  *   changeDetection: ON_PUSH
  * })
  * @View({
- *  inline: "Task Description {{description|promise}}"
+ *  inline: "Task Description {{description|async}}"
  * })
  * class Task {
  *  description:Promise<string>;


### PR DESCRIPTION
the syntax is now combined with `|async` rather than separate `|promise`
