### PR TITLE
fix(dart/transform): Fix transformer output declaration

### DIFF
--- a/modules_dart/transform/lib/src/transform/bind_generator/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/bind_generator/transformer.dart
@@ -26,17 +26,19 @@ class BindGenerator extends Transformer implements DeclaringTransformer {
 
   @override
   declareOutputs(DeclaringTransform transform) {
+    transform.consumePrimary();
     transform.declareOutput(transform.primaryId);
   }
 
   @override
   Future apply(Transform transform) async {
     await log.initZoned(transform, () async {
-      var id = transform.primaryInput.id;
+      var primaryId = transform.primaryInput.id;
       var reader = new AssetReader.fromTransform(transform);
-      var transformedCode = await createNgSettersAndGetters(reader, id);
+      var transformedCode = await createNgSettersAndGetters(reader, primaryId);
+      transform.consumePrimary();
       transform.addOutput(new Asset.fromString(
-          id, formatter.format(transformedCode, uri: id.path)));
+          primaryId, formatter.format(transformedCode, uri: primaryId.path)));
     });
   }
 }

--- a/modules_dart/transform/lib/src/transform/deferred_rewriter/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/deferred_rewriter/transformer.dart
@@ -24,6 +24,7 @@ class DeferredRewriter extends Transformer implements DeclaringTransformer {
 
   @override
   declareOutputs(DeclaringTransform transform) {
+    transform.consumePrimary();
     transform.declareOutput(transform.primaryId);
   }
 
@@ -33,9 +34,11 @@ class DeferredRewriter extends Transformer implements DeclaringTransformer {
       var asset = transform.primaryInput;
       var reader = new AssetReader.fromTransform(transform);
       var transformedCode = await rewriteDeferredLibraries(reader, asset.id);
+      transform.consumePrimary();
       if (transformedCode != null) {
-        transform.addOutput(
-            new Asset.fromString(transform.primaryInput.id, transformedCode));
+        transform.addOutput(new Asset.fromString(asset.id, transformedCode));
+      } else {
+        transform.addOutput(asset);
       }
     });
   }

--- a/modules_dart/transform/lib/src/transform/reflection_remover/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/reflection_remover/transformer.dart
@@ -30,12 +30,14 @@ class ReflectionRemover extends Transformer implements DeclaringTransformer {
 
   @override
   declareOutputs(DeclaringTransform transform) {
+    transform.consumePrimary();
     transform.declareOutput(transform.primaryId);
   }
 
   @override
   Future apply(Transform transform) async {
     await log.initZoned(transform, () async {
+      var primaryId = transform.primaryInput.id;
       var mirrorMode = options.mirrorMode;
       var writeStaticInit = options.initReflector;
       if (options.modeName == TRANSFORM_DYNAMIC_MODE) {
@@ -47,10 +49,10 @@ class ReflectionRemover extends Transformer implements DeclaringTransformer {
       }
 
       var transformedCode = await removeReflectionCapabilities(
-          new AssetReader.fromTransform(transform), transform.primaryInput.id,
+          new AssetReader.fromTransform(transform), primaryId,
           mirrorMode: mirrorMode, writeStaticInit: writeStaticInit);
-      transform.addOutput(
-          new Asset.fromString(transform.primaryInput.id, transformedCode));
+      transform.consumePrimary();
+      transform.addOutput(new Asset.fromString(primaryId, transformedCode));
     });
   }
 }

--- a/modules_dart/transform/lib/src/transform/template_compiler/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/template_compiler/transformer.dart
@@ -28,6 +28,7 @@ class TemplateCompiler extends Transformer implements DeclaringTransformer {
 
   @override
   declareOutputs(DeclaringTransform transform) {
+    transform.consumePrimary();
     transform.declareOutput(transform.primaryId);
   }
 
@@ -35,13 +36,15 @@ class TemplateCompiler extends Transformer implements DeclaringTransformer {
   Future apply(Transform transform) async {
     await log.initZoned(transform, () async {
       Html5LibDomAdapter.makeCurrent();
-      var id = transform.primaryInput.id;
+      var primaryId = transform.primaryInput.id;
       var reader = new AssetReader.fromTransform(transform);
-      var transformedCode = formatter.format(await processTemplates(reader, id,
+      var transformedCode = formatter.format(await processTemplates(
+          reader, primaryId,
           generateChangeDetectors: options.generateChangeDetectors,
           reflectPropertiesAsAttributes:
               options.reflectPropertiesAsAttributes));
-      transform.addOutput(new Asset.fromString(id, transformedCode));
+      transform.consumePrimary();
+      transform.addOutput(new Asset.fromString(primaryId, transformedCode));
     });
   }
 }


### PR DESCRIPTION
Ensure that the transformers are properly declaring all consumed
outputs. In particular, when a transformer overwrites an output, make
sure the transformer calls `consumePrimary` followed by `addOutput` for
that file.
