### PR TITLE
refactor(Async): Unify TS and Dart PromiseCompleter naming

### DIFF
--- a/modules/angular2/src/core/application_common.ts
+++ b/modules/angular2/src/core/application_common.ts
@@ -30,7 +30,7 @@ import {StyleInliner} from 'angular2/src/render/dom/compiler/style_inliner';
 import {ViewResolver} from './compiler/view_resolver';
 import {DirectiveResolver} from './compiler/directive_resolver';
 import {List, ListWrapper} from 'angular2/src/facade/collection';
-import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
+import {Promise, PromiseWrapper, PromiseCompleter} from 'angular2/src/facade/async';
 import {NgZone} from 'angular2/src/core/zone/ng_zone';
 import {LifeCycle} from 'angular2/src/core/life_cycle/life_cycle';
 import {ShadowDomStrategy} from 'angular2/src/render/dom/shadow_dom/shadow_dom_strategy';
@@ -280,7 +280,7 @@ export function commonBootstrap(
     appComponentType: /*Type*/ any,
     componentInjectableBindings: List<Type | Binding | List<any>> = null): Promise<ApplicationRef> {
   BrowserDomAdapter.makeCurrent();
-  var bootstrapProcess = PromiseWrapper.completer();
+  var bootstrapProcess: PromiseCompleter<any> = PromiseWrapper.completer();
   var zone = createNgZone(new ExceptionHandler(DOM));
   zone.run(() => {
     // TODO(rado): prepopulate template cache, so applications with only

--- a/modules/angular2/src/facade/async.dart
+++ b/modules/angular2/src/facade/async.dart
@@ -29,7 +29,7 @@ class PromiseWrapper {
     return promise.catchError(onError);
   }
 
-  static CompleterWrapper completer() => new CompleterWrapper(new Completer());
+  static PromiseCompleter<dynamic> completer() => new PromiseCompleter(new Completer());
 }
 
 class TimerWrapper {
@@ -104,10 +104,10 @@ class EventEmitter extends Stream {
   }
 }
 
-class CompleterWrapper {
-  final Completer c;
+class PromiseCompleter<T> {
+  final Completer<T> c;
 
-  CompleterWrapper(this.c);
+  PromiseCompleter(this.c);
 
   Future get promise => c.future;
 

--- a/modules/angular2/src/forms/directives/ng_form.ts
+++ b/modules/angular2/src/forms/directives/ng_form.ts
@@ -1,4 +1,9 @@
-import {PromiseWrapper, ObservableWrapper, EventEmitter} from 'angular2/src/facade/async';
+import {
+  PromiseWrapper,
+  ObservableWrapper,
+  EventEmitter,
+  PromiseCompleter
+} from 'angular2/src/facade/async';
 import {StringMapWrapper, List, ListWrapper} from 'angular2/src/facade/collection';
 import {isPresent, isBlank, CONST_EXPR} from 'angular2/src/facade/lang';
 import {Directive} from 'angular2/annotations';
@@ -134,7 +139,7 @@ export class NgForm extends ControlContainer implements Form {
   }
 
   _later(fn) {
-    var c = PromiseWrapper.completer();
+    var c: PromiseCompleter<any> = PromiseWrapper.completer();
     PromiseWrapper.then(c.promise, fn, (_) => {});
     c.resolve(null);
   }

--- a/modules/angular2/src/render/xhr_impl.ts
+++ b/modules/angular2/src/render/xhr_impl.ts
@@ -1,11 +1,11 @@
 import {Injectable} from 'angular2/di';
-import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
+import {Promise, PromiseWrapper, PromiseCompleter} from 'angular2/src/facade/async';
 import {XHR} from './xhr';
 
 @Injectable()
 export class XHRImpl extends XHR {
   get(url: string): Promise<string> {
-    var completer = PromiseWrapper.completer();
+    var completer: PromiseCompleter < string >= PromiseWrapper.completer();
     var xhr = new XMLHttpRequest();
     xhr.open('GET', url, true);
     xhr.responseType = 'text';

--- a/modules/angular2/src/render/xhr_mock.ts
+++ b/modules/angular2/src/render/xhr_mock.ts
@@ -1,7 +1,7 @@
 import {XHR} from 'angular2/src/render/xhr';
 import {List, ListWrapper, Map, MapWrapper} from 'angular2/src/facade/collection';
 import {isBlank, isPresent, normalizeBlank, BaseException} from 'angular2/src/facade/lang';
-import {PromiseWrapper, Promise} from 'angular2/src/facade/async';
+import {PromiseCompleter, PromiseWrapper, Promise} from 'angular2/src/facade/async';
 
 export class MockXHR extends XHR {
   private _expectations: List<_Expectation>;
@@ -77,7 +77,7 @@ export class MockXHR extends XHR {
 
 class _PendingRequest {
   url: string;
-  completer;
+  completer: PromiseCompleter<string>;
 
   constructor(url) {
     this.url = url;

--- a/modules/angular2/src/web-workers/worker/application_common.ts
+++ b/modules/angular2/src/web-workers/worker/application_common.ts
@@ -26,7 +26,7 @@ import {ExceptionHandler} from 'angular2/src/core/exception_handler';
 import {DirectiveResolver} from 'angular2/src/core/compiler/directive_resolver';
 import {ViewResolver} from 'angular2/src/core/compiler/view_resolver';
 import {List, ListWrapper} from 'angular2/src/facade/collection';
-import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
+import {Promise, PromiseWrapper, PromiseCompleter} from 'angular2/src/facade/async';
 import {NgZone} from 'angular2/src/core/zone/ng_zone';
 import {LifeCycle} from 'angular2/src/core/life_cycle/life_cycle';
 import {XHR} from 'angular2/src/render/xhr';
@@ -137,7 +137,7 @@ function _injectorBindings(appComponentType, bus: WorkerMessageBus,
 export function bootstrapWebworkerCommon(
     appComponentType: Type, bus: WorkerMessageBus,
     componentInjectableBindings: List<Type | Binding | List<any>> = null): Promise<ApplicationRef> {
-  var bootstrapProcess = PromiseWrapper.completer();
+  var bootstrapProcess: PromiseCompleter<any> = PromiseWrapper.completer();
 
   var zone = createNgZone(new ExceptionHandler(new PrintLogger()));
   zone.run(() => {

--- a/modules/angular2/src/web-workers/worker/broker.ts
+++ b/modules/angular2/src/web-workers/worker/broker.ts
@@ -41,7 +41,7 @@ export class MessageBroker {
     var promise: Promise<any>;
     var id: string = null;
     if (returnType != null) {
-      var completer = PromiseWrapper.completer();
+      var completer: PromiseCompleter<any> = PromiseWrapper.completer();
       id = this._generateMessageId(args.type + args.method);
       this._pending.set(id, completer.resolve);
       PromiseWrapper.catchError(completer.promise, (err, stack?) => {

--- a/modules/angular2/test/core/compiler/compiler_spec.ts
+++ b/modules/angular2/test/core/compiler/compiler_spec.ts
@@ -16,7 +16,7 @@ import {
 
 import {List, ListWrapper, Map, MapWrapper, StringMapWrapper} from 'angular2/src/facade/collection';
 import {IMPLEMENTS, Type, isBlank, stringify, isPresent, isArray} from 'angular2/src/facade/lang';
-import {PromiseWrapper, Promise} from 'angular2/src/facade/async';
+import {PromiseCompleter, PromiseWrapper, Promise} from 'angular2/src/facade/async';
 
 import {Compiler, CompilerCache} from 'angular2/src/core/compiler/compiler';
 import {AppProtoView} from 'angular2/src/core/compiler/view';
@@ -442,7 +442,8 @@ export function main() {
 
     it('should re-use components being compiled', inject([AsyncTestCompleter], (async) => {
          tplResolver.setView(MainComponent, new viewAnn.View({template: '<div></div>'}));
-         var renderProtoViewCompleter = PromiseWrapper.completer();
+         var renderProtoViewCompleter: PromiseCompleter<renderApi.ProtoViewDto> =
+             PromiseWrapper.completer();
          var expectedProtoView = createProtoView();
          var compiler = createCompiler([renderProtoViewCompleter.promise],
                                        [rootProtoView, rootProtoView, expectedProtoView]);

--- a/modules/angular2/test/core/zone/ng_zone_spec.ts
+++ b/modules/angular2/test/core/zone/ng_zone_spec.ts
@@ -13,7 +13,7 @@ import {
   isInInnerZone
 } from 'angular2/test_lib';
 
-import {PromiseWrapper, TimerWrapper} from 'angular2/src/facade/async';
+import {PromiseCompleter, PromiseWrapper, TimerWrapper} from 'angular2/src/facade/async';
 import {BaseException} from 'angular2/src/facade/lang';
 import {DOM} from 'angular2/src/dom/dom_adapter';
 
@@ -65,7 +65,7 @@ export function main() {
       it('should produce long stack traces', inject([AsyncTestCompleter], (async) => {
            macroTask(() => {
              _zone.overrideOnErrorHandler(logError);
-             var c = PromiseWrapper.completer();
+             var c: PromiseCompleter<any> = PromiseWrapper.completer();
 
              _zone.run(() => {
                TimerWrapper.setTimeout(() => {
@@ -88,7 +88,7 @@ export function main() {
          inject([AsyncTestCompleter], (async) => {
            macroTask(() => {
              _zone.overrideOnErrorHandler(logError);
-             var c = PromiseWrapper.completer();
+             var c: PromiseCompleter<any> = PromiseWrapper.completer();
 
              _zone.run(() => {
                microTask(() => {
@@ -116,7 +116,7 @@ export function main() {
       it('should disable long stack traces', inject([AsyncTestCompleter], (async) => {
            macroTask(() => {
              _zone.overrideOnErrorHandler(logError);
-             var c = PromiseWrapper.completer();
+             var c: PromiseCompleter<any> = PromiseWrapper.completer();
 
              _zone.run(() => {
                TimerWrapper.setTimeout(() => {
@@ -304,8 +304,8 @@ function commonTests() {
 
     it('should call onTurnStart and onTurnDone before and after each turn',
        inject([AsyncTestCompleter], (async) => {
-         var a;
-         var b;
+         var a: PromiseCompleter<string>;
+         var b: PromiseCompleter<string>;
 
          macroTask(() => {
            _zone.run(() => {
@@ -345,7 +345,7 @@ function commonTests() {
 
     it('should call onTurnStart and onTurnDone when an inner microtask is scheduled from outside angular',
        inject([AsyncTestCompleter], (async) => {
-         var completer;
+         var completer: PromiseCompleter<any>;
 
          macroTask(
              () => { _zone.runOutsideAngular(() => { completer = PromiseWrapper.completer(); }); });
@@ -495,7 +495,8 @@ function commonTests() {
 
     it('should call onTurnStart and onTurnDone before and after each turn, respectively',
        inject([AsyncTestCompleter], (async) => {
-         var completerA, completerB;
+         var completerA: PromiseCompleter<any>;
+         var completerB: PromiseCompleter<any>;
 
          macroTask(() => {
            _zone.run(() => {

--- a/modules/angular2/test/router/outlet_spec.ts
+++ b/modules/angular2/test/router/outlet_spec.ts
@@ -19,7 +19,13 @@ import {Injector, bind} from 'angular2/di';
 import {Component, View} from 'angular2/src/core/annotations/decorators';
 import * as annotations from 'angular2/src/core/annotations_impl/view';
 import {CONST, NumberWrapper, isPresent} from 'angular2/src/facade/lang';
-import {Promise, PromiseWrapper, EventEmitter, ObservableWrapper} from 'angular2/src/facade/async';
+import {
+  Promise,
+  PromiseWrapper,
+  PromiseCompleter,
+  EventEmitter,
+  ObservableWrapper
+} from 'angular2/src/facade/async';
 
 import {RootRouter} from 'angular2/src/router/router';
 import {Pipeline} from 'angular2/src/router/pipeline';
@@ -42,7 +48,8 @@ import {CanActivate} from 'angular2/src/router/lifecycle_annotations';
 import {Instruction} from 'angular2/src/router/instruction';
 import {DirectiveResolver} from 'angular2/src/core/compiler/directive_resolver';
 
-var cmpInstanceCount, log, eventBus, completer;
+var cmpInstanceCount, log, eventBus;
+var completer: PromiseCompleter<any>;
 
 export function main() {
   describe('Outlet Directive', () => {


### PR DESCRIPTION
Also add explicit typing wherever we use PromiseCompleter
