### PR TITLE
Unify error handling

### DIFF
--- a/modules/angular2/src/core/application.dart
+++ b/modules/angular2/src/core/application.dart
@@ -15,7 +15,7 @@ export 'application_common.dart' show ApplicationRef;
 ///
 /// See [commonBootstrap] for detailed documentation.
 Future<ApplicationRef> bootstrap(Type appComponentType,
-    [List componentInjectableBindings, Function errorReporter]) {
+    [List componentInjectableBindings]) {
   reflector.reflectionCapabilities = new ReflectionCapabilities();
-  return commonBootstrap(appComponentType, componentInjectableBindings, errorReporter);
+  return commonBootstrap(appComponentType, componentInjectableBindings);
 }

--- a/modules/angular2/src/core/application_static.dart
+++ b/modules/angular2/src/core/application_static.dart
@@ -8,7 +8,6 @@ import 'application_common.dart';
 /// See [commonBootstrap] for detailed documentation.
 Future<ApplicationRef> bootstrapStatic(
     Type appComponentType,
-    [List componentInjectableBindings,
-    Function errorReporter]) {
-  return commonBootstrap(appComponentType, componentInjectableBindings, errorReporter);
+    [List componentInjectableBindings]) {
+  return commonBootstrap(appComponentType, componentInjectableBindings);
 }

--- a/modules/angular2/src/core/compiler/element_injector.ts
+++ b/modules/angular2/src/core/compiler/element_injector.ts
@@ -496,8 +496,10 @@ export class ElementInjector extends TreeNode<ElementInjector> implements Depend
 
   private _debugContext(): any {
     var p = this._preBuiltObjects;
-    return new _Context(p.elementRef.nativeElement, p.view.getHostElement().nativeElement,
-                        this._injector);
+    var element = isPresent(p.elementRef) ? p.elementRef.nativeElement : null;
+    var hostRef = p.view.getHostElement();
+    var componentElement = isPresent(hostRef) ? hostRef.nativeElement : null;
+    return new _Context(element, componentElement, this._injector);
   }
 
   private _reattachInjectors(imperativelyCreatedInjector: Injector): void {

--- a/modules/angular2/src/core/exception_handler.ts
+++ b/modules/angular2/src/core/exception_handler.ts
@@ -28,7 +28,7 @@ import {DOM} from 'angular2/src/dom/dom_adapter';
 export class ExceptionHandler {
   logError: Function = DOM.logError;
 
-  call(exception: Object, stackTrace: string | string[] = null, reason: string = null) {
+  call(exception: Object, stackTrace: any = null, reason: string = null) {
     var longStackTrace = isListLikeIterable(stackTrace) ?
                              (<any>stackTrace).join("\n\n-----async gap-----\n") :
                              stackTrace;

--- a/modules/angular2/src/core/life_cycle/life_cycle.ts
+++ b/modules/angular2/src/core/life_cycle/life_cycle.ts
@@ -1,7 +1,6 @@
 import {Injectable} from 'angular2/di';
 import {ChangeDetector} from 'angular2/change_detection';
 import {NgZone} from 'angular2/src/core/zone/ng_zone';
-import {ExceptionHandler} from 'angular2/src/core/exception_handler';
 import {isPresent, BaseException} from 'angular2/src/facade/lang';
 
 /**
@@ -32,17 +31,11 @@ import {isPresent, BaseException} from 'angular2/src/facade/lang';
  */
 @Injectable()
 export class LifeCycle {
-  _errorHandler;
   _changeDetector: ChangeDetector;
   _enforceNoNewChanges: boolean;
   _runningTick: boolean = false;
 
-  constructor(exceptionHandler: ExceptionHandler, changeDetector: ChangeDetector = null,
-              enforceNoNewChanges: boolean = false) {
-    this._errorHandler = (exception, stackTrace) => {
-      exceptionHandler.call(exception, stackTrace);
-      throw exception;
-    };
+  constructor(changeDetector: ChangeDetector = null, enforceNoNewChanges: boolean = false) {
     this._changeDetector =
         changeDetector;  // may be null when instantiated from application bootstrap
     this._enforceNoNewChanges = enforceNoNewChanges;
@@ -55,8 +48,6 @@ export class LifeCycle {
     if (isPresent(changeDetector)) {
       this._changeDetector = changeDetector;
     }
-
-    zone.overrideOnErrorHandler(this._errorHandler);
     zone.overrideOnTurnDone(() => this.tick());
   }
 

--- a/modules/angular2/test/core/application_spec.ts
+++ b/modules/angular2/test/core/application_spec.ts
@@ -83,8 +83,7 @@ export function main() {
 
     it('should throw if bootstrapped Directive is not a Component',
        inject([AsyncTestCompleter], (async) => {
-         var refPromise =
-             bootstrap(HelloRootDirectiveIsNotCmp, testBindings, (e, t) => { throw e; });
+         var refPromise = bootstrap(HelloRootDirectiveIsNotCmp, testBindings);
 
          PromiseWrapper.then(refPromise, null, (reason) => {
            expect(reason.message)
@@ -96,7 +95,7 @@ export function main() {
        }));
 
     it('should throw if no element is found', inject([AsyncTestCompleter], (async) => {
-         var refPromise = bootstrap(HelloRootCmp, [], (e, t) => { throw e; });
+         var refPromise = bootstrap(HelloRootCmp, []);
          PromiseWrapper.then(refPromise, null, (reason) => {
            expect(reason.message).toContain('The selector "hello-app" did not match any elements');
            async.done();

--- a/modules/angular2/test/core/exception_handler_spec.ts
+++ b/modules/angular2/test/core/exception_handler_spec.ts
@@ -1,0 +1,90 @@
+import {
+  AsyncTestCompleter,
+  beforeEach,
+  ddescribe,
+  describe,
+  expect,
+  iit,
+  inject,
+  it,
+  xdescribe,
+  xit,
+  IS_DARTIUM,
+  Log
+} from 'angular2/test_lib';
+import {BaseException} from 'angular2/src/facade/lang';
+import {ExceptionHandler} from 'angular2/src/core/exception_handler';
+
+class _CustomException {
+  context = "some context";
+}
+
+export function main() {
+  describe('ExceptionHandler', () => {
+    var log, handler;
+
+    beforeEach(() => {
+      log = new Log();
+      handler = new ExceptionHandler();
+      handler.logError = (e) => log.add(e);
+    });
+
+    it("should output exception", () => {
+      try {
+        handler.call(new BaseException("message!"));
+      } catch (e) {
+      }
+      expect(log.result()).toContain("message!");
+    });
+
+    it("should output stackTrace", () => {
+      try {
+        handler.call(new BaseException("message!"), "stack!");
+      } catch (e) {
+      }
+      expect(log.result()).toContain("stack!");
+    });
+
+    it("should join a long stackTrace", () => {
+      try {
+        handler.call(new BaseException("message!"), ["stack1", "stack2"]);
+      } catch (e) {
+      }
+      expect(log.result()).toContain("stack1");
+      expect(log.result()).toContain("stack2");
+    });
+
+    it("should output reason when present", () => {
+      try {
+        handler.call(new BaseException("message!"), null, "reason!");
+      } catch (e) {
+      }
+      expect(log.result()).toContain("reason!");
+    });
+
+    it("should print context", () => {
+      try {
+        handler.call(new BaseException("message!", null, null, "context!"));
+      } catch (e) {
+      }
+      expect(log.result()).toContain("context!");
+    });
+
+    it("should print nested context", () => {
+      try {
+        var original = new BaseException("message!", null, null, "context!");
+        handler.call(new BaseException("message", original));
+      } catch (e) {
+      }
+      expect(log.result()).toContain("context!");
+    });
+
+    it("should not print context when the passed-in exception is not a BaseException", () => {
+      try {
+        handler.call(new _CustomException());
+      } catch (e) {
+      }
+      expect(log.result()).not.toContain("context");
+    });
+  });
+}

--- a/modules/angular2/test/core/life_cycle/life_cycle_spec.ts
+++ b/modules/angular2/test/core/life_cycle/life_cycle_spec.ts
@@ -21,7 +21,7 @@ export function main() {
   describe("LifeCycle", () => {
     it("should throw when reentering tick", () => {
       var cd = <any>new SpyChangeDetector();
-      var lc = new LifeCycle(null, cd, false);
+      var lc = new LifeCycle(cd, false);
 
       cd.spy("detectChanges").andCallFake(() => lc.tick());
       expect(() => lc.tick()).toThrowError("LifeCycle.tick is called recursively");


### PR DESCRIPTION
The way error handling is done in master is not very straightforward. Different error handlers are called depending whether it is the very first digest or not. This results in very confusing behavior when you see one way of error reporting when playing with an app, and another one after you wrapped some component in an NgIf. This PR unifies the two ways. 
