### PR TITLE
chore(build): don't use global module format in router bundle

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -941,9 +941,12 @@ var bundleConfig = {
   meta: {
     // auto-detection fails to detect properly here - https://github.com/systemjs/builder/issues/123
     'rx': {
-        format: 'cjs'
-      }
+      format: 'cjs'
+    },
+    'angular2/src/router/route_definition': {
+      format: 'es6'
     }
+  }
 };
 
 // production build


### PR DESCRIPTION
Empty ES6 files are detected as "global" module format by
default which means that we end up with 2 module formats in
a bundle (es6 and global). This makes module loading more
complex and make break with certain SystemJS builder / loader
combinations.

Fixes #3528
