### PR TITLE
docs(View): correct templateUrl and template definition

### DIFF
--- a/modules/angular2/src/core/annotations_impl/view.ts
+++ b/modules/angular2/src/core/annotations_impl/view.ts
@@ -37,14 +37,14 @@ export {ViewEncapsulation} from 'angular2/src/render/api';
 @CONST()
 export class View {
   /**
-   * Specifies an inline template for an angular component.
+   * Specifies a template URL for an angular component.
    *
    * NOTE: either `templateUrl` or `template` should be used, but not both.
    */
   templateUrl: string;
 
   /**
-   * Specifies a template URL for an angular component.
+   * Specifies an inline template for an angular component.
    *
    * NOTE: either `templateUrl` or `template` should be used, but not both.
    */


### PR DESCRIPTION
docs(View)

correct templateUrl and template definition.
closes #3444
