### PR TITLE
fix(bundle): don’t bundle traceur/reflect into benchpress

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,6 +137,7 @@ var BENCHPRESS_BUNDLE_CONFIG = {
   ],
   excludes: [
     'traceur',
+    'traceur/bin/traceur-runtime',
     'reflect-metadata',
     'selenium-webdriver',
     'rtts_assert',


### PR DESCRIPTION
Don’t need to bundle them as they are already
present in G3.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular/2769)

<!-- Reviewable:end -->
