### PR TITLE
fix(query): the view should not be visible to @Query.

### DIFF
--- a/modules/angular2/src/core/compiler/element_injector.ts
+++ b/modules/angular2/src/core/compiler/element_injector.ts
@@ -658,11 +658,14 @@ export class ElementInjector extends TreeNode<ElementInjector> implements Depend
   }
 
   private _addViewQueries(host: ElementInjector): void {
-    if (isPresent(host._query0) && host._query0.originator == host)
+    if (isPresent(host._query0) && host._query0.originator == host &&
+        host._query0.query.isViewQuery)
       this._addViewQuery(host._query0);
-    if (isPresent(host._query1) && host._query1.originator == host)
+    if (isPresent(host._query1) && host._query1.originator == host &&
+        host._query1.query.isViewQuery)
       this._addViewQuery(host._query1);
-    if (isPresent(host._query2) && host._query2.originator == host)
+    if (isPresent(host._query2) && host._query2.originator == host &&
+        host._query2.query.isViewQuery)
       this._addViewQuery(host._query2);
   }
 

--- a/modules/angular2/test/core/compiler/query_integration_spec.ts
+++ b/modules/angular2/test/core/compiler/query_integration_spec.ts
@@ -397,7 +397,10 @@ class TextDirective {
 }
 
 @Component({selector: 'needs-query'})
-@View({directives: [NgFor], template: '<div *ng-for="var dir of query">{{dir.text}}|</div>'})
+@View({
+  directives: [NgFor, TextDirective],
+  template: '<div text="ignoreme"></div><div *ng-for="var dir of query">{{dir.text}}|</div>'
+})
 @Injectable()
 class NeedsQuery {
   query: QueryList<TextDirective>;


### PR DESCRIPTION
@ViewQuery is the correct way to query the view template.
