### PR TITLE
refactor(change_detect): Move common fields to AbstractChangeDetector

### DIFF
--- a/modules/angular2/src/change_detection/change_detection.ts
+++ b/modules/angular2/src/change_detection/change_detection.ts
@@ -42,7 +42,8 @@ export {
   ChangeDetector,
   ChangeDispatcher,
   ChangeDetection,
-  ChangeDetectorDefinition
+  ChangeDetectorDefinition,
+  DebugContext
 } from './interfaces';
 export {CHECK_ONCE, CHECK_ALWAYS, DETACHED, CHECKED, ON_PUSH, DEFAULT} from './constants';
 export {DynamicProtoChangeDetector} from './proto_change_detector';

--- a/modules/angular2/src/change_detection/dynamic_change_detector.ts
+++ b/modules/angular2/src/change_detection/dynamic_change_detector.ts
@@ -10,19 +10,16 @@ import {ChangeDetectionUtil, SimpleChange} from './change_detection_util';
 
 import {ProtoRecord, RecordType} from './proto_record';
 
-export class DynamicChangeDetector extends AbstractChangeDetector {
-  locals: Locals = null;
+export class DynamicChangeDetector extends AbstractChangeDetector<any> {
   values: List<any>;
   changes: List<any>;
   localPipes: List<any>;
   prevContexts: List<any>;
   directives: any = null;
-  alreadyChecked: boolean = false;
-  private pipes: Pipes = null;
 
   constructor(id: string, private changeControlStrategy: string, dispatcher: any,
-              private protos: List<ProtoRecord>, private directiveRecords: List<any>) {
-    super(id, dispatcher);
+              protos: List<ProtoRecord>, directiveRecords: List<any>) {
+    super(id, dispatcher, protos, directiveRecords);
     this.values = ListWrapper.createFixedSize(protos.length + 1);
     this.localPipes = ListWrapper.createFixedSize(protos.length + 1);
     this.prevContexts = ListWrapper.createFixedSize(protos.length + 1);

--- a/modules/angular2/src/change_detection/interfaces.ts
+++ b/modules/angular2/src/change_detection/interfaces.ts
@@ -2,7 +2,7 @@ import {List} from 'angular2/src/facade/collection';
 import {CONST} from 'angular2/src/facade/lang';
 import {Locals} from './parser/locals';
 import {BindingRecord} from './binding_record';
-import {DirectiveRecord} from './directive_record';
+import {DirectiveIndex, DirectiveRecord} from './directive_record';
 
 /**
  * Interface used by Angular to control the change detection strategy for an application.
@@ -36,7 +36,13 @@ export class ChangeDetection {
   }
 }
 
+export class DebugContext {
+  constructor(public element: any, public componentElement: any, public directive: any,
+              public context: any, public locals: any, public injector: any) {}
+}
+
 export interface ChangeDispatcher {
+  getDebugContext(elementIndex: number, directiveIndex: DirectiveIndex): DebugContext;
   notifyOnBinding(bindingRecord: BindingRecord, value: any): void;
   notifyOnAllChangesDone(): void;
 }
@@ -58,7 +64,7 @@ export interface ChangeDetector {
   checkNoChanges(): void;
 }
 
-export interface ProtoChangeDetector { instantiate(dispatcher: any): ChangeDetector; }
+export interface ProtoChangeDetector { instantiate(dispatcher: ChangeDispatcher): ChangeDetector; }
 
 export class ChangeDetectorDefinition {
   constructor(public id: string, public strategy: string, public variableNames: List<string>,

--- a/modules/angular2/src/core/compiler/view.ts
+++ b/modules/angular2/src/core/compiler/view.ts
@@ -8,15 +8,16 @@ import {
 } from 'angular2/src/facade/collection';
 import {
   AST,
-  Locals,
-  ChangeDispatcher,
-  ProtoChangeDetector,
-  ChangeDetector,
   BindingRecord,
-  DirectiveRecord,
+  ChangeDetector,
+  ChangeDetectorRef,
+  ChangeDispatcher,
   DirectiveIndex,
-  ChangeDetectorRef
+  DirectiveRecord,
+  Locals,
+  ProtoChangeDetector
 } from 'angular2/src/change_detection/change_detection';
+import {DebugContext} from 'angular2/src/change_detection/interfaces';
 
 import {
   ProtoElementInjector,
@@ -30,6 +31,8 @@ import * as renderApi from 'angular2/src/render/api';
 import {RenderEventDispatcher} from 'angular2/src/render/api';
 import {ViewRef, ProtoViewRef, internalView} from './view_ref';
 import {ElementRef} from './element_ref';
+
+export {DebugContext} from 'angular2/src/change_detection/interfaces';
 
 export class AppProtoViewMergeMapping {
   renderProtoViewRef: renderApi.RenderProtoViewRef;
@@ -299,11 +302,6 @@ function _localsToStringMap(locals: Locals): StringMap<string, any> {
     c = c.parent;
   }
   return res;
-}
-
-export class DebugContext {
-  constructor(public element: any, public componentElement: any, public directive: any,
-              public context: any, public locals: any, public injector: any) {}
 }
 
 /**

--- a/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
@@ -23,19 +23,12 @@ void initReflector() {
   _gen.preGeneratedProtoDetectors['MyComponent_comp_0'] =
       _MyComponent_ChangeDetector0.newProtoChangeDetector;
 }
-class _MyComponent_ChangeDetector0 extends _gen.AbstractChangeDetector {
-  _gen.Pipes _pipes;
-  final _gen.List<_gen.ProtoRecord> _protos;
-  final _gen.List<_gen.DirectiveRecord> _directiveRecords;
-  dynamic _locals = null;
-  dynamic _alreadyChecked = false;
-  dynamic currentProto = null;
-  MyComponent _context;
-  var _myNum0, _interpolate1;
+class _MyComponent_ChangeDetector0
+    extends _gen.AbstractChangeDetector<MyComponent> {
+  var myNum0, interpolate1;
 
-  _MyComponent_ChangeDetector0(
-      dynamic dispatcher, this._protos, this._directiveRecords)
-      : super("MyComponent_comp_0", dispatcher) {
+  _MyComponent_ChangeDetector0(dispatcher, protos, directiveRecords)
+      : super("MyComponent_comp_0", dispatcher, protos, directiveRecords) {
     dehydrateDirectives(false);
   }
 
@@ -46,48 +39,53 @@ class _MyComponent_ChangeDetector0 extends _gen.AbstractChangeDetector {
     try {
       __detectChangesInRecords(throwOnChange);
     } catch (e, s) {
-      throwError(currentProto, e, s);
+      throwError(this.currentProto, e, s);
     }
   }
 
   void __detectChangesInRecords(throwOnChange) {
-    var context, c_context, myNum0, c_myNum0, interpolate1, c_interpolate1;
-    c_context = c_myNum0 = c_interpolate1 = false;
+    this.currentProto = null;
+    var l_context = this.context,
+        l_myNum0,
+        c_myNum0,
+        l_interpolate1,
+        c_interpolate1;
+    c_myNum0 = c_interpolate1 = false;
     var isChanged = false;
-    currentProto = null;
     var changes = null;
 
-    context = _context;
-    currentProto = _protos[0];
-    myNum0 = context.myNum;
-    if (_gen.looseNotIdentical(myNum0, _myNum0)) {
+    this.currentProto = this.protos[0];
+    l_myNum0 = l_context.myNum;
+    if (_gen.looseNotIdentical(l_myNum0, this.myNum0)) {
       c_myNum0 = true;
 
-      _myNum0 = myNum0;
+      this.myNum0 = l_myNum0;
     }
     if (c_myNum0) {
-      currentProto = _protos[1];
-      interpolate1 = "Salad: " "${myNum0 == null ? "" : myNum0}" " is awesome";
-      if (_gen.looseNotIdentical(interpolate1, _interpolate1)) {
+      this.currentProto = this.protos[1];
+      l_interpolate1 =
+          "Salad: " "${l_myNum0 == null ? "" : l_myNum0}" " is awesome";
+      if (_gen.looseNotIdentical(l_interpolate1, this.interpolate1)) {
         c_interpolate1 = true;
         if (throwOnChange) {
-          _gen.ChangeDetectionUtil.throwOnChange(currentProto,
+          _gen.ChangeDetectionUtil.throwOnChange(this.currentProto,
               _gen.ChangeDetectionUtil.simpleChange(
-                  _interpolate1, interpolate1));
+                  this.interpolate1, l_interpolate1));
         }
 
-        dispatcher.notifyOnBinding(currentProto.bindingRecord, interpolate1);
+        this.dispatcher.notifyOnBinding(
+            this.currentProto.bindingRecord, l_interpolate1);
 
-        _interpolate1 = interpolate1;
+        this.interpolate1 = l_interpolate1;
       }
     } else {
-      interpolate1 = _interpolate1;
+      l_interpolate1 = this.interpolate1;
     }
     changes = null;
 
     isChanged = false;
 
-    _alreadyChecked = true;
+    this.alreadyChecked = true;
   }
 
   void checkNoChanges() {
@@ -95,30 +93,30 @@ class _MyComponent_ChangeDetector0 extends _gen.AbstractChangeDetector {
   }
 
   void callOnAllChangesDone() {
-    dispatcher.notifyOnAllChangesDone();
+    this.dispatcher.notifyOnAllChangesDone();
   }
 
   void hydrate(MyComponent context, locals, directives, pipes) {
-    mode = 'ALWAYS_CHECK';
-    _context = context;
-    _locals = locals;
+    this.mode = 'ALWAYS_CHECK';
+    this.context = context;
+    this.locals = locals;
     hydrateDirectives(directives);
-    _alreadyChecked = false;
-    _pipes = pipes;
+    this.alreadyChecked = false;
+    this.pipes = pipes;
   }
 
   void dehydrate() {
     dehydrateDirectives(true);
-    _locals = null;
-    _pipes = null;
+    this.locals = null;
+    this.pipes = null;
   }
 
   void dehydrateDirectives(destroyPipes) {
-    _context = null;
-    _myNum0 = _interpolate1 = _gen.ChangeDetectionUtil.uninitialized;
+    this.context = null;
+    this.myNum0 = this.interpolate1 = _gen.ChangeDetectionUtil.uninitialized;
   }
 
-  hydrated() => _context != null;
+  hydrated() => this.context != null;
 
   static _gen.ProtoChangeDetector newProtoChangeDetector(
       _gen.ChangeDetectorDefinition def) {

--- a/modules/benchmarks/src/change_detection/change_detection_benchmark.ts
+++ b/modules/benchmarks/src/change_detection/change_detection_benchmark.ts
@@ -8,6 +8,7 @@ import {
   Parser,
   ChangeDispatcher,
   ChangeDetection,
+  DebugContext,
   DynamicChangeDetection,
   JitChangeDetection,
   ChangeDetectorDefinition,
@@ -380,6 +381,9 @@ class FakeDirectives {
 }
 
 class DummyDispatcher implements ChangeDispatcher {
+  getDebugContext(elementIndex: number, directiveIndex: DirectiveIndex): DebugContext {
+    throw "getDebugContext not implemented.";
+  }
   notifyOnBinding(bindingRecord, newValue) { throw "Should not be used"; }
   notifyOnAllChangesDone() {}
 }


### PR DESCRIPTION
Move fields common to Dynamic, Jit, and Pregen change detectors into the
`AbstractChangeDetector` superclass to save on codegen size and reduce
code duplication.

Update to #3248
