### PR TITLE
refactor(change_detect): Move (de)hydrate methods into superclass

### DIFF
--- a/modules/angular2/src/change_detection/codegen_name_util.ts
+++ b/modules/angular2/src/change_detection/codegen_name_util.ts
@@ -124,11 +124,11 @@ export class CodegenNameUtil {
   genDehydrateFields(): string {
     var fields = this.getAllFieldNames();
     ListWrapper.removeAt(fields, CONTEXT_INDEX);
-    if (!ListWrapper.isEmpty(fields)) {
-      // At least one assignment.
-      fields.push(`${this.utilName}.uninitialized;`);
-    }
-    return `${this.getFieldName(CONTEXT_INDEX)} = null; ${ListWrapper.join(fields, ' = ')}`;
+    if (ListWrapper.isEmpty(fields)) return '';
+
+    // At least one assignment.
+    fields.push(`${this.utilName}.uninitialized;`);
+    return ListWrapper.join(fields, ' = ');
   }
 
   /**

--- a/modules/angular2/src/transform/template_compiler/change_detector_codegen.dart
+++ b/modules/angular2/src/transform/template_compiler/change_detector_codegen.dart
@@ -104,22 +104,11 @@ class _CodegenState {
 
         $_changeDetectorTypeName(dispatcher, protos, directiveRecords)
           : super(${_encodeValue(_changeDetectorDefId)},
-              dispatcher, protos, directiveRecords) {
+              dispatcher, protos, directiveRecords, '$_changeDetectionMode') {
           dehydrateDirectives(false);
         }
 
-        void detectChangesInRecords(throwOnChange) {
-          if (!hydrated()) {
-            $_UTIL.throwDehydrated();
-          }
-          try {
-            __detectChangesInRecords(throwOnChange);
-          } catch (e, s) {
-            throwError(${_names.getCurrentProtoName()}, e, s);
-          }
-        }
-
-        void __detectChangesInRecords(throwOnChange) {
+        void detectChangesInRecordsInternal(throwOnChange) {
           ${_names.getCurrentProtoName()} = null;
 
           ${_names.genInitLocals()}
@@ -137,27 +126,9 @@ class _CodegenState {
           ${_getCallOnAllChangesDoneBody()}
         }
 
-        void hydrate(
-            $_contextTypeName context, locals, directives, pipes) {
-          ${_names.getModeName()} = '$_changeDetectionMode';
-          ${_names.getFieldName(CONTEXT_INDEX)} = context;
-          ${_names.getLocalsAccessorName()} = locals;
-          hydrateDirectives(directives);
-          ${_names.getAlreadyCheckedName()} = false;
-          ${_names.getPipesAccessorName()} = pipes;
-        }
-
         ${_maybeGenHydrateDirectives()}
 
-        void dehydrate() {
-          dehydrateDirectives(true);
-          ${_names.getLocalsAccessorName()} = null;
-          ${_names.getPipesAccessorName()} = null;
-        }
-
         ${_maybeGenDehydrateDirectives()}
-
-        hydrated() => ${_names.getFieldName(CONTEXT_INDEX)} != null;
 
         static $_GEN_PREFIX.ProtoChangeDetector
             $PROTO_CHANGE_DETECTOR_FACTORY_METHOD(

--- a/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
@@ -27,23 +27,13 @@ class _MyComponent_ChangeDetector0
     extends _gen.AbstractChangeDetector<MyComponent> {
   var myNum0, interpolate1;
 
-  _MyComponent_ChangeDetector0(dispatcher, protos, directiveRecords)
-      : super("MyComponent_comp_0", dispatcher, protos, directiveRecords) {
+  _MyComponent_ChangeDetector0(dispatcher, protos, directiveRecords) : super(
+          "MyComponent_comp_0", dispatcher, protos, directiveRecords,
+          'ALWAYS_CHECK') {
     dehydrateDirectives(false);
   }
 
-  void detectChangesInRecords(throwOnChange) {
-    if (!hydrated()) {
-      _gen.ChangeDetectionUtil.throwDehydrated();
-    }
-    try {
-      __detectChangesInRecords(throwOnChange);
-    } catch (e, s) {
-      throwError(this.currentProto, e, s);
-    }
-  }
-
-  void __detectChangesInRecords(throwOnChange) {
+  void detectChangesInRecordsInternal(throwOnChange) {
     this.currentProto = null;
     var l_context = this.context,
         l_myNum0,
@@ -96,27 +86,9 @@ class _MyComponent_ChangeDetector0
     this.dispatcher.notifyOnAllChangesDone();
   }
 
-  void hydrate(MyComponent context, locals, directives, pipes) {
-    this.mode = 'ALWAYS_CHECK';
-    this.context = context;
-    this.locals = locals;
-    hydrateDirectives(directives);
-    this.alreadyChecked = false;
-    this.pipes = pipes;
-  }
-
-  void dehydrate() {
-    dehydrateDirectives(true);
-    this.locals = null;
-    this.pipes = null;
-  }
-
   void dehydrateDirectives(destroyPipes) {
-    this.context = null;
     this.myNum0 = this.interpolate1 = _gen.ChangeDetectionUtil.uninitialized;
   }
-
-  hydrated() => this.context != null;
 
   static _gen.ProtoChangeDetector newProtoChangeDetector(
       _gen.ChangeDetectorDefinition def) {


### PR DESCRIPTION
Move the implementation of `(de)hydrate`, `hydrated`, and
`detectChangesInRecords` into `AbstractChangeDetector`.

Add comments clarifying the contract between `AbstractChangeDetector`
and its subclasses.

Closes #3245
