### PR TITLE
fix(router): require explicit base href

### DIFF
--- a/modules/angular2/src/dom/browser_adapter.dart
+++ b/modules/angular2/src/dom/browser_adapter.dart
@@ -342,8 +342,11 @@ class BrowserDomAdapter extends GenericBrowserDomAdapter {
     return window.location;
   }
   getBaseHref() {
-    var uri = document.baseUri;
-    var baseUri = Uri.parse(uri);
+    var href = getBaseElementHref();
+    if (href == null) {
+      return null;
+    }
+    var baseUri = Uri.parse(href);
     return baseUri.path;
   }
   String getUserAgent() {
@@ -359,4 +362,16 @@ class BrowserDomAdapter extends GenericBrowserDomAdapter {
   setGlobalVar(String name, value) {
     js.context[name] = value;
   }
+}
+
+
+var baseElement = null;
+String getBaseElementHref() {
+  if (baseElement == null) {
+    baseElement = document.querySelector('base');
+    if (baseElement == null) {
+      return null;
+    }
+  }
+  return baseElement.getAttribute('href');
 }

--- a/modules/angular2/src/dom/browser_adapter.ts
+++ b/modules/angular2/src/dom/browser_adapter.ts
@@ -263,12 +263,30 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   }
   getHistory(): History { return window.history; }
   getLocation(): Location { return window.location; }
-  getBaseHref(): string { return relativePath(document.baseURI); }
+  getBaseHref(): string {
+    var href = getBaseElementHref();
+    if (isBlank(href)) {
+      return null;
+    }
+    return relativePath(href);
+  }
   getUserAgent(): string { return window.navigator.userAgent; }
   setData(element, name: string, value: string) { element.dataset[name] = value; }
   getData(element, name: string): string { return element.dataset[name]; }
   // TODO(tbosch): move this into a separate environment class once we have it
   setGlobalVar(name: string, value: any) { global[name] = value; }
+}
+
+
+var baseElement = null;
+function getBaseElementHref(): string {
+  if (isBlank(baseElement)) {
+    baseElement = document.querySelector('base');
+    if (isBlank(baseElement)) {
+      return null;
+    }
+  }
+  return baseElement.attr('href');
 }
 
 // based on urlUtils.js in AngularJS 1

--- a/modules/angular2/src/router/location.ts
+++ b/modules/angular2/src/router/location.ts
@@ -1,6 +1,7 @@
 import {LocationStrategy} from './location_strategy';
 import {StringWrapper, isPresent, CONST_EXPR} from 'angular2/src/facade/lang';
 import {EventEmitter, ObservableWrapper} from 'angular2/src/facade/async';
+import {BaseException, isBlank} from 'angular2/src/facade/lang';
 import {OpaqueToken, Injectable, Optional, Inject} from 'angular2/di';
 
 export const appBaseHrefToken: OpaqueToken = CONST_EXPR(new OpaqueToken('locationHrefToken'));
@@ -22,8 +23,14 @@ export class Location {
 
   constructor(public _platformStrategy: LocationStrategy,
               @Optional() @Inject(appBaseHrefToken) href?: string) {
-    this._baseHref = stripTrailingSlash(
-        stripIndexHtml(isPresent(href) ? href : this._platformStrategy.getBaseHref()));
+    var browserBaseHref = isPresent(href) ? href : this._platformStrategy.getBaseHref();
+
+    if (isBlank(browserBaseHref)) {
+      throw new BaseException(
+          `No base href set. Either provide a binding to "appBaseHrefToken" or add a base element.`);
+    }
+
+    this._baseHref = stripTrailingSlash(stripIndexHtml(browserBaseHref));
     this._platformStrategy.onPopState((_) => this._onPopState(_));
   }
 

--- a/modules/angular2/test/router/location_spec.ts
+++ b/modules/angular2/test/router/location_spec.ts
@@ -75,5 +75,13 @@ export function main() {
       location.go('user/btford');
       expect(locationStrategy.path()).toEqual('/my/custom/href/user/btford');
     });
+
+    it('should throw when no base href is provided', () => {
+      var locationStrategy = new MockLocationStrategy();
+      locationStrategy.internalBaseHref = null;
+      expect(() => new Location(locationStrategy))
+          .toThrowError(
+              `No base href set. Either provide a binding to "appBaseHrefToken" or add a base element.`);
+    });
   });
 }


### PR DESCRIPTION
Previously, calls to `getBaseHref` used `document.baseURI`, which defaults to the current path in the absence of a base element in the document. This leads to surprising behavior.

With this change, `getBaseHref` returns `null` when a base element is not present in the document, and `Location` throws a more prescriptive error message.

Closes #3096
