### PR TITLE
fix(browser): Moving to es6-shim broke most browsers

### DIFF
--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -12,12 +12,13 @@ module.exports = function(config) {
       // Loaded through the System loader, in `test-main.js`.
       {pattern: 'dist/js/dev/es5/**', included: false, watched: false},
 
+      'node_modules/es6-shim/es6-shim.js',
+
       // zone-microtask must be included first as it contains a Promise monkey patch
       'node_modules/zone.js/dist/zone-microtask.js',
       'node_modules/zone.js/dist/long-stack-trace-zone.js',
       'node_modules/zone.js/dist/jasmine-patch.js',
-
-      'node_modules/es6-shim/es6-shim.js',
+      
       // Including systemjs because it defines `__eval`, which produces correct stack traces.
       'modules/angular2/src/test_lib/shims_for_IE.js',
       'node_modules/systemjs/dist/system.src.js',

--- a/modules/angular2/src/core/compiler/query_list.ts
+++ b/modules/angular2/src/core/compiler/query_list.ts
@@ -1,4 +1,6 @@
 import {ListWrapper, MapWrapper} from 'angular2/src/core/facade/collection';
+import {getSymbolIterator} from 'angular2/src/core/facade/lang';
+
 
 /**
  * An iterable and observable live list of components in the DOM.
@@ -101,7 +103,7 @@ export class QueryList<T> {
 
   map<U>(fn: (item: T) => U): U[] { return this._results.map(fn); }
 
-  [Symbol.iterator](): any { return this._results[Symbol.iterator](); }
+  [getSymbolIterator()](): any { return this._results[getSymbolIterator()](); }
 
   // Internal to the framework.
   fireCallbacks(): void {

--- a/modules/angular2/src/core/facade/collection.ts
+++ b/modules/angular2/src/core/facade/collection.ts
@@ -1,4 +1,11 @@
-import {isJsObject, global, isPresent, isBlank, isArray} from 'angular2/src/core/facade/lang';
+import {
+  isJsObject,
+  global,
+  isPresent,
+  isBlank,
+  isArray,
+  getSymbolIterator
+} from 'angular2/src/core/facade/lang';
 
 export var Map = global.Map;
 export var Set = global.Set;
@@ -289,8 +296,8 @@ export class ListWrapper {
 export function isListLikeIterable(obj: any): boolean {
   if (!isJsObject(obj)) return false;
   return isArray(obj) ||
-         (!(obj instanceof Map) &&  // JS Map are iterables but return entries as [k, v]
-          Symbol.iterator in obj);  // JS Iterable have a Symbol.iterator prop
+         (!(obj instanceof Map) &&      // JS Map are iterables but return entries as [k, v]
+          getSymbolIterator() in obj);  // JS Iterable have a Symbol.iterator prop
 }
 
 export function iterateListLike(obj: any, fn: Function) {
@@ -299,7 +306,7 @@ export function iterateListLike(obj: any, fn: Function) {
       fn(obj[i]);
     }
   } else {
-    var iterator = obj[Symbol.iterator]();
+    var iterator = obj[getSymbolIterator()]();
     var item;
     while (!((item = iterator.next()).done)) {
       fn(item.value);

--- a/modules/angular2/src/core/facade/lang.ts
+++ b/modules/angular2/src/core/facade/lang.ts
@@ -351,3 +351,24 @@ export function setValueOnPath(global: any, path: string, value: any) {
   }
   obj[parts.shift()] = value;
 }
+
+// TODO(mlaval): remove after https://github.com/paulmillr/es6-shim/issues/360
+// Retrieves the key used in es6-shim when Symbol.iterator doesn't exist
+var _symbolIterator = null;
+export function getSymbolIterator(): string | symbol {
+  if (isBlank(_symbolIterator)) {
+    if (isPresent(Symbol) && isPresent(Symbol.iterator)) {
+      _symbolIterator = Symbol.iterator;
+    } else {
+      var keys = Object.getOwnPropertyNames(Map.prototype);
+      for (var i = 0; i < keys.length; ++i) {
+        var key = keys[i];
+        if (key !== 'entries' && key !== 'size' &&
+            Map.prototype[key] === Map.prototype['entries']) {
+          _symbolIterator = key;
+        }
+      }
+    }
+  }
+  return _symbolIterator;
+}

--- a/modules/angular2/test/core/change_detection/iterable.ts
+++ b/modules/angular2/test/core/change_detection/iterable.ts
@@ -1,7 +1,8 @@
+import {getSymbolIterator} from 'angular2/src/core/facade/lang';
 
 export class TestIterable {
   list: number[];
   constructor() { this.list = []; }
 
-  [Symbol.iterator]() { return this.list[Symbol.iterator](); }
+  [getSymbolIterator()]() { return this.list[getSymbolIterator()](); }
 }

--- a/tools/broccoli/html-replace/SCRIPTS.html
+++ b/tools/broccoli/html-replace/SCRIPTS.html
@@ -1,6 +1,6 @@
+<script src="es6-shim.js" type="text/javascript"></script>
 <script src="zone-microtask.js" type="text/javascript"></script>
 <script src="long-stack-trace-zone.js" type="text/javascript"></script>
-<script src="es6-shim.js" type="text/javascript"></script>
 <script src="system.src.js" type="text/javascript"></script>
 <script src="Reflect.js" type="text/javascript"></script>
 <script type="text/javascript">

--- a/tools/broccoli/html-replace/SCRIPTS_benchmarks.html
+++ b/tools/broccoli/html-replace/SCRIPTS_benchmarks.html
@@ -1,7 +1,7 @@
+<script src="es6-shim.js" type="text/javascript"></script>
 <script src="zone-microtask.js" type="text/javascript"></script>
 <script src="long-stack-trace-zone.js" type="text/javascript"></script>
 <script src="url_params_to_form.js" type="text/javascript"></script>
-<script src="es6-shim.js" type="text/javascript"></script>
 <script src="system.src.js" type="text/javascript"></script>
 <script src="Reflect.js" type="text/javascript"></script>
 <script type="text/javascript">

--- a/tools/broccoli/html-replace/SCRIPTS_benchmarks_external.html
+++ b/tools/broccoli/html-replace/SCRIPTS_benchmarks_external.html
@@ -1,8 +1,8 @@
+<script src="es6-shim.js" type="text/javascript"></script>
 <script src="zone-microtask.js" type="text/javascript"></script>
 <script src="long-stack-trace-zone.js" type="text/javascript"></script>
 <script src="angular.js" type="text/javascript"></script>
 <script src="url_params_to_form.js" type="text/javascript"></script>
-<script src="es6-shim.js" type="text/javascript"></script>
 <script src="system.src.js" type="text/javascript"></script>
 <script src="Reflect.js" type="text/javascript"></script>
 <script type="text/javascript">

--- a/tools/broccoli/js-replace/SCRIPTS.js
+++ b/tools/broccoli/js-replace/SCRIPTS.js
@@ -1,2 +1,2 @@
-importScripts("zone-microtask.js", "long-stack-trace-zone.js", "es6-shim.js", "system.src.js",
+importScripts("es6-shim.js", "zone-microtask.js", "long-stack-trace-zone.js", "system.src.js",
               "Reflect.js");

--- a/tools/broccoli/trees/browser_tree.ts
+++ b/tools/broccoli/trees/browser_tree.ts
@@ -138,12 +138,12 @@ module.exports = function makeBrowserTree(options, destinationPath) {
 
   var vendorScriptsTree = flatten(new Funnel('.', {
     files: [
+      'node_modules/es6-shim/es6-shim.js',
       'node_modules/zone.js/dist/zone-microtask.js',
       'node_modules/zone.js/dist/long-stack-trace-zone.js',
       'node_modules/systemjs/dist/system.src.js',
       'node_modules/base64-js/lib/b64.js',
-      'node_modules/reflect-metadata/Reflect.js',
-      'node_modules/es6-shim/es6-shim.js'
+      'node_modules/reflect-metadata/Reflect.js'
     ]
   }));
 


### PR DESCRIPTION
Fixes #4216

For the 2 issues:
1) Thanks to advices in https://github.com/paulmillr/es6-shim/issues/347, loading es6-shim first solves the error.
2) Added a workaround to use the internal string from es6-shim when `Symbol.iterator`is not available.
