### PR TITLE
Add "on event done" zone hook

### DIFF
--- a/modules/angular2/src/core/application.ts
+++ b/modules/angular2/src/core/application.ts
@@ -146,7 +146,7 @@ function _createNgZone(givenReporter: Function): NgZone {
   var reporter = isPresent(givenReporter) ? givenReporter : defaultErrorReporter;
 
   var zone = new NgZone({enableLongStackTrace: assertionsEnabled()});
-  zone.initCallbacks({onErrorHandler: reporter});
+  zone.overrideOnErrorHandler(reporter);
   return zone;
 }
 

--- a/modules/angular2/src/core/life_cycle/life_cycle.ts
+++ b/modules/angular2/src/core/life_cycle/life_cycle.ts
@@ -57,7 +57,8 @@ export class LifeCycle {
       this._changeDetector = changeDetector;
     }
 
-    zone.initCallbacks({onErrorHandler: this._errorHandler, onTurnDone: () => this.tick()});
+    zone.overrideOnErrorHandler(this._errorHandler);
+    zone.overrideOnTurnDone(() => this.tick());
   }
 
   /**


### PR DESCRIPTION
This hook can be used to implement "when stable" in tests (fixes #2808) or any other post-Angular logic at the end of browser event (e.g. to send action metrics to the server, validation)
