### PR TITLE
fix(lowercase,uppercase): make stateless pipes

### DIFF
--- a/modules/angular2/src/change_detection/change_detection.ts
+++ b/modules/angular2/src/change_detection/change_detection.ts
@@ -7,8 +7,8 @@ import {IterableChangesFactory} from './pipes/iterable_changes';
 import {KeyValueChangesFactory} from './pipes/keyvalue_changes';
 import {ObservablePipeFactory} from './pipes/observable_pipe';
 import {PromisePipeFactory} from './pipes/promise_pipe';
-import {UpperCaseFactory} from './pipes/uppercase_pipe';
-import {LowerCaseFactory} from './pipes/lowercase_pipe';
+import {UpperCasePipe} from './pipes/uppercase_pipe';
+import {LowerCasePipe} from './pipes/lowercase_pipe';
 import {JsonPipe} from './pipes/json_pipe';
 import {LimitToPipeFactory} from './pipes/limit_to_pipe';
 import {DatePipe} from './pipes/date_pipe';
@@ -44,13 +44,13 @@ export const async: List<PipeFactory> = CONST_EXPR([
  * Uppercase text transform.
  */
 export const uppercase: List<PipeFactory> =
-    CONST_EXPR([CONST_EXPR(new UpperCaseFactory()), CONST_EXPR(new NullPipeFactory())]);
+    CONST_EXPR([CONST_EXPR(new UpperCasePipe()), CONST_EXPR(new NullPipeFactory())]);
 
 /**
  * Lowercase text transform.
  */
 export const lowercase: List<PipeFactory> =
-    CONST_EXPR([CONST_EXPR(new LowerCaseFactory()), CONST_EXPR(new NullPipeFactory())]);
+    CONST_EXPR([CONST_EXPR(new LowerCasePipe()), CONST_EXPR(new NullPipeFactory())]);
 
 /**
  * Json stringify transform.

--- a/modules/angular2/src/change_detection/pipes/lowercase_pipe.ts
+++ b/modules/angular2/src/change_detection/pipes/lowercase_pipe.ts
@@ -1,5 +1,5 @@
 import {isString, StringWrapper, CONST} from 'angular2/src/facade/lang';
-import {Pipe, PipeFactory} from './pipe';
+import {Pipe, BasePipe, PipeFactory} from './pipe';
 import {ChangeDetectorRef} from '../change_detector_ref';
 
 /**
@@ -22,26 +22,13 @@ import {ChangeDetectorRef} from '../change_detector_ref';
  *
  * ```
  */
-export class LowerCasePipe implements Pipe {
-  _latestValue: string = null;
-
+@CONST()
+export class LowerCasePipe extends BasePipe implements PipeFactory {
   supports(str: any): boolean { return isString(str); }
-
-  onDestroy(): void { this._latestValue = null; }
 
   transform(value: string, args: List<any> = null): string {
-    if (this._latestValue !== value) {
-      this._latestValue = value;
-      return StringWrapper.toLowerCase(value);
-    } else {
-      return this._latestValue;
-    }
+    return StringWrapper.toLowerCase(value);
   }
-}
 
-@CONST()
-export class LowerCaseFactory implements PipeFactory {
-  supports(str: any): boolean { return isString(str); }
-
-  create(cdRef: ChangeDetectorRef): Pipe { return new LowerCasePipe(); }
+  create(cdRef: ChangeDetectorRef): Pipe { return this; }
 }

--- a/modules/angular2/src/change_detection/pipes/uppercase_pipe.ts
+++ b/modules/angular2/src/change_detection/pipes/uppercase_pipe.ts
@@ -1,5 +1,5 @@
 import {isString, StringWrapper, CONST} from 'angular2/src/facade/lang';
-import {Pipe, PipeFactory} from './pipe';
+import {Pipe, BasePipe, PipeFactory} from './pipe';
 import {ChangeDetectorRef} from '../change_detector_ref';
 
 /**
@@ -22,26 +22,13 @@ import {ChangeDetectorRef} from '../change_detector_ref';
  *
  * ```
  */
-export class UpperCasePipe implements Pipe {
-  _latestValue: string = null;
-
+@CONST()
+export class UpperCasePipe extends BasePipe implements PipeFactory {
   supports(str: any): boolean { return isString(str); }
-
-  onDestroy(): void { this._latestValue = null; }
 
   transform(value: string, args: List<any> = null): string {
-    if (this._latestValue !== value) {
-      this._latestValue = value;
-      return StringWrapper.toUpperCase(value);
-    } else {
-      return this._latestValue;
-    }
+    return StringWrapper.toUpperCase(value);
   }
-}
 
-@CONST()
-export class UpperCaseFactory implements PipeFactory {
-  supports(str: any): boolean { return isString(str); }
-
-  create(cdRef: ChangeDetectorRef): Pipe { return new UpperCasePipe(); }
+  create(cdRef: ChangeDetectorRef): Pipe { return this; }
 }


### PR DESCRIPTION
same problem as `json` previously of transforming only on reference
check
closes #3173
