### PR TITLE
chore(npm): update mock-fs version to support io.js@^2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "merge2": "^0.3.5",
     "minimatch": "^2.0.1",
     "minimist": "1.1.x",
-    "mock-fs": "^2.5.0",
+    "mock-fs": "^3.0.0",
     "node-html-encoder": "0.0.2",
     "node-uuid": "1.4.x",
     "on-headers": "^1.0.0",


### PR DESCRIPTION
`$(npm bin)/gulp test.all.js` would fail otherwise with any recent io.js version.

```
$ node -v
v2.3.2
```

``` bash
$ $(npm bin)/gulp test.all.js
Dart SDK is not available, Dart tasks will be skipped.
[20:20:43] Using gulpfile ~/Developer/angular2/angular/gulpfile.js
[20:20:43] Starting 'test.all.js'...
=============================================================================
not found: dart
Unable to locate the dart binary / SDK. Exiting
Dart SDK is not available, Dart tasks will be skipped.
[20:11:54] Using gulpfile ~/Developer/angular2/angular/gulpfile.js
[20:11:54] Starting 'test.js'...
[20:11:54] Starting 'test.unit.tools/ci'...
[20:11:54] 'test.unit.tools/ci' errored after 214 ms
[20:11:54] Error: Jasmine tests failed
[20:11:54] 'test.js' errored after 216 ms
[20:11:54] Error: build sequence failed

    stderr: /Users/olivier/Developer/angular2/angular/node_modules/mock-fs/lib/index.js:31
  throw new Error('Unsupported Node version: ' + nodeVersion);
        ^
Error: Unsupported Node version: 2.3.2
    at Object.<anonymous> (/Users/olivier/Developer/angular2/angular/node_modules/mock-fs/lib/index.js:31:9)
```
