### PR TITLE
fix(RouteRegistry): initialize RouteParams.params

### DIFF
--- a/modules/angular2/src/router/route_registry.ts
+++ b/modules/angular2/src/router/route_registry.ts
@@ -212,7 +212,7 @@ export class RouteRegistry {
       } else if (segment == '' || segment == '.' || segment == '..') {
         throw new BaseException(`"${segment}/" is only allowed at the beginning of a link DSL.`);
       }
-      let params = null;
+      let params = {};
       if (i + 1 < linkParams.length) {
         let nextSegment = linkParams[i + 1];
         if (isStringMap(nextSegment)) {

--- a/modules/angular2/test/router/route_registry_spec.ts
+++ b/modules/angular2/test/router/route_registry_spec.ts
@@ -79,6 +79,13 @@ export function main() {
       expect(url).toEqual('first/one/second/two');
     });
 
+    it('should geneate params as an empty StringMap when no params are given', () => {
+      registry.config(RootHostCmp,
+                      new Route({path: '/test/...', component: DummyParentParamCmp, as: 'test'}));
+      var instruction = registry.generate(['test'], RootHostCmp);
+      expect(instruction.component.params).toEqual({});
+    });
+
     it('should generate URLs of loaded components after they are loaded',
        inject([AsyncTestCompleter], (async) => {
          registry.config(


### PR DESCRIPTION
I decided to try to fix [this](https://github.com/angular/angular/issues/3755#issuecomment-133613666). It took me a lot longer than originally expected, but I think I've done it. The root cause seems to have been that Router.generate was changed apparently in this [commit](https://github.com/angular/angular/commit/f66ce096d8d908fcc0a643a14412136e74025c3d) to allow the deep linking from anywhere. It also changed the method from essentially just passing arguments on to the relevant component's RouteRecognizer to generate the arguments from just a list. When this was done it should have always passed at least an empty StringMap for params, but because params is initialized to null this was not the case. 

I had a bit of trouble testing as the testing scripts are not designed to run on windows, but `./node_modules/.bin/protractor protractor-js.conf.js` runs fine with my edits, but throws an exception if I remove just my edits to route_registry.ts.

`./node_modules/.bin/gulp test.js --browsers=${KARMA_BROWSERS:-ChromeCanary}` seems to run fine in either case.
