### PR TITLE
fix(transformers): fix sort order for reflective imports

### DIFF
--- a/modules/angular2/src/transform/reflection_remover/rewriter.dart
+++ b/modules/angular2/src/transform/reflection_remover/rewriter.dart
@@ -44,7 +44,7 @@ class Rewriter {
       return _code;
     }
 
-    var compare = (AstNode a, AstNode b) => b.offset - a.offset;
+    var compare = (AstNode a, AstNode b) => a.offset - b.offset;
     visitor.reflectionCapabilityImports.sort(compare);
     visitor.reflectionCapabilityAssignments.sort(compare);
 


### PR DESCRIPTION
Fix sort order for reflective imports in reflection_remover/rewriter.dart.
Currently there is only one import so the sort order happens to be correct,
but if another one is added the rewrite code will break.
