### PR TITLE
chore(ShadowDomStrategy): remove redundant field styleInliner

### DIFF
--- a/modules/angular2/src/render/dom/shadow_dom/emulated_scoped_shadow_dom_strategy.ts
+++ b/modules/angular2/src/render/dom/shadow_dom/emulated_scoped_shadow_dom_strategy.ts
@@ -27,11 +27,8 @@ import {
  * - see `ShadowCss` for more information and limitations.
  */
 export class EmulatedScopedShadowDomStrategy extends EmulatedUnscopedShadowDomStrategy {
-  styleInliner: StyleInliner;
-
   constructor(styleInliner: StyleInliner, styleUrlResolver: StyleUrlResolver, styleHost) {
     super(styleInliner, styleUrlResolver, styleHost);
-    this.styleInliner = styleInliner;
   }
 
   processStyleElement(hostComponentId: string, templateUrl: string, styleEl): Promise<any> {


### PR DESCRIPTION
The field is not necessary as it is defined in the super-class already.
