### PR TITLE
feat(http): set the statusText property from the XMLHttpRequest instance

### DIFF
--- a/modules/angular2/src/http/backends/xhr_backend.ts
+++ b/modules/angular2/src/http/backends/xhr_backend.ts
@@ -52,7 +52,10 @@ export class XHRConnection implements Connection {
         if (status === 0) {
           status = body ? 200 : 0;
         }
-        var responseOptions = new ResponseOptions({body, status, headers, url});
+
+        let statusText = _xhr.statusText || 'OK';
+
+        var responseOptions = new ResponseOptions({body, status, headers, statusText, url});
         if (isPresent(baseResponseOptions)) {
           responseOptions = baseResponseOptions.merge(responseOptions);
         }

--- a/modules/angular2/test/http/backends/xhr_backend_spec.ts
+++ b/modules/angular2/test/http/backends/xhr_backend_spec.ts
@@ -42,6 +42,8 @@ class MockBrowserXHR extends BrowserXhr {
   status: number;
   responseHeaders: string;
   responseURL: string;
+  statusText: string;
+
   constructor() {
     super();
     var spy = new SpyObject();
@@ -52,6 +54,8 @@ class MockBrowserXHR extends BrowserXhr {
   }
 
   setStatusCode(status: number) { this.status = status; }
+
+  setStatusText(statusText: string) { this.statusText = statusText; }
 
   setResponse(value: string) { this.response = value; }
 
@@ -333,6 +337,35 @@ export function main() {
            existingXHRs[0].setStatusCode(statusCode);
            existingXHRs[0].dispatchEvent('load');
          }));
+
+      it('should set the status text property from the XMLHttpRequest instance if present',
+         inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+           var statusText = 'test';
+           var connection = new XHRConnection(sampleRequest, new MockBrowserXHR());
+
+           connection.response.subscribe((res: Response) => {
+             expect(res.statusText).toBe(statusText);
+             async.done();
+           });
+
+           existingXHRs[0].setStatusText(statusText);
+           existingXHRs[0].setStatusCode(200);
+           existingXHRs[0].dispatchEvent('load');
+         }));
+
+      it('should set status text to "OK" if it is not present in XMLHttpRequest instance',
+         inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+           var connection = new XHRConnection(sampleRequest, new MockBrowserXHR());
+
+           connection.response.subscribe((res: Response) => {
+             expect(res.statusText).toBe('OK');
+             async.done();
+           });
+
+           existingXHRs[0].setStatusCode(200);
+           existingXHRs[0].dispatchEvent('load');
+         }));
+
     });
   });
 }


### PR DESCRIPTION
It relates to #2800
