### PR TITLE
fix(di): allow `@Inject(…)` to work in dart2js and dynamic reflection

### DIFF
--- a/modules/angular2/src/core/application.ts
+++ b/modules/angular2/src/core/application.ts
@@ -103,19 +103,12 @@ function _injectorBindings(appComponentType): List<Type | Binding | List<any>> {
         .toFactory((styleUrlResolver, doc) =>
                        new EmulatedUnscopedShadowDomStrategy(styleUrlResolver, doc.head),
                    [StyleUrlResolver, DOCUMENT_TOKEN]),
-    // TODO(tbosch): We need an explicit factory here, as
-    // we are getting errors in dart2js with mirrors...
-    bind(DomRenderer)
-        .toFactory((eventManager, shadowDomStrategy, doc) =>
-                       new DomRenderer(eventManager, shadowDomStrategy, doc),
-                   [EventManager, ShadowDomStrategy, DOCUMENT_TOKEN]),
+    DomRenderer,
     DefaultDomCompiler,
     bind(Renderer).toAlias(DomRenderer),
     bind(RenderCompiler).toAlias(DefaultDomCompiler),
     ProtoViewFactory,
-    // TODO(tbosch): We need an explicit factory here, as
-    // we are getting errors in dart2js with mirrors...
-    bind(AppViewPool).toFactory((capacity) => new AppViewPool(capacity), [APP_VIEW_POOL_CAPACITY]),
+    AppViewPool,
     bind(APP_VIEW_POOL_CAPACITY).toValue(10000),
     AppViewManager,
     AppViewManagerUtils,

--- a/modules/angular2/src/reflection/reflection_capabilities.dart
+++ b/modules/angular2/src/reflection/reflection_capabilities.dart
@@ -57,8 +57,8 @@ class ReflectionCapabilities {
   }
 
   List _convertParameter(ParameterMirror p) {
-    var t = p.type.reflectedType;
-    var res = t == dynamic ? [] : [t];
+    var t = p.type;
+    var res = (!t.hasReflectedType || t.reflectedType == dynamic) ? [] : [t.reflectedType];
     res.addAll(p.metadata.map((m) => m.reflectee));
     return res;
   }


### PR DESCRIPTION
Note: We can’t write a unit test for this as our unit tests
are running in Dartium, where the error does not occur.
However, we previously had a failure in our e2e tests
in `hello_world/index_dynamic.html`
when removing the TODOs in `application.ts`.

Closes #2185
