### PR TITLE
feat: allow for forward references in injection

### DIFF
--- a/modules/angular2/angular2.js
+++ b/modules/angular2/angular2.js
@@ -3,6 +3,7 @@ export * from './core';
 export * from './annotations';
 export * from './directives';
 export * from './forms';
+export * from './di';
 export {Observable, EventEmitter} from 'angular2/src/facade/async';
 export * from 'angular2/src/render/api';
 export {DomRenderer, DOCUMENT_TOKEN} from 'angular2/src/render/dom/dom_renderer';

--- a/modules/angular2/di.ts
+++ b/modules/angular2/di.ts
@@ -7,6 +7,7 @@
 
 export * from './src/di/annotations';
 export * from './src/di/decorators';
+export * from './src/di/forward_ref';
 export {Injector} from './src/di/injector';
 export {Binding, ResolvedBinding, Dependency, bind} from './src/di/binding';
 export {Key, KeyRegistry, TypeLiteral} from './src/di/key';

--- a/modules/angular2/src/core/compiler/compiler.js
+++ b/modules/angular2/src/core/compiler/compiler.js
@@ -1,4 +1,4 @@
-import {Binding} from 'angular2/di';
+import {Binding, resolveForwardRef} from 'angular2/di';
 import {Injectable} from 'angular2/src/di/annotations_impl';
 import {Type, isBlank, isPresent, BaseException, normalizeBlank, stringify} from 'angular2/src/facade/lang';
 import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
@@ -237,7 +237,7 @@ export class Compiler {
 
   _flattenList(tree:List<any>, out:List<any> /*<Type|Binding>*/):void {
     for (var i = 0; i < tree.length; i++) {
-      var item = tree[i];
+      var item = resolveForwardRef(tree[i]);
       if (ListWrapper.isList(item)) {
         this._flattenList(item, out);
       } else {

--- a/modules/angular2/src/core/compiler/directive_resolver.js
+++ b/modules/angular2/src/core/compiler/directive_resolver.js
@@ -1,4 +1,5 @@
 import {Injectable} from 'angular2/src/di/annotations_impl';
+import {resolveForwardRef} from 'angular2/di';
 import {Type, isPresent, BaseException, stringify} from 'angular2/src/facade/lang';
 import {Directive} from '../annotations_impl/annotations';
 import {reflector} from 'angular2/src/reflection/reflection';
@@ -6,7 +7,7 @@ import {reflector} from 'angular2/src/reflection/reflection';
 @Injectable()
 export class DirectiveResolver {
   resolve(type:Type):Directive {
-    var annotations = reflector.annotations(type);
+    var annotations = reflector.annotations(resolveForwardRef(type));
     if (isPresent(annotations)) {
       for (var i=0; i<annotations.length; i++) {
         var annotation = annotations[i];

--- a/modules/angular2/src/core/compiler/element_injector.js
+++ b/modules/angular2/src/core/compiler/element_injector.js
@@ -3,7 +3,7 @@ import {EventEmitter, ObservableWrapper} from 'angular2/src/facade/async';
 import {Math} from 'angular2/src/facade/math';
 import {List, ListWrapper, MapWrapper, StringMapWrapper} from 'angular2/src/facade/collection';
 import {Injector, Key, Dependency, bind, Binding, ResolvedBinding, NoBindingError,
-  AbstractBindingError, CyclicDependencyError} from 'angular2/di';
+  AbstractBindingError, CyclicDependencyError, resolveForwardRef} from 'angular2/di';
 import {Parent, Ancestor} from 'angular2/src/core/annotations_impl/visibility';
 import {Attribute, Query} from 'angular2/src/core/annotations_impl/di';
 import * as viewModule from './view';
@@ -220,7 +220,7 @@ export class DirectiveDependency extends Dependency {
 
   static _query(properties) {
     var p = ListWrapper.find(properties, (p) => p instanceof Query);
-    return isPresent(p) ? p.directive : null;
+    return isPresent(p) ? resolveForwardRef(p.directive) : null;
   }
 }
 

--- a/modules/angular2/src/di/forward_ref.dart
+++ b/modules/angular2/src/di/forward_ref.dart
@@ -1,0 +1,17 @@
+library angular2.di.forward_ref;
+
+typedef Type ForwardRefFn();
+
+/**
+ * Dart does not have the forward ref problem, so this function is a noop.
+ */
+forwardRef(ForwardRefFn forwardRefFn) => forwardRefFn();
+
+/**
+ * Lazily retrieve the reference value.
+ *
+ * See: {@link forwardRef}
+ *
+ * @exportedAs angular2/di
+ */
+resolveForwardRef(type) => type;

--- a/modules/angular2/src/di/forward_ref.ts
+++ b/modules/angular2/src/di/forward_ref.ts
@@ -1,0 +1,50 @@
+import {Type} from 'angular2/src/facade/lang';
+
+export interface ForwardRefFn { (): Type; }
+
+/**
+ * Allows to refer to references which are not yet defined.
+ *
+ * This situation arises when the key which we need te refer to for the purposes of DI is declared,
+ * but not yet defined.
+ *
+ * ## Example:
+ *
+ * ```
+ * class Door {
+ *   // Incorrect way to refer to a reference which is defined later.
+ *   // This fails because `Lock` is undefined at this point.
+ *   constructor(lock:Lock) { }
+ *
+ *   // Correct way to refer to a reference which is defined later.
+ *   // The reference needs to be captured in a closure.
+ *   constructor(@Inject(forwardRef(() => Lock)) lock:Lock) { }
+ * }
+ *
+ * // Only at this point the lock is defined.
+ * class Lock {
+ * }
+ * ```
+ *
+ * @exportedAs angular2/di
+ */
+export function forwardRef(forwardRefFn: ForwardRefFn): Type {
+  (<any>forwardRefFn).__forward_ref__ = forwardRef;
+  return (<Type><any>forwardRefFn);
+}
+
+/**
+ * Lazily retrieve the reference value.
+ *
+ * See: {@link forwardRef}
+ *
+ * @exportedAs angular2/di
+ */
+export function resolveForwardRef(type: any): any {
+  if (typeof type == 'function' && type.hasOwnProperty('__forward_ref__') &&
+      type.__forward_ref__ === forwardRef) {
+    return (<ForwardRefFn>type)();
+  } else {
+    return type;
+  }
+}

--- a/modules/angular2/src/di/injector.ts
+++ b/modules/angular2/src/di/injector.ts
@@ -13,6 +13,7 @@ import {
 import {FunctionWrapper, Type, isPresent, isBlank} from 'angular2/src/facade/lang';
 import {PromiseWrapper, Promise} from 'angular2/src/facade/async';
 import {Key} from './key';
+import {resolveForwardRef} from './forward_ref';
 
 var _constructing = new Object();
 var _notFound = new Object();
@@ -370,7 +371,7 @@ class _AsyncInjectorStrategy {
 function _resolveBindings(bindings: List<any>): List<ResolvedBinding> {
   var resolvedList = ListWrapper.createFixedSize(bindings.length);
   for (var i = 0; i < bindings.length; i++) {
-    var unresolved = bindings[i];
+    var unresolved = resolveForwardRef(bindings[i]);
     var resolved;
     if (unresolved instanceof ResolvedBinding) {
       resolved = unresolved;  // ha-ha! I'm easily amused

--- a/modules/angular2/src/di/key.ts
+++ b/modules/angular2/src/di/key.ts
@@ -1,5 +1,5 @@
 import {MapWrapper} from 'angular2/src/facade/collection';
-import {stringify, CONST, Type} from 'angular2/src/facade/lang';
+import {stringify, CONST, Type, isBlank, BaseException} from 'angular2/src/facade/lang';
 import {TypeLiteral} from './type_literal';
 
 export {TypeLiteral} from './type_literal';
@@ -26,6 +26,9 @@ export class Key {
    * @private
    */
   constructor(token: Object, id: number) {
+    if (isBlank(token)) {
+      throw new BaseException('Token must be defined!');
+    }
     this.token = token;
     this.id = id;
   }

--- a/modules/angular2/test/core/forward_ref_integration_spec.dart
+++ b/modules/angular2/test/core/forward_ref_integration_spec.dart
@@ -1,0 +1,6 @@
+/// This file contains tests that make sense only in Dart
+library angular2.test.core.forward_ref_integration_spec;
+
+main() {
+  // Don't run in Dart as it is not relevant, and Dart const rules prevent us from expressing it.
+}

--- a/modules/angular2/test/core/forward_ref_integration_spec.es6
+++ b/modules/angular2/test/core/forward_ref_integration_spec.es6
@@ -1,0 +1,84 @@
+import {
+  AsyncTestCompleter,
+  beforeEach,
+  ddescribe,
+  describe,
+  expect,
+  iit,
+  inject,
+  it,
+  xit
+} from 'angular2/test_lib';
+import {TestBed} from 'angular2/src/test_lib/test_bed';
+import {Directive, Component} from 'angular2/src/core/annotations_impl/annotations';
+import {Query} from 'angular2/src/core/annotations_impl/di';
+import {View} from 'angular2/src/core/annotations_impl/view';
+import {QueryList, NgFor} from 'angular2/angular2';
+import {Inject} from 'angular2/src/di/annotations_impl';
+import {forwardRef, resolveForwardRef, bind} from 'angular2/di';
+import {Type} from 'angular2/src/facade/lang';
+
+export function main() {
+  describe("forwardRef integration", function () {
+    it('should instantiate components which are declared using forwardRef', inject(
+      [TestBed, AsyncTestCompleter],
+      (tb, async) => {
+        tb.createView(App).then((view) => {
+          view.detectChanges();
+          expect(view.rootNodes).toHaveText('frame(lock)');
+          async.done();
+        });
+      })
+    );
+  });
+}
+
+@Component({
+  selector: 'app',
+  injectables: [
+    forwardRef(() => Frame)
+  ]
+})
+@View({
+  template: `<door><lock></lock></door>`,
+  directives: [
+    bind(forwardRef(() => Door)).toClass(forwardRef(() => Door)),
+    bind(forwardRef(() => Lock)).toClass(forwardRef(() => Lock))
+  ]
+})
+class App {
+}
+
+@Component({
+  selector: 'Lock'
+})
+@View({
+  directives: [NgFor],
+  template: `{{frame.name}}(<span *ng-for="var lock of locks">{{lock.name}}</span>)`
+})
+class Door {
+  locks: QueryList;
+  frame: Frame;
+
+  constructor(@Query(forwardRef(() => Lock)) locks: QueryList, @Inject(forwardRef(() => Frame)) frame:Frame) {
+    this.frame = frame;
+    this.locks = locks;
+  }
+}
+
+class Frame {
+  name: string;
+  constructor() {
+    this.name = 'frame';
+  }
+}
+
+@Directive({
+  selector: 'lock'
+})
+class Lock {
+  name: string;
+  constructor() {
+    this.name = 'lock';
+  }
+}

--- a/modules/angular2/test/di/forward_ref_spec.js
+++ b/modules/angular2/test/di/forward_ref_spec.js
@@ -1,0 +1,23 @@
+import {
+  AsyncTestCompleter,
+  beforeEach,
+  ddescribe,
+  describe,
+  expect,
+  iit,
+  inject,
+  it,
+  xit,
+} from 'angular2/test_lib';
+import {forwardRef, resolveForwardRef} from 'angular2/di';
+import {Type} from 'angular2/src/facade/lang';
+
+export function main() {
+  describe("forwardRef", function () {
+    it('should wrap and unwrap the reference', () => {
+      var ref = forwardRef(() => String);
+      expect(ref instanceof Type).toBe(true);
+      expect(resolveForwardRef(ref)).toBe(String);
+    });
+  });
+}


### PR DESCRIPTION
It is possible for a class defined first to be refferencing a class defined later,
and as a result at the time of the definition it is not possbile to acces the later's
class reference. This allows to reffer to the later defined class through
a closure.
