### PR TITLE
feat(dart/transform): Declare transformer outputs

### DIFF
--- a/modules_dart/transform/lib/src/transform/bind_generator/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/bind_generator/transformer.dart
@@ -16,13 +16,18 @@ import 'generator.dart';
 ///
 /// These setters are registered in the same `setupReflection` function with
 /// the `registerType` calls.
-class BindGenerator extends Transformer {
+class BindGenerator extends Transformer implements DeclaringTransformer {
   final TransformerOptions options;
 
   BindGenerator(this.options);
 
   @override
   bool isPrimary(AssetId id) => id.path.endsWith(DEPS_EXTENSION);
+
+  @override
+  declareOutputs(DeclaringTransform transform) {
+    transform.declareOutput(transform.primaryId);
+  }
 
   @override
   Future apply(Transform transform) async {

--- a/modules_dart/transform/lib/src/transform/deferred_rewriter/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/deferred_rewriter/transformer.dart
@@ -13,7 +13,7 @@ import 'rewriter.dart';
 /// Transformer responsible for rewriting deferred library loads to enable
 /// initializing the reflector in a deferred way to keep the code with the
 /// deferred library.
-class DeferredRewriter extends Transformer {
+class DeferredRewriter extends Transformer implements DeclaringTransformer {
   final TransformerOptions options;
 
   DeferredRewriter(this.options);
@@ -21,6 +21,11 @@ class DeferredRewriter extends Transformer {
   @override
   bool isPrimary(AssetId id) =>
       id.extension.endsWith('dart') && !id.path.endsWith(DEPS_EXTENSION);
+
+  @override
+  declareOutputs(DeclaringTransform transform) {
+    transform.declareOutput(transform.primaryId);
+  }
 
   @override
   Future apply(Transform transform) async {

--- a/modules_dart/transform/lib/src/transform/directive_linker/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/directive_linker/transformer.dart
@@ -14,11 +14,16 @@ import 'linker.dart';
 /// {@link DirectiveProcessor} and ensuring that the generated calls to
 /// `setupReflection` call the necessary `setupReflection` method in all
 /// dependencies.
-class DirectiveLinker extends Transformer {
+class DirectiveLinker extends Transformer implements DeclaringTransformer {
   DirectiveLinker();
 
   @override
   bool isPrimary(AssetId id) => id.path.endsWith(DEPS_EXTENSION);
+
+  @override
+  declareOutputs(DeclaringTransform transform) {
+    transform.declareOutput(transform.primaryId);
+  }
 
   @override
   Future apply(Transform transform) async {
@@ -37,11 +42,17 @@ class DirectiveLinker extends Transformer {
 
 /// Transformer responsible for removing unnecessary `.ng_deps.dart` files
 /// created by {@link DirectiveProcessor}.
-class EmptyNgDepsRemover extends Transformer {
+class EmptyNgDepsRemover extends Transformer implements DeclaringTransformer {
   EmptyNgDepsRemover();
 
   @override
   bool isPrimary(AssetId id) => id.path.endsWith(DEPS_EXTENSION);
+
+  /// We occasionally consume the primary input, but that depends on the
+  /// contents of the file, so we conservatively do not declare any outputs nor
+  /// consumption to ensure that we declare a superset of our actual outputs.
+  @override
+  declareOutputs(DeclaringTransform transform) => null;
 
   @override
   Future apply(Transform transform) async {

--- a/modules_dart/transform/lib/src/transform/directive_metadata_extractor/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/directive_metadata_extractor/transformer.dart
@@ -14,13 +14,19 @@ import 'extractor.dart';
 /// {@link DirectiveProcessor} and creating associated `.ng_meta.dart` files.
 /// These files contain commented Json-formatted representations of all
 /// `Directive`s in the associated file.
-class DirectiveMetadataExtractor extends Transformer {
+class DirectiveMetadataExtractor extends Transformer
+    implements DeclaringTransformer {
   final _encoder = const JsonEncoder.withIndent('  ');
 
   DirectiveMetadataExtractor();
 
   @override
   bool isPrimary(AssetId id) => id.path.endsWith(DEPS_EXTENSION);
+
+  @override
+  declareOutputs(DeclaringTransform transform) {
+    transform.declareOutput(_outputAssetId(transform.primaryId));
+  }
 
   @override
   Future apply(Transform transform) async {

--- a/modules_dart/transform/lib/src/transform/directive_processor/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/directive_processor/transformer.dart
@@ -22,13 +22,24 @@ import 'rewriter.dart';
 ///
 /// This transformer is the first phase in a two-phase transform. It should
 /// be followed by {@link DirectiveLinker}.
-class DirectiveProcessor extends Transformer {
+class DirectiveProcessor extends Transformer implements DeclaringTransformer {
   final TransformerOptions options;
 
   DirectiveProcessor(this.options);
 
   @override
   bool isPrimary(AssetId id) => id.extension.endsWith('dart');
+
+  /// We don't always output these, but providing a superset of our outputs
+  /// should be safe. Barback will just have to wait until `apply` finishes to
+  /// determine that one or the other will not be emitted.
+  @override
+  declareOutputs(DeclaringTransform transform) {
+    transform.declareOutput(
+        transform.primaryId.changeExtension(ALIAS_EXTENSION));
+    transform.declareOutput(
+        transform.primaryId.changeExtension(DEPS_EXTENSION));
+  }
 
   @override
   Future apply(Transform transform) async {

--- a/modules_dart/transform/lib/src/transform/reflection_remover/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/reflection_remover/transformer.dart
@@ -19,7 +19,7 @@ import 'remove_reflection_capabilities.dart';
 /// have already been run and that a .ng_deps.dart file has been generated for
 /// {@link options.entryPoint}. The instantiation of {@link ReflectionCapabilities} is
 /// replaced by calling `setupReflection` in that .ng_deps.dart file.
-class ReflectionRemover extends Transformer {
+class ReflectionRemover extends Transformer implements DeclaringTransformer {
   final TransformerOptions options;
 
   ReflectionRemover(this.options);
@@ -27,6 +27,11 @@ class ReflectionRemover extends Transformer {
   @override
   bool isPrimary(AssetId id) => options.entryPointGlobs != null &&
       options.entryPointGlobs.any((g) => g.matches(id.path));
+
+  @override
+  declareOutputs(DeclaringTransform transform) {
+    transform.declareOutput(transform.primaryId);
+  }
 
   @override
   Future apply(Transform transform) async {

--- a/modules_dart/transform/lib/src/transform/template_compiler/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/template_compiler/transformer.dart
@@ -18,13 +18,18 @@ import 'generator.dart';
 /// extracting information about what reflection is necessary to render and
 /// use that template. It then generates code in place of those reflective
 /// accesses.
-class TemplateCompiler extends Transformer {
+class TemplateCompiler extends Transformer implements DeclaringTransformer {
   final TransformerOptions options;
 
   TemplateCompiler(this.options);
 
   @override
   bool isPrimary(AssetId id) => id.path.endsWith(DEPS_EXTENSION);
+
+  @override
+  declareOutputs(DeclaringTransform transform) {
+    transform.declareOutput(transform.primaryId);
+  }
 
   @override
   Future apply(Transform transform) async {
@@ -34,7 +39,8 @@ class TemplateCompiler extends Transformer {
       var reader = new AssetReader.fromTransform(transform);
       var transformedCode = formatter.format(await processTemplates(reader, id,
           generateChangeDetectors: options.generateChangeDetectors,
-          reflectPropertiesAsAttributes: options.reflectPropertiesAsAttributes));
+          reflectPropertiesAsAttributes:
+              options.reflectPropertiesAsAttributes));
       transform.addOutput(new Asset.fromString(id, transformedCode));
     });
   }


### PR DESCRIPTION
Update transformers to declare a superset of their outputs. This helps
barback compute the Asset graph and can lead to faster transformation.
