### PR TITLE
Fix trailing slash in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "filesGlob": [
         "./**/*.ts",
         "!./node_modules/**/*.ts"
-    ],
+    ]
 }


### PR DESCRIPTION
Currently ts fails because of trailing slash in JSON:

```
error TS6050: Unable to open file 'tsconfig.json'
```
