### PR TITLE
chore(broccoli): disable logging in DiffingBroccoliPlugin

### DIFF
--- a/tools/broccoli/diffing-broccoli-plugin.ts
+++ b/tools/broccoli/diffing-broccoli-plugin.ts
@@ -64,16 +64,12 @@ class DiffingPluginWrapper implements BroccoliTree {
 
 
   private calculateDiff(firstRun: boolean): (DiffResult | DiffResult[]) {
+    // TODO(caitp): optionally log trees based on environment variable or command line option
     if (this.treeDiffer) {
       let diffResult = this.treeDiffer.diffTree();
-      diffResult.log(!firstRun);
       return diffResult;
     } else if (this.treeDiffers) {
-      return this.treeDiffers.map((treeDiffer) => treeDiffer.diffTree())
-          .map((diffResult) => {
-            diffResult.log(!firstRun);
-            return diffResult;
-          });
+      return this.treeDiffers.map((treeDiffer) => treeDiffer.diffTree());
     } else {
       throw new Error("Missing TreeDiffer");
     }


### PR DESCRIPTION
It is very noisy, especially when multiple trees are used. Since the
tree differ is fairly quick, it's not measuring the real costs of a
plugin anyhow.
