### PR TITLE
fix(docs): order class members in order of declaration

### DIFF
--- a/docs/dgeni-package/processors/readTypeScriptModules.js
+++ b/docs/dgeni-package/processors/readTypeScriptModules.js
@@ -24,8 +24,8 @@ module.exports = function readTypeScriptModules(tsParser, readFilesProcessor, mo
     basePath: '.',
     // We can ignore members of classes that are private
     hidePrivateMembers: true,
-    // We can sort class members alphabetically
-    sortClassMembers: true,
+    // We leave class members sorted in order of declaration
+    sortClassMembers: false,
     // We can provide a collection of strings or regexes to ignore exports whose export names match
     ignoreExportsMatching: ['___esModule'],
 

--- a/docs/dgeni-package/processors/readTypeScriptModules.spec.js
+++ b/docs/dgeni-package/processors/readTypeScriptModules.spec.js
@@ -46,16 +46,16 @@ describe('readTypeScriptModules', function() {
 
 
   describe('ordering of members', function() {
-    it('should order class members alphabetically (by default)', function() {
+    it('should order class members in order of appearance (by default)', function() {
       processor.sourceFiles = ['orderingOfMembers.ts'];
       var docs = [];
       processor.$process(docs);
       var classDoc = _.find(docs, { docType: 'class' });
       expect(classDoc.docType).toEqual('class');
       expect(getNames(classDoc.members)).toEqual([
-        'doStuff',
         'firstItem',
-        'otherMethod'
+        'otherMethod',
+        'doStuff',
       ]);
     });
 


### PR DESCRIPTION
Previously, class members were ordered alphabetically. This change leaves it up to the class author to determine the order in which they would like properties and methods to appear in class documentation, without having to create methods like `zUnimportantMethod`.

Fixes #2569
