### PR TITLE
fix(examples): add some entrypoints, fix change detector bug in Dart

### DIFF
--- a/modules/angular2/src/change_detection/coalesce.ts
+++ b/modules/angular2/src/change_detection/coalesce.ts
@@ -1,4 +1,4 @@
-import {isPresent, isBlank} from 'angular2/src/facade/lang';
+import {isPresent, isBlank, looseIdentical} from 'angular2/src/facade/lang';
 import {List, ListWrapper, Map} from 'angular2/src/facade/collection';
 import {RecordType, ProtoRecord} from './proto_record';
 
@@ -44,11 +44,11 @@ function _selfRecord(r: ProtoRecord, contextIndex: number, selfIndex: number): P
 }
 
 function _findMatching(r: ProtoRecord, rs: List<ProtoRecord>) {
-  return ListWrapper.find(rs, (rr) => rr.mode !== RecordType.DIRECTIVE_LIFECYCLE &&
-                                      _sameDirIndex(rr, r) && rr.mode === r.mode &&
-                                      rr.funcOrValue === r.funcOrValue &&
-                                      rr.contextIndex === r.contextIndex && rr.name === r.name &&
-                                      ListWrapper.equals(rr.args, r.args));
+  return ListWrapper.find(
+      rs, (rr) => rr.mode !== RecordType.DIRECTIVE_LIFECYCLE && _sameDirIndex(rr, r) &&
+                  rr.mode === r.mode && looseIdentical(rr.funcOrValue, r.funcOrValue) &&
+                  rr.contextIndex === r.contextIndex && looseIdentical(rr.name, r.name) &&
+                  ListWrapper.equals(rr.args, r.args));
 }
 
 function _sameDirIndex(a: ProtoRecord, b: ProtoRecord): boolean {

--- a/modules/angular2/src/facade/lang.dart
+++ b/modules/angular2/src/facade/lang.dart
@@ -198,7 +198,9 @@ Error makeTypeError([String message = ""]) {
 
 const _NAN_KEY = const Object();
 
-// Dart can have identical(str1, str2) == false while str1 == str2
+// Dart can have identical(str1, str2) == false while str1 == str2. Moreover,
+// after compiling with dart2js identical(str1, str2) might return true.
+// (see dartbug.com/22496 for details).
 bool looseIdentical(a, b) =>
     a is String && b is String ? a == b : identical(a, b);
 

--- a/modules/examples/pubspec.yaml
+++ b/modules/examples/pubspec.yaml
@@ -16,20 +16,74 @@ dependency_overrides:
     path: ../angular2_material
 transformers:
 - angular2:
+    $exclude:
     # The build currently fails on material files because there is not yet
     # support for transforming cross-package urls. (see issue #2982)
-    $exclude: 'web/src/material/**'
+    - 'web/src/material/**'
+    - 'web/src/zippy_component/**'
+    # No need to transform the dart:mirrors specific entrypoints
+    - '**/index_dynamic.dart'
     entry_points:
-        - web/src/hello_world/index_common.dart
-        - web/src/todo/index.dart
-    reflection_entry_points:
+        - web/src/gestures/index.dart
         - web/src/hello_world/index.dart
+        - web/src/http/index.dart
+        - web/src/key_events/index.dart
+        - web/src/sourcemap/index.dart
         - web/src/todo/index.dart
+        # These entrypoints are disabled until nested-directives are supported
+        # by transformers (issue #1747):
+        # web/src/model_driven_forms/index.dart
+        # web/src/order_management/index.dart
+        # web/src/person_management/index.dart
+        # web/src/template_driven_forms/index.dart
+        #
+        # These entrypoints are disabled until cross-package urls are working (issue #2982)
+        # - web/src/material/button/index.dart
+        # - web/src/material/checkbox/index.dart
+        # - web/src/material/dialog/index.dart
+        # - web/src/material/grid_list/index.dart
+        # - web/src/material/input/index.dart
+        # - web/src/material/progress-linear/index.dart
+        # - web/src/material/radio/index.dart
+        # - web/src/material/switcher/index.dart
+        # - web/src/zippy_component/index.dart
+        #
+        # This entrypoint is not needed:
+        # - web/src/material/demo_common.dart
+    reflection_entry_points:
+        - web/src/gestures/index.dart
+        - web/src/hello_world/index.dart
+        - web/src/http/index.dart
+        - web/src/key_events/index.dart
+        - web/src/sourcemap/index.dart
+        - web/src/todo/index.dart
+        # These entrypoints are disabled until nested-directives are supported
+        # by transformers (issue #1747):
+        # web/src/model_driven_forms/index.dart
+        # web/src/order_management/index.dart
+        # web/src/person_management/index.dart
+        # web/src/template_driven_forms/index.dart
+        #
+        # These entrypoints are disabled until cross-package urls are working (issue #2982)
+        # - web/src/material/button/index.dart
+        # - web/src/material/checkbox/index.dart
+        # - web/src/material/dialog/index.dart
+        # - web/src/material/grid_list/index.dart
+        # - web/src/material/input/index.dart
+        # - web/src/material/progress-linear/index.dart
+        # - web/src/material/radio/index.dart
+        # - web/src/material/switcher/index.dart
+        # - web/src/zippy_component/index.dart
+        #
+        # This entrypoint is not needed:
+        # - web/src/material/demo_common.dart
+
 - $dart2js:
     minify: false
     commandLineOptions:
-    - --dump-info
     - --show-package-warnings
     - --trust-type-annotations
     - --trust-primitives
     - --enable-experimental-mirrors
+    # Uncomment to generate summaries from dart2js
+    # - --dump-info

--- a/modules/examples/src/sourcemap/index.ts
+++ b/modules/examples/src/sourcemap/index.ts
@@ -1,5 +1,7 @@
 import {BaseException} from 'angular2/src/facade/lang';
 import {bootstrap, Component, View} from 'angular2/angular2';
+import {reflector} from 'angular2/src/reflection/reflection';
+import {ReflectionCapabilities} from 'angular2/src/reflection/reflection_capabilities';
 
 @Component({
   selector: 'error-app',
@@ -13,5 +15,6 @@ export class ErrorComponent {
 }
 
 export function main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();  // for the Dart version
   bootstrap(ErrorComponent);
 }


### PR DESCRIPTION
This change gets us a step closer to having working examples for Dart:
- all examples that now work are listed as an entrypoint in the examples/pubspec.yaml file
- fixed change detector (todomvc was hitting a bug due to https://github.com/dart-lang/sdk/issues/22496)
- add missing reflection capabilities to the sourcemap example

The other examples are still blocked by bug #1747 and #2991 

@yjbanov @vsavkin - could you please take a look?
