### PR TITLE
Update reflection_capabilities.ts

### DIFF
--- a/modules/angular2/src/reflection/reflection_capabilities.ts
+++ b/modules/angular2/src/reflection/reflection_capabilities.ts
@@ -50,21 +50,19 @@ export class ReflectionCapabilities {
   _zipTypesAndAnnotaions(paramTypes, paramAnnotations): List<List<any>> {
     var result;
 
-    if(typeof paramTypes === 'undefined'){
+    if (typeof paramTypes === 'undefined') {
       result = ListWrapper.createFixedSize(paramAnnotations.length);
-    }
-    else{
+    } else {
       result = ListWrapper.createFixedSize(paramTypes.length);
     }
-    
+
     for (var i = 0; i < result.length; i++) {
       // TS outputs Object for parameters without types, while Traceur omits
       // the annotations. For now we preserve the Traceur behavior to aid
       // migration, but this can be revisited.
-      if (typeof paramTypes === 'undefined'){
+      if (typeof paramTypes === 'undefined') {
         result[i] = [];
-      }
-      else if (paramTypes[i] != Object) {
+      } else if (paramTypes[i] != Object) {
         result[i] = [paramTypes[i]];
       } else {
         result[i] = [];

--- a/modules/angular2/src/reflection/reflection_capabilities.ts
+++ b/modules/angular2/src/reflection/reflection_capabilities.ts
@@ -50,17 +50,20 @@ export class ReflectionCapabilities {
   _zipTypesAndAnnotaions(paramTypes, paramAnnotations): List<List<any>> {
     var result;
 
-    if(typeof paramTypes === 'undefined')
-      result = ListWrapper.createFixedSize(paramAnnotations.length);  
-    else
+    if(typeof paramTypes === 'undefined'){
+      result = ListWrapper.createFixedSize(paramAnnotations.length);
+    }
+    else{
       result = ListWrapper.createFixedSize(paramTypes.length);
-
+    }
+    
     for (var i = 0; i < result.length; i++) {
       // TS outputs Object for parameters without types, while Traceur omits
       // the annotations. For now we preserve the Traceur behavior to aid
       // migration, but this can be revisited.
-      if (typeof paramTypes === 'undefined')
+      if (typeof paramTypes === 'undefined'){
         result[i] = [];
+      }
       else if (paramTypes[i] != Object) {
         result[i] = [paramTypes[i]];
       } else {

--- a/modules/angular2/src/reflection/reflection_capabilities.ts
+++ b/modules/angular2/src/reflection/reflection_capabilities.ts
@@ -48,12 +48,20 @@ export class ReflectionCapabilities {
   }
 
   _zipTypesAndAnnotaions(paramTypes, paramAnnotations): List<List<any>> {
-    var result = ListWrapper.createFixedSize(paramTypes.length);
+    var result;
+
+    if(typeof paramTypes === 'undefined')
+      result = ListWrapper.createFixedSize(paramAnnotations.length);  
+    else
+      result = ListWrapper.createFixedSize(paramTypes.length);
+
     for (var i = 0; i < result.length; i++) {
       // TS outputs Object for parameters without types, while Traceur omits
       // the annotations. For now we preserve the Traceur behavior to aid
       // migration, but this can be revisited.
-      if (paramTypes[i] != Object) {
+      if (typeof paramTypes === 'undefined')
+        result[i] = [];
+      else if (paramTypes[i] != Object) {
         result[i] = [paramTypes[i]];
       } else {
         result[i] = [];


### PR DESCRIPTION
Hi,

I get exceptions in the dependency injection code of Angular alpha 23.

In angular2/src/reflection/reflection_capabilities.ts I always get an error message if I use dependency injection with typscript 1.5beta. In a debugging session I found this code snippet:

``` javascript
if (isPresent(paramTypes) || isPresent(paramAnnotations)) {
    return this._zipTypesAndAnnotaions(paramTypes, paramAnnotations);
}
```

In my case paramTypes is undefined but paramAnnotations contains an array and cause of the || _zipTypesAndAnnotaions (a typo? should be named ...AndAnnotations I think) will be called.

In _zipTypesAndAnnotaions this line causes an exception in my demo application:

``` javascript
_zipTypesAndAnnotaions(paramTypes, paramAnnotations): List<List<any>> {
    var result = ListWrapper.createFixedSize(paramTypes.length);
```

cause paramTypes is undefined.

In my opinion it should check if paramTypes is undefined and then take paramAnnotations for creating the result list.

The code changes in my pull request seem to solve the issue.

Here's an excerpt of my code which shows how I tried to use dependency injection:

``` javascript
class test1 {
    gets() { return "balupp";}
}


// Annotation section
@Component({
    selector: 'app',
    injectables: [test1]
})
@View({
...
})

// Component controller
class MyAppComponent {
    constructor(@Inject(test1) webs) {
        ...
    }
```

Best regards,

Josef
