### PR TITLE
fix(build): make e2e tests faster

### DIFF
--- a/modules/benchmarks/src/naive_infinite_scroll/index.html
+++ b/modules/benchmarks/src/naive_infinite_scroll/index.html
@@ -13,7 +13,7 @@
     <button id="run-btn">Run</button>
     <button id="reset-btn">Reset</button>
   </div>
-  <scroll-app></scroll-app>
+  <scroll-app>Loading...</scroll-app>
 
   $SCRIPTS$
 </body>

--- a/modules/examples/e2e_test/message_broker/message_broker_spec.ts
+++ b/modules/examples/e2e_test/message_broker/message_broker_spec.ts
@@ -9,6 +9,7 @@ describe('message bus', function() {
 
   it('should receive a response from the worker', function() {
     browser.get(URL);
+    browser.sleep(5000);
 
     var VALUE = "hi there";
     var input = element.all(by.css("#echo_input")).first();

--- a/protractor-shared.js
+++ b/protractor-shared.js
@@ -192,7 +192,7 @@ function patchProtractorWait(browser) {
   var sleepInterval = process.env.TRAVIS || process.env.JENKINS_URL ? 14000 : 8000;
   browser.get = function() {
     var result = _get.apply(this, arguments);
-    browser.sleep(sleepInterval);
+    browser.driver.wait(protractor.until.elementLocated(By.js('var cs = document.body.children; var isLoading = false; for (var i = 0; i < cs.length; i++) {if (cs[i].textContent.indexOf("Loading...") > -1) isLoading = true; } return !isLoading ? document.body.children : null')), sleepInterval);
     return result;
   }
 }


### PR DESCRIPTION
While trying to put more in SauceLabs, I found out the e2e tests take 20+ minutes in our builds, mainly because protractor waits a lot.
Trying something to improve that.
