### PR TITLE
Revert "chore(benchmarks): disable broken benchmarks"

### DIFF
--- a/protractor-dart2js.conf.js
+++ b/protractor-dart2js.conf.js
@@ -10,11 +10,8 @@ config.exclude.push(
   // TODO: remove this line when largetable dart has been added
   'dist/js/cjs/benchmarks_external/e2e_test/largetable_perf.js',
   'dist/js/cjs/benchmarks_external/e2e_test/polymer_tree_perf.js',
-  'dist/js/cjs/benchmarks_external/e2e_test/react_tree_perf.js',
-  // TODO: remove once https://github.com/angular/angular/issues/3757 is resolved
-  'dist/js/cjs/benchmarks_external/e2e_test/compiler_perf.js',
-  'dist/js/cjs/benchmarks_external/e2e_test/naive_infinite_scroll.js',
-  'dist/js/cjs/benchmarks_external/e2e_test/tree.js'
+  'dist/js/cjs/benchmarks_external/e2e_test/react_tree_perf.js'
+
 );
 
 data.createBenchpressRunner({ lang: 'dart' });

--- a/protractor-js.conf.js
+++ b/protractor-js.conf.js
@@ -5,10 +5,6 @@ config.baseUrl = 'http://localhost:8001/';
 // TODO: remove exclusion when JS verison of scrolling benchmark is available
 config.exclude.push('dist/js/cjs/benchmarks_external/e2e_test/naive_infinite_scroll_spec.js');
 config.exclude.push('dist/js/cjs/benchmarks_external/e2e_test/naive_infinite_scroll_perf.js');
-// TODO: remove once https://github.com/angular/angular/issues/3757 is resolved
-config.exclude.push('dist/js/cjs/benchmarks_external/e2e_test/compiler_perf.js');
-config.exclude.push('dist/js/cjs/benchmarks_external/e2e_test/naive_infinite_scroll.js');
-config.exclude.push('dist/js/cjs/benchmarks_external/e2e_test/tree.js');
 
 data.createBenchpressRunner({ lang: 'js' });
 


### PR DESCRIPTION
This reverts commit 09e0b0ac6ffa39844303b61eba2dae4cbb11debe and fixes #3757
