### PR TITLE
feat: update clang-format to 1.0.21.

### DIFF
--- a/modules/angular2/src/change_detection/parser/lexer.ts
+++ b/modules/angular2/src/change_detection/parser/lexer.ts
@@ -17,7 +17,8 @@ enum TokenType {
   NUMBER
 }
 
-@Injectable() export class Lexer {
+@Injectable()
+export class Lexer {
   tokenize(text: string): List<any> {
     var scanner = new _Scanner(text);
     var tokens = [];

--- a/modules/angular2/src/facade/lang.ts
+++ b/modules/angular2/src/facade/lang.ts
@@ -28,12 +28,11 @@ export function assertionsEnabled(): boolean {
 // TODO: remove calls to assert in production environment
 // Note: Can't just export this and import in in other files
 // as `assert` is a reserved keyword in Dart
-_global.assert =
-    function assert(condition) {
-      if (assertionsEnabled_) {
-        _global['assert'].call(condition);
-      }
-    }
+_global.assert = function assert(condition) {
+  if (assertionsEnabled_) {
+    _global['assert'].call(condition);
+  }
+};
 // This function is needed only to properly support Dart's const expressions
 // see https://github.com/angular/ts2dart/pull/151 for more info
 export function CONST_EXPR<T>(expr: T): T {

--- a/modules/angular2/src/http/enums.ts
+++ b/modules/angular2/src/http/enums.ts
@@ -1,12 +1,47 @@
+export enum RequestModesOpts {
+  Cors,
+  NoCors,
+  SameOrigin
+}
 
-export enum RequestModesOpts {Cors, NoCors, SameOrigin};
+export enum RequestCacheOpts {
+  Default,
+  NoStore,
+  Reload,
+  NoCache,
+  ForceCache,
+  OnlyIfCached
+}
 
-export enum RequestCacheOpts {Default, NoStore, Reload, NoCache, ForceCache, OnlyIfCached};
+export enum RequestCredentialsOpts {
+  Omit,
+  SameOrigin,
+  Include
+}
 
-export enum RequestCredentialsOpts {Omit, SameOrigin, Include};
+export enum RequestMethods {
+  GET,
+  POST,
+  PUT,
+  DELETE,
+  OPTIONS,
+  HEAD,
+  PATCH
+}
 
-export enum RequestMethods {GET, POST, PUT, DELETE, OPTIONS, HEAD, PATCH};
+export enum ReadyStates {
+  UNSENT,
+  OPEN,
+  HEADERS_RECEIVED,
+  LOADING,
+  DONE,
+  CANCELLED
+}
 
-export enum ReadyStates {UNSENT, OPEN, HEADERS_RECEIVED, LOADING, DONE, CANCELLED};
-
-export enum ResponseTypes {Basic, Cors, Default, Error, Opaque}
+export enum ResponseTypes {
+  Basic,
+  Cors,
+  Default,
+  Error,
+  Opaque
+}

--- a/modules/angular2/test/change_detection/change_detector_config.ts
+++ b/modules/angular2/test/change_detection/change_detector_config.ts
@@ -237,16 +237,20 @@ class _DirectiveUpdating {
     'noCallbacks': new _DirectiveUpdating(
         [_DirectiveUpdating.updateA('1', _DirectiveUpdating.recordNoCallbacks)],
         [_DirectiveUpdating.recordNoCallbacks]),
-    'readingDirectives': new _DirectiveUpdating([
-      BindingRecord.createForHostProperty(new DirectiveIndex(0, 0),
-                                          _getParser().parseBinding('a', 'location'), PROP_NAME)
-    ],
-                                                [_DirectiveUpdating.basicRecords[0]]),
-    'interpolation': new _DirectiveUpdating([
-      BindingRecord.createForElement(_getParser().parseInterpolation('B{{a}}A', 'location'), 0,
-                                     PROP_NAME)
-    ],
-                                            [])
+    'readingDirectives':
+        new _DirectiveUpdating(
+            [
+              BindingRecord.createForHostProperty(
+                  new DirectiveIndex(0, 0), _getParser().parseBinding('a', 'location'), PROP_NAME)
+            ],
+            [_DirectiveUpdating.basicRecords[0]]),
+    'interpolation':
+        new _DirectiveUpdating(
+            [
+              BindingRecord.createForElement(_getParser().parseInterpolation('B{{a}}A', 'location'),
+                                             0, PROP_NAME)
+            ],
+            [])
   };
 }
 

--- a/modules/angular2/test/core/compiler/compiler_spec.ts
+++ b/modules/angular2/test/core/compiler/compiler_spec.ts
@@ -317,11 +317,12 @@ export function main() {
          var mainProtoView =
              createProtoView([createComponentElementBinder(directiveResolver, NestedComponent)]);
          var nestedProtoView = createProtoView();
-         var compiler = createCompiler([
-           createRenderProtoView([createRenderComponentElementBinder(0)]),
-           createRenderProtoView()
-         ],
-                                       [[rootProtoView], [mainProtoView], [nestedProtoView]]);
+         var compiler = createCompiler(
+             [
+               createRenderProtoView([createRenderComponentElementBinder(0)]),
+               createRenderProtoView()
+             ],
+             [[rootProtoView], [mainProtoView], [nestedProtoView]]);
          compiler.compileInHost(MainComponent)
              .then((protoViewRef) => {
                expect(internalProtoView(protoViewRef).elementBinders[0].nestedProtoView)

--- a/modules/benchmarks/e2e_test/naive_infinite_scroll_spec.ts
+++ b/modules/benchmarks/e2e_test/naive_infinite_scroll_spec.ts
@@ -14,26 +14,22 @@ describe('ng2 naive infinite scroll benchmark', function() {
     var cells = `${ allScrollItems } .row *`;
     var stageButtons = `${ allScrollItems } .row stage-buttons button`;
 
-    var count =
-        function(selector) {
-          return browser.executeScript(`return ` +
-                                       `document.querySelectorAll("${ selector }").length;`);
-        }
+    var count = function(selector) {
+      return browser.executeScript(`return ` +
+                                   `document.querySelectorAll("${ selector }").length;`);
+    };
 
-    var clickFirstOf =
-        function(selector) {
-          return browser.executeScript(`document.querySelector("${ selector }").click();`);
-        }
+    var clickFirstOf = function(selector) {
+      return browser.executeScript(`document.querySelector("${ selector }").click();`);
+    };
 
-    var firstTextOf =
-        function(selector) {
-          return browser.executeScript(`return ` +
-                                       `document.querySelector("${ selector }").innerText;`);
-        }
+    var firstTextOf = function(selector) {
+      return browser.executeScript(`return ` +
+                                   `document.querySelector("${ selector }").innerText;`);
+    };
 
-        // Make sure rows are rendered
-        count(allScrollItems)
-            .then(function(c) { expect(c).toEqual(expectedRowCount); });
+    // Make sure rows are rendered
+    count(allScrollItems).then(function(c) { expect(c).toEqual(expectedRowCount); });
 
     // Make sure cells are rendered
     count(cells).then(function(c) { expect(c).toEqual(expectedRowCount * expectedCellsPerRow); });
@@ -47,10 +43,9 @@ describe('ng2 naive infinite scroll benchmark', function() {
                 firstTextOf(`${ stageButtons }:enabled`)
                     .then(function(text) { expect(text).toEqual('Won'); })
               });
-        })
+        });
 
-            $("#reset-btn")
-        .click();
+    $("#reset-btn").click();
     $("#run-btn").click();
     browser.wait(() => {
       return $('#done').getText().then(function() { return true; }, function() { return false; });

--- a/modules/benchmarks_external/src/compiler/compiler_benchmark.ts
+++ b/modules/benchmarks_external/src/compiler/compiler_benchmark.ts
@@ -24,61 +24,66 @@ function loadTemplate(templateId, repeatCount) {
 }
 
 angular.module('app', [])
-    .directive('dir0', [
-      '$parse',
-      function($parse) {
-        return {
-          compile: function($element, $attrs) {
-            var expr = $parse($attrs.attr0);
-            return function($scope) { $scope.$watch(expr, angular.noop); }
-          }
-        };
-      }
-    ])
-    .directive('dir1', [
-      '$parse',
-      function($parse) {
-        return {
-          compile: function($element, $attrs) {
-            var expr = $parse($attrs.attr1);
-            return function($scope) { $scope.$watch(expr, angular.noop); }
-          }
-        };
-      }
-    ])
-    .directive('dir2', [
-      '$parse',
-      function($parse) {
-        return {
-          compile: function($element, $attrs) {
-            var expr = $parse($attrs.attr2);
-            return function($scope) { $scope.$watch(expr, angular.noop); }
-          }
-        };
-      }
-    ])
-    .directive('dir3', [
-      '$parse',
-      function($parse) {
-        return {
-          compile: function($element, $attrs) {
-            var expr = $parse($attrs.attr3);
-            return function($scope) { $scope.$watch(expr, angular.noop); }
-          }
-        };
-      }
-    ])
-    .directive('dir4', [
-      '$parse',
-      function($parse) {
-        return {
-          compile: function($element, $attrs) {
-            var expr = $parse($attrs.attr4);
-            return function($scope) { $scope.$watch(expr, angular.noop); }
-          }
-        };
-      }
-    ])
+    .directive('dir0',
+               [
+                 '$parse',
+                 function($parse) {
+                   return {
+                     compile: function($element, $attrs) {
+                       var expr = $parse($attrs.attr0);
+                       return function($scope) { $scope.$watch(expr, angular.noop); }
+                     }
+                   };
+                 }
+               ])
+    .directive('dir1',
+               [
+                 '$parse',
+                 function($parse) {
+                   return {
+                     compile: function($element, $attrs) {
+                       var expr = $parse($attrs.attr1);
+                       return function($scope) { $scope.$watch(expr, angular.noop); }
+                     }
+                   };
+                 }
+               ])
+    .directive('dir2',
+               [
+                 '$parse',
+                 function($parse) {
+                   return {
+                     compile: function($element, $attrs) {
+                       var expr = $parse($attrs.attr2);
+                       return function($scope) { $scope.$watch(expr, angular.noop); }
+                     }
+                   };
+                 }
+               ])
+    .directive('dir3',
+               [
+                 '$parse',
+                 function($parse) {
+                   return {
+                     compile: function($element, $attrs) {
+                       var expr = $parse($attrs.attr3);
+                       return function($scope) { $scope.$watch(expr, angular.noop); }
+                     }
+                   };
+                 }
+               ])
+    .directive('dir4',
+               [
+                 '$parse',
+                 function($parse) {
+                   return {
+                     compile: function($element, $attrs) {
+                       var expr = $parse($attrs.attr4);
+                       return function($scope) { $scope.$watch(expr, angular.noop); }
+                     }
+                   };
+                 }
+               ])
     .run([
       '$compile',
       function($compile) {

--- a/modules/benchmarks_external/src/tree/tree_benchmark.ts
+++ b/modules/benchmarks_external/src/tree/tree_benchmark.ts
@@ -19,41 +19,42 @@ angular.module('app', [])
                })
     // special directive for "if" as angular 1.3 does not support
     // recursive components.
-    .directive('treeIf', [
-      '$compile',
-      '$parse',
-      function($compile, $parse) {
-        var transcludeFn;
-        return {
-          compile: function(element, attrs) {
-            var expr = $parse(attrs.treeIf);
-            var template = '<tree data="' + attrs.treeIf + '"></tree>';
-            var transclude;
-            return function($scope, $element, $attrs) {
-              if (!transclude) {
-                transclude = $compile(template);
-              }
-              var childScope;
-              var childElement;
-              $scope.$watch(expr, function(newValue) {
-                if (childScope) {
-                  childScope.$destroy();
-                  childElement.remove();
-                  childScope = null;
-                  childElement = null;
-                }
-                if (newValue) {
-                  childScope = $scope.$new();
-                  childElement =
-                      transclude(childScope, function(clone) { $element.append(clone); });
-                }
-              });
-            }
+    .directive('treeIf',
+               [
+                 '$compile',
+                 '$parse',
+                 function($compile, $parse) {
+                   var transcludeFn;
+                   return {
+                     compile: function(element, attrs) {
+                       var expr = $parse(attrs.treeIf);
+                       var template = '<tree data="' + attrs.treeIf + '"></tree>';
+                       var transclude;
+                       return function($scope, $element, $attrs) {
+                         if (!transclude) {
+                           transclude = $compile(template);
+                         }
+                         var childScope;
+                         var childElement;
+                         $scope.$watch(expr, function(newValue) {
+                           if (childScope) {
+                             childScope.$destroy();
+                             childElement.remove();
+                             childScope = null;
+                             childElement = null;
+                           }
+                           if (newValue) {
+                             childScope = $scope.$new();
+                             childElement = transclude(childScope,
+                                                       function(clone) { $element.append(clone); });
+                           }
+                         });
+                       }
 
-          }
-        }
-      }
-    ])
+                     }
+                   }
+                 }
+               ])
     .config([
       '$compileProvider',
       function($compileProvider) { $compileProvider.debugInfoEnabled(false); }

--- a/modules/benchpress/src/sample_description.ts
+++ b/modules/benchpress/src/sample_description.ts
@@ -26,12 +26,13 @@ export class SampleDescription {
 var _BINDINGS = [
   bind(SampleDescription)
       .toFactory((metric, id, forceGc, userAgent, validator, defaultDesc, userDesc) =>
-                     new SampleDescription(id, [
-                       {'forceGc': forceGc, 'userAgent': userAgent},
-                       validator.describe(),
-                       defaultDesc,
-                       userDesc
-                     ],
+                     new SampleDescription(id,
+                                           [
+                                             {'forceGc': forceGc, 'userAgent': userAgent},
+                                             validator.describe(),
+                                             defaultDesc,
+                                             userDesc
+                                           ],
                                            metric.describe()),
                  [
                    Metric,

--- a/modules/benchpress/test/metric/perflog_metric_spec.ts
+++ b/modules/benchpress/test/metric/perflog_metric_spec.ts
@@ -333,14 +333,15 @@ export function main() {
 
       describe('frame metrics', () => {
         it('should calculate mean frame time', inject([AsyncTestCompleter], (async) => {
-             aggregate([
-               eventFactory.markStart('frameCapture', 0),
-               eventFactory.instant('frame', 1),
-               eventFactory.instant('frame', 3),
-               eventFactory.instant('frame', 4),
-               eventFactory.markEnd('frameCapture', 5)
-             ],
-                       null, true)
+             aggregate(
+                 [
+                   eventFactory.markStart('frameCapture', 0),
+                   eventFactory.instant('frame', 1),
+                   eventFactory.instant('frame', 3),
+                   eventFactory.instant('frame', 4),
+                   eventFactory.markEnd('frameCapture', 5)
+                 ],
+                 null, true)
                  .then((data) => {
                    expect(data['frameTime.mean']).toBe(((3 - 1) + (4 - 3)) / 2);
                    async.done();
@@ -372,11 +373,12 @@ export function main() {
 
         it('should throw if trying to capture twice', inject([AsyncTestCompleter], (async) => {
              PromiseWrapper.catchError(
-                 aggregate([
-                   eventFactory.markStart('frameCapture', 3),
-                   eventFactory.markStart('frameCapture', 4)
-                 ],
-                           null, true),
+                 aggregate(
+                     [
+                       eventFactory.markStart('frameCapture', 3),
+                       eventFactory.markStart('frameCapture', 4)
+                     ],
+                     null, true),
                  (err) => {
                    expect(() => { throw err; })
                        .toThrowError('can capture frames only once per benchmark run');
@@ -405,17 +407,18 @@ export function main() {
            }));
 
         it('should calculate best and worst frame time', inject([AsyncTestCompleter], (async) => {
-             aggregate([
-               eventFactory.markStart('frameCapture', 0),
-               eventFactory.instant('frame', 1),
-               eventFactory.instant('frame', 9),
-               eventFactory.instant('frame', 15),
-               eventFactory.instant('frame', 18),
-               eventFactory.instant('frame', 28),
-               eventFactory.instant('frame', 32),
-               eventFactory.markEnd('frameCapture', 10)
-             ],
-                       null, true)
+             aggregate(
+                 [
+                   eventFactory.markStart('frameCapture', 0),
+                   eventFactory.instant('frame', 1),
+                   eventFactory.instant('frame', 9),
+                   eventFactory.instant('frame', 15),
+                   eventFactory.instant('frame', 18),
+                   eventFactory.instant('frame', 28),
+                   eventFactory.instant('frame', 32),
+                   eventFactory.markEnd('frameCapture', 10)
+                 ],
+                 null, true)
                  .then((data) => {
                    expect(data['frameTime.worst']).toBe(10);
                    expect(data['frameTime.best']).toBe(3);
@@ -425,14 +428,15 @@ export function main() {
 
         it('should calculate percentage of smoothness to be good',
            inject([AsyncTestCompleter], (async) => {
-             aggregate([
-               eventFactory.markStart('frameCapture', 0),
-               eventFactory.instant('frame', 1),
-               eventFactory.instant('frame', 2),
-               eventFactory.instant('frame', 3),
-               eventFactory.markEnd('frameCapture', 4)
-             ],
-                       null, true)
+             aggregate(
+                 [
+                   eventFactory.markStart('frameCapture', 0),
+                   eventFactory.instant('frame', 1),
+                   eventFactory.instant('frame', 2),
+                   eventFactory.instant('frame', 3),
+                   eventFactory.markEnd('frameCapture', 4)
+                 ],
+                 null, true)
                  .then((data) => {
                    expect(data['frameTime.smooth']).toBe(1.0);
                    async.done();
@@ -441,16 +445,17 @@ export function main() {
 
         it('should calculate percentage of smoothness to be bad',
            inject([AsyncTestCompleter], (async) => {
-             aggregate([
-               eventFactory.markStart('frameCapture', 0),
-               eventFactory.instant('frame', 1),
-               eventFactory.instant('frame', 2),
-               eventFactory.instant('frame', 22),
-               eventFactory.instant('frame', 23),
-               eventFactory.instant('frame', 24),
-               eventFactory.markEnd('frameCapture', 4)
-             ],
-                       null, true)
+             aggregate(
+                 [
+                   eventFactory.markStart('frameCapture', 0),
+                   eventFactory.instant('frame', 1),
+                   eventFactory.instant('frame', 2),
+                   eventFactory.instant('frame', 22),
+                   eventFactory.instant('frame', 23),
+                   eventFactory.instant('frame', 24),
+                   eventFactory.markEnd('frameCapture', 4)
+                 ],
+                 null, true)
                  .then((data) => {
                    expect(data['frameTime.smooth']).toBe(0.75);
                    async.done();
@@ -591,11 +596,12 @@ export function main() {
       describe('microMetrics', () => {
 
         it('should report micro metrics', inject([AsyncTestCompleter], (async) => {
-             aggregate([
-               eventFactory.markStart('mm1', 0),
-               eventFactory.markEnd('mm1', 5),
-             ],
-                       {'mm1': 'micro metric 1'})
+             aggregate(
+                 [
+                   eventFactory.markStart('mm1', 0),
+                   eventFactory.markEnd('mm1', 5),
+                 ],
+                 {'mm1': 'micro metric 1'})
                  .then((data) => {
                    expect(data['mm1']).toBe(5.0);
                    async.done();
@@ -615,11 +621,12 @@ export function main() {
            }));
 
         it('should report micro metric averages', inject([AsyncTestCompleter], (async) => {
-             aggregate([
-               eventFactory.markStart('mm1*20', 0),
-               eventFactory.markEnd('mm1*20', 5),
-             ],
-                       {'mm1': 'micro metric 1'})
+             aggregate(
+                 [
+                   eventFactory.markStart('mm1*20', 0),
+                   eventFactory.markEnd('mm1*20', 5),
+                 ],
+                 {'mm1': 'micro metric 1'})
                  .then((data) => {
                    expect(data['mm1']).toBe(5 / 20);
                    async.done();

--- a/modules/benchpress/test/webdriver/chrome_driver_extension_spec.ts
+++ b/modules/benchpress/test/webdriver/chrome_driver_extension_spec.ts
@@ -277,10 +277,11 @@ export function main() {
 
       it('should throw an error on buffer overflow', inject([AsyncTestCompleter], (async) => {
            PromiseWrapper.catchError(
-               createExtension([
-                 chromeTimelineEvents.start('FunctionCall', 1234),
-               ],
-                               'Tracing.bufferUsage')
+               createExtension(
+                   [
+                     chromeTimelineEvents.start('FunctionCall', 1234),
+                   ],
+                   'Tracing.bufferUsage')
                    .readPerfLog(),
                (err) => {
                  expect(() => { throw err; })

--- a/modules/rtts_assert/src/rtts_assert.ts
+++ b/modules/rtts_assert/src/rtts_assert.ts
@@ -204,22 +204,21 @@ function formatErrors(errors, indent = '  ') {
 // assert a type of given value and throw if does not pass
 var type: any =
     function(actual, T) {
-      var errors = [];
-      // currentStack = [];
+  var errors = [];
+  // currentStack = [];
 
-      if (!isType(actual, T, errors)) {
-        // console.log(JSON.stringify(errors, null, '  '));
-        // TODO(vojta): print "an instance of" only if T starts with uppercase.
-        var msg =
-            'Expected an instance of ' + prettyPrint(T) + ', got ' + prettyPrint(actual) + '!';
-        if (errors.length) {
-          msg += '\n' + formatErrors(errors);
-        }
-
-        throw new Error(msg);
-      }
-      return actual;
+  if (!isType(actual, T, errors)) {
+    // console.log(JSON.stringify(errors, null, '  '));
+    // TODO(vojta): print "an instance of" only if T starts with uppercase.
+    var msg = 'Expected an instance of ' + prettyPrint(T) + ', got ' + prettyPrint(actual) + '!';
+    if (errors.length) {
+      msg += '\n' + formatErrors(errors);
     }
+
+    throw new Error(msg);
+  }
+  return actual;
+}
 
 function returnType(actual, T) {
   var errors = [];
@@ -303,46 +302,45 @@ function define(classOrName, check) {
   return cls;
 }
 
-var assert: any =
-    function(value) {
-      return {
-        is: function is(...types) {
-          // var errors = []
-          var allErrors = [];
-          var errors;
-          for (var i = 0; i < types.length; i++) {
-            var type = types[i];
-            errors = [];
+var assert: any = function(value) {
+  return {
+    is: function is(...types) {
+      // var errors = []
+      var allErrors = [];
+      var errors;
+      for (var i = 0; i < types.length; i++) {
+        var type = types[i];
+        errors = [];
 
-            if (isType(value, type, errors)) {
-              return true;
-            }
-
-            // if no errors, merge multiple "is not instance of " into x/y/z ?
-            allErrors.push(prettyPrint(value) + ' is not instance of ' + prettyPrint(type));
-            if (errors.length) {
-              allErrors.push(errors);
-            }
-          }
-
-          // if (types.length > 1) {
-          //   currentStack.push(['has to be ' + types.map(prettyPrint).join(' or '),
-          //   ...allErrors]);
-          // } else {
-          currentStack.push(...allErrors);
-          // }
-          return false;
+        if (isType(value, type, errors)) {
+          return true;
         }
-      };
+
+        // if no errors, merge multiple "is not instance of " into x/y/z ?
+        allErrors.push(prettyPrint(value) + ' is not instance of ' + prettyPrint(type));
+        if (errors.length) {
+          allErrors.push(errors);
+        }
+      }
+
+      // if (types.length > 1) {
+      //   currentStack.push(['has to be ' + types.map(prettyPrint).join(' or '),
+      //   ...allErrors]);
+      // } else {
+      currentStack.push(...allErrors);
+      // }
+      return false;
     }
+  };
+};
 
 
-    // PUBLIC API
+// PUBLIC API
 
-    // asserting API
+// asserting API
 
-    // throw if no type provided
-    assert.type = type;
+// throw if no type provided
+assert.type = type;
 for (var prop in primitives) {
   assert.type[prop] = primitives[prop];
 }

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -3943,7 +3943,7 @@
       "version": "1.0.19",
       "dependencies": {
         "clang-format": {
-          "version": "1.0.19"
+          "version": "1.0.21"
         },
         "gulp-util": {
           "version": "3.0.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6095,9 +6095,8 @@
       "resolved": "https://registry.npmjs.org/gulp-clang-format/-/gulp-clang-format-1.0.19.tgz",
       "dependencies": {
         "clang-format": {
-          "version": "1.0.19",
-          "from": "clang-format@1.0.19",
-          "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.19.tgz"
+          "version": "1.0.21",
+          "from": "clang-format@1.0.21"
         },
         "gulp-util": {
           "version": "3.0.5",

--- a/tools/broccoli/tree-differ.ts
+++ b/tools/broccoli/tree-differ.ts
@@ -166,4 +166,8 @@ function pad(value, length) {
 }
 
 
-enum FileStatus { ADDED, UNCHANGED, CHANGED }
+enum FileStatus {
+  ADDED,
+  UNCHANGED,
+  CHANGED
+}


### PR DESCRIPTION
This improves formatting for bare function assignments and trailing container literals. It also includes a git hook to make formatting easier.
