### PR TITLE
fix(typings): emit spread parameters

### DIFF
--- a/docs/typescript-package/processors/readTypeScriptModules.js
+++ b/docs/typescript-package/processors/readTypeScriptModules.js
@@ -290,7 +290,11 @@ module.exports = function readTypeScriptModules(tsParser, modules, getFileInfo,
         ' at line ' + location.start.line);
     }
     return declaration.parameters.map(function(parameter) {
-      var paramText = getText(sourceFile, parameter.name);
+      var paramText = '';
+      if (parameter.dotDotDotToken) {
+        paramText += '...';
+      }
+      paramText += getText(sourceFile, parameter.name);
       if (parameter.questionToken || parameter.initializer) {
         paramText += '?';
       }
@@ -298,6 +302,9 @@ module.exports = function readTypeScriptModules(tsParser, modules, getFileInfo,
         paramText += ':' + getType(sourceFile, parameter.type);
       } else {
         paramText += ': any';
+        if (parameter.dotDotDotToken) {
+          paramText += '[]';
+        }
       }
       return paramText.trim();
     });

--- a/typing_spec/router_spec.ts
+++ b/typing_spec/router_spec.ts
@@ -11,6 +11,7 @@ import {RouteConfig, ROUTER_DIRECTIVES, ROUTER_BINDINGS} from 'angular2/router';
   template: '<h1>Hello</h1>',
 })
 class FooCmp {
+  constructor(a: string, b: number) {}
 }
 
 


### PR DESCRIPTION
Surprisingly, this is the only missing spread in the whole .d.ts:

```
$ diff before dist/docs/typings/angular2/angular2.d.ts
2371c2371
<      new(args: any): any;

---
>      new(...args: any): any;
```
