### PR TITLE
chore(build): improve reliability of the saucelabs job

### DIFF
--- a/modules/angular2/src/core/dom/browser_adapter.dart
+++ b/modules/angular2/src/core/dom/browser_adapter.dart
@@ -475,6 +475,10 @@ class BrowserDomAdapter extends GenericBrowserDomAdapter {
   cancelAnimationFrame(id) {
     window.cancelAnimationFrame(id);
   }
+
+  num performanceNow() {
+    return window.performance.now();
+  }
 }
 
 var baseElement = null;

--- a/modules/angular2/src/core/dom/browser_adapter.ts
+++ b/modules/angular2/src/core/dom/browser_adapter.ts
@@ -1,5 +1,11 @@
 import {MapWrapper, ListWrapper} from 'angular2/src/core/facade/collection';
-import {isBlank, isPresent, global, setValueOnPath} from 'angular2/src/core/facade/lang';
+import {
+  isBlank,
+  isPresent,
+  global,
+  setValueOnPath,
+  DateWrapper
+} from 'angular2/src/core/facade/lang';
 import {setRootDomAdapter} from './dom_adapter';
 import {GenericBrowserDomAdapter} from './generic_browser_adapter';
 
@@ -322,6 +328,15 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   setGlobalVar(path: string, value: any) { setValueOnPath(global, path, value); }
   requestAnimationFrame(callback): number { return window.requestAnimationFrame(callback); }
   cancelAnimationFrame(id: number) { window.cancelAnimationFrame(id); }
+  performanceNow(): number {
+    // performance.now() is not available in all browsers, see
+    // http://caniuse.com/#search=performance.now
+    if (isPresent(window.performance) && isPresent(window.performance.now)) {
+      return window.performance.now();
+    } else {
+      return DateWrapper.toMillis(DateWrapper.now());
+    }
+  }
 }
 
 

--- a/modules/angular2/src/core/dom/dom_adapter.ts
+++ b/modules/angular2/src/core/dom/dom_adapter.ts
@@ -138,4 +138,5 @@ export class DomAdapter {
   setGlobalVar(name: string, value: any) { throw _abstract(); }
   requestAnimationFrame(callback): number { throw _abstract(); }
   cancelAnimationFrame(id) { throw _abstract(); }
+  performanceNow(): number { throw _abstract(); }
 }

--- a/modules/angular2/src/core/dom/html_adapter.dart
+++ b/modules/angular2/src/core/dom/html_adapter.dart
@@ -431,4 +431,8 @@ class Html5LibDomAdapter implements DomAdapter {
   cancelAnimationFrame(id) {
     throw 'not implemented';
   }
+
+  performanceNow() {
+    throw 'not implemented';
+  }
 }

--- a/modules/angular2/src/core/dom/parse5_adapter.ts
+++ b/modules/angular2/src/core/dom/parse5_adapter.ts
@@ -9,7 +9,13 @@ var url = require('url');
 
 import {MapWrapper, ListWrapper, StringMapWrapper} from 'angular2/src/core/facade/collection';
 import {DomAdapter, setRootDomAdapter} from './dom_adapter';
-import {isPresent, isBlank, global, setValueOnPath} from 'angular2/src/core/facade/lang';
+import {
+  isPresent,
+  isBlank,
+  global,
+  setValueOnPath,
+  DateWrapper
+} from 'angular2/src/core/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 import {SelectorMatcher, CssSelector} from 'angular2/src/core/render/dom/compiler/selector';
 
@@ -545,6 +551,7 @@ export class Parse5DomAdapter extends DomAdapter {
   setGlobalVar(path: string, value: any) { setValueOnPath(global, path, value); }
   requestAnimationFrame(callback): number { return setTimeout(callback, 0); }
   cancelAnimationFrame(id: number) { clearTimeout(id); }
+  performanceNow(): number { return DateWrapper.toMillis(DateWrapper.now()); }
 }
 
 // TODO: build a proper list, this one is all the keys of a HTMLInputElement

--- a/modules/angular2/src/core/facade/lang.ts
+++ b/modules/angular2/src/core/facade/lang.ts
@@ -342,5 +342,8 @@ export function setValueOnPath(global: any, path: string, value: any) {
       obj = obj[name] = {};
     }
   }
+  if (obj === undefined || obj === null) {
+    obj = {};
+  }
   obj[parts.shift()] = value;
 }

--- a/modules/angular2/src/test_lib/shims_for_IE.js
+++ b/modules/angular2/src/test_lib/shims_for_IE.js
@@ -3,7 +3,8 @@
 if (!Object.hasOwnProperty('name')) {
   Object.defineProperty(Function.prototype, 'name', {
     get: function() {
-      var name = this.toString().match(/^\s*function\s*(\S*)\s*\(/)[1];
+      var matches = this.toString().match(/^\s*function\s*(\S*)\s*\(/);
+      var name = matches && matches.length > 1 ? matches[1] : "";
       // For better performance only parse once, and then cache the
       // result through a new accessor for repeated access.
       Object.defineProperty(this, 'name', {value: name});

--- a/modules/angular2/src/test_lib/test_lib.ts
+++ b/modules/angular2/src/test_lib/test_lib.ts
@@ -2,12 +2,13 @@
 
 import {DOM} from 'angular2/src/core/dom/dom_adapter';
 import {StringMapWrapper} from 'angular2/src/core/facade/collection';
-import {global, isFunction} from 'angular2/src/core/facade/lang';
+import {global, isFunction, Math} from 'angular2/src/core/facade/lang';
 import {NgZoneZone} from 'angular2/src/core/zone/ng_zone';
 
 import {bind} from 'angular2/src/core/di';
 
 import {createTestInjector, FunctionWithParamTokens, inject} from './test_injector';
+import {browserDetection} from './utils';
 
 export {inject} from './test_injector';
 
@@ -52,6 +53,7 @@ var jsmXIt = _global.xit;
 
 var runnerStack = [];
 var inIt = false;
+var globalTimeOut = browserDetection.isSlow ? 3000 : jasmine.DEFAULT_TIMEOUT_INTERVAL;
 
 var testBindings;
 
@@ -130,8 +132,9 @@ export function beforeEachBindings(fn): void {
 }
 
 function _it(jsmFn: Function, name: string, testFn: FunctionWithParamTokens | AnyTestFn,
-             timeOut: number): void {
+             testTimeOut: number): void {
   var runner = runnerStack[runnerStack.length - 1];
+  var timeOut = Math.max(globalTimeOut, testTimeOut);
 
   if (testFn instanceof FunctionWithParamTokens) {
     // The test case uses inject(). ie `it('test', inject([AsyncTestCompleter], (async) => { ...

--- a/modules/angular2/src/test_lib/utils.ts
+++ b/modules/angular2/src/test_lib/utils.ts
@@ -51,6 +51,12 @@ export class BrowserDetection {
     return this._ua.indexOf('AppleWebKit') > -1 && this._ua.indexOf('Edge') == -1;
   }
 
+  get isIOS7(): boolean {
+    return this._ua.indexOf('iPhone OS 7') > -1 || this._ua.indexOf('iPad OS 7') > -1;
+  }
+
+  get isSlow(): boolean { return this.isAndroid || this.isIE || this.isIOS7; }
+
   // The Intl API is only properly supported in recent Chrome and Opera.
   // Note: Edge is disguised as Chrome 42, so checking the "Edge" part is needed,
   // see https://msdn.microsoft.com/en-us/library/hh869301(v=vs.85).aspx

--- a/modules/angular2/src/tools/common_tools.ts
+++ b/modules/angular2/src/tools/common_tools.ts
@@ -1,6 +1,7 @@
 import {ApplicationRef, LifeCycle} from 'angular2/angular2';
 import {isPresent, NumberWrapper} from 'angular2/src/core/facade/lang';
 import {performance, window} from 'angular2/src/core/facade/browser';
+import {DOM} from 'angular2/src/core/dom/dom_adapter';
 
 /**
  * Entry point for all Angular debug tools. This object corresponds to the `ng`
@@ -40,17 +41,19 @@ export class AngularProfiler {
   timeChangeDetection(config: any) {
     var record = isPresent(config) && config['record'];
     var profileName = 'Change Detection';
-    if (record) {
+    // Profiler is not available in Android browsers, nor in IE 9 without dev tools opened
+    var isProfilerAvailable = isPresent(window.console.profile);
+    if (record && isProfilerAvailable) {
       window.console.profile(profileName);
     }
-    var start = window.performance.now();
+    var start = DOM.performanceNow();
     var numTicks = 0;
-    while (numTicks < 5 || (window.performance.now() - start) < 500) {
+    while (numTicks < 5 || (DOM.performanceNow() - start) < 500) {
       this.lifeCycle.tick();
       numTicks++;
     }
-    var end = window.performance.now();
-    if (record) {
+    var end = DOM.performanceNow();
+    if (record && isProfilerAvailable) {
       // need to cast to <any> because type checker thinks there's no argument
       // while in fact there is:
       //

--- a/modules/angular2/test/compiler/style_compiler_spec.ts
+++ b/modules/angular2/test/compiler/style_compiler_spec.ts
@@ -180,12 +180,10 @@ export function main() {
 
       it('should allow to import rules with relative paths',
          runTest(`div {color: red}@import ${IMPORT_REL_MODULE_NAME};`,
-                 ['div {color: red}', 'span {color: blue}'],
-                 [
+                 ['div {color: red}', 'span {color: blue}'], [
                    'div[_ngcontent-%COMP%] {\ncolor: red;\n}',
                    'span[_ngcontent-%COMP%] {\ncolor: blue;\n}'
-                 ]),
-         1000);
+                 ]));
     });
   });
 }

--- a/modules/angular2/test/core/compiler/integration_spec.ts
+++ b/modules/angular2/test/core/compiler/integration_spec.ts
@@ -1703,7 +1703,7 @@ export function main() {
                           var dir = rootTC.debugElement.componentViewChildren[0].inject(
                               DirectiveWithPropDecorators);
                           var native = rootTC.debugElement.componentViewChildren[0].nativeElement;
-                          native.click();
+                          DOM.dispatchEvent(native, DOM.createMouseEvent('click'));
 
                           expect(dir.target).toBe(native);
                           async.done();

--- a/modules/angular2/test/core/dom/shim_spec.dart
+++ b/modules/angular2/test/core/dom/shim_spec.dart
@@ -1,0 +1,5 @@
+library angular2.test.core.dom.shim_spec;
+
+main() {
+  // not relevant for dart.
+}

--- a/modules/angular2/test/core/dom/shim_spec.ts
+++ b/modules/angular2/test/core/dom/shim_spec.ts
@@ -1,0 +1,26 @@
+import {
+  AsyncTestCompleter,
+  beforeEach,
+  ddescribe,
+  describe,
+  el,
+  expect,
+  iit,
+  inject,
+  it,
+  xit
+} from 'angular2/test_lib';
+
+export function main() {
+  describe('Shim', () => {
+
+    it('should provide correct function.name ', () => {
+      var functionWithoutName = function(_) {};
+      function foo(_){};
+
+      expect((<any>functionWithoutName).name).toEqual('');
+      expect((<any>foo).name).toEqual('foo');
+    });
+
+  });
+}

--- a/modules/angular2/test/router/integration/lifecycle_hook_spec.ts
+++ b/modules/angular2/test/router/integration/lifecycle_hook_spec.ts
@@ -100,7 +100,7 @@ export function main() {
                expect(log).toEqual(['activate: null -> /on-activate']);
                async.done();
              });
-       }), 2000);
+       }));
 
     it('should wait for a parent component\'s onActivate hook to resolve before calling its child\'s',
        inject([AsyncTestCompleter], (async) => {
@@ -123,7 +123,7 @@ export function main() {
                      async.done();
                    });
              });
-       }), 2000);
+       }));
 
     it('should call the onDeactivate hook', inject([AsyncTestCompleter], (async) => {
          compile()
@@ -136,7 +136,7 @@ export function main() {
                expect(log).toEqual(['deactivate: /on-deactivate -> /a']);
                async.done();
              });
-       }), 2000);
+       }));
 
     it('should wait for a child component\'s onDeactivate hook to resolve before calling its parent\'s',
        inject([AsyncTestCompleter], (async) => {
@@ -161,7 +161,7 @@ export function main() {
                  async.done();
                });
              });
-       }), 2000);
+       }));
 
     it('should reuse a component when the canReuse hook returns true',
        inject([AsyncTestCompleter], (async) => {
@@ -182,7 +182,7 @@ export function main() {
                expect(cmpInstanceCount).toBe(1);
                async.done();
              });
-       }), 2000);
+       }));
 
 
     it('should not reuse a component when the canReuse hook returns false',
@@ -204,7 +204,7 @@ export function main() {
                expect(cmpInstanceCount).toBe(2);
                async.done();
              });
-       }), 2000);
+       }));
 
 
     it('should navigate when canActivate returns true', inject([AsyncTestCompleter], (async) => {
@@ -224,7 +224,7 @@ export function main() {
                      async.done();
                    });
              });
-       }), 2000);
+       }));
 
     it('should not navigate when canActivate returns false',
        inject([AsyncTestCompleter], (async) => {
@@ -244,7 +244,7 @@ export function main() {
                      async.done();
                    });
              });
-       }), 2000);
+       }));
 
     it('should navigate away when canDeactivate returns true',
        inject([AsyncTestCompleter], (async) => {
@@ -269,7 +269,7 @@ export function main() {
                  async.done();
                });
              });
-       }), 2000);
+       }));
 
     it('should not navigate away when canDeactivate returns false',
        inject([AsyncTestCompleter], (async) => {
@@ -294,7 +294,7 @@ export function main() {
                  async.done();
                });
              });
-       }), 2000);
+       }));
 
 
     it('should run activation and deactivation hooks in the correct order',
@@ -322,7 +322,7 @@ export function main() {
                ]);
                async.done();
              });
-       }), 2000);
+       }));
 
     it('should only run reuse hooks when reusing', inject([AsyncTestCompleter], (async) => {
          compile()
@@ -349,7 +349,7 @@ export function main() {
                ]);
                async.done();
              });
-       }), 2000);
+       }));
 
     it('should not run reuse hooks when not reusing', inject([AsyncTestCompleter], (async) => {
          compile()
@@ -378,7 +378,7 @@ export function main() {
                ]);
                async.done();
              });
-       }), 2000);
+       }));
   });
 }
 

--- a/modules/angular2/test/router/integration/router_integration_spec.ts
+++ b/modules/angular2/test/router/integration/router_integration_spec.ts
@@ -62,7 +62,7 @@ export function main() {
                    async.done();
                  });
                });
-         }), 1000);
+         }));
     });
 
     describe('broken app', () => {
@@ -78,7 +78,7 @@ export function main() {
                async.done();
              });
            });
-         }), 1000);
+         }));
     });
 
     describe('back button app', () => {
@@ -150,7 +150,7 @@ export function main() {
                  });
                  router.navigateByUrl('/parent/child');
                });
-         }), 1000);
+         }));
 
       describe('custom app base ref', () => {
         beforeEachBindings(() => { return [bind(APP_BASE_HREF).toValue('/my/app')]; });
@@ -170,8 +170,7 @@ export function main() {
                           });
                           router.navigateByUrl('/parent/child');
                         });
-                  }),
-           1000);
+                  }));
       });
     });
     // TODO: add a test in which the child component has bindings
@@ -197,7 +196,7 @@ export function main() {
                  router.navigateByUrl('/qs?q=search-for-something');
                  rootTC.detectChanges();
                });
-         }), 1000);
+         }));
     });
   });
 }

--- a/modules/angular2/test/router/integration/router_link_spec.ts
+++ b/modules/angular2/test/router/integration/router_link_spec.ts
@@ -280,7 +280,7 @@ export function main() {
                    async.done();
                  });
                });
-         }), 1000);
+         }));
 
       it('should navigate to link hrefs in presence of base href',
          inject([AsyncTestCompleter], (async) => {
@@ -301,7 +301,7 @@ export function main() {
                    async.done();
                  });
                });
-         }), 1000);
+         }));
     });
   });
 }

--- a/modules/angular2/test/router/location_spec.ts
+++ b/modules/angular2/test/router/location_spec.ts
@@ -63,7 +63,7 @@ export function main() {
            expect(ev['url']).toEqual('/user/btford');
            async.done();
          })
-       }), 2000);
+       }));
 
     it('should normalize location path', () => {
       locationStrategy.internalPath = '/my/app/user/btford';

--- a/modules/angular2/test/router/route_config_spec.ts
+++ b/modules/angular2/test/router/route_config_spec.ts
@@ -66,7 +66,7 @@ export function main() {
                });
                router.navigateByUrl('/parent/child');
              });
-       }), 1000);
+       }));
 
 
     it('should work in an app with redirects', inject([AsyncTestCompleter], (async) => {
@@ -80,7 +80,7 @@ export function main() {
                });
                router.navigateByUrl('/before');
              });
-       }), 1000);
+       }));
 
 
     it('should work in an app with async components', inject([AsyncTestCompleter], (async) => {
@@ -94,7 +94,7 @@ export function main() {
                });
                router.navigateByUrl('/hello');
              });
-       }), 1000);
+       }));
 
 
     it('should work in an app with a constructor component',
@@ -109,7 +109,7 @@ export function main() {
                });
                router.navigateByUrl('/hello');
              });
-       }), 1000);
+       }));
 
     it('should throw if a config is missing a target',
        inject(

--- a/modules/angular2/test/test_lib/utils_spec.ts
+++ b/modules/angular2/test/test_lib/utils_spec.ts
@@ -13,6 +13,8 @@ export function main() {
         isEdge: false,
         isIE: false,
         isWebkit: true,
+        isIOS7: false,
+        isSlow: false,
         supportsIntlApi: true
       },
       {
@@ -23,6 +25,8 @@ export function main() {
         isEdge: false,
         isIE: false,
         isWebkit: true,
+        isIOS7: false,
+        isSlow: false,
         supportsIntlApi: true
       },
       {
@@ -33,6 +37,8 @@ export function main() {
         isEdge: false,
         isIE: false,
         isWebkit: false,
+        isIOS7: false,
+        isSlow: false,
         supportsIntlApi: false
       },
       {
@@ -43,6 +49,8 @@ export function main() {
         isEdge: false,
         isIE: true,
         isWebkit: false,
+        isIOS7: false,
+        isSlow: true,
         supportsIntlApi: false
       },
       {
@@ -53,6 +61,8 @@ export function main() {
         isEdge: false,
         isIE: true,
         isWebkit: false,
+        isIOS7: false,
+        isSlow: true,
         supportsIntlApi: false
       },
       {
@@ -63,6 +73,8 @@ export function main() {
         isEdge: false,
         isIE: true,
         isWebkit: false,
+        isIOS7: false,
+        isSlow: true,
         supportsIntlApi: false
       },
       {
@@ -73,6 +85,8 @@ export function main() {
         isEdge: true,
         isIE: false,
         isWebkit: false,
+        isIOS7: false,
+        isSlow: false,
         supportsIntlApi: false
       },
       {
@@ -83,6 +97,8 @@ export function main() {
         isEdge: false,
         isIE: false,
         isWebkit: true,
+        isIOS7: false,
+        isSlow: true,
         supportsIntlApi: false
       },
       {
@@ -93,6 +109,8 @@ export function main() {
         isEdge: false,
         isIE: false,
         isWebkit: true,
+        isIOS7: false,
+        isSlow: true,
         supportsIntlApi: false
       },
       {
@@ -103,6 +121,8 @@ export function main() {
         isEdge: false,
         isIE: false,
         isWebkit: true,
+        isIOS7: false,
+        isSlow: true,
         supportsIntlApi: false
       },
       {
@@ -113,6 +133,8 @@ export function main() {
         isEdge: false,
         isIE: false,
         isWebkit: true,
+        isIOS7: false,
+        isSlow: false,
         supportsIntlApi: false
       },
       {
@@ -123,6 +145,8 @@ export function main() {
         isEdge: false,
         isIE: false,
         isWebkit: true,
+        isIOS7: false,
+        isSlow: false,
         supportsIntlApi: false
       },
       {
@@ -133,6 +157,8 @@ export function main() {
         isEdge: false,
         isIE: false,
         isWebkit: true,
+        isIOS7: false,
+        isSlow: false,
         supportsIntlApi: false
       },
       {
@@ -143,6 +169,8 @@ export function main() {
         isEdge: false,
         isIE: false,
         isWebkit: true,
+        isIOS7: true,
+        isSlow: true,
         supportsIntlApi: false
       },
       {
@@ -153,6 +181,8 @@ export function main() {
         isEdge: false,
         isIE: false,
         isWebkit: true,
+        isIOS7: false,
+        isSlow: false,
         supportsIntlApi: false
       }
     ];
@@ -165,6 +195,8 @@ export function main() {
         expect(bd.isEdge).toBe(StringMapWrapper.get(browser, 'isEdge'));
         expect(bd.isIE).toBe(StringMapWrapper.get(browser, 'isIE'));
         expect(bd.isWebkit).toBe(StringMapWrapper.get(browser, 'isWebkit'));
+        expect(bd.isIOS7).toBe(StringMapWrapper.get(browser, 'isIOS7'));
+        expect(bd.isSlow).toBe(StringMapWrapper.get(browser, 'isSlow'));
         expect(bd.supportsIntlApi).toBe(StringMapWrapper.get(browser, 'supportsIntlApi'));
       });
     });

--- a/modules/angular2/test/web_workers/shared/message_bus_spec.ts
+++ b/modules/angular2/test/web_workers/shared/message_bus_spec.ts
@@ -38,7 +38,7 @@ export function main() {
          });
          var toEmitter = bus.to(CHANNEL);
          ObservableWrapper.callNext(toEmitter, MESSAGE);
-       }), 1000);
+       }));
 
     it("should broadcast", inject([AsyncTestCompleter], (async) => {
          const CHANNEL = "CHANNEL 1";
@@ -111,7 +111,7 @@ export function main() {
      * Flushes pending messages and then runs the given function.
      */
     // TODO(mlaval): timeout is fragile, test to be rewritten
-    function flushMessages(fn: () => void) { TimerWrapper.setTimeout(fn, 40); }
+    function flushMessages(fn: () => void) { TimerWrapper.setTimeout(fn, 50); }
 
     beforeEach(() => { bus = createConnectedMessageBus(); });
 
@@ -133,7 +133,7 @@ export function main() {
              async.done();
            });
          });
-       }));
+       }), 500);
 
     it("should send messages immediatly when run outside the zone",
        inject([AsyncTestCompleter, NgZone], (async, zone: MockNgZone) => {
@@ -147,6 +147,6 @@ export function main() {
            expect(wasCalled).toBeTruthy();
            async.done();
          });
-       }));
+       }), 500);
   });
 }

--- a/modules/angular2/test/web_workers/shared/message_bus_spec.ts
+++ b/modules/angular2/test/web_workers/shared/message_bus_spec.ts
@@ -110,7 +110,8 @@ export function main() {
     /**
      * Flushes pending messages and then runs the given function.
      */
-    function flushMessages(fn: () => void) { TimerWrapper.setTimeout(fn, 10); }
+    // TODO(mlaval): timeout is fragile, test to be rewritten
+    function flushMessages(fn: () => void) { TimerWrapper.setTimeout(fn, 40); }
 
     beforeEach(() => { bus = createConnectedMessageBus(); });
 


### PR DESCRIPTION
We are currently using Sauce Labs with 14 browsers, so that's about 28k unit tests run each time. Among all of them, there are usually a few of them failing due to timeout being reached. 2 to 3 per run usually, sometimes a bit more (10 max), **sometimes none**.

After 2 weeks of watching the job, there is no clear pattern in these failures. They randomly happen in slow browsers (Androids, IEs, iOS7) among the ~50 tests which are time sensitive.
Let's make these test safer by increasing timeouts and continue watching.

This is a follow up of #4047 which fixes real failures introduced these last days.
