### PR TITLE
docs(annotations): corrections to @Query

### DIFF
--- a/modules/angular2/src/core/annotations_impl/annotations.js
+++ b/modules/angular2/src/core/annotations_impl/annotations.js
@@ -49,8 +49,8 @@ import {DEFAULT} from 'angular2/change_detection';
  *    Shadow DOM root. Current element is not included in the resolution, therefore even if it could resolve it, it will
  *    be ignored.
  * - `@Parent() directive:DirectiveType`: any directive that matches the type on a direct parent element only.
- * - `@Children query:Query<DirectiveType>`: A live collection of direct child directives (will be implemented in later release).
- * - `@Descendants query:Query<DirectiveType>`: A live collection of any child directives (will be implemented in later relaese).
+ * - `@Query query:QueryList<DirectiveType>`: A live collection of direct child directives.
+ * - `@QueryDescendants query:QueryList<DirectiveType>`: A live collection of any child directives.
  *
  * To inject element-specific special objects, declare the constructor parameter as:
  * - `element: ElementRef` to obtain a reference to logical element in the view.
@@ -205,7 +205,7 @@ import {DEFAULT} from 'angular2/change_detection';
  *
  * Note: This is will be implemented in later release. ()
  *
- * Similar to `@Children` above, but also includes the children of the child elements.
+ * Similar to `@Query` above, but also includes the children of the child elements.
  *
  * ```
  * @Directive({ selector: '[my-directive]' })

--- a/modules/angular2/src/core/annotations_impl/annotations.js
+++ b/modules/angular2/src/core/annotations_impl/annotations.js
@@ -49,8 +49,8 @@ import {DEFAULT} from 'angular2/change_detection';
  *    Shadow DOM root. Current element is not included in the resolution, therefore even if it could resolve it, it will
  *    be ignored.
  * - `@Parent() directive:DirectiveType`: any directive that matches the type on a direct parent element only.
- * - `@Query query:QueryList<DirectiveType>`: A live collection of direct child directives.
- * - `@QueryDescendants query:QueryList<DirectiveType>`: A live collection of any child directives.
+ * - `@Query(DirectiveType) query:QueryList<DirectiveType>`: A live collection of direct child directives.
+ * - `@QueryDescendants(DirectiveType) query:QueryList<DirectiveType>`: A live collection of any child directives.
  *
  * To inject element-specific special objects, declare the constructor parameter as:
  * - `element: ElementRef` to obtain a reference to logical element in the view.

--- a/modules/angular2/src/core/annotations_impl/annotations.js
+++ b/modules/angular2/src/core/annotations_impl/annotations.js
@@ -193,7 +193,7 @@ import {DEFAULT} from 'angular2/change_detection';
  * ```
  * @Directive({ selector: '[my-directive]' })
  * class MyDirective {
- *   constructor(@Query(Marker) dependencies:QueryList<Maker>) {
+ *   constructor(@Query(Dependency) dependencies:QueryList<Dependency>) {
  *   }
  * }
  * ```
@@ -210,7 +210,7 @@ import {DEFAULT} from 'angular2/change_detection';
  * ```
  * @Directive({ selector: '[my-directive]' })
  * class MyDirective {
- *   constructor(@QueryDescendents(Marker) dependencies:QueryList<Maker>) {
+ *   constructor(@QueryDescendents(Dependency) dependencies:QueryList<Dependency>) {
  *   }
  * }
  * ```


### PR DESCRIPTION
The docs still show @Children and @Descendents when it looks like that has been updated to @Query and @QueryDescendents. Also, the DirectiveType should be Dependency with the current code example.
