### PR TITLE
fix: handle errors w/o file information.

### DIFF
--- a/tools/broccoli/broccoli-typescript.ts
+++ b/tools/broccoli/broccoli-typescript.ts
@@ -137,10 +137,13 @@ class DiffingTSCompiler implements DiffingBroccoliPlugin {
       let errorMessages = [];
 
       allDiagnostics.forEach(diagnostic => {
-        var {line, character} = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+        var pos = '';
+        if (diagnostic.file) {
+          var {line, character} = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+          pos = `${diagnostic.file.fileName} (${line + 1}, ${character + 1}): `
+        }
         var message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
-        errorMessages.push(
-            `  ${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
+        errorMessages.push(`  ${pos}${message}`);
       });
 
       if (errorMessages.length) {


### PR DESCRIPTION
TypeScript errors do not always include file information, e.g. for
global errors triggered by incorrect compiler options.
