### PR TITLE
fix(bundle): makes interfaces.ts non-empty when transpiled.

### DIFF
--- a/modules/angular2/src/core/compiler/interfaces.ts
+++ b/modules/angular2/src/core/compiler/interfaces.ts
@@ -1,5 +1,10 @@
 import {StringMap} from 'angular2/src/facade/collection';
+import {global} from 'angular2/src/facade/lang';
 
+// This is here only so that after TS transpilation the file is not empty.
+// TODO(rado): find a better way to fix this, or remove if likely culprit
+// https://github.com/systemjs/systemjs/issues/487 gets closed.
+var __ignore_me = global;
 /**
  * Defines lifecycle method [onChange] called after all of component's bound
  * properties are updated.


### PR DESCRIPTION
System.js seems detect an empty file as global and choke on exporting
symbols from angular2/angular2 (possibly a bug in system.js).

As temporary measure we make sure that the file has some (fake) runtime
code left.

Closes: #2343
