### PR TITLE
feat(autoconfiguration): Annotation based binding

### DIFF
--- a/modules/angular2/angular2.ts
+++ b/modules/angular2/angular2.ts
@@ -2,3 +2,4 @@ export * from './core';
 export * from './profile';
 export * from './lifecycle_hooks';
 export * from './bootstrap';
+export * from './auto_configuration';

--- a/modules/angular2/auto_configuration.ts
+++ b/modules/angular2/auto_configuration.ts
@@ -1,0 +1,1 @@
+export * from 'angular2/src/core/auto_configuration/auto_configuration';

--- a/modules/angular2/http.ts
+++ b/modules/angular2/http.ts
@@ -5,6 +5,7 @@
  * class.
  */
 import {bind, Binding} from 'angular2/core';
+import {Configuration} from 'angular2/auto_configuration';
 import {Http, Jsonp} from './src/http/http';
 import {XHRBackend, XHRConnection} from './src/http/backends/xhr_backend';
 import {JSONPBackend, JSONPConnection} from './src/http/backends/jsonp_backend';
@@ -85,3 +86,8 @@ export const JSONP_BINDINGS: any[] = [
   bind(ResponseOptions).toClass(BaseResponseOptions),
   JSONPBackend
 ];
+
+@Configuration()
+export class HttpConfiguration {
+  getBindings() { return HTTP_BINDINGS; }
+}

--- a/modules/angular2/src/core/application_common.ts
+++ b/modules/angular2/src/core/application_common.ts
@@ -16,6 +16,7 @@ import {
   ExceptionHandler
 } from 'angular2/src/core/facade/exceptions';
 import {BrowserDomAdapter} from 'angular2/src/core/dom/browser_adapter';
+import {getAutoconfiguredBindings} from 'angular2/src/core/auto_configuration/helpers';
 import {DOM} from 'angular2/src/core/dom/dom_adapter';
 import {Compiler, CompilerCache} from './compiler/compiler';
 import {Reflector, reflector} from 'angular2/src/core/reflection/reflection';
@@ -349,6 +350,12 @@ function _createAppInjector(appComponentType: Type, bindings: Array<Type | Bindi
   var mergedBindings: any[] =
       isPresent(bindings) ? ListWrapper.concat(_injectorBindings(appComponentType), bindings) :
                             _injectorBindings(appComponentType);
+
+  var autoconfiguredBindings: any[] = getAutoconfiguredBindings(appComponentType);
+  if (isPresent(autoconfiguredBindings)) {
+    mergedBindings = ListWrapper.concat(autoconfiguredBindings, mergedBindings);
+  }
+
   mergedBindings.push(bind(NgZone).toValue(zone));
   return _rootInjector.resolveAndCreateChild(mergedBindings);
 }

--- a/modules/angular2/src/core/auto_configuration/auto_configuration.ts
+++ b/modules/angular2/src/core/auto_configuration/auto_configuration.ts
@@ -1,0 +1,7 @@
+export {
+  Configuration,
+  Autoconfigured,
+  ConfigurationFactory,
+  AutoconfiguredFactory
+} from './decorators';
+export {ConfigurationMetadata, AutoconfiguredMetadata} from './metadata';

--- a/modules/angular2/src/core/auto_configuration/decorators.dart
+++ b/modules/angular2/src/core/auto_configuration/decorators.dart
@@ -1,0 +1,18 @@
+library angular2.auto_configuration.decorators;
+
+import 'metadata.dart';
+export 'metadata.dart';
+
+/**
+ * {@link ConfigurationMetadata}.
+ */
+class Configuration extends ConfigurationMetadata {
+  const Configuration() : super();
+}
+
+/**
+ * {@link AutoconfiguredMetadata}.
+ */
+class Autoconfigured extends AutoconfiguredMetadata {
+  const Autoconfigured() : super();
+}

--- a/modules/angular2/src/core/auto_configuration/decorators.ts
+++ b/modules/angular2/src/core/auto_configuration/decorators.ts
@@ -1,0 +1,33 @@
+import {
+  ConfigurationMetadata,
+  AutoconfiguredMetadata,
+} from './metadata';
+import {makeDecorator, TypeDecorator} from '../util/decorators';
+
+/**
+ * Factory for creating {@link ConfigurationMetadata}.
+ */
+export interface ConfigurationFactory {
+  (): any;
+  new (): ConfigurationMetadata;
+}
+
+/**
+ * Factory for creating {@link AutoconfiguredMetadata}.
+ */
+export interface AutoconfiguredFactory {
+  (): any;
+  new (): AutoconfiguredMetadata;
+}
+
+/**
+ * Factory for creating {@link ConfigurationMetadata}.
+ */
+export var Configuration: ConfigurationFactory =
+    <ConfigurationFactory>makeDecorator(ConfigurationMetadata);
+
+/**
+ * Factory for creating {@link AutoconfiguredMetadata}.
+ */
+export var Autoconfigured: AutoconfiguredFactory =
+    <AutoconfiguredFactory>makeDecorator(AutoconfiguredMetadata);

--- a/modules/angular2/src/core/auto_configuration/helpers.ts
+++ b/modules/angular2/src/core/auto_configuration/helpers.ts
@@ -1,0 +1,45 @@
+import {
+  Configuration,
+  Autoconfigured,
+  ConfigurationFactory,
+  AutoconfiguredFactory
+} from './decorators';
+import {AutoconfiguredMetadata} from './metadata';
+
+import {Type, isPresent} from 'angular2/src/core/facade/lang';
+
+import {reflectRegistry} from 'angular2/src/core/util/decorators';
+
+import {ReflectionCapabilities} from 'angular2/src/core/reflection/reflection_capabilities';
+
+var reflector: ReflectionCapabilities = new ReflectionCapabilities();
+
+export function getAutoconfiguredBindings(appComponentType: Type): any[] {
+  var autoconfigured = getConfigurationAnnotation(appComponentType);
+  var bindings;
+
+  if (isPresent(autoconfigured)) {
+    bindings = getConfigurationBindings();
+  }
+
+  return bindings;
+}
+
+export function getConfigurationAnnotation(appComponentType: Type): AutoconfiguredMetadata {
+  var annotations: any[] = reflector.annotations(appComponentType);
+  var annotation;
+
+  for (var i = 0; i < annotations.length && !isPresent(annotation); i++) {
+    if (annotations[i] instanceof AutoconfiguredMetadata) {
+      annotation = annotations[i];
+    }
+  }
+  return annotation;
+}
+
+export function getConfigurationBindings(): any[] {
+  var bindings: any[] = [];
+  var configList: any[] = reflectRegistry.getForAnnotation(Configuration);
+  configList.forEach((type: Type) => { bindings.push(reflector.factory(type)().getBindings()); });
+  return bindings;
+}

--- a/modules/angular2/src/core/auto_configuration/metadata.ts
+++ b/modules/angular2/src/core/auto_configuration/metadata.ts
@@ -1,0 +1,37 @@
+import {CONST, stringify} from "angular2/src/core/facade/lang";
+
+/**
+ * A configuration metadata that specifies a configuration object with it's priority.
+ *
+ * ```
+ * @Configuration
+ * class SomeConfigurationClass {
+ *   constructor() {}
+ * }
+ * ```
+ */
+
+@CONST()
+export class ConfigurationMetadata {
+  constructor() {}
+  toString(): string { return `@Configuration()`; }
+}
+
+/**
+ * A Autoconfiged metadata that specifies a component that should be configured and bootstrapped
+ * automatically.
+ *
+ * ```
+ * @Autoconfigured
+ * @Component
+ * class SomeComponent {
+ *   constructor() {}
+ * }
+ * ```
+ */
+
+@CONST()
+export class AutoconfiguredMetadata {
+  constructor() {}
+  toString(): string { return `@Autoconfigured()`; }
+}

--- a/modules/angular2/src/core/util/decorators.dart
+++ b/modules/angular2/src/core/util/decorators.dart
@@ -1,1 +1,19 @@
 library angular2.core.util.decorators;
+
+import 'dart:mirrors';
+
+class ReflectRegistry {
+  List<Type> getForAnnotation(Type annotation) {
+    List<Type> list = new List<Type>();
+    currentMirrorSystem().libraries.forEach((uri, lib) {
+      lib.declarations.forEach((s, decl) {
+        decl.metadata.where((m) => m.type.reflectedType == annotation).forEach((m) {
+          list.add(decl.reflectedType);
+        });
+      });
+    });
+    return list;
+  }
+}
+
+ReflectRegistry reflectRegistry = new ReflectRegistry();

--- a/modules/angular2/test/core/auto_configuration/bootstrap_spec.ts
+++ b/modules/angular2/test/core/auto_configuration/bootstrap_spec.ts
@@ -1,0 +1,63 @@
+import {
+  AsyncTestCompleter,
+  beforeEach,
+  xdescribe,
+  ddescribe,
+  describe,
+  el,
+  expect,
+  iit,
+  inject,
+  it
+} from 'angular2/test_lib';
+
+import {
+  Configuration,
+  Autoconfigured
+} from 'angular2/src/core/auto_configuration/auto_configuration';
+
+import {bootstrap} from 'angular2/src/core/bootstrap';
+import {Component, View, Directive} from 'angular2/src/core/metadata';
+import {DOM} from 'angular2/src/core/dom/dom_adapter';
+import {DOCUMENT} from 'angular2/src/core/render/render';
+import {bind, Inject, Injector, Injectable} from 'angular2/src/core/di';
+
+@Injectable()
+class Service {
+  constructor() {}
+  getMessage() { return 'hello'; }
+}
+
+@Autoconfigured()
+@Component({selector: 'hello-app'})
+@View({template: '{{greeting}} world!'})
+class HelloRootCmp {
+  greeting: string;
+  constructor(service: Service) { this.greeting = service.getMessage(); }
+}
+
+@Configuration()
+class ConfigureTests {
+  getBindings() { return [Service] }
+}
+
+export function main() {
+  var fakeDoc, el, testBindings;
+
+  describe('regular bootstrapping with auto configuration', () => {
+    beforeEach(() => {
+      fakeDoc = DOM.createHtmlDocument();
+      el = DOM.createElement('hello-app', fakeDoc);
+      DOM.appendChild(fakeDoc.body, el);
+      testBindings = [bind(DOCUMENT).toValue(fakeDoc)];
+    });
+
+    it('should display hello world', inject([AsyncTestCompleter], (async) => {
+         var refPromise = bootstrap(HelloRootCmp, testBindings);
+         refPromise.then((ref) => {
+           expect(el).toHaveText('hello world!');
+           async.done();
+         });
+       }));
+  });
+}

--- a/modules/angular2/test/core/compiler/integration_dart_spec.dart
+++ b/modules/angular2/test/core/compiler/integration_dart_spec.dart
@@ -241,15 +241,12 @@ class ThrowingComponent2 {
   }
 }
 
-@proxy()
-class PropModel implements Map {
+class PropModel {
   final String foo = 'foo-prop';
 
   operator [](_) => 'foo-map';
-
-  noSuchMethod(_) {
-    throw 'property not found';
-  }
+  
+  bool get doesNotExist => throw 'property not found';
 }
 
 @Component(selector: 'property-access')

--- a/modules/angular2/test/core/metadata/decorators_spec.ts
+++ b/modules/angular2/test/core/metadata/decorators_spec.ts
@@ -10,7 +10,7 @@ import {
   xit,
 } from 'angular2/test_lib';
 
-import {Component, View, Directive} from 'angular2/angular2';
+import {Component, View, Directive} from 'angular2/src/core/metadata';
 import {reflector} from 'angular2/src/core/reflection/reflection';
 
 export function main() {

--- a/modules/angular2/test/core/util/decorators_spec.ts
+++ b/modules/angular2/test/core/util/decorators_spec.ts
@@ -10,7 +10,12 @@ import {
   xit,
 } from 'angular2/test_lib';
 
-import {makeDecorator, makeParamDecorator, Class} from 'angular2/src/core/util/decorators';
+import {
+  makeDecorator,
+  makeParamDecorator,
+  Class,
+  reflectRegistry
+} from 'angular2/src/core/util/decorators';
 import {global} from 'angular2/src/core/facade/lang';
 import {Inject} from 'angular2/angular2';
 import {reflector} from 'angular2/src/core/reflection/reflection';
@@ -25,6 +30,14 @@ class TerminalAnnotation {
 
 class DecoratedParent {}
 class DecoratedChild extends DecoratedParent {}
+
+class SampleAnnotation {}
+
+var SampleDecorator: (...args) => any = makeDecorator(SampleAnnotation);
+
+@SampleDecorator()
+class SampleClass {
+}
 
 export function main() {
   var Reflect = global.Reflect;
@@ -92,6 +105,17 @@ export function main() {
         expect(proto.prototype).toEqual(undefined);
 
         expect(reflector.annotations(MyClass)[0].arg).toEqual('test-works')
+      });
+
+      describe('reflectRegistry', () => {
+        it('should add annotated objects to the registry', () => {
+          var MyClass = (<any>SampleDecorator()).Class(<any>{constructor: function() {}});
+          expect(reflectRegistry.getForAnnotation(SampleAnnotation)).toContain(MyClass);
+        });
+
+        it('should add annotated classes to the registry', () => {
+          expect(reflectRegistry.getForAnnotation(SampleAnnotation)).toContain(SampleClass);
+        });
       });
 
       describe('errors', () => {

--- a/modules/examples/src/hello_world/greeting_service.ts
+++ b/modules/examples/src/hello_world/greeting_service.ts
@@ -1,0 +1,19 @@
+import {Injectable} from 'angular2/core';
+import {Configuration} from 'angular2/auto_configuration';
+import {CONST_EXPR} from 'angular2/src/core/facade/lang';
+
+// A service available to the Injector, used by the HelloCmp component.
+@Injectable()
+export class GreetingService {
+  greeting: string = 'hello';
+}
+
+// CONST_EXPR is only needed because of Dart transpilation
+export const GREETINGS_BINDINGS: any[] = CONST_EXPR([GreetingService]);
+
+// This represents a configuration class to make the GreetingService globally available for
+// those components that are autoconfigured.
+@Configuration()
+class GreetingServiceConfiguration {
+  getBindings() { return GREETINGS_BINDINGS; }
+}

--- a/modules/examples/src/hello_world/index_common.ts
+++ b/modules/examples/src/hello_world/index_common.ts
@@ -1,11 +1,7 @@
 import {ElementRef, Component, Directive, View, Injectable} from 'angular2/core';
 import {Renderer} from 'angular2/render';
-
-// A service available to the Injector, used by the HelloCmp component.
-@Injectable()
-class GreetingService {
-  greeting: string = 'hello';
-}
+import {Autoconfigured} from 'angular2/auto_configuration';
+import {GreetingService} from './greeting_service';
 
 // Directives are light-weight. They don't allow new
 // expression contexts (use @Component for those needs).
@@ -28,9 +24,6 @@ class RedDec {
   // class. The syntax supported is a basic subset of CSS selectors, for example
   // 'element', '[attr]', [attr=foo]', etc.
   selector: 'hello-app',
-  // These are services that would be created if a class in the component's
-  // template tries to inject them.
-  viewBindings: [GreetingService]
 })
 // The template for the component.
 @View({
@@ -44,6 +37,8 @@ class RedDec {
   // misspelled).
   directives: [RedDec]
 })
+// This makes the injector of this componet take all Configuration annotated classes
+@Autoconfigured()
 export class HelloCmp {
   greeting: string;
 

--- a/modules/examples/src/http/http_comp.ts
+++ b/modules/examples/src/http/http_comp.ts
@@ -1,7 +1,8 @@
-import {Component, View, NgFor} from 'angular2/angular2';
+import {Component, View, NgFor, Autoconfigured} from 'angular2/angular2';
 import {Http, Response} from 'angular2/http';
 import {ObservableWrapper} from 'angular2/src/core/facade/async';
 
+@Autoconfigured()
 @Component({selector: 'http-app'})
 @View({
   directives: [NgFor],

--- a/modules/examples/src/http/index.ts
+++ b/modules/examples/src/http/index.ts
@@ -1,9 +1,8 @@
 /// <reference path="../../../angular2/typings/rx/rx.d.ts" />
 
 import {bootstrap} from 'angular2/bootstrap';
-import {HTTP_BINDINGS} from 'angular2/http';
 import {HttpCmp} from './http_comp';
 
 export function main() {
-  bootstrap(HttpCmp, [HTTP_BINDINGS]);
+  bootstrap(HttpCmp);
 }

--- a/modules/examples/src/http/index_dynamic.ts
+++ b/modules/examples/src/http/index_dynamic.ts
@@ -1,8 +1,7 @@
 import {HttpCmp} from './http_comp';
 import {bootstrap} from 'angular2/bootstrap';
-import {HTTP_BINDINGS} from 'angular2/http';
 
 export function main() {
   // This entry point is not transformed and exists for testing dynamic mode.
-  bootstrap(HttpCmp, [HTTP_BINDINGS]);
+  bootstrap(HttpCmp);
 }


### PR DESCRIPTION
This feature is explained in #4004.

Adds two annotations:
- Configuration: annotates a class provided by modules that returns the
  default bindings for that module
- Autoconfigured: annotates a component so that it gets the bindings
  provided by the imported modules automatically (no need to bind'em during the bootstrap).

For an example of the improvements you can check how the [boostraping is now made in the http example](https://github.com/angular/angular/compare/angular:master...alfonso-presa:autoconfigurationFeature?expand=1#diff-359571929599984fdca28ed5e4d17061R7)

I would really appreciate anyone's feedback about this idea.

I hope you find it useful :-).
