### PR TITLE
fix(build): always include ES5 base typings for ts2dart

### DIFF
--- a/tools/broccoli/broccoli-ts2dart.ts
+++ b/tools/broccoli/broccoli-ts2dart.ts
@@ -20,7 +20,10 @@ class TSToDartTranspiler implements DiffingBroccoliPlugin {
   }
 
   rebuild(treeDiff: DiffResult) {
-    // replace with toEmit = [] once https://github.com/angular/angular/issues/3770 is fixed
+    // Matches rootFilePaths in node_tree.ts
+    // These files are not compatible with Typescript's ES6 library
+    // so they must be explicitly included when targetting ES5, as ts2dart does.
+    // see https://github.com/angular/angular/issues/3770
     let toEmit = [path.resolve(this.inputPath, 'angular2/traceur-runtime.d.ts')];
     let getDartFilePath = (path: string) => path.replace(/((\.js)|(\.ts))$/i, '.dart');
     treeDiff.addedPaths.concat(treeDiff.changedPaths)


### PR DESCRIPTION
Fixes #3770
