### PR TITLE
chore(build): add GCS upload of build artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,12 +70,12 @@ deploy:
   provider: gcs
   access_key_id: GOOGIOQTDBEOPBUAWFZQ
   secret_access_key:
-    secure: "rsx0rvLAGWV47rmgJC2CJUmtFtj9TbbvGUGj8b8ykLuhu3LlMMgTpgxj7YNJ0j6HM3UZ9tubNuK0jqNW3eWul9AzNAz4zMvHpUmn852gIIOFKdYhCaB5PGL58QbqeP48B2VyDYqDWaQGH8ClfZYPrTb6XnhVTrZVHba5x9DqHwc="
+    secure: "iu/WI9WLc+FhvqTQsF8MKhLLsZ1kIz7fsA9+AyysxH5jMFTR6nPDgAjjPj9bnwrIHBJnqti7Qlm2HCZPi21C/ejjSvsPB4rLFCA3tIi93lo7jXcDFbi1HzpQIZUO1lBUbvcOHzu0hALTAfxC3odhYa/3hcyEX8xPxYH3gQlczME="
   bucket: angular2-releases
   skip_cleanup: true
   local-dir: dist/dart/angular2
   upload-dir: dart/$TRAVIS_COMMIT
   on:
-    repo: angular/angular
+    repo: alexeagle/angular
     condition: $MODE=dart
     condition: $DART_CHANNEL=stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,3 +65,17 @@ notifications:
     on_start: false     # default: false
   slack:
     secure: EP4MzZ8JMyNQJ4S3cd5LEPWSMjC7ZRdzt3veelDiOeorJ6GwZfCDHncR+4BahDzQAuqyE/yNpZqaLbwRWloDi15qIUsm09vgl/1IyNky1Sqc6lEknhzIXpWSalo4/T9ZP8w870EoDvM/UO+LCV99R3wS8Nm9o99eLoWVb2HIUu0=
+
+deploy:
+  provider: gcs
+  access_key_id: GOOGIOQTDBEOPBUAWFZQ
+  secret_access_key:
+    secure: "rsx0rvLAGWV47rmgJC2CJUmtFtj9TbbvGUGj8b8ykLuhu3LlMMgTpgxj7YNJ0j6HM3UZ9tubNuK0jqNW3eWul9AzNAz4zMvHpUmn852gIIOFKdYhCaB5PGL58QbqeP48B2VyDYqDWaQGH8ClfZYPrTb6XnhVTrZVHba5x9DqHwc="
+  bucket: angular2-releases
+  skip_cleanup: true
+  local-dir: dist/dart/angular2
+  upload-dir: dart/$TRAVIS_COMMIT
+  on:
+    repo: angular/angular
+    condition: $MODE=dart
+    condition: $DART_CHANNEL=stable


### PR DESCRIPTION
This copies the dart build for each successful travis run
to a google cloud storage bucket.
We only upload for submitted changes, not PRs.
We can use this to fetch the dart sources for each SHA
without having to re-build them, which is hard to reproduce
since the environment might differ (eg. different Dart SDK)
