### PR TITLE
feat(FakeAsync): check pending timers at the end of fakeAsync in Dart

### DIFF
--- a/modules/angular2/pubspec.yaml
+++ b/modules/angular2/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   logging: '>=0.9.0 <0.12.0'
   source_span: '^1.0.0'
   stack_trace: '^1.1.1'
-  quiver: '^0.21.3+1'
+  quiver: '^0.21.4'
 dev_dependencies:
   guinness: '^0.1.17'
 transformers:

--- a/modules/angular2/src/test_lib/fake_async.dart
+++ b/modules/angular2/src/test_lib/fake_async.dart
@@ -30,20 +30,21 @@ Function fakeAsync(Function fn) {
       return new quiver.FakeAsync().run((quiver.FakeAsync async) {
         try {
           _fakeAsync = async;
-          List args = [
-            a0,
-            a1,
-            a2,
-            a3,
-            a4,
-            a5,
-            a6,
-            a7,
-            a8,
-            a9
-          ].takeWhile((a) => a != _u).toList();
+          List args = [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9]
+              .takeWhile((a) => a != _u).toList();
           var res = Function.apply(fn, args);
           _fakeAsync.flushMicrotasks();
+
+          if (async.periodicTimerCount > 0) {
+            throw new BaseException('${async.periodicTimerCount} periodic '
+                'timer(s) still in the queue.');
+          }
+
+          if (async.nonPeriodicTimerCount > 0) {
+            throw new BaseException('${async.nonPeriodicTimerCount} timer(s) '
+                'still in the queue.');
+          }
+
           return res;
         } finally {
           _fakeAsync = null;

--- a/modules/angular2/test/test_lib/fake_async_spec.ts
+++ b/modules/angular2/test/test_lib/fake_async_spec.ts
@@ -158,15 +158,11 @@ export function main() {
          }));
 
       it('should throw an error on dangling timers', () => {
-        // TODO(vicb): https://github.com/google/quiver-dart/issues/248
-        if (IS_DARTIUM) return;
         expect(() => { fakeAsync(() => { TimerWrapper.setTimeout(() => {}, 10); })(); })
             .toThrowError('1 timer(s) still in the queue.');
       });
 
       it('should throw an error on dangling periodic timers', () => {
-        // TODO(vicb): https://github.com/google/quiver-dart/issues/248
-        if (IS_DARTIUM) return;
         expect(() => { fakeAsync(() => { TimerWrapper.setInterval(() => {}, 10); })(); })
             .toThrowError('1 periodic timer(s) still in the queue.');
       });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,4 +4,4 @@ environment:
 dev_dependencies:
   guinness: '^0.1.17'
   unittest: '^0.11.5+4'
-  quiver: '^0.21.3+1'
+  quiver: '^0.21.4'


### PR DESCRIPTION
Made possible with quiver 0.21.4
