### PR TITLE
fix(dart): @proxy is a value, not a factory

### DIFF
--- a/modules/angular2/src/mock/location_mock.ts
+++ b/modules/angular2/src/mock/location_mock.ts
@@ -6,7 +6,7 @@ import {List, ListWrapper} from 'angular2/src/facade/collection';
 import {Location} from 'angular2/src/router/location';
 
 
-@proxy()
+@proxy
 @IMPLEMENTS(Location)
 export class SpyLocation extends SpyObject {
   urlChanges: List<string>;

--- a/modules/angular2/src/test_lib/test_lib.ts
+++ b/modules/angular2/src/test_lib/test_lib.ts
@@ -12,9 +12,7 @@ import {createTestInjector, FunctionWithParamTokens, inject} from './test_inject
 
 export {inject} from './test_injector';
 
-export function proxy(): ClassDecorator {
-  return (t) => t;
-}
+export var proxy: ClassDecorator = (t) => t;
 
 var _global: jasmine.GlobalPolluter = <any>(typeof window === 'undefined' ? global : window);
 

--- a/modules/angular2/test/change_detection/pipes/observable_pipe_spec.ts
+++ b/modules/angular2/test/change_detection/pipes/observable_pipe_spec.ts
@@ -117,7 +117,7 @@ export function main() {
   });
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(ChangeDetectorRef)
 class SpyChangeDetectorRef extends SpyObject {
   constructor() { super(ChangeDetectorRef); }

--- a/modules/angular2/test/change_detection/pipes/promise_pipe_spec.ts
+++ b/modules/angular2/test/change_detection/pipes/promise_pipe_spec.ts
@@ -119,7 +119,7 @@ export function main() {
   });
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(ChangeDetectorRef)
 class SpyChangeDetectorRef extends SpyObject {
   constructor() { super(ChangeDetectorRef); }

--- a/modules/angular2/test/core/compiler/compiler_spec.ts
+++ b/modules/angular2/test/core/compiler/compiler_spec.ts
@@ -658,14 +658,14 @@ class DirectiveWithAttributes {
   constructor(@Attribute('someAttr') someAttr: String) {}
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(RenderCompiler)
 class SpyRenderCompiler extends SpyObject {
   constructor() { super(RenderCompiler); }
   noSuchMethod(m) { return super.noSuchMethod(m) }
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(DirectiveResolver)
 class SpyDirectiveResolver extends SpyObject {
   constructor() { super(DirectiveResolver); }

--- a/modules/angular2/test/core/compiler/element_injector_spec.ts
+++ b/modules/angular2/test/core/compiler/element_injector_spec.ts
@@ -48,7 +48,7 @@ import {ElementRef} from 'angular2/src/core/compiler/element_ref';
 import {DynamicChangeDetector, ChangeDetectorRef, Parser, Lexer} from 'angular2/src/change_detection/change_detection';
 import {QueryList} from 'angular2/src/core/compiler/query_list';
 
-@proxy()
+@proxy
 @IMPLEMENTS(AppView)
 class DummyView extends SpyObject {
   changeDetector;
@@ -59,7 +59,7 @@ class DummyView extends SpyObject {
   noSuchMethod(m) { return super.noSuchMethod(m); }
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(ElementRef)
 class DummyElementRef extends SpyObject {
   boundElementIndex: number = 0;

--- a/modules/angular2/test/core/compiler/proto_view_factory_spec.ts
+++ b/modules/angular2/test/core/compiler/proto_view_factory_spec.ts
@@ -199,7 +199,7 @@ function createRenderViewportElementBinder(nestedProtoView) {
   return new renderApi.ElementBinder({nestedProtoView: nestedProtoView});
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(ChangeDetection)
 class ChangeDetectionSpy extends SpyObject {
   constructor() { super(ChangeDetection); }

--- a/modules/angular2/test/core/compiler/view_container_ref_spec.ts
+++ b/modules/angular2/test/core/compiler/view_container_ref_spec.ts
@@ -62,7 +62,7 @@ export function main() {
   });
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(AppView)
 class AppViewSpy extends SpyObject {
   viewContainers: AppViewContainer[] = [null];
@@ -70,7 +70,7 @@ class AppViewSpy extends SpyObject {
   noSuchMethod(m) { return super.noSuchMethod(m) }
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(AppViewManager)
 class AppViewManagerSpy extends SpyObject {
   constructor() { super(AppViewManager); }

--- a/modules/angular2/test/core/compiler/view_manager_spec.ts
+++ b/modules/angular2/test/core/compiler/view_manager_spec.ts
@@ -507,21 +507,21 @@ export function main() {
   });
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(Renderer)
 class SpyRenderer extends SpyObject {
   constructor() { super(Renderer); }
   noSuchMethod(m) { return super.noSuchMethod(m) }
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(AppViewPool)
 class SpyAppViewPool extends SpyObject {
   constructor() { super(AppViewPool); }
   noSuchMethod(m) { return super.noSuchMethod(m) }
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(AppViewListener)
 class SpyAppViewListener extends SpyObject {
   constructor() { super(AppViewListener); }

--- a/modules/angular2/test/core/compiler/view_manager_utils_spec.ts
+++ b/modules/angular2/test/core/compiler/view_manager_utils_spec.ts
@@ -353,7 +353,7 @@ export function createEmbeddedPv(binders: ElementBinder[] = null) {
 class SomeComponent {
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(ProtoElementInjector)
 class SpyProtoElementInjector extends SpyObject {
   index: number;
@@ -361,21 +361,21 @@ class SpyProtoElementInjector extends SpyObject {
   noSuchMethod(m) { return super.noSuchMethod(m) }
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(ElementInjector)
 class SpyElementInjector extends SpyObject {
   constructor(public parent: ElementInjector) { super(ElementInjector); }
   noSuchMethod(m) { return super.noSuchMethod(m) }
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(PreBuiltObjects)
 class SpyPreBuiltObjects extends SpyObject {
   constructor() { super(PreBuiltObjects); }
   noSuchMethod(m) { return super.noSuchMethod(m) }
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(Injector)
 class SpyInjector extends SpyObject {
   constructor() { super(Injector); }

--- a/modules/angular2/test/router/router_link_spec.ts
+++ b/modules/angular2/test/router/router_link_spec.ts
@@ -79,7 +79,7 @@ class TestComponent {
 }
 
 
-@proxy()
+@proxy
 @IMPLEMENTS(Location)
 class DummyLocation extends SpyObject {
   noSuchMethod(m) { return super.noSuchMethod(m) }
@@ -92,7 +92,7 @@ function makeDummyLocation() {
 }
 
 
-@proxy()
+@proxy
 @IMPLEMENTS(Router)
 class DummyRouter extends SpyObject {
   noSuchMethod(m) { return super.noSuchMethod(m) }

--- a/modules/angular2/test/router/router_spec.ts
+++ b/modules/angular2/test/router/router_spec.ts
@@ -175,7 +175,7 @@ export function main() {
   });
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(RouterOutlet)
 class DummyOutlet extends SpyObject {
   noSuchMethod(m) { return super.noSuchMethod(m) }

--- a/modules/angular2/test/services/ruler_spec.ts
+++ b/modules/angular2/test/services/ruler_spec.ts
@@ -58,7 +58,7 @@ export function main() {
   });
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(ElementRef)
 class SpyElementRef extends SpyObject {
   nativeElement;
@@ -66,7 +66,7 @@ class SpyElementRef extends SpyObject {
   noSuchMethod(m) { return super.noSuchMethod(m) }
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(DomAdapter)
 class SpyDomAdapter extends SpyObject {
   constructor() { super(DomAdapter); }

--- a/modules/angular2/test/test_lib/test_lib_spec.ts
+++ b/modules/angular2/test/test_lib/test_lib_spec.ts
@@ -21,7 +21,7 @@ class TestObj {
   someComplexFunc(a) { return a; }
 }
 
-@proxy()
+@proxy
 @IMPLEMENTS(TestObj)
 class SpyTestObj extends SpyObject {
   constructor() { super(TestObj); }


### PR DESCRIPTION
Previously I added parens everywhere to make this @proxy() because our typing indicated
it was a function that returned a decorator, but this breaks dart. Instead, the typing needs
to be changed.

Fixes #3494
