### PR TITLE
chore(build): enable SauceLabs job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ env:
     # Order: slowest build on top, so that we don't hog VMs while waiting for others to complete.
     - MODE=dart DART_CHANNEL=stable
     - MODE=dart DART_CHANNEL=dev
-    # Disabled until we can make it pass.
-    # - MODE=saucelabs DART_CHANNEL=dev
+    - MODE=saucelabs DART_CHANNEL=dev
     - MODE=dart_experimental DART_CHANNEL=dev
     - MODE=js DART_CHANNEL=dev
     - MODE=lint DART_CHANNEL=dev

--- a/sauce.conf.js
+++ b/sauce.conf.js
@@ -8,7 +8,7 @@ var customLaunchers = {
   'SL_CHROME': {
     base: 'SauceLabs',
     browserName: 'chrome',
-    version: '43'
+    version: '44'
   },
   'SL_CHROMEBETA': {
     base: 'SauceLabs',
@@ -125,7 +125,7 @@ var aliases = {
   'SAFARI': ['SL_SAFARI7', 'SL_SAFARI8'],
   'BETA': ['SL_CHROMEBETA', 'SL_FIREFOXBETA'],
   'DEV': ['SL_CHROMEDEV', 'SL_FIREFOXDEV'],
-  'CI': ['SL_CHROME', 'SL_FIREFOX']
+  'CI': ['SL_CHROME', 'SL_ANDROID5.1']
 };
 
 module.exports = {


### PR DESCRIPTION
Enables SauceLabs job, targetting only Chrome Desktop and Chrome Mobile.
The goal is to get a clean state before adding more browsers.
