### PR TITLE
chore(karma): remove a link to an unexisting file

### DIFF
--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -24,8 +24,7 @@ module.exports = function(config) {
       'node_modules/reflect-metadata/Reflect.js',
       'tools/build/file2modulename.js',
       'test-main.js',
-      {pattern: 'modules/**/test/**/static_assets/**', included: false, watched: false},
-      'modules/angular2/src/test_lib/shims_for_IE.es6'
+      {pattern: 'modules/**/test/**/static_assets/**', included: false, watched: false}
     ],
 
     exclude: [


### PR DESCRIPTION
`shims_for_IE.es6` has been converted to TS:
- it doesn't exist any more
- no need to explicitly watch it (already watched)
