### PR TITLE
feat(base_query_list): delegate toString,valueOf to _results array

### DIFF
--- a/modules/angular2/src/core/compiler/query_list.dart
+++ b/modules/angular2/src/core/compiler/query_list.dart
@@ -46,6 +46,9 @@ class QueryList<T> extends Object with IterableMixin<T> implements IQueryList<T>
   int get length => _results.length;
   T get first => _results.first;
   T get last => _results.last;
+  String toString() {
+    return _results.toString();
+  }
 
   List map(fn(T)) {
     // Note: we need to return a list instead of iterable to match JS.

--- a/modules/angular2/src/core/compiler/query_list.ts
+++ b/modules/angular2/src/core/compiler/query_list.ts
@@ -34,6 +34,8 @@ export class QueryList<T> implements IQueryList<T> {
 
   removeCallback(callback: () => void): void { ListWrapper.remove(this._callbacks, callback); }
 
+  toString(): string { return this._results.toString(); }
+
   get length(): number { return this._results.length; }
   get first(): T { return ListWrapper.first(this._results); }
   get last(): T { return ListWrapper.last(this._results); }

--- a/modules/angular2/test/core/compiler/query_list_spec.ts
+++ b/modules/angular2/test/core/compiler/query_list_spec.ts
@@ -1,6 +1,7 @@
 import {describe, it, expect, beforeEach, ddescribe, iit, xit, el} from 'angular2/test_lib';
 
 import {List, MapWrapper, ListWrapper, iterateListLike} from 'angular2/src/facade/collection';
+import {StringWrapper} from 'angular2/src/facade/lang';
 import {QueryList} from 'angular2/src/core/compiler/query_list';
 
 
@@ -41,6 +42,14 @@ export function main() {
       queryList.add('one');
       queryList.add('two');
       expect(queryList.map((x) => x)).toEqual(['one', 'two']);
+    });
+
+    it('should support toString', () => {
+      queryList.add('one');
+      queryList.add('two');
+      var listString = queryList.toString();
+      expect(StringWrapper.contains(listString, 'one')).toBeTruthy();
+      expect(StringWrapper.contains(listString, 'two')).toBeTruthy();
     });
 
     it('should support first and last', () => {


### PR DESCRIPTION
### Goal

better support for https://github.com/angular/angular/issues/2916 and developers that use `|json` for `QueryList` instances
