### PR TITLE
fix(docs): Replaces old syntax for hostListeners

### DIFF
--- a/modules/angular2/src/core/annotations_impl/annotations.ts
+++ b/modules/angular2/src/core/annotations_impl/annotations.ts
@@ -246,9 +246,9 @@ import {DEFAULT} from 'angular2/change_detection';
  *   properties: [
  *     'text: tooltip'
  *   ],
- *   hostListeners: {
- *     'onmouseenter': 'onMouseEnter()',
- *     'onmouseleave': 'onMouseLeave()'
+ *   host: {
+ *     '(mouseenter)': 'onMouseEnter()',
+ *     '(mouseleave)': 'onMouseLeave()'
  *   }
  * })
  * class Tooltip{


### PR DESCRIPTION
Updates an outdated example of hostListeners in the DirectiveAnotation to work in alpha34.

I found this today while trying to understand how to listen for events properly in Angular. You can see my issue about it and my larger issue now resolved [here](https://github.com/angular/angular/issues/3671). This is obviously a very small change, but I was still not going to make a request about it for fear of getting something wrong; however, I just decided why not.
