### PR TITLE
fix(decorators): stop directives inheriting parent class decorators.

### DIFF
--- a/modules/angular2/src/util/decorators.ts
+++ b/modules/angular2/src/util/decorators.ts
@@ -246,7 +246,7 @@ export function makeDecorator(annotationCls, chainFn: (fn: Function) => void = n
           isFunction(this) && this.annotations instanceof Array ? this.annotations : [];
       chainAnnotation.push(annotationInstance);
       var TypeDecorator: TypeDecorator = <TypeDecorator>function TypeDecorator(cls) {
-        var annotations = Reflect.getMetadata('annotations', cls);
+        var annotations = Reflect.getOwnMetadata('annotations', cls);
         annotations = annotations || [];
         annotations.push(annotationInstance);
         Reflect.defineMetadata('annotations', annotations, cls);

--- a/modules/angular2/test/core/compiler/directive_metadata_reader_spec.ts
+++ b/modules/angular2/test/core/compiler/directive_metadata_reader_spec.ts
@@ -7,6 +7,10 @@ import * as dirAnn from 'angular2/src/core/annotations_impl/annotations';
 class SomeDirective {
 }
 
+@Directive({selector: 'someChildDirective'})
+class SomeChildDirective extends SomeDirective {
+}
+
 class SomeDirectiveWithoutAnnotation {}
 
 export function main() {
@@ -23,6 +27,11 @@ export function main() {
     it('should throw if not matching annotation is found', () => {
       expect(() => { reader.resolve(SomeDirectiveWithoutAnnotation); })
           .toThrowError('No Directive annotation found on SomeDirectiveWithoutAnnotation');
+    });
+
+    it('should not read parent class Directive annotations', function() {
+      var directiveMetadata = reader.resolve(SomeChildDirective);
+      expect(directiveMetadata).toEqual(new dirAnn.Directive({selector: 'someChildDirective'}));
     });
   });
 }

--- a/modules/angular2/test/util/decorators_spec.ts
+++ b/modules/angular2/test/util/decorators_spec.ts
@@ -23,16 +23,18 @@ class TerminalAnnotation {
   terminal = true;
 }
 
+class DecoratedParent {}
+class DecoratedChild extends DecoratedParent {}
+
 export function main() {
   var Reflect = global.Reflect;
 
   var TerminalDecorator = makeDecorator(TerminalAnnotation);
   var TestDecorator = makeDecorator(TestAnnotation, (fn: any) => fn.Terminal = TerminalDecorator);
-  var TestParamDecorator = makeParamDecorator(TestAnnotation);
 
   describe('decorators', () => {
-    it('shoulld invoke as decorator', () => {
-      function Type(){};
+    it('should invoke as decorator', () => {
+      function Type() {}
       TestDecorator({marker: 'WORKS'})(Type);
       var annotations = Reflect.getMetadata('annotations', Type);
       expect(annotations[0].arg.marker).toEqual('WORKS');
@@ -51,6 +53,15 @@ export function main() {
       expect(chain.annotations[0] instanceof TestAnnotation).toEqual(true);
       expect(chain.annotations[0].arg.marker).toEqual('WORKS');
       expect(chain.annotations[1] instanceof TerminalAnnotation).toEqual(true);
+    });
+
+    it('should not apply decorators from the prototype chain', function() {
+      TestDecorator({marker: 'parent'})(DecoratedParent);
+      TestDecorator({marker: 'child'})(DecoratedChild);
+
+      var annotations = Reflect.getOwnMetadata('annotations', DecoratedChild);
+      expect(annotations.length).toBe(1);
+      expect(annotations[0].arg.marker).toEqual('child');
     });
 
     describe('Class', () => {


### PR DESCRIPTION
Fixes #2291
