### PR TITLE
feat(transformers): implement initializing deferred libraries

### DIFF
--- a/modules/angular2/src/transform/deferred_rewriter/rewriter.dart
+++ b/modules/angular2/src/transform/deferred_rewriter/rewriter.dart
@@ -1,0 +1,142 @@
+library angular2.transform.deferred_rewriter.rewriter;
+
+import 'dart:async';
+
+import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/src/generated/ast.dart';
+import 'package:angular2/src/transform/common/asset_reader.dart';
+import 'package:angular2/src/transform/common/logging.dart';
+import 'package:angular2/src/transform/common/names.dart';
+import 'package:barback/barback.dart';
+import 'package:code_transformers/assets.dart';
+import 'package:quiver/iterables.dart' as it;
+
+class Rewriter {
+  final AssetId _entryPoint;
+  final AssetReader _reader;
+
+  Rewriter(this._entryPoint, this._reader);
+
+  /// Rewrites the provided code by finding all the deferred library imports
+  /// and loadLibrary invocations. Then it removes any libraries that don't
+  /// require angular codegen. For the remaining libraries it rewrites the
+  /// import to the corresponding ng_dep file, and chains a future which
+  /// first initializes the library.
+  ///
+  /// To the extent possible, this method does not change line numbers or
+  /// offsets in the provided code to facilitate debugging via source maps.
+  Future<String> rewrite() async {
+    var code = await _reader.readAsString(_entryPoint);
+    var node = parseCompilationUnit(code);
+    if (node == null) return null;
+
+    var visitor = new _FindDeferredLibraries(_reader, _entryPoint);
+    node.accept(visitor);
+    // Look to see if we found any deferred libraries
+    if (!visitor.hasDeferredLibrariesToRewrite()) return null;
+    // Remove any libraries that don't need angular codegen.
+    await visitor.cull();
+    // Check again if there are any deferred libraries.
+    if (!visitor.hasDeferredLibrariesToRewrite()) return null;
+
+    var compare = (AstNode a, AstNode b) => a.offset - b.offset;
+    visitor.deferredImports.sort(compare);
+    visitor.loadLibraryInvocations.sort(compare);
+
+    var buf = new StringBuffer();
+    var idx = visitor.deferredImports.fold(0,
+        (int lastIdx, ImportDirective node) {
+      buf.write(code.substring(lastIdx, node.offset));
+
+      var import = code.substring(node.offset, node.end);
+      buf.write(import.replaceFirst('.dart', DEPS_EXTENSION));
+      return node.end;
+    });
+
+    idx = visitor.loadLibraryInvocations.fold(idx,
+        (int lastIdx, MethodInvocation node) {
+      buf.write(code.substring(lastIdx, node.offset));
+      var value = node.realTarget as SimpleIdentifier;
+      var prefix = value.name;
+      // Chain a future that initializes the reflector.
+      buf.write('$prefix.loadLibrary().then((_) {$prefix.initReflector();})');
+      return node.end;
+    });
+    if (idx < code.length) buf.write(code.substring(idx));
+    return '$buf';
+  }
+}
+
+/// Visitor responsible for finding the deferred libraries that need angular
+/// codegen. Those are the libraries that are loaded deferred and have a
+/// corresponding ng_deps file.
+class _FindDeferredLibraries extends Object with RecursiveAstVisitor<Object> {
+  var deferredImports = new List<ImportDirective>();
+  var loadLibraryInvocations = new List<MethodInvocation>();
+  final AssetReader _reader;
+  final AssetId _entryPoint;
+
+  _FindDeferredLibraries(this._reader, this._entryPoint);
+
+  @override
+  Object visitImportDirective(ImportDirective node) {
+    if (node.deferredKeyword != null) {
+      deferredImports.add(node);
+    }
+    return null;
+  }
+
+  @override
+  Object visitMethodInvocation(MethodInvocation node) {
+    if (node.methodName.name == 'loadLibrary') {
+      loadLibraryInvocations.add(node);
+    }
+    return super.visitMethodInvocation(node);
+  }
+
+  bool hasDeferredLibrariesToRewrite() {
+    if (deferredImports.isEmpty) {
+      logger.fine('There are no deferred library imports.');
+      return false;
+    }
+    if (loadLibraryInvocations.isEmpty) {
+      logger.fine(
+          'There are no loadLibrary invocations that need to be rewritten.');
+      return false;
+    }
+    return true;
+  }
+
+  // Remove all deferredImports that do not have a ng_dep file
+  // then remove all loadLibrary invocations that are not in the set of
+  // prefixes that are left.
+  Future cull() async {
+    // Determine whether a deferred import has ng_deps.
+    var hasInputs = await Future.wait(deferredImports
+        .map((import) => stringLiteralToString(import.uri))
+        .map((uri) => toDepsExtension(uri))
+        .map((depsUri) => uriToAssetId(_entryPoint, depsUri, logger, null,
+            errorOnAbsolute: false))
+        .map((asset) => _reader.hasInput(asset)));
+
+    // Filter out any deferred imports that do not have ng_deps.
+    deferredImports = it
+        .zip([deferredImports, hasInputs])
+        .where((importHasInput) => importHasInput[1])
+        .map((importHasInput) => importHasInput[0])
+        .toList();
+
+    // Find the set of prefixes which have ng_deps.
+    var prefixes =
+        new Set.from(deferredImports.map((import) => import.prefix.name));
+
+    // Filters out any load library invocations where the prefix is not a known
+    // library with ng_deps.
+    loadLibraryInvocations = loadLibraryInvocations.where((library) {
+      var value = library.realTarget as SimpleIdentifier;
+      return prefixes.contains(value.name);
+    }).toList();
+
+    return;
+  }
+}

--- a/modules/angular2/src/transform/deferred_rewriter/transformer.dart
+++ b/modules/angular2/src/transform/deferred_rewriter/transformer.dart
@@ -1,0 +1,49 @@
+library angular2.transform.deferred_rewriter.transformer;
+
+import 'dart:async';
+
+import 'package:angular2/src/transform/common/asset_reader.dart';
+import 'package:angular2/src/transform/common/logging.dart' as log;
+import 'package:angular2/src/transform/common/names.dart';
+import 'package:angular2/src/transform/common/options.dart';
+import 'package:barback/barback.dart';
+
+import 'rewriter.dart';
+
+/// Transformer responsible for rewriting deferred library loads to enable
+/// initializing the reflector in a deferred way to keep the code with the
+/// deferred library.
+class DeferredRewriter extends Transformer {
+  final TransformerOptions options;
+
+  DeferredRewriter(this.options);
+
+  @override
+  bool isPrimary(AssetId id) =>
+      id.extension.endsWith('dart') && !id.path.endsWith(DEPS_EXTENSION);
+
+  @override
+  Future apply(Transform transform) async {
+    log.init(transform);
+
+    try {
+      var asset = transform.primaryInput;
+      var reader = new AssetReader.fromTransform(transform);
+      var transformedCode = await rewriteDeferredLibraries(reader, asset.id);
+      if (transformedCode != null) {
+        transform.addOutput(
+            new Asset.fromString(transform.primaryInput.id, transformedCode));
+      }
+    } catch (ex, stackTrace) {
+      log.logger.warning('Rewritting deferred libraries failed.\n'
+          'Exception: $ex\n'
+          'Stack Trace: $stackTrace');
+    }
+  }
+}
+
+// Visible for testing
+Future<String> rewriteDeferredLibraries(AssetReader reader, AssetId id) async {
+  var rewriter = new Rewriter(id, reader);
+  return await rewriter.rewrite();
+}

--- a/modules/angular2/src/transform/transformer.dart
+++ b/modules/angular2/src/transform/transformer.dart
@@ -3,6 +3,7 @@ library angular2.transform;
 import 'package:barback/barback.dart';
 import 'package:dart_style/dart_style.dart';
 
+import 'deferred_rewriter/transformer.dart';
 import 'directive_linker/transformer.dart';
 import 'directive_metadata_extractor/transformer.dart';
 import 'directive_processor/transformer.dart';
@@ -29,7 +30,11 @@ class AngularTransformerGroup extends TransformerGroup {
     phases.addAll(new List.generate(
         options.optimizationPhases, (_) => [new EmptyNgDepsRemover()]));
     phases.addAll([
-      [new DirectiveLinker(), new DirectiveMetadataExtractor()],
+      [
+        new DirectiveLinker(),
+        new DirectiveMetadataExtractor(),
+        new DeferredRewriter(options)
+      ],
       [new BindGenerator(options)],
       [new TemplateCompiler(options)]
     ]);

--- a/modules/angular2/test/transform/deferred_rewriter/all_tests.dart
+++ b/modules/angular2/test/transform/deferred_rewriter/all_tests.dart
@@ -1,0 +1,58 @@
+library angular2.test.transform.deferred_rewriter.all_tests;
+
+import 'package:barback/barback.dart';
+import 'package:angular2/src/transform/deferred_rewriter/transformer.dart';
+import 'package:angular2/src/transform/common/annotation_matcher.dart';
+import 'package:angular2/src/transform/common/asset_reader.dart';
+import 'package:angular2/src/transform/common/logging.dart' as log;
+import 'package:code_transformers/messages/build_logger.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:guinness/guinness.dart';
+import 'package:path/path.dart' as path;
+import '../common/read_file.dart';
+
+var formatter = new DartFormatter();
+
+main() {
+  allTests();
+}
+
+void allTests() {
+  _testRewriteDeferredLibraries(
+      'should return null when no deferred libraries found.',
+      'no_deferred_libraries/index.dart');
+  _testRewriteDeferredLibraries(
+      'should return null when deferred libraries with no ng_deps.',
+      'no_ng_deps_libraries/index.dart');
+  _testRewriteDeferredLibraries(
+      'should rewrite deferred libraries with ng_deps.',
+      'simple_deferred_example/index.dart');
+  _testRewriteDeferredLibraries(
+      'should not rewrite deferred libraries without ng_deps.',
+      'deferred_example_no_ng_deps/index.dart');
+  _testRewriteDeferredLibraries(
+      'should rewrite deferred libraries with ng_deps leave other deferred library alone.',
+      'complex_deferred_example/index.dart');
+}
+
+void _testRewriteDeferredLibraries(String name, String inputPath) {
+  it(name, () async {
+    var inputId = _assetIdForPath(inputPath);
+    var reader = new TestAssetReader();
+    var expectedPath = path.join(
+        path.dirname(inputPath), 'expected', path.basename(inputPath));
+    var expectedId = _assetIdForPath(expectedPath);
+
+    var output = await rewriteDeferredLibraries(reader, inputId);
+    var input = await reader.readAsString(expectedId);
+    if (input == null) {
+      // Null input signals no output. Ensure that is true.
+      expect(output).toBeNull();
+    } else {
+      expect(formatter.format(output)).toEqual(formatter.format(input));
+    }
+  });
+}
+
+AssetId _assetIdForPath(String path) =>
+    new AssetId('angular2', 'test/transform/deferred_rewriter/$path');

--- a/modules/angular2/test/transform/deferred_rewriter/complex_deferred_example/expected/index.dart
+++ b/modules/angular2/test/transform/deferred_rewriter/complex_deferred_example/expected/index.dart
@@ -1,0 +1,17 @@
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+import 'package:angular2/src/reflection/reflection_capabilities.dart';
+import 'hello.ng_deps.dart' deferred as a; // ng_deps. Should be rewritten.
+import 'b.dart' deferred as b; // No ng_deps. Shouldn't be rewritten.
+
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  a.loadLibrary().then((_) {
+    a.initReflector();
+  }).then((_) {
+    bootstrap(a.HelloCmp);
+  });
+  b.loadLibrary();
+}

--- a/modules/angular2/test/transform/deferred_rewriter/complex_deferred_example/hello.dart
+++ b/modules/angular2/test/transform/deferred_rewriter/complex_deferred_example/hello.dart
@@ -1,0 +1,8 @@
+library examples.src.hello_world.absolute_url_expression_files;
+
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Directive, View, NgElement;
+
+@Component(selector: 'hello-app')
+@View(templateUrl: 'package:other_package/template.html')
+class HelloCmp {}

--- a/modules/angular2/test/transform/deferred_rewriter/complex_deferred_example/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/deferred_rewriter/complex_deferred_example/hello.ng_deps.dart
@@ -18,8 +18,7 @@ void initReflector() {
         const Component(selector: 'hello-app'),
         const View(
             template: r'''{{greeting}}''',
-            templateUrl: r'package:other_package/template.html',
-            styles: const [r'''.greeting { .color: blue; }''',])
+            templateUrl: r'package:other_package/template.html')
       ]
     });
 }

--- a/modules/angular2/test/transform/deferred_rewriter/complex_deferred_example/index.dart
+++ b/modules/angular2/test/transform/deferred_rewriter/complex_deferred_example/index.dart
@@ -1,0 +1,15 @@
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+import 'package:angular2/src/reflection/reflection_capabilities.dart';
+import 'hello.dart' deferred as a; // ng_deps. Should be rewritten.
+import 'b.dart' deferred as b; // No ng_deps. Shouldn't be rewritten.
+
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  a.loadLibrary().then((_) {
+    bootstrap(a.HelloCmp);
+  });
+  b.loadLibrary();
+}

--- a/modules/angular2/test/transform/deferred_rewriter/deferred_example_no_ng_deps/hello.dart
+++ b/modules/angular2/test/transform/deferred_rewriter/deferred_example_no_ng_deps/hello.dart
@@ -1,0 +1,8 @@
+library examples.src.hello_world.absolute_url_expression_files;
+
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Directive, View, NgElement;
+
+@Component(selector: 'hello-app')
+@View(templateUrl: 'package:other_package/template.html')
+class HelloCmp {}

--- a/modules/angular2/test/transform/deferred_rewriter/deferred_example_no_ng_deps/index.dart
+++ b/modules/angular2/test/transform/deferred_rewriter/deferred_example_no_ng_deps/index.dart
@@ -1,0 +1,13 @@
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+import 'package:angular2/src/reflection/reflection_capabilities.dart';
+import 'hello.dart' deferred as a;
+
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  a.loadLibrary().then((_) {
+    bootstrap(a.HelloCmp);
+  });
+}

--- a/modules/angular2/test/transform/deferred_rewriter/no_deferred_libraries/index.dart
+++ b/modules/angular2/test/transform/deferred_rewriter/no_deferred_libraries/index.dart
@@ -1,0 +1,10 @@
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+import 'package:angular2/src/reflection/reflection_capabilities.dart';
+
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  bootstrap(MyComponent);
+}

--- a/modules/angular2/test/transform/deferred_rewriter/no_ng_deps_libraries/index.dart
+++ b/modules/angular2/test/transform/deferred_rewriter/no_ng_deps_libraries/index.dart
@@ -1,0 +1,11 @@
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+import 'package:angular2/src/reflection/reflection_capabilities.dart';
+import 'a.dart' deferred as a;
+
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  bootstrap(MyComponent);
+}

--- a/modules/angular2/test/transform/deferred_rewriter/simple_deferred_example/expected/index.dart
+++ b/modules/angular2/test/transform/deferred_rewriter/simple_deferred_example/expected/index.dart
@@ -1,0 +1,15 @@
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+import 'package:angular2/src/reflection/reflection_capabilities.dart';
+import 'hello.ng_deps.dart' deferred as a;
+
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  a.loadLibrary().then((_) {
+    a.initReflector();
+  }).then((_) {
+    bootstrap(a.HelloCmp);
+  });
+}

--- a/modules/angular2/test/transform/deferred_rewriter/simple_deferred_example/hello.dart
+++ b/modules/angular2/test/transform/deferred_rewriter/simple_deferred_example/hello.dart
@@ -1,0 +1,8 @@
+library examples.src.hello_world.absolute_url_expression_files;
+
+import 'package:angular2/angular2.dart'
+    show bootstrap, Component, Directive, View, NgElement;
+
+@Component(selector: 'hello-app')
+@View(templateUrl: 'package:other_package/template.html')
+class HelloCmp {}

--- a/modules/angular2/test/transform/deferred_rewriter/simple_deferred_example/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/deferred_rewriter/simple_deferred_example/hello.ng_deps.dart
@@ -18,8 +18,7 @@ void initReflector() {
         const Component(selector: 'hello-app'),
         const View(
             template: r'''{{greeting}}''',
-            templateUrl: r'package:other_package/template.html',
-            styles: const [r'''.greeting { .color: blue; }''',])
+            templateUrl: r'package:other_package/template.html')
       ]
     });
 }

--- a/modules/angular2/test/transform/deferred_rewriter/simple_deferred_example/index.dart
+++ b/modules/angular2/test/transform/deferred_rewriter/simple_deferred_example/index.dart
@@ -1,0 +1,13 @@
+library web_foo;
+
+import 'package:angular2/src/core/application.dart';
+import 'package:angular2/src/reflection/reflection.dart';
+import 'package:angular2/src/reflection/reflection_capabilities.dart';
+import 'hello.dart' deferred as a;
+
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  a.loadLibrary().then((_) {
+    bootstrap(a.HelloCmp);
+  });
+}

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/bar.ng_deps.dart
@@ -1,6 +1,7 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+export 'bar.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 export 'foo.dart';

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/expected/bar.ng_deps.dart
@@ -1,6 +1,7 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+export 'bar.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 export 'foo.dart';

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/expected/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/expected/foo.ng_deps.dart
@@ -1,6 +1,7 @@
 library foo.ng_deps.dart;
 
 import 'foo.dart';
+export 'foo.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 

--- a/modules/angular2/test/transform/directive_linker/simple_export_files/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_export_files/foo.ng_deps.dart
@@ -1,6 +1,7 @@
 library foo.ng_deps.dart;
 
 import 'foo.dart';
+export 'foo.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 

--- a/modules/angular2/test/transform/directive_linker/simple_files/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/bar.ng_deps.dart
@@ -1,6 +1,7 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+export 'bar.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 import 'foo.dart' as dep;

--- a/modules/angular2/test/transform/directive_linker/simple_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/expected/bar.ng_deps.dart
@@ -1,6 +1,7 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+export 'bar.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 import 'foo.dart' as dep;

--- a/modules/angular2/test/transform/directive_linker/simple_files/expected/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/expected/foo.ng_deps.dart
@@ -1,6 +1,7 @@
 library foo.ng_deps.dart;
 
 import 'foo.dart';
+export 'foo.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 

--- a/modules/angular2/test/transform/directive_linker/simple_files/foo.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_linker/simple_files/foo.ng_deps.dart
@@ -1,6 +1,7 @@
 library foo.ng_deps.dart;
 
 import 'foo.dart';
+export 'foo.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 

--- a/modules/angular2/test/transform/directive_processor/custom_metadata/expected/package_soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/custom_metadata/expected/package_soup.ng_deps.dart
@@ -1,6 +1,7 @@
 library dinner.package_soup.ng_deps.dart;
 
 import 'package_soup.dart';
+export 'package_soup.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:soup/soup.dart';
 

--- a/modules/angular2/test/transform/directive_processor/custom_metadata/expected/relative_soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/custom_metadata/expected/relative_soup.ng_deps.dart
@@ -1,6 +1,7 @@
 library dinner.relative_soup.ng_deps.dart;
 
 import 'relative_soup.dart';
+export 'relative_soup.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'annotations/soup.dart';
 

--- a/modules/angular2/test/transform/directive_processor/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/expected/hello.ng_deps.dart
@@ -1,6 +1,7 @@
 library examples.src.hello_world.index_common_dart.ng_deps.dart;
 
 import 'hello.dart';
+export 'hello.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Directive, View, NgElement;

--- a/modules/angular2/test/transform/directive_processor/interface_chain_files/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/interface_chain_files/expected/soup.ng_deps.dart
@@ -1,6 +1,7 @@
 library dinner.soup.ng_deps.dart;
 
 import 'soup.dart';
+export 'soup.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 

--- a/modules/angular2/test/transform/directive_processor/interfaces_files/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/interfaces_files/expected/soup.ng_deps.dart
@@ -1,6 +1,7 @@
 library dinner.soup.ng_deps.dart;
 
 import 'soup.dart';
+export 'soup.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 

--- a/modules/angular2/test/transform/directive_processor/invalid_url_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/invalid_url_files/expected/hello.ng_deps.dart
@@ -1,6 +1,7 @@
 library test.transform.directive_processor.invalid_url_files.hello.ng_deps.dart;
 
 import 'hello.dart';
+export 'hello.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Directive, View, NgElement;

--- a/modules/angular2/test/transform/directive_processor/multiple_style_urls_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/multiple_style_urls_files/expected/hello.ng_deps.dart
@@ -1,6 +1,7 @@
 library examples.src.hello_world.multiple_style_urls_files.ng_deps.dart;
 
 import 'hello.dart';
+export 'hello.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Directive, View, NgElement;

--- a/modules/angular2/test/transform/directive_processor/multiple_style_urls_not_inlined_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/multiple_style_urls_not_inlined_files/expected/hello.ng_deps.dart
@@ -1,6 +1,7 @@
 library examples.src.hello_world.multiple_style_urls_not_inlined_files.ng_deps.dart;
 
 import 'hello.dart';
+export 'hello.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Directive, View, NgElement;

--- a/modules/angular2/test/transform/directive_processor/parameter_metadata/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/parameter_metadata/expected/soup.ng_deps.dart
@@ -1,6 +1,7 @@
 library dinner.soup.ng_deps.dart;
 
 import 'soup.dart';
+export 'soup.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 

--- a/modules/angular2/test/transform/directive_processor/split_url_expression_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/split_url_expression_files/expected/hello.ng_deps.dart
@@ -1,6 +1,7 @@
 library examples.src.hello_world.split_url_expression_files.ng_deps.dart;
 
 import 'hello.dart';
+export 'hello.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Directive, View, NgElement;

--- a/modules/angular2/test/transform/directive_processor/static_function_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/static_function_files/expected/hello.ng_deps.dart
@@ -1,6 +1,7 @@
 library static_function_files.hello.ng_deps.dart;
 
 import 'hello.dart';
+export 'hello.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart';
 

--- a/modules/angular2/test/transform/directive_processor/superclass_files/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/superclass_files/expected/soup.ng_deps.dart
@@ -1,6 +1,7 @@
 library dinner.soup.ng_deps.dart;
 
 import 'soup.dart';
+export 'soup.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 

--- a/modules/angular2/test/transform/directive_processor/url_expression_files/expected/hello.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/url_expression_files/expected/hello.ng_deps.dart
@@ -1,6 +1,7 @@
 library examples.src.hello_world.url_expression_files.ng_deps.dart;
 
 import 'hello.dart';
+export 'hello.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/angular2.dart'
     show bootstrap, Component, Directive, View, NgElement;

--- a/modules/angular2/test/transform/integration/list_of_types_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/list_of_types_files/expected/bar.ng_deps.dart
@@ -1,6 +1,7 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+export 'bar.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 import 'foo.dart';

--- a/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/simple_annotation_files/expected/bar.ng_deps.dart
@@ -1,6 +1,7 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+export 'bar.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 

--- a/modules/angular2/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
@@ -1,6 +1,7 @@
 library web_foo.ng_deps.dart;
 
 import 'index.dart';
+export 'index.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/application.dart';
 import 'package:angular2/src/reflection/reflection.dart';

--- a/modules/angular2/test/transform/integration/synthetic_ctor_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/synthetic_ctor_files/expected/bar.ng_deps.dart
@@ -1,6 +1,7 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+export 'bar.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 

--- a/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
@@ -4,6 +4,7 @@ import 'package:angular2/src/change_detection/pregen_proto_change_detector.dart'
     as _gen;
 
 import 'bar.dart';
+export 'bar.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 import 'package:angular2/src/core/annotations_impl/view.dart';

--- a/modules/angular2/test/transform/integration/two_deps_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_deps_files/expected/bar.ng_deps.dart
@@ -1,6 +1,7 @@
 library bar.ng_deps.dart;
 
 import 'bar.dart';
+export 'bar.dart';
 import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/src/core/annotations_impl/annotations.dart';
 import 'foo.dart' as prefix;

--- a/modules/angular2/test/transform/transform.server.spec.dart
+++ b/modules/angular2/test/transform/transform.server.spec.dart
@@ -6,6 +6,7 @@ import 'package:unittest/vm_config.dart';
 
 import 'common/async_string_writer_tests.dart' as asyncStringWriter;
 import 'bind_generator/all_tests.dart' as bindGenerator;
+import 'deferred_rewriter/all_tests.dart' as deferredRewriter;
 import 'directive_linker/all_tests.dart' as directiveLinker;
 import 'directive_metadata_extractor/all_tests.dart' as directiveMeta;
 import 'directive_processor/all_tests.dart' as directiveProcessor;
@@ -22,6 +23,7 @@ main() {
   describe('Directive Processor', directiveProcessor.allTests);
   describe('Reflection Remover', reflectionRemover.allTests);
   describe('Template Compiler', templateCompiler.allTests);
+  describe('Deferred Rewriter', deferredRewriter.allTests);
   // NOTE(kegluneq): These use `code_transformers#testPhases`, which is not
   // designed to work with `guinness`.
   group('Transformer Pipeline', integration.allTests);


### PR DESCRIPTION
Implement deferred libraries to work with dependency injection and other
angular codegen. This is done by not initializing the library in the parent
ng_deps file when it is declared as deferred, rewriting the import and,
chaining a future that initializes the library in any files that are using
deferred libraries which need angular codegen.
