### PR TITLE
Fix .d.ts generation errors caused by invisible types of exported declarations

### DIFF
--- a/modules/angular2/src/change_detection/parser/lexer.ts
+++ b/modules/angular2/src/change_detection/parser/lexer.ts
@@ -8,7 +8,7 @@ import {
   isPresent
 } from "angular2/src/facade/lang";
 
-enum TokenType {
+export enum TokenType {
   CHARACTER,
   IDENTIFIER,
   KEYWORD,

--- a/modules/angular2/src/directives/ng_for.ts
+++ b/modules/angular2/src/directives/ng_for.ts
@@ -123,7 +123,7 @@ export class NgFor {
   }
 }
 
-class RecordViewTuple {
+export class RecordViewTuple {
   view: ViewRef;
   record: any;
   constructor(record, view) {

--- a/modules/angular2/src/render/dom/compiler/selector.ts
+++ b/modules/angular2/src/render/dom/compiler/selector.ts
@@ -338,14 +338,14 @@ export class SelectorMatcher {
 }
 
 
-class SelectorListContext {
+export class SelectorListContext {
   alreadyMatched: boolean = false;
 
   constructor(public selectors: List<CssSelector>) {}
 }
 
 // Store context to pass back selector and context when a selector is matched
-class SelectorContext {
+export class SelectorContext {
   notSelectors: List<CssSelector>;
 
   constructor(public selector: CssSelector, public cbContext: any,

--- a/modules/angular2/src/render/dom/dom_renderer.ts
+++ b/modules/angular2/src/render/dom/dom_renderer.ts
@@ -9,6 +9,7 @@ import {
 import {ListWrapper, MapWrapper, Map, StringMapWrapper, List} from 'angular2/src/facade/collection';
 
 import {DOM} from 'angular2/src/dom/dom_adapter';
+import {LightDom} from './shadow_dom/light_dom';
 
 import {Content} from './shadow_dom/content_tag';
 import {ShadowDomStrategy} from './shadow_dom/shadow_dom_strategy';

--- a/modules/angular2/src/render/dom/dom_renderer.ts
+++ b/modules/angular2/src/render/dom/dom_renderer.ts
@@ -352,7 +352,7 @@ export class DomRenderer extends Renderer {
     return vc;
   }
 
-  _directParentLightDom(view: DomView, boundElementIndex: number) {
+  _directParentLightDom(view: DomView, boundElementIndex: number): LightDom {
     var directParentEl = view.getDirectParentElement(boundElementIndex);
     return isPresent(directParentEl) ? directParentEl.lightDom : null;
   }

--- a/modules/angular2/test/render/dom/dom_testbed.ts
+++ b/modules/angular2/test/render/dom/dom_testbed.ts
@@ -33,7 +33,7 @@ export function elRef(renderView: RenderViewRef, boundElementIndex: number) {
   return new TestRenderElementRef(renderView, boundElementIndex);
 }
 
-class TestRenderElementRef implements RenderElementRef {
+export class TestRenderElementRef implements RenderElementRef {
   constructor(public renderView: RenderViewRef, public boundElementIndex: number) {}
 }
 

--- a/modules/benchpress/src/common_options.ts
+++ b/modules/benchpress/src/common_options.ts
@@ -1,8 +1,8 @@
-import {bind, OpaqueToken} from 'angular2/di';
+import {bind, Binding, OpaqueToken} from 'angular2/di';
 import {DateWrapper} from 'angular2/src/facade/lang';
 
 export class Options {
-  static get DEFAULT_BINDINGS() { return _DEFAULT_BINDINGS; }
+  static get DEFAULT_BINDINGS():Binding[] { return _DEFAULT_BINDINGS; }
   // TODO(tbosch): use static initializer when our transpiler supports it
   static get SAMPLE_ID() { return _SAMPLE_ID; }
   // TODO(tbosch): use static initializer when our transpiler supports it

--- a/modules/benchpress/src/common_options.ts
+++ b/modules/benchpress/src/common_options.ts
@@ -2,7 +2,7 @@ import {bind, Binding, OpaqueToken} from 'angular2/di';
 import {DateWrapper} from 'angular2/src/facade/lang';
 
 export class Options {
-  static get DEFAULT_BINDINGS():Binding[] { return _DEFAULT_BINDINGS; }
+  static get DEFAULT_BINDINGS(): Binding[] { return _DEFAULT_BINDINGS; }
   // TODO(tbosch): use static initializer when our transpiler supports it
   static get SAMPLE_ID() { return _SAMPLE_ID; }
   // TODO(tbosch): use static initializer when our transpiler supports it

--- a/modules/benchpress/src/metric.ts
+++ b/modules/benchpress/src/metric.ts
@@ -8,7 +8,7 @@ import {StringMap} from 'angular2/src/facade/collection';
  */
 @ABSTRACT()
 export class Metric {
-  static bindTo(delegateToken):Binding[] {
+  static bindTo(delegateToken): Binding[] {
     return [bind(Metric).toFactory((delegate) => delegate, [delegateToken])];
   }
 

--- a/modules/benchpress/src/metric.ts
+++ b/modules/benchpress/src/metric.ts
@@ -1,4 +1,4 @@
-import {bind} from 'angular2/di';
+import {bind, Binding} from 'angular2/di';
 import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
 import {ABSTRACT, BaseException} from 'angular2/src/facade/lang';
 import {StringMap} from 'angular2/src/facade/collection';
@@ -8,7 +8,7 @@ import {StringMap} from 'angular2/src/facade/collection';
  */
 @ABSTRACT()
 export class Metric {
-  static bindTo(delegateToken) {
+  static bindTo(delegateToken):Binding[] {
     return [bind(Metric).toFactory((delegate) => delegate, [delegateToken])];
   }
 

--- a/modules/benchpress/src/reporter.ts
+++ b/modules/benchpress/src/reporter.ts
@@ -1,4 +1,4 @@
-import {bind} from 'angular2/di';
+import {bind, Binding} from 'angular2/di';
 import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
 import {ABSTRACT, BaseException} from 'angular2/src/facade/lang';
 import {MeasureValues} from './measure_values';
@@ -9,7 +9,7 @@ import {List} from 'angular2/src/facade/collection';
  */
 @ABSTRACT()
 export class Reporter {
-  static bindTo(delegateToken) {
+  static bindTo(delegateToken): Binding[] {
     return [bind(Reporter).toFactory((delegate) => delegate, [delegateToken])];
   }
 

--- a/modules/benchpress/src/validator.ts
+++ b/modules/benchpress/src/validator.ts
@@ -1,4 +1,4 @@
-import {bind} from 'angular2/di';
+import {bind, Binding} from 'angular2/di';
 import {List, StringMap} from 'angular2/src/facade/collection';
 import {ABSTRACT, BaseException} from 'angular2/src/facade/lang';
 
@@ -11,7 +11,7 @@ import {MeasureValues} from './measure_values';
  */
 @ABSTRACT()
 export class Validator {
-  static bindTo(delegateToken) {
+  static bindTo(delegateToken): Binding[] {
     return [bind(Validator).toFactory((delegate) => delegate, [delegateToken])];
   }
 

--- a/modules/benchpress/src/web_driver_adapter.ts
+++ b/modules/benchpress/src/web_driver_adapter.ts
@@ -1,4 +1,4 @@
-import {bind} from 'angular2/di';
+import {bind, Binding} from 'angular2/di';
 import {Promise} from 'angular2/src/facade/async';
 import {BaseException, ABSTRACT} from 'angular2/src/facade/lang';
 import {List, Map} from 'angular2/src/facade/collection';
@@ -10,7 +10,7 @@ import {List, Map} from 'angular2/src/facade/collection';
  */
 @ABSTRACT()
 export class WebDriverAdapter {
-  static bindTo(delegateToken) {
+  static bindTo(delegateToken): Binding[] {
     return [bind(WebDriverAdapter).toFactory((delegate) => delegate, [delegateToken])];
   }
 


### PR DESCRIPTION
Ran into a few declaration emit errors while looking into broccoli extension. here are the errors for future references:

> [16:41:52] Error: [DiffingTSCompiler]: Typescript found the following errors:
> 
>  angular2/src/di/injector.ts (28, 5): Type 'string' is not assignable to type 'number'.
> 
>  angular2/src/change_detection/parser/lexer.ts (35, 50): Parameter 'type' of constructor from exported class has or is using private name 'TokenType'.
> 
>  angular2/src/directives/ng_for.ts (94, 34): Parameter 'tuples' of public static method from exported class has or is using private name 'RecordViewTuple'.
> 
>  angular2/src/directives/ng_for.ts (95, 60): Return type of public static method from exported class has or is using private name 'RecordViewTuple'.
> 
>  angular2/src/directives/ng_for.ts (111, 34): Parameter 'tuples' of public static method from exported class has or is using private name 'RecordViewTuple'.
> 
>  angular2/src/directives/ng_for.ts (112, 55): Return type of public static method from exported class has or is using private name 'RecordViewTuple'.
> 
>  angular2/src/render/dom/compiler/selector.ts (301, 40): Parameter 'map' of public method from exported class has or is using private name 'SelectorContext'.
> 
>  angular2/src/render/dom/dom_renderer.ts (354, 3): Return type of public method from exported class has or is using name 'LightDom' from external module "angular2/src/render/dom/shadow_dom/light_dom" but cannot be named.
> 
>  angular2/test/render/dom/dom_testbed.ts (32, 17): Return type of exported function has or is using private name 'TestRenderElementRef'.
> 
>  benchpress/src/common_options.ts (5, 14): Return type of public static property getter from exported class has or is using name 'Binding' from external module "angular2/src/di/binding" but cannot be named.
> 
>  benchpress/src/metric.ts (11, 10): Return type of public static method from exported class has or is using name 'Binding' from external module "angular2/src/di/binding" but cannot be named.
> 
>  benchpress/src/reporter.ts (12, 10): Return type of public static method from exported class has or is using name 'Binding' from external module "angular2/src/di/binding" but cannot be named.
> 
>  benchpress/src/validator.ts (14, 10): Return type of public static method from exported class has or is using name 'Binding' from external module "angular2/src/di/binding" but cannot be named.
> 
>  benchpress/src/web_driver_adapter.ts (13, 10): Return type of public static method from exported class has or is using name 'Binding' from externalmodule "angular2/src/di/binding" but cannot be named.
