### PR TITLE
feat(ProtoViewBuilder): throw for invalid event names

### DIFF
--- a/modules/angular2/src/render/dom/view/proto_view_builder.ts
+++ b/modules/angular2/src/render/dom/view/proto_view_builder.ts
@@ -21,6 +21,7 @@ import {
 import {DomProtoView, DomProtoViewRef, resolveInternalDomProtoView} from './proto_view';
 import {DomElementBinder, Event, HostAction} from './element_binder';
 import {ElementSchemaRegistry} from '../schema/element_schema_registry';
+import {DomElementSchemaRegistry} from '../schema/dom_element_schema_registry';
 import {TemplateCloner} from '../template_cloner';
 
 import {
@@ -368,10 +369,13 @@ function buildElementPropertyBindings(
   return propertyBindings;
 }
 
-function isValidElementPropertyBinding(schemaRegistry: ElementSchemaRegistry,
+function isValidElementPropertyBinding(schemaRegistry: DomElementSchemaRegistry,
                                        protoElement: /*element*/ any, isNgComponent: boolean,
                                        binding: ElementPropertyBinding): boolean {
   if (binding.type === PropertyBindingType.PROPERTY) {
+    if (!schemaRegistry.hasEvent(protoElement, binding.property)) {
+      throw new BaseException(`Can't bind to '${binding.property}' since it isn' a valid custom event name`);
+    }
     if (!isNgComponent) {
       return schemaRegistry.hasProperty(protoElement, binding.property);
     } else {

--- a/modules/angular2/test/render/dom/view/proto_view_builder_spec.ts
+++ b/modules/angular2/test/render/dom/view/proto_view_builder_spec.ts
@@ -71,6 +71,14 @@ export function main() {
                   `Can't bind to 'unknownProperty' since it isn't a known property of the '<some-custom>' element and there are no matching directives with a corresponding property`);
         });
 
+        it('should throw for invalid JS field names', () => {
+          var binder = builder.bindElement(el('<some-custom/>'));
+          binder.bindProperty('invalid-[]', emptyExpr());
+          binder.setComponentId('someComponent');
+          expect(() => builder.build(new DomElementSchemaRegistry(), templateCloner))
+            .toThrowError(
+              `Can't bind to 'invalid-[]' since it isn' a valid custom event name`);
+        });
       });
     } else {
       describe('verification of properties', () => {


### PR DESCRIPTION
This integrates #3769 to the `ProtoViewBuilder`

/cc @pkozlowski-opensource
