### PR TITLE
fix(test): improving unit tests results in IE11 and Firefox 38

### DIFF
--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -24,7 +24,8 @@ module.exports = function(config) {
       'node_modules/reflect-metadata/Reflect.js',
       'tools/build/file2modulename.js',
       'test-main.js',
-      {pattern: 'modules/**/test/**/static_assets/**', included: false, watched: false}
+      {pattern: 'modules/**/test/**/static_assets/**', included: false, watched: false},
+      'modules/angular2/src/test_lib/shims_for_IE.es6'
     ],
 
     exclude: [

--- a/modules/angular2/src/dom/browser_adapter.dart
+++ b/modules/angular2/src/dom/browser_adapter.dart
@@ -135,6 +135,9 @@ class BrowserDomAdapter extends GenericBrowserDomAdapter {
   MouseEvent createMouseEvent(String eventType) =>
       new MouseEvent(eventType, canBubble: true);
   Event createEvent(String eventType) => new Event(eventType, canBubble: true);
+  void preventDefault(Event evt) { 
+    evt.preventDefault();
+  }
   String getInnerHTML(Element el) => el.innerHtml;
   String getOuterHTML(Element el) => el.outerHtml;
   void setInnerHTML(Element el, String value) {

--- a/modules/angular2/src/dom/browser_adapter.dart
+++ b/modules/angular2/src/dom/browser_adapter.dart
@@ -326,4 +326,7 @@ class BrowserDomAdapter extends GenericBrowserDomAdapter {
     var baseUri = Uri.parse(uri);
     return baseUri.path;
   }
+  String getUserAgent() {
+    return window.navigator.userAgent;
+  }
 }

--- a/modules/angular2/src/dom/browser_adapter.ts
+++ b/modules/angular2/src/dom/browser_adapter.ts
@@ -276,7 +276,7 @@ getTitle(): string {
   return document.title;
 }
 setTitle(newTitle: string) {
-  document.title = newTitle;
+  document.title = newTitle || '';
 }
 elementMatches(n, selector: string): boolean {
   return n instanceof HTMLElement && n.matches(selector);

--- a/modules/angular2/src/dom/browser_adapter.ts
+++ b/modules/angular2/src/dom/browser_adapter.ts
@@ -372,6 +372,9 @@ getLocation() {
 getBaseHref() {
   return relativePath(document.baseURI);
 }
+getUserAgent(): string {
+  return window.navigator.userAgent;
+}
 }
 
 // based on urlUtils.js in AngularJS 1

--- a/modules/angular2/src/dom/browser_adapter.ts
+++ b/modules/angular2/src/dom/browser_adapter.ts
@@ -270,7 +270,11 @@ defaultDoc() {
   return document;
 }
 getBoundingClientRect(el) {
-  return el.getBoundingClientRect();
+  try {
+    return el.getBoundingClientRect();
+  } catch (e) {
+    return {top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0};
+  }
 }
 getTitle(): string {
   return document.title;

--- a/modules/angular2/src/dom/browser_adapter.ts
+++ b/modules/angular2/src/dom/browser_adapter.ts
@@ -77,6 +77,10 @@ createMouseEvent(eventType: string): MouseEvent {
 createEvent(eventType): Event {
   return new Event(eventType, true);
 }
+preventDefault(evt: Event) {
+  evt.preventDefault();
+  evt.returnValue = false;
+}
 getInnerHTML(el) {
   return el.innerHTML;
 }

--- a/modules/angular2/src/dom/browser_adapter.ts
+++ b/modules/angular2/src/dom/browser_adapter.ts
@@ -70,12 +70,14 @@ dispatchEvent(el, evt) {
   el.dispatchEvent(evt);
 }
 createMouseEvent(eventType: string): MouseEvent {
-  var evt: MouseEvent = new MouseEvent(eventType);
+  var evt: MouseEvent = document.createEvent('MouseEvent');
   evt.initEvent(eventType, true, true);
   return evt;
 }
 createEvent(eventType): Event {
-  return new Event(eventType, true);
+  var evt: Event = document.createEvent('Event');
+  evt.initEvent(eventType, true, true);
+  return evt;
 }
 preventDefault(evt: Event) {
   evt.preventDefault();

--- a/modules/angular2/src/dom/browser_adapter.ts
+++ b/modules/angular2/src/dom/browser_adapter.ts
@@ -279,7 +279,8 @@ setTitle(newTitle: string) {
   document.title = newTitle || '';
 }
 elementMatches(n, selector: string): boolean {
-  return n instanceof HTMLElement && n.matches(selector);
+  return n instanceof HTMLElement && n.matches ? n.matches(selector) :
+                                                 n.msMatchesSelector(selector);
 }
 isTemplateElement(el: any): boolean {
   return el instanceof HTMLElement && el.nodeName == "TEMPLATE";

--- a/modules/angular2/src/dom/dom_adapter.ts
+++ b/modules/angular2/src/dom/dom_adapter.ts
@@ -33,6 +33,7 @@ export class DomAdapter {
   dispatchEvent(el, evt) { throw _abstract(); }
   createMouseEvent(eventType): any { throw _abstract(); }
   createEvent(eventType: string): any { throw _abstract(); }
+  preventDefault(evt) { throw _abstract(); }
   getInnerHTML(el): string { throw _abstract(); }
   getOuterHTML(el): string { throw _abstract(); }
   nodeName(node): string { throw _abstract(); }

--- a/modules/angular2/src/dom/dom_adapter.ts
+++ b/modules/angular2/src/dom/dom_adapter.ts
@@ -114,4 +114,5 @@ export class DomAdapter {
   getHistory() { throw _abstract(); }
   getLocation() { throw _abstract(); }
   getBaseHref() { throw _abstract(); }
+  getUserAgent() { throw _abstract(); }
 }

--- a/modules/angular2/src/dom/html_adapter.dart
+++ b/modules/angular2/src/dom/html_adapter.dart
@@ -76,6 +76,9 @@ class Html5LibDomAdapter implements DomAdapter {
   createEvent(eventType) {
     throw 'not implemented';
   }
+  preventDefault(evt) { 
+    throw 'not implemented';
+  }
   getInnerHTML(el) {
     return el.innerHtml;
   }

--- a/modules/angular2/src/dom/html_adapter.dart
+++ b/modules/angular2/src/dom/html_adapter.dart
@@ -303,4 +303,7 @@ class Html5LibDomAdapter implements DomAdapter {
   getBaseHref() {
     throw 'not implemented';
   }
+  String getUserAgent() {
+    throw 'not implemented';
+  }
 }

--- a/modules/angular2/src/dom/parse5_adapter.cjs
+++ b/modules/angular2/src/dom/parse5_adapter.cjs
@@ -134,6 +134,9 @@ export class Parse5DomAdapter extends DomAdapter {
       };
     return evt;
   }
+  preventDefault(evt) { 
+    evt.returnValue = false;
+  }
   getInnerHTML(el) {
     return serializer.serialize(this.templateAwareRoot(el));
   }

--- a/modules/angular2/src/dom/parse5_adapter.cjs
+++ b/modules/angular2/src/dom/parse5_adapter.cjs
@@ -540,6 +540,9 @@ export class Parse5DomAdapter extends DomAdapter {
   getLocation() {
     throw 'not implemented';
   }
+  getUserAgent() {
+    return "Fake user agent";
+  }
 }
 
 //TODO: build a proper list, this one is all the keys of a HTMLInputElement

--- a/modules/angular2/src/router/router_link.js
+++ b/modules/angular2/src/router/router_link.js
@@ -54,7 +54,7 @@ export class RouterLink {
     this._location = location;
     this._params = StringMapWrapper.create();
     DOM.on(this._domEl, 'click', (evt) => {
-      evt.preventDefault();
+      DOM.preventDefault(evt);
       this._router.navigate(this._navigationHref);
     });
   }

--- a/modules/angular2/src/test_lib/shims_for_IE.es6
+++ b/modules/angular2/src/test_lib/shims_for_IE.es6
@@ -1,0 +1,13 @@
+//function.name
+/*! @source http://stackoverflow.com/questions/6903762/function-name-not-supported-in-ie*/
+if (!(function f() {}).name) {
+    Object.defineProperty(Function.prototype, 'name', {
+        get: function() {
+            var name = this.toString().match(/^\s*function\s*(\S*)\s*\(/)[1];
+            // For better performance only parse once, and then cache the
+            // result through a new accessor for repeated access.
+            Object.defineProperty(this, 'name', { value: name });
+            return name;
+        }
+    });
+}

--- a/modules/angular2/test/change_detection/pipes/promise_pipe_spec.js
+++ b/modules/angular2/test/change_detection/pipes/promise_pipe_spec.js
@@ -5,6 +5,7 @@ import {PromisePipe} from 'angular2/src/change_detection/pipes/promise_pipe';
 import {WrappedValue} from 'angular2/src/change_detection/pipes/pipe';
 import {ChangeDetectorRef} from 'angular2/src/change_detection/change_detector_ref';
 import {PromiseWrapper, TimerWrapper} from 'angular2/src/facade/async';
+import {DOM} from 'angular2/src/dom/dom_adapter';
 
 export function main() {
   describe("PromisePipe", () => {
@@ -12,6 +13,8 @@ export function main() {
     var pipe;
     var completer;
     var ref;
+    //adds longer timers for passing tests in IE
+    var timer = (DOM.getUserAgent().indexOf("Trident") > -1) ? 50 : 0;
 
     beforeEach(() => {
       completer = PromiseWrapper.completer();
@@ -43,7 +46,7 @@ export function main() {
         TimerWrapper.setTimeout(() => {
           expect(pipe.transform(completer.promise)).toEqual(new WrappedValue(message));
           async.done();
-        }, 0)
+        }, timer)
       }));
 
       it("should return unwrapped value when nothing has changed since the last call",
@@ -55,7 +58,7 @@ export function main() {
           pipe.transform(completer.promise);
           expect(pipe.transform(completer.promise)).toBe(message);
           async.done();
-        }, 0)
+        }, timer)
       }));
 
       it("should dispose of the existing subscription when subscribing to a new promise",
@@ -71,7 +74,7 @@ export function main() {
         TimerWrapper.setTimeout(() => {
           expect(pipe.transform(newCompleter.promise)).toBe(null);
           async.done();
-        }, 0)
+        }, timer)
       }));
 
       it("should request a change detection check upon receiving a new value",
@@ -82,7 +85,7 @@ export function main() {
         TimerWrapper.setTimeout(() => {
           expect(ref.spy('requestCheck')).toHaveBeenCalled();
           async.done();
-        }, 0)
+        }, timer)
       }));
 
       describe("onDestroy", () => {
@@ -101,7 +104,7 @@ export function main() {
             pipe.onDestroy();
             expect(pipe.transform(completer.promise)).toBe(null);
             async.done();
-          }, 0);
+          }, timer);
         }));
       });
     });

--- a/modules/angular2/test/core/zone/ng_zone_spec.js
+++ b/modules/angular2/test/core/zone/ng_zone_spec.js
@@ -16,12 +16,15 @@ import {
 import {PromiseWrapper, TimerWrapper} from 'angular2/src/facade/async';
 import {ListWrapper} from 'angular2/src/facade/collection';
 import {BaseException} from 'angular2/src/facade/lang';
+import {DOM} from 'angular2/src/dom/dom_adapter';
 
 import {NgZone} from 'angular2/src/core/zone/ng_zone';
 
+var isIE = DOM.getUserAgent().indexOf("Trident") > -1;
 // Schedules a macrotask (using a timer)
-function macroTask(fn: Function): void {
-  _zone.runOutsideAngular(() => TimerWrapper.setTimeout(fn, 1));
+function macroTask(fn: Function, timer = 1): void {
+  //adds longer timers for passing tests in IE
+  _zone.runOutsideAngular(() => TimerWrapper.setTimeout(fn, isIE ? timer : 1));
 }
 
 // Schedules a microtasks (using a resolved promise .then())
@@ -192,7 +195,7 @@ function commonTests() {
         // The microtask (async) is executed after the macrotask (run)
         expect(_log.result()).toEqual('onTurnStart; run start; run end; async; onTurnDone');
         async.done();
-      });
+      }, 50);
     }));
 
     it('should not run onTurnStart and onTurnDone for nested Zone.run',
@@ -211,7 +214,7 @@ function commonTests() {
       macroTask(() => {
         expect(_log.result()).toEqual('onTurnStart; start run; nested run; end run; nested run microtask; onTurnDone');
         async.done();
-      });
+      }, 50);
     }));
 
     it('should call onTurnStart and onTurnDone before and after each top-level run',
@@ -256,7 +259,7 @@ function commonTests() {
       macroTask(() => {
         expect(_log.result()).toEqual('onTurnStart; run start; onTurnDone; onTurnStart; a then; b then; onTurnDone');
         async.done();
-      });
+      }, 50);
     }));
 
     it('should run a function outside of the angular zone', inject([AsyncTestCompleter], (async) => {
@@ -303,7 +306,7 @@ function commonTests() {
             'onTurnStart; executedMicrotask; onTurnDone'
         );
         async.done();
-      });
+      }, 50);
     }));
 
     it('should call onTurnStart before executing a microtask scheduled in onTurnDone as well as ' +
@@ -334,7 +337,7 @@ function commonTests() {
             'onTurnStart; executedMicrotask; onTurnDone(begin); onTurnDone(end)'
         );
         async.done();
-      });
+      }, 50);
     }));
 
     it('should call onTurnStart and onTurnDone for a scheduleMicrotask in onTurnDone triggered by ' +
@@ -369,8 +372,7 @@ function commonTests() {
             'onTurnStart; onTurnDone(executeMicrotask); onTurnDone(begin); onTurnDone(end)'
         );
         async.done();
-
-      });
+      }, 50);
     }));
 
     it('should execute promises scheduled in onTurnStart before promises scheduled in run',
@@ -426,7 +428,7 @@ function commonTests() {
             'onTurnStart(begin); onTurnStart(end); onTurnDone(executePromise); onTurnDone(begin); onTurnDone(end)'
         );
         async.done();
-      });
+      }, 50);
     }));
 
     it('should call onTurnStart and onTurnDone before and after each turn, respectively',
@@ -447,14 +449,14 @@ function commonTests() {
         _zone.run(() => {
           completerA.resolve(null);
         });
-      });
+      }, 10);
 
 
       macroTask(() => {
         _zone.run(() => {
           completerB.resolve(null);
         });
-      });
+      }, 30);
 
       macroTask(() => {
         expect(_log.result()).toEqual(
@@ -465,7 +467,7 @@ function commonTests() {
             // Third VM turn
             'onTurnStart; b then; onTurnDone');
         async.done();
-      });
+      }, 60);
     }));
 
     it('should call onTurnStart and onTurnDone before and after (respectively) all turns in a chain',
@@ -484,7 +486,7 @@ function commonTests() {
       macroTask(() => {
         expect(_log.result()).toEqual('onTurnStart; run start; run end; async1; async2; onTurnDone');
         async.done();
-      });
+      }, 50);
     }));
 
     it('should call onTurnStart and onTurnDone for promises created outside of run body',
@@ -505,7 +507,7 @@ function commonTests() {
       macroTask(() => {
         expect(_log.result()).toEqual('onTurnStart; zone run; onTurnDone; onTurnStart; promise then; onTurnDone');
         async.done();
-      });
+      }, 50);
     }));
   });
 
@@ -541,7 +543,7 @@ function commonTests() {
         expect(_errors.length).toBe(1);
         expect(_errors[0]).toEqual(exception);
         async.done();
-      });
+      }, 50);
     }));
 
     it('should call onError when onTurnDone throws and the zone is sync',
@@ -561,7 +563,7 @@ function commonTests() {
         expect(_errors.length).toBe(1);
         expect(_errors[0]).toEqual(exception);
         async.done();
-      });
+      }, 50);
     }));
 
     it('should call onError when onTurnDone throws and the zone is async',
@@ -587,7 +589,7 @@ function commonTests() {
         expect(_errors.length).toBe(1);
         expect(_errors[0]).toEqual(exception);
         async.done();
-      });
+      }, 50);
     }));
   });
 }

--- a/modules/angular2/test/render/dom/shadow_dom/native_shadow_dom_strategy_spec.js
+++ b/modules/angular2/test/render/dom/shadow_dom/native_shadow_dom_strategy_spec.js
@@ -30,10 +30,12 @@ export function main() {
       strategy = new NativeShadowDomStrategy(styleUrlResolver);
     });
 
-    it('should use the native shadow root', () => {
-      var host = el('<div><span>original content</span></div>');
-      expect(strategy.prepareShadowRoot(host)).toBe(DOM.getShadowRoot(host));
-    });
+    if (DOM.supportsNativeShadowDOM()) {
+      it('should use the native shadow root', () => {
+        var host = el('<div><span>original content</span></div>');
+        expect(strategy.prepareShadowRoot(host)).toBe(DOM.getShadowRoot(host));
+      });
+    }
 
     it('should rewrite style urls', () => {
       var styleElement = el('<style>.foo {background-image: url("img.jpg");}</style>');

--- a/modules/angular2/test/router/outlet_spec.js
+++ b/modules/angular2/test/router/outlet_spec.js
@@ -221,7 +221,7 @@ export function main() {
             view.detectChanges();
 
             var dispatchedEvent = clickOnElement(view);
-            expect(dispatchedEvent.defaultPrevented).toBe(true);
+            expect(dispatchedEvent.defaultPrevented || !dispatchedEvent.returnValue).toBe(true);
 
             // router navigation is async.
             rtr.subscribe((_) => {
@@ -244,7 +244,7 @@ export function main() {
             view.detectChanges();
 
             var dispatchedEvent = clickOnElement(view);
-            expect(dispatchedEvent.defaultPrevented).toBe(true);
+            expect(dispatchedEvent.defaultPrevented || !dispatchedEvent.returnValue).toBe(true);
 
             // router navigation is async.
             rtr.subscribe((_) => {


### PR DESCRIPTION
A first batch of fixes to improve unit tests results in IE11 and Firefox 38.
With them, the numbers of failures is reduced as follows:
- from 124 to 30 in IE11
- from 39 to 23 in Firefox 38

More fixes will follow, aiming to reach 0 in both.
