### PR TITLE
fix(docs): To run js test 'gulp docs' should be executed

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -134,6 +134,12 @@ You can selectively build either the JS or Dart versions as follows:
 * `$(npm bin)/gulp build.js`
 * `$(npm bin)/gulp build.dart`
 
+Also note that in order for the whole test suite to succeed you will need to generate the docs by running:
+
+```shell
+$(npm bin)/gulp docs
+```
+
 To clean out the `dist` folder, run:
 
 ```shell


### PR DESCRIPTION
I was not able to succesfully complete the tests without generating the docs by running 'gulp docs'.... Did I made something wrong?

I think that running 'gulp docs' is needed for the test suite to complete ('npm test'), because 'test.typings' task is included in the 'test.js' task, but docs are not generated by the 'build' task. It would be good to have this documented in the DEVELOPERS.md file.

Thanks!

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular/2762)

<!-- Reviewable:end -->
