### PR TITLE
build(travis): block travis while we are shutting down the tunnel

### DIFF
--- a/scripts/sauce/sauce_connect_teardown.sh
+++ b/scripts/sauce/sauce_connect_teardown.sh
@@ -4,4 +4,13 @@ set -e -o pipefail
 
 
 echo "Shutting down Sauce Connect tunnel"
+
 killall sc
+
+while [[ -n `ps -ef | grep "bin/sc" | grep -v "grep"` ]]; do
+  printf "."
+  sleep .5
+done
+
+echo ""
+echo "Sauce Connect tunnel has been shut down"


### PR DESCRIPTION
This is to prevent Travis from prematurely shut down the VM while we are still waiting for the sauce connect client
to tear down the tunnel.
