### PR TITLE
fix(dart/transform): Remove malfunctioning zone error handler

### DIFF
--- a/modules/angular2/src/transform/bind_generator/transformer.dart
+++ b/modules/angular2/src/transform/bind_generator/transformer.dart
@@ -32,6 +32,6 @@ class BindGenerator extends Transformer {
       var transformedCode = await createNgSettersAndGetters(reader, id);
       transform.addOutput(new Asset.fromString(
           id, formatter.format(transformedCode, uri: id.path)));
-    }, errorMessage: 'Creating ng setters/getters failed.');
+    });
   }
 }

--- a/modules/angular2/src/transform/common/logging.dart
+++ b/modules/angular2/src/transform/common/logging.dart
@@ -11,20 +11,11 @@ typedef _SimpleCallback();
 final _key = #loggingZonedLoggerKey;
 
 /// Executes {@link fn} inside a new {@link Zone} with its own logger.
-dynamic initZoned(Transform t, _SimpleCallback fn, {String errorMessage: ''}) =>
-    setZoned(new BuildLogger(t), fn, errorMessage: errorMessage);
+dynamic initZoned(Transform t, _SimpleCallback fn) =>
+    setZoned(new BuildLogger(t), fn);
 
-dynamic setZoned(BuildLogger logger, _SimpleCallback fn,
-    {String errorMessage}) {
-  var onError;
-  if (errorMessage != null) {
-    onError = (e, stackTrace) {
-      logger.error('$errorMessage\n'
-          'Exception: $e\n'
-          'Stack Trace: $stackTrace');
-    };
-  }
-  return runZoned(fn, zoneValues: {_key: logger}, onError: onError);
+dynamic setZoned(BuildLogger logger, _SimpleCallback fn) {
+  return runZoned(fn, zoneValues: {_key: logger});
 }
 
 /// The logger for the current {@link Zone}.

--- a/modules/angular2/src/transform/deferred_rewriter/transformer.dart
+++ b/modules/angular2/src/transform/deferred_rewriter/transformer.dart
@@ -32,7 +32,7 @@ class DeferredRewriter extends Transformer {
         transform.addOutput(
             new Asset.fromString(transform.primaryInput.id, transformedCode));
       }
-    }, errorMessage: 'Rewritting deferred libraries failed.');
+    });
   }
 }
 

--- a/modules/angular2/src/transform/directive_linker/transformer.dart
+++ b/modules/angular2/src/transform/directive_linker/transformer.dart
@@ -31,7 +31,7 @@ class DirectiveLinker extends Transformer {
         var formattedCode = formatter.format(transformedCode, uri: assetPath);
         transform.addOutput(new Asset.fromString(assetId, formattedCode));
       }
-    }, errorMessage: 'Linking ng directives failed.');
+    });
   }
 }
 
@@ -50,6 +50,6 @@ class EmptyNgDepsRemover extends Transformer {
       if (!(await isNecessary(reader, transform.primaryInput.id))) {
         transform.consumePrimary();
       }
-    }, errorMessage: 'Removing unnecessary ng deps failed.');
+    });
   }
 }

--- a/modules/angular2/src/transform/directive_metadata_extractor/transformer.dart
+++ b/modules/angular2/src/transform/directive_metadata_extractor/transformer.dart
@@ -33,7 +33,7 @@ class DirectiveMetadataExtractor extends Transformer {
         transform.addOutput(new Asset.fromString(
             _outputAssetId(fromAssetId), _encoder.convert(ngMeta.toJson())));
       }
-    }, errorMessage: 'Extracting ng metadata failed.');
+    });
   }
 }
 

--- a/modules/angular2/src/transform/directive_processor/transformer.dart
+++ b/modules/angular2/src/transform/directive_processor/transformer.dart
@@ -53,6 +53,6 @@ class DirectiveProcessor extends Transformer {
         transform.addOutput(new Asset.fromString(ngAliasesId,
             new JsonEncoder.withIndent("  ").convert(ngMeta.toJson())));
       }
-    }, errorMessage: 'Processing ng directives failed.');
+    });
   }
 }

--- a/modules/angular2/src/transform/reflection_remover/transformer.dart
+++ b/modules/angular2/src/transform/reflection_remover/transformer.dart
@@ -52,6 +52,6 @@ class ReflectionRemover extends Transformer {
           mirrorMode: mirrorMode, writeStaticInit: writeStaticInit);
       transform.addOutput(
           new Asset.fromString(transform.primaryInput.id, transformedCode));
-    }, errorMessage: 'Removing reflection failed.');
+    });
   }
 }

--- a/modules/angular2/src/transform/template_compiler/generator.dart
+++ b/modules/angular2/src/transform/template_compiler/generator.dart
@@ -35,7 +35,8 @@ Future<String> processTemplates(AssetReader reader, AssetId entryPoint,
     {bool generateRegistrations: true,
     bool generateChangeDetectors: true}) async {
   var viewDefResults = await createViewDefinitions(reader, entryPoint);
-  var extractor = new _TemplateExtractor(new DomElementSchemaRegistry(), new XhrImpl(reader, entryPoint));
+  var extractor = new _TemplateExtractor(
+      new DomElementSchemaRegistry(), new XhrImpl(reader, entryPoint));
 
   var registrations = new reg.Codegen();
   var changeDetectorClasses = new change.Codegen();
@@ -112,9 +113,11 @@ class _TemplateExtractor {
 
     var pipeline = new CompilePipeline(_factory.createSteps(viewDef));
 
-    var compileElements =
-        pipeline.processElements(DOM.createTemplate(templateAndStyles.template), ViewType.COMPONENT, viewDef);
-    var protoViewDto = compileElements[0].inheritedProtoView.build(_schemaRegistry);
+    var compileElements = pipeline.processElements(
+        DOM.createTemplate(templateAndStyles.template), ViewType.COMPONENT,
+        viewDef);
+    var protoViewDto =
+        compileElements[0].inheritedProtoView.build(_schemaRegistry);
 
     reflector.reflectionCapabilities = savedReflectionCapabilities;
 

--- a/modules/angular2/src/transform/template_compiler/transformer.dart
+++ b/modules/angular2/src/transform/template_compiler/transformer.dart
@@ -35,6 +35,6 @@ class TemplateCompiler extends Transformer {
       var transformedCode = formatter.format(await processTemplates(reader, id,
           generateChangeDetectors: options.generateChangeDetectors));
       transform.addOutput(new Asset.fromString(id, transformedCode));
-    }, errorMessage: 'Parsing ng templates failed.');
+    });
   }
 }


### PR DESCRIPTION
Remove `onError` zone callback which is consuming exceptions thrown by
the `Transformer`s and can cause `pub` to become unresponsive.

Closes #3368
