### PR TITLE
chore(test): move to using dart:test for dart unit tests

### DIFF
--- a/modules/angular2/pubspec.yaml
+++ b/modules/angular2/pubspec.yaml
@@ -20,8 +20,9 @@ dependencies:
   quiver: '^0.21.4'
   source_span: '^1.0.0'
   stack_trace: '^1.1.1'
+  test: '^0.12.3'
 dev_dependencies:
-  guinness: '^0.1.17'
+  guinness2: '^0.0.3'
 transformers:
 - angular2
 - $dart2js:

--- a/modules/angular2/src/test_lib/test_lib.dart
+++ b/modules/angular2/src/test_lib/test_lib.dart
@@ -2,8 +2,8 @@ library test_lib.test_lib;
 
 import 'dart:async';
 
-import 'package:guinness/guinness.dart' as gns;
-export 'package:guinness/guinness.dart'
+import 'package:guinness2/guinness2.dart' as gns;
+export 'package:guinness2/guinness2.dart'
     hide
         Expect,
         expect,
@@ -23,6 +23,7 @@ import 'package:angular2/src/reflection/reflection_capabilities.dart';
 import 'package:angular2/src/di/binding.dart' show bind;
 import 'package:angular2/src/di/injector.dart' show Injector;
 import 'package:angular2/src/facade/collection.dart' show StringMapWrapper;
+import 'package:angular2/src/dom/browser_adapter.dart';
 
 import 'test_injector.dart';
 export 'test_injector.dart' show inject;
@@ -45,6 +46,7 @@ class AsyncTestCompleter {
 }
 
 void testSetup() {
+  BrowserDomAdapter.makeCurrent();
   reflector.reflectionCapabilities = new ReflectionCapabilities();
   // beforeEach configuration:
   // - Priority 3: clear the bindings before each test,

--- a/modules/angular2/src/test_lib/test_lib.ts
+++ b/modules/angular2/src/test_lib/test_lib.ts
@@ -39,6 +39,10 @@ export class AsyncTestCompleter {
   done() { this._done(); }
 }
 
+export function testSetup() {
+  // Intentionally blank, this exists for compatibility with dart.
+}
+
 var jsmBeforeEach = _global.beforeEach;
 var jsmDescribe = _global.describe;
 var jsmDDescribe = _global.fdescribe;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ environment:
 dependencies:
   observe: '0.13.1'
 dev_dependencies:
-  guinness: '^0.1.17'
+  guinness2: '^0.0.3'
   intl: '^0.12.4'
-  unittest: '^0.11.5+4'
   quiver: '^0.21.4'
+  test: '^0.12.3'

--- a/tools/build/create_dart_test_main.js
+++ b/tools/build/create_dart_test_main.js
@@ -1,0 +1,22 @@
+var glob = require('glob');
+var fs = require('fs');
+
+module.exports = function() {
+  var imports = [
+    '@TestOn("browser")',
+    'import "package:guinness2/guinness2.dart";',
+    'import "package:angular2/src/test_lib/test_lib.dart" show testSetup;'];
+  var executes = [];
+
+  var matches = glob.sync('**/*_spec.dart', {cwd: 'dist/dart/angular2'});
+
+  matches.forEach(function(match) {
+    var varName = match.replace(/[\/.]/g, '_');
+    imports.push('import "' + match + '" as ' + varName +';');
+    executes.push('  ' + varName + '.main();');
+  });
+
+  var output = imports.join('\n') + '\n\nmain() {\n  testSetup();\n' + executes.join('\n') + '\n}';
+
+  fs.writeFileSync('dist/dart/angular2/main_test.dart', output);
+};


### PR DESCRIPTION
This is a work in progress PR showing how Angular2 tests could be migrated to using the new `dart:test` unit test runner and library.
