### PR TITLE
fix(views): remove dynamic component views, free host views, free emb…

### DIFF
--- a/modules/angular2/src/core/annotations_impl/annotations.ts
+++ b/modules/angular2/src/core/annotations_impl/annotations.ts
@@ -848,54 +848,6 @@ export interface ComponentArgs {
  * ```
  *
  *
- * Dynamically loading a component at runtime:
- *
- * Regular Angular components are statically resolved. Dynamic components allows to resolve a
- * component at runtime
- * instead by providing a placeholder into which a regular Angular component can be dynamically
- * loaded. Once loaded,
- * the dynamically-loaded component becomes permanent and cannot be changed.
- * Dynamic components are declared just like components, but without a `@View` annotation.
- *
- *
- * ## Example
- *
- * Here we have `DynamicComp` which acts as the placeholder for `HelloCmp`. At runtime, the dynamic
- * component
- * `DynamicComp` requests loading of the `HelloCmp` component.
- *
- * There is nothing special about `HelloCmp`, which is a regular Angular component. It can also be
- * used in other static
- * locations.
- *
- * ```
- * @Component({
- *   selector: 'dynamic-comp'
- * })
- * class DynamicComp {
- *   helloCmp:HelloCmp;
- *   constructor(loader:DynamicComponentLoader, location:ElementRef) {
- *     loader.load(HelloCmp, location).then((helloCmp) => {
- *       this.helloCmp = helloCmp;
- *     });
- *   }
- * }
- *
- * @Component({
- *   selector: 'hello-cmp'
- * })
- * @View({
- *   template: "{{greeting}}"
- * })
- * class HelloCmp {
- *   greeting:string;
- *   constructor() {
- *     this.greeting = "hello";
- *   }
- * }
- * ```
- *
- *
  * @exportedAs angular2/annotations
  */
 @CONST()

--- a/modules/angular2/src/core/compiler/element_binder.ts
+++ b/modules/angular2/src/core/compiler/element_binder.ts
@@ -24,10 +24,6 @@ export class ElementBinder {
     return isPresent(this.componentDirective) && isPresent(this.nestedProtoView);
   }
 
-  hasDynamicComponent() {
-    return isPresent(this.componentDirective) && isBlank(this.nestedProtoView);
-  }
-
   hasEmbeddedProtoView() {
     return !isPresent(this.componentDirective) && isPresent(this.nestedProtoView);
   }

--- a/modules/angular2/src/core/compiler/proto_view_factory.ts
+++ b/modules/angular2/src/core/compiler/proto_view_factory.ts
@@ -231,7 +231,8 @@ function _createAppProtoView(
     renderProtoView: renderApi.ProtoViewDto, protoChangeDetector: ProtoChangeDetector,
     variableBindings: Map<string, string>, allDirectives: List<DirectiveBinding>): AppProtoView {
   var elementBinders = renderProtoView.elementBinders;
-  var protoView = new AppProtoView(renderProtoView.render, protoChangeDetector, variableBindings);
+  var protoView = new AppProtoView(renderProtoView.render, protoChangeDetector, variableBindings,
+                                   createVariableLocations(elementBinders));
   _createElementBinders(protoView, elementBinders, allDirectives);
   _bindDirectiveEvents(protoView, elementBinders);
 
@@ -274,6 +275,18 @@ function _createVariableNames(parentVariableNames, renderProtoView): List<string
     MapWrapper.forEach(binder.variableBindings, (mappedName, varName) => { res.push(mappedName); });
   });
   return res;
+}
+
+export function createVariableLocations(
+    elementBinders: List<renderApi.ElementBinder>): Map<string, number> {
+  var variableLocations = MapWrapper.create();
+  for (var i = 0; i < elementBinders.length; i++) {
+    var binder = elementBinders[i];
+    MapWrapper.forEach(binder.variableBindings, (mappedName, varName) => {
+      MapWrapper.set(variableLocations, mappedName, i);
+    });
+  }
+  return variableLocations;
 }
 
 function _createElementBinders(protoView, elementBinders, allDirectiveBindings) {

--- a/modules/angular2/src/core/compiler/template_resolver.ts
+++ b/modules/angular2/src/core/compiler/template_resolver.ts
@@ -30,7 +30,6 @@ export class TemplateResolver {
         return annotation;
       }
     }
-    // No annotation = dynamic component!
-    return null;
+    throw new BaseException(`No View annotation found on component ${stringify(component)}`);
   }
 }

--- a/modules/angular2/src/core/compiler/view.ts
+++ b/modules/angular2/src/core/compiler/view.ts
@@ -25,7 +25,6 @@ import {EventDispatcher} from 'angular2/src/render/api';
 export class AppViewContainer {
   // The order in this list matches the DOM order.
   views: List<AppView> = [];
-  freeViews: List<AppView> = [];
 }
 
 /**
@@ -39,9 +38,6 @@ export class AppView implements ChangeDispatcher, EventDispatcher {
   elementInjectors: List<ElementInjector> = null;
   changeDetector: ChangeDetector = null;
   componentChildViews: List<AppView> = null;
-  /// Host views that were added by an imperative view.
-  /// This is a dynamically growing / shrinking array.
-  freeHostViews: List<AppView> = [];
   viewContainers: List<AppViewContainer>;
   preBuiltObjects: List<PreBuiltObjects> = null;
 
@@ -170,7 +166,8 @@ export class AppProtoView {
 
   constructor(public render: renderApi.RenderProtoViewRef,
               public protoChangeDetector: ProtoChangeDetector,
-              public variableBindings: Map<string, string>) {
+              public variableBindings: Map<string, string>,
+              public variableLocations: Map<string, number>) {
     if (isPresent(variableBindings)) {
       MapWrapper.forEach(variableBindings, (templateName, _) => {
         MapWrapper.set(this.protoLocals, templateName, null);

--- a/modules/angular2/src/debug/debug_element.ts
+++ b/modules/angular2/src/debug/debug_element.ts
@@ -35,18 +35,13 @@ export class DebugElement {
     return this._elementInjector.getComponent();
   }
 
-  get dynamicallyCreatedComponentInstance(): any {
-    if (!isPresent(this._elementInjector)) {
-      return null;
-    }
-    return this._elementInjector.getDynamicallyLoadedComponent();
-  }
-
   get domElement(): any {
     return resolveInternalDomView(this._parentView.render)
         .boundElements[this._boundElementIndex]
         .element;
   }
+
+  get elementRef(): ElementRef { return this._elementInjector.getElementRef(); }
 
   getDirectiveInstance(directiveIndex: number): any {
     return this._elementInjector.getDirectiveAtIndex(directiveIndex);

--- a/modules/angular2/src/mock/template_resolver_mock.ts
+++ b/modules/angular2/src/mock/template_resolver_mock.ts
@@ -80,10 +80,6 @@ export class MockTemplateResolver extends TemplateResolver {
     if (isBlank(view)) {
       view = super.resolve(component);
     }
-    if (isBlank(view)) {
-      // dynamic components
-      return null;
-    }
 
     var directives = view.directives;
     var overrides = MapWrapper.get(this._directiveOverrides, component);

--- a/modules/angular2/src/render/api.ts
+++ b/modules/angular2/src/render/api.ts
@@ -308,11 +308,6 @@ export class Renderer {
   }
 
   /**
-   * Detaches a free view's element from the DOM.
-   */
-  detachFreeView(view: RenderViewRef) {}
-
-  /**
    * Creates a regular view out of the given ProtoView
    */
   createView(protoViewRef: RenderProtoViewRef): RenderViewRef { return null; }

--- a/modules/angular2/src/render/dom/dom_renderer.ts
+++ b/modules/angular2/src/render/dom/dom_renderer.ts
@@ -44,11 +44,6 @@ export class DomRenderer extends Renderer {
     return new DomViewRef(this._createView(hostProtoView, element));
   }
 
-  detachFreeView(viewRef: RenderViewRef) {
-    var view = resolveInternalDomView(viewRef);
-    this._removeViewNodes(view);
-  }
-
   createView(protoViewRef: RenderProtoViewRef): RenderViewRef {
     var protoView = resolveInternalDomProtoView(protoViewRef);
     return new DomViewRef(this._createView(protoView, null));

--- a/modules/angular2/src/router/router_outlet.ts
+++ b/modules/angular2/src/router/router_outlet.ts
@@ -64,8 +64,8 @@ export class RouterOutlet {
     ]);
 
     return this.deactivate()
-        .then((_) => this._loader.loadNextToExistingLocation(instruction.component,
-                                                             this._elementRef, outletInjector))
+        .then((_) => this._loader.loadNextToLocation(instruction.component, this._elementRef,
+                                                     outletInjector))
         .then((componentRef) => {
           this._componentRef = componentRef;
           return this._childRouter.commit(instruction.child);

--- a/modules/angular2/test/core/compiler/element_injector_spec.ts
+++ b/modules/angular2/test/core/compiler/element_injector_spec.ts
@@ -671,7 +671,7 @@ export function main() {
           });
 
           it("should instantiate directives that depend on pre built objects", () => {
-            var protoView = new AppProtoView(null, null, null);
+            var protoView = new AppProtoView(null, null, null, null);
             var bindings = ListWrapper.concat([NeedsProtoViewRef], extraBindings);
             var inj = injector(bindings, null, false, new PreBuiltObjects(null, null, protoView));
 
@@ -871,100 +871,6 @@ export function main() {
           }));
         });
 
-        describe("dynamicallyCreateComponent", () => {
-          it("should create a component dynamically", () => {
-            var inj = injector(extraBindings);
-
-            inj.dynamicallyCreateComponent(DirectiveBinding.createFromType(SimpleDirective, null),
-                                           appInjector);
-            expect(inj.getDynamicallyLoadedComponent()).toBeAnInstanceOf(SimpleDirective);
-            expect(inj.get(SimpleDirective)).toBeAnInstanceOf(SimpleDirective);
-          });
-
-          it("should inject parent dependencies into the dynamically-loaded component", () => {
-            var inj = parentChildInjectors(ListWrapper.concat([SimpleDirective], extraBindings), []);
-            inj.dynamicallyCreateComponent(
-                DirectiveBinding.createFromType(NeedsDirectiveFromAncestor, null), appInjector);
-            expect(inj.getDynamicallyLoadedComponent()).toBeAnInstanceOf(NeedsDirectiveFromAncestor);
-            expect(inj.getDynamicallyLoadedComponent().dependency).toBeAnInstanceOf(SimpleDirective);
-          });
-
-          it("should not inject the proxy component into the children of the dynamically-loaded component",
-             () => {
-               var injWithDynamicallyLoadedComponent = injector([SimpleDirective]);
-               injWithDynamicallyLoadedComponent.dynamicallyCreateComponent(
-                   DirectiveBinding.createFromType(SomeOtherDirective, null), appInjector);
-
-               var shadowDomProtoInjector =
-                   createPei(null, 0, ListWrapper.concat([NeedsDirectiveFromAncestor], extraBindings));
-               var shadowDomInj = shadowDomProtoInjector.instantiate(null);
-
-               expect(() => shadowDomInj.hydrate(appInjector, injWithDynamicallyLoadedComponent,
-                                                 defaultPreBuiltObjects))
-                   .toThrowError(containsRegexp(`No provider for ${stringify(SimpleDirective) }`));
-             });
-
-          it("should not inject the dynamically-loaded component into directives on the same element",
-             () => {
-               var dynamicComp =
-                   DirectiveBinding.createFromType(SomeOtherDirective, new dirAnn.Component());
-               var proto = createPei(
-                   null, 0, ListWrapper.concat([dynamicComp, NeedsDirective], extraBindings), 1, true);
-               var inj = proto.instantiate(null);
-               inj.dynamicallyCreateComponent(DirectiveBinding.createFromType(SimpleDirective, null),
-                                              appInjector);
-
-               expect(() => inj.hydrate(Injector.resolveAndCreate([]), null, null))
-                   .toThrowError(
-                       `No provider for SimpleDirective! (${stringify(NeedsDirective) } -> ${stringify(SimpleDirective) })`);
-             });
-
-          it("should inject the dynamically-loaded component into the children of the dynamically-loaded component",
-             () => {
-               var componentDirective = DirectiveBinding.createFromType(SimpleDirective, null);
-               var injWithDynamicallyLoadedComponent = injector([]);
-               injWithDynamicallyLoadedComponent.dynamicallyCreateComponent(componentDirective,
-                                                                            appInjector);
-
-               var shadowDomProtoInjector =
-                   createPei(null, 0, ListWrapper.concat([NeedsDirectiveFromAncestor], extraBindings));
-               var shadowDomInjector = shadowDomProtoInjector.instantiate(null);
-               shadowDomInjector.hydrate(appInjector, injWithDynamicallyLoadedComponent,
-                                         defaultPreBuiltObjects);
-
-               expect(shadowDomInjector.get(NeedsDirectiveFromAncestor))
-                   .toBeAnInstanceOf(NeedsDirectiveFromAncestor);
-               expect(shadowDomInjector.get(NeedsDirectiveFromAncestor).dependency)
-                   .toBeAnInstanceOf(SimpleDirective);
-             });
-
-          it("should remove the dynamically-loaded component when dehydrating", () => {
-            var inj = injector(extraBindings);
-            inj.dynamicallyCreateComponent(
-                DirectiveBinding.createFromType(DirectiveWithDestroy,
-                                                new dirAnn.Directive({lifecycle: [onDestroy]})),
-                appInjector);
-            var dir = inj.getDynamicallyLoadedComponent();
-
-            inj.dehydrate();
-
-            expect(inj.getDynamicallyLoadedComponent()).toBe(null);
-            expect(dir.onDestroyCounter).toBe(1);
-
-            inj.hydrate(null, null, null);
-
-            expect(inj.getDynamicallyLoadedComponent()).toBe(null);
-          });
-
-          it("should inject services of the dynamically-loaded component", () => {
-            var inj = injector(extraBindings);
-            var appInjector = Injector.resolveAndCreate([bind("service").toValue("Service")]);
-            inj.dynamicallyCreateComponent(DirectiveBinding.createFromType(NeedsService, null),
-                                           appInjector);
-            expect(inj.getDynamicallyLoadedComponent().service).toEqual("Service");
-          });
-        });
-
         describe('static attributes', () => {
           it('should be injectable', () => {
             var attributes = MapWrapper.create();
@@ -1016,7 +922,7 @@ export function main() {
           });
 
           it("should inject ProtoViewRef", () => {
-            var protoView = new AppProtoView(null, null, null);
+            var protoView = new AppProtoView(null, null, null, null);
             var inj = injector(ListWrapper.concat([NeedsProtoViewRef], extraBindings), null, false,
                                new PreBuiltObjects(null, null, protoView));
 

--- a/modules/angular2/test/core/compiler/proto_view_factory_spec.ts
+++ b/modules/angular2/test/core/compiler/proto_view_factory_spec.ts
@@ -21,7 +21,8 @@ import {ChangeDetection, ChangeDetectorDefinition} from 'angular2/change_detecti
 import {
   ProtoViewFactory,
   getChangeDetectorDefinitions,
-  createDirectiveVariableBindings
+  createDirectiveVariableBindings,
+  createVariableLocations
 } from 'angular2/src/core/compiler/proto_view_factory';
 import {Component, Directive} from 'angular2/annotations';
 import {Key} from 'angular2/di';
@@ -137,6 +138,18 @@ export function main() {
                     {metadata: renderApi.DirectiveMetadata.create({exportAs: 'exportName'})})
               ]);
         }).not.toThrow();
+      });
+    });
+
+    describe('createVariableLocations', () => {
+      it('should merge the names in the template for all ElementBinders', () => {
+        expect(createVariableLocations([
+          new renderApi.ElementBinder(
+              {variableBindings: MapWrapper.createFromStringMap({"x": "a"})}),
+          new renderApi.ElementBinder(
+              {variableBindings: MapWrapper.createFromStringMap({"y": "b"})})
+
+        ])).toEqual(MapWrapper.createFromStringMap({'a': 0, 'b': 1}));
       });
     });
   });

--- a/modules/angular2/test/core/compiler/view_container_ref_spec.ts
+++ b/modules/angular2/test/core/compiler/view_container_ref_spec.ts
@@ -35,7 +35,7 @@ export function main() {
 
     function wrapView(view: AppView): ViewRef { return new ViewRef(view); }
 
-    function createProtoView() { return new AppProtoView(null, null, null); }
+    function createProtoView() { return new AppProtoView(null, null, null, null); }
 
     function createView() { return new AppView(null, createProtoView(), MapWrapper.create()); }
 

--- a/modules/angular2/test/core/compiler/view_pool_spec.ts
+++ b/modules/angular2/test/core/compiler/view_pool_spec.ts
@@ -24,7 +24,7 @@ export function main() {
 
     function createViewPool({capacity}): AppViewPool { return new AppViewPool(capacity); }
 
-    function createProtoView() { return new AppProtoView(null, null, null); }
+    function createProtoView() { return new AppProtoView(null, null, null, null); }
 
     function createView(pv) { return new AppView(null, pv, MapWrapper.create()); }
 

--- a/modules/angular2/test/render/dom/dom_renderer_integration_spec.ts
+++ b/modules/angular2/test/render/dom/dom_renderer_integration_spec.ts
@@ -40,20 +40,6 @@ export function main() {
              });
        }));
 
-    it('should create and destroy free views',
-       inject([AsyncTestCompleter, DomTestbed], (async, tb) => {
-         tb.compiler.compileHost(someComponent)
-             .then((hostProtoViewDto) => {
-               var view = new TestView(tb.renderer.createView(hostProtoViewDto.render));
-               var hostElement = tb.renderer.getRootNodes(view.viewRef)[0];
-               DOM.appendChild(tb.rootEl, hostElement);
-
-               tb.renderer.detachFreeView(view.viewRef);
-               expect(DOM.parentElement(hostElement)).toBeFalsy();
-               async.done();
-             });
-       }));
-
     it('should attach and detach component views',
        inject([AsyncTestCompleter, DomTestbed], (async, tb) => {
          tb.compileAll([

--- a/modules/angular2_material/src/components/dialog/dialog.ts
+++ b/modules/angular2_material/src/components/dialog/dialog.ts
@@ -59,7 +59,7 @@ export class MdDialog {
     var backdropRefPromise = this._openBackdrop(elementRef, contentInjector);
 
     // First, load the MdDialogContainer, into which the given component will be loaded.
-    return this.componentLoader.loadIntoNewLocation(MdDialogContainer, elementRef)
+    return this.componentLoader.loadNextToLocation(MdDialogContainer, elementRef)
         .then(containerRef => {
           // TODO(tbosch): clean this up when we have custom renderers
           // (https://github.com/angular/angular/issues/1807)
@@ -86,8 +86,8 @@ export class MdDialog {
           dialogRef.containerRef = containerRef;
 
           // Now load the given component into the MdDialogContainer.
-          return this.componentLoader.loadNextToExistingLocation(
-                                         type, containerRef.instance.contentRef, contentInjector)
+          return this.componentLoader.loadNextToLocation(type, containerRef.instance.contentRef,
+                                                         contentInjector)
               .then(contentRef => {
 
                 // Wrap both component refs for the container and the content so that we can return
@@ -107,7 +107,7 @@ export class MdDialog {
 
   /** Loads the dialog backdrop (transparent overlay over the rest of the page). */
   _openBackdrop(elementRef: ElementRef, injector: Injector): Promise<ComponentRef> {
-    return this.componentLoader.loadIntoNewLocation(MdBackdrop, elementRef, injector)
+    return this.componentLoader.loadNextToLocation(MdBackdrop, elementRef, injector)
         .then((componentRef) => {
           // TODO(tbosch): clean this up when we have custom renderers
           // (https://github.com/angular/angular/issues/1807)

--- a/modules/benchmarks/src/compiler/compiler_benchmark.ts
+++ b/modules/benchmarks/src/compiler/compiler_benchmark.ts
@@ -58,12 +58,12 @@ export function main() {
 
   function compileNoBindings() {
     cache.clear();
-    return compiler.compile(BenchmarkComponentNoBindings);
+    return compiler.compileInHost(BenchmarkComponentNoBindings);
   }
 
   function compileWithBindings() {
     cache.clear();
-    return compiler.compile(BenchmarkComponentWithBindings);
+    return compiler.compileInHost(BenchmarkComponentWithBindings);
   }
 
   bindAction('#compileNoBindings', measureWrapper(compileNoBindings, 'No Bindings'));
@@ -122,7 +122,7 @@ class MultipleTemplateResolver extends TemplateResolver {
   }
 }
 
-@Component()
+@Component({selector: 'cmp-nobind'})
 @View({
   directives: [Dir0, Dir1, Dir2, Dir3, Dir4],
   template: `
@@ -140,7 +140,7 @@ class MultipleTemplateResolver extends TemplateResolver {
 class BenchmarkComponentNoBindings {
 }
 
-@Component()
+@Component({selector: 'cmp-withbind'})
 @View({
   directives: [Dir0, Dir1, Dir2, Dir3, Dir4],
   template: `

--- a/modules/benchmarks/src/costs/index.ts
+++ b/modules/benchmarks/src/costs/index.ts
@@ -61,10 +61,10 @@ class DummyComponent {
 class DummyDirective {
 }
 
-@Component({selector: 'dynamic-dummy'})
+@Directive({selector: 'dynamic-dummy'})
 class DynamicDummy {
   constructor(loader: DynamicComponentLoader, location: ElementRef) {
-    loader.loadIntoExistingLocation(DummyComponent, location);
+    loader.loadNextToLocation(DummyComponent, location);
   }
 }
 


### PR DESCRIPTION
…edded views

Closes #2472
Closes #2339

BREAKING CHANGE
- `DynamicComponentLoader.loadInto{Existing,New}Location` is removed
  - use `DynamicComponentLoader.loadNextToLocation` instead
- `DynamicComponentLoader.loadNextToExistingLocation` was renamed into
  `DynamicComponentLoader.loadNextToLocation`
- `AppViewManager.{create,destroy}Free{Host,Embedded}View` was removed
  - use `AppViewManager.createViewInContainer` and then move the view nodes
    manually around via `DomRenderer.getRootNodes()`
