### PR TITLE
fix(gulp): continue watching when tasks throw

### DIFF
--- a/tools/build/watch.js
+++ b/tools/build/watch.js
@@ -49,7 +49,7 @@ function watch(globs, opts, tasks) {
   watcher.close = function() {
     if (timeoutId !== null) clearTimeout(timeoutId);
     close();
-  }
+  };
 
   var eventsRecorded = 0; // Number of events recorded
   var timeoutId = null; // If non-null, event capture window is open
@@ -75,12 +75,14 @@ function watch(globs, opts, tasks) {
   }
 
   function tasksDone(err) {
-    if (err) throw err;
     if (eventsRecorded) {
       // eventsRecorded has increased during the run, run again on the next turn
       timeoutId = setTimeout(invokeCallback, 0);
     } else {
       timeoutId = null;
+    }
+    if (!useRunSequence && err) {
+      console.log('Watch task error:', err.toString());
     }
   }
 }

--- a/tools/build/watch.spec.js
+++ b/tools/build/watch.spec.js
@@ -72,6 +72,28 @@ describe('watch()', function() {
   });
 
 
+  it('should continue to trigger callbacks if task throws', function() {
+    var calls = 0;
+    spyOn(console, 'log');
+    function cb(done) {
+      calls += 1;
+      if (calls === 1) throw new Error('oops!');
+      done();
+    }
+
+    var watcher = watch('./$$fake_path/**/*', { delay: 10 }, cb);
+
+    watcher._emit('change', './$$fake_path/test1.txt');
+    timeout.flush();
+    expect(calls).toBe(1);
+    expect(console.log).toHaveBeenCalledWith('Watch task error:', 'Error: oops!');
+
+    watcher._emit('change', './$$fake_path/test2.txt');
+    timeout.flush();
+    expect(calls).toBe(2);
+  });
+
+
   it('should cancel pending callback if FSWatcher is closed', function() {
     var cb = jasmine.createSpy('callback');
     var watcher = watch('./$$fake_path/**/*', { delay: 10 }, cb);


### PR DESCRIPTION
Also I think we should be exposing the errors passed to `tasksDone` as events via the watcher we return so that the consumer of `watch.js` can choose how to deal with them. Currently tasks exceptions are lost to `setTimeout`.

I'm also not sure how best to test this.

Closes #1915 
