### PR TITLE
fix(http): change http interfaces to types

### DIFF
--- a/modules/angular2/src/http/interfaces.ts
+++ b/modules/angular2/src/http/interfaces.ts
@@ -33,9 +33,7 @@ export class Connection {
  * Interface for options to construct a Request, based on
  * [RequestInit](https://fetch.spec.whatwg.org/#requestinit) from the Fetch spec.
  */
-// TODO(jeffbcross): Change to type declaration when #3828 is fixed
-// https://github.com/angular/angular/issues/3828
-export interface RequestOptionsArgs {
+export type RequestOptionsArgs = {
   url?: string;
   method?: RequestMethods;
   search?: string | URLSearchParams;
@@ -48,7 +46,7 @@ export interface RequestOptionsArgs {
  * Interface for options to construct a Response, based on
  * [ResponseInit](https://fetch.spec.whatwg.org/#responseinit) from the Fetch spec.
  */
-export interface ResponseOptionsArgs {
+export type ResponseOptionsArgs = {
   // TODO: Support Blob, ArrayBuffer, JSON
   body?: string | Object | FormData;
   status?: number;


### PR DESCRIPTION
Types were previously not handled correctly by the type definition
generation process, so a couple of things in http had to be changed 
to interfaces. This issue has been fixed, so now they're types again.
