### PR TITLE
docs(http): fix http documentation

### DIFF
--- a/modules/angular2/src/http/backends/mock_backend.ts
+++ b/modules/angular2/src/http/backends/mock_backend.ts
@@ -55,8 +55,8 @@ export class MockConnection implements Connection {
    *
    * ```
    * var connection;
-   * backend.connections.subscribe(c => connection = c);
-   * http.request('data.json').subscribe(res => console.log(res.text()));
+   * backend.connections.toRx().subscribe(c => connection = c);
+   * http.request('data.json').toRx().subscribe(res => console.log(res.text()));
    * connection.mockRespond(new Response('fake response')); //logs 'fake response'
    * ```
    *
@@ -117,8 +117,8 @@ export class MockConnection implements Connection {
  *   var http = injector.get(Http);
  *   var backend = injector.get(MockBackend);
  *   //Assign any newly-created connection to local variable
- *   backend.connections.subscribe(c => connection = c);
- *   http.request('data.json').subscribe((res) => {
+ *   backend.connections.toRx().subscribe(c => connection = c);
+ *   http.request('data.json').toRx().subscribe((res) => {
  *     expect(res.text()).toBe('awesome');
  *     async.done();
  *   });
@@ -151,8 +151,8 @@ export class MockBackend implements ConnectionBackend {
    *     }, [MockBackend, BaseRequestOptions]]);
    *   var backend = injector.get(MockBackend);
    *   var http = injector.get(Http);
-   *   backend.connections.subscribe(c => connection = c);
-   *   http.request('something.json').subscribe(res => {
+   *   backend.connections.toRx().subscribe(c => connection = c);
+   *   http.request('something.json').toRx().subscribe(res => {
    *     text = res.text();
    *   });
    *   connection.mockRespond(new Response({body: 'Something'}));

--- a/modules/angular2/src/http/backends/xhr_backend.ts
+++ b/modules/angular2/src/http/backends/xhr_backend.ts
@@ -99,7 +99,7 @@ export class XHRConnection implements Connection {
  * })
  * class MyComponent {
  *   constructor(http:Http) {
- *     http('people.json').subscribe(res => this.people = res.json());
+ *     http('people.json').toRx().subscribe(res => this.people = res.json());
  *   }
  * }
  * ```

--- a/modules/angular2/src/http/base_request_options.ts
+++ b/modules/angular2/src/http/base_request_options.ts
@@ -83,7 +83,7 @@ export class RequestOptions {
  *   constructor(baseRequestOptions:BaseRequestOptions, http:Http) {
  *     var options = baseRequestOptions.merge({body: 'foobar', url: 'https://foo'});
  *     var request = new Request(options);
- *     http.request(request).subscribe(res => this.bars = res.json());
+ *     http.request(request).toRx().subscribe(res => this.bars = res.json());
  *   }
  * }
  *

--- a/modules/angular2/src/http/static_response.ts
+++ b/modules/angular2/src/http/static_response.ts
@@ -14,7 +14,7 @@ import {isJsObject} from './http_utils';
  * #Example
  *
  * ```
- * http.request('my-friends.txt').subscribe(response => this.friends = response.text());
+ * http.request('my-friends.txt').toRx().subscribe(response => this.friends = response.text());
  * ```
  *
  * The Response's interface is inspired by the Response constructor defined in the [Fetch


### PR DESCRIPTION
http.request return with EventEmmiter not Rxjs object first call toRx method, then call subscribe.
