### PR TITLE
chore(release): fix pub publish release script.

### DIFF
--- a/scripts/publish/pub_publish.sh
+++ b/scripts/publish/pub_publish.sh
@@ -33,7 +33,7 @@ function publishModule {
 
   node scripts/publish/pubspec_cleaner.js --pubspec-file=$PUBLISH_DIR/pubspec.yaml
 
-  if [[ ! $DRY_RUN ]]; then
+  if [[ "$DRY_RUN" == "false" ]]; then
     (cd $PUBLISH_DIR && pub publish -f)
   fi;
 }


### PR DESCRIPTION
Relevant SO:
http://stackoverflow.com/questions/2953646/how-to-declare-and-use-boolean-variables-in-shell-script

tl;dr - bash does not really have booleans, 'true' and 'false' are just
strings.
