### PR TITLE
feat(build): initial SauceLabs setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
   - KARMA_BROWSERS=DartiumWithWebPlatform
   - E2E_BROWSERS=Dartium
   - LOGS_DIR=/tmp/angular-build/logs
+  - SAUCE_USERNAME=angular-ci
+  - SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987
   - ARCH=linux-x64
   # Token for tsd to increase github rate limit
   # See https://github.com/DefinitelyTyped/tsd#tsdrc
@@ -26,10 +28,15 @@ env:
   # (password is in Valentine)
   - TSDRC='{"token":"ef474500309daea53d5991b3079159a29520a40b"}'
   matrix:
-  - MODE=js DART_CHANNEL=dev
-  - MODE=dart DART_CHANNEL=stable
-  - MODE=dart DART_CHANNEL=dev
-  - MODE=dart_experimental DART_CHANNEL=dev
+    - MODE=js DART_CHANNEL=dev
+    - MODE=dart DART_CHANNEL=stable
+    - MODE=dart DART_CHANNEL=dev
+    - MODE=dart_experimental DART_CHANNEL=dev
+    - MODE=saucelabs DART_CHANNEL=dev
+
+matrix:  
+  allow_failures:
+  - env: "MODE=saucelabs DART_CHANNEL=dev"
 
 addons:
   firefox: "38.0"

--- a/karma-dart.conf.js
+++ b/karma-dart.conf.js
@@ -1,3 +1,5 @@
+var sauceConf = require('./sauce.conf');
+
 // Karma configuration
 // Generated on Thu Sep 25 2014 11:52:02 GMT-0700 (PDT)
 module.exports = function(config) {
@@ -48,11 +50,7 @@ module.exports = function(config) {
       '/packages/examples': '/base/dist/dart/examples/lib'
     },
 
-    customLaunchers: {
-      DartiumWithWebPlatform: {
-        base: 'Dartium',
-        flags: ['--enable-experimental-web-platform-features'] }
-    },
+    customLaunchers: sauceConf.customLaunchers,
     browsers: ['DartiumWithWebPlatform'],
 
     port: 9877

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -1,3 +1,5 @@
+var sauceConf = require('./sauce.conf');
+
 // Karma configuration
 // Generated on Thu Sep 25 2014 11:52:02 GMT-0700 (PDT)
 module.exports = function(config) {
@@ -25,23 +27,42 @@ module.exports = function(config) {
       'node_modules/reflect-metadata/Reflect.js',
       'tools/build/file2modulename.js',
       'test-main.js',
-      {pattern: 'modules/**/test/**/static_assets/**', included: false, watched: false}
+      {pattern: 'modules/**/test/**/static_assets/**', included: false, watched: false},
+      'modules/angular2/src/test_lib/shims_for_IE.ts'
     ],
 
     exclude: [
       'dist/js/dev/es5/**/e2e_test/**',
     ],
 
-    customLaunchers: {
-      DartiumWithWebPlatform: {
-        base: 'Dartium',
-        flags: ['--enable-experimental-web-platform-features'] },
-      ChromeNoSandbox: {
-        base: 'Chrome',
-        flags: ['--no-sandbox'] }
+    customLaunchers: sauceConf.customLaunchers,
+
+    sauceLabs: {
+      testName: 'Angular2',
+      startConnect: false,
+      recordVideo: false,
+      recordScreenshots: false,
+      options:  {
+          'selenium-version': '2.45.0',
+          'command-timeout': 600,
+          'idle-timeout': 600,
+          'max-duration': 5400
+      }
     },
+
     browsers: ['ChromeCanary'],
 
     port: 9876
   });
+
+  if (process.env.TRAVIS) {
+    config.sauceLabs.build = 'TRAVIS #' + process.env.TRAVIS_BUILD_NUMBER + ' (' + process.env.TRAVIS_BUILD_ID + ')';
+    config.sauceLabs.tunnelIdentifier = process.env.TRAVIS_JOB_NUMBER;
+
+    // TODO(mlaval): remove once SauceLabs supports websockets.
+    // This speeds up the capturing a bit, as browsers don't even try to use websocket.
+    config.transports = ['xhr-polling'];
+  }
 };
+
+

--- a/modules/angular2/src/test_lib/test_lib.dart
+++ b/modules/angular2/src/test_lib/test_lib.dart
@@ -162,15 +162,15 @@ void _it(gnsFn, name, fn) {
   });
 }
 
-void it(name, fn) {
+void it(name, fn, [timeOut = null]) {
   _it(gns.it, name, fn);
 }
 
-void iit(name, fn) {
+void iit(name, fn, [timeOut = null]) {
   _it(gns.iit, name, fn);
 }
 
-void xit(name, fn) {
+void xit(name, fn, [timeOut = null]) {
   _it(gns.xit, name, fn);
 }
 

--- a/modules/angular2/src/test_lib/test_lib.ts
+++ b/modules/angular2/src/test_lib/test_lib.ts
@@ -126,7 +126,7 @@ export function beforeEachBindings(fn) {
   });
 }
 
-function _it(jsmFn, name, fn) {
+function _it(jsmFn, name, fn, timeOut) {
   var runner = runnerStack[runnerStack.length - 1];
 
   jsmFn(name, function(done) {
@@ -153,19 +153,19 @@ function _it(jsmFn, name, fn) {
     inIt = false;
 
     if (!async) done();
-  });
+  }, timeOut);
 }
 
-export function it(name, fn) {
-  return _it(jsmIt, name, fn);
+export function it(name, fn, timeOut = null) {
+  return _it(jsmIt, name, fn, timeOut);
 }
 
-export function xit(name, fn) {
-  return _it(jsmXIt, name, fn);
+export function xit(name, fn, timeOut = null) {
+  return _it(jsmXIt, name, fn, timeOut);
 }
 
-export function iit(name, fn) {
-  return _it(jsmIIt, name, fn);
+export function iit(name, fn, timeOut = null) {
+  return _it(jsmIIt, name, fn, timeOut);
 }
 
 // Some Map polyfills don't polyfill Map.toString correctly, which

--- a/modules/angular2/test/render/xhr_impl_spec.ts
+++ b/modules/angular2/test/render/xhr_impl_spec.ts
@@ -27,7 +27,7 @@ export function main() {
            expect(text.trim()).toEqual('<p>hey</p>');
            async.done();
          });
-       }));
+       }), 10000);
 
     it('should reject the Promise on failure', inject([AsyncTestCompleter], (async) => {
          PromiseWrapper.catchError(xhr.get(url404), (e) => {
@@ -35,6 +35,6 @@ export function main() {
            async.done();
            return null;
          });
-       }));
+       }), 10000);
   });
 }

--- a/sauce.conf.js
+++ b/sauce.conf.js
@@ -1,0 +1,138 @@
+var customLaunchers = {
+  'DartiumWithWebPlatform': {
+    base: 'Dartium',
+    flags: ['--enable-experimental-web-platform-features'] },
+  'ChromeNoSandbox': {
+    base: 'Chrome',
+    flags: ['--no-sandbox'] },
+  'SL_CHROME': {
+    base: 'SauceLabs',
+    browserName: 'chrome',
+    version: '43'
+  },
+  'SL_CHROMEBETA': {
+    base: 'SauceLabs',
+    browserName: 'chrome',
+    version: 'beta'
+  },
+  'SL_CHROMEDEV': {
+    base: 'SauceLabs',
+    browserName: 'chrome',
+    version: 'dev'
+  },
+  'SL_FIREFOX': {
+    base: 'SauceLabs',
+    browserName: 'firefox',
+    version: '37'
+  },
+  'SL_FIREFOXBETA': {
+    base: 'SauceLabs',
+    browserName: 'firefox',
+    version: 'beta'
+  },
+  'SL_FIREFOXDEV': {
+    base: 'SauceLabs',
+    browserName: 'firefox',
+    version: 'dev'
+  },
+  'SL_SAFARI7': {
+    base: 'SauceLabs',
+    browserName: 'safari',
+    platform: 'OS X 10.9',
+    version: '7'
+  },
+  'SL_SAFARI8': {
+    base: 'SauceLabs',
+    browserName: 'safari',
+    platform: 'OS X 10.10',
+    version: '8'
+  },
+  'SL_IOS7': {
+    base: 'SauceLabs',
+    browserName: 'iphone',
+    platform: 'OS X 10.10',
+    version: '7.1'
+  },
+  'SL_IOS8': {
+    base: 'SauceLabs',
+    browserName: 'iphone',
+    platform: 'OS X 10.10',
+    version: '8.2'
+  },
+  'SL_IE9': {
+    base: 'SauceLabs',
+    browserName: 'internet explorer',
+    platform: 'Windows 2008',
+    version: '9'
+  },
+  'SL_IE10': {
+    base: 'SauceLabs',
+    browserName: 'internet explorer',
+    platform: 'Windows 2012',
+    version: '10'
+  },
+  'SL_IE11': {
+    base: 'SauceLabs',
+    browserName: 'internet explorer',
+    platform: 'Windows 8.1',
+    version: '11'
+  },
+  'SL_ANDROID5.1': {
+    base: 'SauceLabs',
+    browserName: 'android',
+    platform: 'Linux',
+    version: '5.1'
+  },
+  'SL_ANDROID4.4': {
+    base: 'SauceLabs',
+    browserName: 'android',
+    platform: 'Linux',
+    version: '4.4'
+  },
+  'SL_ANDROID4.3': {
+    base: 'SauceLabs',
+    browserName: 'android',
+    platform: 'Linux',
+    version: '4.3'
+  },
+  'SL_ANDROID4.2': {
+    base: 'SauceLabs',
+    browserName: 'android',
+    platform: 'Linux',
+    version: '4.2'
+  },
+  'SL_ANDROID4.1': {
+    base: 'SauceLabs',
+    browserName: 'android',
+    platform: 'Linux',
+    version: '4.1'
+  },
+  'SL_ANDROID4.0': {
+    base: 'SauceLabs',
+    browserName: 'android',
+    platform: 'Linux',
+    version: '4.0'
+  }
+};
+
+var aliases = {
+  'ALL': Object.keys(customLaunchers).filter(function(item) {return customLaunchers[item].base == 'SauceLabs';}),
+  'DESKTOP': ['SL_CHROME', 'SL_FIREFOX', 'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_SAFARI7', 'SL_SAFARI8'],
+  'MOBILE': ['SL_ANDROID4.0', 'SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4', 'SL_ANDROID5.1', 'SL_IOS7', 'SL_IOS8'],
+  'ANDROID': ['SL_ANDROID4.0', 'SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4', 'SL_ANDROID5.1'],
+  'IE': ['SL_IE9', 'SL_IE10', 'SL_IE11'],
+  'IOS': ['SL_IOS7', 'SL_IOS8'],
+  'SAFARI': ['SL_SAFARI7', 'SL_SAFARI8'],
+  'BETA': ['SL_CHROMEBETA', 'SL_FIREFOXBETA'],
+  'DEV': ['SL_CHROMEDEV', 'SL_FIREFOXDEV'],
+  'CI': ['SL_CHROME', 'SL_FIREFOX']
+};
+
+module.exports = {
+  customLaunchers: customLaunchers,
+  aliases: aliases
+}
+
+if (process.env.TRAVIS) {
+  process.env.SAUCE_ACCESS_KEY = process.env.SAUCE_ACCESS_KEY.split('').reverse().join('');
+}

--- a/scripts/ci/build_and_test.sh
+++ b/scripts/ci/build_and_test.sh
@@ -12,7 +12,12 @@ if [ "$MODE" = "dart_experimental" ]
 then
   ${SCRIPT_DIR}/build_$MODE.sh
 else
-  ${SCRIPT_DIR}/build_$MODE.sh
-  mkdir deploy; tar -czpf deploy/dist.tgz -C dist .
-  ${SCRIPT_DIR}/test_$MODE.sh
+  if [ "$MODE" = "saucelabs" ]
+  then
+    ${SCRIPT_DIR}/test_$MODE.sh
+  else
+    ${SCRIPT_DIR}/build_$MODE.sh
+    mkdir deploy; tar -czpf deploy/dist.tgz -C dist .
+    ${SCRIPT_DIR}/test_$MODE.sh
+  fi
 fi

--- a/scripts/ci/test_saucelabs.sh
+++ b/scripts/ci/test_saucelabs.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+echo =============================================================================
+# go to project dir
+SCRIPT_DIR=$(dirname $0)
+cd $SCRIPT_DIR/../..
+
+./scripts/sauce/sauce_connect_setup.sh
+./scripts/sauce/sauce_connect_block.sh
+./node_modules/.bin/gulp build.js.dev
+./node_modules/.bin/gulp test.unit.js.sauce/ci

--- a/scripts/sauce/sauce_connect_block.sh
+++ b/scripts/sauce/sauce_connect_block.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Wait for Connect to be ready before exiting
+printf "Connecting to Sauce."
+while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
+  printf "."
+  #dart2js takes longer than the travis 10 min timeout to complete
+  sleep .5
+done
+echo "Connected"

--- a/scripts/sauce/sauce_connect_setup.sh
+++ b/scripts/sauce/sauce_connect_setup.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+# Setup and start Sauce Connect for your TravisCI build
+# This script requires your .travis.yml to include the following two private env variables:
+# SAUCE_USERNAME
+# SAUCE_ACCESS_KEY
+# Follow the steps at https://saucelabs.com/opensource/travis to set that up.
+#
+# Curl and run this script as part of your .travis.yml before_script section:
+# before_script:
+#   - curl https://gist.github.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash
+
+CONNECT_URL="https://saucelabs.com/downloads/sc-4.3.8-linux.tar.gz"
+CONNECT_DIR="/tmp/sauce-connect-$RANDOM"
+CONNECT_DOWNLOAD="sc-latest-linux.tar.gz"
+
+CONNECT_LOG="$LOGS_DIR/sauce-connect"
+CONNECT_STDOUT="$LOGS_DIR/sauce-connect.stdout"
+CONNECT_STDERR="$LOGS_DIR/sauce-connect.stderr"
+
+# Get Connect and start it
+mkdir -p $CONNECT_DIR
+cd $CONNECT_DIR
+curl $CONNECT_URL -o $CONNECT_DOWNLOAD 2> /dev/null 1> /dev/null
+mkdir sauce-connect
+tar --extract --file=$CONNECT_DOWNLOAD --strip-components=1 --directory=sauce-connect > /dev/null
+rm $CONNECT_DOWNLOAD
+
+SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
+
+ARGS=""
+
+# Set tunnel-id only on Travis, to make local testing easier.
+if [ ! -z "$TRAVIS_JOB_NUMBER" ]; then
+  ARGS="$ARGS --tunnel-identifier $TRAVIS_JOB_NUMBER"
+fi
+if [ ! -z "$BROWSER_PROVIDER_READY_FILE" ]; then
+  ARGS="$ARGS --readyfile $BROWSER_PROVIDER_READY_FILE"
+fi
+
+
+echo "Starting Sauce Connect in the background, logging into:"
+echo "  $CONNECT_LOG"
+echo "  $CONNECT_STDOUT"
+echo "  $CONNECT_STDERR"
+sauce-connect/bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY $ARGS \
+  --logfile $CONNECT_LOG 2> $CONNECT_STDERR 1> $CONNECT_STDOUT &


### PR DESCRIPTION
Do not merge, it requires more testing on local machines and on Travis.

This PR introduces the ability to run tests on SauceLabs with various browsers (see issue #2239).

To do so, [Sauce Connect](https://docs.saucelabs.com/reference/sauce-connect/) needs to be started with valid credentials.
Then run `gulp test.unit.js --browsers=option1,option2,..,optionN` where options are any mix of browsers and aliases which are defined in the `sauce.conf.js` file. They are case insensitive, and the `SL_` prefix must not be added for browsers.

Some examples of commands:

```
gulp test.unit.js --browsers=Safari8,ie11  //run on Safari 8 and IE11
gulp test.unit.js --browsers=Safari,IE  //run on Safari 7, Safari 8, IE 9, IE 10 and IE 11
gulp test.unit.js --browsers=IOS,safari8,android5.1  //run on iOS 7, iOS 8, Safari 8 and Android 5.1
```

For CI, the idea is to run karma with the `CI` alias defined in the same file.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular/2347)

<!-- Reviewable:end -->
