### PR TITLE
fix(test): improving unit tests results in Firefox 

### DIFF
--- a/modules/angular2/src/dom/browser_adapter.ts
+++ b/modules/angular2/src/dom/browser_adapter.ts
@@ -186,8 +186,8 @@ createScriptTag(attrName: string, attrValue: string, doc = document): HTMLScript
   return el;
 }
 createStyleElement(css: string, doc = document): HTMLStyleElement {
-  var style = <HTMLStyleElement>doc.createElement('STYLE');
-  style.innerText = css;
+  var style = <HTMLStyleElement>doc.createElement('style');
+  this.appendChild(style, this.createTextNode(css));
   return style;
 }
 createShadowRoot(el: HTMLElement): DocumentFragment {

--- a/modules/angular2/test/render/dom/shadow_dom/shadow_css_spec.js
+++ b/modules/angular2/test/render/dom/shadow_dom/shadow_css_spec.js
@@ -84,19 +84,19 @@ export function main() {
     });
 
     it('should support polyfill-unscoped-rule', () => {
-      var css = s("polyfill-unscoped-rule {content: '#menu > .bar';background: blue;}", 'a');
-      expect(StringWrapper.contains(css, '#menu > .bar {;background: blue;}')).toBeTruthy();
+      var css = s("polyfill-unscoped-rule {content: '#menu > .bar';color: blue;}", 'a');
+      expect(StringWrapper.contains(css, '#menu > .bar {;color: blue;}')).toBeTruthy();
 
-      css = s('polyfill-unscoped-rule {content: "#menu > .bar";background: blue;}', 'a');
-      expect(StringWrapper.contains(css, '#menu > .bar {;background: blue;}')).toBeTruthy();
+      css = s('polyfill-unscoped-rule {content: "#menu > .bar";color: blue;}', 'a');
+      expect(StringWrapper.contains(css, '#menu > .bar {;color: blue;}')).toBeTruthy();
     });
 
     it('should support polyfill-rule', () => {
-      var css = s("polyfill-rule {content: ':host.foo .bar';background: blue;}", 'a', 'a-host');
-      expect(css).toEqual('[a-host].foo .bar {background: blue;}');
+      var css = s("polyfill-rule {content: ':host.foo .bar';color: blue;}", 'a', 'a-host');
+      expect(css).toEqual('[a-host].foo .bar {color: blue;}');
 
-      css = s('polyfill-rule {content: ":host.foo .bar";background: blue;}', 'a', 'a-host');
-      expect(css).toEqual('[a-host].foo .bar {background: blue;}');
+      css = s('polyfill-rule {content: ":host.foo .bar";color: blue;}', 'a', 'a-host');
+      expect(css).toEqual('[a-host].foo .bar {color: blue;}');
     });
 
     it('should handle ::shadow', () => {


### PR DESCRIPTION
This PR fixes 17 unit tests that were failing in Firefox only.

About the second commit, Firefox expands `background: blue;` into `background: blue none repeat scroll 0% 0%;` when the rule is added in a style element, making it hard to test.
