### PR TITLE
chore(build): improve reliability of the saucelabs job

### DIFF
--- a/modules/angular2/test/core/zone/ng_zone_spec.ts
+++ b/modules/angular2/test/core/zone/ng_zone_spec.ts
@@ -208,8 +208,9 @@ function commonTests() {
          macroTask(() => {
            expect(_log.result()).toEqual('run; onTurnDone; onEventDone');
            async.done();
-         }, 80);
-       }));
+         }, 150);
+       }), 200);
+    // Timeouts extended for slower browsers (IEs, Androids)
 
     it('should run async tasks scheduled inside onEventDone outside Angular zone',
        inject([AsyncTestCompleter], (async) => {
@@ -230,7 +231,8 @@ function commonTests() {
            TimerWrapper.setTimeout(() => {
              expect(_log.result()).toEqual('run; onTurnDone; onEventDone; asyncTask');
              async.done();
-           }, 10);
+           }, 20);
+           // Timeout increased for slower browsers (IEs, Androids)
          });
        }));
 
@@ -272,6 +274,7 @@ function commonTests() {
            async.done();
          }, 150);
        }), 200);
+    // Timeouts extended for slower browsers (IEs, Androids)
 
     it('should not run onTurnStart and onTurnDone for nested Zone.run invoked from onTurnDone',
        inject([AsyncTestCompleter], (async) => {
@@ -402,8 +405,9 @@ function commonTests() {
                    // Second VM Turn => microtask enqueued from onTurnDone
                    'onTurnStart; executedMicrotask; onTurnDone(begin); onTurnDone(end)');
            async.done();
-         }, 80);
-       }));
+         }, 150);
+       }), 200);
+    // Timeouts extended for slower browsers (IEs, Androids)
 
     it('should call onTurnStart and onTurnDone for a scheduleMicrotask in onTurnDone triggered by ' +
            'a scheduleMicrotask in run',
@@ -437,8 +441,9 @@ function commonTests() {
                    // Second VM Turn => the microtask enqueued from onTurnDone
                    'onTurnStart; onTurnDone(executeMicrotask); onTurnDone(begin); onTurnDone(end)');
            async.done();
-         }, 80);
-       }));
+         }, 150);
+       }), 200);
+    // Timeouts extended for slower browsers (IEs, Androids)
 
     it('should execute promises scheduled in onTurnStart before promises scheduled in run',
        inject([AsyncTestCompleter], (async) => {
@@ -492,8 +497,9 @@ function commonTests() {
                    // Second VM turn: execute the microtask from onTurnEnd
                    'onTurnStart(begin); onTurnStart(end); onTurnDone(executePromise); onTurnDone(begin); onTurnDone(end)');
            async.done();
-         }, 80);
-       }));
+         }, 150);
+       }), 200);
+    // Timeouts extended for slower browsers (IEs, Androids)
 
     it('should call onTurnStart and onTurnDone before and after each turn, respectively',
        inject([AsyncTestCompleter], (async) => {
@@ -513,7 +519,7 @@ function commonTests() {
          macroTask(() => { _zone.run(() => { completerA.resolve(null); }); }, 20);
 
 
-         macroTask(() => { _zone.run(() => { completerB.resolve(null); }); }, 100);
+         macroTask(() => { _zone.run(() => { completerB.resolve(null); }); }, 120);
 
          macroTask(() => {
            expect(_log.result())
@@ -527,6 +533,7 @@ function commonTests() {
            async.done();
          }, 180);
        }), 200);
+    // Timeouts extended for slower browsers (IEs, Androids)
 
     it('should call onTurnStart and onTurnDone before and after (respectively) all turns in a chain',
        inject([AsyncTestCompleter], (async) => {
@@ -545,8 +552,9 @@ function commonTests() {
            expect(_log.result())
                .toEqual('onTurnStart; run start; run end; async1; async2; onTurnDone');
            async.done();
-         }, 80);
-       }));
+         }, 150);
+       }), 200);
+    // Timeouts extended for slower browsers (IEs, Androids)
 
     it('should call onTurnStart and onTurnDone for promises created outside of run body',
        inject([AsyncTestCompleter], (async) => {
@@ -567,8 +575,9 @@ function commonTests() {
            expect(_log.result())
                .toEqual('onTurnStart; zone run; onTurnDone; onTurnStart; promise then; onTurnDone');
            async.done();
-         }, 80);
-       }));
+         }, 150);
+       }), 200);
+    // Timeouts extended for slower browsers (IEs, Androids)
   });
 
   describe('exceptions', () => {
@@ -600,6 +609,7 @@ function commonTests() {
            async.done();
          }, 150);
        }), 200);
+    // Timeouts extended for slower browsers (IEs, Androids)
 
     it('should call onError when onTurnDone throws and the zone is sync',
        inject([AsyncTestCompleter], (async) => {

--- a/modules/angular2/test/router/integration/lifecycle_hook_spec.ts
+++ b/modules/angular2/test/router/integration/lifecycle_hook_spec.ts
@@ -100,7 +100,7 @@ export function main() {
                expect(log).toEqual(['activate: null -> /on-activate']);
                async.done();
              });
-       }));
+       }), 2000);
 
     it('should wait for a parent component\'s onActivate hook to resolve before calling its child\'s',
        inject([AsyncTestCompleter], (async) => {
@@ -123,7 +123,7 @@ export function main() {
                      async.done();
                    });
              });
-       }));
+       }), 2000);
 
     it('should call the onDeactivate hook', inject([AsyncTestCompleter], (async) => {
          compile()
@@ -136,7 +136,7 @@ export function main() {
                expect(log).toEqual(['deactivate: /on-deactivate -> /a']);
                async.done();
              });
-       }));
+       }), 2000);
 
     it('should wait for a child component\'s onDeactivate hook to resolve before calling its parent\'s',
        inject([AsyncTestCompleter], (async) => {
@@ -161,7 +161,7 @@ export function main() {
                  async.done();
                });
              });
-       }));
+       }), 2000);
 
     it('should reuse a component when the canReuse hook returns true',
        inject([AsyncTestCompleter], (async) => {
@@ -182,7 +182,7 @@ export function main() {
                expect(cmpInstanceCount).toBe(1);
                async.done();
              });
-       }));
+       }), 2000);
 
 
     it('should not reuse a component when the canReuse hook returns false',
@@ -204,7 +204,7 @@ export function main() {
                expect(cmpInstanceCount).toBe(2);
                async.done();
              });
-       }));
+       }), 2000);
 
 
     it('should navigate when canActivate returns true', inject([AsyncTestCompleter], (async) => {
@@ -224,7 +224,7 @@ export function main() {
                      async.done();
                    });
              });
-       }));
+       }), 2000);
 
     it('should not navigate when canActivate returns false',
        inject([AsyncTestCompleter], (async) => {
@@ -244,7 +244,7 @@ export function main() {
                      async.done();
                    });
              });
-       }));
+       }), 2000);
 
     it('should navigate away when canDeactivate returns true',
        inject([AsyncTestCompleter], (async) => {
@@ -269,7 +269,7 @@ export function main() {
                  async.done();
                });
              });
-       }));
+       }), 2000);
 
     it('should not navigate away when canDeactivate returns false',
        inject([AsyncTestCompleter], (async) => {
@@ -294,7 +294,7 @@ export function main() {
                  async.done();
                });
              });
-       }));
+       }), 2000);
 
 
     it('should run activation and deactivation hooks in the correct order',
@@ -322,7 +322,7 @@ export function main() {
                ]);
                async.done();
              });
-       }));
+       }), 2000);
 
     it('should only run reuse hooks when reusing', inject([AsyncTestCompleter], (async) => {
          compile()
@@ -349,7 +349,7 @@ export function main() {
                ]);
                async.done();
              });
-       }));
+       }), 2000);
 
     it('should not run reuse hooks when not reusing', inject([AsyncTestCompleter], (async) => {
          compile()
@@ -378,7 +378,7 @@ export function main() {
                ]);
                async.done();
              });
-       }));
+       }), 2000);
   });
 }
 

--- a/modules/angular2/test/router/integration/router_integration_spec.ts
+++ b/modules/angular2/test/router/integration/router_integration_spec.ts
@@ -62,7 +62,7 @@ export function main() {
                    async.done();
                  });
                });
-         }));
+         }), 1000);
     });
 
     describe('broken app', () => {
@@ -78,7 +78,7 @@ export function main() {
                async.done();
              });
            });
-         }));
+         }), 1000);
     });
 
     describe('back button app', () => {
@@ -148,26 +148,27 @@ export function main() {
                  });
                  router.navigate('/parent/child');
                });
-         }));
+         }), 1000);
 
       describe('custom app base ref', () => {
         beforeEachBindings(() => { return [bind(APP_BASE_HREF).toValue('/my/app')]; });
-        it('should bootstrap', inject([AsyncTestCompleter, TestComponentBuilder],
-                                      (async, tcb: TestComponentBuilder) => {
+        it('should bootstrap',
+           inject([AsyncTestCompleter, TestComponentBuilder],
+                  (async, tcb: TestComponentBuilder) => {
 
-                                        tcb.createAsync(HierarchyAppCmp)
-                                            .then((rootTC) => {
-                                              var router = rootTC.componentInstance.router;
-                                              router.subscribe((_) => {
-                                                expect(rootTC.nativeElement)
-                                                    .toHaveText('root { parent { hello } }');
-                                                expect(rootTC.componentInstance.location.path())
-                                                    .toEqual('/my/app/parent/child');
-                                                async.done();
-                                              });
-                                              router.navigate('/parent/child');
-                                            });
-                                      }));
+                    tcb.createAsync(HierarchyAppCmp)
+                        .then((rootTC) => {
+                          var router = rootTC.componentInstance.router;
+                          router.subscribe((_) => {
+                            expect(rootTC.nativeElement).toHaveText('root { parent { hello } }');
+                            expect(rootTC.componentInstance.location.path())
+                                .toEqual('/my/app/parent/child');
+                            async.done();
+                          });
+                          router.navigate('/parent/child');
+                        });
+                  }),
+           1000);
       });
     });
     // TODO: add a test in which the child component has bindings
@@ -192,7 +193,7 @@ export function main() {
                  router.navigate('/qs?q=search-for-something');
                  rootTC.detectChanges();
                });
-         }));
+         }), 1000);
     });
   });
 }

--- a/modules/angular2/test/router/integration/router_link_spec.ts
+++ b/modules/angular2/test/router/integration/router_link_spec.ts
@@ -179,7 +179,7 @@ export function main() {
                    async.done();
                  });
                });
-         }));
+         }), 1000);
 
       it('should navigate to link hrefs in presence of base href',
          inject([AsyncTestCompleter], (async) => {
@@ -200,7 +200,7 @@ export function main() {
                    async.done();
                  });
                });
-         }));
+         }), 1000);
     });
   });
 }

--- a/modules/angular2/test/router/location_spec.ts
+++ b/modules/angular2/test/router/location_spec.ts
@@ -63,7 +63,7 @@ export function main() {
            expect(ev['url']).toEqual('/user/btford');
            async.done();
          })
-       }), 1000);
+       }), 2000);
 
     it('should normalize location path', () => {
       locationStrategy.internalPath = '/my/app/user/btford';

--- a/modules/angular2/test/web_workers/shared/message_bus_spec.ts
+++ b/modules/angular2/test/web_workers/shared/message_bus_spec.ts
@@ -35,7 +35,7 @@ export function main() {
          });
          var toEmitter = bus.to(CHANNEL);
          ObservableWrapper.callNext(toEmitter, MESSAGE);
-       }));
+       }), 1000);
 
     it("should broadcast", inject([AsyncTestCompleter], (async) => {
          const CHANNEL = "CHANNEL 1";


### PR DESCRIPTION
The saucelabs job is not reliable as there are almost always a few tests failing among the 26k which are run. The failures are never the same, but all are about timeout being reached.
It happens mainly in Android 4.3, but also in Android 4.2, IE10, IE9, and sometimes in IE11 and Safari. I.e. in the slow environments.

Let's try to secure these tests by increasing timeouts.
