### PR TITLE
chore(doc-gen): ignore `@param` tags

### DIFF
--- a/docs/dgeni-package/index.js
+++ b/docs/dgeni-package/index.js
@@ -78,7 +78,8 @@ module.exports = new Package('angular', [jsdocPackage, nunjucksPackage, linksPac
   // We actually don't want to parse param docs in this package as we are getting the data out using TS
   parseTagsProcessor.tagDefinitions.forEach(function(tagDef) {
     if (tagDef.name === 'param') {
-      tagDef.ignore = true;
+      tagDef.docProperty = 'paramData';
+      tagDef.transforms = [];
     }
   });
 


### PR DESCRIPTION
At the moment we are not parsing param tags. This commit ignores them
completely.

TODO: hook up param descriptions with the actual param data in the doc.

Closes #2633

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular/2634)

<!-- Reviewable:end -->
