### PR TITLE
feat(dart/change_detect): Add type to ChangeDetector context

### DIFF
--- a/modules/angular2/src/change_detection/change_detection_jit_generator.ts
+++ b/modules/angular2/src/change_detection/change_detection_jit_generator.ts
@@ -131,7 +131,7 @@ export class ChangeDetectorJITGenerator {
       }
 
       ${this.typeName}.prototype.hydrated = function() {
-        return ${CONTEXT_ACCESSOR} !== ${UTIL}.uninitialized();
+        return Boolean(${CONTEXT_ACCESSOR});
       }
 
       return function(dispatcher, pipeRegistry) {
@@ -173,7 +173,11 @@ export class ChangeDetectorJITGenerator {
     fields = fields.concat(this._getNonNullPipeNames());
     fields = fields.concat(this._genGetDirectiveFieldNames());
     fields = fields.concat(this._genGetDetectorFieldNames());
-    return fields.map((n) => `${n} = ${UTIL}.uninitialized();`).join("\n");
+    return fields.map((n) => {
+                   return n == CONTEXT_ACCESSOR ? `${n} = null;` :
+                                                  `${n} = ${UTIL}.uninitialized();`;
+                 })
+        .join("\n");
   }
 
   _genHydrateDirectives(): string {

--- a/modules/angular2/src/transform/template_compiler/generator.dart
+++ b/modules/angular2/src/transform/template_compiler/generator.dart
@@ -48,7 +48,7 @@ Future<String> processTemplates(AssetReader reader, AssetId entryPoint,
       var defs = getChangeDetectorDefinitions(viewDefEntry.hostMetadata,
           result.protoView, viewDefEntry.viewDef.directives);
       for (var i = 0; i < defs.length; ++i) {
-        changeDetectorClasses.generate(
+        changeDetectorClasses.generate('${rType.typeName}',
             '_${rType.typeName}_ChangeDetector$i', defs[i]);
       }
 

--- a/modules/angular2/test/change_detection/generator/gen_change_detectors.dart
+++ b/modules/angular2/test/change_detection/generator/gen_change_detectors.dart
@@ -13,7 +13,7 @@ void main(List<String> args) {
   var allDefs = getAllDefinitions('propName');
   for (var i = 0; i < allDefs.length; ++i) {
     var className = 'ChangeDetector${i}';
-    codegen.generate(className, allDefs[i]);
+    codegen.generate('dynamic', className, allDefs[i]);
     if (i > 0) {
       buf.write(',');
     }

--- a/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
@@ -27,7 +27,7 @@ class _MyComponent_ChangeDetector0 extends _gen.AbstractChangeDetector {
   final _gen.List<_gen.ProtoRecord> _protos;
   final _gen.List<_gen.DirectiveRecord> _directiveRecords;
   dynamic _locals = null;
-  dynamic _context = _gen.ChangeDetectionUtil.uninitialized();
+  MyComponent _context = null;
 
   _MyComponent_ChangeDetector0(this._dispatcher, this._pipeRegistry,
       this._protos, this._directiveRecords)
@@ -45,19 +45,18 @@ class _MyComponent_ChangeDetector0 extends _gen.AbstractChangeDetector {
 
   void callOnAllChangesDone() {}
 
-  void hydrate(context, locals, directives) {
+  void hydrate(MyComponent context, locals, directives) {
     mode = 'ALWAYS_CHECK';
     _context = context;
     _locals = locals;
   }
 
   void dehydrate() {
-    _context = _gen.ChangeDetectionUtil.uninitialized();
+    _context = null;
     _locals = null;
   }
 
-  hydrated() =>
-      !_gen.looseIdentical(_context, _gen.ChangeDetectionUtil.uninitialized());
+  hydrated() => _context == null;
 
   static _gen.ProtoChangeDetector newProtoChangeDetector(
       _gen.PipeRegistry registry, _gen.ChangeDetectorDefinition def) {


### PR DESCRIPTION
Add a type for the `context` field in Dart's pre-generated change
detectors. This requires slight changes to set the dehydrated value of
`context` to `null` rather than `ChangeDetectionUtil.uninitialized()`,
which was its former dehydrated state.

Mirror these chagnes as closely as possible in the
`ChangeDetectionJITGenerator` to allow easier maintenance.

Closes #2070
