### PR TITLE
fix(testability): throw if no testability available

### DIFF
--- a/modules/angular2/src/core/testability/get_testability.dart
+++ b/modules/angular2/src/core/testability/get_testability.dart
@@ -93,6 +93,9 @@ class GetTestability {
   static addToWindow(TestabilityRegistry registry) {
     js.context['getAngularTestability'] = _jsify((Element elem) {
       Testability testability = registry.findTestabilityInTree(elem);
+      if (testability == null) {
+        throw 'Could not find testability for element.';
+      }
       return _jsify(new PublicTestability(testability));
     });
     js.context['getAllAngularTestabilities'] = _jsify(() {


### PR DESCRIPTION
this implements the same behavior for dart that is already implemented in the typescript version
