### PR TITLE
docs(core/compiler/query_list.ts): Correct typo 'partialy' -> 'partially'

### DIFF
--- a/modules/angular2/src/core/compiler/query_list.ts
+++ b/modules/angular2/src/core/compiler/query_list.ts
@@ -34,7 +34,7 @@ import {ListWrapper, MapWrapper} from 'angular2/src/core/facade/collection';
  *
  * A possible solution would be for a `<pane>` to inject `<tabs>` component and then register itself
  * with `<tabs>` component's on `hydrate` and deregister on `dehydrate` event. While a reasonable
- * approach, this would only work partialy since `*ng-for` could rearrange the list of `<pane>`
+ * approach, this would only work partially since `*ng-for` could rearrange the list of `<pane>`
  * components which would not be reported to `<tabs>` component and thus the list of `<pane>`
  * components would be out of sync with respect to the list of `<pane>` elements.
  *


### PR DESCRIPTION
Typo located in modules/angular2/src/core/compiler/query_list.ts
