### PR TITLE
docs(web_workers/shared/message_bus.ts): correct typo 'messsage' to '…

### DIFF
--- a/modules/angular2/src/web_workers/shared/message_bus.ts
+++ b/modules/angular2/src/web_workers/shared/message_bus.ts
@@ -32,7 +32,7 @@ export /* abstract (with TS 1.6) */ class MessageBus implements MessageBusSource
   attachToZone(zone: NgZone): void { throw _abstract(); }
 
   /**
-   * Returns an {@link EventEmitter} that emits every time a messsage
+   * Returns an {@link EventEmitter} that emits every time a message
    * is received on the given channel.
    */
   from(channel: string): EventEmitter { throw _abstract(); }


### PR DESCRIPTION
…message'

Corrects the typo 'messsage' to 'message' on line 35.
