### PR TITLE
style: fix clang-format glitches

### DIFF
--- a/modules/angular2/src/change_detection/change_detection.ts
+++ b/modules/angular2/src/change_detection/change_detection.ts
@@ -19,44 +19,43 @@ import {isPresent, BaseException} from 'angular2/src/facade/lang';
  *
  * @exportedAs angular2/pipes
  */
-export var keyValDiff: List < PipeFactory >= [new KeyValueChangesFactory(), new NullPipeFactory()];
+export var keyValDiff: List<PipeFactory> = [new KeyValueChangesFactory(), new NullPipeFactory()];
 
 /**
  * Structural diffing for `Iterable` types such as `Array`s.
  *
  * @exportedAs angular2/pipes
  */
-export var iterableDiff: List <
-    PipeFactory >= [new IterableChangesFactory(), new NullPipeFactory()];
+export var iterableDiff: List<PipeFactory> = [new IterableChangesFactory(), new NullPipeFactory()];
 
 /**
  * Async binding to such types as Observable.
  *
  * @exportedAs angular2/pipes
  */
-export var async: List <
-    PipeFactory >= [new ObservablePipeFactory(), new PromisePipeFactory(), new NullPipeFactory()];
+export var async: List<
+    PipeFactory> = [new ObservablePipeFactory(), new PromisePipeFactory(), new NullPipeFactory()];
 
 /**
  * Uppercase text transform.
  *
  * @exportedAs angular2/pipes
  */
-export var uppercase: List < PipeFactory >= [new UpperCaseFactory(), new NullPipeFactory()];
+export var uppercase: List<PipeFactory> = [new UpperCaseFactory(), new NullPipeFactory()];
 
 /**
  * Lowercase text transform.
  *
  * @exportedAs angular2/pipes
  */
-export var lowercase: List < PipeFactory >= [new LowerCaseFactory(), new NullPipeFactory()];
+export var lowercase: List<PipeFactory> = [new LowerCaseFactory(), new NullPipeFactory()];
 
 /**
  * Json stringify transform.
  *
  * @exportedAs angular2/pipes
  */
-export var json: List < PipeFactory >= [new JsonPipeFactory(), new NullPipeFactory()];
+export var json: List<PipeFactory> = [new JsonPipeFactory(), new NullPipeFactory()];
 
 export var defaultPipes = {
   "iterableDiff": iterableDiff,

--- a/modules/angular2/src/change_detection/dynamic_change_detector.ts
+++ b/modules/angular2/src/change_detection/dynamic_change_detector.ts
@@ -76,7 +76,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector {
   hydrated(): boolean { return this.values[0] !== uninitialized; }
 
   detectChangesInRecords(throwOnChange: boolean) {
-    var protos: List < ProtoRecord >= this.protos;
+    var protos: List<ProtoRecord> = this.protos;
 
     var changes = null;
     var isChanged = false;

--- a/modules/angular2/src/change_detection/proto_change_detector.ts
+++ b/modules/angular2/src/change_detection/proto_change_detector.ts
@@ -102,7 +102,7 @@ class ProtoRecordBuilder {
 
   constructor() { this.records = []; }
 
-  addAst(b: BindingRecord, variableNames: List < string >= null) {
+  addAst(b: BindingRecord, variableNames: List<string> = null) {
     var oldLast = ListWrapper.last(this.records);
     if (isPresent(oldLast) && oldLast.bindingRecord.directiveRecord == b.directiveRecord) {
       oldLast.lastInDirective = false;


### PR DESCRIPTION
@mprobst does clang understands generics ? (this would be needed to fix `List<Type>=...` thing where `>=` is interpreted as an operator.

After the current PR there is still a carriage return after `List<` which is not very nice.
