### PR TITLE
fix(router): linking to redirects

### DIFF
--- a/modules/angular2/src/facade/collection.dart
+++ b/modules/angular2/src/facade/collection.dart
@@ -217,6 +217,27 @@ class ListWrapper {
     if (end == null) return len;
     return end < 0 ? max(len + end, 0) : min(end, len);
   }
+
+
+  static maximum(List l, fn(item)) {
+    if (l.length == 0) {
+      return null;
+    }
+    var solution = null;
+    var maxValue = double.NEGATIVE_INFINITY;
+    for (var index = 0; index < l.length; index++) {
+      var candidate = l[index];
+      if (candidate == null) {
+        continue;
+      }
+      var candidateValue = fn(candidate);
+      if (candidateValue > maxValue) {
+        solution = candidate;
+        maxValue = candidateValue;
+      }
+    }
+    return solution;
+  }
 }
 
 bool isListLikeIterable(obj) => obj is Iterable;

--- a/modules/angular2/src/facade/collection.ts
+++ b/modules/angular2/src/facade/collection.ts
@@ -1,4 +1,4 @@
-import {isJsObject, global, isPresent, isArray} from 'angular2/src/facade/lang';
+import {isJsObject, global, isPresent, isBlank, isArray} from 'angular2/src/facade/lang';
 
 export var List = global.Array;
 export var Map = global.Map;
@@ -266,6 +266,26 @@ export class ListWrapper {
   }
   static toString<T>(l: List<T>): string { return l.toString(); }
   static toJSON<T>(l: List<T>): string { return JSON.stringify(l); }
+
+  static maximum<T>(list: List<T>, predicate: (T) => number): T {
+    if (list.length == 0) {
+      return null;
+    }
+    var solution = null;
+    var maxValue = -Infinity;
+    for (var index = 0; index < list.length; index++) {
+      var candidate = list[index];
+      if (isBlank(candidate)) {
+        continue;
+      }
+      var candidateValue = predicate(candidate);
+      if (candidateValue > maxValue) {
+        solution = candidate;
+        maxValue = candidateValue;
+      }
+    }
+    return solution;
+  }
 }
 
 export function isListLikeIterable(obj: any): boolean {

--- a/modules/angular2/src/router/url_parser.ts
+++ b/modules/angular2/src/router/url_parser.ts
@@ -57,6 +57,14 @@ export class RootUrl extends Url {
   }
 }
 
+export function pathSegmentsToUrl(pathSegments: List<string>): Url {
+  var url = new Url(pathSegments[pathSegments.length - 1]);
+  for (var i = pathSegments.length - 2; i >= 0; i -= 1) {
+    url = new Url(pathSegments[i], url);
+  }
+  return url;
+}
+
 var SEGMENT_RE = RegExpWrapper.create('^[^\\/\\(\\)\\?;=&]+');
 function matchUrlSegment(str: string): string {
   var match = RegExpWrapper.firstMatch(SEGMENT_RE, str);

--- a/modules/angular2/test/facade/collection_spec.ts
+++ b/modules/angular2/test/facade/collection_spec.ts
@@ -76,6 +76,20 @@ export function main() {
       it('should respect the startIndex parameter',
          () => { expect(ListWrapper.indexOf(l, 1, 1)).toEqual(-1); });
     });
+
+    describe('maximum', () => {
+      it('should return the maximal element',
+         () => { expect(ListWrapper.maximum([1, 2, 3, 4], x => x)).toEqual(4); });
+
+      it('should ignore null values',
+         () => { expect(ListWrapper.maximum([null, 2, 3, null], x => x)).toEqual(3); });
+
+      it('should use the provided function to determine maximum',
+         () => { expect(ListWrapper.maximum([1, 2, 3, 4], x => -x)).toEqual(1); });
+
+      it('should return null for an empty list',
+         () => { expect(ListWrapper.maximum([], x => x)).toEqual(null); });
+    });
   });
 
   describe('StringMapWrapper', () => {

--- a/modules/angular2/test/router/route_registry_spec.ts
+++ b/modules/angular2/test/router/route_registry_spec.ts
@@ -14,7 +14,13 @@ import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
 import {Type} from 'angular2/src/facade/lang';
 
 import {RouteRegistry} from 'angular2/src/router/route_registry';
-import {RouteConfig, Route, AuxRoute, AsyncRoute} from 'angular2/src/router/route_config_decorator';
+import {
+  RouteConfig,
+  Route,
+  Redirect,
+  AuxRoute,
+  AsyncRoute
+} from 'angular2/src/router/route_config_decorator';
 import {stringifyInstruction} from 'angular2/src/router/instruction';
 import {IS_DART} from '../platform';
 
@@ -43,6 +49,24 @@ export function main() {
           .toEqual('first/second');
       expect(stringifyInstruction(registry.generate(['secondCmp'], DummyParentCmp)))
           .toEqual('second');
+    });
+
+    it('should generate URLs that account for redirects', () => {
+      registry.config(
+          RootHostCmp,
+          new Route({path: '/first/...', component: DummyParentRedirectCmp, as: 'firstCmp'}));
+
+      expect(stringifyInstruction(registry.generate(['firstCmp'], RootHostCmp)))
+          .toEqual('first/second');
+    });
+
+    it('should generate URLs in a hierarchy of redirects', () => {
+      registry.config(
+          RootHostCmp,
+          new Route({path: '/first/...', component: DummyMultipleRedirectCmp, as: 'firstCmp'}));
+
+      expect(stringifyInstruction(registry.generate(['firstCmp'], RootHostCmp)))
+          .toEqual('first/second/third');
     });
 
     it('should generate URLs with params', () => {
@@ -254,6 +278,28 @@ class DummyAsyncCmp {
 
 class DummyCmpA {}
 class DummyCmpB {}
+
+@RouteConfig([
+  new Redirect({path: '/', redirectTo: '/third'}),
+  new Route({path: '/third', component: DummyCmpB, as: 'thirdCmp'})
+])
+class DummyRedirectCmp {
+}
+
+
+@RouteConfig([
+  new Redirect({path: '/', redirectTo: '/second'}),
+  new Route({path: '/second/...', component: DummyRedirectCmp, as: 'secondCmp'})
+])
+class DummyMultipleRedirectCmp {
+}
+
+@RouteConfig([
+  new Redirect({path: '/', redirectTo: '/second'}),
+  new Route({path: '/second', component: DummyCmpB, as: 'secondCmp'})
+])
+class DummyParentRedirectCmp {
+}
 
 @RouteConfig([new Route({path: '/second', component: DummyCmpB, as: 'secondCmp'})])
 class DummyParentCmp {


### PR DESCRIPTION
I pulled out the logic for finding a maximal element in a list into a facade, and parameterized it so you can provide your own mapping from element to value.

I've described pitfalls of this approach here: https://github.com/angular/angular/issues/3335#issuecomment-130487657

Nevertheless, I think this is the best solution for now. I think we'll have to revisit redirects again to cover more general cases.
