### PR TITLE
fix(UrlResolver): encode URLs before resolving

### DIFF
--- a/modules/angular2/src/services/url_resolver.ts
+++ b/modules/angular2/src/services/url_resolver.ts
@@ -272,7 +272,7 @@ function _joinAndCanonicalizePath(parts: List<any>): string {
  * @return {string}
  */
 function _resolveUrl(base: string, url: string): string {
-  var parts = _split(url);
+  var parts = _split(encodeURI(url));
   var baseParts = _split(base);
 
   if (isPresent(parts[_ComponentIndex.SCHEME])) {

--- a/modules/angular2/test/services/url_resolver_spec.ts
+++ b/modules/angular2/test/services/url_resolver_spec.ts
@@ -70,5 +70,13 @@ export function main() {
         expect(resolver.resolve('foo/baz/', '/bar')).toEqual('/bar');
       });
     });
+
+    describe('corner and error cases', () => {
+      it('should encode URLs before resolving', () => {
+        expect(resolver.resolve('foo/baz', `<p #p>Hello
+        </p>`))
+            .toEqual('foo/%3Cp%20#p%3EHello%0A%20%20%20%20%20%20%20%20%3C/p%3E');
+      });
+    });
   });
 }


### PR DESCRIPTION
This commits makes JS implementation to behave like Dart one.

Fixes #3543
