### PR TITLE
chore(Build): rename .es6 output files to .js

### DIFF
--- a/docs/dgeni-package/services/tsParser.js
+++ b/docs/dgeni-package/services/tsParser.js
@@ -9,7 +9,7 @@ module.exports = function tsParser(createCompilerHost, log) {
     // During migration from Traceur, there is a mix of `.ts`, `.es6` and `.js` (atScript)
     // files in the project and the TypeScript compiler only looks for `.ts` files when trying
     // to load imports.
-    extensions: ['.ts', '.js', '.es6'],
+    extensions: ['.ts', '.js'],
 
     // The options for the TS compiler
     options: {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -695,7 +695,7 @@ gulp.task('!build.js.cjs', function() {
 
 var bundleConfig = {
   paths: {
-    "*": "dist/js/prod/es6/*.es6",
+    "*": "dist/js/prod/es6/*.js",
     "rx": "node_modules/rx/dist/rx.js"
   },
   meta: {
@@ -735,7 +735,7 @@ gulp.task('bundle.js.dev', ['build.js.dev'], function() {
   var devBundleConfig = merge(true, bundleConfig);
   devBundleConfig.paths =
       merge(true, devBundleConfig.paths, {
-       "*": "dist/js/dev/es6/*.es6"
+       "*": "dist/js/dev/es6/*.js"
       });
   return bundler.bundle(
       devBundleConfig,
@@ -748,7 +748,7 @@ gulp.task('router.bundle.js.dev', ['build.js.dev'], function() {
   var devBundleConfig = merge(true, bundleConfig);
   devBundleConfig.paths =
     merge(true, devBundleConfig.paths, {
-      "*": "dist/js/dev/es6/*.es6"
+      "*": "dist/js/dev/es6/*.js"
     });
   return bundler.bundle(
     devBundleConfig,
@@ -766,7 +766,7 @@ gulp.task('bundle.js.sfx.dev', ['build.js.dev'], function() {
   var devBundleConfig = merge(true, bundleConfig);
   devBundleConfig.paths =
       merge(true, devBundleConfig.paths, {
-       '*': 'dist/js/dev/es6/*.es6'
+       '*': 'dist/js/dev/es6/*.js'
       });
   return bundler.bundle(
       devBundleConfig,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -222,7 +222,7 @@ gulp.task('build/checkCircularDependencies', function (done) {
   var dependencyObject = madge(CONFIG.dest.js.dev.es6, {
     format: 'es6',
     paths: [CONFIG.dest.js.dev.es6],
-    extensions: ['.js', '.es6'],
+    extensions: ['.js'],
     onParseFile: function(data) {
       data.src = data.src.replace(/import \* as/g, "//import * as");
     }

--- a/modules/examples/e2e_test/sourcemap/sourcemap_spec.ts
+++ b/modules/examples/e2e_test/sourcemap/sourcemap_spec.ts
@@ -34,7 +34,7 @@ describe('sourcemaps', function() {
 
       var originalPosition = decoder.originalPositionFor({line: errorLine, column: errorColumn});
 
-      var finalMapData = fs.readFileSync('dist/js/prod/es6/examples/src/sourcemap/index.es6.map');
+      var finalMapData = fs.readFileSync('dist/js/prod/es6/examples/src/sourcemap/index.js.map');
       var finalDecoder = new sourceMap.SourceMapConsumer(JSON.parse(finalMapData));
 
       var finalPosition = finalDecoder.originalPositionFor(originalPosition);

--- a/modules/rtts_assert/README.js.md
+++ b/modules/rtts_assert/README.js.md
@@ -3,7 +3,7 @@
 A run-time type assertion library for JavaScript.
 Designed to be used with [Traceur](https://github.com/google/traceur-compiler).
 
-All sources are in ES6 format and have the suffix `.es6`. They don't depend on any runtime
+All sources are in ES6 format. They don't depend on any runtime
 and can be used by any modern ES6 -> ES5 transpiler.
 
 As a convenience, we provide you with `es5build.js`, a script to transpile the sources into es5

--- a/tools/broccoli/traceur/index.ts
+++ b/tools/broccoli/traceur/index.ts
@@ -13,7 +13,7 @@ let xtend = require('xtend');
 class DiffingTraceurCompiler implements DiffingBroccoliPlugin {
   constructor(public inputPath: string, public cachePath: string, public options) {}
 
-  static includeExtensions = ['.js', '.es6', '.cjs'];
+  static includeExtensions = ['.js', '.cjs'];
 
   rebuild(treeDiff: DiffResult) {
     treeDiff.changedPaths.forEach((changedFilePath) => {

--- a/tools/broccoli/trees/browser_tree.ts
+++ b/tools/broccoli/trees/browser_tree.ts
@@ -64,7 +64,7 @@ module.exports = function makeBrowserTree(options, destinationPath) {
 
   // Use Traceur to transpile *.js sources to ES6
   var traceurTree = transpileWithTraceur(modulesTree, {
-    destExtension: '.es6',
+    destExtension: '.js',
     destSourceMapExtension: '.map',
     traceurOptions: {
       sourceMaps: true,
@@ -93,7 +93,6 @@ module.exports = function makeBrowserTree(options, destinationPath) {
     sourceRoot: '.',
     target: 'ES6'
   });
-  typescriptTree = stew.rename(typescriptTree, '.js', '.es6');
 
   var es6Tree = mergeTrees([traceurTree, typescriptTree]);
 

--- a/tools/build/es5build.js
+++ b/tools/build/es5build.js
@@ -46,11 +46,8 @@ if (!module.parent) {
 }
 
 function run(config) {
-  var src = ['!node_modules', '!node_modules/**', './**/*.es6'];
+  var src = ['!node_modules', '!node_modules/**', './**/*.js'];
   return gulp.src(src, {cwd: config.src})
-    .pipe(rename(function(file) {
-      file.extname = file.extname.replace('.es6', '.js');
-    }))
     // TODO(tbosch): Using sourcemaps.init({loadMaps:true}) does not combine
     // the sourcemaps correctly!
     .pipe(sourcemaps.init())


### PR DESCRIPTION
Change es6 source files in npm distribution to use .js extensions.

Closes #2447
