### PR TITLE
fix(typings): include static members

### DIFF
--- a/docs/typescript-definition-package/templates/type-definition.template.html
+++ b/docs/typescript-definition-package/templates/type-definition.template.html
@@ -10,7 +10,7 @@
 
 {%- macro memberInfo(member) -%}
 {$ commentBlock(member, 5) $}
-     {$ member.name $}{% if member.optional %}?{% endif -%}
+     {% if member.isStatic -%}static {% endif -%}{$ member.name $}{% if member.optional %}?{% endif -%}
 {% if member.typeParameters %}<{% for typeParam in member.typeParameters %}{$ typeParam $}{% if not loop.last %}, {% endif %}{% endfor %}>{% endif -%}
 {%- if member.parameters -%}({% for param in member.parameters %}{$ param $}{% if not loop.last %}, {% endif %}{% endfor %}){%- endif -%}
 {%- if member.returnType -%}
@@ -58,6 +58,9 @@ declare module {$ module.namespace $} {
   {%- if export.callMember %}
     {$ memberInfo(export.callMember) $}
   {% endif -%}
+  {%- for static in export.statics %}
+    {$ memberInfo(static) $}
+  {%- endfor -%}
   {%- for member in export.members %}
     {$ memberInfo(member) $}
   {%- endfor %}

--- a/docs/typescript-package/processors/readTypeScriptModules.js
+++ b/docs/typescript-package/processors/readTypeScriptModules.js
@@ -64,6 +64,7 @@ module.exports = function readTypeScriptModules(tsParser, modules, getFileInfo,
           log.debug('>>>> EXPORT: ' + exportDoc.name + ' (' + exportDoc.docType + ') from ' + moduleDoc.id);
 
           exportDoc.members = [];
+          exportDoc.statics = [];
 
           // Generate docs for each of the export's members
           if (resolvedExport.flags & ts.SymbolFlags.HasMembers) {
@@ -101,6 +102,16 @@ module.exports = function readTypeScriptModules(tsParser, modules, getFileInfo,
               var memberDoc = createMemberDoc(memberSymbol, exportDoc, basePath, parseInfo.typeChecker);
               docs.push(memberDoc);
               exportDoc.members.push(memberDoc);
+            }
+          } else if (resolvedExport.flags & ts.SymbolFlags.HasExports) {
+            for (var exported in resolvedExport.exports) {
+              if (exported === 'prototype') continue;
+              if (hidePrivateMembers && exported.charAt(0) === '_') continue;
+              var memberSymbol = resolvedExport.exports[exported];
+              var memberDoc = createMemberDoc(memberSymbol, exportDoc, basePath, parseInfo.typeChecker);
+              memberDoc.isStatic = true;
+              docs.push(memberDoc);
+              exportDoc.statics.push(memberDoc);
             }
           }
 

--- a/modules/angular2/src/di/key.ts
+++ b/modules/angular2/src/di/key.ts
@@ -16,9 +16,6 @@ export {TypeLiteral} from './type_literal';
  * injector to index in arrays rather than looking up items in maps.
  */
 export class Key {
-  /**
-   * @private
-   */
   constructor(public token: Object, public id: number) {
     if (isBlank(token)) {
       throw new BaseException('Token must be defined!');


### PR DESCRIPTION
Fixes #3175 

diff:

``````
$ diff before.d.ts dist/docs/typings/angular2/angular2.d.ts
1c1
< // Type definitions for Angular v2.0.0-local_sha.65344fc

---
> // Type definitions for Angular v2.0.0-local_sha.bc2a5ee
2022a2023,2024
>      static wrap(value: any): WrappedValue;
>
2077a2080,2103
>      static create(factories: IterableDifferFactory[], parent?: IterableDiffers): IterableDiffers;
>
>
>     /**
>      * Takes an array of {@link IterableDifferFactory} and returns a binding used to extend the
>      * inherited {@link IterableDiffers} instance with the provided factories and return a new
>      * {@link IterableDiffers} instance.
>      *
>      * The following example shows how to extend an existing list of factories,
>      * which will only be applied to the injector for this component and its children.
>      * This step is all that's required to make a new {@link IterableDiffer} available.
>      *
>      * # Example
>      *
>      * ```
>      * @Component({
>      *   viewBindings: [
>      *     IterableDiffers.extend([new ImmutableListDiffer()])
>      *   ]
>      * })
>      * ```
>      */
>      static extend(factories: IterableDifferFactory[]): Binding;
>
2106a2133,2156
>      static create(factories: KeyValueDifferFactory[], parent?: KeyValueDiffers): KeyValueDiffers;
>
>
>     /**
>      * Takes an array of {@link KeyValueDifferFactory} and returns a binding used to extend the
>      * inherited {@link KeyValueDiffers} instance with the provided factories and return a new
>      * {@link KeyValueDiffers} instance.
>      *
>      * The following example shows how to extend an existing list of factories,
>      * which will only be applied to the injector for this component and its children.
>      * This step is all that's required to make a new {@link KeyValueDiffer} available.
>      *
>      * # Example
>      *
>      * ```
>      * @Component({
>      *   viewBindings: [
>      *     KeyValueDiffers.extend([new ImmutableMapDiffer()])
>      *   ]
>      * })
>      * ```
>      */
>      static extend(factories: KeyValueDifferFactory[]): Binding;
>
3548a3599,3644
>      * Turns a list of binding definitions into an internal resolved list of resolved bindings.
>      *
>      * A resolution is a process of flattening multiple nested lists and converting individual
>      * bindings into a list of {@link ResolvedBinding}s. The resolution can be cached by `resolve`
>      * for the {@link Injector} for performance-sensitive code.
>      *
>      * @param `bindings` can be a list of `Type`, {@link Binding}, {@link ResolvedBinding}, or a
>      * recursive list of more bindings.
>      *
>      * The returned list is sparse, indexed by `id` for the {@link Key}. It is generally not useful to
>      * application code
>      * other than for passing it to {@link Injector} functions that require resolved binding lists,
>      * such as
>      * `fromResolvedBindings` and `createChildFromResolved`.
>      */
>      static resolve(bindings: List<Type | Binding | List<any>>): List<ResolvedBinding>;
>
>
>     /**
>      * Resolves bindings and creates an injector based on those bindings. This function is slower than
>      * the corresponding `fromResolvedBindings` because it needs to resolve bindings first. See
>      * `resolve`
>      * for the {@link Injector}.
>      *
>      * Prefer `fromResolvedBindings` in performance-critical code that creates lots of injectors.
>      *
>      * @param `bindings` can be a list of `Type`, {@link Binding}, {@link ResolvedBinding}, or a
>      * recursive list of more
>      * bindings.
>      * @param `depProvider`
>      */
>      static resolveAndCreate(bindings: List<Type | Binding | List<any>>, depProvider?: DependencyProvider): Injector;
>
>
>     /**
>      * Creates an injector from previously resolved bindings. This bypasses resolution and flattening.
>      * This API is the recommended way to construct injectors in performance-sensitive parts.
>      *
>      * @param `bindings` A sparse list of {@link ResolvedBinding}s. See `resolve` for the
>      * {@link Injector}.
>      * @param `depProvider`
>      */
>      static fromResolvedBindings(bindings: List<ResolvedBinding>, depProvider?: DependencyProvider): Injector;
>
>
>     /**
3985a4082,4083
>      static fromKey(key: Key): Dependency;
>
4024a4123,4134
>
>     /**
>      * Retrieves a `Key` for a token.
>      */
>      static get(token: Object): Key;
>
>
>     /**
>      * @returns the number of keys registered in the system.
>      */
>      static numberOfKeys: number;
>
4382a4493,4496
>      static bulkRemove(tuples: List<RecordViewTuple>, viewContainer: ViewContainerRef): List<RecordViewTuple>;
>
>      static bulkInsert(tuples: List<RecordViewTuple>, viewContainer: ViewContainerRef, templateRef: TemplateRef): List<RecordViewTuple>;
>
5316a5431,5440
>
>      static required(c:Control): StringMap<string, boolean>;
>
>      static nullValidator(c: any): StringMap<string, boolean>;
>
>      static compose(validators: List<Function>): Function;
>
>      static group(c:ControlGroup): StringMap<string, boolean>;
>
>      static array(c:ControlArray): StringMap<string, boolean>;
5406a5531,5554
>      static DIRECTIVE_TYPE: any;
>
>      static COMPONENT_TYPE: any;
>
>      static create({id, selector, compileChildren, events, host, properties, readAttributes, type,
>                  callOnDestroy, callOnChange, callOnCheck, callOnInit, callOnAllChangesDone,
>                  changeDetection, exportAs}: {
>     id?: string,
>     selector?: string,
>     compileChildren?: boolean,
>     events?: List<string>,
>     host?: Map<string, string>,
>     properties?: List<string>,
>     readAttributes?: List<string>,
>     type?: number,
>     callOnDestroy?: boolean,
>     callOnChange?: boolean,
>     callOnCheck?: boolean,
>     callOnInit?: boolean,
>     callOnAllChangesDone?: boolean,
>     changeDetection?: string,
>     exportAs?: string
>   }): RenderDirectiveMetadata;
>
``````
