### PR TITLE
feat(compiler): detect dangling property bindings

### DIFF
--- a/modules/angular2/src/render/dom/compiler/directive_parser.ts
+++ b/modules/angular2/src/render/dom/compiler/directive_parser.ts
@@ -149,6 +149,7 @@ export class DirectiveParser implements CompileStep {
     if (isPresent(bindingAst)) {
       directiveBinderBuilder.bindProperty(dirProperty, bindingAst);
     }
+    compileElement.bindElement().bindPropertyToDirective(dashCaseToCamelCase(elProp));
   }
 
   _bindDirectiveEvent(eventName, action, compileElement, directiveBinderBuilder) {

--- a/modules/angular2/src/render/dom/view/property_setter_factory.ts
+++ b/modules/angular2/src/render/dom/view/property_setter_factory.ts
@@ -18,7 +18,7 @@ const CLASS_PREFIX = 'class.';
 const STYLE_PREFIX = 'style.';
 
 export class PropertySetterFactory {
-  private static _noopSetter(el, value) {}
+  static noopSetter(el, value) {}
 
   private _lazyPropertySettersCache: StringMap<string, Function> = StringMapWrapper.create();
   private _eagerPropertySettersCache: StringMap<string, Function> = StringMapWrapper.create();
@@ -69,7 +69,7 @@ export class PropertySetterFactory {
         if (DOM.hasProperty(protoElement, property)) {
           setterFn = reflector.setter(property);
         } else {
-          setterFn = PropertySetterFactory._noopSetter;
+          setterFn = PropertySetterFactory.noopSetter;
         }
         StringMapWrapper.set(this._eagerPropertySettersCache, property, setterFn);
       }

--- a/modules/angular2/test/core/directive_lifecycle_integration_spec.ts
+++ b/modules/angular2/test/core/directive_lifecycle_integration_spec.ts
@@ -36,7 +36,7 @@ export function main() {
          tb.overrideView(
              MyComp,
              new viewAnn.View(
-                 {template: '<div [field]="123" [lifecycle]></div>', directives: [LifecycleDir]}));
+                 {template: '<div [field]="123" lifecycle></div>', directives: [LifecycleDir]}));
 
          tb.createView(MyComp, {context: ctx})
              .then((view) => {

--- a/modules/angular2/test/directives/ng_for_spec.ts
+++ b/modules/angular2/test/directives/ng_for_spec.ts
@@ -205,7 +205,7 @@ export function main() {
 
     it('should repeat over nested arrays with no intermediate element',
        inject([TestBed, AsyncTestCompleter], (tb: TestBed, async) => {
-         var template = '<div><template [ng-for] #item [ng-for-of]="items">' +
+         var template = '<div><template ng-for #item [ng-for-of]="items">' +
                         '<div template="ng-for #subitem of item">' +
                         '{{subitem}}-{{item.length}};' +
                         '</div></template></div>';

--- a/modules/angular2/test/directives/ng_switch_spec.ts
+++ b/modules/angular2/test/directives/ng_switch_spec.ts
@@ -79,8 +79,8 @@ export function main() {
                           '<template [ng-switch-when]="\'b\'"><li>when b1;</li></template>' +
                           '<template [ng-switch-when]="\'a\'"><li>when a2;</li></template>' +
                           '<template [ng-switch-when]="\'b\'"><li>when b2;</li></template>' +
-                          '<template [ng-switch-default]><li>when default1;</li></template>' +
-                          '<template [ng-switch-default]><li>when default2;</li></template>' +
+                          '<template ng-switch-default><li>when default1;</li></template>' +
+                          '<template ng-switch-default><li>when default2;</li></template>' +
                           '</ul></div>';
 
            tb.createView(TestComponent, {html: template})
@@ -108,7 +108,7 @@ export function main() {
                           '<ul [ng-switch]="switchValue">' +
                           '<template [ng-switch-when]="when1"><li>when 1;</li></template>' +
                           '<template [ng-switch-when]="when2"><li>when 2;</li></template>' +
-                          '<template [ng-switch-default]><li>when default;</li></template>' +
+                          '<template ng-switch-default><li>when default;</li></template>' +
                           '</ul></div>';
 
            tb.createView(TestComponent, {html: template})

--- a/modules/angular2/test/render/dom/shadow_dom_emulation_integration_spec.ts
+++ b/modules/angular2/test/render/dom/shadow_dom_emulation_integration_spec.ts
@@ -511,7 +511,7 @@ var conditionalContentComponent = DirectiveMetadata.create({
 });
 
 var autoViewportDirective = DirectiveMetadata.create(
-    {selector: '[auto]', id: '[auto]', type: DirectiveMetadata.DIRECTIVE_TYPE});
+    {selector: '[auto]', id: 'auto', properties: ['auto'], type: DirectiveMetadata.DIRECTIVE_TYPE});
 
 var tabComponent =
     DirectiveMetadata.create({selector: 'tab', id: 'tab', type: DirectiveMetadata.COMPONENT_TYPE});

--- a/modules/benchmarks/src/costs/index.ts
+++ b/modules/benchmarks/src/costs/index.ts
@@ -77,7 +77,7 @@ class DynamicDummy {
     </div>
 
     <div *ng-if="testingWithDirectives">
-      <dummy [dummy-decorator] *ng-for="#i of list"></dummy>
+      <dummy dummy-decorator *ng-for="#i of list"></dummy>
     </div>
 
     <div *ng-if="testingDynamicComponents">

--- a/modules/benchmarks/src/largetable/largetable_benchmark.ts
+++ b/modules/benchmarks/src/largetable/largetable_benchmark.ts
@@ -232,7 +232,7 @@ class CellData {
         </tbody>
         <tbody template="ng-switch-when 'interpolationAttr'">
           <tr template="ng-for #row of data">
-            <td template="ng-for #column of row" i="{{column.i}}" j="{{column.j}}">
+            <td template="ng-for #column of row" attr.i="{{column.i}}" attr.j="{{column.j}}">
               i,j attrs
             </td>
           </tr>
@@ -269,7 +269,7 @@ class LargetableComponent {
 @Component({selector: 'app'})
 @View({
   directives: [LargetableComponent],
-  template: `<largetable [data]='data' [benchmarkType]='benchmarkType'></largetable>`
+  template: `<largetable [data]='data' [benchmark-type]='benchmarkType'></largetable>`
 })
 class AppComponent {
   data;


### PR DESCRIPTION
BREAKING CHANGE: compiler will throw on binding to non-existing properties.

Till now it was possible to have a binding to a non-existing property,
ex.: `<div [foo]="exp">`. From now on this is compilation error - any
property binding needs to have at least one associated property:
eaither on an HTML element or on any directive associated with a
given element (directives' properites need to be declared using the
`properties` field in the `@Directive` / `@Component` annotation).
