### PR TITLE
fix(router): recognize child components with empty segments

### DIFF
--- a/modules/angular2/src/router/route_registry.ts
+++ b/modules/angular2/src/router/route_registry.ts
@@ -120,7 +120,7 @@ export class RouteRegistry {
   private _recognizePrimaryRoute(parsedUrl: Url, parentComponent): Promise<PrimaryInstruction> {
     var componentRecognizer = this._rules.get(parentComponent);
     if (isBlank(componentRecognizer)) {
-      return PromiseWrapper.resolve(null);
+      return _resolveToNull;
     }
 
     // Matches some beginning part of the given URL
@@ -137,12 +137,8 @@ export class RouteRegistry {
     return instruction.resolveComponentType().then((componentType) => {
       this.configFromComponent(componentType);
 
-      if (isBlank(partialMatch.remaining)) {
-        if (instruction.terminal) {
-          return new PrimaryInstruction(instruction, null, partialMatch.remainingAux);
-        } else {
-          return null;
-        }
+      if (instruction.terminal) {
+        return new PrimaryInstruction(instruction, null, partialMatch.remainingAux);
       }
 
       return this._recognizePrimaryRoute(partialMatch.remaining, componentType)

--- a/modules/angular2/test/router/integration/navigation_spec.ts
+++ b/modules/angular2/test/router/integration/navigation_spec.ts
@@ -115,6 +115,18 @@ export function main() {
              });
        }));
 
+    it('should navigate to child routes that capture an empty path',
+       inject([AsyncTestCompleter], (async) => {
+         compile('outer { <router-outlet></router-outlet> }')
+             .then((_) => rtr.config([new Route({path: '/a/...', component: ParentCmp})]))
+             .then((_) => rtr.navigateByUrl('/a'))
+             .then((_) => {
+               rootTC.detectChanges();
+               expect(rootTC.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+               async.done();
+             });
+       }));
+
 
     it('should navigate to child routes of async routes', inject([AsyncTestCompleter], (async) => {
          compile('outer { <router-outlet></router-outlet> }')
@@ -309,7 +321,8 @@ function parentLoader() {
 
 @Component({selector: 'parent-cmp'})
 @View({template: "inner { <router-outlet></router-outlet> }", directives: [RouterOutlet]})
-@RouteConfig([new Route({path: '/b', component: HelloCmp})])
+@RouteConfig(
+    [new Route({path: '/b', component: HelloCmp}), new Route({path: '/', component: HelloCmp})])
 class ParentCmp {
   constructor() {}
 }


### PR DESCRIPTION
Previously, recognition ended when a parent captured all the parsed URL segments.
This caused routes that delegated from a parent to a child with an empty segment
to never be recognized.
