### PR TITLE
Added a missing space

### DIFF
--- a/modules/angular2/annotations.ts
+++ b/modules/angular2/annotations.ts
@@ -6,7 +6,7 @@
  * Annotations provide the additional information that Angular requires in order to run your
  * application. This module
  * contains {@link Component}, {@link Directive}, and {@link View} annotations, as well as {@link
- * Parent} and {@link Ancestor} annotations that are
+ * Parent} and {@link Ancestor} annotations that are 
  * used by Angular to resolve dependencies.
  *
  */


### PR DESCRIPTION
![mistake](https://cloud.githubusercontent.com/assets/1916642/7789812/6edb6f8e-0288-11e5-9204-77ccff20197d.png)
I read the page and it has a typo, "...annotations that areused by Angular..." is changed now to "...annotations that are used by Angular...".
Mistake was found on this page : https://angular.io/docs/js/latest/api/annotations/
