### PR TITLE
feat(transformers): add more information to factory debug reflection

### DIFF
--- a/modules/angular2/src/reflection/debug_reflection_capabilities.dart
+++ b/modules/angular2/src/reflection/debug_reflection_capabilities.dart
@@ -1,5 +1,6 @@
 library reflection.debug_reflection_capabilities;
 
+import 'dart:mirrors';
 import 'package:logging/logging.dart' as log;
 import 'package:stack_trace/stack_trace.dart';
 import 'types.dart';
@@ -25,7 +26,8 @@ class ReflectionCapabilities extends standard.ReflectionCapabilities {
   }
 
   Function factory(Type type) {
-    _notify('factory', type);
+    ClassMirror classMirror = reflectType(type);
+    _notify('factory', '${classMirror.qualifiedName}');
     return super.factory(type);
   }
 


### PR DESCRIPTION
Add the symbol information to debug_reflection_capabilities when asking
for a factory to make finding the type easier in large codebases.
