### PR TITLE
build(broccoli): add support for DiffResult#addedPaths

### DIFF
--- a/tools/broccoli/broccoli-dartfmt.ts
+++ b/tools/broccoli/broccoli-dartfmt.ts
@@ -30,12 +30,13 @@ class DartFormatter implements DiffingBroccoliPlugin {
 
   rebuild(treeDiff: DiffResult): Promise<any> {
     let args = ['-w'];
-    treeDiff.changedPaths.forEach((changedFile) => {
-      let sourcePath = path.join(this.inputPath, changedFile);
-      let destPath = path.join(this.cachePath, changedFile);
-      if (/\.dart$/.test(changedFile)) args.push(destPath);
-      fse.copySync(sourcePath, destPath);
-    });
+    treeDiff.addedPaths.concat(treeDiff.changedPaths)
+        .forEach((changedFile) => {
+          let sourcePath = path.join(this.inputPath, changedFile);
+          let destPath = path.join(this.cachePath, changedFile);
+          if (/\.dart$/.test(changedFile)) args.push(destPath);
+          fse.copySync(sourcePath, destPath);
+        });
     treeDiff.removedPaths.forEach((removedFile) => {
       let destPath = path.join(this.cachePath, removedFile);
       fse.removeSync(destPath);

--- a/tools/broccoli/broccoli-dest-copy.ts
+++ b/tools/broccoli/broccoli-dest-copy.ts
@@ -15,13 +15,14 @@ class DestCopy implements DiffingBroccoliPlugin {
 
 
   rebuild(treeDiff: DiffResult) {
-    treeDiff.changedPaths.forEach((changedFilePath) => {
-      var destFilePath = path.join(this.outputRoot, changedFilePath);
+    treeDiff.addedPaths.concat(treeDiff.changedPaths)
+        .forEach((changedFilePath) => {
+          var destFilePath = path.join(this.outputRoot, changedFilePath);
 
-      var destDirPath = path.dirname(destFilePath);
-      fse.mkdirsSync(destDirPath);
-      fse.copySync(path.join(this.inputPath, changedFilePath), destFilePath);
-    });
+          var destDirPath = path.dirname(destFilePath);
+          fse.mkdirsSync(destDirPath);
+          fse.copySync(path.join(this.inputPath, changedFilePath), destFilePath);
+        });
 
     treeDiff.removedPaths.forEach((removedFilePath) => {
       var destFilePath = path.join(this.outputRoot, removedFilePath);

--- a/tools/broccoli/broccoli-flatten.spec.ts
+++ b/tools/broccoli/broccoli-flatten.spec.ts
@@ -52,4 +52,26 @@ describe('Flatten', () => {
 
     expect(fs.readdirSync('output')).toEqual(['file-1.1.txt', 'file-2.txt', 'file-3.txt']);
   });
+
+
+  it('should throw an exception if duplicates are found', () => {
+    let testDir = {
+      'input': {
+        'dir1': {
+          'file-1.txt': mockfs.file({content: 'file-1.txt content', mtime: new Date(1000)}),
+          'subdir-1': {
+            'file-1.txt': mockfs.file({content: 'file-1.1.txt content', mtime: new Date(1000)})
+          },
+          'empty-dir': {}
+        },
+      },
+      'output': {}
+    };
+    mockfs(testDir);
+
+    let differ = new TreeDiffer('testLabel', 'input');
+    let flattenedTree = flatten('input');
+    expect(() => flattenedTree.rebuild(differ.diffTree())).
+      toThrowError("Duplicate file 'file-1.txt' found in path 'dir1/subdir-1/file-1.txt'");
+  });
 });

--- a/tools/broccoli/broccoli-lodash.ts
+++ b/tools/broccoli/broccoli-lodash.ts
@@ -37,7 +37,7 @@ export class LodashRenderer implements DiffingBroccoliPlugin {
       fs.unlinkSync(destFilePath);
     };
 
-    treeDiff.changedPaths.forEach(processFile);
+    treeDiff.addedPaths.concat(treeDiff.changedPaths).forEach(processFile);
     treeDiff.removedPaths.forEach(removeFile);
   }
 }

--- a/tools/broccoli/broccoli-ts2dart.ts
+++ b/tools/broccoli/broccoli-ts2dart.ts
@@ -23,16 +23,17 @@ class TSToDartTranspiler implements DiffingBroccoliPlugin {
   rebuild(treeDiff: DiffResult) {
     let toEmit = [];
     let getDartFilePath = (path: string) => path.replace(/((\.js)|(\.ts))$/i, '.dart');
-    treeDiff.changedPaths.forEach((changedPath) => {
-      let inputFilePath = path.resolve(this.inputPath, changedPath);
+    treeDiff.addedPaths.concat(treeDiff.changedPaths)
+        .forEach((changedPath) => {
+          let inputFilePath = path.resolve(this.inputPath, changedPath);
 
-      // Ignore files which don't need to be transpiled to Dart
-      let dartInputFilePath = getDartFilePath(inputFilePath);
-      if (fs.existsSync(dartInputFilePath)) return;
+          // Ignore files which don't need to be transpiled to Dart
+          let dartInputFilePath = getDartFilePath(inputFilePath);
+          if (fs.existsSync(dartInputFilePath)) return;
 
-      // Prepare to rebuild
-      toEmit.push(path.resolve(this.inputPath, changedPath));
-    });
+          // Prepare to rebuild
+          toEmit.push(path.resolve(this.inputPath, changedPath));
+        });
 
     treeDiff.removedPaths.forEach((removedPath) => {
       let absolutePath = path.resolve(this.inputPath, removedPath);

--- a/tools/broccoli/broccoli-typescript.ts
+++ b/tools/broccoli/broccoli-typescript.ts
@@ -50,16 +50,17 @@ class DiffingTSCompiler implements DiffingBroccoliPlugin {
     let pathsToEmit = [];
     let pathsWithErrors = [];
 
-    treeDiff.changedPaths.forEach((tsFilePath) => {
-      if (!this.fileRegistry[tsFilePath]) {
-        this.fileRegistry[tsFilePath] = {version: 0};
-        this.rootFilePaths.push(tsFilePath);
-      } else {
-        this.fileRegistry[tsFilePath].version++;
-      }
+    treeDiff.addedPaths.concat(treeDiff.changedPaths)
+        .forEach((tsFilePath) => {
+          if (!this.fileRegistry[tsFilePath]) {
+            this.fileRegistry[tsFilePath] = {version: 0};
+            this.rootFilePaths.push(tsFilePath);
+          } else {
+            this.fileRegistry[tsFilePath].version++;
+          }
 
-      pathsToEmit.push(tsFilePath);
-    });
+          pathsToEmit.push(tsFilePath);
+        });
 
     treeDiff.removedPaths.forEach((tsFilePath) => {
       console.log('removing outputs for', tsFilePath);

--- a/tools/broccoli/traceur/index.ts
+++ b/tools/broccoli/traceur/index.ts
@@ -16,29 +16,31 @@ class DiffingTraceurCompiler implements DiffingBroccoliPlugin {
   static includeExtensions = ['.js', '.es6', '.cjs'];
 
   rebuild(treeDiff: DiffResult) {
-    treeDiff.changedPaths.forEach((changedFilePath) => {
-      var traceurOpts = xtend({filename: changedFilePath}, this.options.traceurOptions);
+    treeDiff.addedPaths.concat(treeDiff.changedPaths)
+        .forEach((changedFilePath) => {
+          var traceurOpts = xtend({filename: changedFilePath}, this.options.traceurOptions);
 
-      var fsOpts = {encoding: 'utf-8'};
-      var absoluteInputFilePath = path.join(this.inputPath, changedFilePath);
-      var sourcecode = fs.readFileSync(absoluteInputFilePath, fsOpts);
+          var fsOpts = {encoding: 'utf-8'};
+          var absoluteInputFilePath = path.join(this.inputPath, changedFilePath);
+          var sourcecode = fs.readFileSync(absoluteInputFilePath, fsOpts);
 
-      var result = traceur.compile(traceurOpts, changedFilePath, sourcecode);
+          var result = traceur.compile(traceurOpts, changedFilePath, sourcecode);
 
-      // TODO: we should fix the sourceMappingURL written by Traceur instead of overriding
-      // (but we might switch to typescript first)
-      var mapFilepath = changedFilePath.replace(/\.\w+$/, '') + this.options.destSourceMapExtension;
-      result.js = result.js + '\n//# sourceMappingURL=./' + path.basename(mapFilepath);
+          // TODO: we should fix the sourceMappingURL written by Traceur instead of overriding
+          // (but we might switch to typescript first)
+          var mapFilepath =
+              changedFilePath.replace(/\.\w+$/, '') + this.options.destSourceMapExtension;
+          result.js = result.js + '\n//# sourceMappingURL=./' + path.basename(mapFilepath);
 
-      var destFilepath = changedFilePath.replace(/\.\w+$/, this.options.destExtension);
-      var destFile = path.join(this.cachePath, destFilepath);
-      fse.mkdirsSync(path.dirname(destFile));
-      fs.writeFileSync(destFile, result.js, fsOpts);
+          var destFilepath = changedFilePath.replace(/\.\w+$/, this.options.destExtension);
+          var destFile = path.join(this.cachePath, destFilepath);
+          fse.mkdirsSync(path.dirname(destFile));
+          fs.writeFileSync(destFile, result.js, fsOpts);
 
-      var destMap = path.join(this.cachePath, mapFilepath);
-      result.sourceMap.file = destFilepath;
-      fs.writeFileSync(destMap, JSON.stringify(result.sourceMap), fsOpts);
-    });
+          var destMap = path.join(this.cachePath, mapFilepath);
+          result.sourceMap.file = destFilepath;
+          fs.writeFileSync(destMap, JSON.stringify(result.sourceMap), fsOpts);
+        });
 
     treeDiff.removedPaths.forEach((removedFilePath) => {
       var destFilepath = removedFilePath.replace(/\.\w+$/, this.options.destExtension);

--- a/tools/broccoli/tree-differ.spec.ts
+++ b/tools/broccoli/tree-differ.spec.ts
@@ -11,9 +11,9 @@ describe('TreeDiffer', () => {
   afterEach(() => mockfs.restore());
 
 
-  describe('diff of changed files', () => {
+  describe('diff of added and changed files', () => {
 
-    it('should list all files but no directories during the first diff', () => {
+    it('should list all files (but no directories) during the first diff', () => {
       let testDir = {
         'dir1': {
           'file-1.txt': mockfs.file({content: 'file-1.txt content', mtime: new Date(1000)}),
@@ -30,9 +30,10 @@ describe('TreeDiffer', () => {
 
       let diffResult = differ.diffTree();
 
-      expect(diffResult.changedPaths)
+      expect(diffResult.addedPaths)
           .toEqual(['file-1.txt', 'file-2.txt', 'subdir-1/file-1.1.txt']);
 
+      expect(diffResult.changedPaths).toEqual([]);
       expect(diffResult.removedPaths).toEqual([]);
     });
 
@@ -53,11 +54,13 @@ describe('TreeDiffer', () => {
 
       let diffResult = differ.diffTree();
 
-      expect(diffResult.changedPaths).not.toEqual([]);
+      expect(diffResult.addedPaths).not.toEqual([]);
+      expect(diffResult.changedPaths).toEqual([]);
       expect(diffResult.removedPaths).toEqual([]);
 
       diffResult = differ.diffTree();
 
+      expect(diffResult.addedPaths).toEqual([]);
       expect(diffResult.changedPaths).toEqual([]);
       expect(diffResult.removedPaths).toEqual([]);
     });
@@ -80,7 +83,7 @@ describe('TreeDiffer', () => {
 
       let diffResult = differ.diffTree();
 
-      expect(diffResult.changedPaths)
+      expect(diffResult.addedPaths)
           .toEqual(['file-1.txt', 'file-2.txt', 'subdir-1/file-1.1.txt']);
 
       // change two files
@@ -126,7 +129,7 @@ describe('TreeDiffer', () => {
 
       let diffResult = differ.diffTree();
 
-      expect(diffResult.changedPaths)
+      expect(diffResult.addedPaths)
           .toEqual(['file-1.txt', 'file-2.txt', 'subdir-1/file-1.1.txt']);
 
       // change two files
@@ -138,8 +141,8 @@ describe('TreeDiffer', () => {
 
       diffResult = differ.diffTree();
 
+      expect(diffResult.addedPaths).toEqual([]);
       expect(diffResult.changedPaths).toEqual(['file-1.txt', 'subdir-1/file-1.1.txt']);
-
       expect(diffResult.removedPaths).toEqual([]);
 
       // change one file
@@ -155,6 +158,7 @@ describe('TreeDiffer', () => {
       mockfs(testDir);
 
       diffResult = differ.diffTree();
+      expect(diffResult.addedPaths).toEqual([]);
       expect(diffResult.changedPaths).toEqual([]);
       expect(diffResult.removedPaths).toEqual(['file-1.txt']);
 
@@ -171,7 +175,8 @@ describe('TreeDiffer', () => {
       mockfs(testDir);
 
       diffResult = differ.diffTree();
-      expect(diffResult.changedPaths).toEqual(['file-1.txt']);
+      expect(diffResult.addedPaths).toEqual(['file-1.txt']);
+      expect(diffResult.changedPaths).toEqual([]);
       expect(diffResult.removedPaths).toEqual([]);
     });
 
@@ -204,7 +209,9 @@ describe('TreeDiffer', () => {
 
       let diffResult = differ.diffTree();
 
-      expect(diffResult.changedPaths).toEqual(['file-1.js', 'file-3.coffee']);
+      expect(diffResult.addedPaths).toEqual(['file-1.js', 'file-3.coffee']);
+      expect(diffResult.changedPaths).toEqual([]);
+      expect(diffResult.removedPaths).toEqual([]);
 
       // change two files
       testDir['dir1']['file-1.js'] = mockfs.file({content: 'new content', mtime: new Date(1000)});
@@ -216,8 +223,8 @@ describe('TreeDiffer', () => {
 
       diffResult = differ.diffTree();
 
+      expect(diffResult.addedPaths).toEqual([]);
       expect(diffResult.changedPaths).toEqual(['file-1.js', 'file-3.coffee']);
-
       expect(diffResult.removedPaths).toEqual([]);
 
       // change one file
@@ -250,7 +257,7 @@ describe('TreeDiffer', () => {
 
       let diffResult = differ.diffTree();
 
-      expect(diffResult.changedPaths)
+      expect(diffResult.addedPaths)
           .toEqual(['file-1.cs', 'file-1.ts', 'file-1d.cs', 'file-3.ts']);
 
       // change two files
@@ -265,8 +272,8 @@ describe('TreeDiffer', () => {
 
       diffResult = differ.diffTree();
 
+      expect(diffResult.addedPaths).toEqual([]);
       expect(diffResult.changedPaths).toEqual(['file-1.cs', 'file-1.ts', 'file-3.ts']);
-
       expect(diffResult.removedPaths).toEqual([]);
 
       // change one file
@@ -280,7 +287,7 @@ describe('TreeDiffer', () => {
 
   describe('diff of new files', () => {
 
-    it('should detect file additions and report them as changed files', () => {
+    it('should detect file additions', () => {
       let testDir = {
         'dir1':
             {'file-1.txt': mockfs.file({content: 'file-1.txt content', mtime: new Date(1000)})}
@@ -294,7 +301,9 @@ describe('TreeDiffer', () => {
       mockfs(testDir);
 
       let diffResult = differ.diffTree();
-      expect(diffResult.changedPaths).toEqual(['file-2.txt']);
+      expect(diffResult.addedPaths).toEqual(['file-2.txt']);
+      expect(diffResult.changedPaths).toEqual([]);
+      expect(diffResult.removedPaths).toEqual([]);
     });
 
 
@@ -313,7 +322,8 @@ describe('TreeDiffer', () => {
       mockfs(testDir);
 
       let diffResult = differ.diffTree();
-      expect(diffResult.changedPaths).toEqual(['file-1.txt', 'file-2.txt']);
+      expect(diffResult.addedPaths).toEqual(['file-2.txt']);
+      expect(diffResult.changedPaths).toEqual(['file-1.txt']);
     });
   });
 
@@ -358,7 +368,8 @@ describe('TreeDiffer', () => {
       mockfs(testDir);
 
       let diffResult = differ.diffTree();
-      expect(diffResult.changedPaths).toEqual(['file-1.txt', 'file-3.txt']);
+      expect(diffResult.addedPaths).toEqual(['file-3.txt']);
+      expect(diffResult.changedPaths).toEqual(['file-1.txt']);
       expect(diffResult.removedPaths).toEqual(['file-2.txt']);
     });
   });


### PR DESCRIPTION
Some plugins want to explicitly know of new paths, so we need to distinguish them from changed paths.
