### PR TITLE
fix(Compiler): change compiler to throw selector errors

### DIFF
--- a/modules/angular2/src/render/dom/compiler/compiler.ts
+++ b/modules/angular2/src/render/dom/compiler/compiler.ts
@@ -35,15 +35,28 @@ export class DomCompiler extends RenderCompiler {
   }
 
   compileHost(directiveMetadata: DirectiveMetadata): Promise<ProtoViewDto> {
+    var flatExceptionText = `Directive must not span element boundaries, but had '${directiveMetadata.selector}'`;
     var hostViewDef = new ViewDefinition({
-      componentId: directiveMetadata.id,
-      templateAbsUrl: null, template: null,
-      styles: null,
-      styleAbsUrls: null,
-      directives: [directiveMetadata]
-    });
-    var element = DOM.createElement(directiveMetadata.selector);
-    return this._compileTemplate(hostViewDef, element, ViewType.HOST);
+        componentId: directiveMetadata.id,
+        templateAbsUrl: null, 
+        template: null,
+        styles: null,
+        styleAbsUrls: null,
+        directives: [directiveMetadata]
+      });
+    var element;
+    try {      
+      element = DOM.createElement(directiveMetadata.selector);
+      if(directiveMetadata.selector.indexOf(' ') > -1) {
+        throw new BaseException(flatExceptionText);
+      } else {
+        return this._compileTemplate(hostViewDef, element, ViewType.HOST);
+      }
+    } catch(e) {
+      if(!element || element.name.indexOf(' ') > -1) {
+        throw new BaseException(flatExceptionText);
+      }
+    }
   }
 
   _compileTemplate(viewDef: ViewDefinition, tplElement,

--- a/modules/angular2/src/render/dom/compiler/directive_parser.ts
+++ b/modules/angular2/src/render/dom/compiler/directive_parser.ts
@@ -31,8 +31,28 @@ export class DirectiveParser implements CompileStep {
     for (var i = 0; i < _directives.length; i++) {
       var directive = _directives[i];
       var selector = CssSelector.parse(directive.selector);
+      this._ensureDirectiveSelectorIsFlat(selector, directive);
       this._ensureComponentOnlyHasElementSelector(selector, directive);
       this._selectorMatcher.addSelectables(selector, i);
+    }
+  }
+
+  _ensureDirectiveSelectorIsFlat(selector, directive) {
+    var flatExceptionText = `Directive must not span element boundaries, but had '${directive.selector}'`;
+    var element;
+
+    if(selector.length === 1 && selector[0].isElementSelector()) {
+      try {
+        element = DOM.createElement(directive.selector);
+        if(directive.selector.indexOf(' ') > -1) {
+          throw new BaseException(flatExceptionText);
+        }
+      } catch(e) { // For Dart and JS
+        if(!element || directive.selector.indexOf(' ') > -1) {
+          throw new BaseException(flatExceptionText);
+        }
+      }
+
     }
   }
 

--- a/modules/angular2/test/render/dom/compiler/compiler_common_tests.ts
+++ b/modules/angular2/test/render/dom/compiler/compiler_common_tests.ts
@@ -134,6 +134,13 @@ export function runCompilerCommonTests() {
                });
          }));
 
+        it('should report selector errors', () => {
+          expect(() => { 
+            var compiler = createCompiler(EMPTY_STEP);
+            compiler.compileHost(invalidSelectorComponent);
+          })
+          .toThrowError(`Directive must not span element boundaries, but had 'some-comp invalid'`);
+        });
     });
 
   });
@@ -191,5 +198,13 @@ class FakeViewLoader extends ViewLoader {
   }
 }
 
-var someComponent = DirectiveMetadata.create(
-    {selector: 'some-comp', id: 'someComponent', type: DirectiveMetadata.COMPONENT_TYPE});
+var someComponent = DirectiveMetadata.create({
+  selector: 'some-comp',
+  id: 'someComponent',
+  type: DirectiveMetadata.COMPONENT_TYPE
+});
+var invalidSelectorComponent = DirectiveMetadata.create({
+  selector: 'some-comp invalid',
+  id: 'someComponent',
+  type: DirectiveMetadata.COMPONENT_TYPE
+});

--- a/modules/angular2/test/render/dom/compiler/directive_parser_spec.ts
+++ b/modules/angular2/test/render/dom/compiler/directive_parser_spec.ts
@@ -160,6 +160,11 @@ export function main() {
       expect(eventBinding.source.source).toEqual('doItGlobal()');
     });
 
+    it('should throw when the provided selector is not flat', () => {
+      expect(() => { createPipeline(null, [directiveWithNonFlatElementSelector]); })
+          .toThrowError();
+    });
+
     // TODO: assertions should be enabled when running tests:
     // https://github.com/angular/angular/issues/1340
     describe('component directives', () => {
@@ -258,3 +263,10 @@ var componentWithNonElementSelector = DirectiveMetadata.create({
   selector: '[attr]',
   type: DirectiveMetadata.COMPONENT_TYPE
 });
+
+var directiveWithNonFlatElementSelector = DirectiveMetadata.create({
+  id: 'directiveWithNonFlatElementSelector',
+  selector: 'not flat'
+});
+
+


### PR DESCRIPTION
These fixes change the functionality of the compiler so that it throws an error when a selector
that spans element boundaries are provided.

Closes #2589

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular/2784)

<!-- Reviewable:end -->
