### PR TITLE
fix the naive scrolling benchmark

### DIFF
--- a/modules/benchmarks/e2e_test/naive_infinite_scroll_perf.ts
+++ b/modules/benchmarks/e2e_test/naive_infinite_scroll_perf.ts
@@ -12,6 +12,7 @@ describe('ng2 naive infinite scroll benchmark', function() {
         url: URL,
         id: 'ng2.naive_infinite_scroll',
         work: function() {
+          browser.sleep(1000);
           $('#reset-btn').click();
           $('#run-btn').click();
           browser.wait(() => {

--- a/modules/benchmarks/src/naive_infinite_scroll/app.ts
+++ b/modules/benchmarks/src/naive_infinite_scroll/app.ts
@@ -83,5 +83,5 @@ export class App {
 
   _locateFinishedMarker() { return DOM.querySelector(document.body, '#done'); }
 
-  _getScrollDiv() { return DOM.query('body /deep/ #testArea /deep/ #scrollDiv'); }
+  _getScrollDiv() { return DOM.query('body /deep/ #testArea /deep/ .scrollDiv'); }
 }

--- a/modules/benchmarks/src/naive_infinite_scroll/scroll_area.ts
+++ b/modules/benchmarks/src/naive_infinite_scroll/scroll_area.ts
@@ -23,11 +23,11 @@ import {NgFor} from 'angular2/directives';
   directives: [ScrollItemComponent, NgFor],
   template: `
     <div>
-        <div id="scrollDiv"
+        <div class="scrollDiv"
              [style]="scrollDivStyle"
              on-scroll="onScroll($event)">
-            <div id="padding"></div>
-            <div id="inner">
+            <div class="padding"></div>
+            <div class="inner">
                 <scroll-item
                     template="ng-for #item of visibleItems"
                     [offering]="item">
@@ -61,10 +61,10 @@ export class ScrollAreaComponent {
     if (evt != null) {
       var scrollDiv = evt.target;
       if (this.paddingDiv == null) {
-        this.paddingDiv = scrollDiv.querySelector('#padding');
+        this.paddingDiv = scrollDiv.querySelector('.padding');
       }
       if (this.innerDiv == null) {
-        this.innerDiv = scrollDiv.querySelector('#inner');
+        this.innerDiv = scrollDiv.querySelector('.inner');
         this.innerDiv.style.setProperty('width', `${ROW_WIDTH}px`);
       }
       scrollTop = scrollDiv.scrollTop;


### PR DESCRIPTION
@tbosch I've fixed this by removing the explicit `browser.wait()`. IIRC you told me this is not required any more and for some reason it seems to be blocking and prevent the scrolling from happening.

Also switch from `id` to `class` for repeated elements (`id`s are supposed to be unique - must be releated to switching to the emulated SDS).

fixes #1706
