### PR TITLE
refactor(core.js): export NgZone

### DIFF
--- a/modules/angular2/core.ts
+++ b/modules/angular2/core.ts
@@ -18,3 +18,5 @@ export * from './src/core/compiler/dynamic_component_loader';
 export {ViewRef, ProtoViewRef} from './src/core/compiler/view_ref';
 export {ViewContainerRef} from './src/core/compiler/view_container_ref';
 export {ElementRef} from './src/core/compiler/element_ref';
+
+export {NgZone} from './src/core/zone/ng_zone';


### PR DESCRIPTION
Export NgZone so it can be used in applications where large data streams should be processed outside of Angular.
