### PR TITLE
fix(typescript): update to typescript with fixed system emit

### DIFF
--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -10785,7 +10785,7 @@
     },
     "typescript": {
       "version": "1.5.3",
-      "resolved": "git://github.com/alexeagle/TypeScript.git#90373cd85a87bd5d6d20dac58ba0df046da01b1d"
+      "resolved": "git://github.com/alexeagle/TypeScript.git#d5acfd6ddd05801e48c2af1aed6f0360d1be55ac"
     },
     "vinyl": {
       "version": "0.4.6",
@@ -10820,5 +10820,5 @@
     }
   },
   "name": "angular",
-  "version": "2.0.0-alpha.33"
+  "version": "2.0.0-alpha.34"
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "angular",
-  "version": "2.0.0-alpha.33",
+  "version": "2.0.0-alpha.34",
   "dependencies": {
     "angular": {
       "version": "1.3.5",
@@ -16676,7 +16676,7 @@
     "typescript": {
       "version": "1.5.3",
       "from": "alexeagle/TypeScript#1.5_error_is_class",
-      "resolved": "git://github.com/alexeagle/TypeScript.git#90373cd85a87bd5d6d20dac58ba0df046da01b1d"
+      "resolved": "git://github.com/alexeagle/TypeScript.git#d5acfd6ddd05801e48c2af1aed6f0360d1be55ac"
     },
     "vinyl": {
       "version": "0.4.6",


### PR DESCRIPTION
Picks up two commits from our TypeScript fork:
https://github.com/alexeagle/TypeScript/compare/90373cd85a87bd5d6d20dac58ba0df046da01b1d...alexeagle:1.5_error_is_class
