### PR TITLE
feat(url_resolver): Allow a developer to customize their package prefix

### DIFF
--- a/modules/angular2/src/services/url_resolver.dart
+++ b/modules/angular2/src/services/url_resolver.dart
@@ -4,6 +4,16 @@ import 'package:angular2/di.dart' show Injectable;
 
 @Injectable()
 class UrlResolver {
+  /// This will be the location where 'package:' Urls will resolve. Default is
+  /// '/packages'
+  final String packagePrefix;
+
+  const UrlResolver() : packagePrefix = '/packages';
+
+  /// Creates a UrlResolver that will resolve 'package:' Urls to a different
+  /// prefixed location.
+  const UrlResolver.withUrlPrefix(this.packagePrefix);
+
   /**
    * Resolves the `url` given the `baseUrl`:
    * - when the `url` is null, the `baseUrl` is returned,
@@ -20,7 +30,7 @@ class UrlResolver {
     Uri uri = Uri.parse(url);
 
     if (uri.scheme == 'package') {
-      return '/packages/${uri.path}';
+      return '$packagePrefix/${uri.path}';
     }
 
     if (uri.isAbsolute) return uri.toString();


### PR DESCRIPTION
Allow a developer to specify a package prefix where the 'package:' dart urls
will be resolved. By default this will be '/packages' keeping the current
behavior, but allows for flexibility of different environments where a
developer may not control their directory structure.
