### PR TITLE
chore: move to clang-format 1.0.17.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -211,12 +211,8 @@ gulp.task('build/pubbuild.dart', pubbuild(gulp, gulpPlugins, {
 // formatting
 
 function doCheckFormat() {
-  return gulp.src(['Brocfile*.js', 'modules/**/*.ts', 'tools/**/*.ts', '!**/typings/**/*.d.ts',
-                   // skipped  due to https://github.com/angular/clang-format/issues/4
-                   '!tools/broccoli/tree-differ.ts',
-                   // skipped  due to https://github.com/angular/gulp-clang-format/issues/3
-                   '!tools/broccoli/broccoli-typescript.ts' ])
-    .pipe(format.checkFormat('file'));
+  return gulp.src(['Brocfile*.js', 'modules/**/*.ts', 'tools/**/*.ts', '!**/typings/**/*.d.ts'])
+      .pipe(format.checkFormat('file'));
 }
 
 gulp.task('check-format', function() {

--- a/modules/angular2/router.ts
+++ b/modules/angular2/router.ts
@@ -35,7 +35,8 @@ export var routerInjectables: List<any> = [
   Pipeline,
   BrowserLocation,
   Location,
-  bind(Router).toFactory((registry, pipeline, location, appRoot) =>
-                         { return new RootRouter(registry, pipeline, location, appRoot);},
-                         [RouteRegistry, Pipeline, Location, appComponentTypeToken])
+  bind(Router)
+      .toFactory((registry, pipeline, location,
+                  appRoot) => { return new RootRouter(registry, pipeline, location, appRoot);},
+                 [RouteRegistry, Pipeline, Location, appComponentTypeToken])
 ];

--- a/modules/angular2/src/change_detection/change_detection.ts
+++ b/modules/angular2/src/change_detection/change_detection.ts
@@ -33,8 +33,8 @@ export var iterableDiff: List<PipeFactory> = [new IterableChangesFactory(), new 
  *
  * @exportedAs angular2/pipes
  */
-export var async: List<
-    PipeFactory> = [new ObservablePipeFactory(), new PromisePipeFactory(), new NullPipeFactory()];
+export var async: List<PipeFactory> =
+    [new ObservablePipeFactory(), new PromisePipeFactory(), new NullPipeFactory()];
 
 /**
  * Uppercase text transform.

--- a/modules/angular2/src/change_detection/coalesce.ts
+++ b/modules/angular2/src/change_detection/coalesce.ts
@@ -45,9 +45,9 @@ function _selfRecord(r: ProtoRecord, contextIndex: number, selfIndex: number): P
 
 function _findMatching(r: ProtoRecord, rs: List<ProtoRecord>) {
   return ListWrapper.find(rs, (rr) => rr.mode !== RECORD_TYPE_DIRECTIVE_LIFECYCLE &&
-                                      rr.mode === r.mode && rr.funcOrValue === r.funcOrValue &&
-                                      rr.contextIndex === r.contextIndex &&
-                                      ListWrapper.equals(rr.args, r.args));
+                                  rr.mode === r.mode && rr.funcOrValue === r.funcOrValue &&
+                                  rr.contextIndex === r.contextIndex &&
+                                  ListWrapper.equals(rr.args, r.args));
 }
 
 function _replaceIndices(r: ProtoRecord, selfIndex: number, indexMap: Map<any, any>) {

--- a/modules/angular2/src/core/application.ts
+++ b/modules/angular2/src/core/application.ts
@@ -71,21 +71,21 @@ function _injectorBindings(appComponentType): List<Type | Binding | List<any>> {
         .toValue(DOM.defaultDoc()),
     bind(appComponentTypeToken).toValue(appComponentType),
     bind(appComponentRefToken)
-        .toAsyncFactory((dynamicComponentLoader, injector, testability, registry) =>
-                        {
+        .toAsyncFactory(
+            (dynamicComponentLoader, injector, testability, registry) => {
 
-                          // TODO(rado): investigate whether to support bindings on root component.
-                          return dynamicComponentLoader.loadAsRoot(appComponentType, null, injector)
-                              .then((componentRef) => {
-                                var domView = resolveInternalDomView(componentRef.hostView.render);
-                                // We need to do this here to ensure that we create Testability and
-                                // it's ready on the window for users.
-                                registry.registerApplication(domView.boundElements[0], testability);
+              // TODO(rado): investigate whether to support bindings on root component.
+              return dynamicComponentLoader.loadAsRoot(appComponentType, null, injector)
+                  .then((componentRef) => {
+                    var domView = resolveInternalDomView(componentRef.hostView.render);
+                    // We need to do this here to ensure that we create Testability and
+                    // it's ready on the window for users.
+                    registry.registerApplication(domView.boundElements[0], testability);
 
-                                return componentRef;
-                              });
-                        },
-                        [DynamicComponentLoader, Injector, Testability, TestabilityRegistry]),
+                    return componentRef;
+                  });
+            },
+            [DynamicComponentLoader, Injector, Testability, TestabilityRegistry]),
 
     bind(appComponentType).toFactory((ref) => ref.instance, [appComponentRefToken]),
     bind(LifeCycle)
@@ -93,8 +93,7 @@ function _injectorBindings(appComponentType): List<Type | Binding | List<any>> {
                    [ExceptionHandler]),
     bind(EventManager)
         .toFactory(
-            (ngZone) =>
-            {
+            (ngZone) => {
               var plugins =
                   [new HammerGesturesPlugin(), new KeyEventsPlugin(), new DomEventsPlugin()];
               return new EventManager(plugins, ngZone);
@@ -102,7 +101,7 @@ function _injectorBindings(appComponentType): List<Type | Binding | List<any>> {
             [NgZone]),
     bind(ShadowDomStrategy)
         .toFactory((styleUrlResolver, doc) =>
-                       new EmulatedUnscopedShadowDomStrategy(styleUrlResolver, doc.head),
+                           new EmulatedUnscopedShadowDomStrategy(styleUrlResolver, doc.head),
                    [StyleUrlResolver, DOCUMENT_TOKEN]),
     DomRenderer,
     DefaultDomCompiler,
@@ -293,8 +292,7 @@ export function bootstrap(appComponentType: Type,
 
     PromiseWrapper.then(
         appInjector.asyncGet(appComponentRefToken),
-        (componentRef) =>
-        {
+        (componentRef) => {
           var appChangeDetector = internalView(componentRef.hostView).changeDetector;
           // retrieve life cycle: may have already been created if injected in root component
           var lc = appInjector.get(LifeCycle);

--- a/modules/angular2/src/core/compiler/compiler.ts
+++ b/modules/angular2/src/core/compiler/compiler.ts
@@ -94,11 +94,9 @@ export class Compiler {
 
     var directiveMetadata = componentBinding.metadata;
     return this._render.compileHost(directiveMetadata)
-        .then((hostRenderPv) =>
-              {
-                return this._compileNestedProtoViews(componentBinding, hostRenderPv,
-                                                     [componentBinding]);
-              })
+        .then((hostRenderPv) => {
+          return this._compileNestedProtoViews(componentBinding, hostRenderPv, [componentBinding]);
+        })
         .then((appProtoView) => { return new ProtoViewRef(appProtoView); });
   }
 

--- a/modules/angular2/src/dom/parse5_adapter.ts
+++ b/modules/angular2/src/dom/parse5_adapter.ts
@@ -239,7 +239,7 @@ export class Parse5DomAdapter extends DomAdapter {
   createTextNode(text: string) { throw _notImplemented('createTextNode'); }
   createScriptTag(attrName: string, attrValue: string) {
     return treeAdapter.createElement("script", 'http://www.w3.org/1999/xhtml',
-                                                   [{name: attrName, value: attrValue}]);
+                                     [{name: attrName, value: attrValue}]);
   }
   createStyleElement(css: string) {
     var style = this.createElement('style');

--- a/modules/angular2/src/test_lib/test_injector.ts
+++ b/modules/angular2/src/test_lib/test_injector.ts
@@ -86,7 +86,7 @@ function _getAppBindings() {
         .toValue(appDoc),
     bind(ShadowDomStrategy)
         .toFactory((styleUrlResolver, doc) =>
-                       new EmulatedUnscopedShadowDomStrategy(styleUrlResolver, doc.head),
+                           new EmulatedUnscopedShadowDomStrategy(styleUrlResolver, doc.head),
                    [StyleUrlResolver, DOCUMENT_TOKEN]),
     DomRenderer,
     DefaultDomCompiler,
@@ -118,14 +118,14 @@ function _getAppBindings() {
     TestComponentBuilder,
     bind(NgZone).toClass(MockNgZone),
     bind(EventManager)
-        .toFactory((zone) =>
-                   {
-                     var plugins = [
-                       new DomEventsPlugin(),
-                     ];
-                     return new EventManager(plugins, zone);
-                   },
-                   [NgZone]),
+        .toFactory(
+            (zone) => {
+              var plugins = [
+                new DomEventsPlugin(),
+              ];
+              return new EventManager(plugins, zone);
+            },
+            [NgZone]),
   ];
 }
 

--- a/modules/angular2/src/test_lib/test_lib.ts
+++ b/modules/angular2/src/test_lib/test_lib.ts
@@ -334,11 +334,10 @@ export class SpyObject {
 }
 
 function elementText(n) {
-  var hasNodes = (n) =>
-  {
+  var hasNodes = (n) => {
     var children = DOM.childNodes(n);
     return children && children.length > 0;
-  }
+  };
 
   if (n instanceof Array) {
     return n.map((nn) => elementText(nn)).join("");

--- a/modules/angular2/test/change_detection/change_detector_spec.ts
+++ b/modules/angular2/test/change_detection/change_detector_spec.ts
@@ -239,22 +239,22 @@ export function main() {
         {
           "dynamic": (bindingRecords, variableBindings = null, directiveRecords = null,
                       registry = null, strategy = null) =>
-                         new DynamicProtoChangeDetector(
-                             registry,
-                             new ChangeDetectorDefinition(
-                                 null, strategy, isBlank(variableBindings) ? [] : variableBindings,
-                                 isBlank(bindingRecords) ? [] : bindingRecords,
-                                 isBlank(directiveRecords) ? [] : directiveRecords)),
+                             new DynamicProtoChangeDetector(
+                                 registry, new ChangeDetectorDefinition(
+                                               null, strategy,
+                                               isBlank(variableBindings) ? [] : variableBindings,
+                                               isBlank(bindingRecords) ? [] : bindingRecords,
+                                               isBlank(directiveRecords) ? [] : directiveRecords)),
 
-          "JIT":
-              (bindingRecords, variableBindings = null, directiveRecords = null, registry = null,
-               strategy = null) =>
-                  new JitProtoChangeDetector(
-                      registry, new ChangeDetectorDefinition(
-                                    null, strategy, isBlank(variableBindings) ? [] :
-                                                                                variableBindings,
-                                    isBlank(bindingRecords) ? [] : bindingRecords,
-                                    isBlank(directiveRecords) ? [] : directiveRecords))
+          "JIT": (bindingRecords, variableBindings = null, directiveRecords = null, registry = null,
+                  strategy = null) =>
+                         new JitProtoChangeDetector(
+                             registry, new ChangeDetectorDefinition(
+                                           null,
+                                           strategy, isBlank(variableBindings) ? [] :
+                                                                                 variableBindings,
+                                           isBlank(bindingRecords) ? [] : bindingRecords,
+                                           isBlank(directiveRecords) ? [] : directiveRecords))
 
         },
         (createProtoChangeDetector, name) => {

--- a/modules/angular2/test/change_detection/coalesce_spec.ts
+++ b/modules/angular2/test/change_detection/coalesce_spec.ts
@@ -19,12 +19,8 @@ export function main() {
     it("should remove non-terminal duplicate records" +
            " and update the context indices referencing them",
        () => {
-         var rs = coalesce([
-           r("user", [], 0, 1),
-           r("first", [], 1, 2),
-           r("user", [], 0, 3),
-           r("last", [], 3, 4)
-         ]);
+         var rs = coalesce(
+             [r("user", [], 0, 1), r("first", [], 1, 2), r("user", [], 0, 3), r("last", [], 3, 4)]);
 
          expect(rs).toEqual([r("user", [], 0, 1), r("first", [], 1, 2), r("last", [], 1, 3)]);
        });

--- a/modules/angular2/test/change_detection/parser/parser_spec.ts
+++ b/modules/angular2/test/change_detection/parser/parser_spec.ts
@@ -456,14 +456,14 @@ export function main() {
 
       function exprSources(templateBindings) {
         return ListWrapper.map(templateBindings, (binding) => isPresent(binding.expression) ?
-                                                                  binding.expression.source :
-                                                                  null);
+                                                     binding.expression.source :
+                                                     null);
       }
 
       function exprAsts(templateBindings) {
         return ListWrapper.map(templateBindings, (binding) => isPresent(binding.expression) ?
-                                                                  binding.expression :
-                                                                  null);
+                                                     binding.expression :
+                                                     null);
       }
 
       it('should parse an empty string', () => {

--- a/modules/angular2/test/change_detection/pipes/keyvalue_changes_spec.ts
+++ b/modules/angular2/test/change_detection/pipes/keyvalue_changes_spec.ts
@@ -58,14 +58,12 @@ export function main() {
         MapWrapper.set(m, 1, 20);
         changes.check(m);
 
-        changes.forEachChangedItem((record) =>
-                                   {
-                                     previous = record.previousValue;
-                                     current = record.currentValue;
-                                   })
+        changes.forEachChangedItem((record) => {
+          previous = record.previousValue;
+          current = record.currentValue;
+        });
 
-            expect(previous)
-                .toEqual(10);
+        expect(previous).toEqual(10);
         expect(current).toEqual(20);
       });
 
@@ -97,11 +95,8 @@ export function main() {
         MapWrapper.delete(m, 'b');
         changes.check(m);
         expect(changes.toString())
-            .toEqual(kvChangesAsString({
-              map: ['a', 'd'],
-              previous: ['a', 'b[BB->null]', 'd'],
-              removals: ['b[BB->null]']
-            }));
+            .toEqual(kvChangesAsString(
+                {map: ['a', 'd'], previous: ['a', 'b[BB->null]', 'd'], removals: ['b[BB->null]']}));
 
         MapWrapper.clear(m);
         changes.check(m);

--- a/modules/angular2/test/core/compiler/compiler_spec.ts
+++ b/modules/angular2/test/core/compiler/compiler_spec.ts
@@ -77,8 +77,7 @@ export function main() {
       }
 
       function captureDirective(directive): Promise<renderApi.DirectiveMetadata> {
-        return captureTemplate(
-                   new viewAnn.View({template: '<div></div>', directives: [directive]}))
+        return captureTemplate(new viewAnn.View({template: '<div></div>', directives: [directive]}))
             .then((renderTpl) => {
               expect(renderTpl.directives.length).toBe(1);
               return renderTpl.directives[0];
@@ -315,9 +314,11 @@ export function main() {
              createProtoView([createComponentElementBinder(directiveResolver, NestedComponent)]);
          var nestedProtoView = createProtoView();
          var compiler = createCompiler([
-           createRenderProtoView([createRenderViewportElementBinder(
-               createRenderProtoView([createRenderComponentElementBinder(0)],
-                                     renderApi.ProtoViewDto.EMBEDDED_VIEW_TYPE))]),
+           createRenderProtoView([
+             createRenderViewportElementBinder(
+                 createRenderProtoView([createRenderComponentElementBinder(0)],
+                                       renderApi.ProtoViewDto.EMBEDDED_VIEW_TYPE))
+           ]),
            createRenderProtoView()
          ],
                                        [[mainProtoView, viewportProtoView], [nestedProtoView]]);
@@ -336,11 +337,10 @@ export function main() {
          var expectedProtoView = createProtoView();
          var compiler = createCompiler([renderProtoView], [[expectedProtoView]]);
          compiler.compile(MainComponent)
-             .then((protoViewRef) =>
-                   {
-                     expect(internalProtoView(protoViewRef)).toBe(expectedProtoView);
-                     return compiler.compile(MainComponent);
-                   })
+             .then((protoViewRef) => {
+               expect(internalProtoView(protoViewRef)).toBe(expectedProtoView);
+               return compiler.compile(MainComponent);
+             })
              .then((protoViewRef) => {
                expect(internalProtoView(protoViewRef)).toBe(expectedProtoView);
                async.done();

--- a/modules/angular2/test/core/compiler/dynamic_component_loader_spec.ts
+++ b/modules/angular2/test/core/compiler/dynamic_component_loader_spec.ts
@@ -76,31 +76,27 @@ export function main() {
              view.context.ctxBoolProp = true;
              view.detectChanges();
              var dynamicComponent = view.rawView.viewContainers[0].views[0].locals.get("dynamic");
-             dynamicComponent.done.then((_) =>
-                                        {
-                                          view.detectChanges();
-                                          expect(view.rootNodes).toHaveText('hello');
+             var promise = dynamicComponent.done.then((_) => {
+               view.detectChanges();
+               expect(view.rootNodes).toHaveText('hello');
 
-                                          view.context.ctxBoolProp = false;
-                                          view.detectChanges();
+               view.context.ctxBoolProp = false;
+               view.detectChanges();
 
-                                          expect(view.rawView.viewContainers[0].views.length)
-                                              .toBe(0);
-                                          expect(view.rootNodes).toHaveText('');
+               expect(view.rawView.viewContainers[0].views.length).toBe(0);
+               expect(view.rootNodes).toHaveText('');
 
-                                          view.context.ctxBoolProp = true;
-                                          view.detectChanges();
+               view.context.ctxBoolProp = true;
+               view.detectChanges();
 
-                                          var dynamicComponent =
-                                              view.rawView.viewContainers[0].views[0].locals.get(
-                                                  "dynamic");
-                                          return dynamicComponent.done;
-                                        })
-                 .then((_) => {
-                   view.detectChanges();
-                   expect(view.rootNodes).toHaveText('hello');
-                   async.done();
-                 });
+               var dynamicComponent = view.rawView.viewContainers[0].views[0].locals.get("dynamic");
+               return dynamicComponent.done;
+             });
+             promise.then((_) => {
+               view.detectChanges();
+               expect(view.rootNodes).toHaveText('hello');
+               async.done();
+             });
            });
          }));
     });

--- a/modules/angular2/test/core/compiler/integration_spec.ts
+++ b/modules/angular2/test/core/compiler/integration_spec.ts
@@ -107,8 +107,8 @@ export function main() {
 
       it('should consume binding to aria-* attributes',
          inject([TestBed, AsyncTestCompleter], (tb, async) => {
-           tb.overrideView(
-               MyComp, new viewAnn.View({template: '<div [attr.aria-label]="ctxProp"></div>'}));
+           tb.overrideView(MyComp,
+                           new viewAnn.View({template: '<div [attr.aria-label]="ctxProp"></div>'}));
 
            tb.createView(MyComp, {context: ctx})
                .then((view) => {
@@ -229,10 +229,12 @@ export function main() {
 
       describe('pipes', () => {
         beforeEachBindings(() => {
-          return [bind(ChangeDetection)
-                      .toFactory(() => new DynamicChangeDetection(
-                                     new PipeRegistry({"double": [new DoublePipeFactory()]})),
-                                 [])];
+          return [
+            bind(ChangeDetection)
+                .toFactory(() => new DynamicChangeDetection(
+                               new PipeRegistry({"double": [new DoublePipeFactory()]})),
+                           [])
+          ];
         });
 
         it("should support pipes in bindings and bind config",
@@ -307,8 +309,8 @@ export function main() {
 
       it('should support directives where a selector matches property binding',
          inject([TestBed, AsyncTestCompleter], (tb, async) => {
-           tb.overrideView(MyComp, new viewAnn.View(
-                                       {template: '<p [id]="ctxProp"></p>', directives: [IdDir]}));
+           tb.overrideView(
+               MyComp, new viewAnn.View({template: '<p [id]="ctxProp"></p>', directives: [IdDir]}));
 
            tb.createView(MyComp, {context: ctx})
                .then((view) => {
@@ -1002,11 +1004,8 @@ export function main() {
               </parent-providing-event-bus>
             </grand-parent-providing-event-bus>
           `,
-             directives: [
-               GrandParentProvidingEventBus,
-               ParentProvidingEventBus,
-               ChildConsumingEventBus
-             ]
+             directives:
+                 [GrandParentProvidingEventBus, ParentProvidingEventBus, ChildConsumingEventBus]
            }));
            tb.createView(MyComp, {context: ctx})
                .then((view) => {
@@ -1134,8 +1133,7 @@ export function main() {
           tb.overrideView(MyComp, new viewAnn.View({template: inlineTpl}));
           PromiseWrapper.then(
               tb.createView(MyComp),
-              (value) =>
-              {
+              (value) => {
                 throw new BaseException(
                     "Test failure: should not have come here as an exception was expected");
               },
@@ -1611,11 +1609,15 @@ function createParentBusView(p) {
 }
 @Component({
   selector: 'parent-providing-event-bus',
-  hostInjector: [new Binding(
-      EventBus, {toFactory: createParentBusHost, deps: [[EventBus, new visAnn.Unbounded()]]})],
-  viewInjector: [new Binding(
-      EventBus,
-      {toFactory: createParentBusView, deps: [[FORWARD_REF(() => ParentProvidingEventBus)]]})]
+  hostInjector: [
+    new Binding(EventBus,
+                {toFactory: createParentBusHost, deps: [[EventBus, new visAnn.Unbounded()]]})
+  ],
+  viewInjector: [
+    new Binding(
+        EventBus,
+        {toFactory: createParentBusView, deps: [[FORWARD_REF(() => ParentProvidingEventBus)]]})
+  ]
 })
 @View({
   directives: [FORWARD_REF(() => ChildConsumingEventBus)],

--- a/modules/angular2/test/core/directive_lifecycle_integration_spec.ts
+++ b/modules/angular2/test/core/directive_lifecycle_integration_spec.ts
@@ -48,8 +48,7 @@ export function main() {
 }
 
 
-@Directive(
-    {selector: "[lifecycle]", properties: ['field'], lifecycle: [onChange, onCheck, onInit]})
+@Directive({selector: "[lifecycle]", properties: ['field'], lifecycle: [onChange, onCheck, onInit]})
 class LifecycleDir {
   field;
   log: List<string>;

--- a/modules/angular2/test/core/zone/ng_zone_spec.ts
+++ b/modules/angular2/test/core/zone/ng_zone_spec.ts
@@ -290,18 +290,17 @@ function commonTests() {
          var ran = false;
          _zone.initCallbacks({
            onTurnStart: _log.fn('onTurnStart'),
-           onTurnDone: () =>
-                       {
-                         _log.add('onTurnDone(begin)');
-                         if (!ran) {
-                           microTask(() => {
-                             ran = true;
-                             _log.add('executedMicrotask');
-                           });
-                         }
+           onTurnDone: () => {
+             _log.add('onTurnDone(begin)');
+             if (!ran) {
+               microTask(() => {
+                 ran = true;
+                 _log.add('executedMicrotask');
+               });
+             }
 
-                         _log.add('onTurnDone(end)');
-                       }
+             _log.add('onTurnDone(end)');
+           }
          });
 
          macroTask(() => { _zone.run(_log.fn('run')); });
@@ -323,18 +322,17 @@ function commonTests() {
          var ran = false;
          _zone.initCallbacks({
            onTurnStart: _log.fn('onTurnStart'),
-           onTurnDone: () =>
-                       {
-                         _log.add('onTurnDone(begin)');
-                         if (!ran) {
-                           _log.add('onTurnDone(scheduleMicrotask)');
-                           microTask(() => {
-                             ran = true;
-                             _log.add('onTurnDone(executeMicrotask)');
-                           });
-                         }
-                         _log.add('onTurnDone(end)');
-                       }
+           onTurnDone: () => {
+             _log.add('onTurnDone(begin)');
+             if (!ran) {
+               _log.add('onTurnDone(scheduleMicrotask)');
+               microTask(() => {
+                 ran = true;
+                 _log.add('onTurnDone(executeMicrotask)');
+               });
+             }
+             _log.add('onTurnDone(end)');
+           }
          });
 
          macroTask(() => {
@@ -361,37 +359,36 @@ function commonTests() {
          var startPromiseRan = false;
 
          _zone.initCallbacks({
-           onTurnStart: () =>
-                        {
-                          _log.add('onTurnStart(begin)');
-                          if (!startPromiseRan) {
-                            _log.add('onTurnStart(schedulePromise)');
-                            microTask(_log.fn('onTurnStart(executePromise)'));
-                            startPromiseRan = true;
-                          }
-                          _log.add('onTurnStart(end)');
-                        },
-           onTurnDone: () =>
-                       {
-                         _log.add('onTurnDone(begin)');
-                         if (!donePromiseRan) {
-                           _log.add('onTurnDone(schedulePromise)');
-                           microTask(_log.fn('onTurnDone(executePromise)'));
-                           donePromiseRan = true;
-                         }
-                         _log.add('onTurnDone(end)');
-                       }
+           onTurnStart: () => {
+             _log.add('onTurnStart(begin)');
+             if (!startPromiseRan) {
+               _log.add('onTurnStart(schedulePromise)');
+               microTask(_log.fn('onTurnStart(executePromise)'));
+               startPromiseRan = true;
+             }
+             _log.add('onTurnStart(end)');
+           },
+           onTurnDone: () => {
+             _log.add('onTurnDone(begin)');
+             if (!donePromiseRan) {
+               _log.add('onTurnDone(schedulePromise)');
+               microTask(_log.fn('onTurnDone(executePromise)'));
+               donePromiseRan = true;
+             }
+             _log.add('onTurnDone(end)');
+           }
          });
 
          macroTask(() => {
            _zone.run(() => {
              _log.add('run start');
-             PromiseWrapper.resolve(null).then((_) => {
-                                           _log.add('promise then');
-                                           PromiseWrapper.resolve(null)
-                                               .then(_log.fn('promise foo'));
-                                           return PromiseWrapper.resolve(null);
-                                         }).then(_log.fn('promise bar'));
+             PromiseWrapper.resolve(null)
+                 .then((_) => {
+                   _log.add('promise then');
+                   PromiseWrapper.resolve(null).then(_log.fn('promise foo'));
+                   return PromiseWrapper.resolve(null);
+                 })
+                 .then(_log.fn('promise bar'));
              _log.add('run end');
            });
          });

--- a/modules/angular2/test/di/async_spec.ts
+++ b/modules/angular2/test/di/async_spec.ts
@@ -68,9 +68,8 @@ export function main() {
       it('should return a promise when instantiating a sync binding ' +
              'with an async dependency',
          inject([AsyncTestCompleter], (async) => {
-           var injector =
-               Injector
-                   .resolveAndCreate([bind(UserList).toAsyncFactory(fetchUsers), UserController]);
+           var injector = Injector.resolveAndCreate(
+               [bind(UserList).toAsyncFactory(fetchUsers), UserController]);
 
            injector.asyncGet(UserController)
                .then(function(userController) {
@@ -145,9 +144,8 @@ export function main() {
 
       it('should not throw when instantiating a sync binding with a resolved async dependency',
          inject([AsyncTestCompleter], (async) => {
-           var injector =
-               Injector
-                   .resolveAndCreate([bind(UserList).toAsyncFactory(fetchUsers), UserController]);
+           var injector = Injector.resolveAndCreate(
+               [bind(UserList).toAsyncFactory(fetchUsers), UserController]);
 
            injector.asyncGet(UserList).then((_) => {
              expect(() => { injector.get(UserController); }).not.toThrow();

--- a/modules/angular2/test/di/injector_spec.ts
+++ b/modules/angular2/test/di/injector_spec.ts
@@ -167,9 +167,8 @@ export function main() {
     });
 
     it('should support overriding factory dependencies', () => {
-      var injector =
-          Injector
-              .resolveAndCreate([Engine, bind(Car).toFactory((e) => new SportsCar(e), [Engine])]);
+      var injector = Injector.resolveAndCreate(
+          [Engine, bind(Car).toFactory((e) => new SportsCar(e), [Engine])]);
 
       var car = injector.get(Car);
       expect(car).toBeAnInstanceOf(SportsCar);
@@ -191,9 +190,8 @@ export function main() {
     });
 
     it("should use the last binding when there are multiple bindings for same token", () => {
-      var injector =
-          Injector
-              .resolveAndCreate([bind(Engine).toClass(Engine), bind(Engine).toClass(TurboEngine)]);
+      var injector = Injector.resolveAndCreate(
+          [bind(Engine).toClass(Engine), bind(Engine).toClass(TurboEngine)]);
 
       expect(injector.get(Engine)).toBeAnInstanceOf(TurboEngine);
     });
@@ -278,7 +276,7 @@ export function main() {
 
     describe("default bindings", () => {
       it("should be used when no matching binding found", () => {
-        var injector = Injector.resolveAndCreate([], { defaultBindings: true });
+        var injector = Injector.resolveAndCreate([], {defaultBindings: true});
 
         var car = injector.get(Car);
 
@@ -327,7 +325,7 @@ export function main() {
       });
 
       it("should create child injectors without default bindings", () => {
-        var parent = Injector.resolveAndCreate([], { defaultBindings: true });
+        var parent = Injector.resolveAndCreate([], {defaultBindings: true});
         var child = parent.resolveAndCreateChild([]);
 
         // child delegates to parent the creation of Car
@@ -393,10 +391,11 @@ export function main() {
       });
 
       it('should support overriding factory dependencies with dependency annotations', () => {
-        var bindings = Injector.resolve(
-            [bind("token")
-                    .toFactory((e) => "result",
-                               [[new ann.Inject("dep"), new CustomDependencyAnnotation()]])]);
+        var bindings = Injector.resolve([
+          bind("token")
+              .toFactory((e) => "result",
+                         [[new ann.Inject("dep"), new CustomDependencyAnnotation()]])
+        ]);
         var binding = bindings[Key.get("token").id];
 
         expect(binding.dependencies[0].key.token).toEqual("dep");

--- a/modules/angular2/test/forms/model_spec.ts
+++ b/modules/angular2/test/forms/model_spec.ts
@@ -152,10 +152,8 @@ export function main() {
         });
 
         it("should support nested groups", () => {
-          var g = new ControlGroup({
-            "one": new Control("111"),
-            "nested": new ControlGroup({"two": new Control("222")})
-          });
+          var g = new ControlGroup(
+              {"one": new Control("111"), "nested": new ControlGroup({"two": new Control("222")})});
           expect(g.value).toEqual({"one": "111", "nested": {"two": "222"}});
 
           g.controls["nested"].controls["two"].updateValue("333");
@@ -167,10 +165,8 @@ export function main() {
       describe("find", () => {
         var g;
         beforeEach(() => {
-          g = new ControlGroup({
-            "one": new Control("111"),
-            "nested": new ControlGroup({"two": new Control("222")})
-          });
+          g = new ControlGroup(
+              {"one": new Control("111"), "nested": new ControlGroup({"two": new Control("222")})});
         });
 
         it("should return a control if it is present", () => {

--- a/modules/angular2/test/mock/template_resolver_mock_spec.ts
+++ b/modules/angular2/test/mock/template_resolver_mock_spec.ts
@@ -42,11 +42,9 @@ export function main() {
 
       it('should not allow overriding a template after it has been resolved', () => {
         resolver.resolve(SomeComponent);
-        expect(() =>
-               {
-                 resolver.setView(SomeComponent,
-                                  new viewImpl.View({template: 'overridden template'}));
-               })
+        expect(() => {
+          resolver.setView(SomeComponent, new viewImpl.View({template: 'overridden template'}));
+        })
             .toThrowError(
                 `The component ${stringify(SomeComponent)} has already been compiled, its configuration can not be changed`);
       });
@@ -101,9 +99,9 @@ export function main() {
 
       it('should not allow overriding a directive after its template has been resolved', () => {
         resolver.resolve(SomeComponent);
-        expect(
-            () =>
-            { resolver.overrideViewDirective(SomeComponent, SomeDirective, SomeOtherDirective); })
+        expect(() => {
+          resolver.overrideViewDirective(SomeComponent, SomeDirective, SomeOtherDirective);
+        })
             .toThrowError(
                 `The component ${stringify(SomeComponent)} has already been compiled, its configuration can not be changed`);
       });

--- a/modules/angular2/test/render/dom/compiler/directive_parser_spec.ts
+++ b/modules/angular2/test/render/dom/compiler/directive_parser_spec.ts
@@ -36,14 +36,13 @@ export function main() {
       if (isBlank(directives)) directives = annotatedDirectives;
 
       return new CompilePipeline([
-        new MockStep((parent, current, control) =>
-                     {
-                       if (isPresent(propertyBindings)) {
-                         StringMapWrapper.forEach(propertyBindings, (ast, name) => {
-                           current.bindElement().bindProperty(name, ast);
-                         });
-                       }
-                     }),
+        new MockStep((parent, current, control) => {
+          if (isPresent(propertyBindings)) {
+            StringMapWrapper.forEach(propertyBindings, (ast, name) => {
+              current.bindElement().bindProperty(name, ast);
+            });
+          }
+        }),
         new DirectiveParser(parser, directives)
       ]);
     }

--- a/modules/angular2/test/render/dom/compiler/pipeline_spec.ts
+++ b/modules/angular2/test/render/dom/compiler/pipeline_spec.ts
@@ -39,12 +39,14 @@ export function main() {
 
     it('should inherit protoViewBuilders to children', () => {
       var element = el('<div><div><span viewroot><span></span></span></div></div>');
-      var pipeline = new CompilePipeline([new MockStep((parent, current, control) => {
-        if (isPresent(DOM.getAttribute(current.element, 'viewroot'))) {
-          current.inheritedProtoView =
-              new ProtoViewBuilder(current.element, ProtoViewDto.EMBEDDED_VIEW_TYPE);
-        }
-      })]);
+      var pipeline = new CompilePipeline([
+        new MockStep((parent, current, control) => {
+          if (isPresent(DOM.getAttribute(current.element, 'viewroot'))) {
+            current.inheritedProtoView =
+                new ProtoViewBuilder(current.element, ProtoViewDto.EMBEDDED_VIEW_TYPE);
+          }
+        })
+      ]);
       var results = pipeline.process(element);
       expect(results[0].inheritedProtoView).toBe(results[1].inheritedProtoView);
       expect(results[2].inheritedProtoView).toBe(results[3].inheritedProtoView);
@@ -52,11 +54,13 @@ export function main() {
 
     it('should inherit elementBinderBuilders to children', () => {
       var element = el('<div bind><div><span bind><span></span></span></div></div>');
-      var pipeline = new CompilePipeline([new MockStep((parent, current, control) => {
-        if (isPresent(DOM.getAttribute(current.element, 'bind'))) {
-          current.bindElement();
-        }
-      })]);
+      var pipeline = new CompilePipeline([
+        new MockStep((parent, current, control) => {
+          if (isPresent(DOM.getAttribute(current.element, 'bind'))) {
+            current.bindElement();
+          }
+        })
+      ]);
       var results = pipeline.process(element);
       expect(results[0].inheritedElementBinder).toBe(results[1].inheritedElementBinder);
       expect(results[2].inheritedElementBinder).toBe(results[3].inheritedElementBinder);
@@ -70,11 +74,13 @@ export function main() {
 
     it('should calculate distanceToParent / parent correctly', () => {
       var element = el('<div bind><div bind></div><div><div bind></div></div></div>');
-      var pipeline = new CompilePipeline([new MockStep((parent, current, control) => {
-        if (isPresent(DOM.getAttribute(current.element, 'bind'))) {
-          current.bindElement();
-        }
-      })]);
+      var pipeline = new CompilePipeline([
+        new MockStep((parent, current, control) => {
+          if (isPresent(DOM.getAttribute(current.element, 'bind'))) {
+            current.bindElement();
+          }
+        })
+      ]);
       var results = pipeline.process(element);
       expect(results[0].inheritedElementBinder.distanceToParent).toBe(0);
       expect(results[1].inheritedElementBinder.distanceToParent).toBe(1);
@@ -101,8 +107,8 @@ export function main() {
         var element = el('<div id="1"><span wrap0="1" id="2"><b id="3"></b></span></div>');
         var step0Log = [];
         var step1Log = [];
-        var pipeline = new CompilePipeline(
-            [createWrapperStep('wrap0', step0Log), createLoggerStep(step1Log)]);
+        var pipeline =
+            new CompilePipeline([createWrapperStep('wrap0', step0Log), createLoggerStep(step1Log)]);
         var result = pipeline.process(element);
         expect(step0Log).toEqual(['1', '1<2', '2<3']);
         expect(step1Log).toEqual(['1', '1<wrap0#0', 'wrap0#0<2', '2<3']);
@@ -149,8 +155,8 @@ export function main() {
         var element = el('<div id="1"><span wrap0="2" id="2"><b id="3"></b></span></div>');
         var step0Log = [];
         var step1Log = [];
-        var pipeline = new CompilePipeline(
-            [createWrapperStep('wrap0', step0Log), createLoggerStep(step1Log)]);
+        var pipeline =
+            new CompilePipeline([createWrapperStep('wrap0', step0Log), createLoggerStep(step1Log)]);
         var result = pipeline.process(element);
         expect(step0Log).toEqual(['1', '1<2', '2<3']);
         expect(step1Log).toEqual(['1', '1<wrap0#0', 'wrap0#0<wrap0#1', 'wrap0#1<2', '2<3']);
@@ -165,12 +171,11 @@ export function main() {
         var resultLog = [];
         var newChild = new CompileElement(el('<div id="3"></div>'));
         var pipeline = new CompilePipeline([
-          new MockStep((parent, current, control) =>
-                       {
-                         if (StringWrapper.equals(DOM.getAttribute(current.element, 'id'), '1')) {
-                           control.addChild(newChild);
-                         }
-                       }),
+          new MockStep((parent, current, control) => {
+            if (StringWrapper.equals(DOM.getAttribute(current.element, 'id'), '1')) {
+              control.addChild(newChild);
+            }
+          }),
           createLoggerStep(resultLog)
         ]);
         var result = pipeline.process(element);

--- a/modules/angular2/test/render/dom/compiler/property_binding_parser_spec.ts
+++ b/modules/angular2/test/render/dom/compiler/property_binding_parser_spec.ts
@@ -15,12 +15,11 @@ export function main() {
   describe('PropertyBindingParser', () => {
     function createPipeline(hasNestedProtoView = false) {
       return new CompilePipeline([
-        new MockStep((parent, current, control) =>
-                     {
-                       if (hasNestedProtoView) {
-                         current.bindElement().bindNestedProtoView(el('<template></template>'));
-                       }
-                     }),
+        new MockStep((parent, current, control) => {
+          if (hasNestedProtoView) {
+            current.bindElement().bindNestedProtoView(el('<template></template>'));
+          }
+        }),
         new PropertyBindingParser(new Parser(new Lexer()))
       ]);
     }

--- a/modules/angular2/test/render/dom/compiler/template_loader_spec.ts
+++ b/modules/angular2/test/render/dom/compiler/template_loader_spec.ts
@@ -52,12 +52,11 @@ export function main() {
          xhr.expect('base/foo', 'xhr template');
          var template = new ViewDefinition({absUrl: 'base/foo'});
          loader.load(template)
-             .then((el) =>
-                   {
-                     expect(DOM.content(el)).toHaveText('xhr template');
-                     firstEl = el;
-                     return loader.load(template);
-                   })
+             .then((el) => {
+               expect(DOM.content(el)).toHaveText('xhr template');
+               firstEl = el;
+               return loader.load(template);
+             })
              .then((el) => {
                expect(el).not.toBe(firstEl);
                expect(DOM.content(el)).toHaveText('xhr template');

--- a/modules/angular2/test/render/dom/dom_renderer_integration_spec.ts
+++ b/modules/angular2/test/render/dom/dom_renderer_integration_spec.ts
@@ -59,8 +59,7 @@ export function main() {
        inject([AsyncTestCompleter, DomTestbed], (async, tb) => {
          tb.compileAll([
              someComponent,
-             new ViewDefinition(
-                 {componentId: 'someComponent', template: 'hello', directives: []})
+             new ViewDefinition({componentId: 'someComponent', template: 'hello', directives: []})
            ])
              .then((protoViewDtos) => {
                var rootView = tb.createRootView(protoViewDtos[0]);
@@ -75,8 +74,7 @@ export function main() {
     it('should update text nodes', inject([AsyncTestCompleter, DomTestbed], (async, tb) => {
          tb.compileAll([
              someComponent,
-             new ViewDefinition(
-                 {componentId: 'someComponent', template: '{{a}}', directives: []})
+             new ViewDefinition({componentId: 'someComponent', template: '{{a}}', directives: []})
            ])
              .then((protoViewDtos) => {
                var rootView = tb.createRootView(protoViewDtos[0]);

--- a/modules/angular2/test/render/dom/shadow_dom/light_dom_spec.ts
+++ b/modules/angular2/test/render/dom/shadow_dom/light_dom_spec.ts
@@ -158,10 +158,11 @@ export function main() {
       it("should include view container nodes", () => {
         var lightDomEl = el("<div><template></template></div>");
         var lightDom = createLightDom(
-            new FakeView(
-                [new FakeViewContainer(DOM.firstChild(lightDomEl),  // template element
-                                       [el('<a></a>')]  // light DOM nodes of view container
-                                       )]),
+            new FakeView([
+              new FakeViewContainer(DOM.firstChild(lightDomEl),  // template element
+                                    [el('<a></a>')]  // light DOM nodes of view container
+                                    )
+            ]),
             null, lightDomEl);
 
         expect(toHtml(lightDom.expandedDomNodes())).toEqual(["<a></a>"]);
@@ -169,12 +170,14 @@ export function main() {
 
       it("should include content nodes", () => {
         var lightDomEl = el("<div><content></content></div>");
-        var lightDom = createLightDom(
-            new FakeView([new FakeContentTag(DOM.firstChild(lightDomEl),  // content element
-                                             '',                          // selector
-                                             [el('<a></a>')]  // light DOM nodes of content tag
-                                             )]),
-            null, lightDomEl);
+        var lightDom =
+            createLightDom(new FakeView([
+                             new FakeContentTag(DOM.firstChild(lightDomEl),  // content element
+                                                '',                          // selector
+                                                [el('<a></a>')]  // light DOM nodes of content tag
+                                                )
+                           ]),
+                           null, lightDomEl);
 
         expect(toHtml(lightDom.expandedDomNodes())).toEqual(["<a></a>"]);
       });

--- a/modules/angular2/test/render/dom/shadow_dom_emulation_integration_spec.ts
+++ b/modules/angular2/test/render/dom/shadow_dom_emulation_integration_spec.ts
@@ -43,8 +43,8 @@ export function main() {
                              styleInliner, styleUrlResolver, null),
                          [StyleInliner, StyleUrlResolver]),
       "unscoped": bind(ShadowDomStrategy)
-                      .toFactory((styleUrlResolver) =>
-                                     new EmulatedUnscopedShadowDomStrategy(styleUrlResolver, null),
+                      .toFactory((styleUrlResolver) => new EmulatedUnscopedShadowDomStrategy(
+                                     styleUrlResolver, null),
                                  [StyleUrlResolver])
     };
     if (DOM.supportsNativeShadowDOM()) {
@@ -404,8 +404,8 @@ var mainDir =
 var simple = new DirectiveMetadata(
     {selector: 'simple', id: 'simple', type: DirectiveMetadata.COMPONENT_TYPE});
 
-var empty = new DirectiveMetadata(
-    {selector: 'empty', id: 'empty', type: DirectiveMetadata.COMPONENT_TYPE});
+var empty =
+    new DirectiveMetadata({selector: 'empty', id: 'empty', type: DirectiveMetadata.COMPONENT_TYPE});
 
 var dynamicComponent = new DirectiveMetadata(
     {selector: 'dynamic', id: 'dynamic', type: DirectiveMetadata.COMPONENT_TYPE});
@@ -425,11 +425,11 @@ var outerWithIndirectNestedComponent = new DirectiveMetadata({
   type: DirectiveMetadata.COMPONENT_TYPE
 });
 
-var outerComponent = new DirectiveMetadata(
-    {selector: 'outer', id: 'outer', type: DirectiveMetadata.COMPONENT_TYPE});
+var outerComponent =
+    new DirectiveMetadata({selector: 'outer', id: 'outer', type: DirectiveMetadata.COMPONENT_TYPE});
 
-var innerComponent = new DirectiveMetadata(
-    {selector: 'inner', id: 'inner', type: DirectiveMetadata.COMPONENT_TYPE});
+var innerComponent =
+    new DirectiveMetadata({selector: 'inner', id: 'inner', type: DirectiveMetadata.COMPONENT_TYPE});
 
 var innerInnerComponent = new DirectiveMetadata(
     {selector: 'innerinner', id: 'innerinner', type: DirectiveMetadata.COMPONENT_TYPE});

--- a/modules/angular2/test/router/outlet_spec.ts
+++ b/modules/angular2/test/router/outlet_spec.ts
@@ -46,9 +46,10 @@ export function main() {
       RouteRegistry,
       DirectiveResolver,
       bind(Location).toClass(SpyLocation),
-      bind(Router).toFactory((registry, pipeline, location) =>
-                             { return new RootRouter(registry, pipeline, location, MyComp); },
-                             [RouteRegistry, Pipeline, Location])
+      bind(Router)
+          .toFactory((registry, pipeline,
+                      location) => { return new RootRouter(registry, pipeline, location, MyComp); },
+                     [RouteRegistry, Pipeline, Location])
     ]);
 
     beforeEach(inject([TestBed, Router, Location], (testBed, router, loc) => {
@@ -60,10 +61,10 @@ export function main() {
     }));
 
     function compile(template: string = "<router-outlet></router-outlet>") {
-      tb.overrideView(MyComp, new annotations.View({
-        template: ('<div>' + template + '</div>'),
-        directives: [RouterOutlet, RouterLink]
-      }));
+      tb.overrideView(
+          MyComp,
+          new annotations.View(
+              {template: ('<div>' + template + '</div>'), directives: [RouterOutlet, RouterLink]}));
       return tb.createView(MyComp, {context: ctx}).then((v) => { view = v; });
     }
 
@@ -84,11 +85,10 @@ export function main() {
          compile()
              .then((_) => rtr.config({'path': '/user/:name', 'component': UserCmp}))
              .then((_) => rtr.navigate('/user/brian'))
-             .then((_) =>
-                   {
-                     view.detectChanges();
-                     expect(view.rootNodes).toHaveText('hello brian');
-                   })
+             .then((_) => {
+               view.detectChanges();
+               expect(view.rootNodes).toHaveText('hello brian');
+             })
              .then((_) => rtr.navigate('/user/igor'))
              .then((_) => {
                view.detectChanges();
@@ -116,11 +116,10 @@ export function main() {
              .then((_) => rtr.config({'path': '/ab', 'components': {'left': A, 'right': B}}))
              .then((_) => rtr.config({'path': '/ba', 'components': {'left': B, 'right': A}}))
              .then((_) => rtr.navigate('/ab'))
-             .then((_) =>
-                   {
-                     view.detectChanges();
-                     expect(view.rootNodes).toHaveText('left { A } | right { B }');
-                   })
+             .then((_) => {
+               view.detectChanges();
+               expect(view.rootNodes).toHaveText('left { A } | right { B }');
+             })
              .then((_) => rtr.navigate('/ba'))
              .then((_) => {
                view.detectChanges();
@@ -175,12 +174,11 @@ export function main() {
          compile()
              .then((_) => rtr.config({'path': '/team/:id', 'component': TeamCmp}))
              .then((_) => rtr.navigate('/team/angular/user/rado'))
-             .then((_) =>
-                   {
-                     view.detectChanges();
-                     expect(teamCmpCount).toBe(1);
-                     expect(view.rootNodes).toHaveText('team angular { hello rado }');
-                   })
+             .then((_) => {
+               view.detectChanges();
+               expect(teamCmpCount).toBe(1);
+               expect(view.rootNodes).toHaveText('team angular { hello rado }');
+             })
              .then((_) => rtr.navigate('/team/angular/user/victor'))
              .then((_) => {
                view.detectChanges();

--- a/modules/angular2/test/router/router_spec.ts
+++ b/modules/angular2/test/router/router_spec.ts
@@ -34,9 +34,10 @@ export function main() {
       RouteRegistry,
       DirectiveResolver,
       bind(Location).toClass(SpyLocation),
-      bind(Router).toFactory((registry, pipeline, location) =>
-                             { return new RootRouter(registry, pipeline, location, AppCmp); },
-                             [RouteRegistry, Pipeline, Location])
+      bind(Router)
+          .toFactory((registry, pipeline,
+                      location) => { return new RootRouter(registry, pipeline, location, AppCmp); },
+                     [RouteRegistry, Pipeline, Location])
     ]);
 
 
@@ -78,11 +79,10 @@ export function main() {
 
          router.registerOutlet(outlet)
              .then((_) => router.navigate('/a'))
-             .then((_) =>
-                   {
-                     expect(outlet.spy('activate')).not.toHaveBeenCalled();
-                     return router.config({'path': '/a', 'component': 'A'});
-                   })
+             .then((_) => {
+               expect(outlet.spy('activate')).not.toHaveBeenCalled();
+               return router.config({'path': '/a', 'component': 'A'});
+             })
              .then((_) => {
                expect(outlet.spy('activate')).toHaveBeenCalled();
                async.done();

--- a/modules/angular2/test/services/url_resolver_spec.ts
+++ b/modules/angular2/test/services/url_resolver_spec.ts
@@ -36,8 +36,7 @@ export function main() {
     });
 
     it('should ignore the base path when the url has a scheme',
-       () =>
-       {
+       () => {
          expect(resolver.resolve('http://www.foo.com', 'http://www.bar.com'))
              .toEqual('http://www.bar.com');
        })

--- a/modules/angular2_material/src/components/input/input.ts
+++ b/modules/angular2_material/src/components/input/input.ts
@@ -58,11 +58,8 @@ export class MdInputContainer {
   selector: 'md-input-container input',
   events: ['mdChange', 'mdFocusChange'],
   hostProperties: {'yes': 'class.md-input'},
-  hostListeners: {
-    'input': 'updateValue($event)',
-    'focus': 'setHasFocus(true)',
-    'blur': 'setHasFocus(false)'
-  }
+  hostListeners:
+      {'input': 'updateValue($event)', 'focus': 'setHasFocus(true)', 'blur': 'setHasFocus(false)'}
 })
 export class MdInput {
   value: string;

--- a/modules/benchmarks/src/naive_infinite_scroll/index.ts
+++ b/modules/benchmarks/src/naive_infinite_scroll/index.ts
@@ -23,19 +23,17 @@ export function setupReflector() {
 
   // TODO(kegluneq): Generate this.
   reflector.registerSetters({
-    'style': (o, m) =>
-             {
-               // HACK
-               MapWrapper.forEach(m, function(v, k) { o.style.setProperty(k, v); });
-             }
+    'style': (o, m) => {
+      // HACK
+      MapWrapper.forEach(m, function(v, k) { o.style.setProperty(k, v); });
+    }
   });
 
   reflector.registerMethods({
-    'onScroll': (o, args) =>
-                {
-                  // HACK
-                  o.onScroll(args[0]);
-                },
+    'onScroll': (o, args) => {
+      // HACK
+      o.onScroll(args[0]);
+    },
     'setStage': (o, args) => o.setStage(args[0])
   });
 }

--- a/modules/benchpress/src/firefox_extension/lib/main.ts
+++ b/modules/benchpress/src/firefox_extension/lib/main.ts
@@ -44,10 +44,9 @@ var data = require("sdk/self").data;
 mod.PageMod({
   include: ['*'],
   contentScriptFile: data.url("installed_script.js"),
-  onAttach: worker =>
-            {
-              worker.port.on('startProfiler', () => startProfiler());
-              worker.port.on('stopAndRecord', filePath => stopAndRecord(filePath));
-              worker.port.on('forceGC', () => forceGC());
-            }
+  onAttach: worker => {
+    worker.port.on('startProfiler', () => startProfiler());
+    worker.port.on('stopAndRecord', filePath => stopAndRecord(filePath));
+    worker.port.on('forceGC', () => forceGC());
+  }
 });

--- a/modules/benchpress/src/metric/perflog_metric.ts
+++ b/modules/benchpress/src/metric/perflog_metric.ts
@@ -242,7 +242,7 @@ var _SET_TIMEOUT = new OpaqueToken('PerflogMetric.setTimeout');
 var _BINDINGS = [
   bind(PerflogMetric)
       .toFactory((driverExtension, setTimeout, microMetrics, forceGc) =>
-                     new PerflogMetric(driverExtension, setTimeout, microMetrics, forceGc),
+                         new PerflogMetric(driverExtension, setTimeout, microMetrics, forceGc),
                  [WebDriverExtension, _SET_TIMEOUT, Options.MICRO_METRICS, Options.FORCE_GC]),
   bind(_SET_TIMEOUT).toValue((fn, millis) => TimerWrapper.setTimeout(fn, millis))
 ];

--- a/modules/benchpress/src/reporter/console_reporter.ts
+++ b/modules/benchpress/src/reporter/console_reporter.ts
@@ -100,7 +100,7 @@ var _COLUMN_WIDTH = new OpaqueToken('ConsoleReporter.columnWidth');
 var _BINDINGS = [
   bind(ConsoleReporter)
       .toFactory((columnWidth, sampleDescription, print) =>
-                     new ConsoleReporter(columnWidth, sampleDescription, print),
+                         new ConsoleReporter(columnWidth, sampleDescription, print),
                  [_COLUMN_WIDTH, SampleDescription, _PRINT]),
   bind(_COLUMN_WIDTH).toValue(18),
   bind(_PRINT).toValue(print)

--- a/modules/benchpress/src/reporter/json_file_reporter.ts
+++ b/modules/benchpress/src/reporter/json_file_reporter.ts
@@ -52,7 +52,7 @@ var _PATH = new OpaqueToken('JsonFileReporter.path');
 var _BINDINGS = [
   bind(JsonFileReporter)
       .toFactory((sampleDescription, path, writeFile, now) =>
-                     new JsonFileReporter(sampleDescription, path, writeFile, now),
+                         new JsonFileReporter(sampleDescription, path, writeFile, now),
                  [SampleDescription, _PATH, Options.WRITE_FILE, Options.NOW]),
   bind(_PATH).toValue('.')
 ];

--- a/modules/benchpress/src/sample_description.ts
+++ b/modules/benchpress/src/sample_description.ts
@@ -23,22 +23,23 @@ export class SampleDescription {
   toJson() { return {'id': this.id, 'description': this.description, 'metrics': this.metrics}; }
 }
 
-var _BINDINGS =
-    [bind(SampleDescription)
-            .toFactory((metric, id, forceGc, userAgent, validator, defaultDesc, userDesc) =>
-                           new SampleDescription(id, [
-                             {'forceGc': forceGc, 'userAgent': userAgent},
-                             validator.describe(),
-                             defaultDesc,
-                             userDesc
-                           ],
-                                                 metric.describe()),
-                       [
-                         Metric,
-                         Options.SAMPLE_ID,
-                         Options.FORCE_GC,
-                         Options.USER_AGENT,
-                         Validator,
-                         Options.DEFAULT_DESCRIPTION,
-                         Options.SAMPLE_DESCRIPTION
-                       ])];
+var _BINDINGS = [
+  bind(SampleDescription)
+      .toFactory((metric, id, forceGc, userAgent, validator, defaultDesc, userDesc) =>
+                         new SampleDescription(id, [
+                           {'forceGc': forceGc, 'userAgent': userAgent},
+                           validator.describe(),
+                           defaultDesc,
+                           userDesc
+                         ],
+                                               metric.describe()),
+                 [
+                   Metric,
+                   Options.SAMPLE_ID,
+                   Options.FORCE_GC,
+                   Options.USER_AGENT,
+                   Validator,
+                   Options.DEFAULT_DESCRIPTION,
+                   Options.SAMPLE_DESCRIPTION
+                 ])
+];

--- a/modules/benchpress/src/sampler.ts
+++ b/modules/benchpress/src/sampler.ts
@@ -95,26 +95,27 @@ export class SampleState {
   constructor(public completeSample: List<any>, public validSample: List<any>) {}
 }
 
-var _BINDINGS =
-    [bind(Sampler)
-            .toFactory((driver, metric, reporter, validator, prepare, execute, now) => new Sampler({
-                         driver: driver,
-                         reporter: reporter,
-                         validator: validator,
-                         metric: metric,
-                         // TODO(tbosch): DI right now does not support null/undefined objects
-                         // Mostly because the cache would have to be initialized with a
-                         // special null object, which is expensive.
-                         prepare: prepare !== false ? prepare : null,
-                         execute: execute,
-                         now: now
-                       }),
-                       [
-                         WebDriverAdapter,
-                         Metric,
-                         Reporter,
-                         Validator,
-                         Options.PREPARE,
-                         Options.EXECUTE,
-                         Options.NOW
-                       ])];
+var _BINDINGS = [
+  bind(Sampler)
+      .toFactory((driver, metric, reporter, validator, prepare, execute, now) => new Sampler({
+                   driver: driver,
+                   reporter: reporter,
+                   validator: validator,
+                   metric: metric,
+                   // TODO(tbosch): DI right now does not support null/undefined objects
+                   // Mostly because the cache would have to be initialized with a
+                   // special null object, which is expensive.
+                   prepare: prepare !== false ? prepare : null,
+                   execute: execute,
+                   now: now
+                 }),
+                 [
+                   WebDriverAdapter,
+                   Metric,
+                   Reporter,
+                   Validator,
+                   Options.PREPARE,
+                   Options.EXECUTE,
+                   Options.NOW
+                 ])
+];

--- a/modules/benchpress/src/web_driver_extension.ts
+++ b/modules/benchpress/src/web_driver_extension.ts
@@ -20,21 +20,20 @@ export class WebDriverExtension {
                               ListWrapper.map(childTokens, (token) => injector.asyncGet(token))),
                           [Injector]),
       bind(WebDriverExtension)
-          .toFactory((children, capabilities) =>
-                     {
-                       var delegate;
-                       ListWrapper.forEach(children, (extension) => {
-                         if (extension.supports(capabilities)) {
-                           delegate = extension;
-                         }
-                       });
-                       if (isBlank(delegate)) {
-                         throw new BaseException(
-                             'Could not find a delegate for given capabilities!');
-                       }
-                       return delegate;
-                     },
-                     [_CHILDREN, Options.CAPABILITIES])
+          .toFactory(
+              (children, capabilities) => {
+                var delegate;
+                ListWrapper.forEach(children, (extension) => {
+                  if (extension.supports(capabilities)) {
+                    delegate = extension;
+                  }
+                });
+                if (isBlank(delegate)) {
+                  throw new BaseException('Could not find a delegate for given capabilities!');
+                }
+                return delegate;
+              },
+              [_CHILDREN, Options.CAPABILITIES])
     ];
   }
 

--- a/modules/benchpress/src/webdriver/chrome_driver_extension.ts
+++ b/modules/benchpress/src/webdriver/chrome_driver_extension.ts
@@ -132,5 +132,7 @@ function normalizeEvent(chromeEvent: StringMap<string, any>,
   return result;
 }
 
-var _BINDINGS = [bind(ChromeDriverExtension)
-                     .toFactory((driver) => new ChromeDriverExtension(driver), [WebDriverAdapter])];
+var _BINDINGS = [
+  bind(ChromeDriverExtension)
+      .toFactory((driver) => new ChromeDriverExtension(driver), [WebDriverAdapter])
+];

--- a/modules/benchpress/src/webdriver/ios_driver_extension.ts
+++ b/modules/benchpress/src/webdriver/ios_driver_extension.ts
@@ -128,5 +128,7 @@ function createMarkEndEvent(name, time) {
   return createEvent('e', name, time);
 }
 
-var _BINDINGS = [bind(IOsDriverExtension)
-                     .toFactory((driver) => new IOsDriverExtension(driver), [WebDriverAdapter])];
+var _BINDINGS = [
+  bind(IOsDriverExtension)
+      .toFactory((driver) => new IOsDriverExtension(driver), [WebDriverAdapter])
+];

--- a/modules/benchpress/test/metric/perflog_metric_spec.ts
+++ b/modules/benchpress/test/metric/perflog_metric_spec.ts
@@ -44,11 +44,10 @@ export function main() {
       PerflogMetric.BINDINGS,
       bind(Options.MICRO_METRICS).toValue(microMetrics),
       bind(PerflogMetric.SET_TIMEOUT)
-          .toValue((fn, millis) =>
-                   {
-                     ListWrapper.push(commandLog, ['setTimeout', millis]);
-                     fn();
-                   }),
+          .toValue((fn, millis) => {
+            ListWrapper.push(commandLog, ['setTimeout', millis]);
+            fn();
+          }),
       bind(WebDriverExtension)
           .toValue(new MockDriverExtension(perfLogs, commandLog, perfLogFeatures))
     ];
@@ -125,12 +124,14 @@ export function main() {
 
       it('should mark and aggregate events in between the marks',
          inject([AsyncTestCompleter], (async) => {
-           var events = [[
-             eventFactory.markStart('benchpress0', 0),
-             eventFactory.start('script', 4),
-             eventFactory.end('script', 6),
-             eventFactory.markEnd('benchpress0', 10)
-           ]];
+           var events = [
+             [
+               eventFactory.markStart('benchpress0', 0),
+               eventFactory.start('script', 4),
+               eventFactory.end('script', 6),
+               eventFactory.markEnd('benchpress0', 10)
+             ]
+           ];
            var metric = createMetric(events);
            metric.beginMeasure()
                .then((_) => metric.endMeasure(false))
@@ -224,11 +225,10 @@ export function main() {
            var metric = createMetric(events);
            metric.beginMeasure()
                .then((_) => metric.endMeasure(true))
-               .then((data) =>
-                     {
-                       expect(data['scriptTime']).toBe(0);
-                       return metric.endMeasure(true)
-                     })
+               .then((data) => {
+                 expect(data['scriptTime']).toBe(0);
+                 return metric.endMeasure(true)
+               })
                .then((data) => {
                  expect(commandLog)
                      .toEqual([
@@ -247,16 +247,18 @@ export function main() {
       describe('with forced gc', () => {
         var events;
         beforeEach(() => {
-          events = [[
-            eventFactory.markStart('benchpress0', 0),
-            eventFactory.start('script', 4),
-            eventFactory.end('script', 6),
-            eventFactory.markEnd('benchpress0', 10),
-            eventFactory.markStart('benchpress1', 11),
-            eventFactory.start('gc', 12, {'usedHeapSize': 2500}),
-            eventFactory.end('gc', 15, {'usedHeapSize': 1000}),
-            eventFactory.markEnd('benchpress1', 20)
-          ]];
+          events = [
+            [
+              eventFactory.markStart('benchpress0', 0),
+              eventFactory.start('script', 4),
+              eventFactory.end('script', 6),
+              eventFactory.markEnd('benchpress0', 10),
+              eventFactory.markStart('benchpress1', 11),
+              eventFactory.start('gc', 12, {'usedHeapSize': 2500}),
+              eventFactory.end('gc', 15, {'usedHeapSize': 1000}),
+              eventFactory.markEnd('benchpress1', 20)
+            ]
+          ];
         });
 
         it('should measure forced gc', inject([AsyncTestCompleter], (async) => {
@@ -359,14 +361,16 @@ export function main() {
       it('should ignore events from different processed as the start mark',
          inject([AsyncTestCompleter], (async) => {
            var otherProcessEventFactory = new TraceEventFactory('timeline', 'pid1');
-           var metric = createMetric([[
-             eventFactory.markStart('benchpress0', 0),
-             eventFactory.start('script', 0, null),
-             eventFactory.end('script', 5, null),
-             otherProcessEventFactory.start('script', 10, null),
-             otherProcessEventFactory.end('script', 17, null),
-             eventFactory.markEnd('benchpress0', 20)
-           ]]);
+           var metric = createMetric([
+             [
+               eventFactory.markStart('benchpress0', 0),
+               eventFactory.start('script', 0, null),
+               eventFactory.end('script', 5, null),
+               otherProcessEventFactory.start('script', 10, null),
+               otherProcessEventFactory.end('script', 17, null),
+               eventFactory.markEnd('benchpress0', 20)
+             ]
+           ]);
            metric.beginMeasure()
                .then((_) => metric.endMeasure(false))
                .then((data) => {

--- a/modules/benchpress/test/reporter/json_file_reporter_spec.ts
+++ b/modules/benchpress/test/reporter/json_file_reporter_spec.ts
@@ -30,14 +30,13 @@ export function main() {
         bind(JsonFileReporter.PATH).toValue(path),
         bind(Options.NOW).toValue(() => DateWrapper.fromMillis(1234)),
         bind(Options.WRITE_FILE)
-            .toValue((filename, content) =>
-                     {
-                       loggedFile = {
-                         'filename': filename,
-                         'content': content
-                       };
-                       return PromiseWrapper.resolve(null);
-                     })
+            .toValue((filename, content) => {
+              loggedFile = {
+                'filename': filename,
+                'content': content
+              };
+              return PromiseWrapper.resolve(null);
+            })
       ];
       return Injector.resolveAndCreate(bindings).get(JsonFileReporter);
     }
@@ -58,11 +57,13 @@ export function main() {
              .toEqual({
                "description":
                    {"id": "someId", "description": {"a": 2}, "metrics": {"script": "script time"}},
-               "completeSample": [{
-                 "timeStamp": "1970-01-01T00:00:00.000Z",
-                 "runIndex": 0,
-                 "values": {"a": 3, "b": 6}
-               }],
+               "completeSample": [
+                 {
+                   "timeStamp": "1970-01-01T00:00:00.000Z",
+                   "runIndex": 0,
+                   "values": {"a": 3, "b": 6}
+                 }
+               ],
                "validSample": [
                  {
                    "timeStamp": "1970-01-01T00:00:00.000Z",

--- a/modules/benchpress/test/runner_spec.ts
+++ b/modules/benchpress/test/runner_spec.ts
@@ -36,12 +36,12 @@ export function main() {
       }
       runner = new Runner([
         defaultBindings,
-        bind(Sampler).toFactory((_injector) =>
-                                {
-                                  injector = _injector;
-                                  return new MockSampler();
-                                },
-                                [Injector]),
+        bind(Sampler).toFactory(
+            (_injector) => {
+              injector = _injector;
+              return new MockSampler();
+            },
+            [Injector]),
         bind(Metric).toFactory(() => new MockMetric(), []),
         bind(Validator).toFactory(() => new MockValidator(), []),
         bind(WebDriverAdapter).toFactory(() => new MockWebDriverAdapter(), [])
@@ -61,8 +61,7 @@ export function main() {
 
     it('should merge SampleDescription.description', inject([AsyncTestCompleter], (async) => {
          createRunner([bind(Options.DEFAULT_DESCRIPTION).toValue({'a': 1})])
-             .sample(
-                 {id: 'someId', bindings: [bind(Options.SAMPLE_DESCRIPTION).toValue({'b': 2})]})
+             .sample({id: 'someId', bindings: [bind(Options.SAMPLE_DESCRIPTION).toValue({'b': 2})]})
              .then((_) => injector.asyncGet(SampleDescription))
              .then((desc) => {
 

--- a/modules/benchpress/test/sampler_spec.ts
+++ b/modules/benchpress/test/sampler_spec.ts
@@ -151,18 +151,17 @@ export function main() {
          var iterationCount = 1;
          createSampler({
            validator: createCountingValidator(2),
-           metric: new MockMetric([], () =>
-                                      {
-                                        var result = PromiseWrapper.resolve({'script': scriptTime});
-                                        scriptTime = 0;
-                                        return result;
-                                      }),
+           metric: new MockMetric([],
+                                  () => {
+                                    var result = PromiseWrapper.resolve({'script': scriptTime});
+                                    scriptTime = 0;
+                                    return result;
+                                  }),
            prepare: () => { scriptTime = 1 * iterationCount; },
-           execute: () =>
-                    {
-                      scriptTime = 10 * iterationCount;
-                      iterationCount++;
-                    }
+           execute: () => {
+             scriptTime = 10 * iterationCount;
+             iterationCount++;
+           }
          });
          sampler.sample().then((state) => {
            expect(state.completeSample.length).toBe(2);
@@ -192,11 +191,8 @@ export function main() {
 
            expect(log.length).toBe(2);
            expect(log[0]).toEqual(['validate', [mv(0, 1000, {'script': 0})], null]);
-           expect(log[1]).toEqual([
-             'validate',
-             [mv(0, 1000, {'script': 0}), mv(1, 1001, {'script': 1})],
-             validSample
-           ]);
+           expect(log[1]).toEqual(
+               ['validate', [mv(0, 1000, {'script': 0}), mv(1, 1001, {'script': 1})], validSample]);
 
            async.done();
          });

--- a/modules/benchpress/test/webdriver/chrome_driver_extension_spec.ts
+++ b/modules/benchpress/test/webdriver/chrome_driver_extension_spec.ts
@@ -135,8 +135,10 @@ export function main() {
          }));
 
       it('should ignore FunctionCalls from webdriver', inject([AsyncTestCompleter], (async) => {
-           createExtension([chromeTimelineEvents.start(
-                               'FunctionCall', 0, {'data': {'scriptName': 'InjectedScript'}})])
+           createExtension([
+             chromeTimelineEvents.start('FunctionCall', 0,
+                                        {'data': {'scriptName': 'InjectedScript'}})
+           ])
                .readPerfLog()
                .then((events) => {
                  expect(events).toEqual([]);
@@ -270,8 +272,7 @@ class MockDriverAdapter extends WebDriverAdapter {
     if (type === 'performance') {
       return PromiseWrapper.resolve(this._events.map((event) => {
         return {
-          'message':
-              Json.stringify({'message': {'method': this._messageMethod, 'params': event}})
+          'message': Json.stringify({'message': {'method': this._messageMethod, 'params': event}})
         };
       }));
     } else {

--- a/modules/examples/src/forms/index.ts
+++ b/modules/examples/src/forms/index.ts
@@ -181,10 +181,9 @@ class SurveyBuilder {
     // We are disabling the responseLength control when the question type is checkbox.
     var typeCtrl: Control = newQuestion.controls['type'];
 
-    ObservableWrapper.subscribe(typeCtrl.valueChanges,
-                                (v) => v == 'text' || v == 'textarea' ?
-                                           newQuestion.include('responseLength') :
-                                           newQuestion.exclude('responseLength'));
+    ObservableWrapper.subscribe(typeCtrl.valueChanges, (v) => v == 'text' || v == 'textarea' ?
+                                                           newQuestion.include('responseLength') :
+                                                           newQuestion.exclude('responseLength'));
 
     (<ControlArray>this.form.controls['questions']).push(newQuestion);
   }

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -4270,7 +4270,7 @@
           }
         },
         "clang-format": {
-          "version": "1.0.15"
+          "version": "1.0.17"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6593,9 +6593,9 @@
           }
         },
         "clang-format": {
-          "version": "1.0.15",
-          "from": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.15.tgz",
-          "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.15.tgz"
+          "version": "1.0.17",
+          "from": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.17.tgz",
+          "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.17.tgz"
         }
       }
     },

--- a/tools/broccoli/broccoli-typescript.ts
+++ b/tools/broccoli/broccoli-typescript.ts
@@ -50,26 +50,24 @@ class DiffingTSCompiler implements DiffingBroccoliPlugin {
     let pathsToEmit = [];
     let pathsWithErrors = [];
 
-    treeDiff.changedPaths
-        .forEach((tsFilePath) => {
-          if (!this.fileRegistry[tsFilePath]) {
-            this.fileRegistry[tsFilePath] = {version: 0};
-            this.rootFilePaths.push(tsFilePath);
-          } else {
-            this.fileRegistry[tsFilePath].version++;
-          }
+    treeDiff.changedPaths.forEach((tsFilePath) => {
+      if (!this.fileRegistry[tsFilePath]) {
+        this.fileRegistry[tsFilePath] = {version: 0};
+        this.rootFilePaths.push(tsFilePath);
+      } else {
+        this.fileRegistry[tsFilePath].version++;
+      }
 
-          pathsToEmit.push(tsFilePath);
-        });
+      pathsToEmit.push(tsFilePath);
+    });
 
-    treeDiff.removedPaths
-        .forEach((tsFilePath) => {
-          console.log('removing outputs for', tsFilePath);
+    treeDiff.removedPaths.forEach((tsFilePath) => {
+      console.log('removing outputs for', tsFilePath);
 
-          this.rootFilePaths.splice(this.rootFilePaths.indexOf(tsFilePath), 1);
-          this.fileRegistry[tsFilePath] = null;
-          this.removeOutputFor(tsFilePath);
-        });
+      this.rootFilePaths.splice(this.rootFilePaths.indexOf(tsFilePath), 1);
+      this.fileRegistry[tsFilePath] = null;
+      this.removeOutputFor(tsFilePath);
+    });
 
     if (this.firstRun) {
       this.firstRun = false;
@@ -134,9 +132,10 @@ class DiffingTSCompiler implements DiffingBroccoliPlugin {
       let errorMessages = [];
 
       allDiagnostics.forEach(diagnostic => {
-        var { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+        var {line, character} = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
         var message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
-        errorMessages.push(`  ${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
+        errorMessages.push(
+            `  ${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
       });
 
       if (errorMessages.length) {

--- a/tools/broccoli/diffing-broccoli-plugin.ts
+++ b/tools/broccoli/diffing-broccoli-plugin.ts
@@ -34,7 +34,7 @@ export interface DiffingBroccoliPlugin {
 
 
 type DiffingPluginWrapperFactory = (inputTrees: (BroccoliTree | BroccoliTree[]), options?) =>
-    BroccoliTree;
+                                       BroccoliTree;
 
 
 class DiffingPluginWrapper implements BroccoliTree {

--- a/tools/broccoli/tree-differ.spec.ts
+++ b/tools/broccoli/tree-differ.spec.ts
@@ -110,8 +110,7 @@ describe('TreeDiffer', () => {
           'file-1.txt': mockfs.file({content: 'file-1.txt content', mtime: new Date(1000)}),
           'file-2.txt': mockfs.file({content: 'file-2.txt content', mtime: new Date(1000)}),
           'subdir-1': {
-            'file-1.1.txt':
-                mockfs.file({content: 'file-1.1.txt content', mtime: new Date(1000)})
+            'file-1.1.txt': mockfs.file({content: 'file-1.1.txt content', mtime: new Date(1000)})
           }
         },
         'symlinks': {

--- a/tools/broccoli/tree-differ.ts
+++ b/tools/broccoli/tree-differ.ts
@@ -129,7 +129,7 @@ class DirtyCheckingDiffResult {
   public startTime: number = Date.now();
   public endTime: number = null;
 
-  constructor(public label:string, public directoryName: string) {}
+  constructor(public label: string, public directoryName: string) {}
 
   toString() {
     return `${pad(this.label, 30)}, ${pad(this.endTime - this.startTime, 5)}ms, ` +

--- a/tools/broccoli/trees/node_tree.ts
+++ b/tools/broccoli/trees/node_tree.ts
@@ -84,11 +84,13 @@ module.exports = function makeNodeTree(destinationPath) {
   // TODO: remove this when we no longer use traceur
   var traceurCompatibleTsModulesTree = replace(modulesTree, {
     files: ['**/*.ts'],
-    patterns: [{
-      // Empty replacement needed so that replaceWithPath gets triggered...
-      match: /$/g,
-      replacement: ""
-    }],
+    patterns: [
+      {
+        // Empty replacement needed so that replaceWithPath gets triggered...
+        match: /$/g,
+        replacement: ""
+      }
+    ],
     replaceWithPath: function(path, content) {
       if (!path.endsWith('.d.ts')) {
         content += '\r\nexport var __esModule = true;\n';
@@ -120,11 +122,13 @@ module.exports = function makeNodeTree(destinationPath) {
       return "var parse5Adapter = require('angular2/src/dom/parse5_adapter'); " +
              "parse5Adapter.Parse5DomAdapter.makeCurrent();" + content;
     },
-    patterns: [{
-      // Append main() to all tests since all of our tests are wrapped in exported main fn
-      match: /$/g,
-      replacement: "\r\n main();"
-    }]
+    patterns: [
+      {
+        // Append main() to all tests since all of our tests are wrapped in exported main fn
+        match: /$/g,
+        replacement: "\r\n main();"
+      }
+    ]
   });
 
   return destCopy(nodeTree, destinationPath);


### PR DESCRIPTION
clang-format 1.0.17 substantially improves formatting for fat arrow functions
and array literal detection. It also fixes a number of minor formatting issues.
