### PR TITLE
fix(ComponentUrlMapper): support relative template URLs in Dartium

### DIFF
--- a/modules/angular2/src/core/compiler/component_url_mapper.ts
+++ b/modules/angular2/src/core/compiler/component_url_mapper.ts
@@ -1,6 +1,7 @@
 import {Injectable} from 'angular2/di';
 import {Type, isPresent} from 'angular2/src/core/facade/lang';
 import {Map, MapWrapper} from 'angular2/src/core/facade/collection';
+import {reflector} from 'angular2/src/core/reflection/reflection';
 
 /**
  * Resolve a `Type` from a {@link ComponentMetadata} into a URL.
@@ -17,7 +18,9 @@ export class ComponentUrlMapper {
    * - an absolute URL,
    * - a path relative to the application
    */
-  getUrl(component: Type): string { return './'; }
+  getUrl(component: Type): string {
+    return reflector.isReflectionEnabled() ? reflector.importUri(component) : './';
+  }
 }
 
 export class RuntimeComponentUrlMapper extends ComponentUrlMapper {

--- a/modules/angular2/src/core/reflection/platform_reflection_capabilities.ts
+++ b/modules/angular2/src/core/reflection/platform_reflection_capabilities.ts
@@ -10,4 +10,5 @@ export interface PlatformReflectionCapabilities {
   getter(name: string): GetterFn;
   setter(name: string): SetterFn;
   method(name: string): MethodFn;
+  importUri(type: Type): string;
 }

--- a/modules/angular2/src/core/reflection/reflection.dart
+++ b/modules/angular2/src/core/reflection/reflection.dart
@@ -38,6 +38,8 @@ class NoReflectionCapabilities implements PlatformReflectionCapabilities {
   MethodFn method(String name) {
     throw "Cannot find method ${name}";
   }
+
+  String importUri(Type type) => './';
 }
 
 final Reflector reflector = new Reflector(new NoReflectionCapabilities());

--- a/modules/angular2/src/core/reflection/reflection_capabilities.dart
+++ b/modules/angular2/src/core/reflection/reflection_capabilities.dart
@@ -297,4 +297,8 @@ class ReflectionCapabilities implements PlatformReflectionCapabilities {
     ClassMirror classMirror = reflectType(type);
     return classMirror.metadata;
   }
+
+  String importUri(Type type) {
+    return '${(reflectClass(type).owner as LibraryMirror).uri}';
+  }
 }

--- a/modules/angular2/src/core/reflection/reflection_capabilities.ts
+++ b/modules/angular2/src/core/reflection/reflection_capabilities.ts
@@ -155,4 +155,7 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
         return o.${name}.apply(o, args);`;
     return <MethodFn>new Function('o', 'args', functionBody);
   }
+
+  // There is not a concept of import uri in Js, but this is useful in developing Dart applications.
+  importUri(type: Type): string { return './'; }
 }

--- a/modules/angular2/src/core/reflection/reflector.ts
+++ b/modules/angular2/src/core/reflection/reflector.ts
@@ -153,6 +153,8 @@ export class Reflector {
   }
 
   _containsReflectionInfo(typeOrFunc) { return this._injectableInfo.has(typeOrFunc); }
+
+  importUri(type: Type): string { return this.reflectionCapabilities.importUri(type); }
 }
 
 function _mergeMaps(target: Map<any, any>, config: StringMap<string, Function>): void {

--- a/modules/angular2/test/core/compiler/component_url_mapper_spec.dart
+++ b/modules/angular2/test/core/compiler/component_url_mapper_spec.dart
@@ -1,0 +1,17 @@
+library angular2.test.core.compiler.component_url_mapper_spec;
+
+import 'package:angular2/test_lib.dart';
+import 'package:angular2/src/core/compiler/component_url_mapper.dart';
+
+main() {
+  describe("ComponentUrlMapper", () {
+    it("should return the URL of the component's library", () {
+      var mapper = new ComponentUrlMapper();
+      expect(mapper
+          .getUrl(SomeComponent)
+          .endsWith("core/compiler/component_url_mapper_spec.dart")).toBeTrue();
+    });
+  });
+}
+
+class SomeComponent {}

--- a/modules_dart/transform/lib/src/transform/template_compiler/reflection/reflection_capabilities.dart
+++ b/modules_dart/transform/lib/src/transform/template_compiler/reflection/reflection_capabilities.dart
@@ -10,9 +10,7 @@ class NullReflectionCapabilities implements ReflectionCapabilities {
 
   _notImplemented(String name) => throw 'Not implemented: $name';
 
-  bool isReflectionEnabled() {
-    return false;
-  }
+  bool isReflectionEnabled() => false;
 
   Function factory(Type type) => _notImplemented("factory");
 
@@ -27,6 +25,8 @@ class NullReflectionCapabilities implements ReflectionCapabilities {
   SetterFn setter(String name) => _nullSetter;
 
   MethodFn method(String name) => _nullMethod;
+
+  String importUri(Type type) => './';
 }
 
 _nullGetter(Object p) => null;


### PR DESCRIPTION
@tbosch , what do you think of this approach, adapted from munificent's https://github.com/angular/angular/pull/2827? I believe it solves the same problem but without the need for a dedicated transformer.

When running in Dartium without using transformers (i.e. with a normal
static web server), handle relative template URLs. This works by using
mirrors to get the URL of the library where the component class is
defined.

Closes #2771
