### PR TITLE
fix(typings): Minor issues preventing angular2.d.ts from working on DT

### DIFF
--- a/docs/dgeni-package/processors/readTypeScriptModules.js
+++ b/docs/dgeni-package/processors/readTypeScriptModules.js
@@ -68,6 +68,10 @@ module.exports = function readTypeScriptModules(tsParser, readFilesProcessor, mo
 
             exportDoc.members = [];
             for(var memberName in resolvedExport.members) {
+              // FIXME(alexeagle): why do generic type params appear in members?
+              if (memberName === 'T') {
+                continue;
+              }
               log.silly('>>>>>> member: ' + memberName + ' from ' + exportDoc.id + ' in ' + moduleDoc.id);
               var memberSymbol = resolvedExport.members[memberName];
               var memberDoc = createMemberDoc(memberSymbol, exportDoc, basePath, parseInfo.typeChecker);
@@ -227,6 +231,8 @@ module.exports = function readTypeScriptModules(tsParser, readFilesProcessor, mo
       }
       if (parameter.type) {
         paramText += ':' + getType(sourceFile, parameter.type);
+      } else {
+        paramText += ': any';
       }
       return paramText.trim();
     });

--- a/docs/dgeni-package/services/tsParser/getExportDocType.js
+++ b/docs/dgeni-package/services/tsParser/getExportDocType.js
@@ -45,7 +45,7 @@ module.exports = function getExportDocType(log) {
     var node = symbol.valueDeclaration;
     while(node) {
       if ( node.flags & 0x2000 /* const */) {
-        return 'const';
+        return 'var'; // change to const when targetting TS 1.5
       }
       node = node.parent;
     }

--- a/docs/dgeni-package/templates/type-definition.template.html
+++ b/docs/dgeni-package/templates/type-definition.template.html
@@ -6,7 +6,7 @@
 {$ '*/' | indent(level, true) | replace(r/\n$/, "") $}{% endif -%}
 {%- endmacro -%}
 
-// Type definitions for Angular v{$ versionInfo.currentVersion.full $}
+// Type definitions for Angular v{$ versionInfo.currentVersion.full | replace(r/\+/, "_") $}
 // Project: http://angular.io/
 // Definitions by: angular team <https://github.com/angular/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -34,8 +34,8 @@ declare module "angular2/angular2" {
 
   // See https://github.com/Microsoft/TypeScript/issues/1168
   class BaseException /* extends Error */ {
-    message;
-    stack;
+    message: string;
+    stack: string;
     toString(): string;
   }
 }
@@ -53,15 +53,15 @@ declare module "{$ module.id $}" {
     {$ commentBlock(member, 5) $}
     {$ member.name $}
     {%- if member.parameters %}({% for param in member.parameters %}{$ param $}{% if not loop.last %}, {% endif %}{% endfor %}){%- endif %}
-    {%- if member.returnType %}: {$ member.returnType $}{% endif -%}
+    {%- if member.returnType %}: {$ member.returnType $}{%- else -%}: any{% endif -%}
     ;
   {%- endfor %}
   }
 
   {%- elif export.docType == 'enum' %} {
-    {%- for member in export.members %} 
-    {$ member $}{% if not loop.last %}, 
-    {%- endif -%} 
+    {%- for member in export.members %}
+    {$ member $}{% if not loop.last %},
+    {%- endif -%}
     {%- endfor %}
   }
 


### PR DESCRIPTION
This removes some, but not all, of the manual work needed to patch up our
.d.ts for pushing to DefinitelyTyped. Remaining manual steps are:
- some types still missing
- declaration of decorators
- remove destructuring args

See #2686.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular/2734)

<!-- Reviewable:end -->
