### PR TITLE
chore(doc-gen): fix versionInfo population

### DIFF
--- a/docs/dgeni-package/templates/lib/githubLinks.html
+++ b/docs/dgeni-package/templates/lib/githubLinks.html
@@ -1,3 +1,3 @@
 {% macro githubViewLink(doc) -%}
-  <a href="https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInfo.repo $}/tree/{$ versionInfo.currentVersion.isSnapshot and 'master' or versionInfo.currentVersion.raw $}/modules/{$ doc.fileInfo.relativePath $}#L{$ doc.location.start.line+1 $}-L{$ doc.location.end.line+1 $}">
+  <a href="https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInfo.repo $}/tree/{$ versionInfo.currentVersion.isSnapshot and versionInfo.currentVersion.SHA or versionInfo.currentVersion.raw $}/modules/{$ doc.fileInfo.relativePath $}#L{$ doc.location.start.line+1 $}-L{$ doc.location.end.line+1 $}">
 {%- endmacro -%}


### PR DESCRIPTION
The `versionInfo.js` was making some assumptions about the tagging which was the case for the `angular.js` repo that this was taken from: 1) That the version tags would be annotated. 2) That the annotation would have a codename. 3) That the tag would be prefixed with a 'v'.
