### PR TITLE
feat(XHRConnection): set headers for xhr

### DIFF
--- a/modules/angular2/src/http/backends/xhr_backend.ts
+++ b/modules/angular2/src/http/backends/xhr_backend.ts
@@ -7,6 +7,9 @@ import {Injectable} from 'angular2/di';
 import {BrowserXhr} from './browser_xhr';
 import {EventEmitter, ObservableWrapper} from 'angular2/src/facade/async';
 import {isPresent, ENUM_INDEX} from 'angular2/src/facade/lang';
+import {StringMapWrapper, ListWrapper} from 'angular2/src/facade/collection';
+
+const HEADER_DIVIDER = "; ";
 
 /**
  * Creates connections using `XMLHttpRequest`. Given a fully-qualified
@@ -35,6 +38,14 @@ export class XHRConnection implements Connection {
     this._xhr = browserXHR.build();
     // TODO(jeffbcross): implement error listening/propagation
     this._xhr.open(requestMethodsMap.getMethod(ENUM_INDEX(req.method)), req.url);
+
+    if (isPresent(req.headers)) {
+      req.headers.forEach((values, key) => {
+        var value = ListWrapper.join(values, HEADER_DIVIDER);
+        this._xhr.setRequestHeader(key, value);
+      });
+    }
+
     this._xhr.addEventListener('load', (_) => {
       var responseOptions = new ResponseOptions(
           {body: isPresent(this._xhr.response) ? this._xhr.response : this._xhr.responseText});


### PR DESCRIPTION
The default content type is `text/plain` which means you have to do
workarounds on the server [express-server-example.js#L80](https://github.com/angular-class/angular
2-webpack-starter/blob/727aad443cf4b90838f8cfe7de6a640a37eb9fde/server/e
xpress-server-example.js#L80)
- [x] Tests
