### PR TITLE
feat(render): re-export render and export `DirectiveResolver`

### DIFF
--- a/modules/angular2/core.ts
+++ b/modules/angular2/core.ts
@@ -13,13 +13,7 @@ export * from './src/core/annotations/di';
 export * from './src/core/compiler/compiler';
 export * from './src/core/compiler/interfaces';
 export * from './src/core/compiler/query_list';
-
-// TODO(tbosch): remove this once render migration is complete
-export * from './src/render/dom/compiler/template_loader';
-export * from './src/render/dom/shadow_dom/shadow_dom_strategy';
-export * from './src/render/dom/shadow_dom/native_shadow_dom_strategy';
-export * from './src/render/dom/shadow_dom/emulated_scoped_shadow_dom_strategy';
-export * from './src/render/dom/shadow_dom/emulated_unscoped_shadow_dom_strategy';
+export * from './src/core/compiler/directive_resolver';
 export * from './src/core/compiler/dynamic_component_loader';
 export {ViewRef, ProtoViewRef} from './src/core/compiler/view_ref';
 export {ViewContainerRef} from './src/core/compiler/view_container_ref';

--- a/modules/angular2/render.ts
+++ b/modules/angular2/render.ts
@@ -1,0 +1,13 @@
+/**
+ * @module
+ * @public
+ * @description
+ * This module provides advanced support for extending dom strategy.
+ */
+
+export * from './src/render/dom/compiler/template_loader';
+export * from './src/render/dom/shadow_dom/shadow_dom_strategy';
+export * from './src/render/dom/shadow_dom/native_shadow_dom_strategy';
+export * from './src/render/dom/shadow_dom/emulated_scoped_shadow_dom_strategy';
+export * from './src/render/dom/shadow_dom/emulated_unscoped_shadow_dom_strategy';
+export * from './src/render/api';


### PR DESCRIPTION
If you want to use native web components in your App then your bootstrap file would look like this.

``` es6
import {bootstrap} from 'angular2/angular2';
import {bind} from 'angular2/di';
import {ShadowDomStrategy} from 'angular2/src/render/dom/shadow_dom/shadow_dom_strategy';
import {NativeShadowDomStrategy} from 'angular2/src/render/dom/shadow_dom/native_shadow_dom_strategy';

import {App} from './app';

bootstrap(App, [
  bind(ShadowDomStrategy).toClass(NativeShadowDomStrategy)
]);
```

rather than something like this

``` es6
import {ShadowDomStrategy, NativeShadowDomStrategy} from 'angular2/render';
import {bootstrap, bind} from 'angular2/angular2';

import {App} from './app';

bootstrap(App, [
  bind(ShadowDomStrategy).toClass(NativeShadowDomStrategy)
]);
```

also complete a todo from @tbosch 
https://github.com/angular/angular/blob/master/modules/angular2/core.js#L17

I'm re-exporting render in core unless you want me to remove it

it would also be nice to have `DirectiveResolver` exported in `angular/core` so I added that here.
