### PR TITLE
chore(lint): require semicolons

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -278,6 +278,7 @@ gulp.task('lint', ['build.tools'], function() {
   // https://github.com/palantir/tslint#supported-rules
   var tslintConfig = {
     "rules": {
+      "semicolon": true,
       "requireReturnType": true
     }
   };

--- a/modules/angular2/src/change_detection/change_detection_jit_generator.ts
+++ b/modules/angular2/src/change_detection/change_detection_jit_generator.ts
@@ -182,7 +182,7 @@ export class ChangeDetectorJITGenerator {
     var lines = ListWrapper.createFixedSize(directiveFieldNames.length);
     for (var i = 0, iLen = directiveFieldNames.length; i < iLen; ++i) {
       lines[i] =
-          `${directiveFieldNames[i]} = directives.getDirectiveFor(${DIRECTIVES_ACCESSOR}[${i}].directiveIndex);`
+          `${directiveFieldNames[i]} = directives.getDirectiveFor(${DIRECTIVES_ACCESSOR}[${i}].directiveIndex);`;
     }
     return lines.join('\n');
   }
@@ -192,7 +192,7 @@ export class ChangeDetectorJITGenerator {
     var lines = ListWrapper.createFixedSize(detectorFieldNames.length);
     for (var i = 0, iLen = detectorFieldNames.length; i < iLen; ++i) {
       lines[i] = `${detectorFieldNames[i]} =
-          directives.getDetectorFor(${DIRECTIVES_ACCESSOR}[${i}].directiveIndex);`
+          directives.getDetectorFor(${DIRECTIVES_ACCESSOR}[${i}].directiveIndex);`;
     }
     return lines.join('\n');
   }

--- a/modules/angular2/src/change_detection/parser/parser.ts
+++ b/modules/angular2/src/change_detection/parser/parser.ts
@@ -167,7 +167,7 @@ class _ParseAST {
   expectIdentifierOrKeyword(): string {
     var n = this.next;
     if (!n.isIdentifier() && !n.isKeyword()) {
-      this.error(`Unexpected token ${n}, expected identifier or keyword`)
+      this.error(`Unexpected token ${n}, expected identifier or keyword`);
     }
     this.advance();
     return n.toString();
@@ -176,7 +176,7 @@ class _ParseAST {
   expectIdentifierOrKeywordOrString(): string {
     var n = this.next;
     if (!n.isIdentifier() && !n.isKeyword() && !n.isString()) {
-      this.error(`Unexpected token ${n}, expected identifier, keyword, or string`)
+      this.error(`Unexpected token ${n}, expected identifier, keyword, or string`);
     }
     this.advance();
     return n.toString();

--- a/modules/angular2/src/change_detection/pipes/date_pipe.ts
+++ b/modules/angular2/src/change_detection/pipes/date_pipe.ts
@@ -96,5 +96,5 @@ export class DatePipe extends BasePipe implements PipeFactory {
 
   supports(obj): boolean { return isDate(obj) || isNumber(obj); }
 
-  create(cdRef: ChangeDetectorRef): Pipe { return this }
+  create(cdRef: ChangeDetectorRef): Pipe { return this; }
 }

--- a/modules/angular2/src/change_detection/pipes/iterable_changes.ts
+++ b/modules/angular2/src/change_detection/pipes/iterable_changes.ts
@@ -130,7 +130,7 @@ export class IterableChanges extends BasePipe {
           record = this._verifyReinsertion(record, item, index);
         }
         record = record._next;
-        index++
+        index++;
       });
       this._length = index;
     }

--- a/modules/angular2/src/change_detection/pipes/json_pipe.ts
+++ b/modules/angular2/src/change_detection/pipes/json_pipe.ts
@@ -29,5 +29,5 @@ import {ChangeDetectorRef} from '../change_detector_ref';
 export class JsonPipe extends BasePipe implements PipeFactory {
   transform(value, args: List<any> = null): string { return Json.stringify(value); }
 
-  create(cdRef: ChangeDetectorRef): Pipe { return this }
+  create(cdRef: ChangeDetectorRef): Pipe { return this; }
 }

--- a/modules/angular2/src/change_detection/pipes/number_pipe.ts
+++ b/modules/angular2/src/change_detection/pipes/number_pipe.ts
@@ -48,7 +48,7 @@ export class NumberPipe extends BasePipe implements PipeFactory {
 
   supports(obj): boolean { return isNumber(obj); }
 
-  create(cdRef: ChangeDetectorRef): Pipe { return this }
+  create(cdRef: ChangeDetectorRef): Pipe { return this; }
 }
 
 /**

--- a/modules/angular2/src/change_detection/pipes/observable_pipe.ts
+++ b/modules/angular2/src/change_detection/pipes/observable_pipe.ts
@@ -65,7 +65,7 @@ export class ObservablePipe implements Pipe {
 
   _subscribe(obs: Observable): void {
     this._observable = obs;
-    this._subscription = ObservableWrapper.subscribe(obs, value => {this._updateLatestValue(value)},
+    this._subscription = ObservableWrapper.subscribe(obs, value => this._updateLatestValue(value),
                                                      e => { throw e; });
   }
 

--- a/modules/angular2/src/change_detection/pipes/pipes.ts
+++ b/modules/angular2/src/change_detection/pipes/pipes.ts
@@ -95,7 +95,7 @@ export class Pipes {
       },
       // Dependency technically isn't optional, but we can provide a better error message this way.
       deps: [[Pipes, new UnboundedMetadata(), new OptionalMetadata()]]
-    })
+    });
   }
 
   private _getListOfFactories(type: string, obj: any): PipeFactory[] {

--- a/modules/angular2/src/core/annotations/decorators.ts
+++ b/modules/angular2/src/core/annotations/decorators.ts
@@ -52,7 +52,7 @@ export interface ViewDecorator extends TypeDecorator {
     renderer?: string,
     styles?: List<string>,
     styleUrls?: List<string>,
-  }): ViewDecorator
+  }): ViewDecorator;
 }
 
 /**

--- a/modules/angular2/src/core/application.ts
+++ b/modules/angular2/src/core/application.ts
@@ -300,7 +300,7 @@ export function bootstrap(appComponentType: Type,
       bootstrapProcess.resolve(new ApplicationRef(componentRef, appComponentType, appInjector));
     };
     PromiseWrapper.then(compRefToken, tick,
-                        (err, stackTrace) => {bootstrapProcess.reject(err, stackTrace)});
+                        (err, stackTrace) => bootstrapProcess.reject(err, stackTrace));
   });
 
   return bootstrapProcess.promise;

--- a/modules/angular2/src/core/compiler/view_manager_utils.ts
+++ b/modules/angular2/src/core/compiler/view_manager_utils.ts
@@ -100,7 +100,7 @@ export class AppViewManagerUtils {
     if (atIndex == 0) {
       sibling = null;
     } else {
-      sibling = ListWrapper.last(viewContainer.views[atIndex - 1].rootElementInjectors)
+      sibling = ListWrapper.last(viewContainer.views[atIndex - 1].rootElementInjectors);
     }
     var elementInjector = contextView.elementInjectors[contextBoundElementIndex];
     for (var i = view.rootElementInjectors.length - 1; i >= 0; i--) {

--- a/modules/angular2/src/core/zone/ng_zone.ts
+++ b/modules/angular2/src/core/zone/ng_zone.ts
@@ -62,7 +62,7 @@ export class NgZone {
     if (global.zone) {
       this._disabled = false;
       this._mountZone = global.zone;
-      this._innerZone = this._createInnerZone(this._mountZone, enableLongStackTrace)
+      this._innerZone = this._createInnerZone(this._mountZone, enableLongStackTrace);
     } else {
       this._disabled = true;
       this._mountZone = null;
@@ -159,9 +159,9 @@ export class NgZone {
 
     if (enableLongStackTrace) {
       errorHandling = StringMapWrapper.merge(Zone.longStackTraceZone,
-                                             {onError: function(e) { ngZone._onError(this, e) }});
+                                             {onError: function(e) { ngZone._onError(this, e); }});
     } else {
-      errorHandling = {onError: function(e) { ngZone._onError(this, e) }};
+      errorHandling = {onError: function(e) { ngZone._onError(this, e); }};
     }
 
     return zone.fork(errorHandling)
@@ -200,7 +200,7 @@ export class NgZone {
                   }
                 }
               }
-            }
+            };
           },
           '$scheduleMicrotask': function(parentScheduleMicrotask) {
             return function(fn) {
@@ -213,7 +213,7 @@ export class NgZone {
                 }
               };
               parentScheduleMicrotask.call(this, microtask);
-            }
+            };
           },
           _innerZone: true
         });

--- a/modules/angular2/src/directives/ng_switch.ts
+++ b/modules/angular2/src/directives/ng_switch.ts
@@ -164,7 +164,7 @@ export class NgSwitchWhen {
     this._view = new SwitchView(viewContainer, protoViewRef);
   }
 
-  onDestroy() { this._switch }
+  onDestroy() { this._switch; }
 
   set ngSwitchWhen(value) {
     this._switch._onWhenValueChanged(this._value, value, this._view);

--- a/modules/angular2/src/facade/collection.ts
+++ b/modules/angular2/src/facade/collection.ts
@@ -22,7 +22,7 @@ var createMapFromPairs: {(pairs: List<any>): Map<any, any>} = (function() {
       map.set(pair[0], pair[1]);
     }
     return map;
-  }
+  };
 })();
 var createMapFromMap: {(m: Map<any, any>): Map<any, any>} = (function() {
   try {
@@ -35,7 +35,7 @@ var createMapFromMap: {(m: Map<any, any>): Map<any, any>} = (function() {
     var map = new Map();
     m.forEach((v, k) => { map.set(k, v); });
     return map;
-  }
+  };
 })();
 var _clearValues: {(m: Map<any, any>)} = (function() {
   if ((<any>(new Map()).keys()).next) {
@@ -49,7 +49,7 @@ var _clearValues: {(m: Map<any, any>)} = (function() {
   } else {
     return function _clearValuesWithForeEach(m: Map<any, any>) {
       m.forEach((v, k) => { m.set(k, null); });
-    }
+    };
   }
 })();
 

--- a/modules/angular2/src/facade/intl.ts
+++ b/modules/angular2/src/facade/intl.ts
@@ -14,7 +14,7 @@ declare module Intl {
     format(value: number): string;
   }
 
-  var NumberFormat: { new (locale?: string, options?: NumberFormatOptions): NumberFormat; }
+  var NumberFormat: {new (locale?: string, options?: NumberFormatOptions): NumberFormat};
 
   interface DateTimeFormatOptions {
     localeMatcher?: string;
@@ -35,7 +35,7 @@ declare module Intl {
     format(date?: Date | number): string;
   }
 
-  var DateTimeFormat: { new (locale?: string, options?: DateTimeFormatOptions): DateTimeFormat; }
+  var DateTimeFormat: {new (locale?: string, options?: DateTimeFormatOptions): DateTimeFormat};
 }
 
 export enum NumberFormatStyle {

--- a/modules/angular2/src/forms/validators.ts
+++ b/modules/angular2/src/forms/validators.ts
@@ -26,7 +26,7 @@ export class Validators {
         return isPresent(errors) ? StringMapWrapper.merge(res, errors) : res;
       }, {});
       return StringMapWrapper.isEmpty(res) ? null : res;
-    }
+    };
   }
 
   static group(c: modelModule.ControlGroup): StringMap<string, boolean> {

--- a/modules/angular2/src/http/backends/xhr_backend.ts
+++ b/modules/angular2/src/http/backends/xhr_backend.ts
@@ -42,7 +42,7 @@ export class XHRConnection implements Connection {
         responseOptions = baseResponseOptions.merge(responseOptions);
       }
 
-      ObservableWrapper.callNext(this.response, new Response(responseOptions))
+      ObservableWrapper.callNext(this.response, new Response(responseOptions));
     });
     // TODO(jeffbcross): make this more dynamic based on body type
 

--- a/modules/angular2/src/render/dom/compiler/style_inliner.ts
+++ b/modules/angular2/src/render/dom/compiler/style_inliner.ts
@@ -80,8 +80,7 @@ export class StyleInliner {
           if (isPromise(inlinedCss)) {
             // wait until nested @import are inlined
             return (<Promise<string>>inlinedCss)
-                .then((css) => {return prefix + this._transformImportedCss(css, mediaQuery, url) +
-                                       '\n'});
+                .then((css) => prefix + this._transformImportedCss(css, mediaQuery, url) + '\n');
           } else {
             // there are no nested @import, return the css
             return prefix + this._transformImportedCss(<string>inlinedCss, mediaQuery, url) + '\n';

--- a/modules/angular2/src/util/decorators.ts
+++ b/modules/angular2/src/util/decorators.ts
@@ -70,7 +70,7 @@ export interface ParameterDecorator {
   /**
    * Invoke as ES7 decorator.
    */
-  (cls: Type, unusedKey: any, index: number): void
+  (cls: Type, unusedKey: any, index: number): void;
 }
 
 function extractAnnotation(annotation: any): any {


### PR DESCRIPTION
Relying on ASI (automatic semicolon insertion)
is allowed in TypeScript because JavaScript allows
it. However, when we run clang-format it doesn’t
understand that these statements are terminated
with a newline and changes the indentation, in bad
cases even breaking the code.

Fixes #817
