### PR TITLE
chore(test): migrate remaining core tests to testcomponentbuilder

### DIFF
--- a/modules/angular2/src/debug/debug_element.ts
+++ b/modules/angular2/src/debug/debug_element.ts
@@ -145,6 +145,10 @@ export function inspectElement(elementRef: ElementRef): DebugElement {
   return DebugElement.create(elementRef);
 }
 
+export function asNativeElements(arr: List<DebugElement>): List<any> {
+  return arr.map((debugEl) => debugEl.nativeElement);
+}
+
 /**
  * @exportedAs angular2/test
  */

--- a/modules/angular2/test/core/compiler/integration_dart_spec.dart
+++ b/modules/angular2/test/core/compiler/integration_dart_spec.dart
@@ -3,7 +3,6 @@ library angular2.test.di.integration_dart_spec;
 
 import 'package:angular2/angular2.dart';
 import 'package:angular2/di.dart';
-import 'package:angular2/src/test_lib/test_bed.dart';
 import 'package:angular2/test_lib.dart';
 
 class MockException implements Error {
@@ -40,16 +39,16 @@ void functionThatThrowsNonError() {
 main() {
   describe('TypeLiteral', () {
     it('should publish via appInjector', inject([
-      TestBed,
+      TestComponentBuilder,
       AsyncTestCompleter
     ], (tb, async) {
       tb.overrideView(Dummy, new View(
           template: '<type-literal-component></type-literal-component>',
-          directives: [TypeLiteralComponent]));
+          directives: [TypeLiteralComponent]))
 
-      tb.createView(Dummy).then((view) {
-        view.detectChanges();
-        expect(view.rootNodes).toHaveText('[Hello, World]');
+      .createAsync(Dummy).then((tc) {
+        tc.detectChanges();
+        expect(asNativeElements(tc.componentViewChildren)).toHaveText('[Hello, World]');
         async.done();
       });
     }));
@@ -57,28 +56,28 @@ main() {
 
   describe('Error handling', () {
     it('should preserve Error stack traces thrown from components', inject([
-      TestBed,
+      TestComponentBuilder,
       AsyncTestCompleter
     ], (tb, async) {
       tb.overrideView(Dummy, new View(
           template: '<throwing-component></throwing-component>',
-          directives: [ThrowingComponent]));
+          directives: [ThrowingComponent]))
 
-      tb.createView(Dummy).catchError((e, stack) {
+      .createAsync(Dummy).catchError((e, stack) {
         expect(stack.toString().split('\n')[0]).toEqual(e.message);
         async.done();
       });
     }));
 
     it('should preserve non-Error stack traces thrown from components', inject([
-      TestBed,
+      TestComponentBuilder,
       AsyncTestCompleter
     ], (tb, async) {
       tb.overrideView(Dummy, new View(
           template: '<throwing-component2></throwing-component2>',
-          directives: [ThrowingComponent2]));
+          directives: [ThrowingComponent2]))
 
-      tb.createView(Dummy).catchError((e, stack) {
+      .createAsync(Dummy).catchError((e, stack) {
         expect(stack.toString().split('\n')[0]).toEqual(e.message);
         async.done();
       });
@@ -87,30 +86,30 @@ main() {
 
   describe('Property access', () {
     it('should distinguish between map and property access', inject([
-      TestBed,
+      TestComponentBuilder,
       AsyncTestCompleter
     ], (tb, async) {
       tb.overrideView(Dummy, new View(
           template: '<property-access></property-access>',
-          directives: [PropertyAccess]));
+          directives: [PropertyAccess]))
 
-      tb.createView(Dummy).then((view) {
-        view.detectChanges();
-        expect(view.rootNodes).toHaveText('prop:foo-prop;map:foo-map');
+      .createAsync(Dummy).then((tc) {
+        tc.detectChanges();
+        expect(asNativeElements(tc.componentViewChildren)).toHaveText('prop:foo-prop;map:foo-map');
         async.done();
       });
     }));
 
     it('should not fallback on map access if property missing', inject([
-      TestBed,
+      TestComponentBuilder,
       AsyncTestCompleter
     ], (tb, async) {
       tb.overrideView(Dummy, new View(
           template: '<no-property-access></no-property-access>',
-          directives: [NoPropertyAccess]));
+          directives: [NoPropertyAccess]))
 
-      tb.createView(Dummy).then((view) {
-        expect(() => view.detectChanges())
+      .createAsync(Dummy).then((tc) {
+        expect(() => tc.detectChanges())
             .toThrowError(new RegExp('property not found'));
         async.done();
       });
@@ -119,16 +118,16 @@ main() {
 
   describe('OnChange', () {
     it('should be notified of changes', inject([
-      TestBed,
+      TestComponentBuilder,
       AsyncTestCompleter
     ], (tb, async) {
       tb.overrideView(Dummy, new View(
           template: '''<on-change [prop]="'hello'"></on-change>''',
-          directives: [OnChangeComponent]));
+          directives: [OnChangeComponent]))
 
-      tb.createView(Dummy).then((view) {
-        view.detectChanges();
-        var cmp = view.rawView.elementInjectors[0].get(OnChangeComponent);
+      .createAsync(Dummy).then((tc) {
+        tc.detectChanges();
+        var cmp = tc.componentViewChildren[0].inject(OnChangeComponent);
         expect(cmp.prop).toEqual('hello');
         expect(cmp.changes.containsKey('prop')).toEqual(true);
         async.done();

--- a/modules/angular2/test/core/directive_lifecycle_integration_spec.ts
+++ b/modules/angular2/test/core/directive_lifecycle_integration_spec.ts
@@ -9,11 +9,11 @@ import {
   it,
   xdescribe,
   xit,
+  TestComponentBuilder,
   IS_DARTIUM
 } from 'angular2/test_lib';
 
 import {ListWrapper} from 'angular2/src/facade/collection';
-import {TestBed} from 'angular2/src/test_lib/test_bed';
 import {
   Directive,
   Component,
@@ -27,25 +27,21 @@ import * as viewAnn from 'angular2/src/core/annotations_impl/view';
 
 export function main() {
   describe('directive lifecycle integration spec', () => {
-    var ctx;
-
-    beforeEach(() => { ctx = new MyComp(); });
 
     it('should invoke lifecycle methods onChange > onInit > onCheck > onAllChangesDone',
-       inject([TestBed, AsyncTestCompleter], (tb: TestBed, async) => {
-         tb.overrideView(
-             MyComp,
-             new viewAnn.View(
-                 {template: '<div [field]="123" lifecycle></div>', directives: [LifecycleDir]}));
-
-         tb.createView(MyComp, {context: ctx})
-             .then((view) => {
-               var dir = view.rawView.elementInjectors[0].get(LifecycleDir);
-               view.detectChanges();
+       inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
+         tcb.overrideView(
+                MyComp,
+                new viewAnn.View(
+                    {template: '<div [field]="123" lifecycle></div>', directives: [LifecycleDir]}))
+             .createAsync(MyComp)
+             .then((tc) => {
+               var dir = tc.componentViewChildren[0].inject(LifecycleDir);
+               tc.detectChanges();
 
                expect(dir.log).toEqual(["onChange", "onInit", "onCheck", "onAllChangesDone"]);
 
-               view.detectChanges();
+               tc.detectChanges();
 
                expect(dir.log).toEqual([
                  "onChange",

--- a/modules/angular2/test/core/forward_ref_integration_spec.ts
+++ b/modules/angular2/test/core/forward_ref_integration_spec.ts
@@ -1,5 +1,7 @@
 import {
   AsyncTestCompleter,
+  TestComponentBuilder,
+  asNativeElements,
   beforeEach,
   ddescribe,
   describe,
@@ -9,7 +11,6 @@ import {
   it,
   xit
 } from 'angular2/test_lib';
-import {TestBed} from 'angular2/src/test_lib/test_bed';
 import {Directive, Component, Query, View} from 'angular2/annotations';
 import {QueryList, NgFor} from 'angular2/angular2';
 import {forwardRef, resolveForwardRef, bind, Inject} from 'angular2/di';
@@ -18,10 +19,10 @@ import {Type} from 'angular2/src/facade/lang';
 export function main() {
   describe("forwardRef integration", function() {
     it('should instantiate components which are declared using forwardRef',
-       inject([TestBed, AsyncTestCompleter], (tb: TestBed, async) => {
-         tb.createView(App).then((view) => {
-           view.detectChanges();
-           expect(view.rootNodes).toHaveText('frame(lock)');
+       inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
+         tcb.createAsync(App).then((tc) => {
+           tc.detectChanges();
+           expect(asNativeElements(tc.componentViewChildren)).toHaveText('frame(lock)');
            async.done();
          });
        }));


### PR DESCRIPTION
Also add a small utility function to debug element to get an
array of native elements, which works smoothly with the
toHaveText matcher.
