### PR TITLE
fix(build): fix paths in `test.typings` task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -571,7 +571,7 @@ gulp.task('post-test-checks', function(done) {
 });
 
 
-gulp.task('!pre.test.typings', [], function(done) {
+gulp.task('!pre.test.typings', [], function() {
   return gulp
     .src([
       'modules/angular2/typings/**/*'], {
@@ -584,7 +584,7 @@ gulp.task('!pre.test.typings', [], function(done) {
 // -----------------
 // TODO: Use a version of TypeScript that matches what is used by DefinitelyTyped.
 gulp.task('test.typings', ['!pre.test.typings'], function() {
-  return gulp.src(['typing_spec/*.ts', 'dist/docs/typings/angular2.d.ts'])
+  return gulp.src(['typing_spec/*.ts', 'dist/docs/typings/angular2/angular2.d.ts'])
       .pipe(tsc({target: 'ES5', module: 'commonjs',
                  // Don't use the version of typescript that gulp-typescript depends on, we need 1.5
                  // see https://github.com/ivogabe/gulp-typescript#typescript-version

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -583,17 +583,12 @@ gulp.task('!pre.test.typings', [], function(done) {
 
 // -----------------
 // TODO: Use a version of TypeScript that matches what is used by DefinitelyTyped.
-gulp.task('test.typings', ['!pre.test.typings'], function(done) {
-  var stream = gulp.src(['typings_spec/*.ts', 'dist/docs/typings/angular2/angular2.d.ts'])
+gulp.task('test.typings', ['!pre.test.typings'], function() {
+  return gulp.src(['typing_spec/*.ts', 'dist/docs/typings/angular2.d.ts'])
       .pipe(tsc({target: 'ES5', module: 'commonjs',
                  // Don't use the version of typescript that gulp-typescript depends on, we need 1.5
                  // see https://github.com/ivogabe/gulp-typescript#typescript-version
-                 typescript: require('typescript')}))
-      .on('error', function(error) {
-        // nodejs doesn't propagate errors from the src stream into the final stream so we are
-        // forwarding the error into the final stream
-        stream.emit('error', error);
-      });
+                 typescript: require('typescript')}));
 });
 
 // -----------------

--- a/typing_spec/basic_spec.ts
+++ b/typing_spec/basic_spec.ts
@@ -1,4 +1,4 @@
-///<reference path="../dist/docs/angular2.d.ts"/>
+///<reference path="../dist/docs/typings/angular2/angular2.d.ts"/>
 
 import {Component, bootstrap, View} from 'angular2/angular2'
 


### PR DESCRIPTION
@dariajung or @rkirov mind taking a look at this?

I fixed the paths in the test.typings task, and returned the task stream instead of listening for errors, so gulp could manage the error propagation/handling. https://github.com/gulpjs/gulp/blob/master/docs/API.md#return-a-stream
