### PR TITLE
fix(docs): export simple name and full name for doc alias

### DIFF
--- a/docs/dgeni-package/processors/readTypeScriptModules.js
+++ b/docs/dgeni-package/processors/readTypeScriptModules.js
@@ -139,11 +139,23 @@ module.exports = function readTypeScriptModules(tsParser, readFilesProcessor, mo
       }
     });
 
+    /**
+     * Fixes issue where @link aliases in docs are referring to the token name (i.e. QueryList),
+     * but the name variable contains the token name plus generic information and heritage, (i.e.
+     * QueryList<T> extends List<T>). See https://github.com/angular/angular/issues/2452
+     */
+    var exportAliasNames = [name];
+    var simpleAliasRegexp = /^([a-zA-Z0-9]+).*$/i;
+    var simpleNameMatch = simpleAliasRegexp.exec(name);
+    if (simpleNameMatch && simpleNameMatch.length > 1 && simpleNameMatch[1] !== name) {
+      exportAliasNames.push(simpleNameMatch[1]);
+    }
+
     var exportDoc = {
       docType: getExportDocType(exportSymbol),
       name: name,
       id: name,
-      aliases: [name],
+      aliases: exportAliasNames,
       moduleDoc: moduleDoc,
       content: getContent(exportSymbol),
       fileInfo: getFileInfo(exportSymbol, basePath),

--- a/modules/angular2/src/core/annotations_impl/annotations.ts
+++ b/modules/angular2/src/core/annotations_impl/annotations.ts
@@ -512,7 +512,7 @@ export class Directive extends Injectable {
    * For example, we could write a binding that updates the directive on structural changes, rather
    * than on reference changes, as normally occurs in change detection.
    *
-   * See {@link Pipe} and {@link pipes/keyValDiff} documentation for more details.
+   * See {@link Pipe} and {@link KeyValueChanges} documentation for more details.
    *
    * ```
    * @Directive({
@@ -724,8 +724,8 @@ export class Directive extends Injectable {
   /**
    * Specifies a set of lifecycle hostListeners in which the directive participates.
    *
-   * See {@link annotations/onChange}, {@link annotations/onDestroy},
-   * {@link annotations/onAllChangesDone} for details.
+   * See {@link /angular2/annotations/onChange}, {@link /angular2/annotations/onDestroy},
+   * {@link /angular2/annotations/onAllChangesDone} for details.
    */
   lifecycle: List<LifecycleEvent>;
 


### PR DESCRIPTION
(Still needs fix to the dangling link warnings, possibly in the [dgeni-packages](https://github.com/angular/dgeni-packages) repo)

Fixes #2452
