### PR TITLE
fix(facade): Make PromiseWrapper#all semantics equivalent

### DIFF
--- a/modules/angular2/src/facade/async.dart
+++ b/modules/angular2/src/facade/async.dart
@@ -9,9 +9,12 @@ class PromiseWrapper {
   static Future reject(obj, stackTrace) => new Future.error(obj,
       stackTrace != null ? stackTrace : obj is Error ? obj.stackTrace : null);
 
-  static Future<List> all(List<Future> promises) => Future.wait(promises);
+  static Future<List> all(List<dynamic> promises) {
+    return Future
+        .wait(promises.map((p) => p is Future ? p : new Future.value(p)));
+  }
 
-  static Future then(Future promise, success(value), Function onError) {
+  static Future then(Future promise, success(value), [Function onError]) {
     if (success == null) return promise.catchError(onError);
     return promise.then(success, onError: onError);
   }

--- a/modules/angular2/src/facade/async.ts
+++ b/modules/angular2/src/facade/async.ts
@@ -18,13 +18,13 @@ export class PromiseWrapper {
     return promise.catch(onError);
   }
 
-  static all(promises: List<Promise<any>>): Promise<any> {
+  static all(promises: List<any>): Promise<any> {
     if (promises.length == 0) return Promise.resolve([]);
     return Promise.all(promises);
   }
 
   static then<T>(promise: Promise<T>, success: (value: any) => T | Thenable<T>,
-                 rejection: (error: any, stack?: any) => T | Thenable<T>): Promise<T> {
+                 rejection?: (error: any, stack?: any) => T | Thenable<T>): Promise<T> {
     return promise.then(success, rejection);
   }
 


### PR DESCRIPTION
The semantics between ES6 `Promise#all` and Dart's `Future#wait` are
different for values that are not `Promise`/`Future`s. In ES6,
non-`Promise` values are immediately completed to their current value.
In Dart, non-`Future` values cause an error.

Updated Dart's `PromiseWrapper#all` implementation to conform to the ES6
spec.
