### PR TITLE
test(integration): verify that duplicated directives are not firing

### DIFF
--- a/modules/angular2/src/core/compiler/compiler.ts
+++ b/modules/angular2/src/core/compiler/compiler.ts
@@ -153,8 +153,8 @@ export class Compiler {
       }
     }
 
-    var boundDirectives =
-        ListWrapper.map(directives, (directive) => this._bindDirective(directive));
+    var boundDirectives = this._removeDuplicatedDirectives(
+        ListWrapper.map(directives, (directive) => this._bindDirective(directive)));
 
     var renderTemplate = this._buildRenderTemplate(component, view, boundDirectives);
     pvPromise =
@@ -165,6 +165,12 @@ export class Compiler {
 
     this._compiling.set(component, pvPromise);
     return pvPromise;
+  }
+
+  private _removeDuplicatedDirectives(directives: List<DirectiveBinding>): List<DirectiveBinding> {
+    var directivesMap: Map<number, DirectiveBinding> = new Map();
+    directives.forEach((dirBinding) => { directivesMap.set(dirBinding.key.id, dirBinding); });
+    return MapWrapper.values(directivesMap);
   }
 
   private _compileNestedProtoViews(componentBinding, renderPv, directives): Promise<AppProtoView>|

--- a/modules/angular2/test/core/compiler/integration_spec.ts
+++ b/modules/angular2/test/core/compiler/integration_spec.ts
@@ -299,6 +299,40 @@ export function main() {
                .then((rootTC) => { async.done(); });
          }));
 
+      it('should execute a given directive once, even if specified multiple times',
+         inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
+           tcb.overrideView(MyComp, new viewAnn.View({
+                template: '<p no-duplicate></p>',
+                directives: [
+                  DuplicateDir,
+                  DuplicateDir,
+                  [DuplicateDir, [DuplicateDir, bind(DuplicateDir).toClass(DuplicateDir)]]
+                ]
+              }))
+               .createAsync(MyComp)
+               .then((rootTC) => {
+                 expect(rootTC.nativeElement).toHaveText('noduplicate');
+                 async.done();
+               });
+         }));
+
+      it('should use the last directive binding per directive',
+         inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
+           tcb.overrideView(MyComp, new viewAnn.View({
+                template: '<p no-duplicate></p>',
+                directives: [
+                  bind(DuplicateDir)
+                      .toClass(DuplicateDir),
+                  bind(DuplicateDir).toClass(OtherDuplicateDir)
+                ]
+              }))
+               .createAsync(MyComp)
+               .then((rootTC) => {
+                 expect(rootTC.nativeElement).toHaveText('othernoduplicate');
+                 async.done();
+               });
+         }));
+
       it('should support directives where a selector matches property binding',
          inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
            tcb.overrideView(MyComp, new viewAnn.View(
@@ -1805,4 +1839,18 @@ class ExportDir {
 
 @Component({selector: 'comp'})
 class ComponentWithoutView {
+}
+
+@Directive({selector: '[no-duplicate]'})
+class DuplicateDir {
+  constructor(renderer: DomRenderer, private elRef: ElementRef) {
+    DOM.setText(elRef.nativeElement, DOM.getText(elRef.nativeElement) + 'noduplicate');
+  }
+}
+
+@Directive({selector: '[no-duplicate]'})
+class OtherDuplicateDir {
+  constructor(renderer: DomRenderer, private elRef: ElementRef) {
+    DOM.setText(elRef.nativeElement, DOM.getText(elRef.nativeElement) + 'othernoduplicate');
+  }
 }


### PR DESCRIPTION
I wasn't sure if we've got some mechanism in place to avoiding matching all the directives specified in the `@View` annotation, so add a test. We might easily get into duplicate directives situation, as soon as we start to include `coreDirectives` in the `@View` by default.

Not sure if this test is mandatory, but I couldn't find the place where we filter out duplicates....

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular/2568)

<!-- Reviewable:end -->
