### PR TITLE
fix(publish): add force flag for pub publish script

### DIFF
--- a/scripts/publish/pub_publish.sh
+++ b/scripts/publish/pub_publish.sh
@@ -34,7 +34,7 @@ function publishModule {
   node scripts/publish/pubspec_cleaner.js --pubspec-file=$PUBLISH_DIR/pubspec.yaml
 
   if [[ ! $DRY_RUN ]]; then
-    (cd $PUBLISH_DIR && pub publish)
+    (cd $PUBLISH_DIR && pub publish -f)
   fi;
 }
 


### PR DESCRIPTION
The pub publish process was not following through with publishing
packages because the -f flag was not be provided to pub publish,
causing the process to prompt for confirmation before publishing,
which was causing the pub_publish.sh script to skip publishing.

CC @rkirov 

Closes #3077
