### PR TITLE
chore(transform): Remove reflection_entry_points from examples pubspec

### DIFF
--- a/modules/examples/pubspec.yaml
+++ b/modules/examples/pubspec.yaml
@@ -48,30 +48,6 @@ transformers:
         #
         # This entrypoint is not needed:
         # - web/src/material/demo_common.dart
-    reflection_entry_points:
-        - web/src/gestures/index.dart
-        - web/src/hello_world/index.dart
-        - web/src/key_events/index.dart
-        - web/src/sourcemap/index.dart
-        - web/src/todo/index.dart
-        - web/src/model_driven_forms/index.dart
-        - web/src/observable_models/index.dart
-        - web/src/order_management/index.dart
-        - web/src/person_management/index.dart
-        - web/src/template_driven_forms/index.dart
-        # These entrypoints are disabled until cross-package urls are working (issue #2982)
-        # - web/src/material/button/index.dart
-        # - web/src/material/checkbox/index.dart
-        # - web/src/material/dialog/index.dart
-        # - web/src/material/grid_list/index.dart
-        # - web/src/material/input/index.dart
-        # - web/src/material/progress-linear/index.dart
-        # - web/src/material/radio/index.dart
-        # - web/src/material/switcher/index.dart
-        # - web/src/zippy_component/index.dart
-        #
-        # This entrypoint is not needed:
-        # - web/src/material/demo_common.dart
 
 - $dart2js:
     minify: false


### PR DESCRIPTION
Specifying `reflection_entry_points` is no longer necessary for most
Angular 2 apps.
