### PR TITLE
fix(errors): require passing stack traces explicitly in ng2 own code

### DIFF
--- a/modules/angular2/src/core/application.js
+++ b/modules/angular2/src/core/application.js
@@ -259,8 +259,8 @@ export function bootstrap(appComponentType: Type,
         bootstrapProcess.resolve(new ApplicationRef(componentRef, appComponentType, appInjector));
       },
 
-      (err) => {
-        bootstrapProcess.reject(err)
+      (err, stackTrace) => {
+        bootstrapProcess.reject(err, stackTrace)
       });
   });
 

--- a/modules/angular2/src/di/injector.ts
+++ b/modules/angular2/src/di/injector.ts
@@ -338,7 +338,7 @@ class _AsyncInjectorStrategy {
     var deps = this.injector._resolveDependencies(key, binding, true);
     var depsPromise = PromiseWrapper.all(deps);
 
-    var promise = PromiseWrapper.then(depsPromise, null, (e) => this._errorHandler(key, e))
+    var promise = PromiseWrapper.then(depsPromise, null, (e, s) => this._errorHandler(key, e, s))
                       .then(deps => this._findOrCreate(key, binding, deps))
                       .then(instance => this._cacheInstance(key, instance));
 
@@ -346,9 +346,9 @@ class _AsyncInjectorStrategy {
     return promise;
   }
 
-  _errorHandler(key: Key, e): Promise<any> {
+  _errorHandler(key: Key, e, stack): Promise<any> {
     if (e instanceof AbstractBindingError) e.addKey(key);
-    return PromiseWrapper.reject(e);
+    return PromiseWrapper.reject(e, stack);
   }
 
   _findOrCreate(key: Key, binding: ResolvedBinding, deps: List<any>) {

--- a/modules/angular2/src/facade/async.dart
+++ b/modules/angular2/src/facade/async.dart
@@ -6,9 +6,13 @@ export 'dart:async' show Future, Stream, StreamController, StreamSubscription;
 class PromiseWrapper {
   static Future resolve(obj) => new Future.value(obj);
 
-  static Future reject(obj) => new Future.error(
+  static Future reject(obj, stackTrace) => new Future.error(
       obj,
-      obj is Error ? obj.stackTrace : null);
+      stackTrace != null
+        ? stackTrace
+        : obj is Error
+          ? obj.stackTrace
+          : null);
 
   static Future<List> all(List<Future> promises) => Future.wait(promises);
 
@@ -23,7 +27,7 @@ class PromiseWrapper {
     return promise.catchError(onError);
   }
 
-  static _Completer completer() => new _Completer(new Completer());
+  static CompleterWrapper completer() => new CompleterWrapper(new Completer());
 
   // TODO(vic): create a TimerWrapper
   static Timer setTimeout(fn(), int millis)
@@ -99,10 +103,10 @@ class EventEmitter extends Stream {
   }
 }
 
-class _Completer {
+class CompleterWrapper {
   final Completer c;
 
-  _Completer(this.c);
+  CompleterWrapper(this.c);
 
   Future get promise => c.future;
 
@@ -110,11 +114,10 @@ class _Completer {
     c.complete(v);
   }
 
-  void reject(v) {
-    var stack = null;
-    if (v is Error) {
-      stack = v.stackTrace;
+  void reject(error, stack) {
+    if (stack == null && error is Error) {
+      stack = error.stackTrace;
     }
-    c.completeError(v, stack);
+    c.completeError(error, stack);
   }
 }

--- a/modules/angular2/src/facade/async.ts
+++ b/modules/angular2/src/facade/async.ts
@@ -15,7 +15,7 @@ export var Promise = (<any>global).Promise;
 export class PromiseWrapper {
   static resolve(obj): Promise<any> { return Promise.resolve(obj); }
 
-  static reject(obj): Promise<any> { return Promise.reject(obj); }
+  static reject(obj, _): Promise<any> { return Promise.reject(obj); }
 
   // Note: We can't rename this method into `catch`, as this is not a valid
   // method name in Dart.
@@ -29,7 +29,7 @@ export class PromiseWrapper {
   }
 
   static then<T>(promise: Promise<T>, success: (value: any) => T | Thenable<T>,
-                 rejection: (error: any) => T | Thenable<T>): Promise<T> {
+                 rejection: (error: any, stack?: any) => T | Thenable<T>): Promise<T> {
     return promise.then(success, rejection);
   }
 

--- a/modules/angular2/src/mock/xhr_mock.js
+++ b/modules/angular2/src/mock/xhr_mock.js
@@ -88,7 +88,7 @@ class _PendingRequest {
 
   complete(response: string) {
     if (isBlank(response)) {
-      this.completer.reject(`Failed to load ${this.url}`);
+      this.completer.reject(`Failed to load ${this.url}`, null);
     } else {
       this.completer.resolve(response);
     }

--- a/modules/angular2/test/render/dom/compiler/compiler_common_tests.js
+++ b/modules/angular2/test/render/dom/compiler/compiler_common_tests.js
@@ -219,7 +219,7 @@ class FakeTemplateLoader extends TemplateLoader {
       }
     }
 
-    return PromiseWrapper.reject('Load failed');
+    return PromiseWrapper.reject('Load failed', null);
   }
 }
 

--- a/modules/angular2/test/render/dom/shadow_dom/emulated_scoped_shadow_dom_strategy_spec.js
+++ b/modules/angular2/test/render/dom/shadow_dom/emulated_scoped_shadow_dom_strategy_spec.js
@@ -131,7 +131,7 @@ class FakeXHR extends XHR {
   get(url: string): Promise<string> {
     var response = MapWrapper.get(this._responses, url);
     if (isBlank(response)) {
-      return PromiseWrapper.reject('xhr error');
+      return PromiseWrapper.reject('xhr error', null);
     }
 
     return PromiseWrapper.resolve(response);

--- a/modules/angular2/test/render/dom/shadow_dom/style_inliner_spec.js
+++ b/modules/angular2/test/render/dom/shadow_dom/style_inliner_spec.js
@@ -223,7 +223,7 @@ class FakeXHR extends XHR {
   get(url: string): Promise<string> {
     var response = MapWrapper.get(this._responses, url);
     if (isBlank(response)) {
-      return PromiseWrapper.reject('xhr error');
+      return PromiseWrapper.reject('xhr error', null);
     }
 
     return PromiseWrapper.resolve(response);

--- a/tools/build/dartanalyzer.js
+++ b/tools/build/dartanalyzer.js
@@ -76,8 +76,8 @@ module.exports = function(gulp, plugins, config) {
             return;
           }
         }
-        // TODO(yjbanov): fix ng2 code and remove the check below
-        if (line.match(/_stack/)) {
+        // TODO: https://github.com/angular/ts2dart/issues/168
+        if (line.match(/_stack' is not used/)) {
           return;
         }
 


### PR DESCRIPTION
Fixes https://github.com/angular/angular/issues/1962.

Here's the new stack trace for @jbdeboer's repro (points straight into `origin`):

```
Caught an error: Error:[An exception. Can you see origin() in the stack?] Stack:[
#0      origin (http://localhost:8080/test.dart:13:3)
#1      MyComp.MyComp (http://localhost:8080/test.dart:47:5)
#2      _LocalClassMirror._invokeConstructor (dart:mirrors-patch/mirrors_impl.dart:944)
#3      _LocalClassMirror.newInstance (dart:mirrors-patch/mirrors_impl.dart:860)
#4      ReflectionCapabilities.factory.<anonymous closure> (package:angular2/src/reflection/reflection_capabilities.dart:19:28)
#5      ElementInjector._new (package:angular2/src/core/compiler/element_injector.dart:866:22)
#6      ElementInjector._getObjByKeyId (package:angular2/src/core/compiler/element_injector.dart:1162:27)
#7      ElementInjector.hydrate (package:angular2/src/core/compiler/element_injector.dart:745:36)
#8      AppViewManagerUtils._hydrateView (package:angular2/src/core/compiler/view_manager_utils.dart:197:25)
```
