### PR TITLE
fix(projection): allow to project to a non text node

### DIFF
--- a/modules/angular2/src/render/dom/view/element_binder.ts
+++ b/modules/angular2/src/render/dom/view/element_binder.ts
@@ -1,5 +1,6 @@
 import {AST} from 'angular2/change_detection';
 import {List, ListWrapper} from 'angular2/src/facade/collection';
+import {isPresent} from 'angular2/src/facade/lang';
 
 export class DomElementBinder {
   textNodeIndices: List<number>;
@@ -23,7 +24,7 @@ export class DomElementBinder {
     this.eventLocals = eventLocals;
     this.localEvents = localEvents;
     this.globalEvents = globalEvents;
-    this.hasNativeShadowRoot = hasNativeShadowRoot;
+    this.hasNativeShadowRoot = isPresent(hasNativeShadowRoot) ? hasNativeShadowRoot : false;
   }
 }
 

--- a/modules/angular2/src/render/dom/view/proto_view_merger.ts
+++ b/modules/angular2/src/render/dom/view/proto_view_merger.ts
@@ -339,7 +339,7 @@ function updateElementBinderTextNodeIndices(elementBinder: DomElementBinder,
       eventLocals: null,
       localEvents: [],
       globalEvents: [],
-      hasNativeShadowRoot: null
+      hasNativeShadowRoot: false
     });
   } else {
     result = new DomElementBinder({

--- a/modules/angular2/test/core/compiler/projection_integration_spec.ts
+++ b/modules/angular2/test/core/compiler/projection_integration_spec.ts
@@ -73,6 +73,25 @@ export function main() {
              });
        }));
 
+    it('should support projecting text interpolation to a non bound element',
+       inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
+         tcb.overrideView(
+                Simple,
+                new viewAnn.View(
+                    {template: 'SIMPLE(<div><ng-content></ng-content></div>)', directives: []}))
+             .overrideView(
+                 MainComp,
+                 new viewAnn.View({template: '<simple>{{text}}</simple>', directives: [Simple]}))
+             .createAsync(MainComp)
+             .then((main) => {
+
+               main.componentInstance.text = 'A';
+               main.detectChanges();
+               expect(main.nativeElement).toHaveText('SIMPLE(A)');
+               async.done();
+             });
+       }));
+
     it('should not show the light dom even if there is no content tag',
        inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
          tcb.overrideView(MainComp,


### PR DESCRIPTION
We already had a test for this, but too low level that it did not catch this null value in `hasNativeShadowRoot`

Fixes #3230
