### PR TITLE
fix(build): only pass ts files to ts2dart transpilation.

### DIFF
--- a/tools/broccoli/broccoli-ts2dart.ts
+++ b/tools/broccoli/broccoli-ts2dart.ts
@@ -10,7 +10,7 @@ import ts2dart = require('ts2dart');
 import {wrapDiffingPlugin, DiffingBroccoliPlugin, DiffResult} from './diffing-broccoli-plugin';
 
 class TSToDartTranspiler implements DiffingBroccoliPlugin {
-  static includeExtensions = ['.js', '.ts'];
+  static includeExtensions = ['.ts'];
 
   private basePath: string;
   private transpiler: ts2dart.Transpiler;


### PR DESCRIPTION
Originally, we had .js as transpilation targets, but all those files
have been converted.
