### PR TITLE
refactor(dart/transform): Show friendly messages for transform failures

### DIFF
--- a/modules/angular2/test/transform/directive_linker/all_tests.dart
+++ b/modules/angular2/test/transform/directive_linker/all_tests.dart
@@ -25,7 +25,7 @@ void allTests() {
       inputPath = 'directive_linker/simple_files/$inputPath';
       var actual = formatter
           .format(await linkNgDeps(reader, new AssetId('a', inputPath)));
-      expect(actual).toEqual(expected);
+      expect(actual).toEqual(formatter.format(expected));
     }
   });
 
@@ -41,7 +41,7 @@ void allTests() {
       inputPath = 'directive_linker/simple_export_files/$inputPath';
       var actual = formatter
           .format(await linkNgDeps(reader, new AssetId('a', inputPath)));
-      expect(actual).toEqual(expected);
+      expect(actual).toEqual(formatter.format(expected));
     }
   });
 }


### PR DESCRIPTION
Previously, the error messages coming out of the Dart transformer were
opaque when those errors came from the analyzer (for example, analyzer
parse errors). Log more useful errors when they are caught by the
transform code.
