### PR TITLE
chore(browsers): fix failing tests in Firefox

### DIFF
--- a/modules/angular2/src/dom/browser_adapter.dart
+++ b/modules/angular2/src/dom/browser_adapter.dart
@@ -188,6 +188,9 @@ class BrowserDomAdapter extends GenericBrowserDomAdapter {
   void preventDefault(Event evt) {
     evt.preventDefault();
   }
+  bool isPrevented(Event evt) {
+    return evt.defaultPrevented;
+  }
   String getInnerHTML(Element el) => el.innerHtml;
   String getOuterHTML(Element el) => el.outerHtml;
   void setInnerHTML(Element el, String value) {

--- a/modules/angular2/src/dom/browser_adapter.ts
+++ b/modules/angular2/src/dom/browser_adapter.ts
@@ -104,6 +104,9 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     evt.preventDefault();
     evt.returnValue = false;
   }
+  isPrevented(evt: Event): boolean {
+    return evt.defaultPrevented || isPresent(evt.returnValue) && !evt.returnValue;
+  }
   getInnerHTML(el): string { return el.innerHTML; }
   getOuterHTML(el): string { return el.outerHTML; }
   nodeName(node: Node): string { return node.nodeName; }

--- a/modules/angular2/src/dom/dom_adapter.ts
+++ b/modules/angular2/src/dom/dom_adapter.ts
@@ -43,6 +43,7 @@ export class DomAdapter {
   createMouseEvent(eventType): any { throw _abstract(); }
   createEvent(eventType: string): any { throw _abstract(); }
   preventDefault(evt) { throw _abstract(); }
+  isPrevented(evt): boolean { throw _abstract(); }
   getInnerHTML(el): string { throw _abstract(); }
   getOuterHTML(el): string { throw _abstract(); }
   nodeName(node): string { throw _abstract(); }

--- a/modules/angular2/src/dom/html_adapter.dart
+++ b/modules/angular2/src/dom/html_adapter.dart
@@ -102,6 +102,9 @@ class Html5LibDomAdapter implements DomAdapter {
   preventDefault(evt) {
     throw 'not implemented';
   }
+  isPrevented(evt) {
+    throw 'not implemented';
+  }
   getInnerHTML(el) {
     return el.innerHtml;
   }

--- a/modules/angular2/src/dom/parse5_adapter.ts
+++ b/modules/angular2/src/dom/parse5_adapter.ts
@@ -154,6 +154,7 @@ export class Parse5DomAdapter extends DomAdapter {
     return evt;
   }
   preventDefault(evt) { evt.returnValue = false; }
+  isPrevented(evt): boolean { return isPresent(evt.returnValue) && !evt.returnValue; }
   getInnerHTML(el): string { return serializer.serialize(this.templateAwareRoot(el)); }
   getOuterHTML(el): string {
     serializer.html = '';

--- a/modules/angular2/src/render/dom/view/view.ts
+++ b/modules/angular2/src/render/dom/view/view.ts
@@ -79,7 +79,7 @@ export class DomView {
       allowDefaultBehavior =
           this.eventDispatcher.dispatchRenderEvent(elementIndex, eventName, evalLocals);
       if (!allowDefaultBehavior) {
-        event.preventDefault();
+        DOM.preventDefault(event);
       }
     }
     return allowDefaultBehavior;

--- a/modules/angular2/test/core/compiler/integration_spec.ts
+++ b/modules/angular2/test/core/compiler/integration_spec.ts
@@ -899,14 +899,14 @@ export function main() {
 
                  .createAsync(MyComp)
                  .then((rootTC) => {
-                   expect(DOM.getChecked(rootTC.componentViewChildren[0].nativeElement))
-                       .toBeFalsy();
-                   expect(DOM.getChecked(rootTC.componentViewChildren[1].nativeElement))
-                       .toBeFalsy();
+                   var dispatchedEvent = DOM.createMouseEvent('click');
+                   var dispatchedEvent2 = DOM.createMouseEvent('click');
                    DOM.dispatchEvent(rootTC.componentViewChildren[0].nativeElement,
-                                     DOM.createMouseEvent('click'));
+                                     dispatchedEvent);
                    DOM.dispatchEvent(rootTC.componentViewChildren[1].nativeElement,
-                                     DOM.createMouseEvent('click'));
+                                     dispatchedEvent2);
+                   expect(DOM.isPrevented(dispatchedEvent)).toBe(true);
+                   expect(DOM.isPrevented(dispatchedEvent2)).toBe(false);
                    expect(DOM.getChecked(rootTC.componentViewChildren[0].nativeElement))
                        .toBeFalsy();
                    expect(DOM.getChecked(rootTC.componentViewChildren[1].nativeElement))

--- a/modules/angular2/test/dom/dom_adapter_spec.ts
+++ b/modules/angular2/test/dom/dom_adapter_spec.ts
@@ -34,7 +34,7 @@ export function main() {
 
       expect(clone).not.toBe(el1);
       DOM.setAttribute(clone, 'test', '1');
-      expect(DOM.getOuterHTML(clone)).toEqual('<div x="y" test="1">a<span>b</span></div>');
+      expect(stringifyElement(clone)).toEqual('<div test="1" x="y">a<span>b</span></div>');
       expect(DOM.getAttribute(el1, 'test')).toBeFalsy();
 
       var cNodes = DOM.childNodes(clone);

--- a/modules/angular2/test/render/dom/view/proto_view_merger_integration_spec.ts
+++ b/modules/angular2/test/render/dom/view/proto_view_merger_integration_spec.ts
@@ -265,8 +265,8 @@ export function main() {
                  tb.merge([rootProtoViewDto, componentProtoViewDto])
                      .then(mergeMappings => {
                        var domPv = resolveInternalDomProtoView(mergeMappings.mergedProtoViewRef);
-                       expect(DOM.getInnerHTML(templateRoot(domPv)))
-                           .toEqual('<root class="ng-binding" a="b"></root>');
+                       expect(stringifyElement(templateRoot(domPv)))
+                           .toEqual('<template><root a="b" class="ng-binding"></root></template>');
                        async.done();
                      });
                });

--- a/modules/angular2/test/router/outlet_spec.ts
+++ b/modules/angular2/test/router/outlet_spec.ts
@@ -541,8 +541,7 @@ export function main() {
                  rootTC.detectChanges();
 
                  var dispatchedEvent = clickOnElement(rootTC);
-                 expect(dispatchedEvent.defaultPrevented || !dispatchedEvent.returnValue)
-                     .toBe(true);
+                 expect(DOM.isPrevented(dispatchedEvent)).toBe(true);
 
                  // router navigation is async.
                  rtr.subscribe((_) => {
@@ -563,8 +562,7 @@ export function main() {
                  rootTC.detectChanges();
 
                  var dispatchedEvent = clickOnElement(rootTC);
-                 expect(dispatchedEvent.defaultPrevented || !dispatchedEvent.returnValue)
-                     .toBe(true);
+                 expect(DOM.isPrevented(dispatchedEvent)).toBe(true);
 
                  // router navigation is async.
                  rtr.subscribe((_) => {


### PR DESCRIPTION
Fixes 3 unit test failures in Firefox:
- 2 need to use the `stringifyElement` function to compare stringified elements
- the test of prevent default is updated to more directly test the feature, in a way which is also compatible with IE11. Using checkbox element is not working fine.

This doesn't solves the issue raised in #3333 (Internationalization API).
