### PR TITLE
WIP: detect dangling properties on custom elements

### DIFF
--- a/modules/angular2/src/dom/browser_adapter.ts
+++ b/modules/angular2/src/dom/browser_adapter.ts
@@ -142,6 +142,12 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     return t;
   }
   createElement(tagName, doc = document): HTMLElement { return doc.createElement(tagName); }
+  registerElement(tagName, tagType): void {
+    if (this.supportsCustomElements()) {
+      // TODO(pk): I guess TS definition of the Document object should be extended...
+      (<any>document).registerElement(tagName, tagType);
+    }
+  }
   createTextNode(text: string, doc = document): Text { return doc.createTextNode(text); }
   createScriptTag(attrName: string, attrValue: string, doc = document): HTMLScriptElement {
     var el = <HTMLScriptElement>doc.createElement('SCRIPT');

--- a/modules/angular2/src/dom/dom_adapter.ts
+++ b/modules/angular2/src/dom/dom_adapter.ts
@@ -67,6 +67,7 @@ export class DomAdapter {
   setChecked(el, value: boolean) { throw _abstract(); }
   createTemplate(html): HTMLElement { throw _abstract(); }
   createElement(tagName, doc = null): HTMLElement { throw _abstract(); }
+  registerElement(tagName, tagType): void { throw _abstract(); }
   createTextNode(text: string, doc = null): Text { throw _abstract(); }
   createScriptTag(attrName: string, attrValue: string, doc = null): HTMLElement {
     throw _abstract();
@@ -116,6 +117,7 @@ export class DomAdapter {
   cssToRules(css: string): List<any> { throw _abstract(); }
   supportsDOMEvents(): boolean { throw _abstract(); }
   supportsNativeShadowDOM(): boolean { throw _abstract(); }
+  supportsCustomElements(): boolean { throw _abstract(); }
   getGlobalEventTarget(target: string): any { throw _abstract(); }
   getHistory(): History { throw _abstract(); }
   getLocation(): Location { throw _abstract(); }

--- a/modules/angular2/src/dom/generic_browser_adapter.ts
+++ b/modules/angular2/src/dom/generic_browser_adapter.ts
@@ -37,4 +37,5 @@ export class GenericBrowserDomAdapter extends DomAdapter {
   supportsNativeShadowDOM(): boolean {
     return isFunction((<any>this.defaultDoc().body).createShadowRoot);
   }
+  supportsCustomElements(): boolean { return isFunction((<any>this.defaultDoc()).registerElement); }
 }

--- a/modules/angular2/src/dom/html_adapter.dart
+++ b/modules/angular2/src/dom/html_adapter.dart
@@ -178,6 +178,9 @@ class Html5LibDomAdapter implements DomAdapter {
   createElement(tagName, [doc]) {
     return new Element.tag(tagName);
   }
+  registerElement(String tagName, tagType) {
+    throw 'not implemented';
+  }
   createTextNode(String text, [doc]) {
     throw 'not implemented';
   }
@@ -311,6 +314,9 @@ class Html5LibDomAdapter implements DomAdapter {
   }
   bool supportsNativeShadowDOM() {
     throw 'not implemented';
+  }
+  bool supportsCustomElements() {
+    return false;
   }
   getHistory() {
     throw 'not implemented';

--- a/modules/angular2/src/dom/parse5_adapter.ts
+++ b/modules/angular2/src/dom/parse5_adapter.ts
@@ -254,6 +254,7 @@ export class Parse5DomAdapter extends DomAdapter {
   createElement(tagName): HTMLElement {
     return treeAdapter.createElement(tagName, 'http://www.w3.org/1999/xhtml', []);
   }
+  registerElement(tagName, tagType): void { throw _notImplemented('registerElement'); }
   createTextNode(text: string): Text { throw _notImplemented('createTextNode'); }
   createScriptTag(attrName: string, attrValue: string): HTMLElement {
     return treeAdapter.createElement("script", 'http://www.w3.org/1999/xhtml',
@@ -507,6 +508,7 @@ export class Parse5DomAdapter extends DomAdapter {
   }
   supportsDOMEvents(): boolean { return false; }
   supportsNativeShadowDOM(): boolean { return false; }
+  supportsCustomElements(): boolean { return false; }
   getGlobalEventTarget(target: string): any {
     if (target == "window") {
       return (<any>this.defaultDoc())._window;

--- a/modules/angular2/src/render/dom/view/proto_view_builder.ts
+++ b/modules/angular2/src/render/dom/view/proto_view_builder.ts
@@ -306,6 +306,7 @@ export class EventBuilder extends AstTransformer {
   }
 }
 
+var customElmsCache = new Map<String, any>();
 var PROPERTY_PARTS_SEPARATOR = new RegExp('\\.');
 const ATTRIBUTE_PREFIX = 'attr';
 const CLASS_PREFIX = 'class';
@@ -330,16 +331,19 @@ function buildElementPropertyBindings(protoElement: /*element*/ any, isNgCompone
 
 function isValidElementPropertyBinding(protoElement: /*element*/ any, isNgComponent: boolean,
                                        binding: api.ElementPropertyBinding): boolean {
+  var elInstance = protoElement;
+  var tagName = DOM.tagName(protoElement);
+
   if (binding.type === api.PropertyBindingType.PROPERTY) {
-    var tagName = DOM.tagName(protoElement);
-    var possibleCustomElement = tagName.indexOf('-') !== -1;
-    if (possibleCustomElement && !isNgComponent) {
-      // can't tell now as we don't know which properties a custom element will get
-      // once it is instantiated
-      return true;
-    } else {
-      return DOM.hasProperty(protoElement, binding.property);
+    if (!isNgComponent && DOM.supportsCustomElements() && tagName.indexOf('-') !== -1) {
+      if (customElmsCache.has(tagName)) {
+        elInstance = customElmsCache.get(tagName);
+      } else {
+        elInstance = DOM.createElement(tagName);
+        customElmsCache.set(tagName, elInstance);
+      }
     }
+    return DOM.hasProperty(elInstance, binding.property);
   }
   return true;
 }

--- a/modules/angular2/test/render/dom/view/test_custom_element.dart
+++ b/modules/angular2/test/render/dom/view/test_custom_element.dart
@@ -1,0 +1,2 @@
+class TestCustomElement {
+}

--- a/modules/angular2/test/render/dom/view/test_custom_element.ts
+++ b/modules/angular2/test/render/dom/view/test_custom_element.ts
@@ -1,0 +1,8 @@
+import {DOM} from 'angular2/src/dom/dom_adapter';
+
+// TODO(pk): can't use a class here due to https://github.com/Microsoft/TypeScript/issues/574
+export var TestCustomElement = {
+  // should be Object.create(HTMLElement.prototype, { but HTMLElement is an interface in TS :-/
+  prototype: Object.create(Object.getPrototypeOf(DOM.createElement('div')),
+                           {knownProperty: {value: function() { return 'known value';}}})
+};


### PR DESCRIPTION
@mhevery @tbosch this is an attempt to query web component properties at run-time to detect invalid property bindings. I've managed to make it work in JS, but it would need more effort in TS / Dart (still, should be manageable).

But before spending more time on it, I would like to validate the approach with you: essentially we are creating an instance of a custom element if:
- we are in a browser that supports custom elements
- name of a tag looks like a custom element (contains -)

As soon as we've got an instance of a custom element we can query its properties. This has an advantage over static / hand-written "schema", since people don't have to write it by hand and valid properties can be discovered at run-time. Not sure about the potential perf impact (we can easily cache results of those checks, this would be roughly equivalent of maintaing static schema in memory). I also need to check if there are no side effect for elements that are created by not attached to the DOM. 
