### PR TITLE
fix(di/exceptions): initialize Error superclass with message

### DIFF
--- a/modules/angular2/src/facade/lang.dart
+++ b/modules/angular2/src/facade/lang.dart
@@ -175,7 +175,7 @@ class FunctionWrapper {
 }
 
 class BaseException extends Error {
-  final String message;
+  String message;
 
   BaseException([this.message]);
 

--- a/modules/angular2/src/facade/lang.ts
+++ b/modules/angular2/src/facade/lang.ts
@@ -7,14 +7,14 @@ export type Type = new (...args: any[]) => any;
 
 export class BaseException extends Error {
   message;
-  stack;
   constructor(message?: string) {
     super(message);
     this.message = message;
-    this.stack = (<any>new Error(message)).stack;
   }
 
   toString(): string { return this.message; }
+
+  get stack() { return (<any>new Error(this.message)).stack }
 }
 
 export var Math = _global.Math;

--- a/modules/angular2/test/di/exceptions_spec.dart
+++ b/modules/angular2/test/di/exceptions_spec.dart
@@ -1,0 +1,3 @@
+library angular2.test.di.exceptions_spec;
+// Not implemented
+main() {}

--- a/modules/angular2/test/di/exceptions_spec.ts
+++ b/modules/angular2/test/di/exceptions_spec.ts
@@ -1,0 +1,24 @@
+import {
+  AsyncTestCompleter,
+  beforeEach,
+  ddescribe,
+  describe,
+  expect,
+  iit,
+  inject,
+  it,
+  xit,
+} from 'angular2/test_lib';
+import {AbstractBindingError} from 'angular2/di';
+
+export function main() {
+  describe('exceptions', () => {
+    it('should have the proper message when thrown', () => {
+      try {
+        throw new AbstractBindingError('foo', () => { return 'message'; });
+      } catch (e) {
+        expect(e.stack.split('\n')[0]).toBe('Error: message');
+      }
+    });
+  });
+}

--- a/modules/angular2/test/facade/lang_spec.ts
+++ b/modules/angular2/test/facade/lang_spec.ts
@@ -6,10 +6,30 @@ import {
   RegExpWrapper,
   RegExpMatcherWrapper,
   StringWrapper,
-  CONST_EXPR
+  CONST_EXPR,
+  BaseException,
+  isString
 } from 'angular2/src/facade/lang';
 
 export function main() {
+  describe('BaseException', () => {
+    it('should include error message in stack, if added after initialization', () => {
+      try {
+        var exception = new BaseException();
+        exception.message = 'Msg';
+        throw exception;
+      } catch (e) {
+        if (isString(e.stack)) {
+          // In JS, the stack contains the message, so we verify that added message is in the stack
+          expect(`${e.stack}`.split('\n')[0]).toBe('Error: Msg');
+        } else {
+          // In Dart, the stack does not contain the message, so we toString the error directly
+          expect(e.toString()).toBe('Msg');
+        }
+      }
+    });
+  });
+
   describe('RegExp', () => {
     it('should expose the index for each match', () => {
       var re = RegExpWrapper.create('(!)');


### PR DESCRIPTION
For subclasses of Error, initializing classes without providing a 
message to super() would cause any messages to be suppressed from
logged errors. This fix provides an initial message to super().

Fixes #2570
