### PR TITLE
fix(debug): make debug tools take ComponentRef

### DIFF
--- a/modules/angular2/src/core/application_common.ts
+++ b/modules/angular2/src/core/application_common.ts
@@ -219,7 +219,7 @@ export function platform(bindings?: Array<Type | Binding | any[]>): PlatformRef 
  * - `errorReporter`: `function(exception:any, stackTrace:string)` a default error reporter
  *   for unhandled exceptions.
  *
- * Returns a `Promise` of {@link ApplicationRef}.
+ * Returns a `Promise` of {@link ComponentRef}.
  */
 export function commonBootstrap(appComponentType: /*Type*/ any,
                                 appBindings: Array<Type | Binding | any[]> = null):

--- a/modules/angular2/src/tools/common_tools.ts
+++ b/modules/angular2/src/tools/common_tools.ts
@@ -1,4 +1,5 @@
-import {ApplicationRef, LifeCycle} from 'angular2/angular2';
+import {LifeCycle} from 'angular2/angular2';
+import {ComponentRef} from 'angular2/src/core/compiler/dynamic_component_loader';
 import {isPresent, NumberWrapper} from 'angular2/src/core/facade/lang';
 import {performance, window} from 'angular2/src/core/facade/browser';
 import {DOM} from 'angular2/src/core/dom/dom_adapter';
@@ -10,7 +11,7 @@ import {DOM} from 'angular2/src/core/dom/dom_adapter';
 export class AngularTools {
   profiler: AngularProfiler;
 
-  constructor(appRef: ApplicationRef) { this.profiler = new AngularProfiler(appRef); }
+  constructor(ref: ComponentRef) { this.profiler = new AngularProfiler(ref); }
 }
 
 /**
@@ -20,7 +21,7 @@ export class AngularTools {
 export class AngularProfiler {
   lifeCycle: LifeCycle;
 
-  constructor(appRef: ApplicationRef) { this.lifeCycle = appRef.injector.get(LifeCycle); }
+  constructor(ref: ComponentRef) { this.lifeCycle = ref.injector.get(LifeCycle); }
 
   /**
    * Exercises change detection in a loop and then prints the average amount of

--- a/modules/angular2/src/tools/tools.dart
+++ b/modules/angular2/src/tools/tools.dart
@@ -1,7 +1,7 @@
 library angular2.src.tools.tools;
 
 import 'dart:js';
-import 'package:angular2/angular2.dart' show ApplicationRef;
+import 'package:angular2/src/core/compiler/dynamic_component_loader.dart' show ComponentRef;
 import 'common_tools.dart' show AngularTools;
 
 /**
@@ -15,8 +15,8 @@ import 'common_tools.dart' show AngularTools;
  * 1. Try the change detection profiler `ng.profiler.timeChangeDetection()`
  *    then hit Enter.
  */
-void enableDebugTools(ApplicationRef appRef) {
-  final tools = new AngularTools(appRef);
+void enableDebugTools(ComponentRef ref) {
+  final tools = new AngularTools(ref);
   context['ng'] = new JsObject.jsify({
     'profiler': {
       'timeChangeDetection': ([config]) {

--- a/modules/angular2/src/tools/tools.ts
+++ b/modules/angular2/src/tools/tools.ts
@@ -1,5 +1,5 @@
 import {global} from 'angular2/src/core/facade/lang';
-import {ApplicationRef} from 'angular2/angular2';
+import {ComponentRef} from 'angular2/src/core/compiler/dynamic_component_loader';
 import {AngularTools} from './common_tools';
 
 var context = <any>global;
@@ -15,8 +15,8 @@ var context = <any>global;
  * 1. Try the change detection profiler `ng.profiler.timeChangeDetection()`
  *    then hit Enter.
  */
-export function enableDebugTools(appRef: ApplicationRef): void {
-  context.ng = new AngularTools(appRef);
+export function enableDebugTools(ref: ComponentRef): void {
+  context.ng = new AngularTools(ref);
 }
 
 /**

--- a/modules/angular2/test/tools/spies.dart
+++ b/modules/angular2/test/tools/spies.dart
@@ -1,6 +1,7 @@
 import 'package:angular2/test_lib.dart' show SpyObject;
-import 'package:angular2/core.dart'
-    show ApplicationRef, LifeCycle, Injector, bind;
+import 'package:angular2/core.dart' show LifeCycle, Injector, bind;
+import 'package:angular2/src/core/compiler/dynamic_component_loader.dart'
+    show ComponentRef;
 import 'dart:js';
 
 @proxy
@@ -9,19 +10,18 @@ class SpyLifeCycle extends SpyObject implements LifeCycle {
 }
 
 @proxy
-class SpyApplicationRef extends SpyObject implements ApplicationRef {
+class SpyComponentRef extends SpyObject implements ComponentRef {
   Injector injector;
 
-  SpyApplicationRef() {
-    this.injector = Injector.resolveAndCreate([
-      bind(LifeCycle).toClass(SpyLifeCycle)
-    ]);
+  SpyComponentRef() {
+    this.injector =
+        Injector.resolveAndCreate([bind(LifeCycle).toClass(SpyLifeCycle)]);
   }
 
   noSuchMethod(m) => super.noSuchMethod(m);
 }
 
 void callNgProfilerTimeChangeDetection([config]) {
-  context['ng']['profiler'].callMethod('timeChangeDetection',
-      config != null ? [config] : []);
+  context['ng']['profiler']
+      .callMethod('timeChangeDetection', config != null ? [config] : []);
 }

--- a/modules/angular2/test/tools/spies.ts
+++ b/modules/angular2/test/tools/spies.ts
@@ -1,8 +1,9 @@
 import {SpyObject} from 'angular2/test_lib';
-import {ApplicationRef, LifeCycle, Injector, bind} from 'angular2/angular2';
+import {LifeCycle, Injector, bind} from 'angular2/angular2';
+import {ComponentRef} from 'angular2/src/core/compiler/dynamic_component_loader';
 import {global} from 'angular2/src/core/facade/lang';
 
-export class SpyApplicationRef extends SpyObject {
+export class SpyComponentRef extends SpyObject {
   injector;
   constructor() {
     super();

--- a/modules/angular2/test/tools/tools_spec.ts
+++ b/modules/angular2/test/tools/tools_spec.ts
@@ -11,11 +11,11 @@ import {
 } from 'angular2/test_lib';
 
 import {enableDebugTools, disableDebugTools} from 'angular2/tools';
-import {SpyApplicationRef, callNgProfilerTimeChangeDetection} from './spies';
+import {SpyComponentRef, callNgProfilerTimeChangeDetection} from './spies';
 
 export function main() {
   describe('profiler', () => {
-    beforeEach(() => { enableDebugTools((<any>new SpyApplicationRef())); });
+    beforeEach(() => { enableDebugTools((<any>new SpyComponentRef())); });
 
     afterEach(() => { disableDebugTools(); });
 


### PR DESCRIPTION
The debug tools used to take ApplicationRefs, which are the old return
type of bootstrap. Now bootstrap returns ComponentRef, so the debug
tools should be updated.

Fixes #4202 
