### PR TITLE
test(ProtoViewBuilder): correct duplicate tests

### DIFF
--- a/modules/angular2/test/render/dom/view/proto_view_builder_spec.ts
+++ b/modules/angular2/test/render/dom/view/proto_view_builder_spec.ts
@@ -31,21 +31,20 @@ export function main() {
                 `Can't bind to 'unknownProperty' since it isn't a know property of the 'div' element and there are no matching directives with a corresponding property`);
       });
 
-      it('should should allow unknown properties if a directive uses it', () => {
-        builder.bindElement(el('<div/>')).bindProperty('unknownProperty', emptyExpr());
-        expect(() => builder.build())
-            .toThrowError(
-                `Can't bind to 'unknownProperty' since it isn't a know property of the 'div' element and there are no matching directives with a corresponding property`);
+      it('should allow unknown properties if a directive uses it', () => {
+        var binder = builder.bindElement(el('<div/>'));
+        binder.bindDirective(0).bindProperty('someDirProperty', emptyExpr(), 'directiveProperty');
+        binder.bindProperty('directiveProperty', emptyExpr());
+        expect(() => builder.build()).not.toThrow();
       });
 
       it('should allow unknown properties on custom elements', () => {
         var binder = builder.bindElement(el('<some-custom/>'));
         binder.bindProperty('unknownProperty', emptyExpr());
-        binder.bindDirective(0).bindProperty('someDirProperty', emptyExpr(), 'unknownProperty');
         expect(() => builder.build()).not.toThrow();
       });
 
-      it('should throw for unkown properties on custom elements if there is an ng component', () => {
+      it('should throw for unknown properties on custom elements if there is an ng component', () => {
         var binder = builder.bindElement(el('<some-custom/>'));
         binder.bindProperty('unknownProperty', emptyExpr());
         binder.setComponentId('someComponent');


### PR DESCRIPTION
One of the tests was a straight duplicate of another test, but with a changed name. Removed duplicated code and implemented a missing test.
