### PR TITLE
fix(test): error in karma when systemjs imports fail

### DIFF
--- a/test-main.js
+++ b/test-main.js
@@ -39,8 +39,7 @@ System.import('angular2/src/core/dom/browser_adapter').then(function(browser_ada
 .then(function() {
   __karma__.start();
 }, function(error) {
-  console.error(error.stack || error);
-  __karma__.start();
+  __karma__.error(error.stack || error);
 });
 
 


### PR DESCRIPTION
Fixes Karma only running a subset of unit tests and passing (!) when System.js can't parse a spec file due to invalid imports or syntax errors.
