### PR TITLE
chore(transformers): remove reflector parameter from initReflector

### DIFF
--- a/modules/angular2/src/transform/directive_linker/linker.dart
+++ b/modules/angular2/src/transform/directive_linker/linker.dart
@@ -72,8 +72,7 @@ Future<String> linkNgDeps(AssetReader reader, AssetId entryPoint) async {
       importBuf.write('''
         import '${linkedDepsMap[it.current]}' as i${i};
       ''');
-      declarationBuf
-          .write('i${i}.${SETUP_METHOD_NAME}(${REFLECTOR_VAR_NAME});');
+      declarationBuf.write('i${i}.${SETUP_METHOD_NAME}();');
       ++i;
     }
   }

--- a/modules/angular2/src/transform/directive_processor/rewriter.dart
+++ b/modules/angular2/src/transform/directive_processor/rewriter.dart
@@ -94,6 +94,7 @@ class CreateNgDepsVisitor extends Object with SimpleAstVisitor<Object> {
     if (_wroteBaseLibImport) return;
     _wroteBaseLibImport = true;
     writer.print('''import '${path.basename(assetId.path)}';''');
+    writer.print("import '$_REFLECTOR_IMPORT' as $_REF_PREFIX;");
   }
 
   void _updateUsesNonLangLibs(UriBasedDirective directive) {
@@ -118,7 +119,7 @@ class CreateNgDepsVisitor extends Object with SimpleAstVisitor<Object> {
   void _openFunctionWrapper() {
     _maybeWriteImport();
     writer.print('var _visited = false;'
-        'void ${SETUP_METHOD_NAME}(${REFLECTOR_VAR_NAME}) {'
+        'void ${SETUP_METHOD_NAME}() {'
         'if (_visited) return; _visited = true;');
   }
 
@@ -256,6 +257,9 @@ class CreateNgDepsVisitor extends Object with SimpleAstVisitor<Object> {
     _foundNgInjectable = true;
 
     // The receiver for cascaded calls.
-    writer.print(REFLECTOR_VAR_NAME);
+    writer.print('$_REF_PREFIX.$REFLECTOR_VAR_NAME');
   }
 }
+
+const _REF_PREFIX = '_ngRef';
+const _REFLECTOR_IMPORT = 'package:angular2/src/reflection/reflection.dart';

--- a/modules/angular2/src/transform/reflection_remover/codegen.dart
+++ b/modules/angular2/src/transform/reflection_remover/codegen.dart
@@ -53,8 +53,7 @@ class Codegen {
 
     var count = 0;
     return importUris
-        .map((_) =>
-            '${prefix}${count++}.${SETUP_METHOD_NAME}(${reflectorExpression});')
+        .map((_) => '${prefix}${count++}.${SETUP_METHOD_NAME}();')
         .join('');
   }
 }

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/bar.ng_deps.dart
@@ -1,14 +1,15 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 export 'foo.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(MyComponent, {
       'factory': () => new MyComponent(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/expected/bar.ng_deps.dart
@@ -1,19 +1,20 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 export 'foo.dart';
 import 'foo.ng_deps.dart' as i0;
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(MyComponent, {
       'factory': () => new MyComponent(),
       'parameters': const [],
       'annotations': const [const Component(selector: '[soup]')]
     });
-  i0.initReflector(reflector);
+  i0.initReflector();
 }

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/expected/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/expected/foo.ng_deps.dart
@@ -1,13 +1,14 @@
 library foo.ng_deps.dart;
 
 import 'foo.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(DependencyComponent, {
       'factory': () => new DependencyComponent(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/expected/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/expected/index.ng_deps.dart
@@ -1,13 +1,14 @@
 library web_foo.ng_deps.dart;
 
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/application.dart';
 import 'package:angular2/src/reflection/reflection_capabilities.dart';
 import 'bar.dart';
 import 'bar.ng_deps.dart' as i0;
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  i0.initReflector(reflector);
+  i0.initReflector();
 }

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/foo.ng_deps.dart
@@ -1,13 +1,14 @@
 library foo.ng_deps.dart;
 
 import 'foo.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(DependencyComponent, {
       'factory': () => new DependencyComponent(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/index.ng_deps.dart
@@ -1,11 +1,12 @@
 library web_foo.ng_deps.dart;
 
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/application.dart';
 import 'package:angular2/src/reflection/reflection_capabilities.dart';
 import 'bar.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
 }

--- a/modules/angular2/test/transform/directive_linker/simple_files/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/bar.ng_deps.dart
@@ -1,14 +1,15 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 import 'foo.dart' as dep;
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(MyComponent, {
       'factory': () => new MyComponent(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_linker/simple_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/expected/bar.ng_deps.dart
@@ -1,15 +1,16 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 import 'foo.dart' as dep;
 import 'foo.ng_deps.dart' as i0;
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(MyComponent, {
       'factory': () => new MyComponent(),
       'parameters': const [],
@@ -18,5 +19,5 @@ void initReflector(reflector) {
             selector: '[soup]', viewInjector: const [dep.DependencyComponent])
       ]
     });
-  i0.initReflector(reflector);
+  i0.initReflector();
 }

--- a/modules/angular2/test/transform/directive_linker/simple_files/expected/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/expected/foo.ng_deps.dart
@@ -1,13 +1,14 @@
 library foo.ng_deps.dart;
 
 import 'foo.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(DependencyComponent, {
       'factory': () => new DependencyComponent(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_linker/simple_files/expected/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/expected/index.ng_deps.dart
@@ -1,13 +1,14 @@
 library web_foo.ng_deps.dart;
 
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/application.dart';
 import 'package:angular2/src/reflection/reflection_capabilities.dart';
 import 'bar.dart';
 import 'bar.ng_deps.dart' as i0;
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  i0.initReflector(reflector);
+  i0.initReflector();
 }

--- a/modules/angular2/test/transform/directive_linker/simple_files/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/foo.ng_deps.dart
@@ -1,13 +1,14 @@
 library foo.ng_deps.dart;
 
 import 'foo.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(DependencyComponent, {
       'factory': () => new DependencyComponent(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_linker/simple_files/index.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/index.ng_deps.dart
@@ -1,11 +1,12 @@
 library web_foo.ng_deps.dart;
 
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/application.dart';
 import 'package:angular2/src/reflection/reflection_capabilities.dart';
 import 'bar.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
 }

--- a/modules/angular2/test/transform/directive_processor/absolute_url_expression_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/absolute_url_expression_files/expected/hello.ng_deps.dart
@@ -1,14 +1,15 @@
 library examples.src.hello_world.absolute_url_expression_files.ng_deps.dart;
 
 import 'hello.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Directive, View, NgElement;
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(HelloCmp, {
       'factory': () => new HelloCmp(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_processor/custom_metadata/expected/package_soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/custom_metadata/expected/package_soup.ng_deps.dart
@@ -1,13 +1,14 @@
 library dinner.package_soup.ng_deps.dart;
 
 import 'package_soup.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:soup/soup.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(PackageSoup, {
       'factory': () => new PackageSoup(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_processor/custom_metadata/expected/relative_soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/custom_metadata/expected/relative_soup.ng_deps.dart
@@ -1,13 +1,14 @@
 library dinner.relative_soup.ng_deps.dart;
 
 import 'relative_soup.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'annotations/soup.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(RelativeSoup, {
       'factory': () => new RelativeSoup(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_processor/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/expected/hello.ng_deps.dart
@@ -1,14 +1,15 @@
 library examples.src.hello_world.index_common_dart.ng_deps.dart;
 
 import 'hello.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Directive, View, NgElement;
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(HelloCmp, {
       'factory': () => new HelloCmp(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_processor/interface_chain_files/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/interface_chain_files/expected/soup.ng_deps.dart
@@ -1,13 +1,14 @@
 library dinner.soup.ng_deps.dart;
 
 import 'soup.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(ChangingSoupComponent, {
       'factory': () => new ChangingSoupComponent(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_processor/interfaces_files/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/interfaces_files/expected/soup.ng_deps.dart
@@ -1,13 +1,14 @@
 library dinner.soup.ng_deps.dart;
 
 import 'soup.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(ChangingSoupComponent, {
       'factory': () => new ChangingSoupComponent(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_processor/invalid_url_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/invalid_url_files/expected/hello.ng_deps.dart
@@ -1,14 +1,15 @@
 library test.transform.directive_processor.invalid_url_files.hello.ng_deps.dart;
 
 import 'hello.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Directive, View, NgElement;
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(HelloCmp, {
       'factory': () => new HelloCmp(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_processor/multiple_style_urls_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/multiple_style_urls_files/expected/hello.ng_deps.dart
@@ -1,14 +1,15 @@
 library examples.src.hello_world.multiple_style_urls_files.ng_deps.dart;
 
 import 'hello.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Directive, View, NgElement;
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(HelloCmp, {
       'factory': () => new HelloCmp(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_processor/multiple_style_urls_not_inlined_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/multiple_style_urls_not_inlined_files/expected/hello.ng_deps.dart
@@ -1,14 +1,15 @@
 library examples.src.hello_world.multiple_style_urls_not_inlined_files.ng_deps.dart;
 
 import 'hello.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Directive, View, NgElement;
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(HelloCmp, {
       'factory': () => new HelloCmp(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_processor/parameter_metadata/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/parameter_metadata/expected/soup.ng_deps.dart
@@ -1,13 +1,14 @@
 library dinner.soup.ng_deps.dart;
 
 import 'soup.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(SoupComponent, {
       'factory':
           (String description, salt) => new SoupComponent(description, salt),

--- a/modules/angular2/test/transform/directive_processor/split_url_expression_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/split_url_expression_files/expected/hello.ng_deps.dart
@@ -1,14 +1,15 @@
 library examples.src.hello_world.split_url_expression_files.ng_deps.dart;
 
 import 'hello.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Directive, View, NgElement;
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(HelloCmp, {
       'factory': () => new HelloCmp(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_processor/static_function_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/static_function_files/expected/hello.ng_deps.dart
@@ -1,13 +1,14 @@
 library static_function_files.hello.ng_deps.dart;
 
 import 'hello.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerFunction(getMessage, {
       'parameters': const [const [const Inject(Message)]],
       'annotations': const Injectable()

--- a/modules/angular2/test/transform/directive_processor/superclass_files/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/superclass_files/expected/soup.ng_deps.dart
@@ -1,13 +1,14 @@
 library dinner.soup.ng_deps.dart;
 
 import 'soup.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(ChangingSoupComponent, {
       'factory': () => new ChangingSoupComponent(),
       'parameters': const [],

--- a/modules/angular2/test/transform/directive_processor/url_expression_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/url_expression_files/expected/hello.ng_deps.dart
@@ -1,14 +1,15 @@
 library examples.src.hello_world.url_expression_files.ng_deps.dart;
 
 import 'hello.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Directive, View, NgElement;
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(HelloCmp, {
       'factory': () => new HelloCmp(),
       'parameters': const [],

--- a/modules/angular2/test/transform/integration/list_of_types_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/list_of_types_files/expected/bar.ng_deps.dart
@@ -1,14 +1,15 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 import 'foo.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(MyComponent, {
       'factory': (MyContext c) => new MyComponent(c),
       'parameters': const [const [MyContext]],

--- a/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_deps.dart
@@ -1,13 +1,14 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(MyComponent, {
       'factory': () => new MyComponent(),
       'parameters': const [],

--- a/modules/angular2/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
@@ -1,6 +1,7 @@
 library web_foo.ng_deps.dart;
 
 import 'index.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/application.dart';
 import 'package:angular2/src/reflection/reflection.dart';
 import 'index.ng_deps.dart' as ngStaticInit0;
@@ -8,8 +9,8 @@ import 'bar.dart';
 import 'bar.ng_deps.dart' as i0;
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  i0.initReflector(reflector);
+  i0.initReflector();
 }

--- a/modules/angular2/test/transform/integration/synthetic_ctor_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/synthetic_ctor_files/expected/bar.ng_deps.dart
@@ -1,13 +1,14 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(MyComponent, {
       'factory': () => new MyComponent(),
       'parameters': const [],

--- a/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
@@ -4,14 +4,15 @@ import 'package:angular2/src/change_detection/pregen_proto_change_detector.dart'
     as _gen;
 
 import 'bar.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 import 'package:angular2/src/core/annotations_impl/view.dart';
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(MyComponent, {
       'factory': () => new MyComponent(),
       'parameters': const [],

--- a/modules/angular2/test/transform/integration/two_deps_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_deps_files/expected/bar.ng_deps.dart
@@ -1,14 +1,15 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 import 'foo.dart' as prefix;
 
 var _visited = false;
-void initReflector(reflector) {
+void initReflector() {
   if (_visited) return;
   _visited = true;
-  reflector
+  _ngRef.reflector
     ..registerType(MyComponent, {
       'factory':
           (prefix.MyContext c, String inValue) => new MyComponent(c, inValue),

--- a/modules/angular2/test/transform/reflection_remover/debug_files/expected/index.dart
+++ b/modules/angular2/test/transform/reflection_remover/debug_files/expected/index.dart
@@ -16,7 +16,7 @@ import 'package:angular2/src/reflection/reflection.dart';
 import 'package:angular2/src/reflection/debug_reflection_capabilities.dart';import 'index.ng_deps.dart' as ngStaticInit0;
 
 void main() {
-  reflector.reflectionCapabilities = new ReflectionCapabilities();ngStaticInit0.initReflector(reflector);
+  reflector.reflectionCapabilities = new ReflectionCapabilities();ngStaticInit0.initReflector();
   bootstrap(MyComponent);
 }
 """;

--- a/modules/angular2/test/transform/reflection_remover/debug_mirrors_files/expected/index.dart
+++ b/modules/angular2/test/transform/reflection_remover/debug_mirrors_files/expected/index.dart
@@ -16,7 +16,7 @@ import 'package:angular2/src/reflection/reflection.dart';
 import 'package:angular2/src/reflection/debug_reflection_capabilities.dart';import 'index.ng_deps.dart' as ngStaticInit0;
 
 void main() {
-  reflector.reflectionCapabilities = new ReflectionCapabilities();ngStaticInit0.initReflector(reflector);
+  reflector.reflectionCapabilities = new ReflectionCapabilities();ngStaticInit0.initReflector();
   bootstrap(MyComponent);
 }
 """;

--- a/modules/angular2/test/transform/reflection_remover/reflection_remover_files/expected/index.dart
+++ b/modules/angular2/test/transform/reflection_remover/reflection_remover_files/expected/index.dart
@@ -16,7 +16,7 @@ import 'package:angular2/src/reflection/reflection.dart';
 /*import 'package:angular2/src/reflection/reflection_capabilities.dart';*/import 'index.ng_deps.dart' as ngStaticInit0;
 
 void main() {
-  /*reflector.reflectionCapabilities = new ReflectionCapabilities();*/ngStaticInit0.initReflector(reflector);
+  /*reflector.reflectionCapabilities = new ReflectionCapabilities();*/ngStaticInit0.initReflector();
   bootstrap(MyComponent);
 }
 """;

--- a/modules/angular2/test/transform/reflection_remover/verbose_files/expected/index.dart
+++ b/modules/angular2/test/transform/reflection_remover/verbose_files/expected/index.dart
@@ -16,7 +16,7 @@ import 'package:angular2/src/reflection/reflection.dart';
 import 'package:angular2/src/reflection/debug_reflection_capabilities.dart';import 'index.ng_deps.dart' as ngStaticInit0;
 
 void main() {
-  reflector.reflectionCapabilities = new ReflectionCapabilities(verbose: true);ngStaticInit0.initReflector(reflector);
+  reflector.reflectionCapabilities = new ReflectionCapabilities(verbose: true);ngStaticInit0.initReflector();
   bootstrap(MyComponent);
 }
 """;


### PR DESCRIPTION
Remove reflector parameter from initReflector method to simplify ng_deps for reflection
initialization. It wasn't used and was added for testability, but wasn't used. This
keeps the interface simplier.
