### PR TITLE
docs(core): fixed typo in RenderCompiler comments

### DIFF
--- a/modules/angular2/src/core/render/api.ts
+++ b/modules/angular2/src/core/render/api.ts
@@ -358,7 +358,7 @@ export class RenderProtoViewMergeMapping {
 
 export class RenderCompiler {
   /**
-   * Creats a ProtoViewDto that contains a single nested component with the given componentId.
+   * Creates a ProtoViewDto that contains a single nested component with the given componentId.
    */
   compileHost(directiveMetadata: RenderDirectiveMetadata): Promise<ProtoViewDto> { return null; }
 


### PR DESCRIPTION
Just a small typo fix :)
