### PR TITLE
feat(router): allow configuring app base href via token

### DIFF
--- a/modules/angular2/router.ts
+++ b/modules/angular2/router.ts
@@ -12,7 +12,7 @@ export {RouterLink} from './src/router/router_link';
 export {RouteParams} from './src/router/instruction';
 export {RouteRegistry} from './src/router/route_registry';
 export {BrowserLocation} from './src/router/browser_location';
-export {Location} from './src/router/location';
+export {Location, appBaseHrefToken} from './src/router/location';
 export {Pipeline} from './src/router/pipeline';
 export * from './src/router/route_config_decorator';
 

--- a/modules/angular2/src/mock/browser_location_mock.ts
+++ b/modules/angular2/src/mock/browser_location_mock.ts
@@ -1,0 +1,43 @@
+import {proxy, SpyObject} from 'angular2/test_lib';
+import {IMPLEMENTS, BaseException} from 'angular2/src/facade/lang';
+import {EventEmitter, ObservableWrapper} from 'angular2/src/facade/async';
+import {List, ListWrapper} from 'angular2/src/facade/collection';
+import {BrowserLocation} from 'angular2/src/router/browser_location';
+
+@proxy
+@IMPLEMENTS(BrowserLocation)
+export class DummyBrowserLocation extends SpyObject {
+  internalBaseHref: string = '/';
+  internalPath: string = '/';
+  internalTitle: string = '';
+  urlChanges: List<string> = ListWrapper.create();
+  _subject: EventEmitter = new EventEmitter();
+  constructor() { super(); }
+
+  simulatePopState(url): void {
+    this.internalPath = url;
+    ObservableWrapper.callNext(this._subject, null);
+  }
+
+  path(): string { return this.internalPath; }
+
+  simulateUrlPop(pathname: string): void {
+    ObservableWrapper.callNext(this._subject, {'url': pathname});
+  }
+
+  pushState(ctx: any, title: string, url: string): void {
+    this.internalTitle = title;
+    this.internalPath = url;
+    ListWrapper.push(this.urlChanges, url);
+  }
+
+  forward(): void { throw new BaseException('Not implemented yet!'); }
+
+  back(): void { throw new BaseException('Not implemented yet!'); }
+
+  onPopState(fn): void { ObservableWrapper.subscribe(this._subject, fn); }
+
+  getBaseHref(): string { return this.internalBaseHref; }
+
+  noSuchMethod(m) { return super.noSuchMethod(m); }
+}

--- a/modules/angular2/src/router/location.ts
+++ b/modules/angular2/src/router/location.ts
@@ -1,16 +1,19 @@
 import {BrowserLocation} from './browser_location';
-import {StringWrapper} from 'angular2/src/facade/lang';
+import {StringWrapper, isPresent, CONST_EXPR} from 'angular2/src/facade/lang';
 import {EventEmitter, ObservableWrapper} from 'angular2/src/facade/async';
-import {Injectable} from 'angular2/di';
+import {OpaqueToken, Injectable, Optional, Inject} from 'angular2/di';
+
+export const appBaseHrefToken: OpaqueToken = CONST_EXPR(new OpaqueToken('locationHrefToken'));
 
 @Injectable()
 export class Location {
   private _subject: EventEmitter;
   private _baseHref: string;
 
-  constructor(public _browserLocation: BrowserLocation) {
+  constructor(public _browserLocation: BrowserLocation,
+              @Optional() @Inject(appBaseHrefToken) href?: string) {
     this._subject = new EventEmitter();
-    this._baseHref = stripIndexHtml(this._browserLocation.getBaseHref());
+    this._baseHref = stripIndexHtml(isPresent(href) ? href : this._browserLocation.getBaseHref());
     this._browserLocation.onPopState((_) => this._onPopState(_));
   }
 


### PR DESCRIPTION
Rather than relying on `<base href>`, you can bind a string to `appBaseHrefToken` to define the root URL for your app.
