### PR TITLE
feat(EventEmitter): dispose method

### DIFF
--- a/modules/angular2/src/facade/async.dart
+++ b/modules/angular2/src/facade/async.dart
@@ -91,6 +91,10 @@ class EventEmitter extends Stream {
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 
+  void cancel() {
+    _controller.cancel();
+  }
+
   void add(value) {
     _controller.add(value);
   }

--- a/modules/angular2/src/facade/async.ts
+++ b/modules/angular2/src/facade/async.ts
@@ -118,6 +118,8 @@ export class EventEmitter extends Observable {
 
   toRx(): Rx.Observable<any> { return this._subject; }
 
+  dispose() { this._subject.dispose(); }
+
   next(value) { this._subject.onNext(value); }
 
   throw(error) { this._subject.onError(error); }

--- a/modules/angular2/test/facade/async_spec.ts
+++ b/modules/angular2/test/facade/async_spec.ts
@@ -50,6 +50,18 @@ export function main() {
          ObservableWrapper.callReturn(emitter);
        }));
 
+    it("should dispose _subject", () => {
+      var called = false;
+      ObservableWrapper.subscribe(emitter,
+                                  (value) => { called = true; },
+                                  (value) => { called = true; },
+                                  (value) => { called = true; });
+      ObservableWrapper.dispose(emitter);
+      var next = () => ObservableWrapper.callNext(emitter, 99);
+      expect(next).toThrow();
+      expect(called).toBe(false);
+    });
+
     it("should subscribe to the wrapper asynchronously", () => {
       var called = false;
       ObservableWrapper.subscribe(emitter, (value) => { called = true; });


### PR DESCRIPTION
### reason

one requirement for #2668
### goal

allow developer to dispose internal Subject/StreamController

status: [blocked]
Dart StreamController is different from Rx Subject
