### PR TITLE
feat(change_detection): do not reparse AST when using generated detec…

### DIFF
--- a/modules/angular2/src/change_detection/change_detection.ts
+++ b/modules/angular2/src/change_detection/change_detection.ts
@@ -38,7 +38,7 @@ export {
 } from './interfaces';
 export {CHECK_ONCE, CHECK_ALWAYS, DETACHED, CHECKED, ON_PUSH, DEFAULT} from './constants';
 export {DynamicProtoChangeDetector} from './proto_change_detector';
-export {BindingRecord} from './binding_record';
+export {BindingRecord, BindingTarget} from './binding_record';
 export {DirectiveIndex, DirectiveRecord} from './directive_record';
 export {DynamicChangeDetector} from './dynamic_change_detector';
 export {ChangeDetectorRef} from './change_detector_ref';
@@ -93,13 +93,14 @@ export class PreGeneratedChangeDetection extends ChangeDetection {
 
   static isSupported(): boolean { return PregenProtoChangeDetector.isSupported(); }
 
-  createProtoChangeDetector(definition: ChangeDetectorDefinition): ProtoChangeDetector {
-    var id = definition.id;
+  getProtoChangeDetector(id: string, definition: ChangeDetectorDefinition): ProtoChangeDetector {
     if (StringMapWrapper.contains(this._protoChangeDetectorFactories, id)) {
       return StringMapWrapper.get(this._protoChangeDetectorFactories, id)(definition);
     }
-    return this._dynamicChangeDetection.createProtoChangeDetector(definition);
+    return this._dynamicChangeDetection.getProtoChangeDetector(id, definition);
   }
+
+  get generateDetectors(): boolean { return true; }
 }
 
 
@@ -110,9 +111,11 @@ export class PreGeneratedChangeDetection extends ChangeDetection {
  */
 @Injectable()
 export class DynamicChangeDetection extends ChangeDetection {
-  createProtoChangeDetector(definition: ChangeDetectorDefinition): ProtoChangeDetector {
+  getProtoChangeDetector(id: string, definition: ChangeDetectorDefinition): ProtoChangeDetector {
     return new DynamicProtoChangeDetector(definition);
   }
+
+  get generateDetectors(): boolean { return true; }
 }
 
 /**
@@ -126,7 +129,9 @@ export class DynamicChangeDetection extends ChangeDetection {
 export class JitChangeDetection extends ChangeDetection {
   static isSupported(): boolean { return JitProtoChangeDetector.isSupported(); }
 
-  createProtoChangeDetector(definition: ChangeDetectorDefinition): ProtoChangeDetector {
+  getProtoChangeDetector(id: string, definition: ChangeDetectorDefinition): ProtoChangeDetector {
     return new JitProtoChangeDetector(definition);
   }
+
+  get generateDetectors(): boolean { return true; }
 }

--- a/modules/angular2/src/change_detection/change_detection_util.ts
+++ b/modules/angular2/src/change_detection/change_detection_util.ts
@@ -16,6 +16,8 @@ import {
   isDefaultChangeDetectionStrategy
 } from './constants';
 import {implementsOnDestroy} from './pipe_lifecycle_reflector';
+import {BindingTarget} from './binding_record';
+import {DirectiveIndex} from './directive_record';
 
 
 /**
@@ -200,5 +202,14 @@ export class ChangeDetectionUtil {
     if (implementsOnDestroy(pipe)) {
       pipe.onDestroy();
     }
+  }
+
+  static bindingTarget(mode: string, elementIndex: number, name: string, unit: string,
+                       debug: string): BindingTarget {
+    return new BindingTarget(mode, elementIndex, name, unit, debug);
+  }
+
+  static directiveIndex(elementIndex: number, directiveIndex: number): DirectiveIndex {
+    return new DirectiveIndex(elementIndex, directiveIndex);
   }
 }

--- a/modules/angular2/src/change_detection/coalesce.ts
+++ b/modules/angular2/src/change_detection/coalesce.ts
@@ -44,8 +44,8 @@ export function coalesce(records: ProtoRecord[]): ProtoRecord[] {
 
 function _selfRecord(r: ProtoRecord, contextIndex: number, selfIndex: number): ProtoRecord {
   return new ProtoRecord(RecordType.SELF, "self", null, [], r.fixedArgs, contextIndex,
-                         r.directiveIndex, selfIndex, r.bindingRecord, r.expressionAsString,
-                         r.lastInBinding, r.lastInDirective, false, false);
+                         r.directiveIndex, selfIndex, r.bindingRecord, r.lastInBinding,
+                         r.lastInDirective, false, false, r.propertyBindingIndex);
 }
 
 function _findMatching(r: ProtoRecord, rs: List<ProtoRecord>) {
@@ -70,9 +70,9 @@ function _replaceIndices(r: ProtoRecord, selfIndex: number, indexMap: Map<any, a
   var args = ListWrapper.map(r.args, (a) => _map(indexMap, a));
   var contextIndex = _map(indexMap, r.contextIndex);
   return new ProtoRecord(r.mode, r.name, r.funcOrValue, args, r.fixedArgs, contextIndex,
-                         r.directiveIndex, selfIndex, r.bindingRecord, r.expressionAsString,
-                         r.lastInBinding, r.lastInDirective, r.argumentToPureFunction,
-                         r.referencedBySelf);
+                         r.directiveIndex, selfIndex, r.bindingRecord, r.lastInBinding,
+                         r.lastInDirective, r.argumentToPureFunction, r.referencedBySelf,
+                         r.propertyBindingIndex);
 }
 
 function _map(indexMap: Map<any, any>, value: number) {

--- a/modules/angular2/src/change_detection/codegen_logic_util.ts
+++ b/modules/angular2/src/change_detection/codegen_logic_util.ts
@@ -1,8 +1,9 @@
 import {ListWrapper} from 'angular2/src/facade/collection';
-import {BaseException, Json, StringWrapper} from 'angular2/src/facade/lang';
+import {BaseException, Json, StringWrapper, isPresent, isBlank} from 'angular2/src/facade/lang';
 import {CodegenNameUtil} from './codegen_name_util';
 import {codify, combineGeneratedStrings, rawString} from './codegen_facade';
 import {ProtoRecord, RecordType} from './proto_record';
+import {BindingTarget} from './binding_record';
 import {DirectiveRecord} from './directive_record';
 
 /**
@@ -121,6 +122,23 @@ export class CodegenLogicUtil {
     } else {
       return exp;
     }
+  }
+
+  genPropertyBindingTargets(propertyBindingTargets: BindingTarget[], devMode: boolean): string {
+    var bs = propertyBindingTargets.map(b => {
+      if (isBlank(b)) return "null";
+
+      var debug = devMode ? codify(b.debug) : "null";
+      return `${this._utilName}.bindingTarget(${codify(b.mode)}, ${b.elementIndex}, ${codify(b.name)}, ${codify(b.unit)}, ${debug})`;
+    });
+    return `[${bs.join(", ")}]`;
+  }
+
+  genDirectiveIndices(directiveRecords: DirectiveRecord[]): string {
+    var bs = directiveRecords.map(
+        b =>
+            `${this._utilName}.directiveIndex(${b.directiveIndex.elementIndex}, ${b.directiveIndex.directiveIndex})`);
+    return `[${bs.join(", ")}]`;
   }
 
   _genInterpolation(protoRec: ProtoRecord): string {

--- a/modules/angular2/src/change_detection/codegen_name_util.ts
+++ b/modules/angular2/src/change_detection/codegen_name_util.ts
@@ -10,8 +10,8 @@ import {EventBinding} from './event_binding';
 // detection will fail.
 const _ALREADY_CHECKED_ACCESSOR = "alreadyChecked";
 const _CONTEXT_ACCESSOR = "context";
-const _FIRST_PROTO_IN_CURRENT_BINDING = "firstProtoInCurrentBinding";
-const _DIRECTIVES_ACCESSOR = "directiveRecords";
+const _PROP_BINDING_INDEX = "propertyBindingIndex";
+const _DIRECTIVES_ACCESSOR = "directiveIndices";
 const _DISPATCHER_ACCESSOR = "dispatcher";
 const _LOCALS_ACCESSOR = "locals";
 const _MODE_ACCESSOR = "mode";
@@ -79,9 +79,7 @@ export class CodegenNameUtil {
 
   getModeName(): string { return this._addFieldPrefix(_MODE_ACCESSOR); }
 
-  getFirstProtoInCurrentBinding(): string {
-    return this._addFieldPrefix(_FIRST_PROTO_IN_CURRENT_BINDING);
-  }
+  getPropertyBindingIndex(): string { return this._addFieldPrefix(_PROP_BINDING_INDEX); }
 
   getLocalName(idx: int): string { return `l_${this._sanitizedNames[idx]}`; }
 

--- a/modules/angular2/src/change_detection/exceptions.ts
+++ b/modules/angular2/src/change_detection/exceptions.ts
@@ -1,4 +1,3 @@
-import {ProtoRecord} from './proto_record';
 import {BaseException} from "angular2/src/facade/lang";
 
 /**
@@ -11,9 +10,9 @@ import {BaseException} from "angular2/src/facade/lang";
  * This exception is only thrown in dev mode.
  */
 export class ExpressionChangedAfterItHasBeenCheckedException extends BaseException {
-  constructor(proto: ProtoRecord, change: any, context: any) {
-    super(`Expression '${proto.expressionAsString}' has changed after it was checked. ` +
-          `Previous value: '${change.previousValue}'. Current value: '${change.currentValue}'`);
+  constructor(exp: string, oldValue: any, currValue: any, context: any) {
+    super(`Expression '${exp}' has changed after it was checked. ` +
+          `Previous value: '${oldValue}'. Current value: '${currValue}'`);
   }
 }
 
@@ -28,10 +27,9 @@ export class ChangeDetectionError extends BaseException {
    */
   location: string;
 
-  constructor(proto: ProtoRecord, originalException: any, originalStack: any, context: any) {
-    super(`${originalException} in [${proto.expressionAsString}]`, originalException, originalStack,
-          context);
-    this.location = proto.expressionAsString;
+  constructor(exp: string, originalException: any, originalStack: any, context: any) {
+    super(`${originalException} in [${exp}]`, originalException, originalStack, context);
+    this.location = exp;
   }
 }
 

--- a/modules/angular2/src/change_detection/interfaces.ts
+++ b/modules/angular2/src/change_detection/interfaces.ts
@@ -1,7 +1,7 @@
 import {List} from 'angular2/src/facade/collection';
 import {CONST} from 'angular2/src/facade/lang';
 import {Locals} from './parser/locals';
-import {BindingRecord} from './binding_record';
+import {BindingTarget, BindingRecord} from './binding_record';
 import {DirectiveIndex, DirectiveRecord} from './directive_record';
 import {ChangeDetectorRef} from './change_detector_ref';
 
@@ -32,9 +32,11 @@ import {ChangeDetectorRef} from './change_detector_ref';
  */
 @CONST()
 export class ChangeDetection {
-  createProtoChangeDetector(definition: ChangeDetectorDefinition): ProtoChangeDetector {
+  getProtoChangeDetector(id: string, definition: ChangeDetectorDefinition): ProtoChangeDetector {
     return null;
   }
+
+  get generateDetectors(): boolean { return null; }
 }
 
 export class DebugContext {
@@ -44,7 +46,7 @@ export class DebugContext {
 
 export interface ChangeDispatcher {
   getDebugContext(elementIndex: number, directiveIndex: DirectiveIndex): DebugContext;
-  notifyOnBinding(bindingRecord: BindingRecord, value: any): void;
+  notifyOnBinding(bindingTarget: BindingTarget, value: any): void;
   notifyOnAllChangesDone(): void;
 }
 
@@ -72,5 +74,5 @@ export interface ProtoChangeDetector { instantiate(dispatcher: ChangeDispatcher)
 export class ChangeDetectorDefinition {
   constructor(public id: string, public strategy: string, public variableNames: List<string>,
               public bindingRecords: BindingRecord[], public eventRecords: BindingRecord[],
-              public directiveRecords: DirectiveRecord[], public generateCheckNoChanges: boolean) {}
+              public directiveRecords: DirectiveRecord[], public devMode: boolean) {}
 }

--- a/modules/angular2/src/change_detection/jit_proto_change_detector.ts
+++ b/modules/angular2/src/change_detection/jit_proto_change_detector.ts
@@ -1,4 +1,5 @@
 import {ListWrapper} from 'angular2/src/facade/collection';
+import {isPresent} from 'angular2/src/facade/lang';
 
 import {ProtoChangeDetector, ChangeDetector, ChangeDetectorDefinition} from './interfaces';
 import {ChangeDetectorJITGenerator} from './change_detection_jit_generator';
@@ -20,9 +21,11 @@ export class JitProtoChangeDetector implements ProtoChangeDetector {
   _createFactory(definition: ChangeDetectorDefinition) {
     var propertyBindingRecords = createPropertyRecords(definition);
     var eventBindingRecords = createEventRecords(definition);
+    var propertyBindingTargets = this.definition.bindingRecords.map(b => b.target);
+
     return new ChangeDetectorJITGenerator(
-               definition.id, definition.strategy, propertyBindingRecords, eventBindingRecords,
-               this.definition.directiveRecords, this.definition.generateCheckNoChanges)
+               definition.id, definition.strategy, propertyBindingRecords, propertyBindingTargets,
+               eventBindingRecords, this.definition.directiveRecords, this.definition.devMode)
         .generate();
   }
 }

--- a/modules/angular2/src/change_detection/pregen_proto_change_detector.dart
+++ b/modules/angular2/src/change_detection/pregen_proto_change_detector.dart
@@ -1,10 +1,6 @@
 library angular2.src.change_detection.pregen_proto_change_detector;
 
-import 'package:angular2/src/change_detection/coalesce.dart';
-import 'package:angular2/src/change_detection/directive_record.dart';
 import 'package:angular2/src/change_detection/interfaces.dart';
-import 'package:angular2/src/change_detection/proto_change_detector.dart';
-import 'package:angular2/src/change_detection/proto_record.dart';
 import 'package:angular2/src/facade/lang.dart' show looseIdentical;
 
 export 'dart:core' show List;
@@ -26,8 +22,7 @@ export 'package:angular2/src/facade/lang.dart' show looseIdentical;
 typedef ProtoChangeDetector PregenProtoChangeDetectorFactory(
     ChangeDetectorDefinition definition);
 
-typedef ChangeDetector InstantiateMethod(dynamic dispatcher,
-    List<ProtoRecord> protoRecords, List<DirectiveRecord> directiveRecords);
+typedef ChangeDetector InstantiateMethod(dynamic dispatcher);
 
 /// Implementation of [ProtoChangeDetector] for use by pre-generated change
 /// detectors in Angular 2 Dart.
@@ -41,31 +36,18 @@ class PregenProtoChangeDetector extends ProtoChangeDetector {
   /// Closure used to generate an actual [ChangeDetector].
   final InstantiateMethod _instantiateMethod;
 
-  // [ChangeDetector] dependencies.
-  final List<ProtoRecord> _protoRecords;
-  final List<DirectiveRecord> _directiveRecords;
-
   /// Internal ctor.
-  PregenProtoChangeDetector._(this.id, this._instantiateMethod,
-      this._protoRecords, this._directiveRecords);
+  PregenProtoChangeDetector._(this.id, this._instantiateMethod);
 
   static bool isSupported() => true;
 
   factory PregenProtoChangeDetector(
       InstantiateMethod instantiateMethod, ChangeDetectorDefinition def) {
-    // TODO(kegluneq): Pre-generate these (#2067).
-    var recordBuilder = new ProtoRecordBuilder();
-    def.bindingRecords.forEach((b) {
-      recordBuilder.add(b, def.variableNames);
-    });
-    var protoRecords = coalesce(recordBuilder.records);
-    return new PregenProtoChangeDetector._(
-        def.id, instantiateMethod, protoRecords, def.directiveRecords);
+    return new PregenProtoChangeDetector._(def.id, instantiateMethod);
   }
 
   @override
-  instantiate(dynamic dispatcher) =>
-      _instantiateMethod(dispatcher, _protoRecords, _directiveRecords);
+  instantiate(dynamic dispatcher) => _instantiateMethod(dispatcher);
 }
 
 /// Provided as an optimization to cut down on '!' characters in generated

--- a/modules/angular2/src/change_detection/proto_record.ts
+++ b/modules/angular2/src/change_detection/proto_record.ts
@@ -26,9 +26,9 @@ export class ProtoRecord {
   constructor(public mode: RecordType, public name: string, public funcOrValue,
               public args: List<any>, public fixedArgs: List<any>, public contextIndex: number,
               public directiveIndex: DirectiveIndex, public selfIndex: number,
-              public bindingRecord: BindingRecord, public expressionAsString: string,
-              public lastInBinding: boolean, public lastInDirective: boolean,
-              public argumentToPureFunction: boolean, public referencedBySelf: boolean) {}
+              public bindingRecord: BindingRecord, public lastInBinding: boolean,
+              public lastInDirective: boolean, public argumentToPureFunction: boolean,
+              public referencedBySelf: boolean, public propertyBindingIndex: number) {}
 
   isPureFunction(): boolean {
     return this.mode === RecordType.INTERPOLATE || this.mode === RecordType.COLLECTION_LITERAL;

--- a/modules/angular2/src/core/compiler/view.ts
+++ b/modules/angular2/src/core/compiler/view.ts
@@ -8,12 +8,12 @@ import {
 } from 'angular2/src/facade/collection';
 import {
   AST,
-  BindingRecord,
   ChangeDetector,
   ChangeDetectorRef,
   ChangeDispatcher,
   DirectiveIndex,
   DirectiveRecord,
+  BindingTarget,
   Locals,
   ProtoChangeDetector
 } from 'angular2/src/change_detection/change_detection';
@@ -171,7 +171,7 @@ export class AppView implements ChangeDispatcher, RenderEventDispatcher {
   }
 
   // dispatch to element injector or text nodes based on context
-  notifyOnBinding(b: BindingRecord, currentValue: any): void {
+  notifyOnBinding(b: BindingTarget, currentValue: any): void {
     if (b.isTextNode()) {
       this.renderer.setText(
           this.render, this.mainMergeMapping.renderTextIndices[b.elementIndex + this.textOffset],
@@ -179,14 +179,14 @@ export class AppView implements ChangeDispatcher, RenderEventDispatcher {
     } else {
       var elementRef = this.elementRefs[this.elementOffset + b.elementIndex];
       if (b.isElementProperty()) {
-        this.renderer.setElementProperty(elementRef, b.propertyName, currentValue);
+        this.renderer.setElementProperty(elementRef, b.name, currentValue);
       } else if (b.isElementAttribute()) {
-        this.renderer.setElementAttribute(elementRef, b.propertyName, currentValue);
+        this.renderer.setElementAttribute(elementRef, b.name, currentValue);
       } else if (b.isElementClass()) {
-        this.renderer.setElementClass(elementRef, b.propertyName, currentValue);
+        this.renderer.setElementClass(elementRef, b.name, currentValue);
       } else if (b.isElementStyle()) {
-        var unit = isPresent(b.propertyUnit) ? b.propertyUnit : '';
-        this.renderer.setElementStyle(elementRef, b.propertyName, `${currentValue}${unit}`);
+        var unit = isPresent(b.unit) ? b.unit : '';
+        this.renderer.setElementStyle(elementRef, b.name, `${currentValue}${unit}`);
       } else {
         throw new BaseException('Unsupported directive record');
       }

--- a/modules/angular2/src/facade/collection.dart
+++ b/modules/angular2/src/facade/collection.dart
@@ -134,6 +134,12 @@ class ListWrapper {
     list.forEach(fn);
   }
 
+  static void forEachWithIndex(List list, fn(item, index)) {
+    for (var i = 0; i < list.length; ++i) {
+      fn(list[i], i);
+    }
+  }
+
   static reduce(List list, fn(a, b), init) {
     return list.fold(init, fn);
   }

--- a/modules/angular2/src/facade/collection.ts
+++ b/modules/angular2/src/facade/collection.ts
@@ -182,6 +182,11 @@ export class ListWrapper {
       fn(array[i]);
     }
   }
+  static forEachWithIndex<T>(array: List<T>, fn: (T, number) => void) {
+    for (var i = 0; i < array.length; i++) {
+      fn(array[i], i);
+    }
+  }
   static first<T>(array: List<T>): T {
     if (!array) return null;
     return array[0];

--- a/modules/angular2/src/transform/template_compiler/reflection/reflection_capabilities.dart
+++ b/modules/angular2/src/transform/template_compiler/reflection/reflection_capabilities.dart
@@ -14,7 +14,7 @@ class NullReflectionCapabilities implements ReflectionCapabilities {
     return false;
   }
 
-  Function factory(Type type) => _notImplemented('factory');
+  Function factory(Type type) => _notImplemented("factory");
 
   List<List> parameters(typeOrFunc) => _notImplemented('parameters');
 

--- a/modules/angular2/test/change_detection/change_detection_spec.ts
+++ b/modules/angular2/test/change_detection/change_detection_spec.ts
@@ -30,12 +30,12 @@ export function main() {
       var map = {'id': (def) => proto};
       var cd = new PreGeneratedChangeDetection(map);
 
-      expect(cd.createProtoChangeDetector(def)).toBe(proto)
+      expect(cd.getProtoChangeDetector('id', def)).toBe(proto)
     });
 
     it("should delegate to dynamic change detection otherwise", () => {
       var cd = new PreGeneratedChangeDetection({});
-      expect(cd.createProtoChangeDetector(def)).toBeAnInstanceOf(DynamicProtoChangeDetector);
+      expect(cd.getProtoChangeDetector('id', def)).toBeAnInstanceOf(DynamicProtoChangeDetector);
     });
   });
 }

--- a/modules/angular2/test/change_detection/change_detector_spec.ts
+++ b/modules/angular2/test/change_detection/change_detector_spec.ts
@@ -1135,8 +1135,8 @@ class TestDispatcher implements ChangeDispatcher {
     this.onAllChangesDoneCalled = true;
   }
 
-  notifyOnBinding(binding, value) {
-    this.log.push(`${binding.propertyName}=${this._asString(value)}`);
+  notifyOnBinding(target, value) {
+    this.log.push(`${target.name}=${this._asString(value)}`);
     this.loggedValues.push(value);
   }
 

--- a/modules/angular2/test/change_detection/coalesce_spec.ts
+++ b/modules/angular2/test/change_detection/coalesce_spec.ts
@@ -21,8 +21,7 @@ export function main() {
     if (isBlank(argumentToPureFunction)) argumentToPureFunction = false;
 
     return new ProtoRecord(mode, name, funcOrValue, args, null, contextIndex, directiveIndex,
-                           selfIndex, null, null, lastInBinding, false, argumentToPureFunction,
-                           false);
+                           selfIndex, null, lastInBinding, false, argumentToPureFunction, false, 0);
   }
 
   describe("change detection - coalesce", () => {
@@ -64,7 +63,7 @@ export function main() {
           [r("user", [], 0, 1, {lastInBinding: true}), r("user", [], 0, 2, {lastInBinding: true})]);
 
       expect(rs[1]).toEqual(new ProtoRecord(RecordType.SELF, "self", null, [], null, 1, null, 2,
-                                            null, null, true, false, false, false));
+                                            null, true, false, false, false, 0));
     });
 
     it("should set referencedBySelf", () => {

--- a/modules/angular2/test/change_detection/proto_record_builder_spec.ts
+++ b/modules/angular2/test/change_detection/proto_record_builder_spec.ts
@@ -19,7 +19,7 @@ export function main() {
     it('should set argumentToPureFunction flag', inject([Parser], (p: Parser) => {
          var builder = new ProtoRecordBuilder();
          var ast = p.parseBinding("[1,2]", "location");  // collection literal is a pure function
-         builder.add(BindingRecord.createForElementProperty(ast, 0, "property"), []);
+         builder.add(BindingRecord.createForElementProperty(ast, 0, "property"), [], 0);
 
          var isPureFunc = builder.records.map(r => r.argumentToPureFunction);
          expect(isPureFunc).toEqual([true, true, false]);
@@ -29,7 +29,7 @@ export function main() {
        inject([Parser], (p: Parser) => {
          var builder = new ProtoRecordBuilder();
          var ast = p.parseBinding("f(1,2)", "location");
-         builder.add(BindingRecord.createForElementProperty(ast, 0, "property"), []);
+         builder.add(BindingRecord.createForElementProperty(ast, 0, "property"), [], 0);
 
          var isPureFunc = builder.records.map(r => r.argumentToPureFunction);
          expect(isPureFunc).toEqual([false, false, false]);

--- a/modules/angular2/test/change_detection/proto_record_spec.ts
+++ b/modules/angular2/test/change_detection/proto_record_spec.ts
@@ -20,8 +20,8 @@ export function main() {
     if (isBlank(argumentToPureFunction)) argumentToPureFunction = false;
     if (isBlank(referencedBySelf)) referencedBySelf = false;
 
-    return new ProtoRecord(mode, name, null, [], null, 0, directiveIndex, 0, null, null,
-                           lastInBinding, false, argumentToPureFunction, referencedBySelf);
+    return new ProtoRecord(mode, name, null, [], null, 0, directiveIndex, 0, null, lastInBinding,
+                           false, argumentToPureFunction, referencedBySelf, 0);
   }
 
   describe("ProtoRecord", () => {

--- a/modules/angular2/test/core/compiler/element_injector_spec.ts
+++ b/modules/angular2/test/core/compiler/element_injector_spec.ts
@@ -980,7 +980,7 @@ export function main() {
           });
 
           it("should inject ChangeDetectorRef of the component's view into the component", () => {
-            var cd = new DynamicChangeDetector(null, null, null, [], [], []);
+            var cd = new DynamicChangeDetector(null, null, 0, [], [], null, [], [], []);
             var view = <any>new DummyView();
             var childView = new DummyView();
             childView.changeDetector = cd;
@@ -993,7 +993,7 @@ export function main() {
           });
 
           it("should inject ChangeDetectorRef of the containing component into directives", () => {
-            var cd = new DynamicChangeDetector(null, null, null, [], [], []);
+            var cd = new DynamicChangeDetector(null, null, 0, [], [], null, [], [], []);
             var view = <any>new DummyView();
             view.changeDetector =cd;
             var binding = DirectiveBinding.createFromType(DirectiveNeedsChangeDetectorRef, new DirectiveMetadata());

--- a/modules/angular2/test/facade/collection_spec.ts
+++ b/modules/angular2/test/facade/collection_spec.ts
@@ -90,6 +90,18 @@ export function main() {
       it('should return null for an empty list',
          () => { expect(ListWrapper.maximum([], x => x)).toEqual(null); });
     });
+
+    describe('forEachWithIndex', () => {
+      var l;
+
+      beforeEach(() => { l = ["a", "b"]; });
+
+      it('should iterate over an array passing values and indices', () => {
+        var record = [];
+        ListWrapper.forEachWithIndex(l, (value, index) => record.push([value, index]));
+        expect(record).toEqual([["a", 0], ["b", 1]]);
+      });
+    });
   });
 
   describe('StringMapWrapper', () => {

--- a/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
+++ b/modules/angular2/test/transform/integration/two_annotations_files/expected/bar.ng_deps.dart
@@ -13,12 +13,10 @@ void initReflector() {
   if (_visited) return;
   _visited = true;
   _ngRef.reflector
-    ..registerType(
-        MyComponent,
-        new _ngRef.ReflectionInfo(const [
-          const Component(selector: '[soup]'),
-          const View(template: 'Salad: {{myNum}} is awesome')
-        ], const [], () => new MyComponent()))
+    ..registerType(MyComponent, new _ngRef.ReflectionInfo(const [
+      const Component(selector: '[soup]'),
+      const View(template: 'Salad: {{myNum}} is awesome')
+    ], const [], () => new MyComponent()))
     ..registerGetters({'myNum': (o) => o.myNum});
   _gen.preGeneratedProtoDetectors['MyComponent_comp_0'] =
       _MyComponent_ChangeDetector0.newProtoChangeDetector;
@@ -28,19 +26,23 @@ class _MyComponent_ChangeDetector0
     extends _gen.AbstractChangeDetector<MyComponent> {
   var myNum0, interpolate1;
 
-  _MyComponent_ChangeDetector0(dispatcher, protos, directiveRecords)
-      : super("MyComponent_comp_0", dispatcher, protos, directiveRecords,
-            'ALWAYS_CHECK') {
+  _MyComponent_ChangeDetector0(dispatcher) : super(
+          "MyComponent_comp_0", dispatcher, 2,
+          _MyComponent_ChangeDetector0.gen_propertyBindingTargets,
+          _MyComponent_ChangeDetector0.gen_directiveIndices, 'ALWAYS_CHECK') {
     dehydrateDirectives(false);
   }
 
   void detectChangesInRecordsInternal(throwOnChange) {
-    var l_context = this.context, l_myNum0, c_myNum0, l_interpolate1;
+    var l_context = this.context,
+        l_myNum0,
+        c_myNum0,
+        l_interpolate1;
     c_myNum0 = false;
     var isChanged = false;
     var changes = null;
 
-    this.firstProtoInCurrentBinding = 1;
+    this.propertyBindingIndex = 0;
     l_myNum0 = l_context.myNum;
     if (_gen.looseNotIdentical(l_myNum0, this.myNum0)) {
       c_myNum0 = true;
@@ -75,9 +77,16 @@ class _MyComponent_ChangeDetector0
     this.myNum0 = this.interpolate1 = _gen.ChangeDetectionUtil.uninitialized;
   }
 
+  static var gen_propertyBindingTargets = [
+    _gen.ChangeDetectionUtil.bindingTarget("textNode", 0, null, null,
+        "Salad: {{myNum}} is awesome in MyComponent: <template>")
+  ];
+
+  static var gen_directiveIndices = [];
+
   static _gen.ProtoChangeDetector newProtoChangeDetector(
       _gen.ChangeDetectorDefinition def) {
     return new _gen.PregenProtoChangeDetector(
-        (a, b, c) => new _MyComponent_ChangeDetector0(a, b, c), def);
+        (a) => new _MyComponent_ChangeDetector0(a), def);
   }
 }

--- a/modules/benchmarks/src/change_detection/change_detection_benchmark.ts
+++ b/modules/benchmarks/src/change_detection/change_detection_benchmark.ts
@@ -249,8 +249,8 @@ function setUpChangeDetection(changeDetection: ChangeDetection, iterations, obje
   var dispatcher = new DummyDispatcher();
   var parser = new Parser(new Lexer());
 
-  var parentProto = changeDetection.createProtoChangeDetector(
-      new ChangeDetectorDefinition('parent', null, [], [], [], [], false));
+  var parentProto = changeDetection.getProtoChangeDetector(
+      "id", new ChangeDetectorDefinition('parent', null, [], [], [], [], false));
   var parentCd = parentProto.instantiate(dispatcher);
 
   var directiveRecord = new DirectiveRecord({directiveIndex: new DirectiveIndex(0, 0)});
@@ -277,7 +277,8 @@ function setUpChangeDetection(changeDetection: ChangeDetection, iterations, obje
                                      reflector.setter("field9"), directiveRecord)
   ];
 
-  var proto = changeDetection.createProtoChangeDetector(
+  var proto = changeDetection.getProtoChangeDetector(
+      "id",
       new ChangeDetectorDefinition("proto", null, [], bindings, [], [directiveRecord], false));
 
   var targetObj = new Obj();


### PR DESCRIPTION
…tors
1. Renamed createProtoChangeDetector into getProtoChangedDetector. getProtoChangedDetector takes two arguments: id and definition. The definition object is null when using generated detectors.
2. Extracted BindingTarget from BindingRecord. BindingTarget needs to be preserved at runtime.
3. Changed AbstractChangeDetector not to use proto records.

Closes #2067
