### PR TITLE
fix(dart/transform): Handle mixed lifecycle specs

### DIFF
--- a/modules/angular2/test/transform/directive_processor/all_tests.dart
+++ b/modules/angular2/test/transform/directive_processor/all_tests.dart
@@ -165,7 +165,9 @@ void _testProcessor(String name, String inputPath,
       }
     });
 
-    if (expectedLogs != null) {
+    if (expectedLogs == null) {
+      expect(logger.hasErrors).toBeFalse();
+    } else {
       expect(logger.logs, expectedLogs);
     }
   });
@@ -180,6 +182,8 @@ class RecordingLogger implements BuildLogger {
   @override
   final bool convertErrorsToWarnings = false;
 
+  bool hasErrors = false;
+
   List<String> logs = [];
 
   void _record(prefix, msg) => logs.add('$prefix: $msg');
@@ -190,7 +194,10 @@ class RecordingLogger implements BuildLogger {
 
   void warning(msg, {AssetId asset, SourceSpan span}) => _record('WARN', msg);
 
-  void error(msg, {AssetId asset, SourceSpan span}) => _record('ERROR', msg);
+  void error(msg, {AssetId asset, SourceSpan span}) {
+    hasErrors = true;
+    _record('ERROR', msg);
+  }
 
   Future writeOutput() => throw new UnimplementedError();
   Future addLogFilesFromAsset(AssetId id, [int nextNumber = 1]) =>

--- a/modules/angular2/test/transform/directive_processor/multiple_interface_lifecycle_files/expected/soup.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/multiple_interface_lifecycle_files/expected/soup.ng_deps.dart
@@ -22,5 +22,15 @@ void initReflector() {
       OnChange,
       OnDestroy,
       OnInit
-    ]));
+    ]))
+    ..registerType(MixedSoupComponent, new _ngRef.ReflectionInfo(const [
+      const Component(
+          selector: '[soup]',
+          lifecycle: const [LifecycleEvent.onChange, LifecycleEvent.onCheck])
+    ], const [], () => new MixedSoupComponent(), const [OnChange]))
+    ..registerType(MatchedSoupComponent, new _ngRef.ReflectionInfo(const [
+      const Component(
+          selector: '[soup]',
+          lifecycle: const [LifecycleEvent.onChange])
+    ], const [], () => new MatchedSoupComponent(), const [OnChange]));
 }

--- a/modules/angular2/test/transform/directive_processor/multiple_interface_lifecycle_files/soup.dart
+++ b/modules/angular2/test/transform/directive_processor/multiple_interface_lifecycle_files/soup.dart
@@ -4,3 +4,9 @@ import 'package:angular2/annotations.dart';
 
 @Component(selector: '[soup]')
 class MultiSoupComponent implements OnChange, OnDestroy, OnInit {}
+
+@Component(selector: '[soup]', lifecycle: const [LifecycleEvent.onCheck])
+class MixedSoupComponent implements OnChange {}
+
+@Component(selector: '[soup]', lifecycle: const [LifecycleEvent.onChange])
+class MatchedSoupComponent implements OnChange {}


### PR DESCRIPTION
Update the transformer to handle classes which both have a `lifecycle`
value and `implement` lifecycle interfaces.

Closes #3276
