### PR TITLE
fix(docs): Fix docs for Directive.compileChildren

### DIFF
--- a/modules/angular2/src/core/annotations_impl/annotations.ts
+++ b/modules/angular2/src/core/annotations_impl/annotations.ts
@@ -720,7 +720,7 @@ export class Directive extends Injectable {
   lifecycle: List<LifecycleEvent>;
 
   /**
-   * If set to true the compiler does not compile the children of this directive.
+   * If set to false the compiler does not compile the children of this directive.
    */
   // TODO(vsavkin): This would better fall under the Macro directive concept.
   compileChildren: boolean;


### PR DESCRIPTION
`compileChildren` should be false in order to not compile the children.
