### PR TITLE
feat(core): add support for @HostProperty and @HostListener

### DIFF
--- a/modules/angular2/metadata.ts
+++ b/modules/angular2/metadata.ts
@@ -40,7 +40,13 @@ export {
   PropertyMetadata,
   Event,
   EventFactory,
-  EventMetadata
+  EventMetadata,
+  HostBinding,
+  HostBindingFactory,
+  HostBindingMetadata,
+  HostListener,
+  HostListenerFactory,
+  HostListenerMetadata
 } from './src/core/metadata';
 
 export {

--- a/modules/angular2/src/core/metadata.dart
+++ b/modules/angular2/src/core/metadata.dart
@@ -112,3 +112,19 @@ class Event extends EventMetadata {
   const Event([String bindingPropertyName])
     : super(bindingPropertyName);
 }
+
+/**
+ * See: [HostBindingMetadata] for docs.
+ */
+class HostBinding extends HostBindingMetadata {
+  const HostBinding([String hostPropertyName])
+    : super(hostPropertyName);
+}
+
+/**
+ * See: [HostListenerMetadata] for docs.
+ */
+class HostListener extends HostListenerMetadata {
+  const HostListener(String eventName, [List<String> args])
+    : super(eventName, args);
+}

--- a/modules/angular2/src/core/metadata.ts
+++ b/modules/angular2/src/core/metadata.ts
@@ -15,7 +15,9 @@ export {
   PipeMetadata,
   LifecycleEvent,
   PropertyMetadata,
-  EventMetadata
+  EventMetadata,
+  HostBindingMetadata,
+  HostListenerMetadata
 } from './metadata/directives';
 
 export {ViewMetadata, ViewEncapsulation} from './metadata/view';
@@ -33,7 +35,9 @@ import {
   PipeMetadata,
   LifecycleEvent,
   PropertyMetadata,
-  EventMetadata
+  EventMetadata,
+  HostBindingMetadata,
+  HostListenerMetadata
 } from './metadata/directives';
 
 import {ViewMetadata, ViewEncapsulation} from './metadata/view';
@@ -448,6 +452,45 @@ export interface EventFactory {
 }
 
 /**
+ * {@link HostBindingMetadata} factory for creating decorators.
+ *
+ * ## Example as TypeScript Decorator
+ *
+ * ```
+ * @Directive({
+ *   selector: 'sample-dir'
+ * })
+ * class SampleDir {
+ *   @HostBinding() prop1; // Same as @HostBinding('prop1') prop1;
+ *   @HostBinding("el-prop") prop1;
+ * }
+ * ```
+ */
+export interface HostBindingFactory {
+  (hostPropertyName?: string): any;
+  new (hostPropertyName?: string): any;
+}
+
+/**
+ * {@link HostListenerMetadata} factory for creating decorators.
+ *
+ * ## Example as TypeScript Decorator
+ *
+ * ```
+ * @Directive({
+ *   selector: 'sample-dir'
+ * })
+ * class SampleDir {
+ *   @HostListener("change", ['$event.target.value']) onChange(value){}
+ * }
+ * ```
+ */
+export interface HostListenerFactory {
+  (eventName: string, args?: string[]): any;
+  new (eventName: string, args?: string[]): any;
+}
+
+/**
  * {@link ComponentMetadata} factory function.
  */
 export var Component: ComponentFactory =
@@ -493,3 +536,13 @@ export var Property: PropertyFactory = makePropDecorator(PropertyMetadata);
  * {@link EventMetadata} factory function.
  */
 export var Event: EventFactory = makePropDecorator(EventMetadata);
+
+/**
+ * {@link HostBindingMetadata} factory function.
+ */
+export var HostBinding: HostBindingFactory = makePropDecorator(HostBindingMetadata);
+
+/**
+ * {@link HostListenerMetadata} factory function.
+ */
+export var HostListener: HostListenerFactory = makePropDecorator(HostListenerMetadata);

--- a/modules/angular2/src/core/metadata/directives.ts
+++ b/modules/angular2/src/core/metadata/directives.ts
@@ -1110,3 +1110,67 @@ export class PropertyMetadata {
 export class EventMetadata {
   constructor(public bindingPropertyName?: string) {}
 }
+
+/**
+ * Declare a host property binding.
+ *
+ * ## Example
+ *
+ * ```
+ * @Directive({
+ *   selector: 'sample-dir'
+ * })
+ * class SampleDir {
+ *   @HostBinding() prop1; // Same as @HostBinding('prop1') prop1;
+ *   @HostBinding("el-prop") prop2;
+ * }
+ * ```
+ *
+ * This is equivalent to
+ *
+ * ```
+ * @Directive({
+ *   selector: 'sample-dir',
+ *   host: {'[prop1]': 'prop1', '[el-prop]': 'prop2'}
+ * })
+ * class SampleDir {
+ *   prop1;
+ *   prop2;
+ * }
+ * ```
+ */
+@CONST()
+export class HostBindingMetadata {
+  constructor(public hostPropertyName?: string) {}
+}
+
+/**
+ * Declare a host listener.
+ *
+ * ## Example
+ *
+ * ```
+ * @Directive({
+ *   selector: 'sample-dir'
+ * })
+ * class SampleDir {
+ *   @HostListener("change", ['$event.target.value']) onChange(value){}
+ * }
+ * ```
+ *
+ * This is equivalent to
+ *
+ * ```
+ * @Directive({
+ *   selector: 'sample-dir',
+ *   host: {'(change)': 'onChange($event.target.value)'}
+ * })
+ * class SampleDir {
+ *   onChange(value){}
+ * }
+ * ```
+ */
+@CONST()
+export class HostListenerMetadata {
+  constructor(public eventName: string, public args?: string[]) {}
+}


### PR DESCRIPTION
Example:

```
@Directive({selector: 'my-directive'})
class MyDirective {
  @HostProperty("attr.my-attr") myAttr: string;
  @HostListener("click", ["$event.target"])
  onClick(target) {
    this.target = target;
  }
}
```
