### PR TITLE
fix(router): ensure navigation via back button works

### DIFF
--- a/modules/angular2/src/mock/mock_location_strategy.ts
+++ b/modules/angular2/src/mock/mock_location_strategy.ts
@@ -31,4 +31,12 @@ export class MockLocationStrategy extends LocationStrategy {
   onPopState(fn: (value: any) => void): void { ObservableWrapper.subscribe(this._subject, fn); }
 
   getBaseHref(): string { return this.internalBaseHref; }
+
+  back(): void {
+    if (this.urlChanges.length > 0) {
+      this.urlChanges.pop();
+      var nextUrl = this.urlChanges.length > 0 ? this.urlChanges[this.urlChanges.length - 1] : '';
+      this.simulatePopState(nextUrl);
+    }
+  }
 }

--- a/modules/angular2/src/router/location.ts
+++ b/modules/angular2/src/router/location.ts
@@ -34,7 +34,9 @@ export class Location {
     this._platformStrategy.onPopState((_) => this._onPopState(_));
   }
 
-  _onPopState(_): void { ObservableWrapper.callNext(this._subject, {'url': this.path()}); }
+  _onPopState(_): void {
+    ObservableWrapper.callNext(this._subject, {'url': this.path(), 'pop': true});
+  }
 
   path(): string { return this.normalize(this._platformStrategy.path()); }
 

--- a/modules/angular2/test/router/location_spec.ts
+++ b/modules/angular2/test/router/location_spec.ts
@@ -83,5 +83,27 @@ export function main() {
           .toThrowError(
               `No base href set. Either provide a binding to "appBaseHrefToken" or add a base element.`);
     });
+
+    it('should revert to the previous path when a back() operation is executed', () => {
+      var locationStrategy = new MockLocationStrategy();
+      var location = new Location(locationStrategy);
+
+      location.go('/ready');
+      assertUrl('/ready');
+
+      location.go('/ready/set');
+      assertUrl('/ready/set');
+
+      location.go('/ready/set/go');
+      assertUrl('/ready/set/go');
+
+      location.back();
+      assertUrl('/ready/set');
+
+      location.back();
+      assertUrl('/ready');
+
+      function assertUrl(path) { expect(location.path()).toEqual(path); }
+    });
   });
 }

--- a/modules/angular2/test/router/location_spec.ts
+++ b/modules/angular2/test/router/location_spec.ts
@@ -88,6 +88,8 @@ export function main() {
       var locationStrategy = new MockLocationStrategy();
       var location = new Location(locationStrategy);
 
+      function assertUrl(path) { expect(location.path()).toEqual(path); }
+
       location.go('/ready');
       assertUrl('/ready');
 
@@ -102,8 +104,6 @@ export function main() {
 
       location.back();
       assertUrl('/ready');
-
-      function assertUrl(path) { expect(location.path()).toEqual(path); }
     });
   });
 }

--- a/modules/angular2/test/router/router_spec.ts
+++ b/modules/angular2/test/router/router_spec.ts
@@ -76,6 +76,20 @@ export function main() {
              });
        }));
 
+    it('should not push a history change on when navigate is called with skipUrlChange',
+       inject([AsyncTestCompleter], (async) => {
+         var outlet = makeDummyOutlet();
+
+         router.registerOutlet(outlet)
+             .then((_) => router.config([new Route({path: '/b', component: DummyComponent})]))
+             .then((_) => router.navigate('/b', true))
+             .then((_) => {
+               expect(outlet.spy('commit')).toHaveBeenCalled();
+               expect(location.urlChanges).toEqual([]);
+               async.done();
+             });
+       }));
+
 
     it('should navigate after being configured', inject([AsyncTestCompleter], (async) => {
          var outlet = makeDummyOutlet();


### PR DESCRIPTION
The router will now navigate and respect the current address value
accordingly whenever a popState event is handled.

Closes #2201
