### PR TITLE
fix(compiler): Implement Token#toString for Operator

### DIFF
--- a/modules/angular2/src/core/change_detection/parser/lexer.ts
+++ b/modules/angular2/src/core/change_detection/parser/lexer.ts
@@ -75,9 +75,10 @@ export class Token {
   toString(): string {
     switch (this.type) {
       case TokenType.Character:
-      case TokenType.String:
       case TokenType.Identifier:
       case TokenType.Keyword:
+      case TokenType.Operator:
+      case TokenType.String:
         return this.strValue;
       case TokenType.Number:
         return this.numValue.toString();


### PR DESCRIPTION
Include a case for `TokenType.Operator`.

Closes #4049
