### PR TITLE
chore: reenable analyzer_plugin tests

### DIFF
--- a/tools/build/run_server_dart_tests.js
+++ b/tools/build/run_server_dart_tests.js
@@ -16,10 +16,6 @@ module.exports = function(gulp, plugins, config) {
   };
 
   function run(dir) {
-    if (dir == 'dist/dart/analyzer_plugin') {
-      // TODO: reenable after migration from unittest to test
-      return Q.resolve();
-    }
     var testDir = path.join(dir, 'test');
     var relativeMasterTestFile = 'test/_all_tests.dart';
     var testFiles = [].slice.call(glob.sync('**/*.server.spec.dart', {


### PR DESCRIPTION
Should be ok to reenable now that `package:unittest` is in sync with `package:test`
