### PR TITLE
chore(build): watch logger should honor `ignoreInitial` option

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -335,10 +335,7 @@ function createDocsTasks(publicBuild) {
 
   gulp.task(taskPrefix, [taskPrefix + '/assets', taskPrefix + '/app', taskPrefix + '/dgeni']);
   gulp.task(taskPrefix + '/watch', function() {
-    return watch('docs/app/**/*', {
-      ignoreInitial: false,
-      log: watchLog
-    }, [taskPrefix + '/app']);
+    return watch('docs/app/**/*', [taskPrefix + '/app']);
   });
 
   gulp.task(taskPrefix + '/test', function (done) {
@@ -439,7 +436,7 @@ gulp.task('test.unit.dart', function (done) {
         return;
       }
 
-      watch('modules/angular2/**', { ignoreInitial: true, log: watchLog }, [
+      watch('modules/angular2/**', { ignoreInitial: true }, [
         '!build/tree.dart',
         '!test.unit.dart/karma-run'
       ]);
@@ -488,7 +485,7 @@ gulp.task('test.unit.cjs', ['build/clean.js', 'build.tools'], function (neverDon
     'test.unit.cjs/ci'
   ];
 
-  watch('modules/**', { ignoreInitial: false, log: watchLog }, buildAndTest);
+  watch('modules/**', buildAndTest);
 });
 
 
@@ -506,10 +503,7 @@ gulp.task('test.unit.tools', ['build/clean.tools'],  function(done) {
     'test.unit.tools/ci'
   ];
 
-  watch(['tools/**', '!tools/**/test-fixtures/**'], {
-    ignoreInitial: false,
-    log: watchLog
-  }, buildAndTest);
+  watch(['tools/**', '!tools/**/test-fixtures/**'], buildAndTest);
 });
 
 
@@ -895,21 +889,3 @@ process.on('beforeExit', function() {
   beforeExitRan = true;
   gulp.start('cleanup.builder');
 });
-
-function watchLog(triggerCount) {
-  // Ignore initial event
-  if (!--triggerCount) return;
-
-  process.stdout.write([
-    '',
-    '==================================================',
-    ' WATCH TRIGGERED BY FILE CHANGE #' + triggerCount,
-    ' On: ' + prettyTime(),
-    '==================================================\n',
-  ].join('\n'));
-
-  function prettyTime() {
-    var now = new Date();
-    return now.toLocaleDateString() + " at " + now.toLocaleTimeString();
-  }
-}

--- a/tools/build/watch.spec.js
+++ b/tools/build/watch.spec.js
@@ -27,7 +27,7 @@ describe('watch()', function() {
 
   it('should fire callback once for events which occur within `delay` window', function() {
     var cb = jasmine.createSpy('callback');
-    watcher = watch('./$$fake_path/**/*', { delay: 10 }, cb);
+    watcher = watch('./$$fake_path/**/*', { delay: 10, log: false }, cb);
 
     watcher._emit('add', './$$fake_path/test.txt');
     timeout.flush(9);
@@ -61,7 +61,7 @@ describe('watch()', function() {
       expect(timeout.pending).toBe(1);
     }
 
-    var watcher = watch('./$$fake_path/**/*', { delay: 10 }, cb);
+    var watcher = watch('./$$fake_path/**/*', { delay: 10, log: false }, cb);
 
     watcher._emit('change', './$$fake_path/test1.txt');
     expect(timeout.pending).toBe(1);
@@ -81,7 +81,7 @@ describe('watch()', function() {
       done();
     }
 
-    var watcher = watch('./$$fake_path/**/*', { delay: 10 }, cb);
+    var watcher = watch('./$$fake_path/**/*', { delay: 10, log: false }, cb);
 
     watcher._emit('change', './$$fake_path/test1.txt');
     timeout.flush();
@@ -96,7 +96,7 @@ describe('watch()', function() {
 
   it('should cancel pending callback if FSWatcher is closed', function() {
     var cb = jasmine.createSpy('callback');
-    var watcher = watch('./$$fake_path/**/*', { delay: 10 }, cb);
+    var watcher = watch('./$$fake_path/**/*', { delay: 10, log: false }, cb);
 
     watcher._emit('change', './$$fake_path/test1.txt');
     expect(timeout.pending).toBe(1);
@@ -119,7 +119,7 @@ describe('watch()', function() {
       expect(timeout.pending).toBe(0);
     }
 
-    var watcher = watch('./$$fake_path/**/*', { delay: 10 }, cb);
+    var watcher = watch('./$$fake_path/**/*', { delay: 10, log: false }, cb);
     watcher._emit('change', './$$fake_path/test1.txt');
 
     timeout.flush(10);


### PR DESCRIPTION
It was confusing because the test.unit.dart task does ignore the initial, and
the logger was hardcoded to always ignore the first task, leading to the appearance
that a run was happening twice for no reason.

Also, fixed the "fake ignoreInitial" handling to not rely on a fake event, which
is not necessary.

Closes #2093 (I think!)
