### PR TITLE
fix(Compiler): fix text nodes after content tags

### DIFF
--- a/modules/angular2/src/render/dom/shadow_dom/shadow_dom_compile_step.ts
+++ b/modules/angular2/src/render/dom/shadow_dom/shadow_dom_compile_step.ts
@@ -47,13 +47,15 @@ export class ShadowDomCompileStep implements CompileStep {
     var selector = MapWrapper.get(attrs, 'select');
     selector = isPresent(selector) ? selector : '';
 
+    // The content tag should be replaced by a pair of marker tags (start & end).
+    // The end marker creation is delayed to keep the number of elements constant.
+    // Creating the end marker here would invalidate the parent's textNodeIndices for the subsequent
+    // text nodes
     var contentStart = DOM.createScriptTag('type', 'ng/contentStart');
     if (assertionsEnabled()) {
       DOM.setAttribute(contentStart, 'select', selector);
     }
-    var contentEnd = DOM.createScriptTag('type', 'ng/contentEnd');
     DOM.insertBefore(current.element, contentStart);
-    DOM.insertBefore(current.element, contentEnd);
     DOM.remove(current.element);
 
     current.element = contentStart;

--- a/modules/angular2/test/render/dom/shadow_dom/content_tag_spec.ts
+++ b/modules/angular2/test/render/dom/shadow_dom/content_tag_spec.ts
@@ -13,7 +13,6 @@ import {DOM} from 'angular2/src/dom/dom_adapter';
 import {Content} from 'angular2/src/render/dom/shadow_dom/content_tag';
 
 var _scriptStart = `<script start=""></script>`;
-var _scriptEnd = `<script end=""></script>`;
 
 export function main() {
   describe('Content', function() {
@@ -21,35 +20,32 @@ export function main() {
     var content;
 
     beforeEach(() => {
-      parent = el(`<div>${_scriptStart}${_scriptEnd}`);
-      content = DOM.firstChild(parent);
+      parent = el(`<div>${_scriptStart}</div>`);
+      let contentStartMarker = DOM.firstChild(parent);
+      content = new Content(contentStartMarker, '');
     });
 
     it("should insert the nodes", () => {
-      var c = new Content(content, '');
-      c.init(null);
-      c.insert([el("<a></a>"), el("<b></b>")])
+      content.init(null);
+      content.insert([el("<a>A</a>"), el("<b>B</b>")]);
 
-          expect(DOM.getInnerHTML(parent))
-              .toEqual(`${_scriptStart}<a></a><b></b>${_scriptEnd}`);
+      expect(parent).toHaveText('AB');
     });
 
     it("should remove the nodes from the previous insertion", () => {
-      var c = new Content(content, '');
-      c.init(null);
-      c.insert([el("<a></a>")]);
-      c.insert([el("<b></b>")]);
+      content.init(null);
+      content.insert([el("<a>A</a>")]);
+      content.insert([el("<b>B</b>")]);
 
-      expect(DOM.getInnerHTML(parent)).toEqual(`${_scriptStart}<b></b>${_scriptEnd}`);
+      expect(parent).toHaveText('B');
     });
 
-    it("should insert empty list", () => {
-      var c = new Content(content, '');
-      c.init(null);
-      c.insert([el("<a></a>")]);
-      c.insert([]);
+    it("should clear nodes on inserting an empty list", () => {
+      content.init(null);
+      content.insert([el("<a>A</a>")]);
+      content.insert([]);
 
-      expect(DOM.getInnerHTML(parent)).toEqual(`${_scriptStart}${_scriptEnd}`);
+      expect(parent).toHaveText('');
     });
   });
 }

--- a/modules/angular2/test/render/dom/shadow_dom_emulation_integration_spec.ts
+++ b/modules/angular2/test/render/dom/shadow_dom_emulation_integration_spec.ts
@@ -60,10 +60,9 @@ export function main() {
     }
 
     StringMapWrapper.forEach(strategies, (strategyBinding, name) => {
-
-      beforeEachBindings(() => { return [strategyBinding, DomTestbed]; });
-
       describe(`${name} shadow dom strategy`, () => {
+        beforeEachBindings(() => { return [strategyBinding, DomTestbed]; });
+
         // GH-2095 - https://github.com/angular/angular/issues/2095
         it('should support text nodes after content tags',
            inject([DomTestbed, AsyncTestCompleter], (tb, async) => {

--- a/modules/angular2/test/render/dom/shadow_dom_emulation_integration_spec.ts
+++ b/modules/angular2/test/render/dom/shadow_dom_emulation_integration_spec.ts
@@ -10,7 +10,7 @@ import {
   it,
   xit,
   beforeEachBindings,
-  SpyObject,
+  SpyObject
 } from 'angular2/test_lib';
 
 import {bind} from 'angular2/di';
@@ -33,6 +33,10 @@ import {StyleUrlResolver} from 'angular2/src/render/dom/shadow_dom/style_url_res
 import {StyleInliner} from 'angular2/src/render/dom/shadow_dom/style_inliner';
 
 import {DomTestbed} from './dom_testbed';
+
+import {Injectable} from 'angular2/di';
+
+import {Component, View} from 'angular2/annotations';
 
 export function main() {
   describe('ShadowDom integration tests', function() {
@@ -60,6 +64,26 @@ export function main() {
       beforeEachBindings(() => { return [strategyBinding, DomTestbed]; });
 
       describe(`${name} shadow dom strategy`, () => {
+        // GH-2095 - https://github.com/angular/angular/issues/2095
+        it('should support text nodes after content tags',
+           inject([DomTestbed, AsyncTestCompleter], (tb, async) => {
+             tb.compileAll([
+                 simple,
+                 new ViewDefinition({
+                   componentId: 'simple',
+                   template: '<content></content><p>P,</p>{{a}}',
+                   directives: []
+                 })
+               ])
+                 .then((protoViewDtos) => {
+                   var rootView = tb.createRootView(protoViewDtos[0]);
+                   var cmpView = tb.createComponentView(rootView.viewRef, 0, protoViewDtos[1]);
+
+                   tb.renderer.setText(cmpView.viewRef, 0, 'text');
+                   expect(tb.rootEl).toHaveText('P,text');
+                   async.done();
+                 });
+           }));
 
         it('should support simple components',
            inject([AsyncTestCompleter, DomTestbed], (async, tb) => {
@@ -493,3 +517,9 @@ var tabTemplate = new ViewDefinition({
   template: '<div><div *auto="cond">TAB(<content></content>)</div></div>',
   directives: [autoViewportDirective]
 });
+
+@Component({selector: 'textAfterContent'})
+@View({template: `<content></content><p>P,</p>{{ 'text' }}`})
+@Injectable()
+class TextAfterContentTag {
+}

--- a/modules/angular2/test/test_lib/test_component_builder_spec.ts
+++ b/modules/angular2/test/test_lib/test_component_builder_spec.ts
@@ -28,7 +28,7 @@ import * as viewAnn from 'angular2/src/core/annotations_impl/view';
 import {NgIf} from 'angular2/src/directives/ng_if';
 
 @Component({selector: 'child-comp'})
-@View({template: `<snap>Original {{childBinding}}</span>`, directives: []})
+@View({template: `<span>Original {{childBinding}}</span>`, directives: []})
 @Injectable()
 class ChildComp {
   childBinding: string;


### PR DESCRIPTION
Before 

```
<content></content>
{{ }} // text node, index = 1

 // compiles to

<script start></script> // a single <content> generates 2 <script> -> mess with offset
<script end></script>
{{ }} // text node, index = 1 the actual index is 2
```

After

```
<content></content>
{{ }} // text node, index = 1

 // compiles to

<script start></script> // the end script marker is generated lazily when needed
{{ }} // text node, index = 1
```

/cc @vsavkin @yjbanov 
