### PR TITLE
fix(wtf): fix NgZone.run instrumentation

### DIFF
--- a/modules/angular2/src/core/zone/ng_zone.ts
+++ b/modules/angular2/src/core/zone/ng_zone.ts
@@ -139,14 +139,14 @@ export class NgZone {
    */
   run(fn: () => any): any {
     if (this._disabled) {
+      return fn();
+    } else {
       var s = this._zone_run_scope();
       try {
-        return fn();
+        return this._innerZone.run(fn);
       } finally {
         wtfLeave(s);
       }
-    } else {
-      return this._innerZone.run(fn);
     }
   }
 


### PR DESCRIPTION
The wrong branch was instrumented (when zone are disabled ie in CJS tests).

@mhevery what is the correct naming convention for scopes ?
- `_zone_run_scope`: `_scope` suffix, snake cased
- `_zone_microtask`: no suffix

What about using camel case as elsewhere ?
