### PR TITLE
fix(router): ensure that RouteRecognizer understands hash-prefixed URLs

### DIFF
--- a/modules/angular2/src/router/route_recognizer.ts
+++ b/modules/angular2/src/router/route_recognizer.ts
@@ -62,6 +62,11 @@ export class RouteRecognizer {
    */
   recognize(url: string): List<RouteMatch> {
     var solutions = [];
+
+    if (url[0] == '#') {
+      url = url.substring(1);
+    }
+
     if (url.length > 0 && url[url.length - 1] == '/') {
       url = url.substring(0, url.length - 1);
     }

--- a/modules/angular2/test/router/route_recognizer_spec.ts
+++ b/modules/angular2/test/router/route_recognizer_spec.ts
@@ -107,6 +107,13 @@ export function main() {
          expect(solutions[0].matchedUrl).toBe('/matias');
        });
 
+    it('should strip a the hash character if it is the first character in the provided url',
+       () => {
+         recognizer.addConfig('/matsko', handler);
+         var solutions = recognizer.recognize('#/matsko');
+         expect(solutions[0].matchedUrl).toBe('/matsko');
+       });
+
     it('should generate URLs with params', () => {
       recognizer.addConfig('/app/user/:name', handler, 'user');
       expect(recognizer.generate('user', {'name': 'misko'})['url']).toEqual('app/user/misko');


### PR DESCRIPTION
This patch fixes the issue where if a page is refreshed then the
previous route is loaded properly when a hash-prefixed URLs are used.

Closes #2920
