### PR TITLE
fix(build): do not run build/pubbuild.dart twice

### DIFF
--- a/scripts/ci/test_e2e_dart.sh
+++ b/scripts/ci/test_e2e_dart.sh
@@ -16,7 +16,7 @@ function killServer () {
 # So we do this only for post-commit testing.
 # Pull requests test with Dartium and pub serve
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-  ./node_modules/.bin/gulp build/pubbuild.dart
+  # WARNING: the build/pubbuild.dart task is assumed to have been run before, in test_server_dart.sh 
   ./node_modules/.bin/gulp serve.js.dart2js&
   serverPid=$!
 else


### PR DESCRIPTION
The `build/pubbuild.dart` should not run twice in a build.

Do not merge yet, the PR checks have been inverted for testing purpose.
