### PR TITLE
chore(windows): fix the test.unit.dart task

### DIFF
--- a/tools/build/dartdetect.js
+++ b/tools/build/dartdetect.js
@@ -10,7 +10,7 @@ module.exports = function(gulp) {
         ANALYZER: 'dartanalyzer.bat',
         DARTFMT: 'dartfmt.bat',
         PUB: 'pub.bat',
-        VM: 'dart.bat'
+        VM: 'dart.exe'
       };
     } else {
       DART_SDK = {


### PR DESCRIPTION
With https://github.com/angular/ts2dart/pull/216, it makes the test.unit.dart task fully work on Windows, both for the initial and the incremental builds.

About the fix in `broccoli-merge-trees.ts`, it is because `treeDiff.removedPaths`, `treeDiff.changedPaths` and `treeDiff.addedPaths` happen to be undefined at some step of the incremental build. It solves the exception and makes the task work, but it feels a bit hacky.
@IgorMinar @caitp any suggestion for a better fix or a way to investigate that please?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular/2676)

<!-- Reviewable:end -->
