### PR TITLE
refactor(change detect): Clean up change detector test layout

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -831,7 +831,7 @@ gulp.task('!build/change_detect.dart', function(done) {
   var srcDir = path.join(changeDetectDir, 'generator');
   var destDir = path.join(changeDetectDir, 'generated');
 
-  var dartStream = fs.createWriteStream(path.join(destDir, 'simple_watch_classes.dart'));
+  var dartStream = fs.createWriteStream(path.join(destDir, 'change_detector_classes.dart'));
   var genMain = path.join(srcDir, 'gen_change_detectors.dart');
   var proc = spawn(DART_SDK.VM, [genMain], { stdio:['ignore', 'pipe', 'inherit'] });
   proc.on('error', function(code) {

--- a/modules/angular2/test/change_detection/change_detector_config.ts
+++ b/modules/angular2/test/change_detection/change_detector_config.ts
@@ -14,6 +14,11 @@ import {
 import {reflector} from 'angular2/src/reflection/reflection';
 import {ReflectionCapabilities} from 'angular2/src/reflection/reflection_capabilities';
 
+/*
+ * This file defines `ChangeDetectorDefinition` objects which are used in the tests defined in
+ * the change_detector_spec library. Please see that library for more information.
+ */
+
 var _parser = new Parser(new Lexer());
 
 function _getParser() {

--- a/modules/angular2/test/change_detection/change_detector_spec.ts
+++ b/modules/angular2/test/change_detection/change_detector_spec.ts
@@ -46,14 +46,24 @@ import {
   ProtoChangeDetector
 } from 'angular2/change_detection';
 
-import {getDefinition} from './simple_watch_config';
-import {getFactoryById} from './generated/simple_watch_classes';
+import {getDefinition} from './change_detector_config';
+import {getFactoryById} from './generated/change_detector_classes';
 
 const _DEFAULT_CONTEXT = CONST_EXPR(new Object());
 
+/**
+ * Tests in this spec run against three different implementations of `AbstractChangeDetector`,
+ * `dynamic` (which use reflection to inspect objects), `JIT` (which are generated only for
+ * Javascript at runtime using `eval` to avoid the need for reflection) and `Pregen` (which are
+ * generated only for Dart prior to app deploy to avoid the need for reflection).
+ *
+ * Pre-generated classes require knowledge of the shape of the change detector at the time of Dart
+ * transformation, so in these tests we abstract a `ChangeDetectorDefinition` out into the
+ * change_detector_config library and define a build step which pre-generates the necessary change
+ * detectors to execute these tests. Once that built step has run, those generated change detectors
+ * can be found in the generated/change_detector_classes library.
+ */
 export function main() {
-  // These tests also run against pre-generated Dart Change Detectors. We will move tests up from
-  // the loop below as they are converted.
   ListWrapper.forEach(['dynamic', 'JIT', 'Pregen'], (cdType) => {
 
     if (cdType == "JIT" && IS_DARTIUM) return;

--- a/modules/angular2/test/change_detection/generated/change_detector_classes.ts
+++ b/modules/angular2/test/change_detection/generated/change_detector_classes.ts
@@ -1,4 +1,5 @@
 // Ignore me, needed to support Angular 2 Dart.
+// See ../change_detector_spec for more details.
 
 export function getFactoryById(id: string) {
   return null;

--- a/modules/angular2/test/change_detection/generator/gen_change_detectors.dart
+++ b/modules/angular2/test/change_detection/generator/gen_change_detectors.dart
@@ -5,8 +5,12 @@ import 'dart:io';
 
 import 'package:dart_style/dart_style.dart';
 import 'package:angular2/src/transform/template_compiler/change_detector_codegen.dart';
-import '../simple_watch_config.dart';
+import '../change_detector_config.dart';
 
+/// This tool consumes pre-defined `ChangeDetectorDefinition` objects and
+/// outputs code defining `AbstractChangeDetector` implementations corresponding
+/// to those definitions. These are used by the tests in
+/// ../change_detector_spec. Please see that library for more details.
 void main(List<String> args) {
   var buf = new StringBuffer('var $_MAP_NAME = {');
   var codegen = new Codegen();


### PR DESCRIPTION
- Rename simple_watch_config > change_detector_config
- Add a bunch of comments explaining what's going on with the change
  detector tests.
