### PR TITLE
feat(code size): make assertionsEnabled() statically computable

### DIFF
--- a/modules/angular2/src/core/facade/lang.dart
+++ b/modules/angular2/src/core/facade/lang.dart
@@ -243,17 +243,11 @@ bool isJsObject(o) {
   return false;
 }
 
-var _assertionsEnabled = null;
 bool assertionsEnabled() {
-  if (_assertionsEnabled == null) {
-    try {
-      assert(false);
-      _assertionsEnabled = false;
-    } catch (e) {
-      _assertionsEnabled = true;
-    }
-  }
-  return _assertionsEnabled;
+  // TODO(yjbanov): verify that this is inlined after https://github.com/dart-lang/sdk/issues/24355
+  bool k = false;
+  assert((k = true));
+  return k;
 }
 
 // Can't be all uppercase as our transpiler would think it is a special directive...


### PR DESCRIPTION
See #3872. This PR alone does not fix the issue. We also need `dart2js` fixes (see below).

Our existing implementation prevented dart2js from statically deducing the
return value. This fix does not yet result in better tree-shaking due to the
following dart2js bugs:

https://github.com/dart-lang/sdk/issues/24354
https://github.com/dart-lang/sdk/issues/24355
