### PR TITLE
WIP add missing exports to angular2.api.ts, add enum generation

### DIFF
--- a/docs/dgeni-package/processors/createTypeDefinitionFile.js
+++ b/docs/dgeni-package/processors/createTypeDefinitionFile.js
@@ -10,7 +10,7 @@ module.exports = function createTypeDefinitionFile() {
         id: 'type-definition',
         aliases: ['type-definition'],
         path: 'type-definition',
-        outputPath: 'angular2.d.ts',
+        outputPath: 'typings/angular2/angular2.d.ts',
         modules: []
       };
       _.forEach(docs, function(doc) {

--- a/docs/dgeni-package/processors/readTypeScriptModules.js
+++ b/docs/dgeni-package/processors/readTypeScriptModules.js
@@ -91,6 +91,13 @@ module.exports = function readTypeScriptModules(tsParser, readFilesProcessor, mo
             }
           }
 
+          if (exportDoc.docType == 'enum') {
+            exportDoc.members = [];
+            for (var etype in resolvedExport.exports) {
+              exportDoc.members.push(etype);
+            }
+          }
+
           // Add this export doc to its module doc
           moduleDoc.exports.push(exportDoc);
           docs.push(exportDoc);
@@ -165,6 +172,7 @@ module.exports = function readTypeScriptModules(tsParser, readFilesProcessor, mo
       fileInfo: getFileInfo(exportSymbol, basePath),
       location: getLocation(exportSymbol)
     };
+
     if(exportSymbol.flags & ts.SymbolFlags.Function) {
       exportDoc.parameters = getParameters(typeChecker, exportSymbol);
     }

--- a/docs/dgeni-package/templates/type-definition.template.html
+++ b/docs/dgeni-package/templates/type-definition.template.html
@@ -57,6 +57,14 @@ declare module "{$ module.id $}" {
     ;
   {%- endfor %}
   }
+
+  {%- elif export.docType == 'enum' %} {
+    {%- for member in export.members %} 
+    {$ member $}{% if not loop.last %}, 
+    {%- endif -%} 
+    {%- endfor %}
+  }
+
   {%- else -%}
     {% if export.parameters %}({% for param in export.parameters %}{$ param $}{% if not loop.last %}, {% endif %}{% endfor %}){%- endif %}
     {%- if export.returnType %} : {$ export.returnType $} {% endif -%}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -389,7 +389,7 @@ function runKarma(configFile, done) {
 
 gulp.task('test.js', function(done) {
   runSequence('test.unit.tools/ci', 'test.transpiler.unittest', 'docs/test', 'test.unit.js/ci',
-              'test.unit.cjs/ci', sequenceComplete(done));
+              'test.unit.cjs/ci', 'test.typings', sequenceComplete(done));
 });
 
 gulp.task('test.dart', function(done) {
@@ -557,6 +557,31 @@ gulp.task('test.server.dart', runServerDartTests(gulp, gulpPlugins, {
 // test builders
 gulp.task('test.transpiler.unittest', function(done) {
   runJasmineTests(['tools/transpiler/unittest/**/*.js'], done);
+});
+
+gulp.task('!pre.test.typings', [], function(done) {
+  return gulp
+    .src([
+      'modules/angular2/typings/**/*'], {
+        base: 'modules/angular2/typings/**'
+      }
+    )
+    .pipe(gulp.dest('dist/docs/typings/*'));
+});
+
+// -----------------
+// TODO: Use a version of TypeScript that matches what is used by DefinitelyTyped.
+gulp.task('test.typings', ['!pre.test.typings'], function(done) {
+  var stream = gulp.src(['typings_spec/*.ts', 'dist/docs/typings/angular2/angular2.d.ts'])
+      .pipe(tsc({target: 'ES5', module: 'commonjs',
+                 // Don't use the version of typescript that gulp-typescript depends on, we need 1.5
+                 // see https://github.com/ivogabe/gulp-typescript#typescript-version
+                 typescript: require('typescript')}))
+      .on('error', function(error) {
+        // nodejs doesn't propagate errors from the src stream into the final stream so we are
+        // forwarding the error into the final stream
+        stream.emit('error', error);
+      });
 });
 
 // -----------------

--- a/modules/angular2/angular2.api.ts
+++ b/modules/angular2/angular2.api.ts
@@ -11,14 +11,16 @@ export * from './angular2';
 // 1) if the symbol is intended to be part of the public API, then re-export somewhere else
 // 2) if the symbol should be omitted from the public API, then the class exposing it should
 //    not be exported, or should avoid exposing the symbol.
-export {AbstractChangeDetector} from './src/change_detection/abstract_change_detector';
-export {ProtoRecord} from './src/change_detection/proto_record';
+export {ProtoRecord, RecordType} from './src/change_detection/proto_record';
 export * from './src/core/compiler/element_injector';
+export {DependencyAnnotation} from './src/di/annotations_impl';
 // FIXME: this is a workaround for https://github.com/angular/angular/issues/2356
 // We export the Directive *annotation* instead of the *decorator*.
 // But it breaks the build.
 export {Directive, LifecycleEvent} from './src/core/annotations_impl/annotations';
 export {Form} from './src/forms/directives/form_interface';
+export {TypeDecorator, ClassDefinition} from './src/util/decorators';
+export {Query} from './src/core/annotations_impl/di';
 export {ControlContainer} from './src/forms/directives/control_container';
 export {Injectable} from './src/di/annotations_impl';
 export {BaseQueryList} from './src/core/compiler/base_query_list';

--- a/modules/angular2/angular2.ts
+++ b/modules/angular2/angular2.ts
@@ -17,7 +17,16 @@ export {
   JitChangeDetection,
   PreGeneratedChangeDetection,
   preGeneratedProtoDetectors,
-  defaultPipeRegistry
+  defaultPipeRegistry,
+  DirectiveIndex,
+  BindingRecord,
+  ProtoChangeDetector,
+  ChangeDispatcher,
+  ChangeDetector,
+  Locals,
+  ChangeDetectorDefinition,
+  BasePipe,
+  DirectiveRecord
 } from './change_detection';
 
 export {
@@ -40,7 +49,10 @@ export {
   InstantiationError,
   InvalidBindingError,
   NoAnnotationError,
-  OpaqueToken
+  OpaqueToken,
+  ResolvedBinding,
+  BindingBuilder,
+  Dependency
 } from './di';
 
 export * from './core';

--- a/modules/angular2/change_detection.ts
+++ b/modules/angular2/change_detection.ts
@@ -45,7 +45,7 @@ export {DynamicChangeDetector} from './src/change_detection/dynamic_change_detec
 export {ChangeDetectorRef} from './src/change_detection/change_detector_ref';
 export {PipeRegistry} from './src/change_detection/pipes/pipe_registry';
 export {uninitialized} from './src/change_detection/change_detection_util';
-export {WrappedValue, Pipe, PipeFactory} from './src/change_detection/pipes/pipe';
+export {WrappedValue, Pipe, PipeFactory, BasePipe} from './src/change_detection/pipes/pipe';
 export {NullPipe, NullPipeFactory} from './src/change_detection/pipes/null_pipe';
 export {
   defaultPipes,

--- a/modules/angular2/http.ts
+++ b/modules/angular2/http.ts
@@ -16,8 +16,18 @@ export {Request} from 'angular2/src/http/static_request';
 export {Response} from 'angular2/src/http/static_response';
 
 export {Http, XHRBackend, XHRConnection, BaseRequestOptions, RequestOptions, HttpFactory};
-export {IHttp} from 'angular2/src/http/interfaces';
+export {
+  IHttp,
+  IRequestOptions,
+  IRequest,
+  IResponse,
+  Connection,
+  ConnectionBackend
+} from 'angular2/src/http/interfaces';
 export {Headers} from 'angular2/src/http/headers';
+
+export * from 'angular2/src/http/enums';
+export {URLSearchParams} from 'angular2/src/http/url_search_params';
 
 /**
  * Provides a basic set of injectables to use the {@link Http} service in any application.

--- a/modules/angular2/src/http/interfaces.ts
+++ b/modules/angular2/src/http/interfaces.ts
@@ -20,7 +20,7 @@ export interface IRequestOptions {
   cache?: RequestCacheOpts;
 }
 
-export interface Request {
+export interface IRequest {
   method: RequestMethods;
   mode: RequestModesOpts;
   credentials: RequestCredentialsOpts;
@@ -34,7 +34,7 @@ export interface ResponseOptions {
   url?: string;
 }
 
-export interface Response {
+export interface IResponse {
   headers: Headers;
   ok: boolean;
   status: number;
@@ -49,12 +49,14 @@ export interface Response {
   json(): Object;
 }
 
-export interface ConnectionBackend { createConnection(observer: any, config: Request): Connection; }
+export interface ConnectionBackend {
+  createConnection(observer: any, config: IRequest): Connection;
+}
 
 export interface Connection {
   readyState: ReadyStates;
-  request: Request;
-  response: Rx.Subject<Response>;
+  request: IRequest;
+  response: Rx.Subject<IResponse>;
   dispose(): void;
 }
 
@@ -81,4 +83,4 @@ export interface Connection {
  */
 // Prefixed as IHttp because used in conjunction with Http class, but interface is callable
 // constructor(@Inject(Http) http:IHttp)
-export interface IHttp { (url: string, options?: IRequestOptions): Rx.Observable<Response> }
+export interface IHttp { (url: string, options?: IRequestOptions): Rx.Observable<IResponse> }

--- a/modules/angular2/src/http/static_request.ts
+++ b/modules/angular2/src/http/static_request.ts
@@ -1,6 +1,6 @@
 import {RequestMethods, RequestModesOpts, RequestCredentialsOpts} from './enums';
 import {URLSearchParams} from './url_search_params';
-import {IRequestOptions, Request as IRequest} from './interfaces';
+import {IRequestOptions, IRequest} from './interfaces';
 import {Headers} from './headers';
 import {BaseException, RegExpWrapper} from 'angular2/src/facade/lang';
 

--- a/modules/angular2/src/http/static_response.ts
+++ b/modules/angular2/src/http/static_response.ts
@@ -1,4 +1,4 @@
-import {Response as IResponse, ResponseOptions} from './interfaces';
+import {IResponse, ResponseOptions} from './interfaces';
 import {ResponseTypes} from './enums';
 import {baseResponseOptions} from './base_response_options';
 import {BaseException, isJsObject, isString, global} from 'angular2/src/facade/lang';

--- a/typing_spec/basic_spec.ts
+++ b/typing_spec/basic_spec.ts
@@ -1,0 +1,18 @@
+///<reference path="../dist/docs/angular2.d.ts"/>
+
+import {Component, bootstrap, View} from 'angular2/angular2'
+
+@Component({
+  selector: 'my-app'
+})
+@View({
+	template: '<h1>Hello {{ name }}</h1>'
+})
+// Component controller
+class MyAppComponent {
+  name: string;
+
+  constructor() { this.name = 'Alice'; }
+}
+
+bootstrap(MyAppComponent);


### PR DESCRIPTION
@rkirov WIP. Add exports to `angular.api.ts` file to make the `.d.ts` generation from complaining. Add hack for generating `enum`s.

Reference path in the `basic_spec.ts` file is to the generated `angular2.d.ts`.
