### PR TITLE
fix(coreDirectives): Added an Error Message for invalid selectors

### DIFF
--- a/modules/angular2/src/core/compiler/selector.ts
+++ b/modules/angular2/src/core/compiler/selector.ts
@@ -2,6 +2,7 @@ import {Map, ListWrapper, MapWrapper} from 'angular2/src/core/facade/collection'
 import {
   isPresent,
   isBlank,
+  isString,
   RegExpWrapper,
   RegExpMatcherWrapper,
   StringWrapper
@@ -32,6 +33,10 @@ export class CssSelector {
   notSelectors: CssSelector[] = [];
 
   static parse(selector: string): CssSelector[] {
+    if (StringWrapper.equals(selector, '')) {
+      throw new BaseException('Selectors must not be an empty string');
+    }
+
     var results: CssSelector[] = [];
     var _addResult = (res: CssSelector[], cssSel) => {
       if (cssSel.notSelectors.length > 0 && isBlank(cssSel.element) &&

--- a/modules/angular2/test/core/compiler/selector_spec.ts
+++ b/modules/angular2/test/core/compiler/selector_spec.ts
@@ -230,6 +230,11 @@ export function main() {
       expect(matched.length).toEqual(2);
       expect(matched).toEqual([s1[0], 1]);
     });
+
+    it('should throw an error if the selector is an empty string', () => {
+      expect(function() { CssSelector.parse(''); })
+          .toThrowError('Selectors must not be an empty string');
+    });
   });
 
   describe('CssSelector.parse', () => {


### PR DESCRIPTION
if the component selector is an empty string, not a string, or not supplied an error will be thrown

Closes #3464
