### PR TITLE
docs(typings): don't emit @private members during the d.ts generation

### DIFF
--- a/docs/typescript-definition-package/processors/code_gen.js
+++ b/docs/typescript-definition-package/processors/code_gen.js
@@ -49,6 +49,8 @@ DtsSerializer.prototype = {
   },
 
   member: function(buffer, ast) {
+    if (ast.private) return;
+
     buffer.push('\n');
     this.comment(buffer, ast.content);
 


### PR DESCRIPTION
Some of our class/interface members are "package private". Typescript doesn't have this concept, so we need to hide them
via the `@private` doc annotation.

Closes #4262
