### PR TITLE
build(test): remove unecessary require

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,6 @@ var pubbuild = require('./tools/build/pubbuild');
 var dartanalyzer = require('./tools/build/dartanalyzer');
 var jsserve = require('./tools/build/jsserve');
 var pubserve = require('./tools/build/pubserve');
-var file2moduleName = require('./tools/build/file2modulename');
 var karma = require('karma');
 var minimist = require('minimist');
 var runServerDartTests = require('./tools/build/run_server_dart_tests');

--- a/karma-dart.conf.js
+++ b/karma-dart.conf.js
@@ -1,7 +1,5 @@
 // Karma configuration
 // Generated on Thu Sep 25 2014 11:52:02 GMT-0700 (PDT)
-var file2moduleName = require('./tools/build/file2modulename');
-
 module.exports = function(config) {
   config.set({
 

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -1,7 +1,5 @@
 // Karma configuration
 // Generated on Thu Sep 25 2014 11:52:02 GMT-0700 (PDT)
-var file2moduleName = require('./tools/build/file2modulename');
-
 module.exports = function(config) {
   config.set({
 


### PR DESCRIPTION
`file2moduleName` looks unused in `gulpfile.js` and `karma-conf/dart.js`
