### PR TITLE
fix(facade): Fix bug in TS indexOf

### DIFF
--- a/modules/angular2/src/facade/collection.ts
+++ b/modules/angular2/src/facade/collection.ts
@@ -171,7 +171,7 @@ export class ListWrapper {
     }
     return null;
   }
-  static indexOf(array: List<any>, value, startIndex = -1) {
+  static indexOf(array: List<any>, value, startIndex = 0) {
     return array.indexOf(value, startIndex);
   }
   static reduce<T, E>(list: List<T>,

--- a/modules/angular2/test/facade/collection_spec.ts
+++ b/modules/angular2/test/facade/collection_spec.ts
@@ -58,6 +58,18 @@ export function main() {
       it('should support negative end',
          () => { expect(ListWrapper.slice(l, -3, -1)).toEqual([2, 3]); });
     });
+
+    describe('indexOf', () => {
+      beforeEach(() => { l = [1, 2, 3, 4]; });
+
+      it('should find values that exist', () => { expect(ListWrapper.indexOf(l, 1)).toEqual(0); });
+
+      it('should not find values that do not exist',
+         () => { expect(ListWrapper.indexOf(l, 9)).toEqual(-1); });
+
+      it('should respect the startIndex parameter',
+         () => { expect(ListWrapper.indexOf(l, 1, 1)).toEqual(-1); });
+    });
   });
 
   describe('StringMapWrapper', () => {


### PR DESCRIPTION
startIndex defaults to -1, which in Chrome results in returning -1
regardless of the other parameters.

Added regression tests.
