### PR TITLE
refactor(change_detect): Create & use `looseNotIdentical`

### DIFF
--- a/modules/angular2/src/change_detection/pregen_proto_change_detector.dart
+++ b/modules/angular2/src/change_detection/pregen_proto_change_detector.dart
@@ -5,6 +5,7 @@ import 'package:angular2/src/change_detection/directive_record.dart';
 import 'package:angular2/src/change_detection/interfaces.dart';
 import 'package:angular2/src/change_detection/proto_change_detector.dart';
 import 'package:angular2/src/change_detection/proto_record.dart';
+import 'package:angular2/src/facade/lang.dart' show looseIdentical;
 
 export 'dart:core' show List;
 export 'package:angular2/src/change_detection/abstract_change_detector.dart'
@@ -66,3 +67,8 @@ class PregenProtoChangeDetector extends ProtoChangeDetector {
   instantiate(dynamic dispatcher) =>
       _instantiateMethod(dispatcher, _protoRecords, _directiveRecords);
 }
+
+/// Provided as an optimization to cut down on '!' characters in generated
+/// change detectors. See https://github.com/angular/angular/issues/3248 for
+/// for details.
+bool looseNotIdentical(a, b) => !looseIdentical(a, b);

--- a/modules/angular2/src/transform/template_compiler/change_detector_codegen.dart
+++ b/modules/angular2/src/transform/template_compiler/change_detector_codegen.dart
@@ -266,7 +266,7 @@ class _CodegenState {
       }
 
       $newValue = $pipe.transform($context, [$argString]);
-      if (!$_IDENTICAL_CHECK_FN($oldValue, $newValue)) {
+      if ($_NOT_IDENTICAL_CHECK_FN($oldValue, $newValue)) {
         $newValue = $_UTIL.unwrapValue($newValue);
         $change = true;
         ${_genUpdateDirectiveOrElement(r)}
@@ -284,7 +284,7 @@ class _CodegenState {
     var check = '''
       $_CURRENT_PROTO = $_PROTOS_ACCESSOR[$protoIndex];
       ${_genUpdateCurrentValue(r)}
-      if (!$_IDENTICAL_CHECK_FN($newValue, $oldValue)) {
+      if ($_NOT_IDENTICAL_CHECK_FN($newValue, $oldValue)) {
         ${_names.getChangeName(r.selfIndex)} = true;
         ${_genUpdateDirectiveOrElement(r)}
         ${_genAddToChanges(r)}
@@ -483,6 +483,7 @@ const _DISPATCHER_ACCESSOR = 'dispatcher';
 const _GEN_PREFIX = '_gen';
 const _GEN_RECORDS_METHOD_NAME = '_createRecords';
 const _IDENTICAL_CHECK_FN = '$_GEN_PREFIX.looseIdentical';
+const _NOT_IDENTICAL_CHECK_FN = '$_GEN_PREFIX.looseNotIdentical';
 const _IS_CHANGED_LOCAL = 'isChanged';
 const _LOCALS_ACCESSOR = '_locals';
 const _MODE_ACCESSOR = 'mode';

--- a/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
@@ -61,7 +61,7 @@ class _MyComponent_ChangeDetector0 extends _gen.AbstractChangeDetector {
     context = _context;
     currentProto = _protos[0];
     myNum0 = context.myNum;
-    if (!_gen.looseIdentical(myNum0, _myNum0)) {
+    if (_gen.looseNotIdentical(myNum0, _myNum0)) {
       c_myNum0 = true;
 
       _myNum0 = myNum0;
@@ -69,7 +69,7 @@ class _MyComponent_ChangeDetector0 extends _gen.AbstractChangeDetector {
     if (c_myNum0) {
       currentProto = _protos[1];
       interpolate1 = "Salad: " "${myNum0 == null ? "" : myNum0}" " is awesome";
-      if (!_gen.looseIdentical(interpolate1, _interpolate1)) {
+      if (_gen.looseNotIdentical(interpolate1, _interpolate1)) {
         c_interpolate1 = true;
         if (throwOnChange) {
           _gen.ChangeDetectionUtil.throwOnChange(currentProto,


### PR DESCRIPTION
Create `looseNotIdentical => !looseIdentical`, which will save a lot of
unnecessary '!' characters in generated change detectors.

Update to https://github.com/angular/angular/issues/3248
