### PR TITLE
chore(doc-gen): fix blank line trimming for Jade docs

### DIFF
--- a/docs/angular.io-package/rendering/trimBlankLines.js
+++ b/docs/angular.io-package/rendering/trimBlankLines.js
@@ -1,9 +1,9 @@
-module.exports = function(encodeCodeBlock) {
+module.exports = function() {
   return {
     name: 'trimBlankLines',
     process: function(str) {
       var lines = str.split(/\r?\n/);
-      while(lines[0] === '') {
+      while(lines.length && (lines[0].trim() === '')) {
         lines.shift();
       }
       return lines.join('\n');

--- a/docs/angular.io-package/rendering/trimBlankLines.spec.js
+++ b/docs/angular.io-package/rendering/trimBlankLines.spec.js
@@ -1,0 +1,18 @@
+var factory = require('./trimBlankLines');
+
+describe('trimBlankLines filter', function() {
+  var filter;
+
+  beforeEach(function() {
+    filter = factory();
+  });
+
+  it('should be called "trimBlankLines"', function() {
+    expect(filter.name).toEqual('trimBlankLines');
+  });
+
+  it('should remove all empty lines from the start of the string', function() {
+    expect(filter.process('\n\n\nsome text\n\nmore text\n\n'))
+        .toEqual('some text\n\nmore text\n\n');
+  });
+});


### PR DESCRIPTION
@IgorMinar this should fix the Jade error message. It turned out that the `/dist/angular.io/partials/api/angular2/core/Type-interface.jade` file contained an illegal blank line between the `:markdown` and the content, as suspected.

``` jade

p.location-badge.
  exported from <a href='../core'>angular2/core</a>
  defined in <a href="https://github.com/angular/angular/tree/2.0.0-alpha.37/modules/angular2/src/core/facade/lang.ts#L23-L23">angular2/src/core/facade/lang.ts (line 23)</a>

:markdown

  Runtime representation of a type.

  In JavaScript a Type is a constructor function.
```
