### PR TITLE
fix(build): surface error and don't run tests if compile fails

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -659,8 +659,8 @@ var firstBuildJsCjs = true;
 /**
  * private task
  */
-gulp.task('!build.js.cjs', function() {
-  return angularBuilder.rebuildNodeTree().then(function() {
+gulp.task('!build.js.cjs', function(done) {
+  angularBuilder.rebuildNodeTree().then(function() {
     if (firstBuildJsCjs) {
       firstBuildJsCjs = false;
       console.log('creating node_modules symlink hack');
@@ -669,7 +669,8 @@ gulp.task('!build.js.cjs', function() {
         dir: CONFIG.dest.js.cjs
       })();
     }
-  });
+    done();
+  }, done);
 });
 
 


### PR DESCRIPTION
In the !build.js.cjs task, the broccoli rebuildNodeTree() promise didn't
have a rejection handler, which would cause gulp to continue as if this
task was successful, which led to confusing behavior when tests would run
but would be executing against stale or missing build artifacts. 

This fix injects the gulp `done` function, to be called on success with no parameters,
and on error with the error object, which prevents subsequent tasks from running.
