### PR TITLE
fix(core): export LifeCycle at top-level modules

### DIFF
--- a/modules/angular2/core.ts
+++ b/modules/angular2/core.ts
@@ -18,6 +18,7 @@ export {AppViewManager} from 'angular2/src/core/compiler/view_manager';
 export {IQueryList} from 'angular2/src/core/compiler/interface_query';
 export {QueryList} from 'angular2/src/core/compiler/query_list';
 export {DynamicComponentLoader} from 'angular2/src/core/compiler/dynamic_component_loader';
+export {LifeCycle} from 'angular2/src/core/life_cycle/life_cycle';
 
 export {ElementRef} from 'angular2/src/core/compiler/element_ref';
 export {TemplateRef} from 'angular2/src/core/compiler/template_ref';

--- a/modules/angular2/test/core/application_spec.ts
+++ b/modules/angular2/test/core/application_spec.ts
@@ -17,7 +17,7 @@ import {Component, Directive, View} from 'angular2/annotations';
 import {DOM} from 'angular2/src/dom/dom_adapter';
 import {PromiseWrapper} from 'angular2/src/facade/async';
 import {bind, Inject, Injector} from 'angular2/di';
-import {LifeCycle} from 'angular2/src/core/life_cycle/life_cycle';
+import {LifeCycle} from 'angular2/core';
 import {ExceptionHandler} from 'angular2/src/core/exception_handler';
 import {Testability, TestabilityRegistry} from 'angular2/src/core/testability/testability';
 import {DOCUMENT_TOKEN} from 'angular2/src/render/render';

--- a/modules/angular2/test/core/life_cycle/life_cycle_spec.ts
+++ b/modules/angular2/test/core/life_cycle/life_cycle_spec.ts
@@ -14,7 +14,7 @@ import {
   inject,
   SpyChangeDetector,
 } from 'angular2/test_lib';
-import {LifeCycle} from 'angular2/src/core/life_cycle/life_cycle';
+import {LifeCycle} from 'angular2/core';
 import {IMPLEMENTS} from 'angular2/src/facade/lang';
 
 export function main() {


### PR DESCRIPTION
LifeCycle can now be imported via angular2/angular2 or
angular2/core, so that end users can inject it without
having to use the full source path.

Closes #3395
