### PR TITLE
Import template contents in DomRenderer, not BrowserAdapter.

### DIFF
--- a/modules/angular2/src/dom/browser_adapter.ts
+++ b/modules/angular2/src/dom/browser_adapter.ts
@@ -204,11 +204,7 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   hasShadowRoot(node): boolean { return node instanceof HTMLElement && isPresent(node.shadowRoot); }
   isShadowRoot(node): boolean { return node instanceof DocumentFragment; }
   importIntoDoc(node: Node) {
-    var toImport = node;
-    if (this.isTemplateElement(node)) {
-      toImport = this.content(node);
-    }
-    return document.importNode(toImport, true);
+    return document.importNode(node, true);
   }
   isPageRule(rule): boolean { return rule.type === CSSRule.PAGE_RULE; }
   isStyleRule(rule): boolean { return rule.type === CSSRule.STYLE_RULE; }

--- a/modules/angular2/src/render/dom/dom_renderer.ts
+++ b/modules/angular2/src/render/dom/dom_renderer.ts
@@ -209,13 +209,15 @@ export class DomRenderer extends Renderer {
   }
 
   _createView(protoView: DomProtoView, inplaceElement): DomView {
-    var rootElementClone =
-        isPresent(inplaceElement) ? inplaceElement : DOM.importIntoDoc(protoView.element);
+    var rootElementClone;
     var elementsWithBindingsDynamic;
     if (protoView.isTemplateElement) {
+      rootElementClone = DOM.importIntoDoc(protoView.element.content);
       elementsWithBindingsDynamic =
           DOM.querySelectorAll(DOM.content(rootElementClone), NG_BINDING_CLASS_SELECTOR);
     } else {
+      rootElementClone = 
+          isPresent(inplaceElement) ? inplaceElement : DOM.importIntoDoc(protoView.element);
       elementsWithBindingsDynamic = DOM.getElementsByClassName(rootElementClone, NG_BINDING_CLASS);
     }
 
@@ -225,15 +227,11 @@ export class DomRenderer extends Renderer {
     }
 
     var viewRootNodes;
+    // TODO(justinfagnani): it would be more general to check for
+    // `rootElementClone instanceof DocumentFragment` rather than
+    // `protoView.isTemplateElement`
     if (protoView.isTemplateElement) {
-      var childNode = DOM.firstChild(DOM.content(rootElementClone));
-      viewRootNodes =
-          [];  // TODO(perf): Should be fixed size, since we could pre-compute in in DomProtoView
-      // Note: An explicit loop is the fastest way to convert a DOM array into a JS array!
-      while (childNode != null) {
-        ListWrapper.push(viewRootNodes, childNode);
-        childNode = DOM.nextSibling(childNode);
-      }
+      viewRootNodes = Array.prototype.slice.call(rootElementClone.childNodes);
     } else {
       viewRootNodes = [rootElementClone];
     }


### PR DESCRIPTION
This is a more correct fix for #1442 than #1970
#1970 changes the semantics of `document.importNode` and prohibits some valid uses of it, like importing a `<template>` element itself, rather than its contents. That change is also is not mirrored in the other browser adapters like the Dart adapter.

This change fixes the use of template and importNode at the source in `DomRenderer`: if the `protoView` is a template, import its element's contents.

There's also a small cleanup/perf improvement when creating `viewRootNodes`, since `rootElementClone` is a `DocumentFragment` and thus a `Node`, to get an Array of its children you can just use `childNodes`, you don't have to walk the children.
