### PR TITLE
feat(NgStyle): Export NgStyle in angular2/directives

### DIFF
--- a/modules/angular2/directives.ts
+++ b/modules/angular2/directives.ts
@@ -15,6 +15,7 @@ export * from './src/directives/class';
 export * from './src/directives/ng_for';
 export * from './src/directives/ng_if';
 export * from './src/directives/ng_non_bindable';
+export * from './src/directives/ng_style';
 export * from './src/directives/ng_switch';
 
 /**


### PR DESCRIPTION
When working in https://github.com/angular/angular/pull/2874 I realized that NgStyle is not exported in angular2/directives. Is this intended?

Thanks!
