### PR TITLE
chore(docs): Explicitly export symbols from angular2.ts

### DIFF
--- a/modules/angular2/angular2.ts
+++ b/modules/angular2/angular2.ts
@@ -43,11 +43,12 @@ export {
   DirectiveResolver,
   DynamicComponentLoader,
   ElementRef,
+  EventEmitter,
   IQueryList,
   NgZone,
+  Observable,
   ProtoViewRef,
   QueryList,
-  RenderElementRef,
   UrlResolver,
   ViewContainerRef,
   ViewRef,
@@ -56,7 +57,6 @@ export {
 } from 'angular2/core';
 
 export {
-  ASTWithSource,
   BasePipe,
   ChangeDetectionError,
   ChangeDetectorRef,
@@ -74,47 +74,86 @@ export {
   defaultPipes
 } from './change_detection';
 
-// we have to reexport * because Dart and TS export two different sets of types
-export * from './di';
+export {
+  AbstractBindingError,
+  AncestorMetadata,
+  AsyncBindingError,
+  Binding,
+  BindingBuilder,
+  CyclicDependencyError,
+  DEFAULT_VISIBILITY,
+  Dependency,
+  DependencyMetadata,
+  DependencyProvider,
+  ForwardRefFn,
+  InjectMetadata,
+  InjectableMetadata,
+  Injector,
+  InstantiationError,
+  InvalidBindingError,
+  Key,
+  KeyRegistry,
+  NoAnnotationError,
+  NoBindingError,
+  OpaqueToken,
+  OptionalMetadata,
+  OutOfBoundsError,
+  PRIVATE,
+  PUBLIC,
+  PUBLIC_AND_PRIVATE,
+  ParentMetadata,
+  ProtoInjector,
+  ResolvedBinding,
+  SelfMetadata,
+  TypeLiteral,
+  UnboundedMetadata,
+  VisibilityMetadata,
+  bind,
+  forwardRef,
+  resolveForwardRef,
+  undefinedValue
+} from './di';
+// We have to reexport * because Dart and TS export two different sets of types.
+export * from './src/di/decorators';
 
 export {
   CSSClass,
   NgFor,
   NgIf,
   NgNonBindable,
+  NgStyle,
   NgSwitch,
+  NgSwitchDefault,
   NgSwitchWhen,
-  NgSwitchDefault
+  coreDirectives
 } from './directives';
 
 export {
   AbstractControl,
   AbstractControlDirective,
+  CheckboxControlValueAccessor,
   Control,
+  ControlArray,
   ControlContainer,
   ControlGroup,
-  ControlArray,
-  Form,
-  NgControlName,
-  NgFormControl,
-  NgModel,
-  NgControl,
-  NgControlGroup,
-  NgFormModel,
-  NgForm,
   ControlValueAccessor,
   DefaultValueAccessor,
-  CheckboxControlValueAccessor,
-  SelectControlValueAccessor,
-  formDirectives,
-  Validators,
-  NgValidator,
-  NgRequiredValidator,
+  Form,
   FormBuilder,
+  NgControl,
+  NgControlGroup,
+  NgControlName,
+  NgForm,
+  NgFormControl,
+  NgFormModel,
+  NgModel,
+  NgValidator, NgRequiredValidator,
+  SelectControlValueAccessor,
+  Validators,
+  formDirectives,
   formInjectables
 } from './forms';
 
-export {Observable, EventEmitter} from 'angular2/src/facade/async';
 export {
   DirectiveBinder,
   DirectiveMetadata,
@@ -124,17 +163,17 @@ export {
   PropertyBindingType,
   ProtoViewDto,
   RenderCompiler,
-  Renderer,
+  RenderElementRef,
   RenderEventDispatcher,
   RenderFragmentRef,
   RenderProtoViewMergeMapping,
   RenderProtoViewRef,
   RenderViewRef,
   RenderViewWithFragments,
+  Renderer,
   ViewDefinition,
   ViewType
 } from 'angular2/src/render/api';
-
 export {
   DomRenderer,
   DOCUMENT_TOKEN,

--- a/modules/angular2/angular2.ts
+++ b/modules/angular2/angular2.ts
@@ -1,42 +1,100 @@
 /**
  * The `angular2` is the single place to import all of the individual types.
  */
-export * from 'angular2/annotations';
-export * from 'angular2/core';
+export {
+  Attribute,
+  AttributeAnnotation,
+  AttributeFactory,
+  Class,
+  ClassDefinition,
+  Component,
+  ComponentAnnotation,
+  ComponentDecorator,
+  ComponentFactory,
+  Directive,
+  DirectiveAnnotation,
+  DirectiveDecorator,
+  DirectiveFactory,
+  LifecycleEvent,
+  OnAllChangesDone,
+  OnChange,
+  OnCheck,
+  OnDestroy,
+  OnInit,
+  ParameterDecorator,
+  Query,
+  QueryAnnotation,
+  QueryFactory,
+  TypeDecorator,
+  View,
+  ViewAnnotation,
+  ViewDecorator,
+  ViewFactory,
+  ViewQuery
+} from 'angular2/annotations';
 
 export {
+  AppRootUrl,
+  AppViewManager,
+  ApplicationRef,
+  Compiler,
+  ComponentRef ,
+  ComponentUrlMapper,
+  DirectiveResolver,
+  DynamicComponentLoader,
+  ElementRef,
+  IQueryList,
+  NgZone,
+  ProtoViewRef,
+  QueryList,
+  RenderElementRef,
+  UrlResolver,
+  ViewContainerRef,
+  ViewRef,
+  appComponentTypeToken,
+  bootstrap
+} from 'angular2/core';
+
+export {
+  ASTWithSource,
+  BasePipe,
+  ChangeDetectionError,
+  ChangeDetectorRef,
+  DEFAULT,
   DehydratedException,
   ExpressionChangedAfterItHasBeenChecked,
-  ChangeDetectionError,
-
-  ON_PUSH,
-  DEFAULT,
-
-  ChangeDetectorRef,
-
-  Pipes,
-  WrappedValue,
-  Pipe,
-  PipeFactory,
+  Locals,
   NullPipe,
   NullPipeFactory,
-  defaultPipes,
-  BasePipe,
-
-  Locals
+  ON_PUSH,
+  Pipe,
+  PipeFactory,
+  Pipes,
+  WrappedValue,
+  defaultPipes
 } from './change_detection';
 
+// we have to reexport * because Dart and TS export two different sets of types
 export * from './di';
-export * from './forms';
 
-export * from './directives';
+export {
+  CSSClass,
+  NgFor,
+  NgIf,
+  NgNonBindable,
+  NgSwitch,
+  NgSwitchWhen,
+  NgSwitchDefault
+} from './directives';
 
 export {
   AbstractControl,
   AbstractControlDirective,
   Control,
+  ControlContainer,
   ControlGroup,
   ControlArray,
+  Form,
   NgControlName,
   NgFormControl,
   NgModel,
@@ -56,16 +114,27 @@ export {
   formInjectables
 } from './forms';
 
-export * from './http';
+export {Observable, EventEmitter} from 'angular2/src/facade/async';
 export {
-  RenderEventDispatcher,
+  DirectiveBinder,
+  DirectiveMetadata,
+  ElementBinder,
+  ElementPropertyBinding,
+  EventBinding,
+  PropertyBindingType,
+  ProtoViewDto,
+  RenderCompiler,
   Renderer,
-  RenderElementRef,
-  RenderViewRef,
-  RenderProtoViewRef,
+  RenderEventDispatcher,
   RenderFragmentRef,
-  RenderViewWithFragments
+  RenderProtoViewMergeMapping,
+  RenderProtoViewRef,
+  RenderViewRef,
+  RenderViewWithFragments,
+  ViewDefinition,
+  ViewType
 } from 'angular2/src/render/api';
+
 export {
   DomRenderer,
   DOCUMENT_TOKEN,

--- a/modules/angular2/directives.ts
+++ b/modules/angular2/directives.ts
@@ -14,7 +14,8 @@ export {CSSClass} from './src/directives/class';
 export {NgFor} from './src/directives/ng_for';
 export {NgIf} from './src/directives/ng_if';
 export {NgNonBindable} from './src/directives/ng_non_bindable';
-export {NgSwitch, NgSwitchWhen, NgSwitchDefault, SwitchView} from './src/directives/ng_switch';
+export {NgStyle} from './src/directives/ng_style';
+export {NgSwitch, NgSwitchWhen, NgSwitchDefault} from './src/directives/ng_switch';
 
 /**
  * A collection of the Angular core directives that are likely to be used in each and every Angular

--- a/modules/angular2/directives.ts
+++ b/modules/angular2/directives.ts
@@ -10,12 +10,11 @@ import {NgIf} from './src/directives/ng_if';
 import {NgNonBindable} from './src/directives/ng_non_bindable';
 import {NgSwitch, NgSwitchWhen, NgSwitchDefault} from './src/directives/ng_switch';
 
-export * from './src/directives/class';
-export * from './src/directives/ng_for';
-export * from './src/directives/ng_if';
-export * from './src/directives/ng_non_bindable';
-export * from './src/directives/ng_style';
-export * from './src/directives/ng_switch';
+export {CSSClass} from './src/directives/class';
+export {NgFor} from './src/directives/ng_for';
+export {NgIf} from './src/directives/ng_if';
+export {NgNonBindable} from './src/directives/ng_non_bindable';
+export {NgSwitch, NgSwitchWhen, NgSwitchDefault, SwitchView} from './src/directives/ng_switch';
 
 /**
  * A collection of the Angular core directives that are likely to be used in each and every Angular


### PR DESCRIPTION
We want to explicitly state what symbols from child modules should be exported by the angular2.ts entry file.

Closes #2653

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular/2709)

<!-- Reviewable:end -->
