### PR TITLE
fix(benchmarks): remove reference to String.prototype.contains()

### DIFF
--- a/modules/benchmarks/src/naive_infinite_scroll/common.ts
+++ b/modules/benchmarks/src/naive_infinite_scroll/common.ts
@@ -1,5 +1,5 @@
 import {Math} from 'angular2/src/facade/math';
-
+import {StringWrapper} from 'angular2/src/facade/lang';
 import {ListWrapper, Map, MapWrapper} from 'angular2/src/facade/collection';
 
 export var ITEMS = 1000;
@@ -86,7 +86,7 @@ export class RawEntity {
   }
 
   remove(key: string) {
-    if (!key.contains('.')) {
+    if (!StringWrapper.contains(key, '.')) {
       return MapWrapper.delete(this._data, key);
     }
     var pieces = key.split('.');


### PR DESCRIPTION
https://github.com/tc39/tc39-notes/blob/master/es6/2014-11/nov-18.md#51--44-arrayprototypecontains-and-stringprototypecontains

removed String.prototype.contains() from standard, and is not
implemented in most runtimes (SpiderMonkey still being an exception).
