### PR TITLE
chore(router): remove unneeded exports

### DIFF
--- a/modules/angular2/router.ts
+++ b/modules/angular2/router.ts
@@ -18,7 +18,6 @@ export * from './src/router/route_definition';
 export {OnActivate, OnDeactivate, OnReuse, CanDeactivate, CanReuse} from './src/router/interfaces';
 export {CanActivate} from './src/router/lifecycle_annotations';
 export {Instruction, ComponentInstruction} from './src/router/instruction';
-export {Url} from './src/router/url_parser';
 export {OpaqueToken} from 'angular2/angular2';
 export {ROUTE_DATA} from './src/router/route_data';
 

--- a/modules/angular2/router.ts
+++ b/modules/angular2/router.ts
@@ -4,7 +4,7 @@
  * Maps application URLs into application states, to support deep-linking and navigation.
  */
 
-export {Router, RootRouter} from './src/router/router';
+export {Router} from './src/router/router';
 export {RouterOutlet} from './src/router/router_outlet';
 export {RouterLink} from './src/router/router_link';
 export {RouteParams} from './src/router/instruction';

--- a/modules/angular2/test/router/integration/router_link_spec.ts
+++ b/modules/angular2/test/router/integration/router_link_spec.ts
@@ -26,7 +26,6 @@ import {SpyLocation} from 'angular2/src/mock/location_mock';
 import {
   Location,
   Router,
-  RootRouter,
   RouteRegistry,
   RouterLink,
   RouterOutlet,
@@ -36,6 +35,7 @@ import {
   RouteConfig,
   ROUTER_DIRECTIVES
 } from 'angular2/router';
+import {RootRouter} from 'angular2/src/router/router';
 
 import {DOM} from 'angular2/src/core/dom/dom_adapter';
 

--- a/modules/angular2/test/router/router_link_spec.ts
+++ b/modules/angular2/test/router/router_link_spec.ts
@@ -22,14 +22,14 @@ import {By} from 'angular2/src/core/debug';
 import {
   Location,
   Router,
-  RootRouter,
   RouteRegistry,
   RouterLink,
   RouterOutlet,
   Route,
-  RouteParams
+  RouteParams,
+  Instruction,
+  ComponentInstruction
 } from 'angular2/router';
-import {Instruction, ComponentInstruction} from 'angular2/src/router/instruction';
 
 import {DOM} from 'angular2/src/core/dom/dom_adapter';
 


### PR DESCRIPTION
This removes `Url` and `RootRouter`, neither of which should ever publicly be called or referenced.
