### PR TITLE
feat(http): xhr error listener invokes onError

### DIFF
--- a/modules/http/src/backends/xhr_backend.ts
+++ b/modules/http/src/backends/xhr_backend.ts
@@ -1,5 +1,5 @@
 import {ConnectionBackend, Connection} from '../interfaces';
-import {ReadyStates, RequestMethods, RequestMethodsMap} from '../enums';
+import {ReadyStates, RequestMethods, RequestMethodsMap, ResponseTypes} from '../enums';
 import {Request} from '../static_request';
 import {Response} from '../static_response';
 import {ResponseOptions, BaseResponseOptions} from '../base_response_options';
@@ -58,6 +58,14 @@ export class XHRConnection implements Connection {
       ObservableWrapper.callNext(this.response, new Response(responseOptions));
       // TODO(gdi2290): defer complete if array buffer until done
       ObservableWrapper.callReturn(this.response);
+    });
+
+    this._xhr.addEventListener('error', (err) => {
+      var responseOptions = new ResponseOptions({body: err, type: ResponseTypes.Error});
+      if (isPresent(baseResponseOptions)) {
+        responseOptions = baseResponseOptions.merge(responseOptions);
+      }
+      ObservableWrapper.callThrow(this.response, new Response(responseOptions))
     });
     // TODO(jeffbcross): make this more dynamic based on body type
 

--- a/modules/http/test/backends/xhr_backend_spec.ts
+++ b/modules/http/test/backends/xhr_backend_spec.ts
@@ -118,6 +118,15 @@ export function main() {
         expect(abortSpy).toHaveBeenCalled();
       });
 
+      it('should create an error Response on error', inject([AsyncTestCompleter], async => {
+           var connection = new XHRConnection(sampleRequest, new MockBrowserXHR(),
+                                              new ResponseOptions({type: ResponseTypes.Error}));
+           ObservableWrapper.subscribe(connection.response, null, res => {
+             expect(res.type).toBe(ResponseTypes.Error);
+             async.done();
+           });
+           existingXHRs[0].dispatchEvent('error');
+         }));
 
       it('should automatically call open with method and url', () => {
         new XHRConnection(sampleRequest, new MockBrowserXHR());


### PR DESCRIPTION
``` es6
    this._xhr.addEventListener('error', (err) => {
      var responseOptions = new ResponseOptions({body: err, type: ResponseTypes.Error});
      if (isPresent(baseResponseOptions)) {
        responseOptions = baseResponseOptions.merge(responseOptions);
      }
      ObservableWrapper.callThrow(this.response, new Response(responseOptions))
    });
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular/2667)

<!-- Reviewable:end -->
