### PR TITLE
fix(router): subscribe should return subscription

### DIFF
--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -242,8 +242,8 @@ export class Router {
   /**
    * Subscribe to URL updates from the router
    */
-  subscribe(onNext: (value: any) => void): void {
-    ObservableWrapper.subscribe(this._subject, onNext);
+  subscribe(onNext: (value: any) => void): Object {
+    return ObservableWrapper.subscribe(this._subject, onNext);
   }
 
 


### PR DESCRIPTION
I don't think this change needs a test– this method itself is already called as a part of other tests, and the behavior of the subscription object returned doesn't need to be tested here.

Closes #3491 
