### PR TITLE
fix(JsonPipe): always transform to json

### DIFF
--- a/modules/angular2/src/change_detection/change_detection.ts
+++ b/modules/angular2/src/change_detection/change_detection.ts
@@ -1,5 +1,5 @@
 import {DynamicProtoChangeDetector, JitProtoChangeDetector} from './proto_change_detector';
-import {PipeFactory} from './pipes/pipe';
+import {PipeFactory, Pipe} from './pipes/pipe';
 import {PipeRegistry} from './pipes/pipe_registry';
 import {IterableChangesFactory} from './pipes/iterable_changes';
 import {KeyValueChangesFactory} from './pipes/keyvalue_changes';
@@ -7,7 +7,7 @@ import {ObservablePipeFactory} from './pipes/observable_pipe';
 import {PromisePipeFactory} from './pipes/promise_pipe';
 import {UpperCaseFactory} from './pipes/uppercase_pipe';
 import {LowerCaseFactory} from './pipes/lowercase_pipe';
-import {JsonPipeFactory} from './pipes/json_pipe';
+import {JsonPipe} from './pipes/json_pipe';
 import {NullPipeFactory} from './pipes/null_pipe';
 import {ChangeDetection, ProtoChangeDetector, ChangeDetectorDefinition} from './interfaces';
 import {Injectable} from 'angular2/src/di/decorators';
@@ -55,7 +55,7 @@ export var lowercase: List<PipeFactory> = [new LowerCaseFactory(), new NullPipeF
  *
  * @exportedAs angular2/pipes
  */
-export var json: List<PipeFactory> = [new JsonPipeFactory(), new NullPipeFactory()];
+export var json: List<PipeFactory | Pipe> = [new JsonPipe(), new NullPipeFactory()];
 
 export var defaultPipes = {
   "iterableDiff": iterableDiff,

--- a/modules/angular2/src/change_detection/pipes/json_pipe.ts
+++ b/modules/angular2/src/change_detection/pipes/json_pipe.ts
@@ -1,4 +1,4 @@
-import {isBlank, isPresent, CONST, Json} from 'angular2/src/facade/lang';
+import {isBlank, isPresent, Json} from 'angular2/src/facade/lang';
 import {Pipe, PipeFactory} from './pipe';
 
 /**
@@ -27,48 +27,9 @@ import {Pipe, PipeFactory} from './pipe';
  * @exportedAs angular2/pipes
  */
 export class JsonPipe extends Pipe {
-  _latestRef: any;
-  _latestValue: any;
-  constructor() {
-    super();
-    this._latestRef = null;
-    this._latestValue = null;
-  }
-
-  onDestroy(): void {
-    if (isPresent(this._latestValue)) {
-      this._latestRef = null;
-      this._latestValue = null;
-    }
-  }
-
   supports(obj): boolean { return true; }
 
-  transform(value): any {
-    if (value === this._latestRef) {
-      return this._latestValue;
-    } else {
-      return this._prettyPrint(value);
-    }
-  }
+  transform(value): string { return Json.stringify(value); }
 
-  _prettyPrint(value) {
-    this._latestRef = value;
-    this._latestValue = Json.stringify(value);
-    return this._latestValue;
-  }
-}
-
-/**
- * Provides a factory for [JsonPipeFactory].
- *
- * @exportedAs angular2/pipes
- */
-@CONST()
-export class JsonPipeFactory extends PipeFactory {
-  constructor() { super(); }
-
-  supports(obj): boolean { return true; }
-
-  create(cdRef): Pipe { return new JsonPipe(); }
+  create(cdRef): Pipe { return this }
 }

--- a/modules/angular2/test/change_detection/pipes/json_pipe_spec.ts
+++ b/modules/angular2/test/change_detection/pipes/json_pipe_spec.ts
@@ -14,6 +14,7 @@ import {
   IS_DARTIUM
 } from 'angular2/test_lib';
 import {Json, RegExp, NumberWrapper, StringWrapper} from 'angular2/src/facade/lang';
+import {ListWrapper} from 'angular2/src/facade/collection';
 
 import {JsonPipe} from 'angular2/src/change_detection/pipes/json_pipe';
 
@@ -25,6 +26,7 @@ export function main() {
     var inceptionObjString;
     var catString;
     var pipe;
+    var collection;
 
     function normalize(obj: string): string { return StringWrapper.replace(obj, regNewLine, ''); }
 
@@ -38,6 +40,7 @@ export function main() {
 
       catString = 'Inception Cat';
       pipe = new JsonPipe();
+      collection = [];
     });
 
     describe("supports", () => {
@@ -72,9 +75,23 @@ export function main() {
         expect(dream1).toEqual(dream2);
       });
 
-      it("should return same value when nothing has changed since the last call", () => {
+      it("should return same ref when nothing has changed since the last call", () => {
         expect(pipe.transform(inceptionObj)).toEqual(inceptionObjString);
         expect(pipe.transform(inceptionObj)).toEqual(inceptionObjString);
+      });
+
+
+      it("should return a new value when something changed but the ref hasn't", () => {
+        var stringCollection = '[]';
+        var stringCollectionWith1 = '[\n' +
+                                    '  1' +
+                                    '\n]';
+
+        expect(pipe.transform(collection)).toEqual(stringCollection);
+
+        ListWrapper.push(collection, 1);
+
+        expect(pipe.transform(collection)).toEqual(stringCollectionWith1);
       });
 
     });


### PR DESCRIPTION
fixes https://github.com/angular/angular/issues/2278#issuecomment-108219190 by not maintaining a ref cache after transformation.

I couldn't run the tests locally due to https://github.com/angular/angular/issues/2281 so I'm pushing this up to have the tests pass here

closes #2278
