### PR TITLE
fix(core): export title service

### DIFF
--- a/modules/angular2/core.ts
+++ b/modules/angular2/core.ts
@@ -28,3 +28,5 @@ export {ComponentRef} from 'angular2/src/core/compiler/dynamic_component_loader'
 
 export {NgZone} from 'angular2/src/core/zone/ng_zone';
 export {Observable, EventEmitter} from 'angular2/src/core/facade/async';
+
+export {Title} from 'angular2/src/core/services/title';


### PR DESCRIPTION
I noticed that the `Title` service was not exported by core. That should fix it.
