### PR TITLE
chore(build): faster feedback for broken lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,14 @@ env:
   # GITHUB_TOKEN_ANGULAR
   - secure: "fq/U7VDMWO8O8SnAQkdbkoSe2X92PVqg4d044HmRYVmcf6YbO48+xeGJ8yOk0pCBwl3ISO4Q2ot0x546kxfiYBuHkZetlngZxZCtQiFT9kyId8ZKcYdXaIW9OVdw3Gh3tQyUwDucfkVhqcs52D6NZjyE2aWZ4/d1V4kWRO/LMgo="
   matrix:
-    # Make slowest build on top, so that we don't hog VMs while waiting for others to complete.
+    # Order: slowest build on top, so that we don't hog VMs while waiting for others to complete.
     - MODE=dart DART_CHANNEL=stable
     - MODE=dart DART_CHANNEL=dev
+    # Disabled until we can make it pass.
+    # - MODE=saucelabs DART_CHANNEL=dev
     - MODE=dart_experimental DART_CHANNEL=dev
     - MODE=js DART_CHANNEL=dev
-    # Dissabled until we can make it pass.
-    # - MODE=saucelabs DART_CHANNEL=dev
+    - MODE=lint DART_CHANNEL=dev
 
 matrix:
   allow_failures:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -556,7 +556,7 @@ function getBrowsersFromCLI() {
   return {
     browsersToRun: outputList.filter(function(item, pos, self) {return self.indexOf(item) == pos;}),
     isSauce: isSauce
-  }
+  };
 }
 
 gulp.task('test.unit.js', ['build.js.dev'], function (done) {
@@ -574,8 +574,13 @@ gulp.task('test.unit.js', ['build.js.dev'], function (done) {
 gulp.task('test.unit.js.sauce', ['build.js.dev'], function (done) {
   var browserConf = getBrowsersFromCLI();
   if (browserConf.isSauce) {
-    karma.server.start({configFile: __dirname + '/karma-js.conf.js',
-      singleRun: true, browserNoActivityTimeout: 240000, captureTimeout: 120000, reporters: ['dots'], browsers: browserConf.browsersToRun}, 
+    karma.server.start({
+        configFile: __dirname + '/karma-js.conf.js',
+        singleRun: true,
+        browserNoActivityTimeout: 240000,
+        captureTimeout: 120000,
+        reporters: ['dots'],
+        browsers: browserConf.browsersToRun},
       function(err) {done(); process.exit(err ? 1 : 0)});
   } else {
     throw new Error('ERROR: no Saucelabs browsers provided, add them with the --browsers option');
@@ -727,14 +732,20 @@ gulp.task('test.transpiler.unittest', function(done) {
 });
 
 // -----------------
-// Pre/Post-test checks
+// Pre-test checks
 
 gulp.task('pre-test-checks', function(done) {
   runSequence('build/checkCircularDependencies', sequenceComplete(done));
 });
 
-gulp.task('post-test-checks', function(done) {
-  runSequence('lint', 'enforce-format', sequenceComplete(done));
+// -----------------
+// Checks which should fail the build, but should not block us running the tests.
+// By adding checks here, they run in a separate travis worker, giving faster
+// feedback without short-circuiting the build from providing test feedback.
+gulp.task('static-checks', ['!build.tools'], function(done) {
+  runSequence(
+    ['enforce-format', 'lint', 'test.typings'],
+    sequenceComplete(done));
 });
 
 

--- a/scripts/ci/build_and_test.sh
+++ b/scripts/ci/build_and_test.sh
@@ -8,16 +8,14 @@ echo ===========================================================================
 SCRIPT_DIR=$(dirname $0)
 cd $SCRIPT_DIR/../..
 
-if [ "$MODE" = "dart_experimental" ]
-then
+if [ "$MODE" = "dart_experimental" ]; then
   ${SCRIPT_DIR}/build_$MODE.sh
+elif [ "$MODE" = "saucelabs" ]; then
+  ${SCRIPT_DIR}/test_$MODE.sh
+elif [ "$MODE" = "lint" ]; then
+  ./node_modules/.bin/gulp static-checks
 else
-  if [ "$MODE" = "saucelabs" ]
-  then
-    ${SCRIPT_DIR}/test_$MODE.sh
-  else
-    ${SCRIPT_DIR}/build_$MODE.sh
-    mkdir deploy; tar -czpf deploy/dist.tgz -C dist .
-    ${SCRIPT_DIR}/test_$MODE.sh
-  fi
+  ${SCRIPT_DIR}/build_$MODE.sh
+  mkdir deploy; tar -czpf deploy/dist.tgz -C dist .
+  ${SCRIPT_DIR}/test_$MODE.sh
 fi

--- a/scripts/ci/test_js.sh
+++ b/scripts/ci/test_js.sh
@@ -15,4 +15,3 @@ fi
 ./node_modules/.bin/gulp pre-test-checks
 ./node_modules/.bin/gulp test.js --browsers=${KARMA_BROWSERS:-ChromeCanary}
 ${SCRIPT_DIR}/test_e2e_js.sh
-./node_modules/.bin/gulp post-test-checks


### PR DESCRIPTION
Originally we ran gulp enforce-format at the beginning of the build.
This was annoying because you came back from lunch to find that no tests
ran so you have to start your PR over.
Then we changed it to run the linters at the end. This is annoying because
you might be ready to merge to master, and could have fixed the lint
issues immediately, but now must wait for another PR or else risk pushing without re-running.
The solution is to run the lint checks in another build. This marks
your PR red very early, but you still get the feedback of whether the
tests are passing.
