### PR TITLE
feat(browser): support Edge

### DIFF
--- a/modules/angular2/src/facade/collection.ts
+++ b/modules/angular2/src/facade/collection.ts
@@ -242,7 +242,7 @@ export class ListWrapper {
   static join(list: List<any>, s: string): string { return list.join(s); }
   static isEmpty(list: List<any>): boolean { return list.length == 0; }
   static fill(list: List<any>, value: any, start: number = 0, end: number = null) {
-    list.fill(value, start, end === null ? undefined : end);
+    list.fill(value, start, end === null ? list.length : end);
   }
   static equals(a: List<any>, b: List<any>): boolean {
     if (a.length != b.length) return false;

--- a/modules/angular2/test/core/zone/ng_zone_spec.ts
+++ b/modules/angular2/test/core/zone/ng_zone_spec.ts
@@ -19,11 +19,12 @@ import {DOM} from 'angular2/src/dom/dom_adapter';
 
 import {NgZone} from 'angular2/src/core/zone/ng_zone';
 
-var isIE = DOM.getUserAgent().indexOf("Trident") > -1;
+var isIEorEdge =
+    DOM.getUserAgent().indexOf("Trident") > -1 || DOM.getUserAgent().indexOf("Edge") > -1;
 // Schedules a macrotask (using a timer)
 function macroTask(fn: Function, timer = 1): void {
-  // adds longer timers for passing tests in IE
-  _zone.runOutsideAngular(() => TimerWrapper.setTimeout(fn, isIE ? timer : 1));
+  // adds longer timers for passing tests in IE and Edge
+  _zone.runOutsideAngular(() => TimerWrapper.setTimeout(fn, isIEorEdge ? timer : 1));
 }
 
 // Schedules a microtasks (using a resolved promise .then())
@@ -511,7 +512,7 @@ function commonTests() {
          macroTask(() => { _zone.run(() => { completerA.resolve(null); }); }, 20);
 
 
-         macroTask(() => { _zone.run(() => { completerB.resolve(null); }); }, 40);
+         macroTask(() => { _zone.run(() => { completerB.resolve(null); }); }, 60);
 
          macroTask(() => {
            expect(_log.result())
@@ -523,7 +524,7 @@ function commonTests() {
                    // Third VM turn
                    'onTurnStart; b then; onTurnDone');
            async.done();
-         }, 80);
+         }, 90);
        }));
 
     it('should call onTurnStart and onTurnDone before and after (respectively) all turns in a chain',

--- a/modules/angular2/test/render/dom/compiler/shadow_css_spec.ts
+++ b/modules/angular2/test/render/dom/compiler/shadow_css_spec.ts
@@ -66,7 +66,8 @@ export function main() {
       });
     }
 
-    if (DOM.getUserAgent().indexOf('AppleWebKit') > -1) {
+    if (DOM.getUserAgent().indexOf('AppleWebKit') > -1 &&
+        DOM.getUserAgent().indexOf('Edge') == -1) {
       it('should handle -webkit-keyframes rules', () => {
         var css = '@-webkit-keyframes foo {0% {-webkit-transform: translate(-50%) scaleX(0);}}';
         var passRe =


### PR DESCRIPTION
Adds support for Edge browser. The only real fix is in `ListWrapper.fill` because Edge doesn't like an explicit `undefined` passed as the `end` argument (it doesn't fill the array).
The rest is test tuning for Edge: timers for NgZone, no support of -webkit-keyframes rules.

Edge also has the same issues as IE11 with the Internationalization API (see issue #3333), so there 5 tests still failing.
