### PR TITLE
test(Router): increase the timeout for the back button test

### DIFF
--- a/modules/angular2/test/router/router_integration_spec.ts
+++ b/modules/angular2/test/router/router_integration_spec.ts
@@ -130,7 +130,7 @@ export function main() {
 
                  router.navigate(history[0][0]);
                });
-         }));
+         }), 1000);
     });
 
     describe('hierarchical app', () => {


### PR DESCRIPTION
The test would fail on Ubuntu 15.04 + Chrome 46 with the standard
timeout.

Error message:

```
Chrome 46.0.2478 (Linux) router injectables back button app should change the url without pushing a new history state for back navigations FAILED
    Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.
```
