### PR TITLE
chore(build): add trend for travis time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,9 @@ notifications:
   webhooks:
     urls:
     - https://webhooks.gitter.im/e/1ef62e23078036f9cee4
-    on_success: change  # options: [always|never|change] default: always
+    # trigger Buildtime Trend Service to parse Travis CI log
+    - https://buildtimetrend.herokuapp.com/travis
+    on_success: always  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
   slack:


### PR DESCRIPTION
We discussed last week that our build has been steadily getting longer.
We should track the time so we can easily notice that it went up and
find the culprit.
This hooks us up to https://buildtimetrend.herokuapp.com/ which seems
capable and very quick to setup. We can easily gather the data and
then evaluate the dashboard.
Note that we want to have two different webhooks, and only notify gitter
on transitions, but we want to have timing for all builds, since a
series of passing builds might have a big jump in build time in the middle.
I don't see how to do this with travis.yml so I've overnotified gitter.
