### PR TITLE
feat(dart/transform): Support `part` directives

### DIFF
--- a/modules/angular2/src/test_lib/test_lib.dart
+++ b/modules/angular2/src/test_lib/test_lib.dart
@@ -100,7 +100,8 @@ class Expect extends gns.Expect {
   void toThrowError([message = ""]) => toThrowWith(message: message);
   void toThrowErrorWith(message) => expectException(this.actual, message);
   void toBePromise() => gns.guinness.matchers.toBeTrue(actual is Future);
-  void toHaveCssClass(className) => gns.guinness.matchers.toBeTrue(DOM.hasClass(actual, className));
+  void toHaveCssClass(className) =>
+      gns.guinness.matchers.toBeTrue(DOM.hasClass(actual, className));
   void toImplement(expected) => toBeA(expected);
   void toBeNaN() =>
       gns.guinness.matchers.toBeTrue(double.NAN.compareTo(actual) == 0);
@@ -139,7 +140,8 @@ class NotExpect extends gns.NotExpect {
 
   void toEqual(expected) => toHaveSameProps(expected);
   void toBePromise() => gns.guinness.matchers.toBeFalse(actual is Future);
-  void toHaveCssClass(className) => gns.guinness.matchers.toBeFalse(DOM.hasClass(actual, className));
+  void toHaveCssClass(className) =>
+      gns.guinness.matchers.toBeFalse(DOM.hasClass(actual, className));
   void toBeNull() => gns.guinness.matchers.toBeFalse(actual == null);
   Function get _expect => gns.guinness.matchers.expect;
 }

--- a/modules/angular2/src/transform/common/async_string_writer.dart
+++ b/modules/angular2/src/transform/common/async_string_writer.dart
@@ -16,7 +16,7 @@ class AsyncStringWriter extends PrintWriter {
       : _curr = curr,
         _bufs = <StringBuffer>[curr];
 
-  AsyncStringWriter() : this._(new StringBuffer());
+  AsyncStringWriter([Object content = ""]) : this._(new StringBuffer(content));
 
   void print(x) {
     _curr.write(x);

--- a/modules/angular2/src/transform/directive_processor/rewriter.dart
+++ b/modules/angular2/src/transform/directive_processor/rewriter.dart
@@ -103,7 +103,7 @@ Future<String> _getAllDeclarations(AssetReader reader, AssetId assetId,
     asyncWriter.asyncPrint(reader.readAsString(partAssetId).then((partCode) {
       if (partCode == null || partCode.isEmpty) {
         logger.warning('Empty part at "${partDirective.uri}. Ignoring.',
-            assetId: partAssetId);
+            asset: partAssetId);
         return '';
       }
       // Remove any directives -- we just want declarations.

--- a/modules/angular2/src/web-workers/ui/event_serializer.dart
+++ b/modules/angular2/src/web-workers/ui/event_serializer.dart
@@ -95,7 +95,8 @@ Map<String, dynamic> serializeKeyboardEvent(dynamic e) {
 }
 
 // TODO(jteplitz602): #3374. See above.
-Map<String, dynamic> addTarget(dynamic e, Map<String, dynamic> serializedEvent) {
+Map<String, dynamic> addTarget(
+    dynamic e, Map<String, dynamic> serializedEvent) {
   if (NODES_WITH_VALUE.contains(e.target.tagName.toLowerCase())) {
     serializedEvent['target'] = {'value': e.target.value};
     if (e.target is InputElement) {

--- a/modules/angular2/test/transform/directive_processor/all_tests.dart
+++ b/modules/angular2/test/transform/directive_processor/all_tests.dart
@@ -24,6 +24,14 @@ void allTests() {
   _testProcessor('should preserve parameter annotations as const instances.',
       'parameter_metadata/soup.dart');
 
+  _testProcessor('should handle `part` directives.', 'part_files/main.dart');
+
+  _testProcessor('should handle multiple `part` directives.',
+      'multiple_part_files/main.dart');
+
+  _testProcessor('should not generate .ng_deps.dart for `part` files.',
+      'part_files/part.dart');
+
   _testProcessor('should recognize custom annotations with package: imports',
       'custom_metadata/package_soup.dart',
       customDescriptors: [
@@ -166,8 +174,9 @@ void _testProcessor(String name, String inputPath,
       if (output == null) {
         expect(await reader.hasInput(expectedNgDepsId)).toBeFalse();
       } else {
-        var input = await reader.readAsString(expectedNgDepsId);
-        expect(formatter.format(output)).toEqual(formatter.format(input));
+        var expectedOutput = await reader.readAsString(expectedNgDepsId);
+        expect(formatter.format(output))
+            .toEqual(formatter.format(expectedOutput));
       }
       if (ngMeta.isEmpty) {
         expect(await reader.hasInput(expectedAliasesId)).toBeFalse();

--- a/modules/angular2/test/transform/directive_processor/all_tests.dart
+++ b/modules/angular2/test/transform/directive_processor/all_tests.dart
@@ -12,6 +12,7 @@ import 'package:code_transformers/messages/build_logger.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:guinness/guinness.dart';
 import 'package:path/path.dart' as path;
+import 'package:source_span/source_span.dart';
 import '../common/read_file.dart';
 
 var formatter = new DartFormatter();

--- a/modules/angular2/test/transform/directive_processor/multiple_part_files/expected/main.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/multiple_part_files/expected/main.ng_deps.dart
@@ -11,15 +11,15 @@ void initReflector() {
   _visited = true;
   _ngRef.reflector
     ..registerType(
-        MainComponent,
-        new _ngRef.ReflectionInfo(const [const Component(selector: '[main]')],
-            const [], () => new MainComponent()))
-    ..registerType(
         Part1Component,
         new _ngRef.ReflectionInfo(const [const Component(selector: '[part1]')],
             const [], () => new Part1Component()))
     ..registerType(
         Part2Component,
         new _ngRef.ReflectionInfo(const [const Component(selector: '[part2]')],
-            const [], () => new Part2Component()));
+            const [], () => new Part2Component()))
+    ..registerType(
+        MainComponent,
+        new _ngRef.ReflectionInfo(const [const Component(selector: '[main]')],
+            const [], () => new MainComponent()));
 }

--- a/modules/angular2/test/transform/directive_processor/multiple_part_files/expected/main.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/multiple_part_files/expected/main.ng_deps.dart
@@ -1,0 +1,25 @@
+library main.ng_deps.dart;
+
+import 'main.dart';
+export 'main.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
+import 'package:angular2/src/core/annotations_impl/annotations.dart';
+
+var _visited = false;
+void initReflector() {
+  if (_visited) return;
+  _visited = true;
+  _ngRef.reflector
+    ..registerType(
+        MainComponent,
+        new _ngRef.ReflectionInfo(const [const Component(selector: '[main]')],
+            const [], () => new MainComponent()))
+    ..registerType(
+        Part1Component,
+        new _ngRef.ReflectionInfo(const [const Component(selector: '[part1]')],
+            const [], () => new Part1Component()))
+    ..registerType(
+        Part2Component,
+        new _ngRef.ReflectionInfo(const [const Component(selector: '[part2]')],
+            const [], () => new Part2Component()));
+}

--- a/modules/angular2/test/transform/directive_processor/multiple_part_files/main.dart
+++ b/modules/angular2/test/transform/directive_processor/multiple_part_files/main.dart
@@ -1,0 +1,11 @@
+library main;
+
+import 'package:angular2/src/core/annotations_impl/annotations.dart';
+
+part 'part1.dart';
+part 'part2.dart';
+
+@Component(selector: '[main]')
+class MainComponent {
+  MainComponent();
+}

--- a/modules/angular2/test/transform/directive_processor/multiple_part_files/part1.dart
+++ b/modules/angular2/test/transform/directive_processor/multiple_part_files/part1.dart
@@ -1,0 +1,6 @@
+part of main;
+
+@Component(selector: '[part1]')
+class Part1Component {
+  Part1Component();
+}

--- a/modules/angular2/test/transform/directive_processor/multiple_part_files/part2.dart
+++ b/modules/angular2/test/transform/directive_processor/multiple_part_files/part2.dart
@@ -1,0 +1,6 @@
+part of main;
+
+@Component(selector: '[part2]')
+class Part2Component {
+  Part2Component();
+}

--- a/modules/angular2/test/transform/directive_processor/part_files/expected/main.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/part_files/expected/main.ng_deps.dart
@@ -11,11 +11,11 @@ void initReflector() {
   _visited = true;
   _ngRef.reflector
     ..registerType(
-        MainComponent,
-        new _ngRef.ReflectionInfo(const [const Component(selector: '[main]')],
-            const [], () => new MainComponent()))
-    ..registerType(
         PartComponent,
         new _ngRef.ReflectionInfo(const [const Component(selector: '[part]')],
-            const [], () => new PartComponent()));
+            const [], () => new PartComponent()))
+    ..registerType(
+        MainComponent,
+        new _ngRef.ReflectionInfo(const [const Component(selector: '[main]')],
+            const [], () => new MainComponent()));
 }

--- a/modules/angular2/test/transform/directive_processor/part_files/expected/main.ng_deps.dart
+++ b/modules/angular2/test/transform/directive_processor/part_files/expected/main.ng_deps.dart
@@ -1,0 +1,21 @@
+library main.ng_deps.dart;
+
+import 'main.dart';
+export 'main.dart';
+import 'package:angular2/src/reflection/reflection.dart' as _ngRef;
+import 'package:angular2/src/core/annotations_impl/annotations.dart';
+
+var _visited = false;
+void initReflector() {
+  if (_visited) return;
+  _visited = true;
+  _ngRef.reflector
+    ..registerType(
+        MainComponent,
+        new _ngRef.ReflectionInfo(const [const Component(selector: '[main]')],
+            const [], () => new MainComponent()))
+    ..registerType(
+        PartComponent,
+        new _ngRef.ReflectionInfo(const [const Component(selector: '[part]')],
+            const [], () => new PartComponent()));
+}

--- a/modules/angular2/test/transform/directive_processor/part_files/main.dart
+++ b/modules/angular2/test/transform/directive_processor/part_files/main.dart
@@ -1,0 +1,10 @@
+library main;
+
+import 'package:angular2/src/core/annotations_impl/annotations.dart';
+
+part 'part.dart';
+
+@Component(selector: '[main]')
+class MainComponent {
+  MainComponent();
+}

--- a/modules/angular2/test/transform/directive_processor/part_files/part.dart
+++ b/modules/angular2/test/transform/directive_processor/part_files/part.dart
@@ -1,0 +1,6 @@
+part of main;
+
+@Component(selector: '[part]')
+class PartComponent {
+  PartComponent();
+}


### PR DESCRIPTION
Allow users to split libraries using the `part` directive.

Closes #1817
