### PR TITLE
tests(ProtoViewBuilder): host properties binding to unknown props

### DIFF
--- a/modules/angular2/src/render/dom/view/proto_view_builder.ts
+++ b/modules/angular2/src/render/dom/view/proto_view_builder.ts
@@ -93,7 +93,7 @@ export class ProtoViewBuilder {
           propertyBindings: dbb.propertyBindings,
           eventBindings: dbb.eventBindings,
           hostPropertyBindings: buildElementPropertyBindings(schemaRegistry, ebb.element, true,
-                                                             dbb.hostPropertyBindings, new Set())
+                                                             dbb.hostPropertyBindings, null)
         });
       });
       var nestedProtoView =
@@ -336,9 +336,15 @@ function buildElementPropertyBindings(
     if (isValidElementPropertyBinding(schemaRegistry, protoElement, isNgComponent,
                                       propertyBinding)) {
       propertyBindings.push(propertyBinding);
-    } else if (!SetWrapper.has(directiveTempaltePropertyNames, propertyNameInTemplate)) {
-      throw new BaseException(
-          `Can't bind to '${propertyNameInTemplate}' since it isn't a known property of the '<${DOM.tagName(protoElement).toLowerCase()}>' element and there are no matching directives with a corresponding property`);
+    } else if (!isPresent(directiveTempaltePropertyNames) ||
+               !SetWrapper.has(directiveTempaltePropertyNames, propertyNameInTemplate)) {
+      // directiveTempaltePropertyNames is null for host property bindings
+      var exMsg =
+          `Can't bind to '${propertyNameInTemplate}' since it isn't a known property of the '<${DOM.tagName(protoElement).toLowerCase()}>' element`;
+      if (isPresent(directiveTempaltePropertyNames)) {
+        exMsg += ' and there are no matching directives with a corresponding property';
+      }
+      throw new BaseException(exMsg);
     }
   });
   return propertyBindings;

--- a/modules/angular2/test/render/dom/view/proto_view_builder_spec.ts
+++ b/modules/angular2/test/render/dom/view/proto_view_builder_spec.ts
@@ -44,6 +44,15 @@ export function main() {
           expect(() => builder.build(new DomElementSchemaRegistry())).not.toThrow();
         });
 
+        it('should throw for unknown host properties even if another directive uses it', () => {
+          var binder = builder.bindElement(el('<div/>'));
+          binder.bindDirective(0).bindProperty('someDirProperty', emptyExpr(), 'someDirProperty');
+          binder.bindDirective(1).bindHostProperty('someDirProperty', emptyExpr());
+          expect(() => builder.build(new DomElementSchemaRegistry()))
+              .toThrowError(
+                  `Can't bind to 'someDirProperty' since it isn't a known property of the '<div>' element`);
+        });
+
         it('should allow unknown properties on custom elements', () => {
           var binder = builder.bindElement(el('<some-custom/>'));
           binder.bindProperty('unknownProperty', emptyExpr());


### PR DESCRIPTION
When binding a host property, we shouldn't try to bind to any
directive properties that might exist on a host element
