### PR TITLE
chore(build): upload dart artifacts to GCS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,3 +66,26 @@ notifications:
   slack:
     secure: EP4MzZ8JMyNQJ4S3cd5LEPWSMjC7ZRdzt3veelDiOeorJ6GwZfCDHncR+4BahDzQAuqyE/yNpZqaLbwRWloDi15qIUsm09vgl/1IyNky1Sqc6lEknhzIXpWSalo4/T9ZP8w870EoDvM/UO+LCV99R3wS8Nm9o99eLoWVb2HIUu0=
 
+deploy:
+  - provider: gcs
+    # This is for project angular-github-babysitter
+    access_key_id: GOOGIOQTDBEOPBUAWFZQ
+    secret_access_key:
+      secure: "MEDggllZ5fw4wI9CEUi8WR6jKsKXqdRF/DLxSNC2JpzM5RlVeBm0uqjntYT1Cf1dASvQ2/+vZCUikL/3A48NcoEYRHXGmxu8D6t/SvleQD8Xv434xFOdsa2QqP/HiCtqCLOI5jJz1JVoB5nNyKKZ33ogTUL1LV1TfcrAioyizW8="
+    # this bucket has a lifecycle to delete after 90 days:
+    # $ echo '{"rule": [{"action": {"type": "Delete"}, "condition": {"age": 90}}]}' > lifecycle.json
+    # $ gsutil lifecycle set lifecycle.json gs://angular2-snapshots
+    bucket: angular2-snapshots
+    # don't delete generated files
+    skip_cleanup: true
+    # serve to public at https://storage.googleapis.com/angular2-snapshots/SHA/dart_stable/dist.tgz
+    acl: public-read
+    # upload the .tgz archive created in scripts/ci/build_and_test.sh
+    local-dir: deploy
+    # create a "subdirectory" for each commit
+    upload-dir: $TRAVIS_COMMIT/dart_stable
+    on:
+      branch: master
+      repo: angular/angular
+      condition: "$MODE = dart && $DART_CHANNEL = stable"
+

--- a/scripts/ci/build_and_test.sh
+++ b/scripts/ci/build_and_test.sh
@@ -9,4 +9,5 @@ SCRIPT_DIR=$(dirname $0)
 cd $SCRIPT_DIR/../..
 
 ${SCRIPT_DIR}/build_$MODE.sh
+mkdir deploy; tar -czpf deploy/dist.tgz -C dist .
 ${SCRIPT_DIR}/test_$MODE.sh


### PR DESCRIPTION
second attempt after rollback of https://github.com/angular/angular/pull/2946

After each successful build in the dart stable variant, this uploads just enough of the dart
artifacts to mirror what we would push to pub.
By uploading the files instead of a zip, this lets dart users depend on an unreleased snapshot
of angular2, and lets us easily fetch the dart artifacts for sync into google3
without having to re-build (potentially in a subtly different environment).
This doesn't upload anything for pull requests.

NOTE: this time I've scaled this back and tested properly. https://travis-ci.org/alexeagle/angular/jobs/70157553 uploaded its result to https://console.developers.google.com/project/resonant-tower-260/storage/browser/angular2-snapshots/e3c6f83df9ad0ee621d6bb1c81df63a4c277cbb5/
