### PR TITLE
fix(build): npm shrinkwrap to pick up changed SHA1.

### DIFF
--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -8594,7 +8594,7 @@
         },
         "source-map-support": {
           "version": "0.2.10",
-          "resolved": "git://github.com/mprobst/node-source-map-support.git#9766df880690100dc99d244a797e83bd6138d2e4",
+          "resolved": "git://github.com/mprobst/node-source-map-support.git#e6e77abddda62dec1581d393fce921cc40e8375b",
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
@@ -8723,7 +8723,7 @@
                   "version": "0.6.6"
                 },
                 "json-stringify-safe": {
-                  "version": "5.0.0"
+                  "version": "5.0.1"
                 },
                 "forever-agent": {
                   "version": "0.5.2"
@@ -8749,7 +8749,7 @@
                       }
                     },
                     "async": {
-                      "version": "0.9.0"
+                      "version": "0.9.2"
                     }
                   }
                 },
@@ -8843,7 +8843,7 @@
                       "version": "0.6.6"
                     },
                     "json-stringify-safe": {
-                      "version": "5.0.0"
+                      "version": "5.0.1"
                     },
                     "forever-agent": {
                       "version": "0.5.2"
@@ -8909,7 +8909,7 @@
                           }
                         },
                         "async": {
-                          "version": "0.9.0"
+                          "version": "0.9.2"
                         }
                       }
                     }
@@ -8968,7 +8968,7 @@
               }
             },
             "universal-analytics": {
-              "version": "0.3.6",
+              "version": "0.3.8",
               "dependencies": {
                 "underscore": {
                   "version": "1.8.3"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2446,64 +2446,64 @@
     },
     "chokidar": {
       "version": "1.0.1",
-      "from": "chokidar@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.1.tgz",
       "dependencies": {
         "anymatch": {
           "version": "1.3.0",
-          "from": "anymatch@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
           "dependencies": {
             "micromatch": {
               "version": "2.1.6",
-              "from": "micromatch@>=2.1.5 <3.0.0",
+              "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
               "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
               "dependencies": {
                 "arr-diff": {
                   "version": "1.0.1",
-                  "from": "arr-diff@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                   "dependencies": {
                     "array-slice": {
                       "version": "0.2.3",
-                      "from": "array-slice@>=0.2.2 <0.3.0",
+                      "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
                       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                     }
                   }
                 },
                 "braces": {
                   "version": "1.8.0",
-                  "from": "braces@>=1.8.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                   "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                   "dependencies": {
                     "expand-range": {
                       "version": "1.8.1",
-                      "from": "expand-range@>=1.8.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                       "dependencies": {
                         "fill-range": {
                           "version": "2.2.2",
-                          "from": "fill-range@>=2.1.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                           "dependencies": {
                             "is-number": {
                               "version": "1.1.2",
-                              "from": "is-number@>=1.1.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                             },
                             "isobject": {
                               "version": "1.0.0",
-                              "from": "isobject@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz"
                             },
                             "randomatic": {
                               "version": "1.1.0",
-                              "from": "randomatic@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
@@ -2512,109 +2512,109 @@
                     },
                     "preserve": {
                       "version": "0.2.0",
-                      "from": "preserve@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                     },
                     "repeat-element": {
                       "version": "1.1.2",
-                      "from": "repeat-element@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                     }
                   }
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.1.3 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "expand-brackets": {
                   "version": "0.1.1",
-                  "from": "expand-brackets@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
                 },
                 "filename-regex": {
                   "version": "2.0.0",
-                  "from": "filename-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                 },
                 "kind-of": {
                   "version": "1.1.0",
-                  "from": "kind-of@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                 },
                 "object.omit": {
                   "version": "0.2.1",
-                  "from": "object.omit@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                   "dependencies": {
                     "for-own": {
                       "version": "0.1.3",
-                      "from": "for-own@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                       "dependencies": {
                         "for-in": {
                           "version": "0.1.4",
-                          "from": "for-in@>=0.1.4 <0.2.0",
+                          "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                         }
                       }
                     },
                     "isobject": {
                       "version": "0.2.0",
-                      "from": "isobject@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
                     }
                   }
                 },
                 "parse-glob": {
                   "version": "3.0.2",
-                  "from": "parse-glob@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                   "dependencies": {
                     "glob-base": {
                       "version": "0.2.0",
-                      "from": "glob-base@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                     },
                     "is-dotfile": {
                       "version": "1.0.0",
-                      "from": "is-dotfile@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
                     },
                     "is-extglob": {
                       "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                     }
                   }
                 },
                 "regex-cache": {
                   "version": "0.4.2",
-                  "from": "regex-cache@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                   "dependencies": {
                     "is-equal-shallow": {
                       "version": "0.1.2",
-                      "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
                       "dependencies": {
                         "is-primitive": {
                           "version": "1.0.0",
-                          "from": "is-primitive@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz"
                         }
                       }
                     },
                     "is-primitive": {
                       "version": "2.0.0",
-                      "from": "is-primitive@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                     }
                   }
@@ -2625,86 +2625,86 @@
         },
         "arrify": {
           "version": "1.0.0",
-          "from": "arrify@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
         },
         "async-each": {
           "version": "0.1.6",
-          "from": "async-each@>=0.1.5 <0.2.0",
+          "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
           "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
         },
         "glob-parent": {
           "version": "1.2.0",
-          "from": "glob-parent@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
         },
         "is-binary-path": {
           "version": "1.0.0",
-          "from": "is-binary-path@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
           "dependencies": {
             "binary-extensions": {
               "version": "1.3.0",
-              "from": "binary-extensions@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.0.tgz"
             }
           }
         },
         "is-glob": {
           "version": "1.1.3",
-          "from": "is-glob@>=1.1.3 <2.0.0",
+          "from": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
         },
         "readdirp": {
           "version": "1.3.0",
-          "from": "readdirp@>=1.3.0 <2.0.0",
+          "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.12 <0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.6.2",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.2.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.26-2 <1.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -2713,12 +2713,12 @@
         },
         "fsevents": {
           "version": "0.3.6",
-          "from": "fsevents@>=0.3.1 <0.4.0",
+          "from": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
           "dependencies": {
             "nan": {
               "version": "1.8.4",
-              "from": "nan@>=1.8.0 <2.0.0",
+              "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
             }
           }
@@ -12638,61 +12638,61 @@
     },
     "rewire": {
       "version": "2.3.3",
-      "from": "rewire@2.3.3",
+      "from": "https://registry.npmjs.org/rewire/-/rewire-2.3.3.tgz",
       "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.3.3.tgz"
     },
     "run-sequence": {
       "version": "1.1.0",
-      "from": "run-sequence@1.1.0",
+      "from": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.1.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.0.0",
-          "from": "chalk@*",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.0.1",
-              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "1.0.3",
-              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 },
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "2.0.1",
-              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "1.1.1",
-                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "1.3.1",
-              "from": "supports-color@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
             }
           }
@@ -13250,34 +13250,34 @@
     },
     "ts2dart": {
       "version": "0.5.2",
-      "from": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.5.2.tgz",
+      "from": "ts2dart@0.5.2",
       "resolved": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.5.2.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.4.2",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+          "from": "source-map@>=0.4.2 <0.5.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
           "dependencies": {
             "amdefine": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+              "from": "amdefine@>=0.0.4",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
             }
           }
         },
         "source-map-support": {
           "version": "0.2.10",
-          "from": "git://github.com/mprobst/node-source-map-support.git#9766df880690100dc99d244a797e83bd6138d2e4",
-          "resolved": "git://github.com/mprobst/node-source-map-support.git#9766df880690100dc99d244a797e83bd6138d2e4",
+          "from": "git://github.com/mprobst/node-source-map-support.git",
+          "resolved": "git://github.com/mprobst/node-source-map-support.git#e6e77abddda62dec1581d393fce921cc40e8375b",
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+              "from": "source-map@0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                  "from": "amdefine@>=0.0.4",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                 }
               }
@@ -13469,9 +13469,9 @@
                   "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
                 },
                 "json-stringify-safe": {
-                  "version": "5.0.0",
+                  "version": "5.0.1",
                   "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "forever-agent": {
                   "version": "0.5.2",
@@ -13511,9 +13511,9 @@
                       }
                     },
                     "async": {
-                      "version": "0.9.0",
+                      "version": "0.9.2",
                       "from": "async@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     }
                   }
                 },
@@ -13658,9 +13658,9 @@
                       "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
                     },
                     "json-stringify-safe": {
-                      "version": "5.0.0",
+                      "version": "5.0.1",
                       "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                     },
                     "forever-agent": {
                       "version": "0.5.2",
@@ -13764,9 +13764,9 @@
                           }
                         },
                         "async": {
-                          "version": "0.9.0",
+                          "version": "0.9.2",
                           "from": "async@>=0.9.0 <0.10.0",
-                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                         }
                       }
                     }
@@ -13853,9 +13853,9 @@
               }
             },
             "universal-analytics": {
-              "version": "0.3.6",
+              "version": "0.3.8",
               "from": "universal-analytics@>=0.3.2 <0.4.0",
-              "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.3.8.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.8.3",
@@ -13893,7 +13893,7 @@
         },
         "typescript": {
           "version": "1.5.0-beta",
-          "from": "https://registry.npmjs.org/typescript/-/typescript-1.5.0-beta.tgz",
+          "from": "typescript@1.5.0-beta",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.5.0-beta.tgz"
         }
       }
@@ -14536,7 +14536,7 @@
     },
     "zone.js": {
       "version": "0.5.0",
-      "from": "zone.js@0.5.0",
+      "from": "https://registry.npmjs.org/zone.js/-/zone.js-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.5.0.tgz"
     }
   }


### PR DESCRIPTION
ts2dart's node-source-map-support dependency was updated to match the main
line patch, but this changed the SHA in the existing repo, breaking Angular's
shrink wrapped dependency.

This update changes the dependency back to an existing SHA.
