### PR TITLE
refactor(http): move mock_backend to test_lib module

### DIFF
--- a/modules/angular2/http.ts
+++ b/modules/angular2/http.ts
@@ -14,7 +14,6 @@ import {BaseRequestOptions, RequestOptions} from './src/http/base_request_option
 import {ConnectionBackend} from './src/http/interfaces';
 import {BaseResponseOptions, ResponseOptions} from './src/http/base_response_options';
 
-export {MockConnection, MockBackend} from './src/http/backends/mock_backend';
 export {Request} from './src/http/static_request';
 export {Response} from './src/http/static_response';
 

--- a/modules/angular2/src/test_lib/mock_backend.ts
+++ b/modules/angular2/src/test_lib/mock_backend.ts
@@ -6,6 +6,21 @@ import {Connection, ConnectionBackend} from 'angular2/src/http/interfaces';
 import {ObservableWrapper, EventEmitter} from 'angular2/src/core/facade/async';
 import {isPresent, BaseException} from 'angular2/src/core/facade/lang';
 
+export {Headers} from 'angular2/src/http/headers';
+export {Request} from 'angular2/src/http/static_request';
+export {URLSearchParams} from 'angular2/src/http/url_search_params';
+export {EventEmitter, Observable} from 'angular2/src/core/facade/async';
+export {Connection, ConnectionBackend} from 'angular2/src/http/interfaces';
+export {Response} from 'angular2/src/http/static_response';
+export {
+  ResponseTypes,
+  ReadyStates,
+  RequestMethods,
+  RequestCredentialsOpts,
+  RequestCacheOpts,
+  RequestModesOpts
+} from 'angular2/src/http/enums';
+
 /**
  *
  * Mock Connection to represent a {@link Connection} for tests.

--- a/modules/angular2/src/test_lib/mock_backend.ts
+++ b/modules/angular2/src/test_lib/mock_backend.ts
@@ -1,11 +1,10 @@
 import {Injectable} from 'angular2/src/core/di';
-import {Request} from '../static_request';
-import {Response} from '../static_response';
-import {ReadyStates} from '../enums';
-import {Connection, ConnectionBackend} from '../interfaces';
+import {Request} from 'angular2/src/http/static_request';
+import {Response} from 'angular2/src/http/static_response';
+import {ReadyStates} from 'angular2/src/http/enums';
+import {Connection, ConnectionBackend} from 'angular2/src/http/interfaces';
 import {ObservableWrapper, EventEmitter} from 'angular2/src/core/facade/async';
-import {isPresent} from 'angular2/src/core/facade/lang';
-import {BaseException} from 'angular2/src/core/facade/lang';
+import {isPresent, BaseException} from 'angular2/src/core/facade/lang';
 
 /**
  *

--- a/modules/angular2/test/http/http_spec.ts
+++ b/modules/angular2/test/http/http_spec.ts
@@ -9,10 +9,11 @@ import {
   inject,
   it,
   xit,
-  SpyObject
+  SpyObject,
+  MockBackend,
+  MockConnection
 } from 'angular2/test_lib';
 import {Injector, bind} from 'angular2/core';
-import {MockBackend, MockConnection} from 'angular2/src/http/backends/mock_backend';
 import {EventEmitter, ObservableWrapper} from 'angular2/src/core/facade/async';
 import {
   BaseRequestOptions,

--- a/modules/angular2/test_lib.ts
+++ b/modules/angular2/test_lib.ts
@@ -2,3 +2,4 @@
 export * from './test';
 export * from './src/test_lib/utils';
 export * from './src/test_lib/fake_async';
+export * from './src/test_lib/mock_backend';


### PR DESCRIPTION
To be consistent with other submodules, the mock_backend should be exported on a new test_lib module,
so it will not be loaded in production code or bundles.

Closes #2554
