### PR TITLE
feat(query): implement query update mechanism based on views.

### DIFF
--- a/modules/angular2/src/core/compiler/view.ts
+++ b/modules/angular2/src/core/compiler/view.ts
@@ -211,7 +211,11 @@ export class AppView implements ChangeDispatcher, RenderEventDispatcher {
   }
 
   notifyAfterViewChecked(): void {
-    // required for query
+    var eiCount = this.proto.elementBinders.length;
+    var ei = this.elementInjectors;
+    for (var i = eiCount - 1; i >= 0; i--) {
+      if (isPresent(ei[i + this.elementOffset])) ei[i + this.elementOffset].afterViewChecked();
+    }
   }
 
   getDirectiveFor(directive: DirectiveIndex): any {
@@ -289,6 +293,8 @@ export class AppView implements ChangeDispatcher, RenderEventDispatcher {
       throw new EventEvaluationError(eventName, e, e.stack, context);
     }
   }
+
+  get ownBindersCount(): number { return this.proto.elementBinders.length; }
 }
 
 function _localsToStringMap(locals: Locals): StringMap<string, any> {

--- a/modules/angular2/src/core/compiler/view_manager_utils.ts
+++ b/modules/angular2/src/core/compiler/view_manager_utils.ts
@@ -122,39 +122,29 @@ export class AppViewManagerUtils {
     ListWrapper.insert(viewContainer.views, atIndex, view);
     var elementInjector = contextView.elementInjectors[contextBoundElementIndex];
 
-    var sibling;
-    if (atIndex == 0) {
-      sibling = elementInjector;
-    } else {
-      sibling = ListWrapper.last(viewContainer.views[atIndex - 1].rootElementInjectors);
-    }
     for (var i = view.rootElementInjectors.length - 1; i >= 0; i--) {
       if (isPresent(elementInjector.parent)) {
-        view.rootElementInjectors[i].linkAfter(elementInjector.parent, sibling);
-      } else {
-        contextView.rootElementInjectors.push(view.rootElementInjectors[i]);
+        view.rootElementInjectors[i].link(elementInjector.parent);
       }
     }
+    elementInjector.traverseAndSetQueriesAsDirty();
   }
 
   detachViewInContainer(parentView: viewModule.AppView, boundElementIndex: number,
                         atIndex: number) {
     var viewContainer = parentView.viewContainers[boundElementIndex];
     var view = viewContainer.views[atIndex];
+
+    parentView.elementInjectors[boundElementIndex].traverseAndSetQueriesAsDirty();
+
     view.changeDetector.remove();
     ListWrapper.removeAt(viewContainer.views, atIndex);
     for (var i = 0; i < view.rootElementInjectors.length; ++i) {
       var inj = view.rootElementInjectors[i];
-      if (isPresent(inj.parent)) {
-        inj.unlink();
-      } else {
-        var removeIdx = ListWrapper.indexOf(parentView.rootElementInjectors, inj);
-        if (removeIdx >= 0) {
-          ListWrapper.removeAt(parentView.rootElementInjectors, removeIdx);
-        }
-      }
+      inj.unlink();
     }
   }
+
 
   hydrateViewInContainer(parentView: viewModule.AppView, boundElementIndex: number,
                          contextView: viewModule.AppView, contextBoundElementIndex: number,

--- a/modules/angular2/src/core/metadata.dart
+++ b/modules/angular2/src/core/metadata.dart
@@ -93,8 +93,8 @@ class Query extends QueryMetadata {
  * See: [ViewQueryMetadata] for docs.
  */
 class ViewQuery extends ViewQueryMetadata {
-  const ViewQuery(dynamic /*Type | string*/ selector, {bool descendants: false})
-    : super(selector, descendants: descendants);
+  const ViewQuery(dynamic /*Type | string*/ selector)
+    : super(selector, descendants: true);
 }
 
 /**

--- a/modules/angular2/test/core/compiler/element_injector_spec.ts
+++ b/modules/angular2/test/core/compiler/element_injector_spec.ts
@@ -44,12 +44,24 @@ import {TemplateRef} from 'angular2/src/core/compiler/template_ref';
 import {ElementRef} from 'angular2/src/core/compiler/element_ref';
 import {DynamicChangeDetector, ChangeDetectorRef, Parser, Lexer} from 'angular2/src/core/change_detection/change_detection';
 import {QueryList} from 'angular2/src/core/compiler/query_list';
+import {AppView, AppViewContainer} from "angular2/src/core/compiler/view";
 
-function createDummyView(detector = null) {
+function createDummyView(detector = null): AppView {
   var res = new SpyView();
   res.prop("changeDetector", detector);
   res.prop("elementOffset", 0);
-  return res;
+  res.prop("elementInjectors", []);
+  res.prop("viewContainers", []);
+  res.prop("ownBindersCount", 0);
+  return <any> res;
+}
+
+function addInj(view, inj) {
+  var injs: ElementInjector[] = view.elementInjectors;
+  injs.push(inj);
+  var containers: AppViewContainer[] = view.viewContainers;
+  containers.push(null);
+  view.prop("ownBindersCount", view.ownBindersCount + 1);
 }
 
 @Injectable()
@@ -63,7 +75,7 @@ class SomeOtherDirective {}
 var _constructionCount = 0;
 @Injectable()
 class CountingDirective {
-  count;
+  count: number;
   constructor() {
     this.count = _constructionCount;
     _constructionCount += 1;
@@ -213,17 +225,8 @@ class DirectiveWithDestroy {
   onDestroy() { this.onDestroyCounter++; }
 }
 
-class TestNode extends TreeNode<TestNode> {
-  message: string;
-  constructor(parent: TestNode, message) {
-    super(parent);
-    this.message = message;
-  }
-  toString() { return this.message; }
-}
-
 export function main() {
-  var defaultPreBuiltObjects = new PreBuiltObjects(null, <any>createDummyView(), <any>new SpyElementRef(), null);
+  var defaultPreBuiltObjects = new PreBuiltObjects(null, createDummyView(), <any>new SpyElementRef(), null);
 
   // An injector with more than 10 bindings will switch to the dynamic strategy
   var dynamicBindings = [];
@@ -239,15 +242,6 @@ export function main() {
       return DirectiveBinding.createFromType(b, null);
     });
     return ProtoElementInjector.create(parent, index, directiveBinding, hasShadowRoot, distance, dirVariableBindings);
-  }
-
-  function humanize(tree: TreeNode<any>, names: any[][]) {
-    var lookupName = (item) =>
-        ListWrapper.last(ListWrapper.find(names, (pair) => pair[0] === item));
-
-    if (tree.children.length == 0) return lookupName(tree);
-    var children = tree.children.map(m => humanize(m, names));
-    return [lookupName(tree), children];
   }
 
   function injector(bindings, imperativelyCreatedInjector = null, isComponent: boolean = false,
@@ -290,74 +284,19 @@ export function main() {
   }
 
   describe('TreeNodes', () => {
-    var root, firstParent, lastParent, node;
+    var root, child;
 
-    /*
-     Build a tree of the following shape:
-     root
-      - p1
-         - c1
-         - c2
-      - p2
-        - c3
-     */
     beforeEach(() => {
-      root = new TestNode(null, 'root');
-      var p1 = firstParent = new TestNode(root, 'p1');
-      var p2 = lastParent = new TestNode(root, 'p2');
-      node = new TestNode(p1, 'c1');
-      new TestNode(p1, 'c2');
-      new TestNode(p2, 'c3');
+      root = new TreeNode(null);
+      child = new TreeNode(root);
     });
 
-    // depth-first pre-order.
-    function walk(node, f) {
-      if (isBlank(node)) return f;
-      f(node);
-      ListWrapper.forEach(node.children, (n) => walk(n, f));
-    }
-
-    function logWalk(node) {
-      var log = '';
-      walk(node, (n) => { log += (log.length != 0 ? ', ' : '') + n.toString(); });
-      return log;
-    }
-
-    it('should support listing children',
-       () => { expect(logWalk(root)).toEqual('root, p1, c1, c2, p2, c3'); });
-
-    it('should support removing the first child node', () => {
-      firstParent.remove();
-
-      expect(firstParent.parent).toEqual(null);
-      expect(logWalk(root)).toEqual('root, p2, c3');
-    });
-
-    it('should support removing the last child node', () => {
-      lastParent.remove();
-
-      expect(logWalk(root)).toEqual('root, p1, c1, c2');
-    });
-
-    it('should support moving a node at the end of children', () => {
-      node.remove();
-      root.addChild(node);
-
-      expect(logWalk(root)).toEqual('root, p1, c2, p2, c3, c1');
-    });
-
-    it('should support moving a node in the beginning of children', () => {
-      node.remove();
-      lastParent.addChildAfter(node, null);
-
-      expect(logWalk(root)).toEqual('root, p1, c2, p2, c1, c3');
-    });
-
-    it('should support moving a node in the middle of children', () => {
-      node.remove();
-      lastParent.addChildAfter(node, firstParent);
-
-      expect(logWalk(root)).toEqual('root, p1, c2, c1, p2, c3');
+    it('should support removing and adding the parent', () => {
+      expect(child.parent).toEqual(root);
+      child.remove();
+      expect(child.parent).toEqual(null);
+      root.addChild(child);
+      expect(child.parent).toEqual(root);
     });
   });
 
@@ -493,8 +432,9 @@ export function main() {
         var c1 = protoChild1.instantiate(p);
         var c2 = protoChild2.instantiate(p);
 
-        expect(humanize(p, [[p, 'parent'], [c1, 'child1'], [c2, 'child2']]))
-            .toEqual(["parent", ["child1", "child2"]]);
+        expect(c1.parent).toEqual(p);
+        expect(c2.parent).toEqual(p);
+        expect(isBlank(p.parent)).toBeTruthy();
       });
 
       describe("direct parent", () => {
@@ -906,38 +846,6 @@ export function main() {
                 extraBindings));
             inj.dehydrate();
           });
-
-          it("should notify queries", inject([AsyncTestCompleter], (async) => {
-            var inj = injector(ListWrapper.concat([NeedsQuery], extraBindings));
-            var query = inj.get(NeedsQuery).query;
-            query.add(new CountingDirective()); // this marks the query as dirty
-
-            query.onChange(() => async.done());
-
-            inj.afterContentChecked();
-          }));
-
-          it("should not notify inherited queries", inject([AsyncTestCompleter], (async) => {
-            var child = parentChildInjectors(ListWrapper.concat([NeedsQuery], extraBindings), []);
-
-            var query = child.parent.get(NeedsQuery).query;
-
-            var calledOnChange = false;
-            query.onChange(() => {
-              // make sure the callback is called only once
-              expect(calledOnChange).toEqual(false);
-              expect(query.length).toEqual(2);
-
-              calledOnChange = true;
-              async.done()
-            });
-
-            query.add(new CountingDirective());
-            child.afterContentChecked(); // this does not notify the query
-
-            query.add(new CountingDirective());
-            child.parent.afterContentChecked();
-          }));
         });
 
         describe('static attributes', () => {
@@ -987,7 +895,7 @@ export function main() {
 
           it("should inject ChangeDetectorRef of the containing component into directives", () => {
             var cd = new DynamicChangeDetector(null, null, 0, [], [], null, [], [], [], null);
-            var view = <any>createDummyView(cd);
+            var view = createDummyView(cd);
             var binding = DirectiveBinding.createFromType(DirectiveNeedsChangeDetectorRef, new DirectiveMetadata());
             var inj = injector(ListWrapper.concat([binding], extraBindings), null, false,
                                new PreBuiltObjects(null, view, <any>new SpyElementRef(), null));
@@ -1022,11 +930,17 @@ export function main() {
         });
 
         describe('queries', () => {
-          var preBuildObjects = defaultPreBuiltObjects;
-          beforeEach(() => { _constructionCount = 0; });
+          var dummyView;
+          var preBuildObjects;
 
-          function expectDirectives(query, type, expectedIndex) {
+          beforeEach(() => { _constructionCount = 0;
+            dummyView = createDummyView();
+            preBuildObjects = new PreBuiltObjects(null, dummyView, <any>new SpyElementRef(), null);
+          });
+
+          function expectDirectives(query: QueryList<any>, type, expectedIndex) {
             var currentCount = 0;
+            expect(query.length).toEqual(expectedIndex.length);
             iterateListLike(query, (i) => {
               expect(i).toBeAnInstanceOf(type);
               expect(i.count).toBe(expectedIndex[currentCount]);
@@ -1047,50 +961,24 @@ export function main() {
               ], extraBindings), null,
               false, preBuildObjects);
 
+            addInj(dummyView, inj);
+            inj.afterContentChecked();
+
             expectDirectives(inj.get(NeedsQuery).query, CountingDirective, [0]);
-          })
+          });
 
           it('should contain PreBuiltObjects on the same injector', () => {
-            var preBuiltObjects = new PreBuiltObjects(null, null, null, new TemplateRef(<any>new SpyElementRef()));
+            var preBuiltObjects = new PreBuiltObjects(null, dummyView, null, new TemplateRef(<any>new SpyElementRef()));
             var inj = injector(ListWrapper.concat([
                 NeedsTemplateRefQuery
               ], extraBindings), null,
               false, preBuiltObjects);
+            addInj(dummyView, inj);
+
+            inj.afterContentChecked();
 
             expect(inj.get(NeedsTemplateRefQuery).query.first).toBe(preBuiltObjects.templateRef);
           });
-
-          it('should contain multiple directives from the same injector', () => {
-            var inj = injector(ListWrapper.concat([
-                NeedsQuery,
-                CountingDirective,
-                FancyCountingDirective,
-                bind(CountingDirective).toAlias(FancyCountingDirective)
-              ], extraBindings), null,
-              false, preBuildObjects);
-
-            expect(inj.get(NeedsQuery).query.length).toEqual(2);
-            expect(inj.get(NeedsQuery).query.first).toBeAnInstanceOf(CountingDirective);
-            expect(inj.get(NeedsQuery).query.last).toBeAnInstanceOf(FancyCountingDirective);
-          })
-
-          it('should contain multiple directives from the same injector after linking', () => {
-            var inj = parentChildInjectors([], ListWrapper.concat([
-                NeedsQuery,
-                CountingDirective,
-                FancyCountingDirective,
-                bind(CountingDirective).toAlias(FancyCountingDirective)
-              ], extraBindings));
-
-            var parent = inj.parent;
-
-            inj.unlink();
-            inj.link(parent);
-
-            expect(inj.get(NeedsQuery).query.length).toEqual(2);
-            expect(inj.get(NeedsQuery).query.first).toBeAnInstanceOf(CountingDirective);
-            expect(inj.get(NeedsQuery).query.last).toBeAnInstanceOf(FancyCountingDirective);
-          })
 
           it('should contain the element when no directives are bound to the var binding', () => {
             var dirs = [NeedsQueryByVarBindings];
@@ -1102,7 +990,10 @@ export function main() {
             var inj = injector(dirs.concat(extraBindings), null,
                                false, preBuildObjects, null, dirVariableBindings);
 
-            expect(inj.get(NeedsQueryByVarBindings).query.first).toBe(defaultPreBuiltObjects.elementRef);
+            addInj(dummyView, inj);
+            inj.afterContentChecked();
+
+            expect(inj.get(NeedsQueryByVarBindings).query.first).toBe(preBuildObjects.elementRef);
           });
 
           it('should contain directives on the same injector when querying by variable bindings' +
@@ -1117,20 +1008,13 @@ export function main() {
             var inj = injector(dirs.concat(extraBindings), null,
                                false, preBuildObjects, null, dirVariableBindings);
 
+            addInj(dummyView, inj);
+            inj.afterContentChecked();
+
             // NeedsQueryByVarBindings queries "one,two", so SimpleDirective should be before NeedsDirective
             expect(inj.get(NeedsQueryByVarBindings).query.first).toBeAnInstanceOf(SimpleDirective);
             expect(inj.get(NeedsQueryByVarBindings).query.last).toBeAnInstanceOf(NeedsDirective);
           });
-
-          // Dart's restriction on static types in (a is A) makes this feature hard to implement.
-          // Current proposal is to add second parameter the Query constructor to take a
-          // comparison function to support user-defined definition of matching.
-
-          //it('should support super class directives', () => {
-          //  var inj = injector([NeedsQuery, FancyCountingDirective], null, null, preBuildObjects);
-          //
-          //  expectDirectives(inj.get(NeedsQuery).query, FancyCountingDirective, [0]);
-          //});
 
           it('should contain directives on the same and a child injector in construction order', () => {
             var protoParent = createPei(null, 0, [NeedsQuery, CountingDirective]);
@@ -1142,89 +1026,11 @@ export function main() {
             parent.hydrate(null, null, preBuildObjects);
             child.hydrate(null, null, preBuildObjects);
 
+            addInj(dummyView, parent);
+            addInj(dummyView, child);
+            parent.afterContentChecked();
+
             expectDirectives(parent.get(NeedsQuery).query, CountingDirective, [0, 1]);
-          });
-
-          it('should reflect unlinking an injector', () => {
-            var protoParent = createPei(null, 0, [NeedsQuery, CountingDirective]);
-            var protoChild =
-                createPei(protoParent, 1, ListWrapper.concat([CountingDirective], extraBindings));
-
-            var parent = protoParent.instantiate(null);
-            var child = protoChild.instantiate(parent);
-            parent.hydrate(null, null, preBuildObjects);
-            child.hydrate(null, null, preBuildObjects);
-
-            child.unlink();
-
-            expectDirectives(parent.get(NeedsQuery).query, CountingDirective, [0]);
-          });
-
-          it('should reflect moving an injector as a last child', () => {
-            var protoParent = createPei(null, 0, [NeedsQuery, CountingDirective]);
-            var protoChild1 = createPei(protoParent, 1, [CountingDirective]);
-            var protoChild2 =
-                createPei(protoParent, 1, ListWrapper.concat([CountingDirective], extraBindings));
-
-            var parent = protoParent.instantiate(null);
-            var child1 = protoChild1.instantiate(parent);
-            var child2 = protoChild2.instantiate(parent);
-
-            parent.hydrate(null, null, preBuildObjects);
-            child1.hydrate(null,  null, preBuildObjects);
-            child2.hydrate(null, null, preBuildObjects);
-
-            child1.unlink();
-            child1.link(parent);
-
-            var queryList = parent.get(NeedsQuery).query;
-            expectDirectives(queryList, CountingDirective, [0, 2, 1]);
-          });
-
-          it('should reflect moving an injector as a first child', () => {
-            var protoParent = createPei(null, 0, [NeedsQuery, CountingDirective]);
-            var protoChild1 = createPei(protoParent, 1, [CountingDirective]);
-            var protoChild2 =
-                createPei(protoParent, 1, ListWrapper.concat([CountingDirective], extraBindings));
-
-            var parent = protoParent.instantiate(null);
-            var child1 = protoChild1.instantiate(parent);
-            var child2 = protoChild2.instantiate(parent);
-
-            parent.hydrate(null, null, preBuildObjects);
-            child1.hydrate(null, null, preBuildObjects);
-            child2.hydrate(null, null, preBuildObjects);
-
-            child2.unlink();
-            child2.linkAfter(parent, null);
-
-            var queryList = parent.get(NeedsQuery).query;
-            expectDirectives(queryList, CountingDirective, [0, 2, 1]);
-          });
-
-          it('should support two concurrent queries for the same directive', () => {
-            var protoGrandParent = createPei(null, 0, [NeedsQuery]);
-            var protoParent = createPei(null, 0, [NeedsQuery]);
-            var protoChild =
-                createPei(protoParent, 1, ListWrapper.concat([CountingDirective], extraBindings));
-
-            var grandParent = protoGrandParent.instantiate(null);
-            var parent = protoParent.instantiate(grandParent);
-            var child = protoChild.instantiate(parent);
-
-            grandParent.hydrate(null,  null, preBuildObjects);
-            parent.hydrate(null, null, preBuildObjects);
-            child.hydrate(null, null, preBuildObjects);
-
-            var queryList1 = grandParent.get(NeedsQuery).query;
-            var queryList2 = parent.get(NeedsQuery).query;
-
-            expectDirectives(queryList1, CountingDirective, [0]);
-            expectDirectives(queryList2, CountingDirective, [0]);
-
-            child.unlink();
-            expectDirectives(queryList1, CountingDirective, []);
-            expectDirectives(queryList2, CountingDirective, []);
           });
         });
       });

--- a/modules/angular2/test/core/compiler/view_manager_utils_spec.ts
+++ b/modules/angular2/test/core/compiler/view_manager_utils_spec.ts
@@ -131,24 +131,23 @@ export function main() {
         var binders = [];
         for (var i = 0; i < numInj; i++) {
           binders.push(createEmptyElBinder(i > 0 ? binders[i - 1] : null))
-        };
+        }
         var contextPv = createHostPv(binders);
         contextView = createViewWithChildren(contextPv);
       }
 
-      it('should link the views rootElementInjectors at the given context', () => {
+      it('should not modify the rootElementInjectors at the given context view', () => {
         createViews();
         utils.attachViewInContainer(parentView, 0, contextView, 0, 0, childView);
-        expect(contextView.rootElementInjectors.length).toEqual(2);
+        expect(contextView.rootElementInjectors.length).toEqual(1);
       });
 
       it('should link the views rootElementInjectors after the elementInjector at the given context',
          () => {
            createViews(2);
            utils.attachViewInContainer(parentView, 0, contextView, 1, 0, childView);
-           expect(childView.rootElementInjectors[0].spy('linkAfter'))
-               .toHaveBeenCalledWith(contextView.elementInjectors[0],
-                                     contextView.elementInjectors[1]);
+           expect(childView.rootElementInjectors[0].spy('link'))
+               .toHaveBeenCalledWith(contextView.elementInjectors[0]);
          });
     });
 


### PR DESCRIPTION
Instead of working with finer grained element injectors, queries now
iterate through the views as static units of modification of the
application structure. Views already contain element injectors in the
correct depth-first preorder.

This allows us to remove children linked lists on element injectors and a
lot of book keeping that is already present at the view level.

Queries are recalculated using the afterContentChecked and
afterViewChecked hooks, only during init and after a view container has
changed.

BREAKING CHANGE:
ViewQuery no longer supports the descendants flag. It queries the whole
component view by default.
