### PR TITLE
chore(test): disable tests based on Intl API in non-Chrome browsers

### DIFF
--- a/modules/angular2/src/pipes/date_pipe.ts
+++ b/modules/angular2/src/pipes/date_pipe.ts
@@ -21,6 +21,9 @@ import {Pipe} from '../core/metadata';
 var defaultLocale: string = 'en-US';
 
 /**
+ * WARNING: this pipe uses the Internationalization API.
+ * Therefore it is only reliable in Chrome and Opera browsers.
+ *
  * Formats a date value to a string based on the requested format.
  *
  * # Usage

--- a/modules/angular2/src/pipes/number_pipe.ts
+++ b/modules/angular2/src/pipes/number_pipe.ts
@@ -57,6 +57,9 @@ export class NumberPipe {
 }
 
 /**
+ * WARNING: this pipe uses the Internationalization API.
+ * Therefore it is only reliable in Chrome and Opera browsers.
+ *
  * Formats a number as local text. i.e. group sizing and seperator and other locale-specific
  * configurations are based on the active locale.
  *
@@ -92,6 +95,9 @@ export class DecimalPipe extends NumberPipe implements PipeTransform {
 }
 
 /**
+ * WARNING: this pipe uses the Internationalization API.
+ * Therefore it is only reliable in Chrome and Opera browsers.
+ *
  * Formats a number as local percent.
  *
  * # Usage
@@ -111,6 +117,9 @@ export class PercentPipe extends NumberPipe implements PipeTransform {
 }
 
 /**
+ * WARNING: this pipe uses the Internationalization API.
+ * Therefore it is only reliable in Chrome and Opera browsers.
+ *
  * Formats a number as local currency.
  *
  * # Usage

--- a/modules/angular2/src/test_lib/utils.ts
+++ b/modules/angular2/src/test_lib/utils.ts
@@ -85,3 +85,10 @@ export function stringifyElement(el): string {
 
   return result;
 }
+
+// The Intl API is only properly supported in Chrome and Opera.
+// Note: Edge is disguised as Chrome 42, so checking the "Edge" part is needed,
+// see https://msdn.microsoft.com/en-us/library/hh869301(v=vs.85).aspx
+export function supportsIntlApi(): boolean {
+  return DOM.getUserAgent().indexOf('Chrome') > -1 && DOM.getUserAgent().indexOf('Edge') == -1;
+}

--- a/modules/angular2/test/pipes/date_pipe_spec.ts
+++ b/modules/angular2/test/pipes/date_pipe_spec.ts
@@ -1,4 +1,14 @@
-import {ddescribe, describe, it, iit, xit, expect, beforeEach, afterEach} from 'angular2/test_lib';
+import {
+  ddescribe,
+  describe,
+  it,
+  iit,
+  xit,
+  expect,
+  beforeEach,
+  afterEach,
+  supportsIntlApi
+} from 'angular2/test_lib';
 
 import {DatePipe} from 'angular2/pipes';
 import {DateWrapper} from 'angular2/src/facade/lang';
@@ -23,42 +33,46 @@ export function main() {
       });
     });
 
-    describe("transform", () => {
-      it('should format each component correctly', () => {
-        expect(pipe.transform(date, ['y'])).toEqual('2015');
-        expect(pipe.transform(date, ['yy'])).toEqual('15');
-        expect(pipe.transform(date, ['M'])).toEqual('6');
-        expect(pipe.transform(date, ['MM'])).toEqual('06');
-        expect(pipe.transform(date, ['MMM'])).toEqual('Jun');
-        expect(pipe.transform(date, ['MMMM'])).toEqual('June');
-        expect(pipe.transform(date, ['d'])).toEqual('15');
-        expect(pipe.transform(date, ['E'])).toEqual('Mon');
-        expect(pipe.transform(date, ['EEEE'])).toEqual('Monday');
-        expect(pipe.transform(date, ['H'])).toEqual('21');
-        expect(pipe.transform(date, ['j'])).toEqual('9 PM');
-        expect(pipe.transform(date, ['m'])).toEqual('43');
-        expect(pipe.transform(date, ['s'])).toEqual('11');
-      });
+    // TODO(mlaval): enable tests when Intl API is no longer used, see
+    // https://github.com/angular/angular/issues/3333
+    if (supportsIntlApi()) {
+      describe("transform", () => {
+        it('should format each component correctly', () => {
+          expect(pipe.transform(date, ['y'])).toEqual('2015');
+          expect(pipe.transform(date, ['yy'])).toEqual('15');
+          expect(pipe.transform(date, ['M'])).toEqual('6');
+          expect(pipe.transform(date, ['MM'])).toEqual('06');
+          expect(pipe.transform(date, ['MMM'])).toEqual('Jun');
+          expect(pipe.transform(date, ['MMMM'])).toEqual('June');
+          expect(pipe.transform(date, ['d'])).toEqual('15');
+          expect(pipe.transform(date, ['E'])).toEqual('Mon');
+          expect(pipe.transform(date, ['EEEE'])).toEqual('Monday');
+          expect(pipe.transform(date, ['H'])).toEqual('21');
+          expect(pipe.transform(date, ['j'])).toEqual('9 PM');
+          expect(pipe.transform(date, ['m'])).toEqual('43');
+          expect(pipe.transform(date, ['s'])).toEqual('11');
+        });
 
-      it('should format common multi component patterns', () => {
-        expect(pipe.transform(date, ['yMEd'])).toEqual('Mon, 6/15/2015');
-        expect(pipe.transform(date, ['MEd'])).toEqual('Mon, 6/15');
-        expect(pipe.transform(date, ['MMMd'])).toEqual('Jun 15');
-        expect(pipe.transform(date, ['yMMMMEEEEd'])).toEqual('Monday, June 15, 2015');
-        expect(pipe.transform(date, ['jms'])).toEqual('9:43:11 PM');
-        expect(pipe.transform(date, ['ms'])).toEqual('43:11');
-      });
+        it('should format common multi component patterns', () => {
+          expect(pipe.transform(date, ['yMEd'])).toEqual('Mon, 6/15/2015');
+          expect(pipe.transform(date, ['MEd'])).toEqual('Mon, 6/15');
+          expect(pipe.transform(date, ['MMMd'])).toEqual('Jun 15');
+          expect(pipe.transform(date, ['yMMMMEEEEd'])).toEqual('Monday, June 15, 2015');
+          expect(pipe.transform(date, ['jms'])).toEqual('9:43:11 PM');
+          expect(pipe.transform(date, ['ms'])).toEqual('43:11');
+        });
 
-      it('should format with pattern aliases', () => {
-        expect(pipe.transform(date, ['medium'])).toEqual('Jun 15, 2015, 9:43:11 PM');
-        expect(pipe.transform(date, ['short'])).toEqual('6/15/2015, 9:43 PM');
-        expect(pipe.transform(date, ['fullDate'])).toEqual('Monday, June 15, 2015');
-        expect(pipe.transform(date, ['longDate'])).toEqual('June 15, 2015');
-        expect(pipe.transform(date, ['mediumDate'])).toEqual('Jun 15, 2015');
-        expect(pipe.transform(date, ['shortDate'])).toEqual('6/15/2015');
-        expect(pipe.transform(date, ['mediumTime'])).toEqual('9:43:11 PM');
-        expect(pipe.transform(date, ['shortTime'])).toEqual('9:43 PM');
+        it('should format with pattern aliases', () => {
+          expect(pipe.transform(date, ['medium'])).toEqual('Jun 15, 2015, 9:43:11 PM');
+          expect(pipe.transform(date, ['short'])).toEqual('6/15/2015, 9:43 PM');
+          expect(pipe.transform(date, ['fullDate'])).toEqual('Monday, June 15, 2015');
+          expect(pipe.transform(date, ['longDate'])).toEqual('June 15, 2015');
+          expect(pipe.transform(date, ['mediumDate'])).toEqual('Jun 15, 2015');
+          expect(pipe.transform(date, ['shortDate'])).toEqual('6/15/2015');
+          expect(pipe.transform(date, ['mediumTime'])).toEqual('9:43:11 PM');
+          expect(pipe.transform(date, ['shortTime'])).toEqual('9:43 PM');
+        });
       });
-    });
+    }
   });
 }

--- a/modules/angular2/test/pipes/number_pipe_spec.ts
+++ b/modules/angular2/test/pipes/number_pipe_spec.ts
@@ -1,58 +1,72 @@
-import {ddescribe, describe, it, iit, xit, expect, beforeEach, afterEach} from 'angular2/test_lib';
+import {
+  ddescribe,
+  describe,
+  it,
+  iit,
+  xit,
+  expect,
+  beforeEach,
+  afterEach,
+  supportsIntlApi
+} from 'angular2/test_lib';
 
 import {DecimalPipe, PercentPipe, CurrencyPipe} from 'angular2/pipes';
 
 export function main() {
-  describe("DecimalPipe", () => {
-    var pipe;
+  // TODO(mlaval): enable tests when Intl API is no longer used, see
+  // https://github.com/angular/angular/issues/3333
+  if (supportsIntlApi()) {
+    describe("DecimalPipe", () => {
+      var pipe;
 
-    beforeEach(() => { pipe = new DecimalPipe(); });
+      beforeEach(() => { pipe = new DecimalPipe(); });
 
-    describe("transform", () => {
-      it('should return correct value for numbers', () => {
-        expect(pipe.transform(12345, [])).toEqual('12,345');
-        expect(pipe.transform(123, ['.2'])).toEqual('123.00');
-        expect(pipe.transform(1, ['3.'])).toEqual('001');
-        expect(pipe.transform(1.1, ['3.4-5'])).toEqual('001.1000');
+      describe("transform", () => {
+        it('should return correct value for numbers', () => {
+          expect(pipe.transform(12345, [])).toEqual('12,345');
+          expect(pipe.transform(123, ['.2'])).toEqual('123.00');
+          expect(pipe.transform(1, ['3.'])).toEqual('001');
+          expect(pipe.transform(1.1, ['3.4-5'])).toEqual('001.1000');
 
-        expect(pipe.transform(1.123456, ['3.4-5'])).toEqual('001.12346');
-        expect(pipe.transform(1.1234, [])).toEqual('1.123');
+          expect(pipe.transform(1.123456, ['3.4-5'])).toEqual('001.12346');
+          expect(pipe.transform(1.1234, [])).toEqual('1.123');
+        });
+
+        it("should not support other objects",
+           () => { expect(() => pipe.transform(new Object(), [])).toThrowError(); });
       });
-
-      it("should not support other objects",
-         () => { expect(() => pipe.transform(new Object(), [])).toThrowError(); });
     });
-  });
 
-  describe("PercentPipe", () => {
-    var pipe;
+    describe("PercentPipe", () => {
+      var pipe;
 
-    beforeEach(() => { pipe = new PercentPipe(); });
+      beforeEach(() => { pipe = new PercentPipe(); });
 
-    describe("transform", () => {
-      it('should return correct value for numbers', () => {
-        expect(pipe.transform(1.23, [])).toEqual('123%');
-        expect(pipe.transform(1.2, ['.2'])).toEqual('120.00%');
+      describe("transform", () => {
+        it('should return correct value for numbers', () => {
+          expect(pipe.transform(1.23, [])).toEqual('123%');
+          expect(pipe.transform(1.2, ['.2'])).toEqual('120.00%');
+        });
+
+        it("should not support other objects",
+           () => { expect(() => pipe.transform(new Object(), [])).toThrowError(); });
       });
-
-      it("should not support other objects",
-         () => { expect(() => pipe.transform(new Object(), [])).toThrowError(); });
     });
-  });
 
-  describe("CurrencyPipe", () => {
-    var pipe;
+    describe("CurrencyPipe", () => {
+      var pipe;
 
-    beforeEach(() => { pipe = new CurrencyPipe(); });
+      beforeEach(() => { pipe = new CurrencyPipe(); });
 
-    describe("transform", () => {
-      it('should return correct value for numbers', () => {
-        expect(pipe.transform(123, [])).toEqual('USD123');
-        expect(pipe.transform(12, ['EUR', false, '.2'])).toEqual('EUR12.00');
+      describe("transform", () => {
+        it('should return correct value for numbers', () => {
+          expect(pipe.transform(123, [])).toEqual('USD123');
+          expect(pipe.transform(12, ['EUR', false, '.2'])).toEqual('EUR12.00');
+        });
+
+        it("should not support other objects",
+           () => { expect(() => pipe.transform(new Object(), [])).toThrowError(); });
       });
-
-      it("should not support other objects",
-         () => { expect(() => pipe.transform(new Object(), [])).toThrowError(); });
     });
-  });
+  }
 }


### PR DESCRIPTION
As discussed with @mhevery , let's disable these tests until we have a proper l10n solution.
This will unblock integrating more browsers to CI (see issue #3333).
