### PR TITLE
test(change detect): Port change detect tests for mode

### DIFF
--- a/modules/angular2/src/transform/template_compiler/change_detector_codegen.dart
+++ b/modules/angular2/src/transform/template_compiler/change_detector_codegen.dart
@@ -208,7 +208,7 @@ class _CodegenState {
     var detectorFieldNames = _genGetDetectorFieldNames();
     for (var i = 0; i < detectorFieldNames.length; ++i) {
       buf.writeln('${detectorFieldNames[i]} = directives.getDetectorFor('
-          '$_DIRECTIVES_ACCESSOR[$i].directiveIndex)');
+          '$_DIRECTIVES_ACCESSOR[$i].directiveIndex);');
     }
     return '$buf';
   }


### PR DESCRIPTION
More the change detect tests that exercise various detection modes to
use the Dart pre-generated change detectors in addition to the `dynamic`
and `JIT` change detectors.

See #502
