### PR TITLE
refactor(view_manager): split `inPlace` views into root and free host…

### DIFF
--- a/modules/angular2/src/core/application.js
+++ b/modules/angular2/src/core/application.js
@@ -54,13 +54,10 @@ function _injectorBindings(appComponentType): List<Binding> {
   return [
       bind(DOCUMENT_TOKEN).toValue(DOM.defaultDoc()),
       bind(appComponentRefToken).toAsyncFactory((dynamicComponentLoader, injector,
-        metadataReader, testability, registry) => {
+        testability, registry) => {
 
-        var annotation = metadataReader.resolve(appComponentType);
-
-        var selector = annotation.selector;
         // TODO(rado): investigate whether to support bindings on root component.
-        return dynamicComponentLoader.loadIntoNewLocation(appComponentType, null, selector, injector).then( (componentRef) => {
+        return dynamicComponentLoader.loadAsRoot(appComponentType, null, injector).then( (componentRef) => {
           var domView = resolveInternalDomView(componentRef.hostView.render);
           // We need to do this here to ensure that we create Testability and
           // it's ready on the window for users.
@@ -68,7 +65,7 @@ function _injectorBindings(appComponentType): List<Binding> {
 
           return componentRef;
         });
-      }, [DynamicComponentLoader, Injector, DirectiveResolver,
+      }, [DynamicComponentLoader, Injector,
         Testability, TestabilityRegistry]),
 
       bind(appComponentType).toFactory((ref) => ref.instance,

--- a/modules/angular2/src/core/compiler/view.js
+++ b/modules/angular2/src/core/compiler/view.js
@@ -32,7 +32,7 @@ export class AppView {
   componentChildViews: List<AppView>;
   /// Host views that were added by an imperative view.
   /// This is a dynamically growing / shrinking array.
-  inPlaceHostViews: List<AppView>;
+  freeHostViews: List<AppView>;
   viewContainers: List<AppViewContainer>;
   preBuiltObjects: List<PreBuiltObjects>;
   proto: AppProtoView;
@@ -64,7 +64,7 @@ export class AppView {
     this.context = null;
     this.locals = new Locals(null, MapWrapper.clone(protoLocals)); //TODO optimize this
     this.renderer = renderer;
-    this.inPlaceHostViews = [];
+    this.freeHostViews = [];
   }
 
   init(changeDetector:ChangeDetector, elementInjectors:List, rootElementInjectors:List,

--- a/modules/angular2/src/core/compiler/view_manager_utils.js
+++ b/modules/angular2/src/core/compiler/view_manager_utils.js
@@ -93,24 +93,23 @@ export class AppViewManagerUtils {
     );
   }
 
-  attachAndHydrateInPlaceHostView(parentComponentHostView:viewModule.AppView, parentComponentBoundElementIndex:number,
+  hydrateRootHostView(hostView:viewModule.AppView, injector:Injector = null) {
+    this._hydrateView(hostView, injector, null, new Object(), null);
+  }
+
+  attachAndHydrateFreeHostView(parentComponentHostView:viewModule.AppView, parentComponentBoundElementIndex:number,
       hostView:viewModule.AppView, injector:Injector = null) {
-    var hostElementInjector = null;
-    if (isPresent(parentComponentHostView)) {
-      hostElementInjector = parentComponentHostView.elementInjectors[parentComponentBoundElementIndex];
-      var parentView = parentComponentHostView.componentChildViews[parentComponentBoundElementIndex];
-      parentView.changeDetector.addChild(hostView.changeDetector);
-      ListWrapper.push(parentView.inPlaceHostViews, hostView);
-    }
+    var hostElementInjector = parentComponentHostView.elementInjectors[parentComponentBoundElementIndex];
+    var parentView = parentComponentHostView.componentChildViews[parentComponentBoundElementIndex];
+    parentView.changeDetector.addChild(hostView.changeDetector);
+    ListWrapper.push(parentView.freeHostViews, hostView);
     this._hydrateView(hostView, injector, hostElementInjector, new Object(), null);
   }
 
-  detachInPlaceHostView(parentView:viewModule.AppView,
+  detachFreeHostView(parentView:viewModule.AppView,
       hostView:viewModule.AppView) {
-    if (isPresent(parentView)) {
-      parentView.changeDetector.removeChild(hostView.changeDetector);
-      ListWrapper.remove(parentView.inPlaceHostViews, hostView);
-    }
+    parentView.changeDetector.removeChild(hostView.changeDetector);
+    ListWrapper.remove(parentView.freeHostViews, hostView);
   }
 
   attachViewInContainer(parentView:viewModule.AppView, boundElementIndex:number,

--- a/modules/angular2/src/render/api.js
+++ b/modules/angular2/src/render/api.js
@@ -187,20 +187,19 @@ export class RenderCompiler {
 
 export class Renderer {
   /**
-   * Creates a host view that includes the given element.
-   * @param {RenderViewRef} parentHostViewRef (might be null)
-   * @param {any} hostElementSelector css selector for the host element
+   * Creates a root host view that includes the given element.
    * @param {RenderProtoViewRef} hostProtoViewRef a RenderProtoViewRef of type ProtoViewDto.HOST_VIEW_TYPE
+   * @param {any} hostElementSelector css selector for the host element (will be queried against the main document)
    * @return {RenderViewRef} the created view
    */
-  createInPlaceHostView(parentHostViewRef:RenderViewRef, hostElementSelector:string, hostProtoViewRef:RenderProtoViewRef):RenderViewRef {
+  createRootHostView(hostProtoViewRef:RenderProtoViewRef, hostElementSelector:string):RenderViewRef {
     return null;
   }
 
   /**
-   * Destroys the given host view in the given parent view.
+   * Detaches a free host view's element from the DOM.
    */
-  destroyInPlaceHostView(parentHostViewRef:RenderViewRef, hostViewRef:RenderViewRef) {
+  detachFreeHostView(parentHostViewRef:RenderViewRef, hostViewRef:RenderViewRef) {
   }
 
   /**

--- a/modules/angular2/src/render/dom/dom_renderer.js
+++ b/modules/angular2/src/render/dom/dom_renderer.js
@@ -19,8 +19,6 @@ import {Renderer, RenderProtoViewRef, RenderViewRef} from '../api';
 // const expressions!
 export const DOCUMENT_TOKEN = 'DocumentToken';
 
-var _DOCUMENT_SELECTOR_REGEX = RegExpWrapper.create('\\:document(.+)');
-
 @Injectable()
 export class DomRenderer extends Renderer {
   _eventManager:EventManager;
@@ -34,27 +32,16 @@ export class DomRenderer extends Renderer {
     this._document = document;
   }
 
-  createInPlaceHostView(parentHostViewRef:RenderViewRef, hostElementSelector:string, hostProtoViewRef:RenderProtoViewRef):RenderViewRef {
-    var containerNode;
-    var documentSelectorMatch = RegExpWrapper.firstMatch(_DOCUMENT_SELECTOR_REGEX, hostElementSelector);
-    if (isPresent(documentSelectorMatch)) {
-      containerNode = this._document;
-      hostElementSelector = documentSelectorMatch[1];
-    } else if (isPresent(parentHostViewRef)) {
-      var parentHostView = resolveInternalDomView(parentHostViewRef);
-      containerNode = parentHostView.shadowRoot;
-    } else {
-      containerNode = this._document;
-    }
-    var element = DOM.querySelector(containerNode, hostElementSelector);
+  createRootHostView(hostProtoViewRef:RenderProtoViewRef, hostElementSelector:string):RenderViewRef {
+    var hostProtoView = resolveInternalDomProtoView(hostProtoViewRef);
+    var element = DOM.querySelector(this._document, hostElementSelector);
     if (isBlank(element)) {
       throw new BaseException(`The selector "${hostElementSelector}" did not match any elements`);
     }
-    var hostProtoView = resolveInternalDomProtoView(hostProtoViewRef);
     return new DomViewRef(this._createView(hostProtoView, element));
   }
 
-  destroyInPlaceHostView(parentHostViewRef:RenderViewRef, hostViewRef:RenderViewRef) {
+  detachFreeHostView(parentHostViewRef:RenderViewRef, hostViewRef:RenderViewRef) {
     var hostView = resolveInternalDomView(hostViewRef);
     this._removeViewNodes(hostView);
   }
@@ -87,6 +74,11 @@ export class DomRenderer extends Renderer {
     this._removeViewNodes(componentView);
     componentView.rootNodes = rootNodes;
     this._moveViewNodesIntoParent(componentView.shadowRoot, componentView);
+  }
+
+  getHostElement(hostViewRef:RenderViewRef) {
+    var hostView = resolveInternalDomView(hostViewRef);
+    return hostView.boundElements[0];
   }
 
   detachComponentView(hostViewRef:RenderViewRef, boundElementIndex:number, componentViewRef:RenderViewRef) {

--- a/modules/angular2/src/test_lib/test_bed.js
+++ b/modules/angular2/src/test_lib/test_bed.js
@@ -94,7 +94,7 @@ export class TestBed {
     DOM.appendChild(doc.body, rootEl);
 
     var componentBinding = bind(component).toValue(context);
-    return this._injector.get(DynamicComponentLoader).loadIntoNewLocation(componentBinding, null, '#root', this._injector).then((hostComponentRef) => {
+    return this._injector.get(DynamicComponentLoader).loadAsRoot(componentBinding,'#root', this._injector).then((hostComponentRef) => {
       return new ViewProxy(hostComponentRef);
     });
   }

--- a/modules/angular2/test/core/compiler/view_manager_utils_spec.js
+++ b/modules/angular2/test/core/compiler/view_manager_utils_spec.js
@@ -31,7 +31,6 @@ import {AppViewManagerUtils} from 'angular2/src/core/compiler/view_manager_utils
 export function main() {
   // TODO(tbosch): add more tests here!
 
-
   describe('AppViewManagerUtils', () => {
 
     var directiveResolver;
@@ -170,7 +169,7 @@ export function main() {
         var shadowView = createView();
         utils.attachComponentView(hostView, 0, shadowView);
 
-        utils.attachAndHydrateInPlaceHostView(null, null, hostView, createInjector());
+        utils.hydrateRootHostView(hostView, createInjector());
 
         expect(spyEventAccessor1.spy('subscribe')).toHaveBeenCalledWith(hostView, 0, dir);
         expect(spyEventAccessor2.spy('subscribe')).toHaveBeenCalledWith(hostView, 1, dir);
@@ -200,7 +199,7 @@ export function main() {
         var shadowView = createView();
         utils.attachComponentView(hostView, 0, shadowView);
 
-        utils.attachAndHydrateInPlaceHostView(null, null, hostView, createInjector());
+        utils.hydrateRootHostView(hostView, createInjector());
 
         expect(spyActionAccessor1.spy('subscribe')).toHaveBeenCalledWith(hostView, 0, dir);
         expect(spyActionAccessor2.spy('subscribe')).toHaveBeenCalledWith(hostView, 1, dir);
@@ -264,6 +263,27 @@ export function main() {
         utils.hydrateViewInContainer(parentView, 0, contextView, 0, 0, null);
         expect(childView.rootElementInjectors[0].spy('instantiateDirectives'))
           .toHaveBeenCalledWith(null, contextView.elementInjectors[0].getHost(), childView.preBuiltObjects[0]);
+      });
+
+    });
+
+    describe('hydrateRootHostView', () => {
+      var hostView;
+
+      function createViews() {
+        var hostPv = createProtoView([
+          createComponentElBinder()
+        ]);
+        hostView = createView(hostPv);
+      }
+
+      it("should instantiate the elementInjectors with the given injector and an empty host element injector", () => {
+        var injector = createInjector();
+        createViews();
+
+        utils.hydrateRootHostView(hostView, injector);
+        expect(hostView.rootElementInjectors[0].spy('instantiateDirectives'))
+          .toHaveBeenCalledWith(injector, null, hostView.preBuiltObjects[0]);
       });
 
     });

--- a/modules/angular2/test/render/dom/dom_testbed.js
+++ b/modules/angular2/test/render/dom/dom_testbed.js
@@ -77,7 +77,7 @@ export class DomTestbed {
   }
 
   createRootView(rootProtoView:ProtoViewDto):TestView {
-    var viewRef = this.renderer.createInPlaceHostView(null, '#root', rootProtoView.render);
+    var viewRef = this.renderer.createRootHostView(rootProtoView.render, '#root');
     this.renderer.hydrateView(viewRef);
     return this._createTestView(viewRef);
   }


### PR DESCRIPTION
… views.

BREAKING CHANGE:
`AppViewManager.createInPlaceHostView` is replaced by
`AppViewManager.createRootHostView` (for bootstrap) and
`AppViewManager.createFreeHostView` (for imperative components).

The later creates new host elements that are not attached anywhere.
To attach them, use `DomRenderer.getHostElement(hostviewRef, 0)`
to get the host element.

Closes #1920
