### PR TITLE
fix(sfx): Include ngHttp in SFX bundle

### DIFF
--- a/modules/angular2/angular2_sfx.ts
+++ b/modules/angular2/angular2_sfx.ts
@@ -1,8 +1,9 @@
 import * as ng from './angular2';
-// the router should have its own SFX bundle
-// But currently the module arithmetic 'angular2/router_sfx - angular2/angular2',
+// the router and http should have their own SFX bundle
+// But currently the module arithemtic 'angular2/router_sfx - angular2/angular2',
 // is not support by system builder.
 import * as router from './router';
+import * as http from './http';
 
 var _prevNg = (<any>window).ng;
 
@@ -10,6 +11,7 @@ var _prevNg = (<any>window).ng;
 
 
 (<any>window).ngRouter = router;
+(<any>window).ngHttp = http;
 /**
  * Calling noConflict will restore window.angular to its pre-angular loading state
  * and return the angular module object.


### PR DESCRIPTION
Seems ngHttp doesn't have it's own SFX bundle, but it doesn't seem to be included in angular2's SFX bundle neither.

I've added it in the angular2's SFX bundle as having it's own SFX bundle was causing some issues (see: #3898 and #3890).

Fixes: #3934
