### PR TITLE
fix(ci): remove non-existent gulp task from test_e2e_dart

### DIFF
--- a/scripts/ci/test_e2e_dart.sh
+++ b/scripts/ci/test_e2e_dart.sh
@@ -16,7 +16,6 @@ function killServer () {
 serverPid=$!
 
 ./node_modules/.bin/gulp build.css.material&
-./node_modules/.bin/gulp build.http.example&
 
 trap killServer EXIT
 


### PR DESCRIPTION
The `build.http.example` task was removed from gulp and replaced by another task, but a reference to the task was not removed from `test_e2e_dart.sh`.

Fixes #2509
