### PR TITLE
fix(render): only look for content tags in views that might have them.

### DIFF
--- a/modules/angular2/src/render/dom/shadow_dom/light_dom.ts
+++ b/modules/angular2/src/render/dom/shadow_dom/light_dom.ts
@@ -52,6 +52,9 @@ export class LightDom {
 
   // Collects the Content directives from the view and all its child views
   private _collectAllContentTags(view: viewModule.DomView, acc: List<Content>): List<Content> {
+    if (view.proto.transitiveContentTagCount === 0) {
+      return acc;
+    }
     var contentTags = view.contentTags;
     var vcs = view.viewContainers;
     for (var i = 0; i < vcs.length; i++) {

--- a/modules/angular2/src/render/dom/view/proto_view.ts
+++ b/modules/angular2/src/render/dom/view/proto_view.ts
@@ -25,10 +25,12 @@ export class DomProtoView {
   elementBinders: List<ElementBinder>;
   isTemplateElement: boolean;
   rootBindingOffset: number;
+  transitiveContentTagCount: number;
 
-  constructor({elementBinders, element}) {
+  constructor({elementBinders, element, transitiveContentTagCount}) {
     this.element = element;
     this.elementBinders = elementBinders;
+    this.transitiveContentTagCount = transitiveContentTagCount;
     this.isTemplateElement = DOM.isTemplateElement(this.element);
     this.rootBindingOffset =
         (isPresent(this.element) && DOM.hasClass(this.element, NG_BINDING_CLASS)) ? 1 : 0;

--- a/modules/angular2/test/render/dom/view/view_spec.ts
+++ b/modules/angular2/test/render/dom/view/view_spec.ts
@@ -31,7 +31,8 @@ export function main() {
         binders = [];
       }
       var rootEl = el('<div></div>');
-      return new DomProtoView({element: rootEl, elementBinders: binders});
+      return new DomProtoView(
+          {element: rootEl, elementBinders: binders, transitiveContentTagCount: 0});
     }
 
     function createView(pv = null, boundElementCount = 0) {


### PR DESCRIPTION
Largetable benchmark with `interpolationAttr` and 200 rows / 20 columns:
Time for destroy/create pair dropped from about 1260ms to about 150ms.
