### PR TITLE
style(facade): awkward spaces

### DIFF
--- a/modules/angular2/src/facade/async.ts
+++ b/modules/angular2/src/facade/async.ts
@@ -78,7 +78,7 @@ export class ObservableWrapper {
 
   static callThrow(emitter: EventEmitter, error: any) { emitter.throw(error); }
 
-  static callReturn(emitter: EventEmitter) { emitter.return (null); }
+  static callReturn(emitter: EventEmitter) { emitter.return(null); }
 }
 
 // TODO: vsavkin change to interface
@@ -113,7 +113,7 @@ export class EventEmitter extends Observable {
     return this._subject.observeOn(this._immediateScheduler)
         .subscribe((value) => { setTimeout(() => generator.next(value)); },
                    (error) => generator.throw ? generator.throw(error) : null,
-                   () => generator.return ? generator.return () : null);
+                   () => generator.return ? generator.return() : null);
   }
 
   toRx(): Rx.Observable<any> { return this._subject; }
@@ -122,5 +122,5 @@ export class EventEmitter extends Observable {
 
   throw(error) { this._subject.onError(error); }
 
-  return (value?) { this._subject.onCompleted(); }
+  return(value?) { this._subject.onCompleted(); }
 }


### PR DESCRIPTION
This is probably due to clang-format and `return` being a keyword

update:
This PR is blocked. 
Travis is failing because clang-format wants the spaces after the `return` keyword. This means clang-format needs to be updated for this case unless this is by design (which is a bit weird to me). If that's the case please close this PR
