### PR TITLE
Removes es5 and es6 from the build path.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,6 +61,8 @@ function throwToolsBuildMissingError() {
 var angularBuilder = {
   rebuildBrowserDevTree: throwToolsBuildMissingError,
   rebuildBrowserProdTree: throwToolsBuildMissingError,
+  rebuildES6DevTree: throwToolsBuildMissingError,
+  rebuildES6ProdTree: throwToolsBuildMissingError,
   rebuildNodeTree: throwToolsBuildMissingError,
   rebuildDartTree: throwToolsBuildMissingError,
   mock: true
@@ -109,15 +111,16 @@ var CONFIG = {
   dest: {
     js: {
       all: 'dist/js',
-      dev: {
-        es6: 'dist/js/dev/es6',
-        es5: 'dist/js/dev/es5'
+      dev: 'dist/js/dev',
+      prod: 'dist/js/prod',
+      es6: {
+        dev: 'dist/js/es6/dev',
+        prod: 'dist/js/es6/prod'
       },
-      prod: {
-        es6: 'dist/js/prod/es6',
-        es5: 'dist/js/prod/es5'
+      cjs: {
+        dev: 'dist/js/cjs/dev',
+        prod: 'dist/js/cjs/prod'
       },
-      cjs: 'dist/js/cjs',
       dart2js: 'dist/js/dart2js'
     },
     dart: 'dist/dart',
@@ -216,24 +219,6 @@ gulp.task('enforce-format', function() {
   });
 });
 
-// ------------
-// check circular dependencies in Node.js context
-gulp.task('build/checkCircularDependencies', function (done) {
-  var dependencyObject = madge(CONFIG.dest.js.dev.es6, {
-    format: 'es6',
-    paths: [CONFIG.dest.js.dev.es6],
-    extensions: ['.js', '.es6'],
-    onParseFile: function(data) {
-      data.src = data.src.replace(/import \* as/g, "//import * as");
-    }
-  });
-  var circularDependencies = dependencyObject.circular().getArray();
-  if (circularDependencies.length > 0) {
-    console.log(circularDependencies);
-    process.exit(1);
-  }
-  done();
-});
 
 // ------------------
 // web servers
@@ -241,14 +226,14 @@ gulp.task('serve.js.dev', ['build.js.dev'], function(neverDone) {
   watch('modules/**', { ignoreInitial: true }, '!broccoli.js.dev');
 
   jsserve(gulp, gulpPlugins, {
-    path: CONFIG.dest.js.dev.es5,
+    path: CONFIG.dest.js.dev,
     port: 8000
   })();
 });
 
 
 gulp.task('serve.js.prod', jsserve(gulp, gulpPlugins, {
-  path: CONFIG.dest.js.prod.es5,
+  path: CONFIG.dest.js.prod,
   port: 8001
 }));
 
@@ -458,7 +443,7 @@ gulp.task('test.unit.dart/ci', function (done) {
 
 
 gulp.task('test.unit.cjs/ci', function(done) {
-  runJasmineTests(['dist/js/cjs/{angular2,benchpress}/test/**/*_spec.js'], done);
+  runJasmineTests(['dist/js/cjs/dev/{angular2,benchpress}/test/**/*_spec.js'], done);
 });
 
 
@@ -467,7 +452,7 @@ gulp.task('test.unit.cjs', ['build/clean.js', 'build.tools'], function (neverDon
   treatTestErrorsAsFatal = false;
 
   var buildAndTest = [
-    '!build.js.cjs',
+    '!build.js.cjs.dev',
     'test.unit.cjs/ci'
   ];
 
@@ -658,7 +643,6 @@ gulp.task('!broccoli.js.dev', function() {
 gulp.task('build.js.dev', ['build/clean.js'], function(done) {
   runSequence(
     'broccoli.js.dev',
-    'build/checkCircularDependencies',
     'check-format',
     sequenceComplete(done)
   );
@@ -673,32 +657,27 @@ gulp.task('build.js.prod', ['build.tools'], function() {
  * public task
  */
 gulp.task('build.js.cjs', ['build.tools'], function(done) {
-  runSequence('!build.js.cjs', sequenceComplete(done));
+  runSequence('!build.js.cjs.dev', sequenceComplete(done));
 });
 
-
-var firstBuildJsCjs = true;
 
 /**
  * private task
  */
-gulp.task('!build.js.cjs', function() {
-  return angularBuilder.rebuildNodeTree().then(function() {
-    if (firstBuildJsCjs) {
-      firstBuildJsCjs = false;
-      console.log('creating node_modules symlink hack');
-      // linknodemodules is all sync
-      linknodemodules(gulp, gulpPlugins, {
-        dir: CONFIG.dest.js.cjs
-      })();
-    }
+gulp.task('!build.js.cjs.dev', function() {
+  return angularBuilder.rebuildNodeDevTree().then(function() {
+    console.log('creating node_modules symlink hack');
+    // linknodemodules is all sync
+    linknodemodules(gulp, gulpPlugins, {
+      dir: CONFIG.dest.js.cjs.dev
+    })();
   });
 });
 
 
 var bundleConfig = {
   paths: {
-    "*": "dist/js/prod/es6/*.es6",
+    "*": "dist/js/es6/prod/*.js",
     "rx": "node_modules/rx/dist/rx.js"
   },
   meta: {
@@ -738,7 +717,7 @@ gulp.task('bundle.js.dev', ['build.js.dev'], function() {
   var devBundleConfig = merge(true, bundleConfig);
   devBundleConfig.paths =
       merge(true, devBundleConfig.paths, {
-       "*": "dist/js/dev/es6/*.es6"
+       "*": "dist/js/es6/dev/*.js"
       });
   return bundler.bundle(
       devBundleConfig,
@@ -751,7 +730,7 @@ gulp.task('router.bundle.js.dev', ['build.js.dev'], function() {
   var devBundleConfig = merge(true, bundleConfig);
   devBundleConfig.paths =
     merge(true, devBundleConfig.paths, {
-      "*": "dist/js/dev/es6/*.es6"
+      "*": "dist/js/es6/dev/*.js"
     });
   return bundler.bundle(
     devBundleConfig,
@@ -769,7 +748,7 @@ gulp.task('bundle.js.sfx.dev', ['build.js.dev'], function() {
   var devBundleConfig = merge(true, bundleConfig);
   devBundleConfig.paths =
       merge(true, devBundleConfig.paths, {
-       '*': 'dist/js/dev/es6/*.es6'
+       '*': 'dist/js/es6/dev/*.js'
       });
   return bundler.bundle(
       devBundleConfig,
@@ -853,8 +832,8 @@ gulp.task('!build/change_detect.dart', function(done) {
 gulp.task('build.http.example', function() {
   //Copy over people.json used in http example
   return gulp.src('modules/examples/src/http/people.json')
-      .pipe(gulp.dest(CONFIG.dest.js.prod.es5 + '/examples/src/http/'))
-      .pipe(gulp.dest(CONFIG.dest.js.dev.es5 + '/examples/src/http/'))
+      .pipe(gulp.dest(CONFIG.dest.js.prod + '/examples/src/http/'))
+      .pipe(gulp.dest(CONFIG.dest.js.dev + '/examples/src/http/'))
       .pipe(gulp.dest(CONFIG.dest.js.dart2js + '/examples/src/http/'));
 });
 
@@ -864,8 +843,8 @@ gulp.task('build.css.material', function() {
   return gulp.src('modules/*/src/**/*.scss')
       .pipe(sass())
       .pipe(autoprefixer())
-      .pipe(gulp.dest(CONFIG.dest.js.prod.es5))
-      .pipe(gulp.dest(CONFIG.dest.js.dev.es5))
+      .pipe(gulp.dest(CONFIG.dest.js.prod))
+      .pipe(gulp.dest(CONFIG.dest.js.dev))
       .pipe(gulp.dest(CONFIG.dest.js.dart2js + '/examples/packages'));
 });
 

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -8,7 +8,7 @@ module.exports = function(config) {
     files: [
       // Sources and specs.
       // Loaded through the es6-module-loader, in `test-main.js`.
-      {pattern: 'dist/js/dev/es5/**', included: false, watched: false},
+      {pattern: 'dist/js/dev/**', included: false, watched: false},
 
       // zone-microtask must be included first as it contains a Promise monkey patch
       'node_modules/zone.js/dist/zone-microtask.js',
@@ -29,7 +29,7 @@ module.exports = function(config) {
     ],
 
     exclude: [
-      'dist/js/dev/es5/**/e2e_test/**',
+      'dist/js/dev/**/e2e_test/**',
     ],
 
     customLaunchers: {

--- a/modules/examples/e2e_test/sourcemap/sourcemap_spec.ts
+++ b/modules/examples/e2e_test/sourcemap/sourcemap_spec.ts
@@ -29,12 +29,12 @@ describe('sourcemaps', function() {
       expect(errorColumn).not.toBeNull();
 
 
-      var sourceMapData = fs.readFileSync('dist/js/prod/es5/examples/src/sourcemap/index.js.map');
+      var sourceMapData = fs.readFileSync('dist/js/prod/examples/src/sourcemap/index.js.map');
       var decoder = new sourceMap.SourceMapConsumer(JSON.parse(sourceMapData));
 
       var originalPosition = decoder.originalPositionFor({line: errorLine, column: errorColumn});
 
-      var finalMapData = fs.readFileSync('dist/js/prod/es6/examples/src/sourcemap/index.es6.map');
+      var finalMapData = fs.readFileSync('dist/js/es6/prod/examples/src/sourcemap/index.js.map');
       var finalDecoder = new sourceMap.SourceMapConsumer(JSON.parse(finalMapData));
 
       var finalPosition = finalDecoder.originalPositionFor(originalPosition);

--- a/scripts/publish/npm_publish.sh
+++ b/scripts/publish/npm_publish.sh
@@ -12,19 +12,6 @@ NPM_DIR=$ROOT_DIR/dist/npm
 rm -fr $NPM_DIR
 FILES='!(test|e2e_test|docs)'
 
-function publishRttsAssert {
-  NAME='rtts_assert'
-  PUBLISH_DIR=$NPM_DIR/$NAME
-  rm -fr $PUBLISH_DIR
-  mkdir -p $PUBLISH_DIR
-
-  mkdir -p $PUBLISH_DIR
-  cp -r $ROOT_DIR/dist/js/es6/prod/$NAME/$FILES $PUBLISH_DIR
-
-  cp -r $ROOT_DIR/dist/js/cjs/$NAME/$FILES $PUBLISH_DIR
-  npm publish $PUBLISH_DIR
-}
-
 function publishModule {
   NAME=$1
   PUBLISH_DIR=$NPM_DIR/$NAME
@@ -45,6 +32,5 @@ function publishModule {
   npm publish $PUBLISH_DIR
 }
 
-publishRttsAssert
 publishModule angular2
 publishModule benchpress

--- a/scripts/publish/npm_publish.sh
+++ b/scripts/publish/npm_publish.sh
@@ -18,8 +18,8 @@ function publishRttsAssert {
   rm -fr $PUBLISH_DIR
   mkdir -p $PUBLISH_DIR
 
-  mkdir -p $PUBLISH_DIR/es6
-  cp -r $ROOT_DIR/dist/js/prod/es6/$NAME/$FILES $PUBLISH_DIR/es6
+  mkdir -p $PUBLISH_DIR
+  cp -r $ROOT_DIR/dist/js/es6/prod/$NAME/$FILES $PUBLISH_DIR
 
   cp -r $ROOT_DIR/dist/js/cjs/$NAME/$FILES $PUBLISH_DIR
   npm publish $PUBLISH_DIR
@@ -32,13 +32,15 @@ function publishModule {
   mkdir -p $PUBLISH_DIR
 
   mkdir -p $PUBLISH_DIR/es6/dev
-  cp -r $ROOT_DIR/dist/js/dev/es6/$NAME/$FILES $PUBLISH_DIR/es6/dev
+  cp -r $ROOT_DIR/dist/js/es6/dev/$NAME/$FILES $PUBLISH_DIR/es6/dev
   mkdir -p $PUBLISH_DIR/es6/prod
-  cp -r $ROOT_DIR/dist/js/prod/es6/$NAME/$FILES $PUBLISH_DIR/es6/prod
+  cp -r $ROOT_DIR/dist/js/es6/prod/$NAME/$FILES $PUBLISH_DIR/es6/prod
   mkdir -p $PUBLISH_DIR/ts
   cp -r $ROOT_DIR/modules/$NAME/$FILES $PUBLISH_DIR/ts
 
-  cp -r $ROOT_DIR/dist/js/cjs/$NAME/$FILES $PUBLISH_DIR
+  cp -r $ROOT_DIR/dist/js/cjs/dev/$NAME/$FILES $PUBLISH_DIR/
+  mkdir -p $PUBLISH_DIR/cjs/prod
+  cp -r $ROOT_DIR/dist/js/cjs/prod/$NAME/$FILES $PUBLISH_DIR/prod
 
   npm publish $PUBLISH_DIR
 }

--- a/test-main.js
+++ b/test-main.js
@@ -17,9 +17,9 @@ System.baseURL = '/base/';
 // So that we can import packages like `core/foo`, instead of `core/src/foo`.
 System.paths = {
   '*': './*.js',
-  'benchpress/*': 'dist/js/dev/es5/benchpress/*.js',
-  'angular2/*': 'dist/js/dev/es5/angular2/*.js',
-  'rtts_assert/*': 'dist/js/dev/es5/rtts_assert/*.js',
+  'benchpress/*': 'dist/js/dev/benchpress/*.js',
+  'angular2/*': 'dist/js/dev/angular2/*.js',
+  'rtts_assert/*': 'dist/js/dev/rtts_assert/*.js',
   'rx': 'node_modules/rx/dist/rx.js'
 };
 

--- a/tools/broccoli/trees/es6_tree.ts
+++ b/tools/broccoli/trees/es6_tree.ts
@@ -3,7 +3,7 @@
 var Funnel = require('broccoli-funnel');
 var htmlReplace = require('../html-replace');
 var path = require('path');
-var stew = require('broccoli-stew');
+var stew = require('broccoli-stew')
 
 import compileWithTypescript from '../broccoli-typescript';
 import destCopy from '../broccoli-dest-copy';
@@ -12,9 +12,7 @@ import mergeTrees from '../broccoli-merge-trees';
 import replace from '../broccoli-replace';
 import {TRACEUR_RUNTIME_PATH} from '../traceur/index';
 
-
 var projectRootDir = path.normalize(path.join(__dirname, '..', '..', '..', '..'));
-
 
 const kServedPaths = [
   // Relative (to /modules) paths to benchmark directories
@@ -57,11 +55,11 @@ const kServedPaths = [
 ];
 
 
-module.exports = function makeBrowserTree(options, destinationPath) {
+module.exports = function makeES6Tree(options, destinationPath) {
   var modulesTree = new Funnel(
       'modules', {include: ['**/**'], exclude: ['benchmarks/e2e_test/**'], destDir: '/'});
 
-  // Use TypeScript to transpile the *.ts files to ES5
+  // Use TypeScript to transpile the *.ts files to ES6
   var typescriptTree = compileWithTypescript(modulesTree, {
     allowNonTsExtensions: false,
     declaration: true,
@@ -71,7 +69,7 @@ module.exports = function makeBrowserTree(options, destinationPath) {
     rootDir: '.',
     sourceMap: true,
     sourceRoot: '.',
-    target: 'ES5'
+    target: 'ES6'
   });
 
   var vendorScriptsTree = flatten(new Funnel('.', {
@@ -156,7 +154,7 @@ module.exports = function makeBrowserTree(options, destinationPath) {
 
   htmlTree = mergeTrees([htmlTree, scripts, polymer, css, react]);
 
-  var es5Tree = mergeTrees([typescriptTree, htmlTree]);
+  var es6Tree = mergeTrees([typescriptTree, htmlTree]);
 
-  return destCopy(es5Tree, destinationPath);
+  return destCopy(es6Tree, destinationPath);
 };


### PR DESCRIPTION
Removes traceur from the build path so that only the typescript compiler is being used to actually compile our modules tree.
