### PR TITLE
build(gulp/travis): move circular check and style check to before pre…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -559,6 +559,20 @@ gulp.task('test.transpiler.unittest', function(done) {
   runJasmineTests(['tools/transpiler/unittest/**/*.js'], done);
 });
 
+
+// -----------------
+// Pre/Post-test checks
+
+gulp.task('pre-test-checks', function(done) {
+  runSequence('build/checkCircularDependencies', sequenceComplete(done));
+});
+
+
+gulp.task('post-test-checks', function(done) {
+  runSequence('enforce-format', sequenceComplete(done));
+});
+
+
 // -----------------
 // orchestrated targets
 
@@ -686,8 +700,6 @@ gulp.task('!broccoli.js.prod', function() {
 gulp.task('build.js.dev', ['build/clean.js'], function(done) {
   runSequence(
     'broccoli.js.dev',
-    'build/checkCircularDependencies',
-    'check-format',
     sequenceComplete(done)
   );
 });

--- a/scripts/ci/build_js.sh
+++ b/scripts/ci/build_js.sh
@@ -8,6 +8,5 @@ SCRIPT_DIR=$(dirname $0)
 source $SCRIPT_DIR/env_dart.sh
 cd $SCRIPT_DIR/../..
 
-./node_modules/.bin/gulp enforce-format
 ./node_modules/.bin/gulp build.js
 ./node_modules/.bin/gulp docs

--- a/scripts/ci/test_js.sh
+++ b/scripts/ci/test_js.sh
@@ -12,5 +12,7 @@ if  ${SCRIPT_DIR}/env_dart.sh 2>&1 > /dev/null ; then
     source $SCRIPT_DIR/env_dart.sh
 fi
 
+./node_modules/.bin/gulp pre-test-checks
 ./node_modules/.bin/gulp test.js --browsers=${KARMA_BROWSERS:-ChromeCanary}
 ${SCRIPT_DIR}/test_e2e_js.sh
+./node_modules/.bin/gulp post-test-checks


### PR DESCRIPTION
…/post-test tasks

In order to speedup the startup time of test.unit.js task, we are moving the circular dependency check into
a pre-test check that executes only on travis. Similarly we are moving the style check to a post-test check
that executes on travis.

This way if a circular dependency issue occurs, we find it before running tests on CI and if the code
is not formatted we fail the build only if all the tests pass.

Related to #2536
Related to #2094
