### PR TITLE
fix(benchpress): add index to root of module

### DIFF
--- a/modules/benchpress/index.dart
+++ b/modules/benchpress/index.dart
@@ -1,0 +1,2 @@
+library benchpress.index;
+//no dart implementation

--- a/modules/benchpress/index.ts
+++ b/modules/benchpress/index.ts
@@ -1,0 +1,2 @@
+require(require('traceur').RUNTIME_PATH);
+module.exports = require('./benchpress.js');


### PR DESCRIPTION
This is necessary when using require('benchpress') in node.
