### PR TITLE
chore(build): enable type-checking for TypeScript ES6 emit.

### DIFF
--- a/modules/angular2/globals.d.ts
+++ b/modules/angular2/globals.d.ts
@@ -3,7 +3,6 @@
  */
 
 /// <reference path="typings/zone/zone.d.ts"/>
-/// <reference path="traceur-runtime.d.ts" />
 declare var assert: any;
 declare type int = number;
 
@@ -32,5 +31,3 @@ interface BrowserNodeGlobal {
   setInterval: Function;
   clearInterval: Function;
 }
-
-declare var global: any;

--- a/modules/angular2/src/di/injector.ts
+++ b/modules/angular2/src/di/injector.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/es6-promise/es6-promise.d.ts" />
-
 import {Map, List, MapWrapper, ListWrapper} from 'angular2/src/facade/collection';
 import {ResolvedBinding, Binding, Dependency, BindingBuilder, bind} from './binding';
 import {

--- a/modules/angular2/src/facade/async.ts
+++ b/modules/angular2/src/facade/async.ts
@@ -1,4 +1,3 @@
-/// <reference path="../../typings/es6-promise/es6-promise.d.ts" />
 /// <reference path="../../typings/rx/rx.d.ts" />
 
 import {global, isPresent} from 'angular2/src/facade/lang';
@@ -9,7 +8,7 @@ export {Promise};
 
 export interface PromiseCompleter<R> {
   promise: Promise<R>;
-  resolve: (value?: R | Thenable<R>) => void;
+  resolve: (value?: R | PromiseLike<R>) => void;
   reject: (error?: any, stackTrace?: string) => void;
 }
 
@@ -20,7 +19,8 @@ export class PromiseWrapper {
 
   // Note: We can't rename this method into `catch`, as this is not a valid
   // method name in Dart.
-  static catchError<T>(promise: Promise<T>, onError: (error: any) => T | Thenable<T>): Promise<T> {
+  static catchError<T>(promise: Promise<T>,
+                       onError: (error: any) => T | PromiseLike<T>): Promise<T> {
     return promise.catch(onError);
   }
 
@@ -29,8 +29,8 @@ export class PromiseWrapper {
     return Promise.all(promises);
   }
 
-  static then<T, U>(promise: Promise<T>, success: (value: T) => U | Thenable<U>,
-                    rejection?: (error: any, stack?: any) => U | Thenable<U>): Promise<U> {
+  static then<T, U>(promise: Promise<T>, success: (value: T) => U | PromiseLike<U>,
+                    rejection?: (error: any, stack?: any) => U | PromiseLike<U>): Promise<U> {
     return promise.then(success, rejection);
   }
 
@@ -66,6 +66,7 @@ export class TimerWrapper {
 }
 
 export class ObservableWrapper {
+  // TODO(vsavkin): when we use rxnext, try inferring the generic type from the first arg
   static subscribe<T>(emitter: Observable, onNext: (value: T) => void,
                       onThrow: (exception: any) => void = null,
                       onReturn: () => void = null): Object {

--- a/modules/angular2/src/facade/collection.ts
+++ b/modules/angular2/src/facade/collection.ts
@@ -9,7 +9,7 @@ export var StringMap = global.Object;
 // Map constructor.  We work around that by manually adding the items.
 var createMapFromPairs: {(pairs: List<any>): Map<any, any>} = (function() {
   try {
-    if (new Map([1, 2]).size === 2) {
+    if (new Map([[1, 2]]).size === 1) {
       return function createMapFromPairs(pairs: List<any>):
           Map<any, any> { return new Map(pairs); };
     }

--- a/modules/angular2/src/test_lib/e2e_util.ts
+++ b/modules/angular2/src/test_lib/e2e_util.ts
@@ -2,7 +2,7 @@
 /// <reference path="../../typings/angular-protractor/angular-protractor.d.ts" />
 /// <reference path="../../typings/jasmine/jasmine"/>
 
-import webdriver = require('selenium-webdriver');
+import * as webdriver from 'selenium-webdriver';
 
 export var browser: protractor.IBrowser = global['browser'];
 export var $: cssSelectorHelper = global['$'];

--- a/modules/angular2/traceur-runtime.d.ts
+++ b/modules/angular2/traceur-runtime.d.ts
@@ -1,3 +1,19 @@
+// This file is used for TypeScript compilation to ES5 only.
+// Since this file is not included in the compilation to ES6, it is an error
+// to <reference> this file from other sources.
+// Instead it is referenced by the rootFilePaths option to the compiler.
+
+// We also want the following typings to be available only when compiling to
+// ES5, because they are redundant with lib.es6.d.ts.
+/// <reference path="../angular2/typings/es6-promise/es6-promise.d.ts"/>
+
+// es6-promise.d.ts chose a different name for this interface than TS lib.es6.d.ts
+// Generic Type Alises are in TS 1.6 (https://github.com/Microsoft/TypeScript/pull/3397)
+// So we cannot write:
+// declare type PromiseLike = Thenable;
+// Until then we use a workaround:
+interface PromiseLike<T> extends Thenable<T> {}
+
 // Extend the ES5 standard library with some ES6 features we polyfill at runtime
 // by loading traceur-runtime.js
 

--- a/modules/angular2/tsd.json
+++ b/modules/angular2/tsd.json
@@ -15,7 +15,7 @@
       "commit": "055b3172e8eb374a75826710c4d08677872620d3"
     },
     "node/node.d.ts": {
-      "commit": "d5f92f93bdb49f332fa662ff1d0cc8700f02e4dc"
+      "commit": "51738fdf1643d269067861b405e87503b7479236"
     },
     "rx/rx.d.ts": {
       "commit": "3882d337bb0808cde9fe4c08012508a48c135482"

--- a/modules/angular2_material/src/components/grid_list/grid_list.ts
+++ b/modules/angular2_material/src/components/grid_list/grid_list.ts
@@ -260,7 +260,7 @@ export class MdGridTile {
   }
 
   set rowspan(value) {
-    this._rowspan = isString(value) ? NumberWrapper.parseInt(value, 10) : <number>value;
+    this._rowspan = isString(value) ? NumberWrapper.parseInt(<any>value, 10) : <number>value;
   }
 
   get rowspan() {
@@ -268,7 +268,7 @@ export class MdGridTile {
   }
 
   set colspan(value) {
-    this._colspan = isString(value) ? NumberWrapper.parseInt(value, 10) : <number>value;
+    this._colspan = isString(value) ? NumberWrapper.parseInt(<any>value, 10) : <number>value;
   }
 
   get colspan() {

--- a/modules/angular2_material/src/components/input/input.ts
+++ b/modules/angular2_material/src/components/input/input.ts
@@ -49,7 +49,8 @@ export class MdInputContainer {
     // classes based on the input state.
     ObservableWrapper.subscribe(input.mdChange, value => { this.inputHasValue = value != ''; });
 
-    ObservableWrapper.subscribe(input.mdFocusChange, hasFocus => {this.inputHasFocus = hasFocus});
+    ObservableWrapper.subscribe<boolean>(input.mdFocusChange,
+                                         hasFocus => this.inputHasFocus = hasFocus);
   }
 }
 

--- a/modules/benchmarks/src/naive_infinite_scroll/common.ts
+++ b/modules/benchmarks/src/naive_infinite_scroll/common.ts
@@ -66,7 +66,7 @@ export class RawEntity {
     var pieces = key.split('.');
     var last = ListWrapper.last(pieces);
     pieces.length = pieces.length - 1;
-    var target = _resolve(pieces, this);
+    var target = this._resolve(pieces, this);
     if (target == null) {
       return null;
     }
@@ -81,7 +81,7 @@ export class RawEntity {
     var pieces = key.split('.');
     var last = ListWrapper.last(pieces);
     pieces.length = pieces.length - 1;
-    var target = _resolve(pieces, this);
+    var target = this._resolve(pieces, this);
     target[last] = value;
   }
 
@@ -92,7 +92,7 @@ export class RawEntity {
     var pieces = key.split('.');
     var last = ListWrapper.last(pieces);
     pieces.length = pieces.length - 1;
-    var target = _resolve(pieces, this);
+    var target = this._resolve(pieces, this);
     return target.remove(last);
   }
 

--- a/modules/benchmarks/src/naive_infinite_scroll/index.ts
+++ b/modules/benchmarks/src/naive_infinite_scroll/index.ts
@@ -9,6 +9,6 @@ export function main() {
   bootstrap(App, createBindings());
 }
 
-function createBindings(): List {
+function createBindings(): List<any> {
   return [bind(APP_VIEW_POOL_CAPACITY).toValue(100000)];
 }

--- a/modules/benchmarks/src/tree/tree_benchmark.ts
+++ b/modules/benchmarks/src/tree/tree_benchmark.ts
@@ -207,7 +207,7 @@ class BaseLineIf {
         this.component = null;
       }
       if (this.condition) {
-        var element = DOM.firstChild(DOM.clone(BASELINE_IF_TEMPLATE).content);
+        var element = DOM.firstChild((<any>DOM.clone(BASELINE_IF_TEMPLATE)).content);
         this.anchor.parentNode.insertBefore(element, DOM.nextSibling(this.anchor));
         this.component = new BaseLineTreeComponent(DOM.firstChild(element));
       }

--- a/modules/benchmarks_external/src/compiler/compiler_benchmark.ts
+++ b/modules/benchmarks_external/src/compiler/compiler_benchmark.ts
@@ -1,6 +1,6 @@
 // compiler benchmark in AngularJS 1.x
 import {getIntParameter, bindAction} from 'angular2/src/test_lib/benchmark_util';
-import angular = require("angular");
+declare var angular: any;
 
 export function main() {
   var ngEl = document.createElement('div');
@@ -9,7 +9,7 @@ export function main() {
 
 function loadTemplate(templateId, repeatCount) {
   var template = document.querySelectorAll(`#${templateId}`)[0];
-  var content = template.innerHTML;
+  var content = (<HTMLElement>template).innerHTML;
   var result = '';
   for (var i = 0; i < repeatCount; i++) {
     result += content;

--- a/modules/benchmarks_external/src/largetable/largetable_benchmark.ts
+++ b/modules/benchmarks_external/src/largetable/largetable_benchmark.ts
@@ -3,7 +3,7 @@ import {
   getStringParameter,
   bindAction
 } from 'angular2/src/test_lib/benchmark_util';
-import angular = require("angular");
+declare var angular: any;
 
 var totalRows = getIntParameter('rows');
 var totalColumns = getIntParameter('columns');

--- a/modules/benchmarks_external/src/static_tree/tree_benchmark.ts
+++ b/modules/benchmarks_external/src/static_tree/tree_benchmark.ts
@@ -1,6 +1,6 @@
 // static tree benchmark in AngularJS 1.x
 import {getIntParameter, bindAction} from 'angular2/src/test_lib/benchmark_util';
-import angular = require("angular");
+declare var angular: any;
 
 const MAX_DEPTH = 10;
 

--- a/modules/benchmarks_external/src/tree/react/react.min.d.ts
+++ b/modules/benchmarks_external/src/tree/react/react.min.d.ts
@@ -1,0 +1,2 @@
+declare var React: any;
+export default React;

--- a/modules/benchmarks_external/src/tree/tree_benchmark.ts
+++ b/modules/benchmarks_external/src/tree/tree_benchmark.ts
@@ -1,6 +1,6 @@
 // tree benchmark in AngularJS 1.x
 import {getIntParameter, bindAction} from 'angular2/src/test_lib/benchmark_util';
-import angular = require("angular");
+declare var angular: any;
 
 export function main() {
   angular.bootstrap(document.querySelector('tree'), ['app']);

--- a/modules/benchpress/index.ts
+++ b/modules/benchpress/index.ts
@@ -3,4 +3,4 @@ require('traceur/bin/traceur-runtime');
 module.exports = require('./benchpress.js');
 // when bundling benchpress to one file, this is used
 // for getting exports out of browserify's scope.
-global.__benchpressExports = module.exports;
+(<any>global).__benchpressExports = module.exports;

--- a/modules/benchpress/src/webdriver/selenium_webdriver_adapter.ts
+++ b/modules/benchpress/src/webdriver/selenium_webdriver_adapter.ts
@@ -2,7 +2,7 @@ import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
 import {bind, Binding} from 'angular2/di';
 import {WebDriverAdapter} from '../web_driver_adapter';
 
-import webdriver = require('selenium-webdriver');
+import * as webdriver from 'selenium-webdriver';
 
 /**
  * Adapter for the selenium-webdriver.
@@ -56,5 +56,7 @@ function convertToLocalProcess(data): Object {
   return JSON.parse(serialized);
 }
 
-var _PROTRACTOR_BINDINGS =
-    [bind(WebDriverAdapter).toFactory(() => new SeleniumWebDriverAdapter(global.browser), [])];
+var _PROTRACTOR_BINDINGS = [
+  bind(WebDriverAdapter)
+      .toFactory(() => new SeleniumWebDriverAdapter((<any>global).browser), [])
+];

--- a/modules/examples/src/http/http_comp.ts
+++ b/modules/examples/src/http/http_comp.ts
@@ -1,5 +1,5 @@
 import {Component, View, NgFor} from 'angular2/angular2';
-import {Http} from 'angular2/http';
+import {Http, Response} from 'angular2/http';
 import {ObservableWrapper} from 'angular2/src/facade/async';
 
 @Component({selector: 'http-app'})
@@ -17,6 +17,7 @@ import {ObservableWrapper} from 'angular2/src/facade/async';
 export class HttpCmp {
   people: Object;
   constructor(http: Http) {
-    ObservableWrapper.subscribe(http.get('./people.json'), res => this.people = res.json());
+    ObservableWrapper.subscribe<Response>(http.get('./people.json'),
+                                          res => this.people = res.json());
   }
 }

--- a/modules/examples/src/http/index.ts
+++ b/modules/examples/src/http/index.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../../angular2/typings/rx/rx.all.d.ts" />
+/// <reference path="../../../angular2/typings/rx/rx.d.ts" />
 
 import {bootstrap} from 'angular2/bootstrap';
 import {httpInjectables} from 'angular2/http';

--- a/modules/examples/src/jsonp/index.ts
+++ b/modules/examples/src/jsonp/index.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../../angular2/typings/rx/rx.all.d.ts" />
+/// <reference path="../../../angular2/typings/rx/rx.d.ts" />
 
 import {bootstrap} from 'angular2/bootstrap';
 import {jsonpInjectables} from 'angular2/http';

--- a/modules/examples/src/jsonp/jsonp_comp.ts
+++ b/modules/examples/src/jsonp/jsonp_comp.ts
@@ -1,5 +1,5 @@
 import {Component, View, NgFor} from 'angular2/angular2';
-import {Jsonp} from 'angular2/http';
+import {Jsonp, Response} from 'angular2/http';
 import {ObservableWrapper} from 'angular2/src/facade/async';
 
 @Component({selector: 'jsonp-app'})
@@ -17,7 +17,7 @@ import {ObservableWrapper} from 'angular2/src/facade/async';
 export class JsonpCmp {
   people: Object;
   constructor(jsonp: Jsonp) {
-    ObservableWrapper.subscribe(jsonp.get('./people.json?callback=JSONP_CALLBACK'),
-                                res => this.people = res.json());
+    ObservableWrapper.subscribe<Response>(jsonp.get('./people.json?callback=JSONP_CALLBACK'),
+                                          res => this.people = res.json());
   }
 }

--- a/modules/examples/src/model_driven_forms/index.ts
+++ b/modules/examples/src/model_driven_forms/index.ts
@@ -1,13 +1,4 @@
-import {
-  bootstrap,
-  onChange,
-  NgIf,
-  NgFor,
-  Component,
-  Directive,
-  View,
-  Host
-} from 'angular2/bootstrap';
+import {bootstrap, NgIf, NgFor, Component, Directive, View, Host} from 'angular2/bootstrap';
 import {formDirectives, NgControl, Validators, NgFormModel, FormBuilder} from 'angular2/forms';
 
 import {RegExpWrapper, print, isPresent} from 'angular2/src/facade/lang';

--- a/modules/examples/src/order_management/index.ts
+++ b/modules/examples/src/order_management/index.ts
@@ -1,6 +1,5 @@
 import {
   bootstrap,
-  onChange,
   NgIf,
   NgFor,
   Component,

--- a/modules/examples/src/person_management/index.ts
+++ b/modules/examples/src/person_management/index.ts
@@ -1,6 +1,5 @@
 import {
   bootstrap,
-  onChange,
   NgIf,
   NgFor,
   Component,

--- a/modules/examples/src/routing/inbox-app.ts
+++ b/modules/examples/src/routing/inbox-app.ts
@@ -8,7 +8,7 @@ import {
   Location,
   RouteParams
 } from 'angular2/router';
-import {Http} from 'angular2/http';
+import {Http, Response} from 'angular2/http';
 import {ObservableWrapper, PromiseWrapper} from 'angular2/src/facade/async';
 import {ListWrapper} from 'angular2/src/facade/collection';
 import {isPresent} from 'angular2/src/facade/lang';
@@ -63,7 +63,8 @@ class DbService {
 
   getData() {
     var p = PromiseWrapper.completer();
-    ObservableWrapper.subscribe(this.http.get('./db.json'), (resp) => { p.resolve(resp.json()); });
+    ObservableWrapper.subscribe<Response>(this.http.get('./db.json'),
+                                          (resp) => { p.resolve(resp.json()); });
     return p.promise;
   }
 

--- a/modules/examples/src/template_driven_forms/index.ts
+++ b/modules/examples/src/template_driven_forms/index.ts
@@ -1,6 +1,5 @@
 import {
   bootstrap,
-  onChange,
   NgIf,
   NgFor,
   Component,

--- a/modules/examples/src/todo/index.ts
+++ b/modules/examples/src/todo/index.ts
@@ -38,7 +38,7 @@ class TodoApp {
     this.todoStore.list.forEach((todo: Todo) => { todo.completed = isComplete; });
   }
 
-  clearCompleted(): void { this.todoStore.removeBy((todo) => todo.completed); }
+  clearCompleted(): void { this.todoStore.removeBy((todo: Todo) => todo.completed); }
 }
 
 export function main() {

--- a/modules/examples/src/todo/services/TodoStore.ts
+++ b/modules/examples/src/todo/services/TodoStore.ts
@@ -1,5 +1,5 @@
 import {Injectable} from 'angular2/angular2';
-import {ListWrapper} from 'angular2/src/facade/collection';
+import {ListWrapper, Predicate} from 'angular2/src/facade/collection';
 
 // base model for RecordStore
 export class KeyModel {
@@ -30,7 +30,7 @@ export class Store {
 
   remove(record: KeyModel): void { this._spliceOut(record); }
 
-  removeBy(callback: Function): void {
+  removeBy(callback: Predicate<KeyModel>): void {
     var records = ListWrapper.filter(this.list, callback);
     ListWrapper.removeAll(this.list, records);
   }

--- a/modules/examples/src/web_workers/todo/index_common.ts
+++ b/modules/examples/src/web_workers/todo/index_common.ts
@@ -56,5 +56,5 @@ export class TodoApp {
     this.todoStore.list.forEach((todo: Todo) => { todo.completed = this.isComplete; });
   }
 
-  clearCompleted(): void { this.todoStore.removeBy((todo) => todo.completed); }
+  clearCompleted(): void { this.todoStore.removeBy((todo: Todo) => todo.completed); }
 }

--- a/modules/examples/src/web_workers/todo/services/TodoStore.ts
+++ b/modules/examples/src/web_workers/todo/services/TodoStore.ts
@@ -1,5 +1,5 @@
 import {Injectable} from 'angular2/angular2';
-import {ListWrapper} from 'angular2/src/facade/collection';
+import {ListWrapper, Predicate} from 'angular2/src/facade/collection';
 
 // base model for RecordStore
 export class KeyModel {
@@ -34,7 +34,7 @@ export class Store {
 
   remove(record: KeyModel): void { this._spliceOut(record); }
 
-  removeBy(callback: Function): void {
+  removeBy(callback: Predicate<KeyModel>): void {
     var records = ListWrapper.filter(this.list, callback);
     ListWrapper.removeAll(this.list, records);
   }

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -10213,10 +10213,6 @@
               }
             }
           }
-        },
-        "typescript": {
-          "version": "1.5.3",
-          "resolved": "git://github.com/microsoft/TypeScript.git#a24aa6f57d281bafd3535f0f4c3f492364a8b4d6"
         }
       }
     },
@@ -10789,7 +10785,7 @@
     },
     "typescript": {
       "version": "1.5.3",
-      "resolved": "git://github.com/alexeagle/TypeScript.git#076bca017732cc9c44000ca0866199be64e21810"
+      "resolved": "git://github.com/alexeagle/TypeScript.git#90373cd85a87bd5d6d20dac58ba0df046da01b1d"
     },
     "vinyl": {
       "version": "0.4.6",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -15753,42 +15753,38 @@
     "ts2dart": {
       "version": "0.7.1",
       "from": "ts2dart@0.7.1",
+      "resolved": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.7.1.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.2 <0.5.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
         },
         "source-map-support": {
           "version": "0.3.2",
-          "from": "source-map-support@>=0.3.1 <0.4.0",
+          "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.2.tgz",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.2.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
-              "from": "source-map@0.1.32",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             }
           }
-        },
-        "typescript": {
-          "version": "1.5.3",
-          "from": "microsoft/TypeScript#release-1.5",
-          "resolved": "git://github.com/microsoft/TypeScript.git#a24aa6f57d281bafd3535f0f4c3f492364a8b4d6"
         }
       }
     },
@@ -16679,8 +16675,8 @@
     },
     "typescript": {
       "version": "1.5.3",
-      "from": "git://github.com/alexeagle/TypeScript.git#076bca017732cc9c44000ca0866199be64e21810",
-      "resolved": "git://github.com/alexeagle/TypeScript.git#076bca017732cc9c44000ca0866199be64e21810"
+      "from": "alexeagle/TypeScript#1.5_error_is_class",
+      "resolved": "git://github.com/alexeagle/TypeScript.git#90373cd85a87bd5d6d20dac58ba0df046da01b1d"
     },
     "vinyl": {
       "version": "0.4.6",


### PR DESCRIPTION
This requires delicate handling of type definitions which collide, because
we use TypeScript-provided lib.d.ts for --target=es5 and lib.es6.d.ts for
--target=es6.
We need to include our polyfill typings only in the --target=es5 case,
and the usages have to be consistent with lib.es6.d.ts.
Also starting with this change we now typecheck additional modules,
so this fixes a bunch of wrong typings which were never checked before.

Fixes #3178
