### PR TITLE
[WIP] chore(build): remove mirrors related warnings that clutter the log

### DIFF
--- a/modules/angular2/pubspec.yaml
+++ b/modules/angular2/pubspec.yaml
@@ -24,3 +24,4 @@ transformers:
 - $dart2js:
     commandLineOptions:
     - --show-package-warnings
+    - --enable-experimental-mirrors

--- a/modules/benchmarks/pubspec.yaml
+++ b/modules/benchmarks/pubspec.yaml
@@ -31,3 +31,4 @@ transformers:
     - --trust-type-annotations
     - --trust-primitives
     - --show-package-warnings
+    - --enable-experimental-mirrors

--- a/modules/examples/pubspec.yaml
+++ b/modules/examples/pubspec.yaml
@@ -29,3 +29,4 @@ transformers:
     - --show-package-warnings
     - --trust-type-annotations
     - --trust-primitives
+    - --enable-experimental-mirrors


### PR DESCRIPTION
**Edit: This is not done yet, there are still some warnings, I'll take a look later on**

We use mirrors and that's fine for now.

Remove unnecessary warnings to highlight the legit ones.

Some of them sounds like they should be fixed ?

/cc @yjbanov @kegluneq  
