### PR TITLE
refactor(change_detect): Make `ChangeDetectionUtil#uninitialized` a var

### DIFF
--- a/modules/angular2/src/change_detection/change_detection.ts
+++ b/modules/angular2/src/change_detection/change_detection.ts
@@ -51,7 +51,6 @@ export {DirectiveIndex, DirectiveRecord} from './directive_record';
 export {DynamicChangeDetector} from './dynamic_change_detector';
 export {ChangeDetectorRef} from './change_detector_ref';
 export {Pipes} from './pipes/pipes';
-export {uninitialized} from './change_detection_util';
 export {WrappedValue, Pipe, PipeFactory, BasePipe} from './pipes/pipe';
 export {NullPipe, NullPipeFactory} from './pipes/null_pipe';
 

--- a/modules/angular2/src/change_detection/change_detection_jit_generator.ts
+++ b/modules/angular2/src/change_detection/change_detection_jit_generator.ts
@@ -198,7 +198,7 @@ export class ChangeDetectorJITGenerator {
 
     return `
       ${CURRENT_PROTO} = ${PROTOS_ACCESSOR}[${protoIndex}];
-      if (${pipe} === ${UTIL}.uninitialized()) {
+      if (${pipe} === ${UTIL}.uninitialized) {
         ${pipe} = ${PIPES_ACCESSOR}.get('${pipeType}', ${context}, ${cdRef});
       } else if (!${pipe}.supports(${context})) {
         ${pipe}.onDestroy();

--- a/modules/angular2/src/change_detection/change_detection_util.ts
+++ b/modules/angular2/src/change_detection/change_detection_util.ts
@@ -1,16 +1,14 @@
-import {isPresent, isBlank, BaseException, Type} from 'angular2/src/facade/lang';
+import {CONST_EXPR, isPresent, isBlank, BaseException, Type} from 'angular2/src/facade/lang';
 import {List, ListWrapper, MapWrapper, StringMapWrapper} from 'angular2/src/facade/collection';
 import {ProtoRecord} from './proto_record';
 import {DehydratedException, ExpressionChangedAfterItHasBeenCheckedException} from './exceptions';
 import {WrappedValue} from './pipes/pipe';
 import {CHECK_ALWAYS, CHECK_ONCE, CHECKED, DETACHED, ON_PUSH} from './constants';
 
-export var uninitialized = new Object();
-
 export class SimpleChange {
   constructor(public previousValue: any, public currentValue: any) {}
 
-  isFirstChange(): boolean { return this.previousValue === uninitialized; }
+  isFirstChange(): boolean { return this.previousValue === ChangeDetectionUtil.uninitialized; }
 }
 
 var _simpleChangesIndex = 0;
@@ -47,7 +45,7 @@ function _simpleChange(previousValue, currentValue): SimpleChange {
 
 /* tslint:disable:requireParameterType */
 export class ChangeDetectionUtil {
-  static uninitialized(): Object { return uninitialized; }
+  static uninitialized: Object = CONST_EXPR<Object>(new Object());
 
   static arrayFn0(): any[] { return []; }
   static arrayFn1(a1): any[] { return [a1]; }

--- a/modules/angular2/src/change_detection/codegen_name_util.ts
+++ b/modules/angular2/src/change_detection/codegen_name_util.ts
@@ -102,7 +102,7 @@ export class CodegenNameUtil {
     ListWrapper.removeAt(fields, _CONTEXT_IDX);
     if (!ListWrapper.isEmpty(fields)) {
       // At least one assignment.
-      fields.push(`${this.utilName}.uninitialized();`);
+      fields.push(`${this.utilName}.uninitialized;`);
     }
     return `${this.getContextName()} = null; ${ListWrapper.join(fields, ' = ')}`;
   }

--- a/modules/angular2/src/change_detection/dynamic_change_detector.ts
+++ b/modules/angular2/src/change_detection/dynamic_change_detector.ts
@@ -5,7 +5,7 @@ import {Locals} from 'angular2/src/change_detection/parser/locals';
 import {AbstractChangeDetector} from './abstract_change_detector';
 import {BindingRecord} from './binding_record';
 import {Pipes} from './pipes/pipes';
-import {ChangeDetectionUtil, SimpleChange, uninitialized} from './change_detection_util';
+import {ChangeDetectionUtil, SimpleChange} from './change_detection_util';
 
 
 import {ProtoRecord, RecordType} from './proto_record';
@@ -29,9 +29,9 @@ export class DynamicChangeDetector extends AbstractChangeDetector {
     this.changes = ListWrapper.createFixedSize(protos.length + 1);
 
     this.values[0] = null;
-    ListWrapper.fill(this.values, uninitialized, 1);
+    ListWrapper.fill(this.values, ChangeDetectionUtil.uninitialized, 1);
     ListWrapper.fill(this.localPipes, null);
-    ListWrapper.fill(this.prevContexts, uninitialized);
+    ListWrapper.fill(this.prevContexts, ChangeDetectionUtil.uninitialized);
     ListWrapper.fill(this.changes, false);
   }
 
@@ -47,10 +47,10 @@ export class DynamicChangeDetector extends AbstractChangeDetector {
   dehydrate() {
     this._destroyPipes();
     this.values[0] = null;
-    ListWrapper.fill(this.values, uninitialized, 1);
+    ListWrapper.fill(this.values, ChangeDetectionUtil.uninitialized, 1);
     ListWrapper.fill(this.changes, false);
     ListWrapper.fill(this.localPipes, null);
-    ListWrapper.fill(this.prevContexts, uninitialized);
+    ListWrapper.fill(this.prevContexts, ChangeDetectionUtil.uninitialized);
     this.locals = null;
     this.pipes = null;
   }

--- a/modules/angular2/src/transform/template_compiler/change_detector_codegen.dart
+++ b/modules/angular2/src/transform/template_compiler/change_detector_codegen.dart
@@ -256,7 +256,7 @@ class _CodegenState {
     var pipeType = r.name;
     return '''
       $_CURRENT_PROTO = $_PROTOS_ACCESSOR[$protoIndex];
-      if ($_IDENTICAL_CHECK_FN($pipe, $_UTIL.uninitialized())) {
+      if ($_IDENTICAL_CHECK_FN($pipe, $_UTIL.uninitialized)) {
         $pipe = $_PIPES_ACCESSOR.get('$pipeType', $context, $cdRef);
       } else if (!$pipe.supports($context)) {
         $pipe.onDestroy();

--- a/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
@@ -37,7 +37,7 @@ class _MyComponent_ChangeDetector0 extends _gen.AbstractChangeDetector {
       dynamic dispatcher, this._protos, this._directiveRecords)
       : super("MyComponent_comp_0", dispatcher) {
     _context = null;
-    _myNum0 = _interpolate1 = _gen.ChangeDetectionUtil.uninitialized();
+    _myNum0 = _interpolate1 = _gen.ChangeDetectionUtil.uninitialized;
   }
 
   void detectChangesInRecords(throwOnChange) {
@@ -108,7 +108,7 @@ class _MyComponent_ChangeDetector0 extends _gen.AbstractChangeDetector {
 
   void dehydrate() {
     _context = null;
-    _myNum0 = _interpolate1 = _gen.ChangeDetectionUtil.uninitialized();
+    _myNum0 = _interpolate1 = _gen.ChangeDetectionUtil.uninitialized;
     _locals = null;
     _pipes = null;
   }


### PR DESCRIPTION
Previously, `uninitialized()` was a method, requiring a call as well as
two extra characters everywhere it was used.

Make this value a variable, saving the characters and avoiding the
method call to get its value.

This change also removes the export of `uninitialized` from
change_detect.ts, which is technically a breaking change, however
`uninitialized` is an implementation detail and nobody should be using
it in app logic. By convention, apps should not be importing from files
under `src/`.

Update to #3248.
