### PR TITLE
chore(browsers): fix failing tests in IE11

### DIFF
--- a/modules/angular2/src/dom/browser_adapter.ts
+++ b/modules/angular2/src/dom/browser_adapter.ts
@@ -118,7 +118,7 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   }
   firstChild(el): Node { return el.firstChild; }
   nextSibling(el): Node { return el.nextSibling; }
-  parentElement(el): Node { return el.parentElement; }
+  parentElement(el): Node { return el.parentNode; }
   childNodes(el): List<Node> { return el.childNodes; }
   childNodesAsList(el): List<any> {
     var childNodes = el.childNodes;
@@ -130,14 +130,14 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   }
   clearNodes(el) {
     while (el.firstChild) {
-      el.firstChild.remove();
+      el.removeChild(el.firstChild);
     }
   }
   appendChild(el, node) { el.appendChild(node); }
   removeChild(el, node) { el.removeChild(node); }
   replaceChild(el: Node, newChild, oldChild) { el.replaceChild(newChild, oldChild); }
   remove(node): Node {
-    node.remove();
+    node.parentNode.removeChild(node);
     return node;
   }
   insertBefore(el, node) { el.parentNode.insertBefore(node, el); }

--- a/modules/angular2/src/test_lib/utils.ts
+++ b/modules/angular2/src/test_lib/utils.ts
@@ -35,7 +35,7 @@ export function containsRegexp(input: string): RegExp {
 export function normalizeCSS(css: string): string {
   css = StringWrapper.replaceAll(css, /\s+/g, ' ');
   css = StringWrapper.replaceAll(css, /:\s/g, ':');
-  css = StringWrapper.replaceAll(css, /'"/g, '"');
+  css = StringWrapper.replaceAll(css, /'/g, '"');
   css = StringWrapper.replaceAllMapped(css, /url\(\"(.+)\\"\)/g, (match) => `url(${match[1]})`);
   css = StringWrapper.replaceAllMapped(css, /\[(.+)=([^"\]]+)\]/g,
                                        (match) => `[${match[1]}="${match[2]}"]`);

--- a/modules/angular2/test/core/zone/ng_zone_spec.ts
+++ b/modules/angular2/test/core/zone/ng_zone_spec.ts
@@ -182,7 +182,7 @@ function commonTests() {
          macroTask(() => {
            expect(_log.result()).toEqual('run; onTurnDone 1; onTurnDone 2; onEventDone');
            async.done();
-         });
+         }, 80);
        }));
 
     it('should not allow onEventDone to cause further digests',
@@ -206,7 +206,7 @@ function commonTests() {
          macroTask(() => {
            expect(_log.result()).toEqual('run; onTurnDone; onEventDone');
            async.done();
-         });
+         }, 80);
        }));
 
     it('should run async tasks scheduled inside onEventDone outside Angular zone',
@@ -247,7 +247,7 @@ function commonTests() {
            // The microtask (async) is executed after the macrotask (run)
            expect(_log.result()).toEqual('onTurnStart; run start; run end; async; onTurnDone');
            async.done();
-         }, 50);
+         }, 80);
        }));
 
     it('should not run onTurnStart and onTurnDone for nested Zone.run',
@@ -268,7 +268,7 @@ function commonTests() {
                .toEqual(
                    'onTurnStart; start run; nested run; end run; nested run microtask; onTurnDone');
            async.done();
-         }, 50);
+         }, 80);
        }));
 
     it('should not run onTurnStart and onTurnDone for nested Zone.run invoked from onTurnDone',
@@ -286,7 +286,7 @@ function commonTests() {
            expect(_log.result())
                .toEqual('start run; onTurnDone:started; nested run; onTurnDone:finished');
            async.done();
-         }, 50);
+         }, 80);
        }));
 
     it('should call onTurnStart and onTurnDone before and after each top-level run',
@@ -330,7 +330,7 @@ function commonTests() {
                .toEqual(
                    'onTurnStart; run start; onTurnDone; onTurnStart; a then; b then; onTurnDone');
            async.done();
-         }, 50);
+         }, 80);
        }));
 
     it('should run a function outside of the angular zone',
@@ -370,7 +370,7 @@ function commonTests() {
                    // Third VM Turn => execute the microtask (inside angular)
                    'onTurnStart; executedMicrotask; onTurnDone');
            async.done();
-         }, 50);
+         }, 80);
        }));
 
     it('should call onTurnStart before executing a microtask scheduled in onTurnDone as well as ' +
@@ -400,7 +400,7 @@ function commonTests() {
                    // Second VM Turn => microtask enqueued from onTurnDone
                    'onTurnStart; executedMicrotask; onTurnDone(begin); onTurnDone(end)');
            async.done();
-         }, 50);
+         }, 80);
        }));
 
     it('should call onTurnStart and onTurnDone for a scheduleMicrotask in onTurnDone triggered by ' +
@@ -435,7 +435,7 @@ function commonTests() {
                    // Second VM Turn => the microtask enqueued from onTurnDone
                    'onTurnStart; onTurnDone(executeMicrotask); onTurnDone(begin); onTurnDone(end)');
            async.done();
-         }, 50);
+         }, 80);
        }));
 
     it('should execute promises scheduled in onTurnStart before promises scheduled in run',
@@ -490,7 +490,7 @@ function commonTests() {
                    // Second VM turn: execute the microtask from onTurnEnd
                    'onTurnStart(begin); onTurnStart(end); onTurnDone(executePromise); onTurnDone(begin); onTurnDone(end)');
            async.done();
-         }, 50);
+         }, 80);
        }));
 
     it('should call onTurnStart and onTurnDone before and after each turn, respectively',
@@ -508,10 +508,10 @@ function commonTests() {
            });
          });
 
-         macroTask(() => { _zone.run(() => { completerA.resolve(null); }); }, 10);
+         macroTask(() => { _zone.run(() => { completerA.resolve(null); }); }, 20);
 
 
-         macroTask(() => { _zone.run(() => { completerB.resolve(null); }); }, 30);
+         macroTask(() => { _zone.run(() => { completerB.resolve(null); }); }, 40);
 
          macroTask(() => {
            expect(_log.result())
@@ -523,7 +523,7 @@ function commonTests() {
                    // Third VM turn
                    'onTurnStart; b then; onTurnDone');
            async.done();
-         }, 60);
+         }, 80);
        }));
 
     it('should call onTurnStart and onTurnDone before and after (respectively) all turns in a chain',
@@ -543,7 +543,7 @@ function commonTests() {
            expect(_log.result())
                .toEqual('onTurnStart; run start; run end; async1; async2; onTurnDone');
            async.done();
-         }, 50);
+         }, 80);
        }));
 
     it('should call onTurnStart and onTurnDone for promises created outside of run body',
@@ -565,7 +565,7 @@ function commonTests() {
            expect(_log.result())
                .toEqual('onTurnStart; zone run; onTurnDone; onTurnStart; promise then; onTurnDone');
            async.done();
-         }, 50);
+         }, 80);
        }));
   });
 
@@ -596,7 +596,7 @@ function commonTests() {
            expect(_errors.length).toBe(1);
            expect(_errors[0]).toEqual(exception);
            async.done();
-         }, 50);
+         }, 80);
        }));
 
     it('should call onError when onTurnDone throws and the zone is sync',
@@ -612,7 +612,7 @@ function commonTests() {
            expect(_errors.length).toBe(1);
            expect(_errors[0]).toEqual(exception);
            async.done();
-         }, 50);
+         }, 80);
        }));
 
     it('should call onError when onTurnDone throws and the zone is async',
@@ -631,7 +631,7 @@ function commonTests() {
            expect(_errors.length).toBe(1);
            expect(_errors[0]).toEqual(exception);
            async.done();
-         }, 50);
+         }, 80);
        }));
   });
 }

--- a/modules/angular2/test/directives/ng_style_spec.ts
+++ b/modules/angular2/test/directives/ng_style_spec.ts
@@ -26,14 +26,14 @@ export function main() {
 
     it('should add styles specified in an object literal',
        inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
-         var template = `<div [ng-style]="{'text-align': 'right'}"></div>`;
+         var template = `<div [ng-style]="{'max-width': '40px'}"></div>`;
 
          tcb.overrideTemplate(TestComponent, template)
              .createAsync(TestComponent)
              .then((rootTC) => {
                rootTC.detectChanges();
-               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'text-align'))
-                   .toEqual('right');
+               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'max-width'))
+                   .toEqual('40px');
 
                async.done();
              });
@@ -48,16 +48,16 @@ export function main() {
              .then((rootTC) => {
                var expr: Map<string, any>;
 
-               rootTC.componentInstance.expr = {'text-align': 'right'};
+               rootTC.componentInstance.expr = {'max-width': '40px'};
                rootTC.detectChanges();
-               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'text-align'))
-                   .toEqual('right');
+               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'max-width'))
+                   .toEqual('40px');
 
                expr = rootTC.componentInstance.expr;
-               expr['text-align'] = 'left';
+               expr['max-width'] = '30%';
                rootTC.detectChanges();
-               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'text-align'))
-                   .toEqual('left');
+               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'max-width'))
+                   .toEqual('30%');
 
                async.done();
              });
@@ -70,14 +70,14 @@ export function main() {
          tcb.overrideTemplate(TestComponent, template)
              .createAsync(TestComponent)
              .then((rootTC) => {
-               rootTC.componentInstance.expr = {'text-align': 'right'};
+               rootTC.componentInstance.expr = {'max-width': '40px'};
                rootTC.detectChanges();
-               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'text-align'))
-                   .toEqual('right');
+               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'max-width'))
+                   .toEqual('40px');
 
-               StringMapWrapper.delete(rootTC.componentInstance.expr, 'text-align');
+               StringMapWrapper.delete(rootTC.componentInstance.expr, 'max-width');
                rootTC.detectChanges();
-               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'text-align'))
+               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'max-width'))
                    .toEqual('');
 
                async.done();
@@ -91,16 +91,16 @@ export function main() {
          tcb.overrideTemplate(TestComponent, template)
              .createAsync(TestComponent)
              .then((rootTC) => {
-               rootTC.componentInstance.expr = {'text-align': 'right'};
+               rootTC.componentInstance.expr = {'max-width': '40px'};
                rootTC.detectChanges();
-               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'text-align'))
-                   .toEqual('right');
+               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'max-width'))
+                   .toEqual('40px');
                expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'font-size'))
                    .toEqual('12px');
 
-               StringMapWrapper.delete(rootTC.componentInstance.expr, 'text-align');
+               StringMapWrapper.delete(rootTC.componentInstance.expr, 'max-width');
                rootTC.detectChanges();
-               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'text-align'))
+               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'max-width'))
                    .toEqual('');
                expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'font-size'))
                    .toEqual('12px');
@@ -116,19 +116,19 @@ export function main() {
          tcb.overrideTemplate(TestComponent, template)
              .createAsync(TestComponent)
              .then((rootTC) => {
-               rootTC.componentInstance.expr = {'text-align': 'right'};
+               rootTC.componentInstance.expr = {'max-width': '40px'};
                rootTC.detectChanges();
-               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'text-align'))
-                   .toEqual('right');
+               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'max-width'))
+                   .toEqual('40px');
                expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'font-size'))
                    .toEqual('12px');
 
-               StringMapWrapper.delete(rootTC.componentInstance.expr, 'text-align');
+               StringMapWrapper.delete(rootTC.componentInstance.expr, 'max-width');
                expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'font-size'))
                    .toEqual('12px');
 
                rootTC.detectChanges();
-               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'text-align'))
+               expect(DOM.getStyle(rootTC.componentViewChildren[0].nativeElement, 'max-width'))
                    .toEqual('');
 
                async.done();

--- a/modules/angular2/test/forms/integration_spec.ts
+++ b/modules/angular2/test/forms/integration_spec.ts
@@ -736,6 +736,11 @@ export function main() {
                   rootTC.componentInstance.form = form;
                   rootTC.detectChanges();
 
+                  // In IE, the element needs to be appended to the real DOM,
+                  // otherwise setting .selectionStart fails with "unspecified error"
+                  var isIE = DOM.getUserAgent().indexOf("Trident") > -1;
+                  if (isIE) DOM.appendChild(DOM.defaultDoc().body, rootTC.nativeElement);
+
                   var input = rootTC.query(By.css("input")).nativeElement;
                   input.value = "aa";
                   input.selectionStart = 1;
@@ -746,6 +751,7 @@ export function main() {
 
                   // selection start has not changed because we did not reset the value
                   expect(input.selectionStart).toEqual(1);
+                  if (isIE) DOM.removeChild(DOM.defaultDoc().body, rootTC.nativeElement);
                 })));
     });
   });

--- a/modules/angular2/test/render/dom/view/view_spec.ts
+++ b/modules/angular2/test/render/dom/view/view_spec.ts
@@ -129,10 +129,10 @@ export function main() {
       });
 
       it('should de-normalize style names', () => {
-        view.setElementStyle(0, 'textAlign', 'right');
-        expect(DOM.getStyle(el, 'text-align')).toEqual('right');
-        view.setElementStyle(0, 'textAlign', null);
-        expect(DOM.getStyle(el, 'text-align')).toEqual('');
+        view.setElementStyle(0, 'maxWidth', '40px');
+        expect(DOM.getStyle(el, 'max-width')).toEqual('40px');
+        view.setElementStyle(0, 'maxWidth', null);
+        expect(DOM.getStyle(el, 'max-width')).toEqual('');
       });
 
     });


### PR DESCRIPTION
Fixes 18 unit test failures in IE11. The
- `Node.parentElement` is not always defined => switching to `Node.parentNode`
- `Element.remove()` is not defined => using `removeChild()` on the parent
- fix a typo in `normalizeCSS()` util function
- add timers to the new tests of `NgZone`, and make the existing ones safer
- `text-align` style property behaves badly (setting it to `null` doesn't change its value) => using `max-width` instead
- carret manipulation throws if the element in not attached to the DOM

This doesn't solves the issues raised in #3333 (Internationalization API).
