### PR TITLE
fix(browser_adapter): fix clearNodes() in IE

### DIFF
--- a/modules/angular2/src/dom/browser_adapter.ts
+++ b/modules/angular2/src/dom/browser_adapter.ts
@@ -130,14 +130,14 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   }
   clearNodes(el) {
     while (el.firstChild) {
-      el.firstChild.remove();
+      el.removeChild(el.firstChild);
     }
   }
   appendChild(el, node) { el.appendChild(node); }
   removeChild(el, node) { el.removeChild(node); }
   replaceChild(el: Node, newChild, oldChild) { el.replaceChild(newChild, oldChild); }
   remove(node): Node {
-    node.remove();
+    node.parentNode.removeChild(node);
     return node;
   }
   insertBefore(el, node) { el.parentNode.insertBefore(node, el); }


### PR DESCRIPTION
Fixes #3295
