### PR TITLE
chore(docgen): Use updated dartdoc tool

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: angular
 environment:
-  sdk: '>=1.9.0 <2.0.0'
+  sdk: '>=1.12.0 <2.0.0'
 dependencies:
   observe: '0.13.1'
 dev_dependencies:

--- a/tools/build/dart.js
+++ b/tools/build/dart.js
@@ -8,7 +8,7 @@ module.exports.detect = function(gulp) {
     if (process.platform === 'win32') {
       DART_SDK = {
         ANALYZER: 'dartanalyzer.bat',
-        DARTDOCGEN: 'dartdocgen.bat',
+        DARTDOCGEN: 'dartdoc.bat',
         DARTFMT: 'dartfmt.bat',
         PUB: 'pub.bat',
         VM: 'dart.exe'
@@ -16,7 +16,7 @@ module.exports.detect = function(gulp) {
     } else {
       DART_SDK = {
         ANALYZER: 'dartanalyzer',
-        DARTDOCGEN: 'dartdocgen',
+        DARTDOCGEN: 'dartdoc',
         DARTFMT: 'dartfmt',
         PUB: 'pub',
         VM: 'dart'

--- a/tools/build/dartapidocs.js
+++ b/tools/build/dartapidocs.js
@@ -19,23 +19,23 @@ module.exports = function(gulp, plugins, config) {
       if (supportedModules.indexOf(dir) === -1) {
         done();
       } else {
-        console.log('INFO: running dartdocgen for ', dir);
+        console.log('INFO: running dartdoc for ', dir);
 
-        var stream = spawn(config.command, ['.'], {
+        var stream = spawn(config.command, ['--input=.'], {
           stdio: [process.stdin, process.stdout, process.stderr],
           cwd: dir
         });
 
         stream.on('exit', function(code) {
           if (code !== 0) {
-            done('ERROR: dartdocgen exited with non-zero status ' + code);
+            done('ERROR: dartdoc exited with non-zero status ' + code);
           } else {
             done();
           }
         });
 
         stream.on('error', function(e) {
-          done('ERROR: dartdocgen reported error: ' + e);
+          done('ERROR: dartdoc reported error: ' + e);
         });
       }
       return defer.promise;


### PR DESCRIPTION
I don't have the hardware to test this on Windows -- does Travis handle that for us?

Use the new `dartdoc` tool, which
[shipped with 1.12](https://groups.google.com/a/dartlang.org/forum/#!topic/announce/Q1JSlVaFFnY)

Update the sdk constraint to 1.12
