### PR TITLE
feat(compiler): add schema support for elements

### DIFF
--- a/modules/angular2/src/render/dom/schema/dom_element_schema.ts
+++ b/modules/angular2/src/render/dom/schema/dom_element_schema.ts
@@ -1,0 +1,18 @@
+import {DOM} from 'angular2/src/dom/dom_adapter';
+
+import {ElementSchemaEntry} from './element_schema_entry';
+
+export class DOMElementSchema implements ElementSchemaEntry {
+  private _domElement;
+
+  constructor(public tagName: string, public extendsElement: string = null) {
+    // TODO(pk): here are are creating a new DOM element for each entry which if far from being
+    // optimal. Consider changing the signature of hasProperty so it takes an element - in that
+    // case we would be constructing a new DOM elements only for potential web components.
+    this._domElement = DOM.createElement(tagName);
+  }
+
+  hasProperty(propName: string): boolean { return DOM.hasProperty(this._domElement, propName); }
+
+  getMappedPropName(propName: string): string { return null; }
+}

--- a/modules/angular2/src/render/dom/schema/dom_element_schema_registry.ts
+++ b/modules/angular2/src/render/dom/schema/dom_element_schema_registry.ts
@@ -1,0 +1,16 @@
+import {ElementSchemaEntry} from './element_schema_entry';
+import {DOMElementSchema} from './dom_element_schema';
+import {ElementSchemaRegistryImpl} from './element_schema_registry';
+
+export const DEFAULT_HTML_EL_NAME = 'HTMLElement';
+
+export class DomElementSchemaRegistry extends ElementSchemaRegistryImpl {
+  constructor(entries: List<ElementSchemaEntry>,
+              private _defaultElementToExtend: string = DEFAULT_HTML_EL_NAME) {
+    super(entries);
+  }
+
+  handleEntryNotFound(tagName: string): ElementSchemaEntry {
+    return new DOMElementSchema(tagName, this._defaultElementToExtend);
+  }
+}

--- a/modules/angular2/src/render/dom/schema/element_schema_entry.ts
+++ b/modules/angular2/src/render/dom/schema/element_schema_entry.ts
@@ -1,0 +1,21 @@
+import {StringMap, StringMapWrapper} from 'angular2/src/facade/collection';
+
+export interface ElementSchemaEntry {
+  tagName: string;
+  extendsElement: string;
+  hasProperty(propName: string): boolean;
+  getMappedPropName(propName: string): string;
+}
+
+export class HashElementSchema implements ElementSchemaEntry {
+  constructor(public tagName: string, private _properties: StringMap<string, string>,
+              public extendsElement: string = null) {}
+
+  hasProperty(propName: string): boolean {
+    return StringMapWrapper.contains(this._properties, propName);
+  }
+
+  getMappedPropName(propName: string): string {
+    return StringMapWrapper.get(this._properties, propName);
+  }
+}

--- a/modules/angular2/src/render/dom/schema/element_schema_registry.ts
+++ b/modules/angular2/src/render/dom/schema/element_schema_registry.ts
@@ -1,0 +1,60 @@
+import {isPresent, BaseException} from 'angular2/src/facade/lang';
+import {List, Map} from 'angular2/src/facade/collection';
+
+import {ElementSchemaEntry} from './element_schema_entry';
+
+export class ElementSchemaRegistry {
+  hasProperty(elName: string, propName: string): boolean { return true; }
+
+  getMappedPropName(elName: string, propName: string): string { return propName; }
+}
+
+export class SchemaRegistryError extends BaseException {
+  constructor(message) { super(message); }
+}
+
+export class ElementSchemaRegistryImpl extends ElementSchemaRegistry {
+  private _schema: Map<string, ElementSchemaEntry> = new Map();
+
+  constructor(entries: List<ElementSchemaEntry>) {
+    super();
+    entries.forEach((entry) => this._schema.set(entry.tagName, entry));
+  }
+
+  hasProperty(elName: string, propName: string): boolean {
+    var entry = this.getEntry(elName);
+
+    while (!entry.hasProperty(propName) && isPresent(entry.extendsElement)) {
+      entry = this.getEntry(entry.extendsElement);
+    }
+
+    return entry.hasProperty(propName);
+  }
+
+  getMappedPropName(elName: string, propName: string): string {
+    var entry = this.getEntry(elName);
+    var mappedPropName = entry.getMappedPropName(propName);
+
+    while (!isPresent(mappedPropName) && isPresent(entry.extendsElement)) {
+      entry = this.getEntry(entry.extendsElement);
+      mappedPropName = entry.getMappedPropName(propName);
+    }
+
+    return isPresent(mappedPropName) ? mappedPropName : propName;
+  }
+
+  getEntry(tagName: string): ElementSchemaEntry {
+    var entry = this._schema.get(tagName);
+    if (!isPresent(entry)) {
+      entry = this.handleEntryNotFound(tagName);
+      if (isPresent(entry)) {
+        this._schema.set(tagName, entry);
+      }
+    }
+    return entry;
+  }
+
+  handleEntryNotFound(tagName: string): ElementSchemaEntry {
+    throw new SchemaRegistryError(`Missing schema entry for '${tagName}'`);
+  }
+}

--- a/modules/angular2/test/render/dom/schema/dom_element_schema_spec.ts
+++ b/modules/angular2/test/render/dom/schema/dom_element_schema_spec.ts
@@ -1,0 +1,50 @@
+import {
+  AsyncTestCompleter,
+  beforeEach,
+  ddescribe,
+  xdescribe,
+  describe,
+  el,
+  expect,
+  iit,
+  inject,
+  it,
+  xit,
+  beforeEachBindings,
+  SpyObject,
+  IS_DARTIUM
+} from 'angular2/test_lib';
+
+import {DOMElementSchema} from 'angular2/src/render/dom/schema/dom_element_schema';
+
+export function main() {
+  // DOMElementSchema can only be used on the JS side where we can safely
+  // use reflection for DOM elements
+  if (IS_DARTIUM) return;
+
+  describe('DOMElementSchema', () => {
+
+    it('should detect properties on regular elements', () => {
+      var entry = new DOMElementSchema('div');
+
+      expect(entry.hasProperty('id')).toBeTruthy();
+      expect(entry.hasProperty('title')).toBeTruthy();
+      expect(entry.hasProperty('unknown')).toBeFalsy();
+    });
+
+    it('should detect properties on custom-like elements', () => {
+      var entry = new DOMElementSchema('custom-like');
+
+      expect(entry.hasProperty('id')).toBeTruthy();
+      expect(entry.hasProperty('title')).toBeTruthy();
+      expect(entry.hasProperty('unknown')).toBeFalsy();
+    });
+
+    it('should not re-map property names', () => {
+      var entry = new DOMElementSchema('div');
+
+      expect(entry.getMappedPropName('title')).toBeNull();
+      expect(entry.getMappedPropName('exotic-unknown')).toBeNull();
+    });
+  });
+}

--- a/modules/angular2/test/render/dom/schema/element_schema_registry_spec.ts
+++ b/modules/angular2/test/render/dom/schema/element_schema_registry_spec.ts
@@ -1,0 +1,70 @@
+import {
+  AsyncTestCompleter,
+  beforeEach,
+  ddescribe,
+  describe,
+  el,
+  expect,
+  iit,
+  inject,
+  it,
+  xit,
+  beforeEachBindings,
+  SpyObject,
+} from 'angular2/test_lib';
+
+import {HashElementSchema} from 'angular2/src/render/dom/schema/element_schema_entry';
+import {ElementSchemaRegistryImpl} from 'angular2/src/render/dom/schema/element_schema_registry';
+
+export function main() {
+  describe('ElementSchemaRegistryImpl', () => {
+
+    it('should detect properties from entries', () => {
+      var registry =
+          new ElementSchemaRegistryImpl([new HashElementSchema('foo-bar', {'id': 'id'})]);
+      expect(registry.hasProperty('foo-bar', 'id')).toBeTruthy();
+      expect(registry.hasProperty('foo-bar', 'unknown')).toBeFalsy();
+    });
+
+    it('should detect properties from extended entries', () => {
+      var registry = new ElementSchemaRegistryImpl([
+        new HashElementSchema('foo-bar', {'id': 'id'}),
+        new HashElementSchema('bar-baz', {}, 'foo-bar')
+      ]);
+      expect(registry.hasProperty('bar-baz', 'id')).toBeTruthy();
+      expect(registry.hasProperty('bar-baz', 'unknown')).toBeFalsy();
+    });
+
+    it('should handle properties re-mapping from entries', () => {
+      var registry =
+          new ElementSchemaRegistryImpl([new HashElementSchema('foo-bar', {'id': 'myId'})]);
+      expect(registry.getMappedPropName('foo-bar', 'id')).toEqual('myId');
+      expect(registry.getMappedPropName('foo-bar', 'unknown')).toEqual('unknown');
+    });
+
+    it('should handle properties re-mapping from extended entries', () => {
+      var registry = new ElementSchemaRegistryImpl([
+        new HashElementSchema('foo-bar', {'id': 'myId'}),
+        new HashElementSchema('bar-baz', {}, 'foo-bar')
+      ]);
+      expect(registry.getMappedPropName('bar-baz', 'id')).toEqual('myId');
+      expect(registry.getMappedPropName('bar-baz', 'unknown')).toEqual('unknown');
+    });
+
+    it('should use property re-mapping from the top-level entry', () => {
+      var registry = new ElementSchemaRegistryImpl([
+        new HashElementSchema('foo-bar', {'id': 'myId'}),
+        new HashElementSchema('bar-baz', {'id': 'topId'}, 'foo-bar'),
+        new HashElementSchema('baz-foo', {}, 'bar-baz')
+      ]);
+      expect(registry.getMappedPropName('baz-foo', 'id')).toEqual('topId');
+      expect(registry.getMappedPropName('baz-foo', 'unknown')).toEqual('unknown');
+    });
+
+    it('should throw for unknown entries', () => {
+      var registry = new ElementSchemaRegistryImpl([]);
+      expect(() => { registry.hasProperty('div', 'someProp'); })
+          .toThrowError("Missing schema entry for 'div'");
+    });
+  })
+}


### PR DESCRIPTION
This PR adds all the infrastructure for schema support (#2014), without plugging it into the existing compiler (as we need to have hand-crafted schema for Dart).

Here the basic info about the design / reasoning:
- schema is "global" since all the default HTML elements and web components are "global", so repeating the same info in each and every @View would be cumbersome
- There are 2 main interfaces: 
  - `ElementSchemaRegistry` - "knows" schema for all the elements in the entire system and handles "extends"
  - `ElementSchemaEntry` - "knows" schema for one element type

``` javascript
export class ElementSchemaRegistry {
  hasProperty(elName: string, propName: string): boolean { return true; }

  getMappedPropName(elName: string, propName: string): string { return propName; }
}
```

``` javascript
export interface ElementSchemaEntry {
  getTagName(): string;
  extendsElement(): string;
  hasProperty(propName: string): boolean;
  getMappedPropName(propName: string): string;
}
```

Currently there are 2 implementations of the `ElementSchemaEntry`: "static" (hand-written) and "reflective" (to be used on the JS side). One registry can combine entries of any types.

@mhevery @tbosch could you please review? I would also like to discuss how we could plug this into the existing compiler (reflective impl will work in JS but will fail in Dart and we need to decide who / when should to hand-craft schema for Dart)
