### PR TITLE
chore(build): add GCS upload of build artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,3 +65,28 @@ notifications:
     on_start: false     # default: false
   slack:
     secure: EP4MzZ8JMyNQJ4S3cd5LEPWSMjC7ZRdzt3veelDiOeorJ6GwZfCDHncR+4BahDzQAuqyE/yNpZqaLbwRWloDi15qIUsm09vgl/1IyNky1Sqc6lEknhzIXpWSalo4/T9ZP8w870EoDvM/UO+LCV99R3wS8Nm9o99eLoWVb2HIUu0=
+
+deploy:
+  - provider: gcs
+    access_key_id: GOOGIOQTDBEOPBUAWFZQ
+    secret_access_key:
+      secure: "rsx0rvLAGWV47rmgJC2CJUmtFtj9TbbvGUGj8b8ykLuhu3LlMMgTpgxj7YNJ0j6HM3UZ9tubNuK0jqNW3eWul9AzNAz4zMvHpUmn852gIIOFKdYhCaB5PGL58QbqeP48B2VyDYqDWaQGH8ClfZYPrTb6XnhVTrZVHba5x9DqHwc="
+    bucket: angular2-releases
+    skip_cleanup: true
+    local-dir: dist
+    upload-dir: $TRAVIS_COMMIT/dart
+    on:
+      repo: angular/angular
+      condition: $MODE=dart
+      condition: $DART_CHANNEL=stable
+  - provider: gcs
+    access_key_id: GOOGIOQTDBEOPBUAWFZQ
+    secret_access_key:
+      secure: "rsx0rvLAGWV47rmgJC2CJUmtFtj9TbbvGUGj8b8ykLuhu3LlMMgTpgxj7YNJ0j6HM3UZ9tubNuK0jqNW3eWul9AzNAz4zMvHpUmn852gIIOFKdYhCaB5PGL58QbqeP48B2VyDYqDWaQGH8ClfZYPrTb6XnhVTrZVHba5x9DqHwc="
+    bucket: angular2-releases
+    skip_cleanup: true
+    local-dir: dist
+    upload-dir: $TRAVIS_COMMIT/js
+    on:
+      repo: angular/angular
+      condition: $MODE=js


### PR DESCRIPTION
This copies the dist/ folder for each successful travis run
to a google cloud storage bucket, under the SHA of the commit.
We only upload for submitted changes, not PRs.
We can use this to fetch the dart sources for each SHA
without having to re-build them, which is hard to reproduce
since the environment might differ (eg. different Dart SDK)
