### PR TITLE
chore(saucelabs): MdButton tests time out

### DIFF
--- a/modules/angular2_material/test/button_spec.ts
+++ b/modules/angular2_material/test/button_spec.ts
@@ -54,7 +54,7 @@ export function main() {
 
              async.done();
            });
-         }));
+         }), 1000);
 
       it('should disable the button', inject([AsyncTestCompleter], (async) => {
            builder.createAsync(TestApp).then(rootTestComponent => {
@@ -78,7 +78,7 @@ export function main() {
              expect(testAppComponent.clickCount).toBe(0);
              async.done();
            });
-         }));
+         }), 1000);
     });
 
     describe('a[md-button]', () => {
@@ -113,7 +113,7 @@ export function main() {
                 // No clear way to test this; see https://github.com/angular/angular/issues/3782
                 async.done();
               }));
-         }));
+         }), 1000);
     });
   });
 }


### PR DESCRIPTION
These tests are reaching the 100ms timeout even for "fast" browsers like Chrome or Firefox in SauceLabs.
For example: https://travis-ci.org/angular/angular/jobs/81001541
