### PR TITLE
cleanup(DI): clean up visibility decorators

### DIFF
--- a/modules/angular2/annotations.ts
+++ b/modules/angular2/annotations.ts
@@ -5,7 +5,7 @@
  * Annotations provide the additional information that Angular requires in order to run your
  * application. This module
  * contains {@link Component}, {@link Directive}, and {@link View} annotations, as well as
- * the {@link Ancestor} annotation that is used by Angular to resolve dependencies.
+ * the {@link Host} annotation that is used by Angular to resolve dependencies.
  *
  */
 

--- a/modules/angular2/di.ts
+++ b/modules/angular2/di.ts
@@ -8,12 +8,10 @@ export {
   InjectMetadata,
   OptionalMetadata,
   InjectableMetadata,
-  VisibilityMetadata,
   SelfMetadata,
-  AncestorMetadata,
-  UnboundedMetadata,
-  DependencyMetadata,
-  DEFAULT_VISIBILITY
+  HostMetadata,
+  SkipSelfMetadata,
+  DependencyMetadata
 } from './src/di/metadata';
 
 // we have to reexport * because Dart and TS export two different sets of types

--- a/modules/angular2/docs/core/02_directives.md
+++ b/modules/angular2/docs/core/02_directives.md
@@ -261,7 +261,7 @@ Injecting other directives into directives follows a similar mechanism as inject
 There are five kinds of visibilities:
 
 * (no annotation): Inject dependent directives only if they are on the current element.
-* `@ancestor`: Inject a directive if it is at any element above the current element.
+* `@SkipSelf()`: Inject a directive if it is at any element above the current element.
 * `@child`: Inject a list of direct children which match a given type. (Used with `Query`)
 * `@descendant`: Inject a list of any children which match a given type. (Used with `Query`)
 
@@ -299,8 +299,8 @@ class FieldSet {                     |
 @Directive({ selector: 'field' })    |
 class Field {                        |
   constructor(                       |
-    @ancestor field:Form,            |
-    @ancestor field:FieldSet,        |
+    @SkipSelf() field:Form,            |
+    @SkipSelf() field:FieldSet,        |
   ) { ... }                          |
 }                                    |
                                      |
@@ -336,7 +336,7 @@ Shadow DOM provides an encapsulation for components, so as a general rule it doe
 })
 class Kid {
   constructor(
-    @Ancestor() dad:Dad,
+    @SkipSelf() dad:Dad,
     @Optional() grandpa:Grandpa
   ) {
     this.name = 'Billy';
@@ -353,7 +353,7 @@ class Kid {
   directives: [Kid]
 })
 class Dad {
-  constructor(@Ancestor() dad:Grandpa) {
+  constructor(@SkipSelf() dad:Grandpa) {
     this.name = 'Joe Jr';
     this.dad = dad.name;
   }

--- a/modules/angular2/src/change_detection/pipes/pipes.ts
+++ b/modules/angular2/src/change_detection/pipes/pipes.ts
@@ -1,7 +1,7 @@
 import {ListWrapper, isListLikeIterable, StringMapWrapper} from 'angular2/src/facade/collection';
 import {isBlank, isPresent, BaseException, CONST} from 'angular2/src/facade/lang';
 import {Pipe, PipeFactory} from './pipe';
-import {Injectable, UnboundedMetadata, OptionalMetadata} from 'angular2/di';
+import {Injectable, OptionalMetadata, SkipSelfMetadata} from 'angular2/di';
 import {ChangeDetectorRef} from '../change_detector_ref';
 import {Binding} from 'angular2/di';
 
@@ -80,7 +80,7 @@ export class Pipes {
         return Pipes.create(config, pipes);
       },
       // Dependency technically isn't optional, but we can provide a better error message this way.
-      deps: [[Pipes, new UnboundedMetadata(), new OptionalMetadata()]]
+      deps: [[Pipes, new SkipSelfMetadata(), new OptionalMetadata()]]
     });
   }
 

--- a/modules/angular2/src/core/annotations_impl/annotations.ts
+++ b/modules/angular2/src/core/annotations_impl/annotations.ts
@@ -53,11 +53,9 @@ import {DEFAULT} from 'angular2/change_detection';
  *
  * To inject other directives, declare the constructor parameter as:
  * - `directive:DirectiveType`: a directive on the current element only
- * - `@Ancestor() directive:DirectiveType`: any directive that matches the type between the current
+ * - `@Host() directive:DirectiveType`: any directive that matches the type between the current
  * element and the
- *    Shadow DOM root. Current element is not included in the resolution, therefore even if it could
- * resolve it, it will
- *    be ignored.
+ *    Shadow DOM root.
  * - `@Query(DirectiveType) query:QueryList<DirectiveType>`: A live collection of direct child
  * directives.
  * - `@QueryDescendants(DirectiveType) query:QueryList<DirectiveType>`: A live collection of any
@@ -164,21 +162,19 @@ import {DEFAULT} from 'angular2/change_detection';
  * ### Injecting a directive from any ancestor elements
  *
  * Directives can inject other directives declared on any ancestor element (in the current Shadow
- * DOM), i.e. on the
- * parent element and its parents. By definition, a directive with an `@Ancestor` annotation does
- * not attempt to
- * resolve dependencies for the current element, even if this would satisfy the dependency.
- *
+ * DOM), i.e. on the current element, the
+ * parent element, or its parents.
  * ```
  * @Directive({ selector: '[my-directive]' })
  * class MyDirective {
- *   constructor(@Ancestor() dependency: Dependency) {
+ *   constructor(@Host() dependency: Dependency) {
  *     expect(dependency.id).toEqual(2);
  *   }
  * }
  * ```
  *
- * `@Ancestor` checks the parent, as well as its parents recursively. If `dependency="2"` didn't
+ * `@Host` checks the current element, the parent, as well as its parents recursively. If
+ * `dependency="2"` didn't
  * exist on the direct parent, this injection would
  * have returned
  * `dependency="1"`.

--- a/modules/angular2/src/core/compiler/element_injector.ts
+++ b/modules/angular2/src/core/compiler/element_injector.ts
@@ -25,7 +25,6 @@ import {
   AbstractBindingError,
   CyclicDependencyError,
   resolveForwardRef,
-  VisibilityMetadata,
   DependencyProvider
 } from 'angular2/di';
 import {
@@ -167,9 +166,10 @@ export class TreeNode<T extends TreeNode<any>> {
 }
 
 export class DirectiveDependency extends Dependency {
-  constructor(key: Key, optional: boolean, visibility: any, properties: List<any>,
-              public attributeName: string, public queryDecorator: Query) {
-    super(key, optional, visibility, properties);
+  constructor(key: Key, optional: boolean, lowerBoundVisibility: Object,
+              upperBoundVisibility: Object, properties: List<any>, public attributeName: string,
+              public queryDecorator: Query) {
+    super(key, optional, lowerBoundVisibility, upperBoundVisibility, properties);
     this._verify();
   }
 
@@ -183,9 +183,9 @@ export class DirectiveDependency extends Dependency {
   }
 
   static createFrom(d: Dependency): Dependency {
-    return new DirectiveDependency(d.key, d.optional, d.visibility, d.properties,
-                                   DirectiveDependency._attributeName(d.properties),
-                                   DirectiveDependency._query(d.properties));
+    return new DirectiveDependency(
+        d.key, d.optional, d.lowerBoundVisibility, d.upperBoundVisibility, d.properties,
+        DirectiveDependency._attributeName(d.properties), DirectiveDependency._query(d.properties));
   }
 
   static _attributeName(properties): string {

--- a/modules/angular2/src/di/decorators.dart
+++ b/modules/angular2/src/di/decorators.dart
@@ -32,15 +32,15 @@ class Self extends SelfMetadata {
 }
 
 /**
- * {@link AncestorMetadata}.
+ * {@link HostMetadata}.
  */
-class Ancestor extends AncestorMetadata {
-  const Ancestor({bool self}) : super(self: self);
+class Host extends HostMetadata {
+  const Host() : super();
 }
 
 /**
- * {@link UnboundedMetadata}.
+ * {@link SkipSelfMetadata}.
  */
-class Unbounded extends UnboundedMetadata {
-  const Unbounded({bool self}) : super(self: self);
+class SkipSelf extends SkipSelfMetadata {
+  const SkipSelf() : super();
 }

--- a/modules/angular2/src/di/decorators.ts
+++ b/modules/angular2/src/di/decorators.ts
@@ -3,9 +3,8 @@ import {
   OptionalMetadata,
   InjectableMetadata,
   SelfMetadata,
-  VisibilityMetadata,
-  AncestorMetadata,
-  UnboundedMetadata
+  HostMetadata,
+  SkipSelfMetadata
 } from './metadata';
 import {makeDecorator, makeParamDecorator, TypeDecorator} from '../util/decorators';
 
@@ -42,19 +41,19 @@ export interface SelfFactory {
 }
 
 /**
- * Factory for creating {@link AncestorMetadata}.
+ * Factory for creating {@link HostMetadata}.
  */
-export interface AncestorFactory {
-  (visibility?: {self: boolean}): any;
-  new (visibility?: {self: boolean}): AncestorMetadata;
+export interface HostFactory {
+  (): any;
+  new (): HostMetadata;
 }
 
 /**
- * Factory for creating {@link UnboundedMetadata}.
+ * Factory for creating {@link SkipSelfMetadata}.
  */
-export interface UnboundedFactory {
-  (visibility?: {self: boolean}): any;
-  new (visibility?: {self: boolean}): UnboundedMetadata;
+export interface SkipSelfFactory {
+  (): any;
+  new (): SkipSelfMetadata;
 }
 
 /**
@@ -78,11 +77,11 @@ export var Injectable: InjectableFactory = <InjectableFactory>makeDecorator(Inje
 export var Self: SelfFactory = makeParamDecorator(SelfMetadata);
 
 /**
- * Factory for creating {@link AncestorMetadata}.
+ * Factory for creating {@link HostMetadata}.
  */
-export var Ancestor: AncestorFactory = makeParamDecorator(AncestorMetadata);
+export var Host: HostFactory = makeParamDecorator(HostMetadata);
 
 /**
- * Factory for creating {@link UnboundedMetadata}.
+ * Factory for creating {@link SkipSelfMetadata}.
  */
-export var Unbounded: UnboundedFactory = makeParamDecorator(UnboundedMetadata);
+export var SkipSelf: SkipSelfFactory = makeParamDecorator(SkipSelfMetadata);

--- a/modules/angular2/src/directives/ng_switch.ts
+++ b/modules/angular2/src/directives/ng_switch.ts
@@ -1,5 +1,5 @@
 import {Directive} from 'angular2/annotations';
-import {Ancestor} from 'angular2/di';
+import {Host} from 'angular2/di';
 import {ViewContainerRef, TemplateRef} from 'angular2/core';
 import {isPresent, isBlank, normalizeBlank} from 'angular2/src/facade/lang';
 import {ListWrapper, List, MapWrapper, Map} from 'angular2/src/facade/collection';
@@ -157,7 +157,7 @@ export class NgSwitchWhen {
   _view: SwitchView;
 
   constructor(viewContainer: ViewContainerRef, templateRef: TemplateRef,
-              @Ancestor() sswitch: NgSwitch) {
+              @Host() sswitch: NgSwitch) {
     // `_whenDefault` is used as a marker for a not yet initialized value
     this._value = _whenDefault;
     this._switch = sswitch;
@@ -187,7 +187,7 @@ export class NgSwitchWhen {
 @Directive({selector: '[ng-switch-default]'})
 export class NgSwitchDefault {
   constructor(viewContainer: ViewContainerRef, templateRef: TemplateRef,
-              @Ancestor() sswitch: NgSwitch) {
+              @Host() sswitch: NgSwitch) {
     sswitch._registerView(_whenDefault, new SwitchView(viewContainer, templateRef));
   }
 }

--- a/modules/angular2/src/forms/directives/ng_control_group.ts
+++ b/modules/angular2/src/forms/directives/ng_control_group.ts
@@ -1,5 +1,5 @@
 import {Directive, LifecycleEvent} from 'angular2/annotations';
-import {Inject, Ancestor, forwardRef, Binding} from 'angular2/di';
+import {Inject, Host, SkipSelf, forwardRef, Binding} from 'angular2/di';
 import {List, ListWrapper} from 'angular2/src/facade/collection';
 import {CONST_EXPR} from 'angular2/src/facade/lang';
 
@@ -57,7 +57,7 @@ const controlGroupBinding =
 })
 export class NgControlGroup extends ControlContainer {
   _parent: ControlContainer;
-  constructor(@Ancestor() _parent: ControlContainer) {
+  constructor(@Host() @SkipSelf() _parent: ControlContainer) {
     super();
     this._parent = _parent;
   }

--- a/modules/angular2/src/forms/directives/ng_control_name.ts
+++ b/modules/angular2/src/forms/directives/ng_control_name.ts
@@ -4,7 +4,7 @@ import {List, StringMap} from 'angular2/src/facade/collection';
 
 import {QueryList} from 'angular2/core';
 import {Query, Directive, LifecycleEvent} from 'angular2/annotations';
-import {forwardRef, Ancestor, Binding, Inject} from 'angular2/di';
+import {forwardRef, Host, SkipSelf, Binding, Inject} from 'angular2/di';
 
 import {ControlContainer} from './control_container';
 import {NgControl} from './ng_control';
@@ -88,7 +88,7 @@ export class NgControlName extends NgControl {
   _added = false;
 
   // Scope the query once https://github.com/angular/angular/issues/2603 is fixed
-  constructor(@Ancestor() parent: ControlContainer,
+  constructor(@Host() @SkipSelf() parent: ControlContainer,
               @Query(NgValidator) ngValidators: QueryList<NgValidator>) {
     super();
     this._parent = parent;

--- a/modules/angular2/src/forms/directives/ng_form_control.ts
+++ b/modules/angular2/src/forms/directives/ng_form_control.ts
@@ -3,7 +3,7 @@ import {EventEmitter, ObservableWrapper} from 'angular2/src/facade/async';
 
 import {QueryList} from 'angular2/core';
 import {Query, Directive, LifecycleEvent} from 'angular2/annotations';
-import {forwardRef, Ancestor, Binding} from 'angular2/di';
+import {forwardRef, Binding} from 'angular2/di';
 
 import {NgControl} from './ng_control';
 import {Control} from '../model';

--- a/modules/angular2/src/forms/directives/ng_model.ts
+++ b/modules/angular2/src/forms/directives/ng_model.ts
@@ -3,7 +3,7 @@ import {EventEmitter, ObservableWrapper} from 'angular2/src/facade/async';
 
 import {QueryList} from 'angular2/core';
 import {Query, Directive, LifecycleEvent} from 'angular2/annotations';
-import {forwardRef, Ancestor, Binding} from 'angular2/di';
+import {forwardRef, Binding} from 'angular2/di';
 
 import {NgControl} from './ng_control';
 import {Control} from '../model';

--- a/modules/angular2_material/src/components/dialog/dialog.ts
+++ b/modules/angular2_material/src/components/dialog/dialog.ts
@@ -3,7 +3,8 @@ import {
   Directive,
   View,
   ViewEncapsulation,
-  Ancestor,
+  Host,
+  SkipSelf,
   ElementRef,
   DynamicComponentLoader,
   ComponentRef,
@@ -212,8 +213,7 @@ export class MdDialogConfig {
 })
 @View({
   templateUrl: 'package:angular2_material/src/components/dialog/dialog.html',
-  directives: [forwardRef(() => MdDialogContent)],
-  encapsulation: ViewEncapsulation.NONE
+  directives: [forwardRef(() => MdDialogContent)]
 })
 class MdDialogContainer {
   // Ref to the dialog content. Used by the DynamicComponentLoader to load the dialog content.
@@ -245,7 +245,7 @@ class MdDialogContainer {
  */
 @Directive({selector: 'md-dialog-content'})
 class MdDialogContent {
-  constructor(@Ancestor() dialogContainer: MdDialogContainer, elementRef: ElementRef) {
+  constructor(@Host() @SkipSelf() dialogContainer: MdDialogContainer, elementRef: ElementRef) {
     dialogContainer.contentRef = elementRef;
   }
 }

--- a/modules/angular2_material/src/components/grid_list/grid_list.ts
+++ b/modules/angular2_material/src/components/grid_list/grid_list.ts
@@ -1,4 +1,11 @@
-import {Component, View, ViewEncapsulation, Ancestor, LifecycleEvent} from 'angular2/angular2';
+import {
+  Component,
+  View,
+  ViewEncapsulation,
+  Host,
+  SkipSelf,
+  LifecycleEvent
+} from 'angular2/angular2';
 
 import {ListWrapper} from 'angular2/src/facade/collection';
 import {StringWrapper, isPresent, isString, NumberWrapper} from 'angular2/src/facade/lang';
@@ -244,7 +251,7 @@ export class MdGridTile {
 
   isRegisteredWithGridList: boolean;
 
-  constructor(@Ancestor() gridList: MdGridList) {
+  constructor(@SkipSelf() @Host() gridList: MdGridList) {
     this.gridList = gridList;
 
     // Tiles default to 1x1, but rowspan and colspan can be changed via binding.

--- a/modules/angular2_material/src/components/input/input.ts
+++ b/modules/angular2_material/src/components/input/input.ts
@@ -1,4 +1,4 @@
-import {Directive, LifecycleEvent, Attribute, Ancestor} from 'angular2/angular2';
+import {Directive, LifecycleEvent, Attribute, Host, SkipSelf} from 'angular2/angular2';
 
 import {ObservableWrapper, EventEmitter} from 'angular2/src/facade/async';
 
@@ -73,7 +73,7 @@ export class MdInput {
   mdChange: EventEmitter;
   mdFocusChange: EventEmitter;
 
-  constructor(@Attribute('value') value: string, @Ancestor() container: MdInputContainer,
+  constructor(@Attribute('value') value: string, @SkipSelf() @Host() container: MdInputContainer,
               @Attribute('id') id: string) {
     // TODO(jelbourn): Remove this when #1402 is done.
     this.yes = true;
@@ -111,7 +111,7 @@ export class MdInput {
 export class MdTextarea extends MdInput {
   constructor(
       @Attribute('value') value: string,
-      @Ancestor() container: MdInputContainer,
+      @SkipSelf() @Host() container: MdInputContainer,
       @Attribute('id') id: string) {
     super(value, container, id);
   }

--- a/modules/angular2_material/src/components/radio/radio_button.ts
+++ b/modules/angular2_material/src/components/radio/radio_button.ts
@@ -3,7 +3,8 @@ import {
   View,
   ViewEncapsulation,
   LifecycleEvent,
-  Ancestor,
+  Host,
+  SkipSelf,
   Attribute,
   Optional
 } from 'angular2/angular2';
@@ -232,7 +233,7 @@ export class MdRadioButton {
 
   role: string;
 
-  constructor(@Optional() @Ancestor() radioGroup: MdRadioGroup, @Attribute('id') id: string,
+  constructor(@Optional() @SkipSelf() @Host() radioGroup: MdRadioGroup, @Attribute('id') id: string,
               @Attribute('tabindex') tabindex: string, radioDispatcher: MdRadioDispatcher) {
     // Assertions. Ideally these should be stripped out by the compiler.
     // TODO(jelbourn): Assert that there's no name binding AND a parent radio group.

--- a/modules/examples/src/model_driven_forms/index.ts
+++ b/modules/examples/src/model_driven_forms/index.ts
@@ -6,7 +6,7 @@ import {
   Component,
   Directive,
   View,
-  Ancestor
+  Host
 } from 'angular2/bootstrap';
 import {formDirectives, NgControl, Validators, NgFormModel, FormBuilder} from 'angular2/forms';
 
@@ -50,7 +50,7 @@ class ShowError {
   controlPath: string;
   errorTypes: List<string>;
 
-  constructor(@Ancestor() formDir: NgFormModel) { this.formDir = formDir; }
+  constructor(@Host() formDir: NgFormModel) { this.formDir = formDir; }
 
   get errorMessage() {
     var c = this.formDir.form.find(this.controlPath);

--- a/modules/examples/src/order_management/index.ts
+++ b/modules/examples/src/order_management/index.ts
@@ -6,7 +6,7 @@ import {
   Component,
   Directive,
   View,
-  Ancestor,
+  Host,
   NgValidator,
   forwardRef,
   Binding,

--- a/modules/examples/src/person_management/index.ts
+++ b/modules/examples/src/person_management/index.ts
@@ -6,7 +6,7 @@ import {
   Component,
   Directive,
   View,
-  Ancestor,
+  Host,
   NgValidator,
   forwardRef,
   Binding

--- a/modules/examples/src/template_driven_forms/index.ts
+++ b/modules/examples/src/template_driven_forms/index.ts
@@ -6,7 +6,7 @@ import {
   Component,
   Directive,
   View,
-  Ancestor,
+  Host,
   NgValidator,
   forwardRef,
   Binding
@@ -76,7 +76,7 @@ class ShowError {
   controlPath: string;
   errorTypes: List<string>;
 
-  constructor(@Ancestor() formDir: NgForm) { this.formDir = formDir; }
+  constructor(@Host() formDir: NgForm) { this.formDir = formDir; }
 
   get errorMessage() {
     var c = this.formDir.form.find(this.controlPath);


### PR DESCRIPTION
BREAKING CHANGE:
    Replace `@Ancestor()` with `@Host() @SkipSelf()`
    Replace `@Unbounded()` with `@SkipSelf()`
    Replace `@Ancestor({self:true})` with `@Host()`
    Replace `@Unbounded({self:true})` with nothing
    Replace new AncestorMetadata() with [new HostMetadata(), new SkipSelfMetadata()]
    Replace new UnboundedMetadata() with new SkipSelfMetadata()
    Replace new Ancestor({self:true}) with new HostMetadata()
