### PR TITLE
chore(dart2js): remove helpless warnings

### DIFF
--- a/modules/examples/pubspec.yaml
+++ b/modules/examples/pubspec.yaml
@@ -29,3 +29,4 @@ transformers:
     - --show-package-warnings
     - --trust-type-annotations
     - --trust-primitives
+    - --enable-experimental-mirrors


### PR DESCRIPTION
Removes the following warning from CI logs

```
[Dart2JS]:
web/src/material/radio/index.dart:
****************************************************************
* WARNING: dart:mirrors support in dart2js is experimental,
*          and not recommended.
*          This implementation of mirrors is incomplete,
*          and often greatly increases the size of the generated
*          JavaScript code.
*
* Your app imports dart:mirrors via:
*   ../demo_common.dart => package:angular2 => dart:mirrors
*
* You can disable this message by using the --enable-experimental-mirrors
* command-line flag.
*
* To learn what to do next, please visit:
*    http://dartlang.org/dart2js-reflection
****************************************************************
```
