### PR TITLE
fix(compiler): directives pointing to forward ref produce an error

### DIFF
--- a/modules/angular2/src/core/compiler/compiler.ts
+++ b/modules/angular2/src/core/compiler/compiler.ts
@@ -183,7 +183,10 @@ export class Compiler {
     var directives = this._flattenDirectives(view);
 
     for (var i = 0; i < directives.length; i++) {
-      if (!Compiler._isValidDirective(directives[i])) {
+      if (!directives[i]) {
+        throw new BaseException(
+          `View annotation on '${stringify(component)}' points to non existent directive: [${directives.map(stringify).join(', ')}]`);
+      } else if (!Compiler._isValidDirective(directives[i])) {
         throw new BaseException(
             `Unexpected directive value '${stringify(directives[i])}' on the View of component '${stringify(component)}'`);
       }


### PR DESCRIPTION
Directives pointing to a forward ref throw an error with the name of the component and the list of directives instead of failing silently.

Example:

``` js
@Component({ selector: 'second-component' })
@View({ template: 'Second Component' })
class SecondComponent{ }

@Component({ selector: 'app' })
@View({
  template: '<inner-component></inner-component>',
  directives: [SecondComponent, InnerComponent]
})
class App{ }

@Component({
  selector: 'inner-component'
})
@View({ template: 'Inner Component' })
class InnerComponent{ }
```

Throws: `EXCEPTION: View annotation on 'App' points to non existent directive: [SecondComponent, undefined]`

Fixes angular/angular#3646
