### PR TITLE
chore(doc-gen): convert heritage for private constructor classes

### DIFF
--- a/docs/typescript-definition-package/index.js
+++ b/docs/typescript-definition-package/index.js
@@ -29,7 +29,7 @@ module.exports = new Package('angular-v2-docs', [jsdocPackage, nunjucksPackage, 
   renderDocsProcessor.extraData.versionInfo = versionInfo;
 })
 
-.config(function(readFilesProcessor, inlineTagProcessor, readTypeScriptModules) {
+.config(function(readFilesProcessor, inlineTagProcessor, readTypeScriptModules, createTypeDefinitionFile) {
 
   // Don't run unwanted processors
   readFilesProcessor.$enabled = false; // We are not using the normal file reading processor
@@ -42,6 +42,21 @@ module.exports = new Package('angular-v2-docs', [jsdocPackage, nunjucksPackage, 
     'angular2/router.ts'
   ];
   readTypeScriptModules.basePath = path.resolve(path.resolve(__dirname, '../../modules'));
+  
+  createTypeDefinitionFile.typeDefinitions = [
+      {
+        id: 'angular2/angular2',
+        modules: {
+          'angular2/angular2': 'angular2/angular2',
+        }
+      },
+      {
+        id: 'angular2/router',
+        modules: {
+          'angular2/router': 'angular2/router'
+        }
+      }    
+  ];
 })
 
 

--- a/docs/typescript-definition-package/mocks/mockPackage.js
+++ b/docs/typescript-definition-package/mocks/mockPackage.js
@@ -1,0 +1,11 @@
+var Package = require('dgeni').Package;
+
+module.exports = function mockPackage() {
+
+  return new Package('mockPackage', [require('../')])
+
+  // provide a mock log service
+  .factory('log', function() { return require('dgeni/lib/mocks/log')(false); })
+//  .factory('templateEngine', function() { return {}; });
+
+};

--- a/docs/typescript-definition-package/processors/createTypeDefinitionFile.js
+++ b/docs/typescript-definition-package/processors/createTypeDefinitionFile.js
@@ -13,20 +13,7 @@ module.exports = function createTypeDefinitionFile(log) {
     },
     dtsPath: 'typings',
     dtsExtension: '.d.ts',
-    typeDefinitions: [
-      {
-        id: 'angular2/angular2',
-        modules: {
-          'angular2/angular2': 'angular2/angular2',
-        }
-      },
-      {
-        id: 'angular2/router',
-        modules: {
-          'angular2/router': 'angular2/router'
-        }
-      }
-    ],
+    typeDefinitions: [],
     $process: function(docs) {
       var dtsPath = this.dtsPath;
       var dtsExtension = this.dtsExtension;

--- a/docs/typescript-definition-package/processors/createTypeDefinitionFile.js
+++ b/docs/typescript-definition-package/processors/createTypeDefinitionFile.js
@@ -76,6 +76,11 @@ module.exports = function createTypeDefinitionFile(log) {
               // Convert this class to an interface with no constructor
               exportDoc.docType = 'interface';
               exportDoc.constructorDoc = null;
+              
+              if (exportDoc.heritage) {
+                // convert the heritage since interfaces use `extends` not `implements`
+                exportDoc.heritage = exportDoc.heritage.replace('implements', 'extends');
+              }
 
               // Add the `declare var SomeClass extends InjectableReference` construct
               modDoc.doc.exports.push({

--- a/docs/typescript-definition-package/processors/createTypeDefinitionFile.spec.js
+++ b/docs/typescript-definition-package/processors/createTypeDefinitionFile.spec.js
@@ -1,0 +1,48 @@
+var mockPackage = require('../mocks/mockPackage');
+var Dgeni = require('dgeni');
+var path = require('canonical-path');
+var _ = require('lodash');
+
+describe('createTypeDefinitionFile processor', function() {
+  var dgeni, injector, processor;
+
+  beforeEach(function() {
+    dgeni = new Dgeni([mockPackage()]);
+    injector = dgeni.configureInjector();
+    processor = injector.get('createTypeDefinitionFile');
+
+    // Initialize the processor
+    processor.typeDefinitions = [{
+      id: 'angular2/angular2',
+      modules: { 'angular2/angular2': 'angular2/angular2' }
+    }];
+  });
+
+
+
+  describe('classes with private constructors', function() {
+    
+    it('should convert heritage from `implements` into `extends`', function() {
+      
+      // Create some mock docs for testing
+      var docs = [
+        {
+          id: 'angular2/angular2',
+          exports: [
+            { docType: 'class', heritage: 'implements Xyz', constructorDoc: { private: true }  }
+          ]
+        }
+      ];
+
+      docs = processor.$process(docs);
+      
+      expect(docs.length).toEqual(1);
+      expect(docs[0].docType).toEqual('type-definition');
+
+      var moduleDoc = docs[0].moduleDocs['angular2/angular2'].doc;
+      expect(moduleDoc.exports.length).toEqual(2);
+      expect(moduleDoc.exports[0].heritage).toEqual('extends Xyz');
+    });
+  });
+	
+});


### PR DESCRIPTION
When we are creating a type definition file for a class has a private constructor,
we convert it to a combination of an instance of a concrete type with no constructor and an interface that contains the other methods.

When this happens, we must also convert the class's heritage from
`implements` to `extends` since interfaces cannot implement other interfaces
or classes.

Fixes a problem with #2996
Closes #3002
