### PR TITLE
chore(build): add a task to watch and render examples and e2e tests for production

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -240,36 +240,49 @@ gulp.task('build/checkCircularDependencies', function (done) {
   done();
 });
 
+function jsServeDev(gulp, gulpPlugins) {
+  return jsserve(gulp, gulpPlugins, {
+    path: CONFIG.dest.js.dev.es5,
+    port: 8000
+  });
+}
+
+function jsServeProd(gulp, gulpPlugins) {
+  return jsserve(gulp, gulpPlugins, {
+    path: CONFIG.dest.js.prod.es5,
+    port: 8001
+  });
+}
+
+function jsServeDartJs(gulp, gulpPlugins) {
+  return jsserve(gulp, gulpPlugins, {
+    path: CONFIG.dest.js.dart2js,
+    port: 8002
+  });
+}
+
 // ------------------
 // web servers
 gulp.task('serve.js.dev', ['build.js.dev'], function(neverDone) {
   watch('modules/**', { ignoreInitial: true }, '!broccoli.js.dev');
-
-  jsserve(gulp, gulpPlugins, {
-    path: CONFIG.dest.js.dev.es5,
-    port: 8000
-  })();
+  jsServeDev(gulp, gulpPlugins)();
 });
+
+gulp.task('serve.js.prod', jsServeProd(gulp, gulpPlugins));
 
 gulp.task('serve.e2e.dev', ['build.js.dev', 'build.js.cjs', 'build.css.material'], function(neverDone) {
   watch('modules/**', { ignoreInitial: true }, '!broccoli.js.dev');
   watch('modules/**', { ignoreInitial: true }, '!build.js.cjs');
-
-  jsserve(gulp, gulpPlugins, {
-    path: CONFIG.dest.js.dev.es5,
-    port: 8000
-  })();
+  jsServeDev(gulp, gulpPlugins)();
 });
 
-gulp.task('serve.js.prod', jsserve(gulp, gulpPlugins, {
-  path: CONFIG.dest.js.prod.es5,
-  port: 8001
-}));
+gulp.task('serve.e2e.prod', ['build.js.prod', 'build.js.cjs', 'build.css.material'], function(neverDone) {
+  watch('modules/**', { ignoreInitial: true }, '!broccoli.js.prod');
+  watch('modules/**', { ignoreInitial: true }, '!build.js.cjs');
+  jsServeProd(gulp, gulpPlugins)();
+});
 
-gulp.task('serve.js.dart2js', jsserve(gulp, gulpPlugins, {
-  path: CONFIG.dest.js.dart2js,
-  port: 8002
-}));
+gulp.task('serve.js.dart2js', jsServeDartJs(gulp, gulpPlugins));
 
 gulp.task('serve/examples.dart', pubserve(gulp, gulpPlugins, {
   command: DART_SDK.PUB,
@@ -668,6 +681,9 @@ gulp.task('!broccoli.js.dev', function() {
   return angularBuilder.rebuildBrowserDevTree();
 });
 
+gulp.task('!broccoli.js.prod', function() {
+  return angularBuilder.rebuildBrowserProdTree();
+});
 
 gulp.task('build.js.dev', ['build/clean.js'], function(done) {
   runSequence(

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -240,49 +240,47 @@ gulp.task('build/checkCircularDependencies', function (done) {
   done();
 });
 
-function jsServeDev(gulp, gulpPlugins) {
+function jsServeDev() {
   return jsserve(gulp, gulpPlugins, {
     path: CONFIG.dest.js.dev.es5,
     port: 8000
-  });
+  })();
 }
 
-function jsServeProd(gulp, gulpPlugins) {
+function jsServeProd() {
   return jsserve(gulp, gulpPlugins, {
     path: CONFIG.dest.js.prod.es5,
     port: 8001
-  });
+  })();
 }
 
-function jsServeDartJs(gulp, gulpPlugins) {
+function jsServeDartJs() {
   return jsserve(gulp, gulpPlugins, {
     path: CONFIG.dest.js.dart2js,
     port: 8002
-  });
+  })();
 }
 
 // ------------------
 // web servers
 gulp.task('serve.js.dev', ['build.js.dev'], function(neverDone) {
   watch('modules/**', { ignoreInitial: true }, '!broccoli.js.dev');
-  jsServeDev(gulp, gulpPlugins)();
+  jsServeDev();
 });
 
-gulp.task('serve.js.prod', jsServeProd(gulp, gulpPlugins));
+gulp.task('serve.js.prod', jsServeProd);
 
 gulp.task('serve.e2e.dev', ['build.js.dev', 'build.js.cjs', 'build.css.material'], function(neverDone) {
-  watch('modules/**', { ignoreInitial: true }, '!broccoli.js.dev');
-  watch('modules/**', { ignoreInitial: true }, '!build.js.cjs');
-  jsServeDev(gulp, gulpPlugins)();
+  watch('modules/**', { ignoreInitial: true }, ['!broccoli.js.dev', '!build.js.cjs']);
+  jsServeDev();
 });
 
 gulp.task('serve.e2e.prod', ['build.js.prod', 'build.js.cjs', 'build.css.material'], function(neverDone) {
-  watch('modules/**', { ignoreInitial: true }, '!broccoli.js.prod');
-  watch('modules/**', { ignoreInitial: true }, '!build.js.cjs');
-  jsServeProd(gulp, gulpPlugins)();
+  watch('modules/**', { ignoreInitial: true }, ['!broccoli.js.prod', '!build.js.cjs']);
+  jsServeProd();
 });
 
-gulp.task('serve.js.dart2js', jsServeDartJs(gulp, gulpPlugins));
+gulp.task('serve.js.dart2js', jsServeDartJs);
 
 gulp.task('serve/examples.dart', pubserve(gulp, gulpPlugins, {
   command: DART_SDK.PUB,
@@ -694,8 +692,8 @@ gulp.task('build.js.dev', ['build/clean.js'], function(done) {
   );
 });
 
-gulp.task('build.js.prod', ['build.tools'], function() {
-  return angularBuilder.rebuildBrowserProdTree();
+gulp.task('build.js.prod', ['build.tools'], function(done) {
+  runSequence('!broccoli.js.prod', sequenceComplete(done));
 });
 
 

--- a/protractor-js-prod.conf.js
+++ b/protractor-js-prod.conf.js
@@ -1,0 +1,3 @@
+var data = module.exports = require('./protractor-shared.js');
+var config = data.config;
+config.baseUrl = 'http://localhost:8001/';


### PR DESCRIPTION
You can now run `gulp serve.e2e.prod` to instantiate a task that watches
and compiles example and module files into the prod directory in dist
and then allows the code to be run via protractor.

Closes #2369
