### PR TITLE
feat(router): enforce "..." syntax for child component routes

### DIFF
--- a/modules/angular2/src/mock/location_mock.ts
+++ b/modules/angular2/src/mock/location_mock.ts
@@ -16,7 +16,7 @@ export class SpyLocation extends SpyObject {
 
   constructor() {
     super();
-    this._path = '/';
+    this._path = '';
     this.urlChanges = [];
     this._subject = new EventEmitter();
     this._baseHref = '';

--- a/modules/angular2/src/router/route_recognizer.ts
+++ b/modules/angular2/src/router/route_recognizer.ts
@@ -14,7 +14,7 @@ import {
   StringMapWrapper
 } from 'angular2/src/facade/collection';
 
-import {PathRecognizer} from './path_recognizer';
+import {PathRecognizer, ContinuationSegment} from './path_recognizer';
 
 /**
  * `RouteRecognizer` is responsible for recognizing routes for a single component.
@@ -34,7 +34,7 @@ export class RouteRecognizer {
 
   addRedirect(path: string, target: string): void { this.redirects.set(path, target); }
 
-  addConfig(path: string, handler: any, alias: string = null): void {
+  addConfig(path: string, handler: any, alias: string = null): boolean {
     var recognizer = new PathRecognizer(path, handler);
     MapWrapper.forEach(this.matchers, (matcher, _) => {
       if (recognizer.regex.toString() == matcher.regex.toString()) {
@@ -46,6 +46,7 @@ export class RouteRecognizer {
     if (isPresent(alias)) {
       this.names.set(alias, recognizer);
     }
+    return recognizer.terminal;
   }
 
 
@@ -62,8 +63,8 @@ export class RouteRecognizer {
         if (path == url) {
           url = target;
         }
-      } else if (StringWrapper.startsWith(url, path)) {
-        url = target + StringWrapper.substring(url, path.length);
+      } else if (url.startsWith(path)) {
+        url = target + url.substring(path.length);
       }
     });
 
@@ -75,7 +76,7 @@ export class RouteRecognizer {
         var unmatchedUrl = '';
         if (url != '/') {
           matchedUrl = match[0];
-          unmatchedUrl = StringWrapper.substring(url, match[0].length);
+          unmatchedUrl = url.substring(match[0].length);
         }
         solutions.push(new RouteMatch({
           specificity: pathRecognizer.specificity,

--- a/modules/angular2/src/router/route_registry.ts
+++ b/modules/angular2/src/router/route_registry.ts
@@ -53,12 +53,16 @@ export class RouteRegistry {
         config, {'component': normalizeComponentDeclaration(config['component'])});
 
     var component = config['component'];
-    this.configFromComponent(component);
+    var terminal = recognizer.addConfig(config['path'], config, config['as']);
 
-    recognizer.addConfig(config['path'], config, config['as']);
+    if (component['type'] == 'constructor') {
+      if (terminal) {
+        assertTerminalComponent(component['constructor'], config['path']);
+      } else {
+        this.configFromComponent(component['constructor']);
+      }
+    }
   }
-
-
   /**
    * Reads the annotations of a component and configures the registry based on them
    */
@@ -220,4 +224,22 @@ function mostSpecific(instructions: List<Instruction>): Instruction {
     }
   }
   return mostSpecificSolution;
+}
+
+function assertTerminalComponent(component, path) {
+  if (!isType(component)) {
+    return;
+  }
+
+  var annotations = reflector.annotations(component);
+  if (isPresent(annotations)) {
+    for (var i = 0; i < annotations.length; i++) {
+      var annotation = annotations[i];
+
+      if (annotation instanceof RouteConfig) {
+        throw new BaseException(
+            `Child routes are not allowed for "${path}". Use "..." on the parent's route path.`);
+      }
+    }
+  }
 }

--- a/modules/angular2/test/router/outlet_spec.ts
+++ b/modules/angular2/test/router/outlet_spec.ts
@@ -100,7 +100,7 @@ export function main() {
 
     it('should work with child routers', inject([AsyncTestCompleter], (async) => {
          compile('outer { <router-outlet></router-outlet> }')
-             .then((_) => rtr.config({'path': '/a', 'component': ParentCmp}))
+             .then((_) => rtr.config({'path': '/a/...', 'component': ParentCmp}))
              .then((_) => rtr.navigate('/a/b'))
              .then((_) => {
                view.detectChanges();
@@ -153,7 +153,7 @@ export function main() {
 
     it('should reuse common parent components', inject([AsyncTestCompleter], (async) => {
          compile()
-             .then((_) => rtr.config({'path': '/team/:id', 'component': TeamCmp}))
+             .then((_) => rtr.config({'path': '/team/:id/...', 'component': TeamCmp}))
              .then((_) => rtr.navigate('/team/angular/user/rado'))
              .then((_) => {
                view.detectChanges();

--- a/modules/angular2/test/router/route_registry_spec.ts
+++ b/modules/angular2/test/router/route_registry_spec.ts
@@ -91,7 +91,7 @@ export function main() {
        }));
 
     it('should match the full URL using child components', inject([AsyncTestCompleter], (async) => {
-         registry.config(rootHostComponent, {'path': '/first', 'component': DummyParentComp});
+         registry.config(rootHostComponent, {'path': '/first/...', 'component': DummyParentComp});
 
          registry.recognize('/first/second', rootHostComponent)
              .then((instruction) => {
@@ -103,7 +103,7 @@ export function main() {
 
     it('should match the URL using async child components',
        inject([AsyncTestCompleter], (async) => {
-         registry.config(rootHostComponent, {'path': '/first', 'component': DummyAsyncComp});
+         registry.config(rootHostComponent, {'path': '/first/...', 'component': DummyAsyncComp});
 
          registry.recognize('/first/second', rootHostComponent)
              .then((instruction) => {
@@ -117,7 +117,7 @@ export function main() {
        inject([AsyncTestCompleter], (async) => {
          registry.config(
              rootHostComponent,
-             {'path': '/first', 'component': {'loader': AsyncParentLoader, 'type': 'loader'}});
+             {'path': '/first/...', 'component': {'loader': AsyncParentLoader, 'type': 'loader'}});
 
          registry.recognize('/first/second', rootHostComponent)
              .then((instruction) => {
@@ -139,6 +139,21 @@ export function main() {
                  {'path': '/some/path', 'component': {'type': 'intentionallyWrongComponentType'}}))
           .toThrowError('Invalid component type \'intentionallyWrongComponentType\'');
     });
+
+    it('should throw when a parent config is missing the `...` suffix any of its children add routes',
+       () => {
+         expect(() =>
+                    registry.config(rootHostComponent, {'path': '/', 'component': DummyParentComp}))
+             .toThrowError(
+                 'Child routes are not allowed for "/". Use "..." on the parent\'s route path.');
+       });
+
+    it('should throw when a parent config is missing the `...` suffix any of its children add routes',
+       () => {
+         expect(() => registry.config(rootHostComponent,
+                                      {'path': '/home/.../fun/', 'component': DummyParentComp}))
+             .toThrowError('Unexpected "..." before the end of the path for "home/.../fun/".');
+       });
   });
 }
 

--- a/modules/angular2/test/router/router_integration_spec.ts
+++ b/modules/angular2/test/router/router_integration_spec.ts
@@ -122,7 +122,7 @@ class ParentCmp {
 
 @Component({selector: 'app-cmp'})
 @View({template: `root { <router-outlet></router-outlet> }`, directives: routerDirectives})
-@RouteConfig([{path: '/parent', component: ParentCmp}])
+@RouteConfig([{path: '/parent/...', component: ParentCmp}])
 class HierarchyAppCmp {
   constructor(public router: Router, public location: BrowserLocation) {}
 }


### PR DESCRIPTION
This commit makes explicit routes that expect a child to capture
the rest of the URL being matched.

Subsumes #2595 – I'm just creating another PR to run CI after the changes to collection facades.
