### PR TITLE
[Do not merge!] Add view ids

### DIFF
--- a/modules/angular2/src/core/compiler/proto_view_factory.ts
+++ b/modules/angular2/src/core/compiler/proto_view_factory.ts
@@ -206,18 +206,11 @@ function _getChangeDetectorDefinitions(
     var directiveRecords =
         bindingRecordsCreator.getDirectiveRecords(elementBinders, allRenderDirectiveMetadata);
     var strategyName = DEFAULT;
-    var typeString;
     if (pvWithIndex.renderProtoView.type === renderApi.ProtoViewDto.COMPONENT_VIEW_TYPE) {
       strategyName = hostComponentMetadata.changeDetection;
-      typeString = 'comp';
-    } else if (pvWithIndex.renderProtoView.type === renderApi.ProtoViewDto.HOST_VIEW_TYPE) {
-      typeString = 'host';
-    } else {
-      typeString = 'embedded';
     }
-    var id = `${hostComponentMetadata.id}_${typeString}_${pvWithIndex.index}`;
     var variableNames = nestedPvVariableNames[pvWithIndex.index];
-    return new ChangeDetectorDefinition(id, strategyName, variableNames, bindingRecords,
+    return new ChangeDetectorDefinition(pvWithIndex.renderProtoView.id, strategyName, variableNames, bindingRecords,
                                         directiveRecords);
   });
 }
@@ -226,7 +219,7 @@ function _createAppProtoView(
     renderProtoView: renderApi.ProtoViewDto, protoChangeDetector: ProtoChangeDetector,
     variableBindings: Map<string, string>, allDirectives: List<DirectiveBinding>): AppProtoView {
   var elementBinders = renderProtoView.elementBinders;
-  var protoView = new AppProtoView(renderProtoView.render, protoChangeDetector, variableBindings);
+  var protoView = new AppProtoView(renderProtoView.id, renderProtoView.render, protoChangeDetector, variableBindings);
 
   // TODO: vsavkin refactor to pass element binders into proto view
   _createElementBinders(protoView, elementBinders, allDirectives);

--- a/modules/angular2/src/core/compiler/view.ts
+++ b/modules/angular2/src/core/compiler/view.ts
@@ -62,7 +62,7 @@ export class AppView implements ChangeDispatcher, EventDispatcher {
    */
   locals: Locals;
 
-  constructor(public renderer: renderApi.Renderer, public proto: AppProtoView,
+  constructor(public id: string, public renderer: renderApi.Renderer, public proto: AppProtoView,
               protoLocals: Map<string, any>) {
     this.render = null;
     this.changeDetector = null;
@@ -171,10 +171,12 @@ export class AppView implements ChangeDispatcher, EventDispatcher {
 export class AppProtoView {
   elementBinders: List<ElementBinder>;
   protoLocals: Map<string, any>;
+  _viewCount: number;
 
   constructor(public id: string, public render: renderApi.RenderProtoViewRef,
               public protoChangeDetector: ProtoChangeDetector,
               public variableBindings: Map<string, string>) {
+    this._viewCount = 0;
     this.elementBinders = [];
     this.protoLocals = MapWrapper.create();
     if (isPresent(variableBindings)) {
@@ -183,6 +185,8 @@ export class AppProtoView {
       });
     }
   }
+
+  nextViewId(): string { return `${this.id}#${this._viewCount++}`; }
 
   bindElement(parent: ElementBinder, distanceToParent: int,
               protoElementInjector: ProtoElementInjector,

--- a/modules/angular2/src/core/compiler/view.ts
+++ b/modules/angular2/src/core/compiler/view.ts
@@ -172,7 +172,7 @@ export class AppProtoView {
   elementBinders: List<ElementBinder>;
   protoLocals: Map<string, any>;
 
-  constructor(public render: renderApi.RenderProtoViewRef,
+  constructor(public id: string, public render: renderApi.RenderProtoViewRef,
               public protoChangeDetector: ProtoChangeDetector,
               public variableBindings: Map<string, string>) {
     this.elementBinders = [];

--- a/modules/angular2/src/core/compiler/view_manager.ts
+++ b/modules/angular2/src/core/compiler/view_manager.ts
@@ -70,8 +70,10 @@ export class AppViewManager {
     if (isBlank(hostElementSelector)) {
       hostElementSelector = hostProtoView.elementBinders[0].componentDirective.metadata.selector;
     }
-    var renderView = this._renderer.createRootHostView(hostProtoView.render, hostElementSelector);
-    var hostView = this._utils.createView(hostProtoView, renderView, this, this._renderer);
+    var viewId = hostProtoView.nextViewId();
+    var renderView =
+        this._renderer.createRootHostView(viewId, hostProtoView.render, hostElementSelector);
+    var hostView = this._utils.createView(viewId, hostProtoView, renderView, this, this._renderer);
     this._renderer.setEventDispatcher(hostView.render, hostView);
     this._createViewRecurse(hostView);
 
@@ -171,7 +173,10 @@ export class AppViewManager {
   _createPooledView(protoView: viewModule.AppProtoView): viewModule.AppView {
     var view = this._viewPool.getView(protoView);
     if (isBlank(view)) {
-      view = this._utils.createView(protoView, this._renderer.createView(protoView.render), this,
+      var viewId = protoView.nextViewId();
+
+      view = this._utils.createView(viewId, protoView,
+                                    this._renderer.createView(viewId, protoView.render), this,
                                     this._renderer);
       this._renderer.setEventDispatcher(view.render, view);
       this._createViewRecurse(view);

--- a/modules/angular2/src/core/compiler/view_manager_utils.ts
+++ b/modules/angular2/src/core/compiler/view_manager_utils.ts
@@ -25,9 +25,9 @@ export class AppViewManagerUtils {
     }
   }
 
-  createView(protoView: viewModule.AppProtoView, renderView: RenderViewRef,
+  createView(viewId: string, protoView: viewModule.AppProtoView, renderView: RenderViewRef,
              viewManager: avmModule.AppViewManager, renderer: Renderer): viewModule.AppView {
-    var view = new viewModule.AppView(renderer, protoView, protoView.protoLocals);
+    var view = new viewModule.AppView(viewId, renderer, protoView, protoView.protoLocals);
     // TODO(tbosch): pass RenderViewRef as argument to AppView!
     view.render = renderView;
 

--- a/modules/angular2/src/render/api.ts
+++ b/modules/angular2/src/render/api.ts
@@ -104,17 +104,20 @@ export class ProtoViewDto {
   // inside of a component view
   static get EMBEDDED_VIEW_TYPE() { return 2; }
 
+  id: string;
   render: RenderProtoViewRef;
   elementBinders: List<ElementBinder>;
   variableBindings: Map<string, string>;
   type: number;
 
-  constructor({render, elementBinders, variableBindings, type}: {
+  constructor({id, render, elementBinders, variableBindings, type}: {
+    id?: string,
     render?: RenderProtoViewRef,
     elementBinders?: List<ElementBinder>,
     variableBindings?: Map<string, string>,
     type?: number
   }) {
+    this.id = id;
     this.render = render;
     this.elementBinders = elementBinders;
     this.variableBindings = variableBindings;

--- a/modules/angular2/src/render/api.ts
+++ b/modules/angular2/src/render/api.ts
@@ -222,13 +222,14 @@ export class RenderCompiler {
 export class Renderer {
   /**
    * Creates a root host view that includes the given element.
+   * @param {string} id Id for the view
    * @param {RenderProtoViewRef} hostProtoViewRef a RenderProtoViewRef of type
    * ProtoViewDto.HOST_VIEW_TYPE
    * @param {any} hostElementSelector css selector for the host element (will be queried against the
    * main document)
    * @return {RenderViewRef} the created view
    */
-  createRootHostView(hostProtoViewRef: RenderProtoViewRef,
+  createRootHostView(viewId: string, hostProtoViewRef: RenderProtoViewRef,
                      hostElementSelector: string): RenderViewRef {
     return null;
   }
@@ -241,7 +242,7 @@ export class Renderer {
   /**
    * Creates a regular view out of the given ProtoView
    */
-  createView(protoViewRef: RenderProtoViewRef): RenderViewRef { return null; }
+  createView(viewId: string, protoViewRef: RenderProtoViewRef): RenderViewRef { return null; }
 
   /**
    * Destroys the given view after it has been dehydrated and detached

--- a/modules/angular2/src/render/dom/compiler/compile_pipeline.ts
+++ b/modules/angular2/src/render/dom/compiler/compile_pipeline.ts
@@ -16,15 +16,16 @@ export class CompilePipeline {
   constructor(steps: List<CompileStep>) { this._control = new CompileControl(steps); }
 
   process(rootElement, protoViewType: number = null,
-          compilationCtxtDescription: string = ''): List<CompileElement> {
+          componentId: string = ''): List<CompileElement> {
     if (isBlank(protoViewType)) {
       protoViewType = ProtoViewDto.COMPONENT_VIEW_TYPE;
     }
     var results = ListWrapper.create();
-    var rootCompileElement = new CompileElement(rootElement, compilationCtxtDescription);
-    rootCompileElement.inheritedProtoView = new ProtoViewBuilder(rootElement, protoViewType);
+    var rootCompileElement = new CompileElement(rootElement, componentId);
+    rootCompileElement.inheritedProtoView =
+        new ProtoViewBuilder(rootElement, protoViewType, componentId);
     rootCompileElement.isViewRoot = true;
-    this._process(results, null, rootCompileElement, compilationCtxtDescription);
+    this._process(results, null, rootCompileElement, componentId);
     return results;
   }
 

--- a/modules/angular2/src/render/dom/dom_renderer.ts
+++ b/modules/angular2/src/render/dom/dom_renderer.ts
@@ -33,14 +33,14 @@ export class DomRenderer extends Renderer {
     this._document = document;
   }
 
-  createRootHostView(hostProtoViewRef: RenderProtoViewRef,
+  createRootHostView(viewId: string, hostProtoViewRef: RenderProtoViewRef,
                      hostElementSelector: string): RenderViewRef {
     var hostProtoView = resolveInternalDomProtoView(hostProtoViewRef);
     var element = DOM.querySelector(this._document, hostElementSelector);
     if (isBlank(element)) {
       throw new BaseException(`The selector "${hostElementSelector}" did not match any elements`);
     }
-    return new DomViewRef(this._createView(hostProtoView, element));
+    return new DomViewRef(this._createView(viewId, hostProtoView, element));
   }
 
   detachFreeHostView(parentHostViewRef: RenderViewRef, hostViewRef: RenderViewRef) {
@@ -48,9 +48,9 @@ export class DomRenderer extends Renderer {
     this._removeViewNodes(hostView);
   }
 
-  createView(protoViewRef: RenderProtoViewRef): RenderViewRef {
+  createView(viewId: string, protoViewRef: RenderProtoViewRef): RenderViewRef {
     var protoView = resolveInternalDomProtoView(protoViewRef);
-    return new DomViewRef(this._createView(protoView, null));
+    return new DomViewRef(this._createView(viewId, protoView, null));
   }
 
   destroyView(view: RenderViewRef) {
@@ -208,7 +208,7 @@ export class DomRenderer extends Renderer {
     view.eventDispatcher = dispatcher;
   }
 
-  _createView(protoView: DomProtoView, inplaceElement): DomView {
+  _createView(viewId: string, protoView: DomProtoView, inplaceElement): DomView {
     var rootElementClone =
         isPresent(inplaceElement) ? inplaceElement : DOM.importIntoDoc(protoView.element);
     var elementsWithBindingsDynamic;
@@ -267,7 +267,8 @@ export class DomRenderer extends Renderer {
       contentTags[binderIdx] = contentTag;
     }
 
-    var view = new DomView(protoView, viewRootNodes, boundTextNodes, boundElements, contentTags);
+    var view =
+        new DomView(viewId, protoView, viewRootNodes, boundTextNodes, boundElements, contentTags);
 
     for (var binderIdx = 0; binderIdx < binders.length; binderIdx++) {
       var binder = binders[binderIdx];

--- a/modules/angular2/src/render/dom/view/proto_view.ts
+++ b/modules/angular2/src/render/dom/view/proto_view.ts
@@ -21,12 +21,14 @@ export class DomProtoViewRef extends RenderProtoViewRef {
 }
 
 export class DomProtoView {
+  id: string;
   element;
   elementBinders: List<ElementBinder>;
   isTemplateElement: boolean;
   rootBindingOffset: number;
 
-  constructor({elementBinders, element}) {
+  constructor({id, elementBinders, element}) {
+    this.id = id;
     this.element = element;
     this.elementBinders = elementBinders;
     this.isTemplateElement = DOM.isTemplateElement(this.element);

--- a/modules/angular2/src/render/dom/view/view.ts
+++ b/modules/angular2/src/render/dom/view/view.ts
@@ -39,7 +39,7 @@ export class DomView {
   eventDispatcher: EventDispatcher;
   eventHandlerRemovers: List<Function>;
 
-  constructor(public proto: DomProtoView, public rootNodes: List</*node*/ any>,
+  constructor(public id: string, public proto: DomProtoView, public rootNodes: List</*node*/ any>,
               public boundTextNodes: List</*node*/ any>,
               public boundElements: List</*element*/ any>, public contentTags: List<Content>) {
     this.viewContainers = ListWrapper.createFixedSize(boundElements.length);

--- a/modules/angular2/test/core/compiler/compiler_spec.ts
+++ b/modules/angular2/test/core/compiler/compiler_spec.ts
@@ -410,7 +410,7 @@ function createDirectiveBinding(directiveResolver, type) {
 }
 
 function createProtoView(elementBinders = null) {
-  var pv = new AppProtoView(null, null, MapWrapper.create());
+  var pv = new AppProtoView(null, null, null, MapWrapper.create());
   if (isBlank(elementBinders)) {
     elementBinders = [];
   }

--- a/modules/angular2/test/core/compiler/element_injector_spec.ts
+++ b/modules/angular2/test/core/compiler/element_injector_spec.ts
@@ -615,7 +615,7 @@ export function main() {
           });
 
           it("should instantiate directives that depend on pre built objects", () => {
-            var protoView = new AppProtoView(null, null, null);
+            var protoView = new AppProtoView(null, null, null, null);
             var bindings = ListWrapper.concat([NeedsProtoViewRef], extraBindings);
             var inj = injector(bindings, null, false, new PreBuiltObjects(null, null, protoView));
 
@@ -919,7 +919,7 @@ export function main() {
           });
 
           it("should inject ProtoViewRef", () => {
-            var protoView = new AppProtoView(null, null, null);
+            var protoView = new AppProtoView(null, null, null, null);
             var inj = injector(ListWrapper.concat([NeedsProtoViewRef], extraBindings), null, false,
                                new PreBuiltObjects(null, null, protoView));
 

--- a/modules/angular2/test/core/compiler/proto_view_factory_spec.ts
+++ b/modules/angular2/test/core/compiler/proto_view_factory_spec.ts
@@ -48,11 +48,11 @@ export function main() {
     describe('getChangeDetectorDefinitions', () => {
 
       it('should create a ChangeDetectorDefinition for the root render proto view', () => {
-        var renderPv = createRenderProtoView();
+        var renderPv = createRenderProtoView(null, null, 'someId');
         var defs =
             getChangeDetectorDefinitions(bindDirective(MainComponent).metadata, renderPv, []);
         expect(defs.length).toBe(1);
-        expect(defs[0].id).toEqual(`${stringify(MainComponent)}_comp_0`);
+        expect(defs[0].id).toEqual('someId');
       });
 
     });
@@ -71,7 +71,7 @@ export function main() {
   });
 }
 
-function createRenderProtoView(elementBinders = null, type: number = null) {
+function createRenderProtoView(elementBinders = null, type: number = null, id: string = null) {
   if (isBlank(type)) {
     type = renderApi.ProtoViewDto.COMPONENT_VIEW_TYPE;
   }
@@ -79,7 +79,7 @@ function createRenderProtoView(elementBinders = null, type: number = null) {
     elementBinders = [];
   }
   return new renderApi.ProtoViewDto(
-      {elementBinders: elementBinders, type: type, variableBindings: MapWrapper.create()});
+      {id: id, elementBinders: elementBinders, type: type, variableBindings: MapWrapper.create()});
 }
 
 function createRenderComponentElementBinder(directiveIndex) {

--- a/modules/angular2/test/core/compiler/view_container_ref_spec.ts
+++ b/modules/angular2/test/core/compiler/view_container_ref_spec.ts
@@ -35,7 +35,7 @@ export function main() {
 
     function wrapView(view: AppView): ViewRef { return new ViewRef(view); }
 
-    function createProtoView() { return new AppProtoView(null, null, null); }
+    function createProtoView() { return new AppProtoView(null, null, null, null); }
 
     function createView() { return new AppView(null, createProtoView(), MapWrapper.create()); }
 

--- a/modules/angular2/test/core/compiler/view_container_ref_spec.ts
+++ b/modules/angular2/test/core/compiler/view_container_ref_spec.ts
@@ -37,7 +37,9 @@ export function main() {
 
     function createProtoView() { return new AppProtoView(null, null, null, null); }
 
-    function createView() { return new AppView(null, createProtoView(), MapWrapper.create()); }
+    function createView() {
+      return new AppView(null, null, createProtoView(), MapWrapper.create());
+    }
 
     function createViewContainer() { return new ViewContainerRef(viewManager, location); }
 

--- a/modules/angular2/test/core/compiler/view_manager_spec.ts
+++ b/modules/angular2/test/core/compiler/view_manager_spec.ts
@@ -75,7 +75,7 @@ export function main() {
           staticChildComponentCount++;
         }
       }
-      var res = new AppProtoView(new MockProtoViewRef(staticChildComponentCount), null, null);
+      var res = new AppProtoView(null, new MockProtoViewRef(staticChildComponentCount), null, null);
       res.elementBinders = binders;
       return res;
     }

--- a/modules/angular2/test/core/compiler/view_manager_spec.ts
+++ b/modules/angular2/test/core/compiler/view_manager_spec.ts
@@ -91,14 +91,14 @@ export function main() {
                             {});
     }
 
-    function createView(pv = null, renderViewRef = null) {
+    function createView(pv = null, renderViewRef = null, id = null) {
       if (isBlank(pv)) {
         pv = createProtoView();
       }
       if (isBlank(renderViewRef)) {
         renderViewRef = new RenderViewRef();
       }
-      var view = new AppView(renderer, pv, MapWrapper.create());
+      var view = new AppView(id, renderer, pv, MapWrapper.create());
       view.render = renderViewRef;
       var elementInjectors = ListWrapper.createFixedSize(pv.elementBinders.length);
       for (var i = 0; i < pv.elementBinders.length; i++) {
@@ -119,8 +119,8 @@ export function main() {
       createdRenderViews = [];
 
       utils.spy('createView')
-          .andCallFake((proto, renderViewRef, _a, _b) => {
-            var view = createView(proto, renderViewRef);
+          .andCallFake((id, proto, renderViewRef, _a, _b) => {
+            var view = createView(proto, renderViewRef, id);
             ListWrapper.push(createdViews, view);
             return view;
           });
@@ -138,13 +138,13 @@ export function main() {
             ListWrapper.insert(viewContainer.views, atIndex, childView);
           });
       renderer.spy('createRootHostView')
-          .andCallFake((_b, _c) => {
+          .andCallFake((_a, _b, _c) => {
             var rv = new RenderViewRef();
             ListWrapper.push(createdRenderViews, rv);
             return rv;
           });
       renderer.spy('createView')
-          .andCallFake((_a) => {
+          .andCallFake((_a, _b) => {
             var rv = new RenderViewRef();
             ListWrapper.push(createdRenderViews, rv);
             return rv;
@@ -209,7 +209,8 @@ export function main() {
         it('should create and set the render view', () => {
           manager.createDynamicComponentView(elementRef(wrapView(hostView), 0),
                                              wrapPv(componentProtoView), null, null);
-          expect(renderer.spy('createView')).toHaveBeenCalledWith(componentProtoView.render);
+          expect(renderer.spy('createView'))
+              .toHaveBeenCalledWith(createdViews[0].id, componentProtoView.render);
           expect(createdViews[0].render).toBe(createdRenderViews[0]);
         });
 
@@ -329,7 +330,8 @@ export function main() {
         it('should create and set the render view', () => {
           manager.createFreeHostView(elementRef(wrapView(parentHostView), 0), wrapPv(hostProtoView),
                                      null);
-          expect(renderer.spy('createView')).toHaveBeenCalledWith(hostProtoView.render);
+          expect(renderer.spy('createView'))
+              .toHaveBeenCalledWith(createdViews[0].id, hostProtoView.render);
           expect(createdViews[0].render).toBe(createdRenderViews[0]);
         });
 
@@ -405,17 +407,17 @@ export function main() {
       });
 
       it('should create and set the render view using the component selector', () => {
-        manager.createRootHostView(wrapPv(hostProtoView), null, null)
-            expect(renderer.spy('createRootHostView'))
-                .toHaveBeenCalledWith(hostProtoView.render, 'someComponent');
+        manager.createRootHostView(wrapPv(hostProtoView), null, null);
+        expect(renderer.spy('createRootHostView'))
+            .toHaveBeenCalledWith(createdViews[0].id, hostProtoView.render, 'someComponent');
         expect(createdViews[0].render).toBe(createdRenderViews[0]);
       });
 
       it('should allow to override the selector', () => {
         var selector = 'someOtherSelector';
-        manager.createRootHostView(wrapPv(hostProtoView), selector, null)
-            expect(renderer.spy('createRootHostView'))
-                .toHaveBeenCalledWith(hostProtoView.render, selector);
+        manager.createRootHostView(wrapPv(hostProtoView), selector, null);
+        expect(renderer.spy('createRootHostView'))
+            .toHaveBeenCalledWith(createdViews[0].id, hostProtoView.render, selector);
       });
 
       it('should set the event dispatcher', () => {
@@ -500,7 +502,8 @@ export function main() {
         it('should create and set the render view', () => {
           manager.createViewInContainer(elementRef(wrapView(parentView), 0), 0,
                                         wrapPv(childProtoView), null, null);
-          expect(renderer.spy('createView')).toHaveBeenCalledWith(childProtoView.render);
+          expect(renderer.spy('createView'))
+              .toHaveBeenCalledWith(createdViews[0].id, childProtoView.render);
           expect(createdViews[0].render).toBe(createdRenderViews[0]);
         });
 

--- a/modules/angular2/test/core/compiler/view_manager_utils_spec.ts
+++ b/modules/angular2/test/core/compiler/view_manager_utils_spec.ts
@@ -85,7 +85,7 @@ export function main() {
       if (isBlank(pv)) {
         pv = createProtoView();
       }
-      var view = new AppView(null, pv, MapWrapper.create());
+      var view = new AppView(null, null, pv, MapWrapper.create());
       var elementInjectors = ListWrapper.createFixedSize(pv.elementBinders.length);
       var preBuiltObjects = ListWrapper.createFixedSize(pv.elementBinders.length);
       for (var i = 0; i < pv.elementBinders.length; i++) {

--- a/modules/angular2/test/core/compiler/view_manager_utils_spec.ts
+++ b/modules/angular2/test/core/compiler/view_manager_utils_spec.ts
@@ -61,7 +61,7 @@ export function main() {
       if (isBlank(binders)) {
         binders = [];
       }
-      var res = new AppProtoView(null, null, null);
+      var res = new AppProtoView(null, null, null, null);
       res.elementBinders = binders;
       return res;
     }

--- a/modules/angular2/test/core/compiler/view_pool_spec.ts
+++ b/modules/angular2/test/core/compiler/view_pool_spec.ts
@@ -24,7 +24,7 @@ export function main() {
 
     function createViewPool({capacity}): AppViewPool { return new AppViewPool(capacity); }
 
-    function createProtoView() { return new AppProtoView(null, null, null); }
+    function createProtoView() { return new AppProtoView(null, null, null, null); }
 
     function createView(pv) { return new AppView(null, pv, MapWrapper.create()); }
 

--- a/modules/angular2/test/core/compiler/view_pool_spec.ts
+++ b/modules/angular2/test/core/compiler/view_pool_spec.ts
@@ -26,7 +26,7 @@ export function main() {
 
     function createProtoView() { return new AppProtoView(null, null, null, null); }
 
-    function createView(pv) { return new AppView(null, pv, MapWrapper.create()); }
+    function createView(pv) { return new AppView(null, null, pv, MapWrapper.create()); }
 
     it('should support multiple AppProtoViews', () => {
       var vf = createViewPool({capacity: 2});

--- a/modules/angular2/test/render/dom/compiler/pipeline_spec.ts
+++ b/modules/angular2/test/render/dom/compiler/pipeline_spec.ts
@@ -42,7 +42,7 @@ export function main() {
       var pipeline = new CompilePipeline([new MockStep((parent, current, control) => {
         if (isPresent(DOM.getAttribute(current.element, 'viewroot'))) {
           current.inheritedProtoView =
-              new ProtoViewBuilder(current.element, ProtoViewDto.EMBEDDED_VIEW_TYPE);
+              new ProtoViewBuilder(current.element, ProtoViewDto.EMBEDDED_VIEW_TYPE, '');
         }
       })]);
       var results = pipeline.process(element);

--- a/modules/angular2/test/render/dom/dom_renderer_integration_spec.ts
+++ b/modules/angular2/test/render/dom/dom_renderer_integration_spec.ts
@@ -29,8 +29,8 @@ export function main() {
          tb.compiler.compileHost(someComponent)
              .then((hostProtoViewDto) => {
                expect(hostProtoViewDto.id).toEqual('someComponent_host_0');
-               var view =
-                   new TestView(tb.renderer.createRootHostView(hostProtoViewDto.render, '#root'));
+               var view = new TestView(
+                   tb.renderer.createRootHostView('someId', hostProtoViewDto.render, '#root'));
                expect(view.rawView.rootNodes[0]).toEqual(tb.rootEl);
 
                tb.renderer.destroyView(view.viewRef);
@@ -46,7 +46,7 @@ export function main() {
          tb.compiler.compileHost(someComponent)
              .then((hostProtoViewDto) => {
                expect(hostProtoViewDto.id).toEqual('someComponent_host_0');
-               var view = new TestView(tb.renderer.createView(hostProtoViewDto.render));
+               var view = new TestView(tb.renderer.createView('someId', hostProtoViewDto.render));
                var hostElement = tb.renderer.getHostElement(view.viewRef);
                DOM.appendChild(tb.rootEl, hostElement);
 

--- a/modules/angular2/test/render/dom/dom_renderer_integration_spec.ts
+++ b/modules/angular2/test/render/dom/dom_renderer_integration_spec.ts
@@ -28,6 +28,7 @@ export function main() {
        inject([AsyncTestCompleter, DomTestbed], (async, tb) => {
          tb.compiler.compileHost(someComponent)
              .then((hostProtoViewDto) => {
+               expect(hostProtoViewDto.id).toEqual('someComponent_host_0');
                var view =
                    new TestView(tb.renderer.createRootHostView(hostProtoViewDto.render, '#root'));
                expect(view.rawView.rootNodes[0]).toEqual(tb.rootEl);
@@ -44,6 +45,7 @@ export function main() {
        inject([AsyncTestCompleter, DomTestbed], (async, tb) => {
          tb.compiler.compileHost(someComponent)
              .then((hostProtoViewDto) => {
+               expect(hostProtoViewDto.id).toEqual('someComponent_host_0');
                var view = new TestView(tb.renderer.createView(hostProtoViewDto.render));
                var hostElement = tb.renderer.getHostElement(view.viewRef);
                DOM.appendChild(tb.rootEl, hostElement);
@@ -64,6 +66,7 @@ export function main() {
            ])
              .then((protoViewDtos) => {
                var rootView = tb.createRootView(protoViewDtos[0]);
+               expect(protoViewDtos[1].id).toEqual('someComponent_comp_0');
                var cmpView = tb.createComponentView(rootView.viewRef, 0, protoViewDtos[1]);
                expect(tb.rootEl).toHaveText('hello');
                tb.destroyComponentView(rootView.viewRef, 0, cmpView.viewRef);
@@ -144,6 +147,7 @@ export function main() {
                var cmpView = tb.createComponentView(rootView.viewRef, 0, protoViewDtos[1]);
 
                var childProto = protoViewDtos[1].elementBinders[0].nestedProtoView;
+               expect(childProto.id).toEqual('someComponent_embedded_1');
                expect(tb.rootEl).toHaveText('');
                var childView = tb.createViewInContainer(cmpView.viewRef, 0, 0, childProto);
                expect(tb.rootEl).toHaveText('hello');

--- a/modules/angular2/test/render/dom/dom_testbed.ts
+++ b/modules/angular2/test/render/dom/dom_testbed.ts
@@ -46,9 +46,11 @@ export class DomTestbed {
   renderer: DomRenderer;
   compiler: DefaultDomCompiler;
   rootEl;
+  _viewCount: number;
 
   constructor(renderer: DomRenderer, compiler: DefaultDomCompiler,
               @Inject(DOCUMENT_TOKEN) document) {
+    this._viewCount = 0;
     this.renderer = renderer;
     this.compiler = compiler;
     this.rootEl = el('<div id="root"></div>');
@@ -70,6 +72,8 @@ export class DomTestbed {
     }));
   }
 
+  nextViewId(): string { return `test${this._viewCount++}`; }
+
   _createTestView(viewRef: RenderViewRef) {
     var testView = new TestView(viewRef);
     this.renderer.setEventDispatcher(viewRef, new LoggingEventDispatcher(testView.events));
@@ -77,14 +81,15 @@ export class DomTestbed {
   }
 
   createRootView(rootProtoView: ProtoViewDto): TestView {
-    var viewRef = this.renderer.createRootHostView(rootProtoView.render, '#root');
+    var viewRef =
+        this.renderer.createRootHostView(this.nextViewId(), rootProtoView.render, '#root');
     this.renderer.hydrateView(viewRef);
     return this._createTestView(viewRef);
   }
 
   createComponentView(parentViewRef: RenderViewRef, boundElementIndex: number,
                       componentProtoView: ProtoViewDto): TestView {
-    var componentViewRef = this.renderer.createView(componentProtoView.render);
+    var componentViewRef = this.renderer.createView(this.nextViewId(), componentProtoView.render);
     this.renderer.attachComponentView(parentViewRef, boundElementIndex, componentViewRef);
     this.renderer.hydrateView(componentViewRef);
     return this._createTestView(componentViewRef);
@@ -109,7 +114,7 @@ export class DomTestbed {
 
   createViewInContainer(parentViewRef: RenderViewRef, boundElementIndex: number, atIndex: number,
                         protoView: ProtoViewDto): TestView {
-    var viewRef = this.renderer.createView(protoView.render);
+    var viewRef = this.renderer.createView(this.nextViewId(), protoView.render);
     this.renderer.attachViewInContainer(parentViewRef, boundElementIndex, atIndex, viewRef);
     this.renderer.hydrateView(viewRef);
     return this._createTestView(viewRef);

--- a/modules/angular2/test/render/dom/view/view_spec.ts
+++ b/modules/angular2/test/render/dom/view/view_spec.ts
@@ -31,7 +31,7 @@ export function main() {
         binders = [];
       }
       var rootEl = el('<div></div>');
-      return new DomProtoView({element: rootEl, elementBinders: binders});
+      return new DomProtoView({id: null, element: rootEl, elementBinders: binders});
     }
 
     function createView(pv = null, boundElementCount = 0) {
@@ -43,7 +43,7 @@ export function main() {
       for (var i = 0; i < boundElementCount; i++) {
         ListWrapper.push(boundElements, el('<span></span'));
       }
-      return new DomView(pv, [DOM.childNodes(root)[0]], [], boundElements, []);
+      return new DomView(null, pv, [DOM.childNodes(root)[0]], [], boundElements, []);
     }
 
     describe('getDirectParentLightDom', () => {


### PR DESCRIPTION
Ids for `ProtoView` and `View` are needed for multiple cases:
- serverside rendering: need to find the elements that were used on the server when the client wakes up in the browser
- change detectors: need a proto view id
- element probe: allow to look up views via an id that is attached to an element

This PR creates these ids centrally within Angular.
