### PR TITLE
refactor(reflection): Store injectable info on the injectable object

### DIFF
--- a/modules/angular2/src/facade/lang.dart
+++ b/modules/angular2/src/facade/lang.dart
@@ -1,6 +1,6 @@
 library angular.core.facade.lang;
 
-export 'dart:core' show Type, RegExp, print, DateTime;
+export 'dart:core' show DateTime, RegExp, Type, print;
 import 'dart:math' as math;
 import 'dart:convert' as convert;
 import 'dart:async' show Future;
@@ -291,6 +291,22 @@ class DateWrapper {
   static String toJson(DateTime date) {
     return date.toUtc().toIso8601String();
   }
+}
+
+class ExpandoWrapper<T> {
+  static int _counter = 0;
+  final Expando<T> _expando;
+
+  ExpandoWrapper([String name]) : _expando = new Expando<T>(name);
+
+  String getName() => _expando.name;
+
+  T set(Object o, T v) {
+    _expando[o] = v;
+    return v;
+  }
+
+  T get(Object o) => _expando[o];
 }
 
 // needed to match the exports from lang.js

--- a/modules/angular2/src/facade/lang.ts
+++ b/modules/angular2/src/facade/lang.ts
@@ -347,3 +347,19 @@ export class DateWrapper {
   static now(): Date { return new Date(); }
   static toJson(date: Date): string { return date.toJSON(); }
 }
+
+export class ExpandoWrapper<T> {
+  static _counter: int = 0;
+  _name: string;
+  _propName: string;
+
+  constructor(private _name: string = null) {
+    var name = this._name || 'prop';
+    this._propName = `${name}${ExpandoWrapper._counter++}`;
+  }
+
+  getName(): string { return this._name; }
+
+  set(o: Object, v: T): T { return o[this._propName] = v; }
+  get(o: Object): T { return o.hasOwnProperty(this._propName) ? o[this._propName] : null; }
+}

--- a/modules/angular2/src/reflection/reflector.ts
+++ b/modules/angular2/src/reflection/reflector.ts
@@ -1,4 +1,4 @@
-import {Type, isPresent, stringify, BaseException} from 'angular2/src/facade/lang';
+import {ExpandoWrapper, Type, isPresent, stringify, BaseException} from 'angular2/src/facade/lang';
 import {
   List,
   ListWrapper,
@@ -28,14 +28,14 @@ export class ReflectionInfo {
 }
 
 export class Reflector {
-  _injectableInfo: Map<any, ReflectionInfo>;
+  _injectableInfo: ExpandoWrapper<ReflectionInfo>;
   _getters: Map<string, GetterFn>;
   _setters: Map<string, SetterFn>;
   _methods: Map<string, MethodFn>;
   reflectionCapabilities: PlatformReflectionCapabilities;
 
   constructor(reflectionCapabilities: PlatformReflectionCapabilities) {
-    this._injectableInfo = new Map();
+    this._injectableInfo = new ExpandoWrapper<ReflectionInfo>('injectable_info');
     this._getters = new Map();
     this._setters = new Map();
     this._methods = new Map();
@@ -74,7 +74,7 @@ export class Reflector {
   }
 
   parameters(typeOrFunc: /*Type*/ any): List<any> {
-    if (this._injectableInfo.has(typeOrFunc)) {
+    if (this._containsReflectionInfo(typeOrFunc)) {
       var res = this._injectableInfo.get(typeOrFunc)._parameters;
       return isPresent(res) ? res : [];
     } else {
@@ -83,7 +83,7 @@ export class Reflector {
   }
 
   annotations(typeOrFunc: /*Type*/ any): List<any> {
-    if (this._injectableInfo.has(typeOrFunc)) {
+    if (this._containsReflectionInfo(typeOrFunc)) {
       var res = this._injectableInfo.get(typeOrFunc)._annotations;
       return isPresent(res) ? res : [];
     } else {
@@ -92,7 +92,7 @@ export class Reflector {
   }
 
   interfaces(type: Type): List<any> {
-    if (this._injectableInfo.has(type)) {
+    if (this._containsReflectionInfo(type)) {
       var res = this._injectableInfo.get(type)._interfaces;
       return isPresent(res) ? res : [];
     } else {
@@ -124,7 +124,7 @@ export class Reflector {
     }
   }
 
-  _containsReflectionInfo(typeOrFunc) { return this._injectableInfo.has(typeOrFunc); }
+  _containsReflectionInfo(typeOrFunc) { return isPresent(this._injectableInfo.get(typeOrFunc)); }
 }
 
 function _mergeMaps(target: Map<any, any>, config: StringMap<string, Function>): void {

--- a/modules/angular2/test/facade/lang_spec.ts
+++ b/modules/angular2/test/facade/lang_spec.ts
@@ -1,6 +1,7 @@
 import {describe, it, expect, beforeEach, ddescribe, iit, xit, el} from 'angular2/test_lib';
 import {
   isPresent,
+  ExpandoWrapper,
   RegExpWrapper,
   RegExpMatcherWrapper,
   StringWrapper,
@@ -59,6 +60,38 @@ export function main() {
       var str = StringWrapper.toLowerCase(upper);
 
       expect(str).toEqual(lower);
+    });
+  });
+
+  describe('ExpandoWrapper', () => {
+    var wrapper = new ExpandoWrapper<string>('test');
+
+    it('should store and retrieve values', () => {
+      var obj = {};
+
+      expect(wrapper.set(obj, 'value')).toEqual('value');
+      expect(wrapper.get(obj)).toEqual('value');
+    });
+
+    it('should return `null` for unset keys', () => { expect(wrapper.get({})).toEqual(null); });
+
+    it('should not confuse different expandos with the same name', () => {
+      var confusing = new ExpandoWrapper<string>('test');
+      var obj = {};
+
+      wrapper.set(obj, 'original');
+      confusing.set(obj, 'different');
+
+      expect(wrapper.get(obj)).toEqual('original');
+      expect(confusing.get(obj)).toEqual('different');
+    });
+
+    it('should tolerate unnamed creation', () => {
+      var nameless = new ExpandoWrapper<string>();
+      var obj = {};
+
+      expect(nameless.set(obj, 'value')).toEqual('value');
+      expect(nameless.get(obj)).toEqual('value');
     });
   });
 }


### PR DESCRIPTION
Previously, information about injectable objects was stored in a big map
with `Type`s as keys and info as values.

This updates that implementation detail to store that information as a
property on the `Type` object itself, which may provide benefits for
`dart2js` generated code.
