### PR TITLE
refactor(transform): Remove reflection_entry_points parameter

### DIFF
--- a/modules/angular2/pubspec.yaml
+++ b/modules/angular2/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   barback: '^0.15.2+2'
   code_transformers: '^0.2.8'
   dart_style: '>=0.1.8 <0.3.0'
+  glob: '^1.0.0'
   html: '^0.12.0'
   intl: '^0.12.4'
   logging: '>=0.9.0 <0.12.0'

--- a/modules/angular2/src/core/compiler/view.ts
+++ b/modules/angular2/src/core/compiler/view.ts
@@ -184,7 +184,7 @@ export class AppView implements ChangeDispatcher, RenderEventDispatcher {
       if (b.isElementProperty()) {
         this.renderer.setElementProperty(elementRef, b.name, currentValue);
       } else if (b.isElementAttribute()) {
-        this.renderer.setElementAttribute(elementRef, b.name, currentValue);
+        this.renderer.setElementAttribute(elementRef, b.name, `${currentValue}`);
       } else if (b.isElementClass()) {
         this.renderer.setElementClass(elementRef, b.name, currentValue);
       } else if (b.isElementStyle()) {

--- a/modules_dart/transform/lib/src/transform/common/options.dart
+++ b/modules_dart/transform/lib/src/transform/common/options.dart
@@ -1,5 +1,7 @@
 library angular2.transform.common.options;
 
+import 'package:glob/glob.dart';
+
 import 'annotation_matcher.dart';
 import 'mirror_mode.dart';
 
@@ -19,12 +21,10 @@ const REFLECTION_ENTRY_POINT_PARAM = 'reflection_entry_points';
 
 /// Provides information necessary to transform an Angular2 app.
 class TransformerOptions {
+  final List<Glob> entryPointGlobs;
+
   /// The path to the files where the application's calls to `bootstrap` are.
   final List<String> entryPoints;
-
-  /// The paths to the files where the application's {@link ReflectionCapabilities}
-  /// are set.
-  final List<String> reflectionEntryPoints;
 
   /// The `BarbackMode#name` we are running in.
   final String modeName;
@@ -62,7 +62,7 @@ class TransformerOptions {
 
   TransformerOptions._internal(
       this.entryPoints,
-      this.reflectionEntryPoints,
+      this.entryPointGlobs,
       this.modeName,
       this.mirrorMode,
       this.initReflector,
@@ -74,8 +74,7 @@ class TransformerOptions {
       this.formatCode});
 
   factory TransformerOptions(List<String> entryPoints,
-      {List<String> reflectionEntryPoints,
-      String modeName: 'release',
+      {String modeName: 'release',
       MirrorMode mirrorMode: MirrorMode.none,
       bool initReflector: true,
       List<ClassDescriptor> customAnnotationDescriptors: const [],
@@ -84,15 +83,15 @@ class TransformerOptions {
       bool generateChangeDetectors: true,
       bool reflectPropertiesAsAttributes: true,
       bool formatCode: false}) {
-    if (reflectionEntryPoints == null || reflectionEntryPoints.isEmpty) {
-      reflectionEntryPoints = entryPoints;
-    }
     var annotationMatcher = new AnnotationMatcher()
       ..addAll(customAnnotationDescriptors);
     optimizationPhases = optimizationPhases.isNegative ? 0 : optimizationPhases;
+    var entryPointGlobs = entryPoints != null
+        ? entryPoints.map((path) => new Glob(path)).toList(growable: false)
+        : null;
     return new TransformerOptions._internal(
         entryPoints,
-        reflectionEntryPoints,
+        entryPointGlobs,
         modeName,
         mirrorMode,
         initReflector,

--- a/modules_dart/transform/lib/src/transform/common/options_reader.dart
+++ b/modules_dart/transform/lib/src/transform/common/options_reader.dart
@@ -7,9 +7,8 @@ import 'options.dart';
 
 TransformerOptions parseBarbackSettings(BarbackSettings settings) {
   var config = settings.configuration;
+  _warnDeprecated(config);
   var entryPoints = _readFileList(config, ENTRY_POINT_PARAM);
-  var reflectionEntryPoints =
-      _readFileList(config, REFLECTION_ENTRY_POINT_PARAM);
   var initReflector =
       _readBool(config, INIT_REFLECTOR_PARAM, defaultValue: true);
   var inlineViews = _readBool(config, INLINE_VIEWS_PARAM, defaultValue: true);
@@ -35,7 +34,6 @@ TransformerOptions parseBarbackSettings(BarbackSettings settings) {
   var optimizationPhases = _readInt(config, OPTIMIZATION_PHASES_PARAM,
       defaultValue: DEFAULT_OPTIMIZATION_PHASES);
   return new TransformerOptions(entryPoints,
-      reflectionEntryPoints: reflectionEntryPoints,
       modeName: settings.mode.name,
       mirrorMode: mirrorMode,
       initReflector: initReflector,
@@ -132,3 +130,10 @@ const CUSTOM_ANNOTATIONS_ERROR = '''
         - name: ...
           import: ...
           superClass: ...''';
+
+void _warnDeprecated(Map config) {
+  if (config.containsKey(REFLECTION_ENTRY_POINT_PARAM)) {
+    print('${REFLECTION_ENTRY_POINT_PARAM} is no longer necessary for '
+        'Angular 2 apps. Please remove it from your pubspec.');
+  }
+}

--- a/modules_dart/transform/lib/src/transform/reflection_remover/codegen.dart
+++ b/modules_dart/transform/lib/src/transform/reflection_remover/codegen.dart
@@ -1,24 +1,18 @@
 library angular2.transform.reflection_remover.codegen;
 
-import 'package:path/path.dart' as path;
-
 import 'package:angular2/src/transform/common/names.dart';
+import 'package:barback/barback.dart';
+import 'package:path/path.dart' as path;
 
 class Codegen {
   static const _PREFIX_BASE = 'ngStaticInit';
+  final AssetId reflectionEntryPoint;
 
   /// The prefix used to import our generated file.
   final String prefix;
 
-  /// The import uris
-  final Iterable<String> importUris;
-
-  Codegen(String reflectionEntryPointPath, Iterable<String> newEntryPointPaths,
-      {String prefix})
-      : this.prefix = prefix == null ? _PREFIX_BASE : prefix,
-        importUris = newEntryPointPaths.map((p) => path
-            .relative(p, from: path.dirname(reflectionEntryPointPath))
-            .replaceAll('\\', '/')) {
+  Codegen(this.reflectionEntryPoint, {String prefix})
+      : this.prefix = prefix == null ? _PREFIX_BASE : prefix {
     if (this.prefix.isEmpty) throw new ArgumentError.value('(empty)', 'prefix');
   }
 
@@ -28,18 +22,14 @@ class Codegen {
   /// The code generated here should follow the example of code generated for
   /// an {@link ImportDirective} node.
   String codegenImport() {
-    var count = 0;
-    return importUris
-        .map((importUri) => 'import \'${importUri}\' as ${prefix}${count++};')
-        .join('');
+    var importUri = path
+        .basename(reflectionEntryPoint.changeExtension(DEPS_EXTENSION).path);
+    return '''import '$importUri' as $prefix;''';
   }
 
   /// Generates code to call the method which sets up Angular2 reflection
   /// statically.
   String codegenSetupReflectionCall() {
-    var count = 0;
-    return importUris
-        .map((_) => '${prefix}${count++}.${SETUP_METHOD_NAME}();')
-        .join('');
+    return '$prefix.$SETUP_METHOD_NAME();';
   }
 }

--- a/modules_dart/transform/lib/src/transform/reflection_remover/remove_reflection_capabilities.dart
+++ b/modules_dart/transform/lib/src/transform/reflection_remover/remove_reflection_capabilities.dart
@@ -2,9 +2,9 @@ library angular2.transform.reflection_remover.remove_reflection_capabilities;
 
 import 'dart:async';
 import 'package:analyzer/analyzer.dart';
-import 'package:barback/barback.dart';
 import 'package:angular2/src/transform/common/asset_reader.dart';
 import 'package:angular2/src/transform/common/mirror_mode.dart';
+import 'package:barback/barback.dart';
 
 import 'codegen.dart';
 import 'rewriter.dart';
@@ -15,16 +15,14 @@ import 'rewriter.dart';
 ///
 /// This only searches the code in `reflectionEntryPoint`, not `part`s,
 /// `import`s, `export`s, etc.
-Future<String> removeReflectionCapabilities(AssetReader reader,
-    AssetId reflectionEntryPoint, Iterable<AssetId> newEntryPoints,
+Future<String> removeReflectionCapabilities(
+    AssetReader reader, AssetId reflectionEntryPoint,
     {MirrorMode mirrorMode: MirrorMode.none,
     bool writeStaticInit: true}) async {
   var code = await reader.readAsString(reflectionEntryPoint);
-  var reflectionEntryPointPath = reflectionEntryPoint.path;
-  var newEntryPointPaths = newEntryPoints.map((id) => id.path);
 
-  var codegen = new Codegen(reflectionEntryPointPath, newEntryPointPaths);
+  var codegen = new Codegen(reflectionEntryPoint);
   return new Rewriter(code, codegen,
           mirrorMode: mirrorMode, writeStaticInit: writeStaticInit)
-      .rewrite(parseCompilationUnit(code, name: reflectionEntryPointPath));
+      .rewrite(parseCompilationUnit(code, name: reflectionEntryPoint.path));
 }

--- a/modules_dart/transform/lib/src/transform/reflection_remover/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/reflection_remover/transformer.dart
@@ -25,18 +25,12 @@ class ReflectionRemover extends Transformer {
   ReflectionRemover(this.options);
 
   @override
-  bool isPrimary(AssetId id) => options.reflectionEntryPoints != null &&
-      options.reflectionEntryPoints.contains(id.path);
+  bool isPrimary(AssetId id) => options.entryPointGlobs != null &&
+      options.entryPointGlobs.any((g) => g.matches(id.path));
 
   @override
   Future apply(Transform transform) async {
     await log.initZoned(transform, () async {
-      var newEntryPoints = options.entryPoints.map((entryPoint) {
-        return new AssetId(transform.primaryInput.id.package, entryPoint)
-            .changeExtension(DEPS_EXTENSION);
-      });
-      var reader = new AssetReader.fromTransform(transform);
-
       var mirrorMode = options.mirrorMode;
       var writeStaticInit = options.initReflector;
       if (options.modeName == TRANSFORM_DYNAMIC_MODE) {
@@ -48,7 +42,7 @@ class ReflectionRemover extends Transformer {
       }
 
       var transformedCode = await removeReflectionCapabilities(
-          reader, transform.primaryInput.id, newEntryPoints,
+          new AssetReader.fromTransform(transform), transform.primaryInput.id,
           mirrorMode: mirrorMode, writeStaticInit: writeStaticInit);
       transform.addOutput(
           new Asset.fromString(transform.primaryInput.id, transformedCode));

--- a/modules_dart/transform/test/transform/integration/all_tests.dart
+++ b/modules_dart/transform/test/transform/integration/all_tests.dart
@@ -14,7 +14,6 @@ main() {
 var formatter = new DartFormatter();
 var transform = new AngularTransformerGroup(new TransformerOptions(
     ['web/index.dart'],
-    reflectionEntryPoints: ['web/index.dart'],
     formatCode: true));
 
 class IntegrationTestConfig {

--- a/modules_dart/transform/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
+++ b/modules_dart/transform/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
@@ -4,7 +4,7 @@ import 'index.dart';
 export 'index.dart';
 import 'package:angular2/src/core/reflection/reflection.dart' as _ngRef;
 import 'package:angular2/bootstrap_static.dart';
-import 'index.ng_deps.dart' as ngStaticInit0;
+import 'index.ng_deps.dart' as ngStaticInit;
 import 'package:angular2/src/core/reflection/reflection.dart';
 import 'bar.dart';
 import 'bar.ng_deps.dart' as i0;

--- a/modules_dart/transform/test/transform/reflection_remover/all_tests.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/all_tests.dart
@@ -4,6 +4,7 @@ import 'package:analyzer/analyzer.dart';
 import 'package:angular2/src/transform/common/mirror_mode.dart';
 import 'package:angular2/src/transform/reflection_remover/codegen.dart';
 import 'package:angular2/src/transform/reflection_remover/rewriter.dart';
+import 'package:barback/barback.dart';
 import 'package:guinness/guinness.dart';
 
 import 'reflection_remover_files/expected/index.dart' as expected;
@@ -16,7 +17,8 @@ import '../common/read_file.dart';
 main() => allTests();
 
 void allTests() {
-  var codegen = new Codegen('web/index.dart', ['web/index.ng_deps.dart']);
+  var assetId = new AssetId('a', 'web/index.dart');
+  var codegen = new Codegen(assetId);
   var code = readFile('reflection_remover/index.dart').replaceAll('\r\n', '\n');
   var bootstrapCode = readFile('reflection_remover/bootstrap_files/index.dart')
       .replaceAll('\r\n', '\n');

--- a/modules_dart/transform/test/transform/reflection_remover/bootstrap_files/expected/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/bootstrap_files/expected/index.dart
@@ -11,9 +11,9 @@ library angular2.test.transform.reflection_remover.reflection_remover_files;
 var code = """
 library web_foo;
 
-import 'package:angular2/bootstrap_static.dart';import 'index.ng_deps.dart' as ngStaticInit0;
+import 'package:angular2/bootstrap_static.dart';import 'index.ng_deps.dart' as ngStaticInit;
 
 void main() async {
-  var appRef = await bootstrapStatic(MyComponent, null, () { ngStaticInit0.initReflector(); });
+  var appRef = await bootstrapStatic(MyComponent, null, () { ngStaticInit.initReflector(); });
 }
 """;

--- a/modules_dart/transform/test/transform/reflection_remover/debug_files/expected/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/debug_files/expected/index.dart
@@ -11,12 +11,12 @@ library angular2.test.transform.debug_reflection_remover_files;
 var code = """
 library web_foo;
 
-import 'package:angular2/bootstrap.dart';import 'index.ng_deps.dart' as ngStaticInit0;
+import 'package:angular2/bootstrap.dart';import 'index.ng_deps.dart' as ngStaticInit;
 import 'package:angular2/src/core/reflection/reflection.dart';
 import 'package:angular2/src/core/reflection/debug_reflection_capabilities.dart';
 
 void main() {
   reflector.reflectionCapabilities = new ReflectionCapabilities();
-  ngStaticInit0.initReflector();bootstrap(MyComponent);
+  ngStaticInit.initReflector();bootstrap(MyComponent);
 }
 """;

--- a/modules_dart/transform/test/transform/reflection_remover/debug_mirrors_files/expected/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/debug_mirrors_files/expected/index.dart
@@ -11,12 +11,12 @@ library angular2.test.transform.reflection_remover.debug_mirrors_files.expected;
 var code = """
 library web_foo;
 
-import 'package:angular2/bootstrap_static.dart';import 'index.ng_deps.dart' as ngStaticInit0;
+import 'package:angular2/bootstrap_static.dart';import 'index.ng_deps.dart' as ngStaticInit;
 import 'package:angular2/src/core/reflection/reflection.dart';
 import 'package:angular2/src/core/reflection/debug_reflection_capabilities.dart';
 
 void main() {
-  ngStaticInit0.initReflector();reflector.reflectionCapabilities = new ReflectionCapabilities();
+  ngStaticInit.initReflector();reflector.reflectionCapabilities = new ReflectionCapabilities();
   bootstrapStatic(MyComponent);
 }
 """;

--- a/modules_dart/transform/test/transform/reflection_remover/reflection_remover_files/expected/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/reflection_remover_files/expected/index.dart
@@ -11,12 +11,12 @@ library angular2.test.transform.reflection_remover.reflection_remover_files;
 var code = """
 library web_foo;
 
-import 'package:angular2/bootstrap_static.dart';import 'index.ng_deps.dart' as ngStaticInit0;
+import 'package:angular2/bootstrap_static.dart';import 'index.ng_deps.dart' as ngStaticInit;
 import 'package:angular2/src/core/reflection/reflection.dart';
 /*import 'package:angular2/src/core/reflection/reflection_capabilities.dart';*/
 
 void main() {
-  ngStaticInit0.initReflector();/*reflector.reflectionCapabilities = new ReflectionCapabilities();*/
+  ngStaticInit.initReflector();/*reflector.reflectionCapabilities = new ReflectionCapabilities();*/
   bootstrapStatic(MyComponent);
 }
 """;

--- a/modules_dart/transform/test/transform/reflection_remover/verbose_files/expected/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/verbose_files/expected/index.dart
@@ -11,12 +11,12 @@ library angular2.test.transform.reflection_remover.verbose_files.expected;
 var code = """
 library web_foo;
 
-import 'package:angular2/bootstrap_static.dart';import 'index.ng_deps.dart' as ngStaticInit0;
+import 'package:angular2/bootstrap_static.dart';import 'index.ng_deps.dart' as ngStaticInit;
 import 'package:angular2/src/core/reflection/reflection.dart';
 import 'package:angular2/src/core/reflection/debug_reflection_capabilities.dart';
 
 void main() {
-  ngStaticInit0.initReflector();reflector.reflectionCapabilities = new ReflectionCapabilities(verbose: true);
+  ngStaticInit.initReflector();reflector.reflectionCapabilities = new ReflectionCapabilities(verbose: true);
   bootstrapStatic(MyComponent);
 }
 """;


### PR DESCRIPTION
Remove the now unnecessary `reflection_entry_points` parameter from the
Angular 2 transformer.

Support glob syntax for `entry_points`.
