### PR TITLE
feat(element_injector): allow @Optional for ProtoViewRef

### DIFF
--- a/modules/angular2/src/core/compiler/element_injector.js
+++ b/modules/angular2/src/core/compiler/element_injector.js
@@ -851,6 +851,10 @@ export class ElementInjector extends TreeNode {
     }
     if (dep.key.id === StaticKeys.instance().protoViewId) {
       if (isBlank(this._preBuiltObjects.protoView)) {
+        if (dep.optional) {
+          return null;
+        }
+
         throw new NoBindingError(dep.key);
       }
       return new ProtoViewRef(this._preBuiltObjects.protoView);

--- a/modules/angular2/test/core/compiler/element_injector_spec.js
+++ b/modules/angular2/test/core/compiler/element_injector_spec.js
@@ -150,6 +150,13 @@ class NeedsProtoViewRef {
   }
 }
 
+class OptionallyInjectsProtoViewRef {
+  protoViewRef;
+  constructor(@Optional() ref:ProtoViewRef) {
+    this.protoViewRef = ref;
+  }
+}
+
 class NeedsChangeDetectorRef {
   changeDetectorRef;
   constructor(cdr:ChangeDetectorRef) {
@@ -810,6 +817,12 @@ export function main() {
         expect(
           () => injector([NeedsProtoViewRef])
         ).toThrowError('No provider for ProtoViewRef! (NeedsProtoViewRef -> ProtoViewRef)');
+      });
+
+      it('should inject null if there is no ProtoViewRef when the dependency is optional', () => {
+        var inj = injector([OptionallyInjectsProtoViewRef]);
+        var instance = inj.get(OptionallyInjectsProtoViewRef);
+        expect(instance.protoViewRef).toBeNull();
       });
     });
 


### PR DESCRIPTION
This allows for directives that may or may not be manually placed into a ViewContainer.
