### PR TITLE
chore(build): remove references to e6-module-loader

### DIFF
--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -9,7 +9,7 @@ module.exports = function(config) {
 
     files: [
       // Sources and specs.
-      // Loaded through the es6-module-loader, in `test-main.js`.
+      // Loaded through the System loader, in `test-main.js`.
       {pattern: 'dist/js/dev/es5/**', included: false, watched: false},
 
       // zone-microtask must be included first as it contains a Promise monkey patch
@@ -18,7 +18,6 @@ module.exports = function(config) {
       'node_modules/zone.js/dist/jasmine-patch.js',
 
       'node_modules/traceur/bin/traceur-runtime.js',
-      'node_modules/es6-module-loader/dist/es6-module-loader-sans-promises.src.js',
       // Including systemjs because it defines `__eval`, which produces correct stack traces.
       'modules/angular2/src/test_lib/shims_for_IE.js',
       'node_modules/systemjs/dist/system.src.js',

--- a/tools/broccoli/html-replace/SCRIPTS.html
+++ b/tools/broccoli/html-replace/SCRIPTS.html
@@ -1,7 +1,6 @@
 <script src="zone-microtask.js" type="text/javascript"></script>
 <script src="long-stack-trace-zone.js" type="text/javascript"></script>
 <script src="traceur-runtime.js" type="text/javascript"></script>
-<script src="es6-module-loader-sans-promises.src.js" type="text/javascript"></script>
 <script src="system.src.js" type="text/javascript"></script>
 <script src="Reflect.js" type="text/javascript"></script>
 <script type="text/javascript">

--- a/tools/broccoli/html-replace/SCRIPTS_benchmarks.html
+++ b/tools/broccoli/html-replace/SCRIPTS_benchmarks.html
@@ -2,7 +2,6 @@
 <script src="long-stack-trace-zone.js" type="text/javascript"></script>
 <script src="url_params_to_form.js" type="text/javascript"></script>
 <script src="traceur-runtime.js" type="text/javascript"></script>
-<script src="es6-module-loader-sans-promises.src.js" type="text/javascript"></script>
 <script src="system.src.js" type="text/javascript"></script>
 <script src="Reflect.js" type="text/javascript"></script>
 <script type="text/javascript">

--- a/tools/broccoli/html-replace/SCRIPTS_benchmarks_external.html
+++ b/tools/broccoli/html-replace/SCRIPTS_benchmarks_external.html
@@ -3,7 +3,6 @@
 <script src="angular.js" type="text/javascript"></script>
 <script src="url_params_to_form.js" type="text/javascript"></script>
 <script src="traceur-runtime.js" type="text/javascript"></script>
-<script src="es6-module-loader-sans-promises.src.js" type="text/javascript"></script>
 <script src="system.src.js" type="text/javascript"></script>
 <script src="Reflect.js" type="text/javascript"></script>
 <script type="text/javascript">

--- a/tools/broccoli/js-replace/SCRIPTS.js
+++ b/tools/broccoli/js-replace/SCRIPTS.js
@@ -1,2 +1,2 @@
 importScripts("/examples/src/assets/zone-microtask-web-workers.js", "long-stack-trace-zone.js",
-              "traceur-runtime.js", "es6-module-loader-sans-promises.src.js", "system.src.js", "Reflect.js");
+              "traceur-runtime.js", "system.src.js", "Reflect.js");

--- a/tools/broccoli/trees/browser_tree.ts
+++ b/tools/broccoli/trees/browser_tree.ts
@@ -126,7 +126,6 @@ module.exports = function makeBrowserTree(options, destinationPath) {
     files: [
       'node_modules/zone.js/dist/zone-microtask.js',
       'node_modules/zone.js/dist/long-stack-trace-zone.js',
-      'node_modules/es6-module-loader/dist/es6-module-loader-sans-promises.src.js',
       'node_modules/systemjs/dist/system.src.js',
       'node_modules/rx/dist/rx.js',
       'node_modules/base64-js/lib/b64.js',


### PR DESCRIPTION
I believe that it is no longer necessery after migration
to a newer version of SystemJS done in e68c978202babc08408d9b78b02f9b0739019029

I'm on Linux atm so can't change package / shrinkwrap, but will push an update as soon as TravisCI gets green and I'm on Mac at home.
