### PR TITLE
refactor(render): add `DomElement`

### DIFF
--- a/modules/angular2/src/core/application.ts
+++ b/modules/angular2/src/core/application.ts
@@ -80,7 +80,7 @@ function _injectorBindings(appComponentType): List<Type | Binding | List<any>> {
                     var domView = resolveInternalDomView(componentRef.hostView.render);
                     // We need to do this here to ensure that we create Testability and
                     // it's ready on the window for users.
-                    registry.registerApplication(domView.boundElements[0], testability);
+                    registry.registerApplication(domView.boundElements[0].element, testability);
 
                     return componentRef;
                   });

--- a/modules/angular2/src/core/compiler/element_ref.ts
+++ b/modules/angular2/src/core/compiler/element_ref.ts
@@ -23,7 +23,9 @@ export class ElementRef {
   // We need a more general way to read/write to the DOM element
   // via a proper abstraction in the render layer
   get domElement() {
-    return resolveInternalDomView(this.parentView.render).boundElements[this.boundElementIndex];
+    return resolveInternalDomView(this.parentView.render)
+        .boundElements[this.boundElementIndex]
+        .element;
   }
 
   /**

--- a/modules/angular2/src/debug/debug_element.ts
+++ b/modules/angular2/src/debug/debug_element.ts
@@ -43,7 +43,9 @@ export class DebugElement {
   }
 
   get domElement(): any {
-    return resolveInternalDomView(this._parentView.render).boundElements[this._boundElementIndex];
+    return resolveInternalDomView(this._parentView.render)
+        .boundElements[this._boundElementIndex]
+        .element;
   }
 
   getDirectiveInstance(directiveIndex: number): any {

--- a/modules/angular2/src/debug/debug_element_view_listener.ts
+++ b/modules/angular2/src/debug/debug_element_view_listener.ts
@@ -61,7 +61,7 @@ export class DebugElementViewListener implements AppViewListener {
     MapWrapper.set(_allIdsByView, view, viewId);
     var renderView = resolveInternalDomView(view.render);
     for (var i = 0; i < renderView.boundElements.length; i++) {
-      _setElementId(renderView.boundElements[i], [viewId, i]);
+      _setElementId(renderView.boundElements[i].element, [viewId, i]);
     }
   }
 

--- a/modules/angular2/src/render/dom/view/element.ts
+++ b/modules/angular2/src/render/dom/view/element.ts
@@ -1,0 +1,11 @@
+import {ElementBinder} from './element_binder';
+import {DomViewContainer} from './view_container';
+import {LightDom} from '../shadow_dom/light_dom';
+import {Content} from '../shadow_dom/content_tag';
+
+export class DomElement {
+  viewContainer: DomViewContainer;
+  lightDom: LightDom;
+  constructor(public proto: ElementBinder, public element: any /* element */,
+              public contentTag: Content) {}
+}

--- a/modules/angular2/test/render/dom/dom_testbed.ts
+++ b/modules/angular2/test/render/dom/dom_testbed.ts
@@ -123,7 +123,7 @@ export class DomTestbed {
   }
 
   triggerEvent(viewRef: RenderViewRef, boundElementIndex: number, eventName: string) {
-    var element = resolveInternalDomView(viewRef).boundElements[boundElementIndex];
+    var element = resolveInternalDomView(viewRef).boundElements[boundElementIndex].element;
     dispatchEvent(element, eventName);
   }
 }

--- a/modules/angular2/test/render/dom/shadow_dom/light_dom_spec.ts
+++ b/modules/angular2/test/render/dom/shadow_dom/light_dom_spec.ts
@@ -18,6 +18,7 @@ import {LightDom} from 'angular2/src/render/dom/shadow_dom/light_dom';
 import {DomView} from 'angular2/src/render/dom/view/view';
 import {DomProtoView} from 'angular2/src/render/dom/view/proto_view';
 import {DomViewContainer} from 'angular2/src/render/dom/view/view_container';
+import {DomElement} from 'angular2/src/render/dom/view/element';
 
 @proxy
 @IMPLEMENTS(DomProtoView)
@@ -31,31 +32,27 @@ class FakeProtoView extends SpyObject {
 @IMPLEMENTS(DomView)
 class FakeView extends SpyObject {
   boundElements;
-  contentTags;
-  viewContainers;
   proto;
 
   constructor(containers = null, transitiveContentTagCount: number = 1) {
     super(DomView);
     this.proto = new FakeProtoView(transitiveContentTagCount);
     this.boundElements = [];
-    this.contentTags = [];
-    this.viewContainers = [];
     if (isPresent(containers)) {
       ListWrapper.forEach(containers, (c) => {
-        var boundElement = null;
+        var element = null;
         var contentTag = null;
         var vc = null;
         if (c instanceof FakeContentTag) {
           contentTag = c;
-          boundElement = c.contentStartElement;
+          element = c.contentStartElement;
         }
         if (c instanceof FakeViewContainer) {
           vc = c;
-          boundElement = c.templateElement;
+          element = c.templateElement;
         }
-        ListWrapper.push(this.contentTags, contentTag);
-        ListWrapper.push(this.viewContainers, vc);
+        var boundElement = new DomElement(null, element, contentTag);
+        boundElement.viewContainer = vc;
         ListWrapper.push(this.boundElements, boundElement);
       });
     }

--- a/modules/angular2/test/render/dom/view/view_spec.ts
+++ b/modules/angular2/test/render/dom/view/view_spec.ts
@@ -15,13 +15,13 @@ import {
   SpyObject,
   proxy
 } from 'angular2/test_lib';
-import {IMPLEMENTS, isBlank} from 'angular2/src/facade/lang';
+import {isBlank} from 'angular2/src/facade/lang';
 import {ListWrapper} from 'angular2/src/facade/collection';
 
 import {DomProtoView} from 'angular2/src/render/dom/view/proto_view';
 import {ElementBinder} from 'angular2/src/render/dom/view/element_binder';
 import {DomView} from 'angular2/src/render/dom/view/view';
-import {LightDom} from 'angular2/src/render/dom/shadow_dom/light_dom';
+import {DomElement} from 'angular2/src/render/dom/view/element';
 import {DOM} from 'angular2/src/dom/dom_adapter';
 
 export function main() {
@@ -42,20 +42,19 @@ export function main() {
       var root = el('<div><div></div></div>');
       var boundElements = [];
       for (var i = 0; i < boundElementCount; i++) {
-        ListWrapper.push(boundElements, el('<span></span'));
+        ListWrapper.push(boundElements,
+                         new DomElement(pv.elementBinders[i], el('<span></span'), null));
       }
-      return new DomView(pv, [DOM.childNodes(root)[0]], [], boundElements, []);
+      return new DomView(pv, [DOM.childNodes(root)[0]], [], boundElements);
     }
 
-    describe('getDirectParentLightDom', () => {
+    describe('getDirectParentElement', () => {
 
-      it('should return the LightDom of the direct parent', () => {
+      it('should return the DomElement of the direct parent', () => {
         var pv = createProtoView(
             [new ElementBinder(), new ElementBinder({parentIndex: 0, distanceToParent: 1})]);
         var view = createView(pv, 2);
-        view.lightDoms[0] = <any>new SpyLightDom();
-        view.lightDoms[1] = <any>new SpyLightDom();
-        expect(view.getDirectParentLightDom(1)).toBe(view.lightDoms[0]);
+        expect(view.getDirectParentElement(1)).toBe(view.boundElements[0]);
       });
 
       it('should return null if the direct parent is not bound', () => {
@@ -65,20 +64,10 @@ export function main() {
           new ElementBinder({parentIndex: 0, distanceToParent: 2})
         ]);
         var view = createView(pv, 3);
-        view.lightDoms[0] = <any>new SpyLightDom();
-        view.lightDoms[1] = <any>new SpyLightDom();
-        view.lightDoms[2] = <any>new SpyLightDom();
-        expect(view.getDirectParentLightDom(2)).toBe(null);
+        expect(view.getDirectParentElement(2)).toBe(null);
       });
 
     });
 
   });
-}
-
-@proxy
-@IMPLEMENTS(LightDom)
-class SpyLightDom extends SpyObject {
-  constructor() { super(LightDom); }
-  noSuchMethod(m) { return super.noSuchMethod(m) }
 }


### PR DESCRIPTION
Replaces the multiple arrays of `DomView`
by a single array with `DomElement`s.

Note: this commit does not show a performance regression
(tested against the tree benchmark locally).
