### PR TITLE
refactor(angular2.ts): Re-export shadow DOM strategy API

### DIFF
--- a/modules/angular2/angular2.ts
+++ b/modules/angular2/angular2.ts
@@ -4,6 +4,7 @@ export * from './annotations';
 export * from './directives';
 export * from './forms';
 export * from './di';
+export * from './render';
 export {Observable, EventEmitter} from 'angular2/src/facade/async';
 export * from 'angular2/src/render/api';
 export {DomRenderer, DOCUMENT_TOKEN} from 'angular2/src/render/dom/dom_renderer';


### PR DESCRIPTION
Enable access to the NativeShadowDomStrategy again.
