### PR TITLE
fix(docs) Fixes typo in ProtoViewRef class

### DIFF
--- a/modules/angular2/src/core/compiler/view_ref.ts
+++ b/modules/angular2/src/core/compiler/view_ref.ts
@@ -96,7 +96,7 @@ export class ViewRef implements HostViewRef {
  * A ProtoView is a reference to a template for easy creation of views.
  * (See {@link AppViewManager#createViewInContainer} and {@link AppViewManager#createRootHostView}).
  *
- * A `ProtoView` is a foctary for creating `View`s.
+ * A `ProtoView` is a factory for creating `View`s.
  *
  * ## Example
  *


### PR DESCRIPTION
Changed 'foctary' to 'factory'.

I wanted to change 
- `{@link AppViewManager#createViewInContainer}` to `{@link AppViewManager#createViewInContainer}#createViewInContainer`
- `{@link AppViewManager#createRootHostView}` to `{@link AppViewManager#createRootHostView}#createRootHostView` 

for readibility (see https://angular.io/docs/js/latest/api/core/ProtoViewRef-class.html it shows `AppViewManager and AppViewManager`). But I'm not sure if that'll work so I'm just going with the typo.

Reference to https://github.com/angular/angular.io/issues/188

Please review, I'm quite new to this.
