### PR TITLE
docs(web_workers): fix typo

### DIFF
--- a/modules/angular2/src/web_workers/ui/application.dart
+++ b/modules/angular2/src/web_workers/ui/application.dart
@@ -45,7 +45,7 @@ class UIMessageBusSource extends IsolateMessageBusSource {
 
 /**
  * Wrapper class that exposes the {@link WebWorkerApplication}
- * Isolate instance and underyling {@link MessageBus} for lower level message passing.
+ * Isolate instance and underlying {@link MessageBus} for lower level message passing.
  */
 class IsolateInstance {
   WebWorkerApplication app;


### PR DESCRIPTION
Corrected spelling of "underlying".
