### PR TITLE
build: speed up karma run by passing in list of dist files that changed

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -416,9 +416,27 @@ gulp.task('docs/angular.io', ['build/clean.docs_angular_io'], function() {
 // CI tests suites
 
 function runKarma(configFile, done) {
+  var fs = require('fs');
+  var path = require('path');
   var cmd = process.platform === 'win32' ? 'node_modules\\.bin\\karma run ' :
                                            'node node_modules/.bin/karma run ';
   cmd += configFile;
+
+  // this file is written into the tmp folder by DestCopy broccoli plugin after each build
+  var karmaArgsPath = path.join('tmp', 'build-log-karma-args.txt');
+
+  if (fs.existsSync(karmaArgsPath)) {
+    var changedFilesArgs = fs.readFileSync(karmaArgsPath, {encoding: 'utf-8'});
+
+    // windows has a limit for the length of the command it can execute, so on win we check the
+    // length of args provide them only if the length is not over the limit.
+    // additionally, the arguments don't help the speedup the initial run, so we can safely ignore
+    // the args when there is lots of them on all platforms
+    if (changedFilesArgs.length > 10 && changedFilesArgs.length + cmd.length < 0x2000) {
+      cmd += changedFilesArgs;
+    }
+  }
+
   exec(cmd, function(e, stdout) {
     // ignore errors, we don't want to fail the build in the interactive (non-ci) mode
     // karma server will print all test failures

--- a/tools/broccoli/broccoli-dest-copy.ts
+++ b/tools/broccoli/broccoli-dest-copy.ts
@@ -30,6 +30,20 @@ class DestCopy implements DiffingBroccoliPlugin {
       // TODO: what about obsolete directories? we are not cleaning those up yet
       fs.unlinkSync(destFilePath);
     });
+
+
+    // Write log of added/changed/removed files to be used when we call `karma run` from gulp.
+    var karmaArgs = '';
+    if (treeDiff.addedPaths.length) {
+      karmaArgs +=  ' --addedFiles ' + treeDiff.addedPaths.join(',');
+    }
+    if (treeDiff.changedPaths.length) {
+      karmaArgs +=  ' --changedFiles ' + treeDiff.changedPaths.join(',');
+    }
+    if (treeDiff.removedPaths.length) {
+      karmaArgs +=  ' --removedFiles ' + treeDiff.removedPaths.join(',')
+    }
+    fs.writeFileSync(path.join('tmp', 'build-log-karma-args.txt'), karmaArgs, {encoding: 'utf-8'});
   }
 }
 


### PR DESCRIPTION
per discussion with @zzo...

This change causes the build system to write a log file into the tmp folder after each build.
This file contains command line arguments that tell karma about all the added/changed/removed files
from the last build. Karma can then use this list instead of doing internal globbing which can be
very expensive especially for hte dart builds that contain thousands of files.

Closes #2437

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular/2778)

<!-- Reviewable:end -->
