### PR TITLE
chore(doc-gen): improve github links to point to the correct tagged URL

### DIFF
--- a/docs/angular.io-package/templates/class.template.html
+++ b/docs/angular.io-package/templates/class.template.html
@@ -1,10 +1,11 @@
+{% include "lib/githubLinks.html" -%}
 {% include "lib/paramList.html" -%}
 {% extends 'layout/base.template.html' -%}
 
 {% block body %}
 p.location-badge.
   exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }
-  defined in <a href="https://github.com/angular/angular/tree/master/modules/{$ doc.fileInfo.relativePath $}#L{$ doc.location.start.line+1 $}-L{$ doc.location.end.line+1 $}">{$ doc.fileInfo.relativePath $} (line {$ doc.location.start.line+1 $})</a>
+  defined in {$ githubViewLink(doc) $}
 
 :markdown
 {$ doc.description | indent(2, true) $}

--- a/docs/angular.io-package/templates/function.template.html
+++ b/docs/angular.io-package/templates/function.template.html
@@ -1,3 +1,4 @@
+{% include "lib/githubLinks.html" -%}
 {% include "lib/paramList.html" -%}
 {% extends 'layout/base.template.html' -%}
 
@@ -13,7 +14,7 @@
 
   p.location-badge.
     exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }
-    defined in <a href="https://github.com/angular/angular/tree/master/modules/{$ doc.fileInfo.relativePath $}#L{$ doc.location.start.line+1 $}-L{$ doc.location.end.line+1 $}">{$ doc.fileInfo.relativePath $} (line {$ doc.location.start.line+1 $})</a>
+    defined in {$ githubViewLink(doc) $}
 
   :markdown
 {$ doc.description | indent(4, true) $}

--- a/docs/angular.io-package/templates/module.template.html
+++ b/docs/angular.io-package/templates/module.template.html
@@ -1,7 +1,8 @@
+{% include "lib/githubLinks.html" -%}
 {% extends 'layout/base.template.html' -%}
 {% block body -%}
 p.location-badge.
-  defined in <a href="https://github.com/angular/angular/tree/master/modules/{$ doc.fileInfo.relativePath $}#L{$ doc.location.start.line+1 $}-L{$ doc.location.end.line+1 $}">{$ doc.fileInfo.relativePath $} (line {$ doc.location.start.line+1 $})</a>
+  defined in {$ githubViewLink(doc) $}
 
 ul
   for page, slug in public.docs[current.path[1]][current.path[2]][current.path[3]][current.path[4]]._data

--- a/docs/angular.io-package/templates/var.template.html
+++ b/docs/angular.io-package/templates/var.template.html
@@ -1,3 +1,4 @@
+{% include "lib/githubLinks.html" -%}
 {% extends 'layout/base.template.html' %}
 
 {% block body %}
@@ -5,6 +6,7 @@
   h2 {$ doc.name $} <span class="type">variable</span>
   p.location-badge.
     exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }
+    defined in {$ githubViewLink(doc) $}
 
   :markdown
 {$ doc.description | indent(4, true) $}

--- a/docs/dgeni-package/index.js
+++ b/docs/dgeni-package/index.js
@@ -1,5 +1,6 @@
 require('../../tools/transpiler/index.js').init();
 
+var versionInfo = require('./versionInfo');
 var Package = require('dgeni').Package;
 var jsdocPackage = require('dgeni-packages/jsdoc');
 var nunjucksPackage = require('dgeni-packages/nunjucks');
@@ -46,6 +47,10 @@ module.exports = new Package('angular', [jsdocPackage, nunjucksPackage, linksPac
   log.level = 'warn';
 })
 
+
+.config(function(renderDocsProcessor) {
+  renderDocsProcessor.extraData.versionInfo = versionInfo;
+})
 
 // Configure file reading
 .config(function(readFilesProcessor, ngdocFileReader, readTypeScriptModules) {

--- a/docs/dgeni-package/templates/class.template.html
+++ b/docs/dgeni-package/templates/class.template.html
@@ -1,11 +1,12 @@
 {% include "lib/paramList.html" -%}
+{% include "lib/githubLinks.html" -%}
 {% extends 'layout/base.template.html' -%}
 
 {% block body %}
 <h1 class="class export">{$ doc.name $} <span class="type">{$ doc.docType $}</span></h1>
 <p class="module">exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }<br/>
-defined in <a href="https://github.com/angular/angular/tree/master/modules/{$ doc.fileInfo.relativePath $}#L{$ doc.location.start.line+1 $}-L{$ doc.location.end.line+1 $}">
-  {$ doc.fileInfo.relativePath $} (line {$ doc.location.start.line+1 $})</a></p>
+defined in {$ githubViewLink(doc) $}
+</p>
 <p>{$ doc.description | marked $}</p>
 
 {%- if doc.constructorDoc or doc.members.length -%}

--- a/docs/dgeni-package/templates/function.template.html
+++ b/docs/dgeni-package/templates/function.template.html
@@ -1,9 +1,11 @@
 {% include "lib/paramList.html" -%}
+{% include "lib/githubLinks.html" -%}
 {% extends 'layout/base.template.html' -%}
 
 {% block body %}
 <h1 class="function export">{$ doc.name $}{$ paramList(doc.parameters) $}</h1>
-<p class="module">exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }</p>
+<p class="module">exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }<br/>
+defined in {$ githubViewLink(doc) $}</p>
 <p>{$ doc.description | marked $}</p>
 
 {% endblock %}

--- a/docs/dgeni-package/templates/lib/githubLinks.html
+++ b/docs/dgeni-package/templates/lib/githubLinks.html
@@ -1,0 +1,3 @@
+{% macro githubViewLink(doc) -%}
+  <a href="https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInfo.repo $}/tree/{$ versionInfo.currentVersion.isSnapshot and 'master' or versionInfo.currentVersion.raw $}/modules/{$ doc.fileInfo.relativePath $}#L{$ doc.location.start.line+1 $}-L{$ doc.location.end.line+1 $}">
+{%- endmacro -%}

--- a/docs/dgeni-package/templates/module.template.html
+++ b/docs/dgeni-package/templates/module.template.html
@@ -1,8 +1,9 @@
+{% include "lib/githubLinks.html" -%}
 {% extends 'layout/base.template.html' %}
 
 {% block body %}
 <h1 class="id">{$ doc.id $} <span class="type">module</span></h1>
-
+<p>defined in {$ githubViewLink(doc) $}</p>
 <p>{$ doc.description | marked $}</p>
 
 {% if doc.exports.length %}

--- a/docs/dgeni-package/templates/var.template.html
+++ b/docs/dgeni-package/templates/var.template.html
@@ -1,8 +1,10 @@
+{% include "lib/githubLinks.html" -%}
 {% extends 'layout/base.template.html' %}
 
 {% block body %}
 <h1>{$ doc.name $} <span class="type">variable</span></h1>
-<p class="module">exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }</p>
+<p class="module">exported from {@link {$ doc.moduleDoc.id $} {$doc.moduleDoc.id $} }<br/>
+defined in {$ githubViewLink(doc) $}</p>
 <p>{$ doc.description | marked $}</p>
 
 {% endblock %}

--- a/docs/dgeni-package/versionInfo.js
+++ b/docs/dgeni-package/versionInfo.js
@@ -1,0 +1,181 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var shell = require('shelljs');
+var semver = require('semver');
+var _ = require('lodash');
+
+var currentPackage, previousVersions, gitRepoInfo;
+
+
+/**
+ * Load information about this project from the package.json
+ * @return {Object} The package information
+ */
+var getPackage = function() {
+  // Search up the folder hierarchy for the first package.json
+  var packageFolder = path.resolve('.');
+  while (!fs.existsSync(path.join(packageFolder, 'package.json'))) {
+    var parent = path.dirname(packageFolder);
+    if (parent === packageFolder) { break; }
+    packageFolder = parent;
+  }
+  return JSON.parse(fs.readFileSync(path.join(packageFolder,'package.json'), 'UTF-8'));
+};
+
+
+/**
+ * Parse the github URL for useful information
+ * @return {Object} An object containing the github owner and repository name
+ */
+var getGitRepoInfo = function() {
+  var GITURL_REGEX = /^https:\/\/github.com\/([^\/]+)\/(.+).git$/;
+  var match = GITURL_REGEX.exec(currentPackage.repository.url);
+  var git = {
+    owner: match[1],
+    repo: match[2]
+  };
+  return git;
+};
+
+
+
+/**
+ * Extract the code name from the tagged commit's message - it should contain the text of the form:
+ * "codename(some-code-name)"
+ * @param  {String} tagName Name of the tag to look in for the codename
+ * @return {String}         The codename if found, otherwise null/undefined
+ */
+var getCodeName = function(tagName) {
+  var gitCatOutput = shell.exec('git cat-file -p ' + tagName, {silent:true}).output;
+  var tagMessage = gitCatOutput.match(/^.*codename.*$/mg)[0];
+  var codeName = tagMessage && tagMessage.match(/codename\((.*)\)/)[1];
+  if (!codeName) {
+    throw new Error("Could not extract release code name. The message of tag " + tagName +
+      " must match '*codename(some release name)*'");
+  }
+  return codeName;
+};
+
+
+/**
+ * Compute a build segment for the version, from the Jenkins build number and current commit SHA
+ * @return {String} The build segment of the version
+ */
+function getBuild() {
+  var hash = shell.exec('git rev-parse --short HEAD', {silent: true}).output.replace('\n', '');
+  return 'sha.' + hash;
+}
+
+
+/**
+ * If the current commit is tagged as a version get that version
+ * @return {SemVer} The version or null
+ */
+var getTaggedVersion = function() {
+  var gitTagResult = shell.exec('git describe --exact-match', {silent:true});
+
+  if (gitTagResult.code === 0) {
+    var tag = gitTagResult.output.trim();
+    var version = semver.parse(tag);
+
+    if (version && semver.satisfies(version, currentPackage.version)) {
+      version.codeName = getCodeName(tag);
+      version.full = version.version;
+      version.branch = 'v' + currentPackage.branchPattern.replace('*', 'x');
+      return version;
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Get a collection of all the previous versions sorted by semantic version
+ * @return {Array.<SemVer>} The collection of previous versions
+ */
+var getPreviousVersions =  function() {
+  // always use the remote tags as the local clone might
+  // not contain all commits when cloned with git clone --depth=...
+  // Needed e.g. for Travis
+  var repo_url = currentPackage.repository.url;
+  var tagResults = shell.exec('git ls-remote --tags ' + repo_url,
+                              {silent: true});
+  if (tagResults.code === 0) {
+    return _(tagResults.output.match(/v[0-9].*[0-9]$/mg))
+      .map(function(tag) {
+        var version = semver.parse(tag);
+        return version;
+      })
+      .filter()
+      .map(function(version) {
+        // angular.js didn't follow semantic version until 1.20rc1
+        if ((version.major === 1 && version.minor === 0 && version.prerelease.length > 0) || (version.major === 1 && version.minor === 2 && version.prerelease[0] === 'rc1')) {
+          version.version = [version.major, version.minor, version.patch].join('.') + version.prerelease.join('');
+          version.raw = 'v' + version.version;
+        }
+        version.docsUrl = 'http://code.angularjs.org/' + version.version + '/docs';
+        // Versions before 1.0.2 had a different docs folder name
+        if (version.major < 1 || (version.major === 1 && version.minor === 0 && version.patch < 2)) {
+          version.docsUrl += '-' + version.version;
+          version.isOldDocsUrl = true;
+        }
+        return version;
+      })
+      .sort(semver.compare)
+      .value();
+  } else {
+    return [];
+  }
+};
+
+/**
+ * Get the unstable snapshot version
+ * @return {SemVer} The snapshot version
+ */
+var getSnapshotVersion = function() {
+  var version = _(previousVersions)
+    .filter(function(tag) {
+      return semver.satisfies(tag, currentPackage.version);
+    })
+    .last();
+
+  if (!version) {
+    // a snapshot version before the first tag on the branch
+    version = semver(currentPackage.branchPattern.replace('*','0-alpha.1'));
+  }
+
+  // We need to clone to ensure that we are not modifying another version
+  version = semver(version.raw);
+
+  var jenkinsBuild = process.env.TRAVIS_BUILD_NUMBER || process.env.BUILD_NUMBER;
+  if (!version.prerelease || !version.prerelease.length) {
+    // last release was a non beta release. Increment the patch level to
+    // indicate the next release that we will be doing.
+    // E.g. last release was 1.3.0, then the snapshot will be
+    // 1.3.1-build.1, which is lesser than 1.3.1 accorind the semver!
+
+    // If the last release was a beta release we don't update the
+    // beta number by purpose, as otherwise the semver comparison
+    // does not work any more when the next beta is released.
+    // E.g. don't generate 1.3.0-beta.2.build.1
+    // as this is bigger than 1.3.0-beta.2 according to semver
+    version.patch++;
+  }
+  version.prerelease = jenkinsBuild ? ['build', jenkinsBuild] : ['local'];
+  version.build = getBuild();
+  version.codeName = 'snapshot';
+  version.isSnapshot = true;
+  version.format();
+  version.full = version.version + '+' + version.build;
+  version.branch = 'master';
+
+  return version;
+};
+
+
+exports.currentPackage = currentPackage = getPackage();
+exports.gitRepoInfo = gitRepoInfo = getGitRepoInfo();
+exports.previousVersions = previousVersions = getPreviousVersions();
+exports.currentVersion = getTaggedVersion() || getSnapshotVersion();

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -8564,6 +8564,9 @@
     "semver": {
       "version": "4.3.4"
     },
+    "shelljs": {
+      "version": "0.5.0"
+    },
     "sorted-object": {
       "version": "1.0.0"
     },
@@ -8984,12 +8987,7 @@
           "version": "0.1.4"
         },
         "minitable": {
-          "version": "0.0.3",
-          "dependencies": {
-            "minichain": {
-              "version": "0.0.1"
-            }
-          }
+          "version": "0.0.3"
         },
         "es6-shim": {
           "version": "0.9.1"
@@ -9255,6 +9253,9 @@
         },
         "detect-indent": {
           "version": "0.1.4"
+        },
+        "minichain": {
+          "version": "0.0.1"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4261,52 +4261,52 @@
     },
     "firefox-profile": {
       "version": "0.3.4",
-      "from": "firefox-profile@0.3.4",
+      "from": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-0.3.4.tgz",
       "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-0.3.4.tgz",
       "dependencies": {
         "jetpack-id": {
           "version": "0.0.4",
-          "from": "jetpack-id@0.0.4",
+          "from": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-0.0.4.tgz",
           "resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-0.0.4.tgz"
         },
         "adm-zip": {
           "version": "0.4.7",
-          "from": "adm-zip@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
           "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
         },
         "archiver": {
           "version": "0.11.0",
-          "from": "archiver@>=0.11.0 <0.12.0",
+          "from": "https://registry.npmjs.org/archiver/-/archiver-0.11.0.tgz",
           "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.11.0.tgz",
           "dependencies": {
             "buffer-crc32": {
               "version": "0.2.5",
-              "from": "buffer-crc32@>=0.2.1 <0.3.0",
+              "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz",
               "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
             },
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.6 <3.3.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.4",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
@@ -4315,54 +4315,54 @@
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "tar-stream": {
               "version": "0.4.7",
-              "from": "tar-stream@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
               "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
-                  "from": "bl@>=0.9.0 <0.10.0",
+                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
                 },
                 "end-of-stream": {
                   "version": "1.1.0",
-                  "from": "end-of-stream@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                   "dependencies": {
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@>=1.3.0 <1.4.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -4373,17 +4373,17 @@
             },
             "zip-stream": {
               "version": "0.4.1",
-              "from": "zip-stream@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.4.1.tgz",
               "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.4.1.tgz",
               "dependencies": {
                 "compress-commons": {
                   "version": "0.1.6",
-                  "from": "compress-commons@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.1.6.tgz",
                   "dependencies": {
                     "crc32-stream": {
                       "version": "0.3.4",
-                      "from": "crc32-stream@>=0.3.1 <0.4.0",
+                      "from": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
                       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz"
                     }
                   }
@@ -4394,71 +4394,71 @@
         },
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "fs-extra": {
           "version": "0.11.1",
-          "from": "fs-extra@>=0.11.0 <0.12.0",
+          "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.11.1.tgz",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.11.1.tgz",
           "dependencies": {
             "ncp": {
               "version": "0.6.0",
-              "from": "ncp@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "jsonfile": {
               "version": "2.0.1",
-              "from": "jsonfile@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.1.tgz"
             },
             "rimraf": {
               "version": "2.3.4",
-              "from": "rimraf@>=2.2.8 <3.0.0",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz"
             }
           }
         },
         "lazystream": {
           "version": "0.1.0",
-          "from": "lazystream@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -4467,27 +4467,27 @@
         },
         "wrench": {
           "version": "1.5.8",
-          "from": "wrench@>=1.5.1 <1.6.0",
+          "from": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz",
           "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz"
         },
         "xml2js": {
           "version": "0.4.9",
-          "from": "xml2js@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.9.tgz",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.9.tgz",
           "dependencies": {
             "sax": {
               "version": "0.6.1",
-              "from": "sax@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
             },
             "xmlbuilder": {
               "version": "2.6.4",
-              "from": "xmlbuilder@>=2.4.6",
+              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.4.tgz",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.4.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "3.9.3",
-                  "from": "lodash@>=3.5.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
                 }
               }
@@ -4496,7 +4496,7 @@
         },
         "ini": {
           "version": "1.2.1",
-          "from": "ini@>=1.2.1 <1.3.0",
+          "from": "https://registry.npmjs.org/ini/-/ini-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.2.1.tgz"
         }
       }
@@ -11002,146 +11002,147 @@
     },
     "jpm": {
       "version": "1.0.0",
-      "from": "jpm@1.0.0",
+      "from": "https://registry.npmjs.org/jpm/-/jpm-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/jpm/-/jpm-1.0.0.tgz",
       "dependencies": {
         "commander": {
           "version": "2.6.0",
-          "from": "commander@2.6.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
         },
         "fs-promise": {
           "version": "0.3.1",
-          "from": "fs-promise@0.3.1",
+          "from": "https://registry.npmjs.org/fs-promise/-/fs-promise-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-0.3.1.tgz",
           "dependencies": {
             "any-promise": {
               "version": "0.1.0",
-              "from": "any-promise@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz"
             }
           }
         },
         "fs-extra": {
           "version": "0.16.4",
-          "from": "fs-extra@0.16.4",
+          "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.4.tgz",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.4.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "graceful-fs@>=3.0.5 <4.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "jsonfile": {
               "version": "2.0.1",
-              "from": "jsonfile@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.1.tgz"
             },
             "rimraf": {
               "version": "2.3.4",
-              "from": "rimraf@>=2.2.8 <3.0.0",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz"
             }
           }
         },
         "fx-runner": {
           "version": "0.0.7",
-          "from": "fx-runner@0.0.7",
+          "from": "https://registry.npmjs.org/fx-runner/-/fx-runner-0.0.7.tgz",
           "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-0.0.7.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@2.4.1"
+              "from": "lodash@2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "when": {
               "version": "3.6.4",
-              "from": "when@3.6.4",
+              "from": "https://registry.npmjs.org/when/-/when-3.6.4.tgz",
               "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz"
             },
             "winreg": {
               "version": "0.0.12",
-              "from": "winreg@0.0.12",
+              "from": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz",
               "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz"
             }
           }
         },
         "jpm-core": {
           "version": "0.0.9",
-          "from": "jpm-core@0.0.9",
+          "from": "https://registry.npmjs.org/jpm-core/-/jpm-core-0.0.9.tgz",
           "resolved": "https://registry.npmjs.org/jpm-core/-/jpm-core-0.0.9.tgz"
         },
         "jetpack-id": {
           "version": "0.0.4",
-          "from": "jetpack-id@0.0.4",
+          "from": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-0.0.4.tgz",
           "resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-0.0.4.tgz"
         },
         "jetpack-validation": {
           "version": "0.0.4",
-          "from": "jetpack-validation@0.0.4",
+          "from": "https://registry.npmjs.org/jetpack-validation/-/jetpack-validation-0.0.4.tgz",
           "resolved": "https://registry.npmjs.org/jetpack-validation/-/jetpack-validation-0.0.4.tgz",
           "dependencies": {
             "resolve": {
               "version": "0.7.4",
-              "from": "resolve@>=0.7.1 <0.8.0",
+              "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
             },
             "semver": {
               "version": "2.3.2",
-              "from": "semver@>=2.3.1 <3.0.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             }
           }
         },
         "firefox-profile": {
           "version": "0.3.9",
-          "from": "firefox-profile@0.3.9",
+          "from": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-0.3.9.tgz",
           "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-0.3.9.tgz",
           "dependencies": {
             "adm-zip": {
               "version": "0.4.7",
-              "from": "adm-zip@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
               "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
             },
             "archiver": {
               "version": "0.14.4",
-              "from": "archiver@>=0.14.3 <0.15.0",
+              "from": "https://registry.npmjs.org/archiver/-/archiver-0.14.4.tgz",
               "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.14.4.tgz",
               "dependencies": {
                 "buffer-crc32": {
                   "version": "0.2.5",
-                  "from": "buffer-crc32@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz",
                   "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
                 },
                 "glob": {
                   "version": "4.3.5",
-                  "from": "glob@>=4.3.0 <4.4.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -11150,59 +11151,59 @@
                 },
                 "lodash": {
                   "version": "3.2.0",
-                  "from": "lodash@>=3.2.0 <3.3.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
                 },
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "tar-stream": {
                   "version": "1.1.5",
-                  "from": "tar-stream@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
                   "dependencies": {
                     "bl": {
                       "version": "0.9.4",
-                      "from": "bl@>=0.9.0 <0.10.0",
+                      "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
                       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
                     },
                     "end-of-stream": {
                       "version": "1.1.0",
-                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                       "dependencies": {
                         "once": {
                           "version": "1.3.2",
-                          "from": "once@>=1.3.0 <1.4.0",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
@@ -11213,22 +11214,22 @@
                 },
                 "zip-stream": {
                   "version": "0.5.2",
-                  "from": "zip-stream@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.2.tgz",
                   "dependencies": {
                     "compress-commons": {
                       "version": "0.2.9",
-                      "from": "compress-commons@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.9.tgz",
                       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.9.tgz",
                       "dependencies": {
                         "crc32-stream": {
                           "version": "0.3.4",
-                          "from": "crc32-stream@>=0.3.1 <0.4.0",
+                          "from": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
                           "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz"
                         },
                         "node-int64": {
                           "version": "0.3.3",
-                          "from": "node-int64@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz",
                           "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz"
                         }
                       }
@@ -11239,37 +11240,37 @@
             },
             "async": {
               "version": "0.9.2",
-              "from": "async@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
             },
             "lazystream": {
               "version": "0.1.0",
-              "from": "lazystream@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.2 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -11278,66 +11279,66 @@
             },
             "lodash": {
               "version": "3.5.0",
-              "from": "lodash@>=3.5.0 <3.6.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
             },
             "wrench": {
               "version": "1.5.8",
-              "from": "wrench@>=1.5.8 <1.6.0",
+              "from": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz",
               "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz"
             },
             "xml2js": {
               "version": "0.4.9",
-              "from": "xml2js@>=0.4.4 <0.5.0",
+              "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.9.tgz",
               "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.9.tgz",
               "dependencies": {
                 "sax": {
                   "version": "0.6.1",
-                  "from": "sax@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
                 },
                 "xmlbuilder": {
                   "version": "2.6.4",
-                  "from": "xmlbuilder@>=2.4.6",
+                  "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.4.tgz",
                   "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.4.tgz"
                 }
               }
             },
             "ini": {
               "version": "1.3.3",
-              "from": "ini@>=1.3.3 <1.4.0",
+              "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
             }
           }
         },
         "jsontoxml": {
           "version": "0.0.11",
-          "from": "jsontoxml@0.0.11",
+          "from": "https://registry.npmjs.org/jsontoxml/-/jsontoxml-0.0.11.tgz",
           "resolved": "https://registry.npmjs.org/jsontoxml/-/jsontoxml-0.0.11.tgz"
         },
         "lodash": {
           "version": "3.3.1",
-          "from": "lodash@3.3.1",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.3.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.3.1.tgz"
         },
         "minimatch": {
           "version": "2.0.4",
-          "from": "minimatch@2.0.4",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.0",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.2.0",
-                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
@@ -11346,69 +11347,69 @@
         },
         "node-watch": {
           "version": "0.3.4",
-          "from": "node-watch@0.3.4",
+          "from": "https://registry.npmjs.org/node-watch/-/node-watch-0.3.4.tgz",
           "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.3.4.tgz"
         },
         "tmp": {
           "version": "0.0.25",
-          "from": "tmp@0.0.25",
+          "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz"
         },
         "open": {
           "version": "0.0.5",
-          "from": "open@0.0.5",
+          "from": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz"
         },
         "promzard": {
           "version": "0.3.0",
-          "from": "promzard@0.3.0",
+          "from": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz"
         },
         "read": {
           "version": "1.0.5",
-          "from": "read@1.0.5",
+          "from": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
           "dependencies": {
             "mute-stream": {
               "version": "0.0.5",
-              "from": "mute-stream@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
             }
           }
         },
         "semver": {
           "version": "4.3.3",
-          "from": "semver@4.3.3",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
         },
         "mozilla-version-comparator": {
           "version": "1.0.2",
-          "from": "mozilla-version-comparator@1.0.2",
+          "from": "https://registry.npmjs.org/mozilla-version-comparator/-/mozilla-version-comparator-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/mozilla-version-comparator/-/mozilla-version-comparator-1.0.2.tgz"
         },
         "mozilla-toolkit-versioning": {
           "version": "0.0.2",
-          "from": "mozilla-toolkit-versioning@0.0.2",
+          "from": "https://registry.npmjs.org/mozilla-toolkit-versioning/-/mozilla-toolkit-versioning-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/mozilla-toolkit-versioning/-/mozilla-toolkit-versioning-0.0.2.tgz"
         },
         "when": {
           "version": "3.7.2",
-          "from": "when@3.7.2",
+          "from": "https://registry.npmjs.org/when/-/when-3.7.2.tgz",
           "resolved": "https://registry.npmjs.org/when/-/when-3.7.2.tgz"
         },
         "zip-dir": {
           "version": "1.0.0",
-          "from": "zip-dir@1.0.0",
+          "from": "https://registry.npmjs.org/zip-dir/-/zip-dir-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/zip-dir/-/zip-dir-1.0.0.tgz",
           "dependencies": {
             "jszip": {
               "version": "2.5.0",
-              "from": "jszip@>=2.4.0 <3.0.0",
+              "from": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz",
               "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz",
               "dependencies": {
                 "pako": {
                   "version": "0.2.6",
-                  "from": "pako@>=0.2.5 <0.3.0",
+                  "from": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
                 }
               }
@@ -12770,7 +12771,7 @@
     },
     "protractor": {
       "version": "2.1.0",
-      "from": "protractor@2.1.0",
+      "from": "https://registry.npmjs.org/protractor/-/protractor-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-2.1.0.tgz",
       "dependencies": {
         "request": {
@@ -12905,7 +12906,7 @@
         },
         "jasminewd2": {
           "version": "0.0.5",
-          "from": "jasminewd2@0.0.5",
+          "from": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.5.tgz"
         },
         "saucelabs": {
@@ -13227,6 +13228,11 @@
       "version": "4.3.4",
       "from": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
+    },
+    "shelljs": {
+      "version": "0.5.0",
+      "from": "shelljs@*",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.0.tgz"
     },
     "sorted-object": {
       "version": "1.0.0",
@@ -13873,14 +13879,7 @@
         "minitable": {
           "version": "0.0.3",
           "from": "https://registry.npmjs.org/minitable/-/minitable-0.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/minitable/-/minitable-0.0.3.tgz",
-          "dependencies": {
-            "minichain": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/minichain/-/minichain-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/minichain/-/minichain-0.0.1.tgz"
-            }
-          }
+          "resolved": "https://registry.npmjs.org/minitable/-/minitable-0.0.3.tgz"
         },
         "es6-shim": {
           "version": "0.9.1",
@@ -14297,6 +14296,11 @@
           "version": "0.1.4",
           "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-0.1.4.tgz"
+        },
+        "minichain": {
+          "version": "0.0.1",
+          "from": "https://registry.npmjs.org/minichain/-/minichain-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/minichain/-/minichain-0.0.1.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "angular",
   "version": "2.0.0-alpha.25",
+  "branchPattern": "2.0.*",
   "description": "Angular 2 - a web framework for modern web apps",
   "homepage": "https://github.com/angular/angular",
   "bugs": "https://github.com/angular/angular/issues",
@@ -105,6 +106,7 @@
     "rewire": "^2.3.3",
     "run-sequence": "^1.1.0",
     "semver": "^4.3.4",
+    "shelljs": "^0.5.0",
     "sorted-object": "^1.0.0",
     "source-map": "^0.3.0",
     "sprintf-js": "1.0.*",


### PR DESCRIPTION
The `versionInfo.js` file checks various things including the `package.json` file and local and remote git tags to work out what the current version information is. This code is mostly copied verbatim from the angular.js 1.x project so it might not fit quite right but it seems to work for now.

The important point is that if the current commit has an annotated tag on it that satisfies the semver version inside package.json then this is used as the current version. If not then a "local" version is created.

If we are on the "local" version then all the view on github links will point to master, otherwise they point to the tagged release.
