### PR TITLE
feat: only check modified files for correct formatting.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var autoprefixer = require('gulp-autoprefixer');
+var gutil = require('gulp-util');
 var del = require('del');
 var format = require('gulp-clang-format');
 var exec = require('child_process').exec;
@@ -204,14 +205,14 @@ function doCheckFormat() {
 
 gulp.task('check-format', function() {
   return doCheckFormat().on('warning', function(e) {
-    console.log("NOTE: this will be promoted to an ERROR in the continuous build");
+    gutil.log("NOTE: this will be promoted to an ERROR in the continuous build");
   });
 });
 
 gulp.task('enforce-format', function() {
   return doCheckFormat().on('warning', function(e) {
-    console.log("ERROR: You forgot to run clang-format on your change.");
-    console.log("See https://github.com/angular/angular/blob/master/DEVELOPER.md#formatting");
+    gutil.log("ERROR: You forgot to run clang-format on your change.");
+    gutil.log("See https://github.com/angular/angular/blob/master/DEVELOPER.md#formatting");
     process.exit(1);
   });
 });
@@ -229,7 +230,7 @@ gulp.task('build/checkCircularDependencies', function (done) {
   });
   var circularDependencies = dependencyObject.circular().getArray();
   if (circularDependencies.length > 0) {
-    console.log(circularDependencies);
+    gutil.log(circularDependencies);
     process.exit(1);
   }
   done();
@@ -290,10 +291,10 @@ var webserver = require('gulp-webserver');
 gulp.task('docs/bower', function() {
   var bowerTask = bower.commands.install(undefined, undefined, { cwd: 'docs' });
   bowerTask.on('log', function (result) {
-    console.log('bower:', result.id, result.data.endpoint.name);
+    gutil.log('bower:', result.id, result.data.endpoint.name);
   });
   bowerTask.on('error', function(error) {
-    console.log(error);
+    gutil.log(error);
   });
   return bowerTask;
 });
@@ -309,8 +310,8 @@ function createDocsTasks(publicBuild) {
       var dgeni = new Dgeni([require(dgeniPackage)]);
       return dgeni.generate();
     } catch(x) {
-      console.log(x);
-      console.log(x.stack);
+      gutil.log(x);
+      gutil.log(x.stack);
       throw x;
     }
   });
@@ -350,8 +351,8 @@ gulp.task('docs/angular.io', function() {
     var dgeni = new Dgeni([require('./docs/angular.io-package')]);
     return dgeni.generate();
   } catch(x) {
-    console.log(x);
-    console.log(x.stack);
+    gutil.log(x);
+    gutil.log(x.stack);
     throw x;
   }
 });
@@ -695,7 +696,7 @@ gulp.task('!build.js.cjs', function() {
   return angularBuilder.rebuildNodeTree().then(function() {
     if (firstBuildJsCjs) {
       firstBuildJsCjs = false;
-      console.log('creating node_modules symlink hack');
+      gutil.log('creating node_modules symlink hack');
       // linknodemodules is all sync
       linknodemodules(gulp, gulpPlugins, {
         dir: CONFIG.dest.js.cjs

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,21 +1,20 @@
 'use strict';
 
 var autoprefixer = require('gulp-autoprefixer');
-var gutil = require('gulp-util');
+var childProcess = require('child_process');
 var del = require('del');
 var format = require('gulp-clang-format');
-var exec = require('child_process').exec;
-var fork = require('child_process').fork;
 var gulp = require('gulp');
 var gulpPlugins = require('gulp-load-plugins')();
-var sass = require('gulp-sass');
-var shell = require('gulp-shell');
-var spawn = require('child_process').spawn;
-var runSequence = require('run-sequence');
+var gutil = require('gulp-util');
 var madge = require('madge');
 var merge = require('merge');
 var merge2 = require('merge2');
+var micromatch = require('micromatch');
 var path = require('path');
+var runSequence = require('run-sequence');
+var sass = require('gulp-sass');
+var shell = require('gulp-shell');
 
 var watch = require('./tools/build/watch');
 
@@ -86,7 +85,7 @@ var treatTestErrorsAsFatal = true;
 
 function runJasmineTests(globs, done) {
   var args = ['--'].concat(globs);
-  fork('./tools/traceur-jasmine', args, {
+  childProcess.fork('./tools/traceur-jasmine', args, {
     stdio: 'inherit'
   }).on('close', function jasmineCloseHandler(exitCode) {
     if (exitCode && treatTestErrorsAsFatal) {
@@ -198,23 +197,47 @@ gulp.task('build/pubbuild.dart', pubbuild(gulp, gulpPlugins, {
 // ------------
 // formatting
 
-function doCheckFormat() {
-  return gulp.src(['modules/**/*.ts', 'tools/**/*.ts', '!**/typings/**/*.d.ts'])
-      .pipe(format.checkFormat('file'));
-}
+var FORMAT_FILES_PATTERN = ['modules/**/*.ts', 'tools/**/*.ts', '!**/typings/**/*.d.ts'];
+var FORMAT_FILES_FILTER = micromatch.filter(FORMAT_FILES_PATTERN);
 
 gulp.task('check-format', function() {
-  return doCheckFormat().on('warning', function(e) {
-    gutil.log("NOTE: this will be promoted to an ERROR in the continuous build");
-  });
+  function runGit(cmd, timeout) {
+    timeout = timeout || 200;
+    return childProcess.execSync('/usr/bin/env git ' + cmd, {timemout: timeout, encoding: 'utf-8'});
+  }
+  var t = Date.now();
+  var modifiedFiles;
+  try {
+    // Parse which remote is angular/angular. This is a bit messy and could fail, but better than
+    // making a remote request on each check-format run.
+    var mainRepoRemoteName =
+        runGit('remote --verbose').match(/^([a-zA-Z]+) .*angular\/angular$/m)[1];
+
+    modifiedFiles = runGit('diff --name-only ' + mainRepoRemoteName + '/master');
+    modifiedFiles = modifiedFiles.split('\n').filter(FORMAT_FILES_FILTER);
+  } catch (e) {
+    gutil.log('Could not find master reference for github.com/angular/angular repository.');
+    gutil.log('You must have a remote pointing to angular/angular');
+    gutil.log(e);
+    process.exit(1);
+  }
+  gutil.log('Found modified files in', Date.now() - t, 'ms');
+  return gulp.src(modifiedFiles)
+      .pipe(format.checkFormat('file'))
+      .on('warning', function(e) {
+        gutil.log("NOTE: this will be promoted to an ERROR in the continuous build");
+      });
 });
 
-gulp.task('enforce-format', function() {
-  return doCheckFormat().on('warning', function(e) {
-    gutil.log("ERROR: You forgot to run clang-format on your change.");
-    gutil.log("See https://github.com/angular/angular/blob/master/DEVELOPER.md#formatting");
-    process.exit(1);
-  });
+gulp.task('enforce-format-all', function() {
+  // NB: Keep pattern in sync with check-format code above.
+  return gulp.src(FORMAT_FILES_PATTERN)
+      .pipe(format.checkFormat('file'))
+      .on('warning', function(e) {
+        gutil.log("ERROR: You forgot to run clang-format on your change.");
+        gutil.log("See https://github.com/angular/angular/blob/master/DEVELOPER.md#formatting");
+        process.exit(1);
+      });
 });
 
 // ------------
@@ -365,7 +388,7 @@ function runKarma(configFile, done) {
   var cmd = process.platform === 'win32' ? 'node_modules\\.bin\\karma run ' :
                                            'node node_modules/.bin/karma run ';
   cmd += configFile;
-  exec(cmd, function(e, stdout) {
+  childProcess.exec(cmd, function(e, stdout) {
     // ignore errors, we don't want to fail the build in the interactive (non-ci) mode
     // karma server will print all test failures
     done();
@@ -849,7 +872,7 @@ gulp.task('!build/change_detect.dart', function(done) {
 
   var dartStream = fs.createWriteStream(path.join(destDir, 'change_detector_classes.dart'));
   var genMain = path.join(srcDir, 'gen_change_detectors.dart');
-  var proc = spawn(DART_SDK.VM, [genMain], { stdio:['ignore', 'pipe', 'inherit'] });
+  var proc = childProcess.spawn(DART_SDK.VM, [genMain], { stdio:['ignore', 'pipe', 'inherit'] });
   proc.on('error', function(code) {
     done(new Error('Failed while generating change detector classes. Please run manually: ' +
                    DART_SDK.VM + ' ' + dartArgs.join(' ')));

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -3945,151 +3945,6 @@
         "clang-format": {
           "version": "1.0.19"
         },
-        "gulp-util": {
-          "version": "3.0.5",
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0"
-            },
-            "array-uniq": {
-              "version": "1.0.2"
-            },
-            "beeper": {
-              "version": "1.1.0"
-            },
-            "chalk": {
-              "version": "1.0.0",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.0.1"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3"
-                },
-                "has-ansi": {
-                  "version": "1.0.3",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1"
-                    },
-                    "get-stdin": {
-                      "version": "4.0.1"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "1.3.1"
-                }
-              }
-            },
-            "dateformat": {
-              "version": "1.0.11",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1"
-                },
-                "meow": {
-                  "version": "3.1.0",
-                  "dependencies": {
-                    "camelcase-keys": {
-                      "version": "1.0.0",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.1.0"
-                        },
-                        "map-obj": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._reescape": {
-              "version": "3.0.0"
-            },
-            "lodash._reevaluate": {
-              "version": "3.0.0"
-            },
-            "lodash._reinterpolate": {
-              "version": "3.0.0"
-            },
-            "lodash.template": {
-              "version": "3.6.1",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.1"
-                },
-                "lodash._basetostring": {
-                  "version": "3.0.0"
-                },
-                "lodash._basevalues": {
-                  "version": "3.0.0"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.9"
-                },
-                "lodash.escape": {
-                  "version": "3.0.0"
-                },
-                "lodash.keys": {
-                  "version": "3.1.1",
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.0"
-                    },
-                    "lodash.isarguments": {
-                      "version": "3.0.3"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.3"
-                    }
-                  }
-                },
-                "lodash.restparam": {
-                  "version": "3.6.1"
-                },
-                "lodash.templatesettings": {
-                  "version": "3.1.0"
-                }
-              }
-            },
-            "multipipe": {
-              "version": "0.1.2",
-              "dependencies": {
-                "duplexer2": {
-                  "version": "0.0.2",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1"
-                        },
-                        "isarray": {
-                          "version": "0.0.1"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.0.0"
-            },
-            "replace-ext": {
-              "version": "0.0.1"
-            }
-          }
-        },
         "pkginfo": {
           "version": "0.3.0"
         },
@@ -6338,151 +6193,6 @@
         "deap": {
           "version": "1.0.0"
         },
-        "gulp-util": {
-          "version": "3.0.5",
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0"
-            },
-            "array-uniq": {
-              "version": "1.0.2"
-            },
-            "beeper": {
-              "version": "1.1.0"
-            },
-            "chalk": {
-              "version": "1.0.0",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.0.1"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3"
-                },
-                "has-ansi": {
-                  "version": "1.0.3",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1"
-                    },
-                    "get-stdin": {
-                      "version": "4.0.1"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "1.3.1"
-                }
-              }
-            },
-            "dateformat": {
-              "version": "1.0.11",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1"
-                },
-                "meow": {
-                  "version": "3.1.0",
-                  "dependencies": {
-                    "camelcase-keys": {
-                      "version": "1.0.0",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.1.0"
-                        },
-                        "map-obj": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._reescape": {
-              "version": "3.0.0"
-            },
-            "lodash._reevaluate": {
-              "version": "3.0.0"
-            },
-            "lodash._reinterpolate": {
-              "version": "3.0.0"
-            },
-            "lodash.template": {
-              "version": "3.6.1",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.1"
-                },
-                "lodash._basetostring": {
-                  "version": "3.0.0"
-                },
-                "lodash._basevalues": {
-                  "version": "3.0.0"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.9"
-                },
-                "lodash.escape": {
-                  "version": "3.0.0"
-                },
-                "lodash.keys": {
-                  "version": "3.1.1",
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.0"
-                    },
-                    "lodash.isarguments": {
-                      "version": "3.0.3"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.3"
-                    }
-                  }
-                },
-                "lodash.restparam": {
-                  "version": "3.6.1"
-                },
-                "lodash.templatesettings": {
-                  "version": "3.1.0"
-                }
-              }
-            },
-            "multipipe": {
-              "version": "0.1.2",
-              "dependencies": {
-                "duplexer2": {
-                  "version": "0.0.2",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1"
-                        },
-                        "isarray": {
-                          "version": "0.0.1"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.1.1"
-            },
-            "replace-ext": {
-              "version": "0.0.1"
-            }
-          }
-        },
         "uglify-js": {
           "version": "2.4.19",
           "dependencies": {
@@ -6531,6 +6241,151 @@
               }
             }
           }
+        }
+      }
+    },
+    "gulp-util": {
+      "version": "3.0.5",
+      "dependencies": {
+        "array-differ": {
+          "version": "1.0.0"
+        },
+        "array-uniq": {
+          "version": "1.0.2"
+        },
+        "beeper": {
+          "version": "1.1.0"
+        },
+        "chalk": {
+          "version": "1.0.0",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3"
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1"
+                },
+                "get-stdin": {
+                  "version": "4.0.1"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1"
+            }
+          }
+        },
+        "dateformat": {
+          "version": "1.0.11",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1"
+            },
+            "meow": {
+              "version": "3.1.0",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "lodash._reescape": {
+          "version": "3.0.0"
+        },
+        "lodash._reevaluate": {
+          "version": "3.0.0"
+        },
+        "lodash._reinterpolate": {
+          "version": "3.0.0"
+        },
+        "lodash.template": {
+          "version": "3.6.1",
+          "dependencies": {
+            "lodash._basecopy": {
+              "version": "3.0.1"
+            },
+            "lodash._basetostring": {
+              "version": "3.0.0"
+            },
+            "lodash._basevalues": {
+              "version": "3.0.0"
+            },
+            "lodash._isiterateecall": {
+              "version": "3.0.9"
+            },
+            "lodash.escape": {
+              "version": "3.0.0"
+            },
+            "lodash.keys": {
+              "version": "3.1.1",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.0"
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.3"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.3"
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1"
+            },
+            "lodash.templatesettings": {
+              "version": "3.1.0"
+            }
+          }
+        },
+        "multipipe": {
+          "version": "0.1.2",
+          "dependencies": {
+            "duplexer2": {
+              "version": "0.0.2",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1"
+                    },
+                    "isarray": {
+                      "version": "0.0.1"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31"
+                    },
+                    "inherits": {
+                      "version": "2.0.1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.1.1"
+        },
+        "replace-ext": {
+          "version": "0.0.1"
         }
       }
     },

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -8391,6 +8391,123 @@
     "merge2": {
       "version": "0.3.5"
     },
+    "micromatch": {
+      "version": "2.1.6",
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.0.1",
+          "dependencies": {
+            "array-slice": {
+              "version": "0.2.3"
+            }
+          }
+        },
+        "braces": {
+          "version": "1.8.0",
+          "dependencies": {
+            "expand-range": {
+              "version": "1.8.1",
+              "dependencies": {
+                "fill-range": {
+                  "version": "2.2.2",
+                  "dependencies": {
+                    "is-number": {
+                      "version": "1.1.2"
+                    },
+                    "isobject": {
+                      "version": "1.0.0"
+                    },
+                    "randomatic": {
+                      "version": "1.1.0"
+                    },
+                    "repeat-string": {
+                      "version": "1.5.2"
+                    }
+                  }
+                }
+              }
+            },
+            "preserve": {
+              "version": "0.2.0"
+            },
+            "repeat-element": {
+              "version": "1.1.2"
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1"
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.1"
+        },
+        "filename-regex": {
+          "version": "2.0.0"
+        },
+        "is-glob": {
+          "version": "1.1.3"
+        },
+        "kind-of": {
+          "version": "1.1.0"
+        },
+        "object.omit": {
+          "version": "0.2.1",
+          "dependencies": {
+            "for-own": {
+              "version": "0.1.3",
+              "dependencies": {
+                "for-in": {
+                  "version": "0.1.4"
+                }
+              }
+            },
+            "isobject": {
+              "version": "0.2.0"
+            }
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.2",
+          "dependencies": {
+            "glob-base": {
+              "version": "0.2.0",
+              "dependencies": {
+                "glob-parent": {
+                  "version": "1.2.0"
+                }
+              }
+            },
+            "is-dotfile": {
+              "version": "1.0.1"
+            },
+            "is-extglob": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "regex-cache": {
+          "version": "0.4.2",
+          "dependencies": {
+            "is-equal-shallow": {
+              "version": "0.1.2",
+              "dependencies": {
+                "is-primitive": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "is-primitive": {
+              "version": "2.0.0"
+            }
+          }
+        }
+      }
+    },
     "minimatch": {
       "version": "2.0.7",
       "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12973,6 +12973,185 @@
       "from": "https://registry.npmjs.org/merge2/-/merge2-0.3.5.tgz",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-0.3.5.tgz"
     },
+    "micromatch": {
+      "version": "2.1.6",
+      "from": "micromatch@*",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.0.1",
+          "from": "arr-diff@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
+          "dependencies": {
+            "array-slice": {
+              "version": "0.2.3",
+              "from": "array-slice@>=0.2.2 <0.3.0",
+              "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+            }
+          }
+        },
+        "braces": {
+          "version": "1.8.0",
+          "from": "braces@>=1.8.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
+          "dependencies": {
+            "expand-range": {
+              "version": "1.8.1",
+              "from": "expand-range@>=1.8.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+              "dependencies": {
+                "fill-range": {
+                  "version": "2.2.2",
+                  "from": "fill-range@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                  "dependencies": {
+                    "is-number": {
+                      "version": "1.1.2",
+                      "from": "is-number@>=1.1.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
+                    },
+                    "isobject": {
+                      "version": "1.0.0",
+                      "from": "isobject@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz"
+                    },
+                    "randomatic": {
+                      "version": "1.1.0",
+                      "from": "randomatic@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
+                    },
+                    "repeat-string": {
+                      "version": "1.5.2",
+                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "preserve": {
+              "version": "0.2.0",
+              "from": "preserve@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+            },
+            "repeat-element": {
+              "version": "1.1.2",
+              "from": "repeat-element@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.1.3 <3.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.1",
+          "from": "expand-brackets@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
+        },
+        "filename-regex": {
+          "version": "2.0.0",
+          "from": "filename-regex@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+        },
+        "is-glob": {
+          "version": "1.1.3",
+          "from": "is-glob@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "from": "kind-of@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+        },
+        "object.omit": {
+          "version": "0.2.1",
+          "from": "object.omit@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
+          "dependencies": {
+            "for-own": {
+              "version": "0.1.3",
+              "from": "for-own@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+              "dependencies": {
+                "for-in": {
+                  "version": "0.1.4",
+                  "from": "for-in@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                }
+              }
+            },
+            "isobject": {
+              "version": "0.2.0",
+              "from": "isobject@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
+            }
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.2",
+          "from": "parse-glob@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
+          "dependencies": {
+            "glob-base": {
+              "version": "0.2.0",
+              "from": "glob-base@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
+              "dependencies": {
+                "glob-parent": {
+                  "version": "1.2.0",
+                  "from": "glob-parent@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
+                }
+              }
+            },
+            "is-dotfile": {
+              "version": "1.0.1",
+              "from": "is-dotfile@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "from": "is-extglob@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+            }
+          }
+        },
+        "regex-cache": {
+          "version": "0.4.2",
+          "from": "regex-cache@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+          "dependencies": {
+            "is-equal-shallow": {
+              "version": "0.1.2",
+              "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
+              "dependencies": {
+                "is-primitive": {
+                  "version": "1.0.0",
+                  "from": "is-primitive@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz"
+                }
+              }
+            },
+            "is-primitive": {
+              "version": "2.0.0",
+              "from": "is-primitive@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
     "minimatch": {
       "version": "2.0.7",
       "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.7.tgz",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2298,59 +2298,59 @@
       "dependencies": {
         "anymatch": {
           "version": "1.3.0",
-          "from": "anymatch@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
           "dependencies": {
             "micromatch": {
               "version": "2.1.6",
-              "from": "micromatch@>=2.1.5 <3.0.0",
+              "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
               "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
               "dependencies": {
                 "arr-diff": {
                   "version": "1.0.1",
-                  "from": "arr-diff@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
                   "dependencies": {
                     "array-slice": {
                       "version": "0.2.3",
-                      "from": "array-slice@>=0.2.2 <0.3.0",
+                      "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
                       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
                     }
                   }
                 },
                 "braces": {
                   "version": "1.8.0",
-                  "from": "braces@>=1.8.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                   "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
                   "dependencies": {
                     "expand-range": {
                       "version": "1.8.1",
-                      "from": "expand-range@>=1.8.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                       "dependencies": {
                         "fill-range": {
                           "version": "2.2.2",
-                          "from": "fill-range@>=2.1.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
                           "dependencies": {
                             "is-number": {
                               "version": "1.1.2",
-                              "from": "is-number@>=1.1.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
                             },
                             "isobject": {
                               "version": "1.0.0",
-                              "from": "isobject@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz"
                             },
                             "randomatic": {
                               "version": "1.1.0",
-                              "from": "randomatic@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
@@ -2359,109 +2359,109 @@
                     },
                     "preserve": {
                       "version": "0.2.0",
-                      "from": "preserve@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                     },
                     "repeat-element": {
                       "version": "1.1.2",
-                      "from": "repeat-element@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                     }
                   }
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.1.3 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "expand-brackets": {
                   "version": "0.1.1",
-                  "from": "expand-brackets@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
                 },
                 "filename-regex": {
                   "version": "2.0.0",
-                  "from": "filename-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                 },
                 "kind-of": {
                   "version": "1.1.0",
-                  "from": "kind-of@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
                 },
                 "object.omit": {
                   "version": "0.2.1",
-                  "from": "object.omit@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
                   "dependencies": {
                     "for-own": {
                       "version": "0.1.3",
-                      "from": "for-own@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                       "dependencies": {
                         "for-in": {
                           "version": "0.1.4",
-                          "from": "for-in@>=0.1.4 <0.2.0",
+                          "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                         }
                       }
                     },
                     "isobject": {
                       "version": "0.2.0",
-                      "from": "isobject@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
                     }
                   }
                 },
                 "parse-glob": {
                   "version": "3.0.2",
-                  "from": "parse-glob@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
                   "dependencies": {
                     "glob-base": {
                       "version": "0.2.0",
-                      "from": "glob-base@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
                     },
                     "is-dotfile": {
                       "version": "1.0.1",
-                      "from": "is-dotfile@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.1.tgz"
                     },
                     "is-extglob": {
                       "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                     }
                   }
                 },
                 "regex-cache": {
                   "version": "0.4.2",
-                  "from": "regex-cache@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                   "dependencies": {
                     "is-equal-shallow": {
                       "version": "0.1.2",
-                      "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
                       "dependencies": {
                         "is-primitive": {
                           "version": "1.0.0",
-                          "from": "is-primitive@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz"
                         }
                       }
                     },
                     "is-primitive": {
                       "version": "2.0.0",
-                      "from": "is-primitive@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                     }
                   }
@@ -2472,86 +2472,86 @@
         },
         "arrify": {
           "version": "1.0.0",
-          "from": "arrify@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
         },
         "async-each": {
           "version": "0.1.6",
-          "from": "async-each@>=0.1.5 <0.2.0",
+          "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
           "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
         },
         "glob-parent": {
           "version": "1.2.0",
-          "from": "glob-parent@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
         },
         "is-binary-path": {
           "version": "1.0.1",
-          "from": "is-binary-path@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
           "dependencies": {
             "binary-extensions": {
               "version": "1.3.1",
-              "from": "binary-extensions@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
             }
           }
         },
         "is-glob": {
           "version": "1.1.3",
-          "from": "is-glob@>=1.1.3 <2.0.0",
+          "from": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
         },
         "readdirp": {
           "version": "1.3.0",
-          "from": "readdirp@>=1.3.0 <2.0.0",
+          "from": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "minimatch": {
               "version": "0.2.14",
-              "from": "minimatch@>=0.2.12 <0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.6.4",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.26-2 <1.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -2560,12 +2560,12 @@
         },
         "fsevents": {
           "version": "0.3.6",
-          "from": "fsevents@>=0.3.1 <0.4.0",
+          "from": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
           "dependencies": {
             "nan": {
               "version": "1.8.4",
-              "from": "nan@>=1.8.0 <2.0.0",
+              "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
               "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
             }
           }
@@ -6096,234 +6096,8 @@
       "dependencies": {
         "clang-format": {
           "version": "1.0.19",
-          "from": "clang-format@1.0.19"
-        },
-        "gulp-util": {
-          "version": "3.0.5",
-          "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.5.tgz",
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-            },
-            "array-uniq": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-            },
-            "beeper": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
-            },
-            "chalk": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                },
-                "has-ansi": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                    },
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
-                }
-              }
-            },
-            "dateformat": {
-              "version": "1.0.11",
-              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
-              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                },
-                "meow": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
-                  "dependencies": {
-                    "camelcase-keys": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
-                        },
-                        "map-obj": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._reescape": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
-            },
-            "lodash._reevaluate": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
-            },
-            "lodash._reinterpolate": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
-            },
-            "lodash.template": {
-              "version": "3.6.1",
-              "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.1.tgz",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-                },
-                "lodash._basetostring": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
-                },
-                "lodash._basevalues": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.9",
-                  "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-                },
-                "lodash.escape": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
-                },
-                "lodash.keys": {
-                  "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.0",
-                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
-                    },
-                    "lodash.isarguments": {
-                      "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
-                    }
-                  }
-                },
-                "lodash.restparam": {
-                  "version": "3.6.1",
-                  "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-                },
-                "lodash.templatesettings": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
-                }
-              }
-            },
-            "multipipe": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-              "dependencies": {
-                "duplexer2": {
-                  "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-            }
-          }
+          "from": "clang-format@1.0.19",
+          "resolved": "file:../src/npm-clang-format"
         },
         "pkginfo": {
           "version": "0.3.0",
@@ -9809,233 +9583,6 @@
           "from": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz"
         },
-        "gulp-util": {
-          "version": "3.0.5",
-          "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.5.tgz",
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-            },
-            "array-uniq": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-            },
-            "beeper": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
-            },
-            "chalk": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                },
-                "has-ansi": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                    },
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
-                }
-              }
-            },
-            "dateformat": {
-              "version": "1.0.11",
-              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
-              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                },
-                "meow": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
-                  "dependencies": {
-                    "camelcase-keys": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
-                        },
-                        "map-obj": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._reescape": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
-            },
-            "lodash._reevaluate": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
-            },
-            "lodash._reinterpolate": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
-            },
-            "lodash.template": {
-              "version": "3.6.1",
-              "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.1.tgz",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-                },
-                "lodash._basetostring": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
-                },
-                "lodash._basevalues": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.9",
-                  "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-                },
-                "lodash.escape": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
-                },
-                "lodash.keys": {
-                  "version": "3.1.1",
-                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.0",
-                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
-                    },
-                    "lodash.isarguments": {
-                      "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
-                    }
-                  }
-                },
-                "lodash.restparam": {
-                  "version": "3.6.1",
-                  "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-                },
-                "lodash.templatesettings": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
-                }
-              }
-            },
-            "multipipe": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-              "dependencies": {
-                "duplexer2": {
-                  "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.13",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.1.1",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-            }
-          }
-        },
         "uglify-js": {
           "version": "2.4.19",
           "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.19.tgz",
@@ -10110,6 +9657,233 @@
               }
             }
           }
+        }
+      }
+    },
+    "gulp-util": {
+      "version": "3.0.5",
+      "from": "gulp-util@*",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.5.tgz",
+      "dependencies": {
+        "array-differ": {
+          "version": "1.0.0",
+          "from": "array-differ@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+        },
+        "array-uniq": {
+          "version": "1.0.2",
+          "from": "array-uniq@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+        },
+        "beeper": {
+          "version": "1.1.0",
+          "from": "beeper@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
+        },
+        "chalk": {
+          "version": "1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+            }
+          }
+        },
+        "dateformat": {
+          "version": "1.0.11",
+          "from": "dateformat@>=1.0.11 <2.0.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@*",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "meow": {
+              "version": "3.1.0",
+              "from": "meow@*",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "lodash._reescape": {
+          "version": "3.0.0",
+          "from": "lodash._reescape@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+        },
+        "lodash._reevaluate": {
+          "version": "3.0.0",
+          "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+        },
+        "lodash._reinterpolate": {
+          "version": "3.0.0",
+          "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+        },
+        "lodash.template": {
+          "version": "3.6.1",
+          "from": "lodash.template@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.1.tgz",
+          "dependencies": {
+            "lodash._basecopy": {
+              "version": "3.0.1",
+              "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+            },
+            "lodash._basetostring": {
+              "version": "3.0.0",
+              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+            },
+            "lodash._basevalues": {
+              "version": "3.0.0",
+              "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+            },
+            "lodash._isiterateecall": {
+              "version": "3.0.9",
+              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+            },
+            "lodash.escape": {
+              "version": "3.0.0",
+              "from": "lodash.escape@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+            },
+            "lodash.keys": {
+              "version": "3.1.1",
+              "from": "lodash.keys@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.0",
+                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.3",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.3",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "from": "lodash.restparam@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+            },
+            "lodash.templatesettings": {
+              "version": "3.1.0",
+              "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+            }
+          }
+        },
+        "multipipe": {
+          "version": "0.1.2",
+          "from": "multipipe@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+          "dependencies": {
+            "duplexer2": {
+              "version": "0.0.2",
+              "from": "duplexer2@0.0.2",
+              "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "from": "replace-ext@0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
         }
       }
     },
@@ -10925,7 +10699,7 @@
               "dependencies": {
                 "camelcase-keys": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
@@ -13557,7 +13331,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -14134,29 +13908,29 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.2",
-          "from": "source-map@>=0.4.2 <0.5.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
           "dependencies": {
             "amdefine": {
               "version": "0.1.1",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
             }
           }
         },
         "source-map-support": {
           "version": "0.3.1",
-          "from": "source-map-support@>=0.3.1 <0.4.0",
+          "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.1.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
-              "from": "source-map@0.1.32",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "0.1.1",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
                 }
               }
@@ -14165,7 +13939,7 @@
         },
         "typescript": {
           "version": "1.5.0",
-          "from": "alexeagle/TypeScript#error_is_class",
+          "from": "git://github.com/alexeagle/TypeScript.git#be9a7edff73ac2592e508732c771c85357041385",
           "resolved": "git://github.com/alexeagle/TypeScript.git#be9a7edff73ac2592e508732c771c85357041385"
         }
       }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "gulp-traceur": "0.17.*",
     "gulp-typescript": "^2.6.0",
     "gulp-uglify": "^1.2.0",
+    "gulp-util": "^3.0.5",
     "gulp-webserver": "^0.8.7",
     "html2jade": "^0.8.3",
     "indent-string": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gulp-insert": "^0.4.0",
     "gulp-modify": "0.0.5",
     "gulp-replace": "^0.5.3",
+    "micromatch": "^2.1.6",
     "node-uuid": "1.4.x",
     "reflect-metadata": "0.1.0",
     "rx": "2.5.1",

--- a/scripts/ci/build_js.sh
+++ b/scripts/ci/build_js.sh
@@ -8,6 +8,6 @@ SCRIPT_DIR=$(dirname $0)
 source $SCRIPT_DIR/env_dart.sh
 cd $SCRIPT_DIR/../..
 
-./node_modules/.bin/gulp enforce-format
+./node_modules/.bin/gulp enforce-format-all
 ./node_modules/.bin/gulp build.js
 ./node_modules/.bin/gulp docs


### PR DESCRIPTION
This does a `diff --name-only` against `upstream/master`, which takes `~70 ms`
on my machine. We'll need a way to find the locally relevant `master` reference
point quickly, both locally and on Travis. Still experimenting around that.
