### PR TITLE
fix(test): solve failures found in Sauce Labs

### DIFF
--- a/modules/angular2/src/core/facade/lang.ts
+++ b/modules/angular2/src/core/facade/lang.ts
@@ -342,5 +342,8 @@ export function setValueOnPath(global: any, path: string, value: any) {
       obj = obj[name] = {};
     }
   }
+  if (obj === undefined || obj === null) {
+    obj = {};
+  }
   obj[parts.shift()] = value;
 }

--- a/modules/angular2/src/test_lib/shims_for_IE.js
+++ b/modules/angular2/src/test_lib/shims_for_IE.js
@@ -3,7 +3,8 @@
 if (!Object.hasOwnProperty('name')) {
   Object.defineProperty(Function.prototype, 'name', {
     get: function() {
-      var name = this.toString().match(/^\s*function\s*(\S*)\s*\(/)[1];
+      var matches = this.toString().match(/^\s*function\s*(\S*)\s*\(/);
+      var name = matches && matches.length > 1 ? matches[1] : "";
       // For better performance only parse once, and then cache the
       // result through a new accessor for repeated access.
       Object.defineProperty(this, 'name', {value: name});

--- a/modules/angular2/test/core/compiler/integration_spec.ts
+++ b/modules/angular2/test/core/compiler/integration_spec.ts
@@ -1703,7 +1703,7 @@ export function main() {
                           var dir = rootTC.debugElement.componentViewChildren[0].inject(
                               DirectiveWithPropDecorators);
                           var native = rootTC.debugElement.componentViewChildren[0].nativeElement;
-                          native.click();
+                          DOM.dispatchEvent(native, DOM.createMouseEvent('click'));
 
                           expect(dir.target).toBe(native);
                           async.done();

--- a/modules/angular2/test/web_workers/shared/message_bus_spec.ts
+++ b/modules/angular2/test/web_workers/shared/message_bus_spec.ts
@@ -110,7 +110,7 @@ export function main() {
     /**
      * Flushes pending messages and then runs the given function.
      */
-    function flushMessages(fn: () => void) { TimerWrapper.setTimeout(fn, 10); }
+    function flushMessages(fn: () => void) { TimerWrapper.setTimeout(fn, 40); }
 
     beforeEach(() => { bus = createConnectedMessageBus(); });
 


### PR DESCRIPTION
Problems found:
- a bug in the function.name shim, it was throwing instead of returning an empty string when the function had no name
- `element.click()` should not be used because of Android browser
- some `StyleCompiler` tests time out in many browsers in Sauce Labs
- in `StyleCompiler`, the Android browsers add an extra space at the end of the some lines
