### PR TITLE
refactor(di): subclasses of BaseException should be immutable #2606

### DIFF
--- a/modules/angular2/src/di/exceptions.ts
+++ b/modules/angular2/src/di/exceptions.ts
@@ -35,18 +35,18 @@ export class AbstractBindingError extends BaseException {
   message: string;
   keys: List<any>;
   constructResolvingMessage: Function;
-  // TODO(tbosch): Can't do key:Key as this results in a circular dependency!
-  constructor(key, constructResolvingMessage: Function, originalException?, originalStack?) {
+
+  constructor(keys: List<any>, constructResolvingMessage: Function, originalException?,
+              originalStack?) {
     super(null, originalException, originalStack);
-    this.keys = [key];
+    this.keys = keys;
     this.constructResolvingMessage = constructResolvingMessage;
     this.message = this.constructResolvingMessage(this.keys);
   }
 
-  // TODO(tbosch): Can't do key:Key as this results in a circular dependency!
-  addKey(key): void {
-    this.keys.push(key);
-    this.message = this.constructResolvingMessage(this.keys);
+  addKey(key): AbstractBindingError {
+    return new AbstractBindingError(ListWrapper.concat(this.keys, [key]),
+                                    this.constructResolvingMessage);
   }
 
   toString(): string { return this.message; }
@@ -59,9 +59,8 @@ export class AbstractBindingError extends BaseException {
  * @exportedAs angular2/di_errors
  */
 export class NoBindingError extends AbstractBindingError {
-  // TODO(tbosch): Can't do key:Key as this results in a circular dependency!
   constructor(key) {
-    super(key, function(keys: List<any>) {
+    super([key], function(keys: List<any>) {
       var first = stringify(ListWrapper.first(keys).token);
       return `No provider for ${first}!${constructResolvingPath(keys)}`;
     });
@@ -93,9 +92,8 @@ export class NoBindingError extends AbstractBindingError {
  * @exportedAs angular2/di_errors
  */
 export class AsyncBindingError extends AbstractBindingError {
-  // TODO(tbosch): Can't do key:Key as this results in a circular dependency!
   constructor(key) {
-    super(key, function(keys: List<any>) {
+    super([key], function(keys: List<any>) {
       var first = stringify(ListWrapper.first(keys).token);
       return `Cannot instantiate ${first} synchronously. It is provided as a promise!${constructResolvingPath(keys)}`;
     });
@@ -121,9 +119,8 @@ export class AsyncBindingError extends AbstractBindingError {
  * @exportedAs angular2/di_errors
  */
 export class CyclicDependencyError extends AbstractBindingError {
-  // TODO(tbosch): Can't do key:Key as this results in a circular dependency!
   constructor(key) {
-    super(key, function(keys: List<any>) {
+    super([key], function(keys: List<any>) {
       return `Cannot instantiate cyclic dependency!${constructResolvingPath(keys)}`;
     });
   }
@@ -139,10 +136,8 @@ export class CyclicDependencyError extends AbstractBindingError {
  */
 export class InstantiationError extends AbstractBindingError {
   causeKey;
-
-  // TODO(tbosch): Can't do key:Key as this results in a circular dependency!
   constructor(originalException, originalStack, key) {
-    super(key, function(keys: List<any>) {
+    super([key], function(keys: List<any>) {
       var first = stringify(ListWrapper.first(keys).token);
       return `Error during instantiation of ${first}!${constructResolvingPath(keys)}.` +
              ` ORIGINAL ERROR: ${originalException}` +

--- a/modules/angular2/src/di/injector.ts
+++ b/modules/angular2/src/di/injector.ts
@@ -621,7 +621,9 @@ export class Injector {
       d18 = length > 18 ? this._getByDependency(binding, deps[18], visibility) : null;
       d19 = length > 19 ? this._getByDependency(binding, deps[19], visibility) : null;
     } catch (e) {
-      if (e instanceof AbstractBindingError) e.addKey(binding.key);
+      if (e instanceof AbstractBindingError) {
+        e = e.addKey(binding.key)
+      };
       throw e;
     }
 


### PR DESCRIPTION
Change AbstractBindingError constructor to take List<any> as keys
Implement the AbstractBindingError.addKey(key) method to return a new AbstractBindingError

Fix issue: refactor(di): subclasses of BaseException should be immutable #2606
BreakingChanges: AbstractBindingError constructor takes now List<any> as keys instead only one key.
