### PR TITLE
fix(change detectors): Fix deduping of protos in transformed dart mode.

### DIFF
--- a/modules/angular2/src/change_detection/coalesce.ts
+++ b/modules/angular2/src/change_detection/coalesce.ts
@@ -46,7 +46,7 @@ function _selfRecord(r: ProtoRecord, contextIndex: number, selfIndex: number): P
 function _findMatching(r: ProtoRecord, rs: List<ProtoRecord>) {
   return ListWrapper.find(rs, (rr) => rr.mode !== RecordType.DIRECTIVE_LIFECYCLE &&
                                       rr.mode === r.mode && rr.funcOrValue === r.funcOrValue &&
-                                      rr.contextIndex === r.contextIndex &&
+                                      rr.contextIndex === r.contextIndex && rr.name === r.name &&
                                       ListWrapper.equals(rr.args, r.args));
 }
 

--- a/modules/angular2/test/change_detection/coalesce_spec.ts
+++ b/modules/angular2/test/change_detection/coalesce_spec.ts
@@ -5,9 +5,9 @@ import {RecordType, ProtoRecord} from 'angular2/src/change_detection/proto_recor
 
 export function main() {
   function r(funcOrValue, args, contextIndex, selfIndex, lastInBinding = false,
-             mode = RecordType.PROPERTY) {
-    return new ProtoRecord(mode, "name", funcOrValue, args, null, contextIndex, null, selfIndex,
-                           null, null, lastInBinding, false);
+             mode = RecordType.PROPERTY, name = "name") {
+    return new ProtoRecord(mode, name, funcOrValue, args, null, contextIndex, null, selfIndex, null,
+                           null, lastInBinding, false);
   }
 
   describe("change detection - coalesce", () => {
@@ -58,6 +58,15 @@ export function main() {
         r("onCheck", [], 0, 1, true, RecordType.DIRECTIVE_LIFECYCLE)
       ]);
 
+      expect(rs.length).toEqual(2);
+    });
+
+    it("should not coalesce protos with different names but same value", () => {
+      var nullFunc = () => {};
+      var rs = coalesce([
+        r(nullFunc, [], 0, 1, false, RecordType.PROPERTY, "foo"),
+        r(nullFunc, [], 0, 1, false, RecordType.PROPERTY, "bar"),
+      ]);
       expect(rs.length).toEqual(2);
     });
   });


### PR DESCRIPTION
In non-transformed mode the funcOrValue check was enough, but once
transformed these all use the same function for getters, so we need
to also check the name.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular/2792)

<!-- Reviewable:end -->
