### PR TITLE
fix(test): solve CSS discrepancies across browsers

### DIFF
--- a/modules/angular2/src/test_lib/utils.ts
+++ b/modules/angular2/src/test_lib/utils.ts
@@ -48,3 +48,14 @@ export function containsRegexp(input: string): RegExp {
   return RegExpWrapper.create(
       StringWrapper.replaceAllMapped(input, _ESCAPE_RE, (match) => `\\${match[0]}`));
 }
+
+export function normalizeCSS(css: string): string {
+  css = StringWrapper.replaceAll(css, RegExpWrapper.create('\\s+'), ' ');
+  css = StringWrapper.replaceAll(css, RegExpWrapper.create(':\\s'), ':');
+  css = StringWrapper.replaceAll(css, RegExpWrapper.create("\\'"), '"');
+  css = StringWrapper.replaceAllMapped(css, RegExpWrapper.create('url\\(\\"(.+)\\"\\)'),
+                                       (match) => `url(${match[1]})`);
+  css = StringWrapper.replaceAllMapped(css, RegExpWrapper.create('\\[(.+)=([^"\\]]+)\\]'),
+                                       (match) => `[${match[1]}="${match[2]}"]`);
+  return css;
+}

--- a/modules/angular2/test/render/dom/shadow_dom/emulated_scoped_shadow_dom_strategy_spec.ts
+++ b/modules/angular2/test/render/dom/shadow_dom/emulated_scoped_shadow_dom_strategy_spec.ts
@@ -10,6 +10,7 @@ import {
   it,
   xit,
   SpyObject,
+  normalizeCSS
 } from 'angular2/test_lib';
 
 import {isPresent, isBlank} from 'angular2/src/facade/lang';
@@ -51,9 +52,8 @@ export function main() {
     it('should rewrite style urls', () => {
       var styleElement = el('<style>.foo {background-image: url("img.jpg");}</style>');
       strategy.processStyleElement('someComponent', 'http://base', styleElement);
-      expect(styleElement)
-          .toHaveText(".foo[_ngcontent-0] {\n" + "background-image: url(http://base/img.jpg);\n" +
-                      "}");
+      expect(normalizeCSS(DOM.getText(styleElement)))
+          .toEqual(".foo[_ngcontent-0] { background-image:url(http://base/img.jpg); }");
     });
 
     it('should scope styles', () => {

--- a/modules/angular2/test/render/dom/shadow_dom/emulated_unscoped_shadow_dom_strategy_spec.ts
+++ b/modules/angular2/test/render/dom/shadow_dom/emulated_unscoped_shadow_dom_strategy_spec.ts
@@ -46,8 +46,7 @@ export function main() {
     it('should rewrite style urls', () => {
       var styleElement = el('<style>.foo {background-image: url("img.jpg");}</style>');
       strategy.processStyleElement('someComponent', 'http://base', styleElement);
-      expect(styleElement)
-          .toHaveText(".foo {" + "background-image: url('http://base/img.jpg');" + "}");
+      expect(styleElement).toHaveText(".foo {background-image: url('http://base/img.jpg');}");
     });
 
     it('should not inline import rules', () => {


### PR DESCRIPTION
This PR fixes 6 unit tests in IE11 and 2 in Firefox.

The `normalizeCSS` function is a simple one that doesn't cover all possible cases, but only the ones found in the existing tests.
