### PR TITLE
refactor(compiler): various cleanups

### DIFF
--- a/modules/angular2/src/compiler/command_compiler.ts
+++ b/modules/angular2/src/compiler/command_compiler.ts
@@ -35,7 +35,8 @@ import {escapeSingleQuoteString} from './util';
 import {Injectable} from 'angular2/src/core/di';
 
 export var TEMPLATE_COMMANDS_MODULE_REF = moduleRef('angular2/src/core/compiler/template_commands');
-const IMPLICIT_VAR = '%implicit';
+
+const IMPLICIT_TEMPLATE_VAR = '\$implicit';
 
 @Injectable()
 export class CommandCompiler {
@@ -207,7 +208,7 @@ class CommandBuilderVisitor<R> implements TemplateAstVisitor {
     var variableNameAndValues = [];
     ast.vars.forEach((varAst) => {
       variableNameAndValues.push(varAst.name);
-      variableNameAndValues.push(varAst.value);
+      variableNameAndValues.push(varAst.value.length > 0 ? varAst.value : IMPLICIT_TEMPLATE_VAR);
     });
     var directives = [];
     ListWrapper.forEachWithIndex(ast.directives, (directiveAst: DirectiveAst, index: number) => {
@@ -227,7 +228,7 @@ class CommandBuilderVisitor<R> implements TemplateAstVisitor {
     if (isBlank(component)) {
       ast.exportAsVars.forEach((varAst) => {
         variableNameAndValues.push(varAst.name);
-        variableNameAndValues.push(IMPLICIT_VAR);
+        variableNameAndValues.push(null);
       });
     }
     var directives = [];

--- a/modules/angular2/src/compiler/compiler.ts
+++ b/modules/angular2/src/compiler/compiler.ts
@@ -5,3 +5,31 @@ export {
   CompileTemplateMetadata
 } from './directive_metadata';
 export {SourceModule, SourceWithImports} from './source_module';
+
+import {assertionsEnabled, Type} from 'angular2/src/core/facade/lang';
+import {bind, Binding} from 'angular2/src/core/di';
+import {TemplateParser} from 'angular2/src/compiler/template_parser';
+import {HtmlParser} from 'angular2/src/compiler/html_parser';
+import {TemplateNormalizer} from 'angular2/src/compiler/template_normalizer';
+import {RuntimeMetadataResolver} from 'angular2/src/compiler/runtime_metadata';
+import {ChangeDetectionCompiler} from 'angular2/src/compiler/change_detector_compiler';
+import {StyleCompiler} from 'angular2/src/compiler/style_compiler';
+import {CommandCompiler} from 'angular2/src/compiler/command_compiler';
+import {TemplateCompiler} from 'angular2/src/compiler/template_compiler';
+import {ChangeDetectorGenConfig} from 'angular2/src/core/change_detection/change_detection';
+
+export function compilerBindings(): Array<Type | Binding | any[]> {
+  return [
+    HtmlParser,
+    TemplateParser,
+    TemplateNormalizer,
+    RuntimeMetadataResolver,
+    StyleCompiler,
+    CommandCompiler,
+    ChangeDetectionCompiler,
+    bind(ChangeDetectorGenConfig)
+        .toValue(
+            new ChangeDetectorGenConfig(assertionsEnabled(), assertionsEnabled(), false, true)),
+    TemplateCompiler,
+  ];
+}

--- a/modules/angular2/src/compiler/html_parser.ts
+++ b/modules/angular2/src/compiler/html_parser.ts
@@ -57,12 +57,7 @@ function parseElement(element: Element, indexInParent: number, parentSourceInfo:
   var sourceInfo = `${parentSourceInfo} > ${nodeName}:nth-child(${indexInParent})`;
   var attrs = parseAttrs(element, sourceInfo);
 
-  var childNodes;
-  if (ignoreChildren(attrs)) {
-    childNodes = [];
-  } else {
-    childNodes = parseChildNodes(element, sourceInfo);
-  }
+  var childNodes = parseChildNodes(element, sourceInfo);
   return new HtmlElementAst(nodeName, attrs, childNodes, sourceInfo);
 }
 
@@ -98,16 +93,6 @@ function parseChildNodes(element: Element, parentSourceInfo: string): HtmlAst[] 
     index++;
   });
   return result;
-}
-
-function ignoreChildren(attrs: HtmlAttrAst[]): boolean {
-  for (var i = 0; i < attrs.length; i++) {
-    var a = attrs[i];
-    if (a.name == NG_NON_BINDABLE) {
-      return true;
-    }
-  }
-  return false;
 }
 
 class UnparseVisitor implements HtmlAstVisitor {

--- a/modules/angular2/src/compiler/style_compiler.ts
+++ b/modules/angular2/src/compiler/style_compiler.ts
@@ -1,4 +1,4 @@
-import {CompileTypeMetadata, CompileDirectiveMetadata} from './directive_metadata';
+import {CompileTypeMetadata, CompileTemplateMetadata} from './directive_metadata';
 import {SourceModule, SourceExpression, moduleRef} from './source_module';
 import {ViewEncapsulation} from 'angular2/src/core/render/api';
 import {XHR} from 'angular2/src/core/render/xhr';
@@ -29,27 +29,28 @@ export class StyleCompiler {
 
   constructor(private _xhr: XHR, private _urlResolver: UrlResolver) {}
 
-  compileComponentRuntime(component: CompileDirectiveMetadata): Promise<string[]> {
-    var styles = component.template.styles;
-    var styleAbsUrls = component.template.styleUrls;
+  compileComponentRuntime(type: CompileTypeMetadata,
+                          template: CompileTemplateMetadata): Promise<string[]> {
+    var styles = template.styles;
+    var styleAbsUrls = template.styleUrls;
     return this._loadStyles(styles, styleAbsUrls,
-                            component.template.encapsulation === ViewEncapsulation.Emulated)
-        .then(styles => styles.map(style => StringWrapper.replaceAll(style, COMPONENT_REGEX,
-                                                                     `${component.type.id}`)));
+                            template.encapsulation === ViewEncapsulation.Emulated)
+        .then(styles => styles.map(
+                  style => StringWrapper.replaceAll(style, COMPONENT_REGEX, `${type.id}`)));
   }
 
-  compileComponentCodeGen(component: CompileDirectiveMetadata): SourceExpression {
-    var shim = component.template.encapsulation === ViewEncapsulation.Emulated;
+  compileComponentCodeGen(type: CompileTypeMetadata,
+                          template: CompileTemplateMetadata): SourceExpression {
+    var shim = template.encapsulation === ViewEncapsulation.Emulated;
     var suffix;
     if (shim) {
-      var componentId = `${ component.type.id}`;
+      var componentId = `${ type.id}`;
       suffix =
           codeGenMapArray(['style'], `style${codeGenReplaceAll(COMPONENT_VARIABLE, componentId)}`);
     } else {
       suffix = '';
     }
-    return this._styleCodeGen(component.template.styles, component.template.styleUrls, shim,
-                              suffix);
+    return this._styleCodeGen(template.styles, template.styleUrls, shim, suffix);
   }
 
   compileStylesheetCodeGen(moduleId: string, cssText: string): SourceModule[] {

--- a/modules/angular2/src/compiler/template_preparser.ts
+++ b/modules/angular2/src/compiler/template_preparser.ts
@@ -30,9 +30,7 @@ export function preparseElement(ast: HtmlElementAst): PreparsedElement {
   selectAttr = normalizeNgContentSelect(selectAttr);
   var nodeName = ast.name;
   var type = PreparsedElementType.OTHER;
-  if (nonBindable) {
-    type = PreparsedElementType.NON_BINDABLE;
-  } else if (nodeName == NG_CONTENT_ELEMENT) {
+  if (nodeName == NG_CONTENT_ELEMENT) {
     type = PreparsedElementType.NG_CONTENT;
   } else if (nodeName == STYLE_ELEMENT) {
     type = PreparsedElementType.STYLE;
@@ -41,7 +39,7 @@ export function preparseElement(ast: HtmlElementAst): PreparsedElement {
   } else if (nodeName == LINK_ELEMENT && relAttr == LINK_STYLE_REL_VALUE) {
     type = PreparsedElementType.STYLESHEET;
   }
-  return new PreparsedElement(type, selectAttr, hrefAttr);
+  return new PreparsedElement(type, selectAttr, hrefAttr, nonBindable);
 }
 
 export enum PreparsedElementType {
@@ -49,13 +47,12 @@ export enum PreparsedElementType {
   STYLE,
   STYLESHEET,
   SCRIPT,
-  NON_BINDABLE,
   OTHER
 }
 
 export class PreparsedElement {
-  constructor(public type: PreparsedElementType, public selectAttr: string,
-              public hrefAttr: string) {}
+  constructor(public type: PreparsedElementType, public selectAttr: string, public hrefAttr: string,
+              public nonBindable: boolean) {}
 }
 
 

--- a/modules/angular2/src/compiler/util.ts
+++ b/modules/angular2/src/compiler/util.ts
@@ -2,8 +2,8 @@ import {StringWrapper, isBlank, isJsObject} from 'angular2/src/core/facade/lang'
 
 var CAMEL_CASE_REGEXP = /([A-Z])/g;
 var DASH_CASE_REGEXP = /-([a-z])/g;
-var SINGLE_QUOTE_ESCAPE_STRING_RE = /'|\\|\n/g;
-var DOUBLE_QUOTE_ESCAPE_STRING_RE = /"|\\|\n/g;
+var SINGLE_QUOTE_ESCAPE_STRING_RE = /'|\\|\n|\$/g;
+var DOUBLE_QUOTE_ESCAPE_STRING_RE = /"|\\|\n|\$/g;
 
 export var IS_DART = !isJsObject({});
 
@@ -33,7 +33,9 @@ export function escapeDoubleQuoteString(input: string): string {
 
 function escapeString(input: string, re: RegExp): string {
   return StringWrapper.replaceAllMapped(input, re, (match) => {
-    if (match[0] == '\n') {
+    if (match[0] == '$') {
+      return IS_DART ? '\\$' : '$';
+    } else if (match[0] == '\n') {
       return '\\n';
     } else {
       return `\\${match[0]}`;

--- a/modules/angular2/src/core/application_ref.ts
+++ b/modules/angular2/src/core/application_ref.ts
@@ -43,7 +43,7 @@ import {PipeResolver} from './compiler/pipe_resolver';
 import {StyleUrlResolver} from 'angular2/src/core/render/dom/compiler/style_url_resolver';
 import {UrlResolver} from 'angular2/src/core/services/url_resolver';
 import {ComponentUrlMapper} from 'angular2/src/core/compiler/component_url_mapper';
-
+import {compilerBindings} from 'angular2/src/compiler/compiler';
 
 /**
  * Constructs the set of bindings meant for use at the platform level.
@@ -95,6 +95,7 @@ export function applicationCommonBindings(): Array<Type | Binding | any[]> {
     bestChangeDetection = new JitChangeDetection();
   }
   return [
+    compilerBindings(),
     ProtoViewFactory,
     AppViewPool,
     bind(APP_VIEW_POOL_CAPACITY).toValue(10000),

--- a/modules/angular2/src/core/compiler/compiler.ts
+++ b/modules/angular2/src/core/compiler/compiler.ts
@@ -129,9 +129,7 @@ export class Compiler {
 
   // Create a hostView as if the compiler encountered <hostcmp></hostcmp>.
   // Used for bootstrapping.
-  compileInHost(componentTypeOrBinding: Type | Binding): Promise<ProtoViewRef> {
-    var componentType = isType(componentTypeOrBinding) ? componentTypeOrBinding :
-                                                         (<Binding>componentTypeOrBinding).token;
+  compileInHost(componentType: Type): Promise<ProtoViewRef> {
     var r = wtfStartTimeRange('Compiler#compile()', stringify(componentType));
 
     var hostAppProtoView = this._compilerCache.getHost(componentType);
@@ -139,7 +137,7 @@ export class Compiler {
     if (isPresent(hostAppProtoView)) {
       hostPvPromise = PromiseWrapper.resolve(hostAppProtoView);
     } else {
-      var componentBinding: DirectiveBinding = this._bindDirective(componentTypeOrBinding);
+      var componentBinding: DirectiveBinding = this._bindDirective(componentType);
       Compiler._assertTypeIsComponent(componentBinding);
 
       var directiveMetadata = componentBinding.metadata;

--- a/modules/angular2/src/core/compiler/dynamic_component_loader.ts
+++ b/modules/angular2/src/core/compiler/dynamic_component_loader.ts
@@ -6,10 +6,6 @@ import {AppViewManager} from 'angular2/src/core/compiler/view_manager';
 import {ElementRef} from './element_ref';
 import {ViewRef, HostViewRef} from './view_ref';
 
-function _asType(typeOrBinding: Type | Binding): Type {
-  return isType(typeOrBinding) ? typeOrBinding : (<Binding>typeOrBinding).token;
-}
-
 /**
  * Angular's reference to a component instance.
  *
@@ -69,7 +65,7 @@ export class DynamicComponentLoader {
    * Loads a root component that is placed at the first element that matches the component's
    * selector.
    *
-   * - `typeOrBinding` `Type` \ {@link Binding} - representing the component to load.
+   * - `typeOrBinding` `Type` - representing the component to load.
    * - `overrideSelector` (optional) selector to load the component at (or use
    *   `@Component.selector`) The selector can be anywhere (i.e. outside the current component.)
    * - `injector` {@link Injector} - optional injector to use for the component.
@@ -120,24 +116,22 @@ export class DynamicComponentLoader {
    * </my-app>
    * ```
    */
-  loadAsRoot(typeOrBinding: Type | Binding, overrideSelector: string, injector: Injector,
+  loadAsRoot(type: Type, overrideSelector: string, injector: Injector,
              onDispose?: () => void): Promise<ComponentRef> {
-    return this._compiler.compileInHost(typeOrBinding)
-        .then(hostProtoViewRef => {
-          var hostViewRef =
-              this._viewManager.createRootHostView(hostProtoViewRef, overrideSelector, injector);
-          var newLocation = this._viewManager.getHostElement(hostViewRef);
-          var component = this._viewManager.getComponent(newLocation);
+    return this._compiler.compileInHost(type).then(hostProtoViewRef => {
+      var hostViewRef =
+          this._viewManager.createRootHostView(hostProtoViewRef, overrideSelector, injector);
+      var newLocation = this._viewManager.getHostElement(hostViewRef);
+      var component = this._viewManager.getComponent(newLocation);
 
-          var dispose = () => {
-            this._viewManager.destroyRootHostView(hostViewRef);
-            if (isPresent(onDispose)) {
-              onDispose();
-            }
-          };
-          return new ComponentRef(newLocation, component, _asType(typeOrBinding), injector,
-                                  dispose);
-        });
+      var dispose = () => {
+        this._viewManager.destroyRootHostView(hostViewRef);
+        if (isPresent(onDispose)) {
+          onDispose();
+        }
+      };
+      return new ComponentRef(newLocation, component, type, injector, dispose);
+    });
   }
 
   /**
@@ -187,11 +181,10 @@ export class DynamicComponentLoader {
    * </my-app>
    * ```
    */
-  loadIntoLocation(typeOrBinding: Type | Binding, hostLocation: ElementRef, anchorName: string,
+  loadIntoLocation(type: Type, hostLocation: ElementRef, anchorName: string,
                    bindings: ResolvedBinding[] = null): Promise<ComponentRef> {
     return this.loadNextToLocation(
-        typeOrBinding, this._viewManager.getNamedElementInComponentView(hostLocation, anchorName),
-        bindings);
+        type, this._viewManager.getNamedElementInComponentView(hostLocation, anchorName), bindings);
   }
 
   /**
@@ -235,23 +228,22 @@ export class DynamicComponentLoader {
    * <child-component>Child</child-component>
    * ```
    */
-  loadNextToLocation(typeOrBinding: Type | Binding, location: ElementRef,
+  loadNextToLocation(type: Type, location: ElementRef,
                      bindings: ResolvedBinding[] = null): Promise<ComponentRef> {
-    return this._compiler.compileInHost(typeOrBinding)
-        .then(hostProtoViewRef => {
-          var viewContainer = this._viewManager.getViewContainer(location);
-          var hostViewRef =
-              viewContainer.createHostView(hostProtoViewRef, viewContainer.length, bindings);
-          var newLocation = this._viewManager.getHostElement(hostViewRef);
-          var component = this._viewManager.getComponent(newLocation);
+    return this._compiler.compileInHost(type).then(hostProtoViewRef => {
+      var viewContainer = this._viewManager.getViewContainer(location);
+      var hostViewRef =
+          viewContainer.createHostView(hostProtoViewRef, viewContainer.length, bindings);
+      var newLocation = this._viewManager.getHostElement(hostViewRef);
+      var component = this._viewManager.getComponent(newLocation);
 
-          var dispose = () => {
-            var index = viewContainer.indexOf(<ViewRef>hostViewRef);
-            if (index !== -1) {
-              viewContainer.remove(index);
-            }
-          };
-          return new ComponentRef(newLocation, component, _asType(typeOrBinding), null, dispose);
-        });
+      var dispose = () => {
+        var index = viewContainer.indexOf(<ViewRef>hostViewRef);
+        if (index !== -1) {
+          viewContainer.remove(index);
+        }
+      };
+      return new ComponentRef(newLocation, component, type, null, dispose);
+    });
   }
 }

--- a/modules/angular2/src/core/compiler/template_commands.ts
+++ b/modules/angular2/src/core/compiler/template_commands.ts
@@ -1,4 +1,4 @@
-import {Type, CONST_EXPR, isPresent, isBlank} from 'angular2/src/core/facade/lang';
+import {Type, CONST_EXPR, CONST, isPresent, isBlank} from 'angular2/src/core/facade/lang';
 import {
   RenderTemplateCmd,
   RenderCommandVisitor,
@@ -9,47 +9,32 @@ import {
   RenderEmbeddedTemplateCmd
 } from 'angular2/src/core/render/render';
 
+/**
+ * A compiled template. This is const as we are storing it as annotation
+ * for the compiled component type.
+ */
+@CONST()
 export class CompiledTemplate {
-  private _changeDetectorFactory: Function = null;
-  private _styles: string[] = null;
-  private _commands: TemplateCmd[] = null;
   // Note: paramGetter is a function so that we can have cycles between templates!
-  constructor(public id: number, private _paramGetter: Function) {}
-
-  private _init() {
-    if (isBlank(this._commands)) {
-      var params = this._paramGetter();
-      this._changeDetectorFactory = params[0];
-      this._commands = params[1];
-      this._styles = params[2];
-    }
-  }
-
-  get changeDetectorFactory(): Function {
-    this._init();
-    return this._changeDetectorFactory;
-  }
-
-  get styles(): string[] {
-    this._init();
-    return this._styles;
-  }
-
-  get commands(): TemplateCmd[] {
-    this._init();
-    return this._commands;
-  }
+  // paramGetter returns a tuple with:
+  // - ChangeDetector factory function
+  // - TemplateCmd[]
+  // - styles
+  constructor(public id: number,
+              public dataGetter: /*()=>[Function, TemplateCmd[], string[]]*/ Function) {}
 }
 
 const EMPTY_ARR = CONST_EXPR([]);
 
 export interface TemplateCmd extends RenderTemplateCmd {
-  visit(visitor: CommandVisitor, context: any): any;
+  visit(visitor: RenderCommandVisitor, context: any): any;
 }
 
 export class TextCmd implements TemplateCmd, RenderTextCmd {
   constructor(public value: string, public isBound: boolean, public ngContentIndex: number) {}
-  visit(visitor: CommandVisitor, context: any): any { return visitor.visitText(this, context); }
+  visit(visitor: RenderCommandVisitor, context: any): any {
+    return visitor.visitText(this, context);
+  }
 }
 
 export function text(value: string, isBound: boolean, ngContentIndex: number): TextCmd {
@@ -59,7 +44,7 @@ export function text(value: string, isBound: boolean, ngContentIndex: number): T
 export class NgContentCmd implements TemplateCmd, RenderNgContentCmd {
   isBound: boolean = false;
   constructor(public ngContentIndex: number) {}
-  visit(visitor: CommandVisitor, context: any): any {
+  visit(visitor: RenderCommandVisitor, context: any): any {
     return visitor.visitNgContent(this, context);
   }
 }
@@ -72,7 +57,7 @@ export interface IBeginElementCmd extends TemplateCmd, RenderBeginElementCmd {
   variableNameAndValues: Array<string | number>;
   eventTargetAndNames: string[];
   directives: Type[];
-  visit(visitor: CommandVisitor, context: any): any;
+  visit(visitor: RenderCommandVisitor, context: any): any;
 }
 
 export class BeginElementCmd implements TemplateCmd, IBeginElementCmd, RenderBeginElementCmd {
@@ -80,7 +65,7 @@ export class BeginElementCmd implements TemplateCmd, IBeginElementCmd, RenderBeg
               public eventTargetAndNames: string[],
               public variableNameAndValues: Array<string | number>, public directives: Type[],
               public isBound: boolean, public ngContentIndex: number) {}
-  visit(visitor: CommandVisitor, context: any): any {
+  visit(visitor: RenderCommandVisitor, context: any): any {
     return visitor.visitBeginElement(this, context);
   }
 }
@@ -94,7 +79,9 @@ export function beginElement(name: string, attrNameAndValues: string[],
 }
 
 export class EndElementCmd implements TemplateCmd {
-  visit(visitor: CommandVisitor, context: any): any { return visitor.visitEndElement(context); }
+  visit(visitor: RenderCommandVisitor, context: any): any {
+    return visitor.visitEndElement(context);
+  }
 }
 
 export function endElement(): TemplateCmd {
@@ -113,7 +100,7 @@ export class BeginComponentCmd implements TemplateCmd, IBeginElementCmd, RenderB
     this.component = directives[0];
     this.templateId = template.id;
   }
-  visit(visitor: CommandVisitor, context: any): any {
+  visit(visitor: RenderCommandVisitor, context: any): any {
     return visitor.visitBeginComponent(this, context);
   }
 }
@@ -127,7 +114,9 @@ export function beginComponent(
 }
 
 export class EndComponentCmd implements TemplateCmd {
-  visit(visitor: CommandVisitor, context: any): any { return visitor.visitEndComponent(context); }
+  visit(visitor: RenderCommandVisitor, context: any): any {
+    return visitor.visitEndComponent(context);
+  }
 }
 
 export function endComponent(): TemplateCmd {
@@ -142,7 +131,7 @@ export class EmbeddedTemplateCmd implements TemplateCmd, IBeginElementCmd,
   constructor(public attrNameAndValues: string[], public variableNameAndValues: string[],
               public directives: Type[], public isMerged: boolean, public ngContentIndex: number,
               public changeDetectorFactory: Function, public children: TemplateCmd[]) {}
-  visit(visitor: CommandVisitor, context: any): any {
+  visit(visitor: RenderCommandVisitor, context: any): any {
     return visitor.visitEmbeddedTemplate(this, context);
   }
 }
@@ -155,7 +144,15 @@ export function embeddedTemplate(attrNameAndValues: string[], variableNameAndVal
                                  ngContentIndex, changeDetectorFactory, children);
 }
 
-export interface CommandVisitor extends RenderCommandVisitor {}
+export interface CommandVisitor extends RenderCommandVisitor {
+  visitText(cmd: TextCmd, context: any): any;
+  visitNgContent(cmd: NgContentCmd, context: any): any;
+  visitBeginElement(cmd: BeginElementCmd, context: any): any;
+  visitEndElement(context: any): any;
+  visitBeginComponent(cmd: BeginComponentCmd, context: any): any;
+  visitEndComponent(context: any): any;
+  visitEmbeddedTemplate(cmd: EmbeddedTemplateCmd, context: any): any;
+}
 
 export function visitAllCommands(visitor: CommandVisitor, cmds: TemplateCmd[],
                                  context: any = null) {

--- a/modules/angular2/src/core/reflection/reflection.dart
+++ b/modules/angular2/src/core/reflection/reflection.dart
@@ -45,7 +45,7 @@ class NoReflectionCapabilities implements PlatformReflectionCapabilities {
 
   String importUri(Type type) => './';
 
-  String moduleId(Type type) => null;
+  String moduleId(Type type) => './';
 }
 
 final Reflector reflector = new Reflector(new NoReflectionCapabilities());

--- a/modules/angular2/src/core/reflection/reflection_capabilities.dart
+++ b/modules/angular2/src/core/reflection/reflection_capabilities.dart
@@ -324,6 +324,9 @@ class ReflectionCapabilities implements PlatformReflectionCapabilities {
   }
 
   String moduleId(Type type) {
-    return '${MirrorSystem.getName((reflectClass(type).owner as LibraryMirror).qualifiedName).replaceAll(DOT_REGEX, "/")}';
+    var rootUri = currentMirrorSystem().isolate.rootLibrary.uri;
+    var moduleUri = (reflectClass(type).owner as LibraryMirror).uri;
+    var relativeUri = new Uri(pathSegments:moduleUri.pathSegments.sublist(rootUri.pathSegments.length-1)).toString();
+    return relativeUri.substring(0, relativeUri.lastIndexOf('.'));
   }
 }

--- a/modules/angular2/src/core/reflection/reflection_capabilities.ts
+++ b/modules/angular2/src/core/reflection/reflection_capabilities.ts
@@ -169,5 +169,5 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
   // There is not a concept of import uri in Js, but this is useful in developing Dart applications.
   importUri(type: Type): string { return './'; }
 
-  moduleId(type: Type): string { return null; }
+  moduleId(type: Type): string { return './'; }
 }

--- a/modules/angular2/src/core/render/api.ts
+++ b/modules/angular2/src/core/render/api.ts
@@ -401,7 +401,7 @@ export interface RenderBeginCmd extends RenderTemplateCmd {
 
 export interface RenderTextCmd extends RenderBeginCmd { value: string; }
 
-export interface RenderNgContentCmd extends RenderBeginCmd { ngContentIndex: number; }
+export interface RenderNgContentCmd { ngContentIndex: number; }
 
 export interface RenderBeginElementCmd extends RenderBeginCmd {
   name: string;
@@ -420,13 +420,13 @@ export interface RenderEmbeddedTemplateCmd extends RenderBeginElementCmd {
 }
 
 export interface RenderCommandVisitor {
-  visitText(cmd: any, context: any): any;
-  visitNgContent(cmd: any, context: any): any;
-  visitBeginElement(cmd: any, context: any): any;
+  visitText(cmd: RenderTextCmd, context: any): any;
+  visitNgContent(cmd: RenderNgContentCmd, context: any): any;
+  visitBeginElement(cmd: RenderBeginElementCmd, context: any): any;
   visitEndElement(context: any): any;
-  visitBeginComponent(cmd: any, context: any): any;
+  visitBeginComponent(cmd: RenderBeginComponentCmd, context: any): any;
   visitEndComponent(context: any): any;
-  visitEmbeddedTemplate(cmd: any, context: any): any;
+  visitEmbeddedTemplate(cmd: RenderEmbeddedTemplateCmd, context: any): any;
 }
 
 

--- a/modules/angular2/src/test_lib/test_injector.ts
+++ b/modules/angular2/src/test_lib/test_injector.ts
@@ -74,6 +74,7 @@ import {
 } from 'angular2/src/core/render/dom/schema/dom_element_schema_registry';
 import {Serializer} from "angular2/src/web_workers/shared/serializer";
 import {Log} from './utils';
+import {compilerBindings} from 'angular2/src/compiler/compiler';
 
 /**
  * Returns the root injector bindings.
@@ -107,8 +108,8 @@ function _getAppBindings() {
   }
 
   return [
-    bind(DOCUMENT)
-        .toValue(appDoc),
+    compilerBindings(),
+    bind(DOCUMENT).toValue(appDoc),
     DomRenderer,
     bind(Renderer).toAlias(DomRenderer),
     bind(APP_ID).toValue('a'),

--- a/modules/angular2/test/compiler/command_compiler_spec.ts
+++ b/modules/angular2/test/compiler/command_compiler_spec.ts
@@ -171,7 +171,7 @@ export function main() {
                        'div',
                        ['a', 'b'],
                        [null, 'click', 'window', 'scroll'],
-                       ['someVar', '%implicit'],
+                       ['someVar', null],
                        [],
                        true,
                        null
@@ -329,25 +329,44 @@ export function main() {
 
       describe('embedded templates', () => {
         it('should create embedded template commands', inject([AsyncTestCompleter], (async) => {
-             var rootComp = createComp({
-               type: RootCompTypeMeta,
-               template: '<template a="b" #some-var="someValue"></template>'
-             });
+             var rootComp =
+                 createComp({type: RootCompTypeMeta, template: '<template a="b"></template>'});
              var dir = createDirective(SomeDirTypeMeta, '[a]');
              run(rootComp, [dir], 1)
                  .then((data) => {
                    expect(data).toEqual([
-                     [
-                       EMBEDDED_TEMPLATE,
-                       ['a', 'b'],
-                       ['someVar', 'someValue'],
-                       ['SomeDirType'],
-                       false,
-                       null,
-                       'cd1',
-                       []
-                     ]
+                     [EMBEDDED_TEMPLATE, ['a', 'b'], [], ['SomeDirType'], false, null, 'cd1', []]
                    ]);
+                   async.done();
+                 });
+           }));
+
+        it('should keep variable name and value for <template> elements',
+           inject([AsyncTestCompleter], (async) => {
+             var rootComp = createComp({
+               type: RootCompTypeMeta,
+               template: '<template #some-var="someValue" #some-empty-var></template>'
+             });
+             var dir = createDirective(SomeDirTypeMeta, '[a]');
+             run(rootComp, [dir], 1)
+                 .then((data) => {
+                   expect(data[0][2])
+                       .toEqual(['someEmptyVar', '$implicit', 'someVar', 'someValue']);
+                   async.done();
+                 });
+           }));
+
+        it('should keep variable name and value for template attributes',
+           inject([AsyncTestCompleter], (async) => {
+             var rootComp = createComp({
+               type: RootCompTypeMeta,
+               template: '<div template="var someVar=someValue; var someEmptyVar"></div>'
+             });
+             var dir = createDirective(SomeDirTypeMeta, '[a]');
+             run(rootComp, [dir], 1)
+                 .then((data) => {
+                   expect(data[0][2])
+                       .toEqual(['someVar', 'someValue', 'someEmptyVar', '$implicit']);
                    async.done();
                  });
            }));

--- a/modules/angular2/test/compiler/runtime_metadata_spec.ts
+++ b/modules/angular2/test/compiler/runtime_metadata_spec.ts
@@ -66,7 +66,8 @@ export function main() {
 
       it('should use the moduleId from the reflector if none is given',
          inject([RuntimeMetadataResolver], (resolver: RuntimeMetadataResolver) => {
-           var expectedValue = IS_DART ? 'angular2/test/compiler/runtime_metadata_spec' : null;
+           var expectedValue =
+               IS_DART ? 'base/dist/dart/angular2/test/compiler/runtime_metadata_spec' : './';
            expect(resolver.getMetadata(DirectiveWithoutModuleId).type.moduleId)
                .toEqual(expectedValue);
          }));

--- a/modules/angular2/test/compiler/style_compiler_spec.ts
+++ b/modules/angular2/test/compiler/style_compiler_spec.ts
@@ -42,6 +42,8 @@ const IMPORT_ABS_MODULE_NAME_WITH_IMPORT =
 export function main() {
   describe('StyleCompiler', () => {
     var xhr: SpyXHR;
+    var typeMeta;
+
     beforeEachBindings(() => {
       xhr = <any>new SpyXHR();
       return [TEST_BINDINGS, bind(XHR).toValue(xhr)];
@@ -49,16 +51,10 @@ export function main() {
 
     var compiler: StyleCompiler;
 
-    beforeEach(inject([StyleCompiler], (_compiler) => { compiler = _compiler; }));
-
-    function comp(styles: string[], styleAbsUrls: string[], encapsulation: ViewEncapsulation):
-        CompileDirectiveMetadata {
-      return CompileDirectiveMetadata.create({
-        type: new CompileTypeMetadata({id: 23, moduleId: 'someUrl'}),
-        template: new CompileTemplateMetadata(
-            {styles: styles, styleUrls: styleAbsUrls, encapsulation: encapsulation})
-      });
-    }
+    beforeEach(inject([StyleCompiler], (_compiler) => {
+      typeMeta = new CompileTypeMetadata({id: 23, moduleId: 'someUrl'});
+      compiler = _compiler;
+    }));
 
     describe('compileComponentRuntime', () => {
       var xhrUrlResults;
@@ -84,7 +80,9 @@ export function main() {
           }
           return PromiseWrapper.resolve(response);
         });
-        return compiler.compileComponentRuntime(comp(styles, styleAbsUrls, encapsulation));
+        return compiler.compileComponentRuntime(
+            typeMeta, new CompileTemplateMetadata(
+                          {styles: styles, styleUrls: styleAbsUrls, encapsulation: encapsulation}));
       }
 
       describe('no shim', () => {
@@ -199,8 +197,9 @@ export function main() {
     describe('compileComponentCodeGen', () => {
       function compile(styles: string[], styleAbsUrls: string[], encapsulation: ViewEncapsulation):
           Promise<string[]> {
-        var sourceExpression =
-            compiler.compileComponentCodeGen(comp(styles, styleAbsUrls, encapsulation));
+        var sourceExpression = compiler.compileComponentCodeGen(
+            typeMeta, new CompileTemplateMetadata(
+                          {styles: styles, styleUrls: styleAbsUrls, encapsulation: encapsulation}));
         var sourceWithImports = testableExpression(sourceExpression).getSourceWithImports();
         return evalModule(sourceWithImports.source, sourceWithImports.imports, null);
       };

--- a/modules/angular2/test/compiler/template_normalizer_spec.ts
+++ b/modules/angular2/test/compiler/template_normalizer_spec.ts
@@ -145,6 +145,14 @@ export function main() {
 
       });
 
+      it('should throw if no template was specified',
+         inject([TemplateNormalizer], (normalizer: TemplateNormalizer) => {
+           expect(() => normalizer.normalizeTemplate(
+                      dirType, new CompileTemplateMetadata(
+                                   {encapsulation: null, styles: [], styleUrls: []})))
+               .toThrowError('No template specified for component SomeComp');
+         }));
+
     });
 
     describe('normalizeLoadedTemplate', () => {
@@ -274,16 +282,23 @@ export function main() {
            expect(template.encapsulation).toEqual(ViewEncapsulation.None);
          }));
 
-      it('should ignore elements with ng-non-bindable attribute and their children',
+      it('should ignore ng-content in elements with ng-non-bindable',
          inject([TemplateNormalizer], (normalizer: TemplateNormalizer) => {
            var template = normalizer.normalizeLoadedTemplate(
                dirType,
                new CompileTemplateMetadata({encapsulation: null, styles: [], styleUrls: []}),
-               '<div ng-non-bindable><ng-content select="a"></ng-content></div><ng-content ng-non-bindable select="b"></ng-content>',
-               'some/module/');
+               '<div ng-non-bindable><ng-content select="a"></ng-content></div>', 'some/module/');
            expect(template.ngContentSelectors).toEqual([]);
          }));
 
+      it('should still collect <style> in elements with ng-non-bindable',
+         inject([TemplateNormalizer], (normalizer: TemplateNormalizer) => {
+           var template = normalizer.normalizeLoadedTemplate(
+               dirType,
+               new CompileTemplateMetadata({encapsulation: null, styles: [], styleUrls: []}),
+               '<div ng-non-bindable><style>div {color:red}</style></div>', 'some/module/');
+           expect(template.styles).toEqual(['div {color:red}']);
+         }));
     });
   });
 }

--- a/modules/angular2/test/compiler/template_preparser_spec.ts
+++ b/modules/angular2/test/compiler/template_preparser_spec.ts
@@ -1,0 +1,58 @@
+import {
+  ddescribe,
+  describe,
+  xdescribe,
+  it,
+  iit,
+  xit,
+  expect,
+  beforeEach,
+  afterEach,
+  AsyncTestCompleter,
+  inject,
+  beforeEachBindings
+} from 'angular2/test_lib';
+
+import {HtmlParser} from 'angular2/src/compiler/html_parser';
+import {
+  preparseElement,
+  PreparsedElementType,
+  PreparsedElement
+} from 'angular2/src/compiler/template_preparser';
+
+export function main() {
+  describe('preparseElement', () => {
+    var htmlParser;
+    beforeEach(inject([HtmlParser], (_htmlParser: HtmlParser) => { htmlParser = _htmlParser; }));
+
+    function preparse(html: string): PreparsedElement {
+      return preparseElement(htmlParser.parse(html, '')[0]);
+    }
+
+    it('should detect script elements', inject([HtmlParser], (htmlParser: HtmlParser) => {
+         expect(preparse('<script>').type).toBe(PreparsedElementType.SCRIPT);
+       }));
+
+    it('should detect style elements', inject([HtmlParser], (htmlParser: HtmlParser) => {
+         expect(preparse('<style>').type).toBe(PreparsedElementType.STYLE);
+       }));
+
+    it('should detect stylesheet elements', inject([HtmlParser], (htmlParser: HtmlParser) => {
+         expect(preparse('<link rel="stylesheet">').type).toBe(PreparsedElementType.STYLESHEET);
+         expect(preparse('<link rel="stylesheet" href="someUrl">').hrefAttr).toEqual('someUrl');
+         expect(preparse('<link rel="someRel">').type).toBe(PreparsedElementType.OTHER);
+       }));
+
+    it('should detect ng-content elements', inject([HtmlParser], (htmlParser: HtmlParser) => {
+         expect(preparse('<ng-content>').type).toBe(PreparsedElementType.NG_CONTENT);
+       }));
+
+    it('should normalize ng-content.select attribute',
+       inject([HtmlParser], (htmlParser: HtmlParser) => {
+         expect(preparse('<ng-content>').selectAttr).toEqual('*');
+         expect(preparse('<ng-content select>').selectAttr).toEqual('*');
+         expect(preparse('<ng-content select="*">').selectAttr).toEqual('*');
+       }));
+
+  });
+}

--- a/modules/angular2/test/compiler/test_bindings.ts
+++ b/modules/angular2/test/compiler/test_bindings.ts
@@ -1,26 +1,5 @@
 import {bind, Binding} from 'angular2/src/core/di';
-import {TemplateParser} from 'angular2/src/compiler/template_parser';
-import {HtmlParser} from 'angular2/src/compiler/html_parser';
-import {TemplateNormalizer} from 'angular2/src/compiler/template_normalizer';
-import {RuntimeMetadataResolver} from 'angular2/src/compiler/runtime_metadata';
-import {ChangeDetectionCompiler} from 'angular2/src/compiler/change_detector_compiler';
-import {StyleCompiler} from 'angular2/src/compiler/style_compiler';
-import {CommandCompiler} from 'angular2/src/compiler/command_compiler';
-import {TemplateCompiler} from 'angular2/src/compiler/template_compiler';
-import {ChangeDetectorGenConfig} from 'angular2/src/core/change_detection/change_detection';
 import {MockSchemaRegistry} from './schema_registry_mock';
 import {ElementSchemaRegistry} from 'angular2/src/core/render/dom/schema/element_schema_registry';
 
-// TODO(tbosch): move this into test_injector once the new compiler pipeline is used fully
-export var TEST_BINDINGS = [
-  HtmlParser,
-  TemplateParser,
-  TemplateNormalizer,
-  RuntimeMetadataResolver,
-  StyleCompiler,
-  CommandCompiler,
-  ChangeDetectionCompiler,
-  bind(ChangeDetectorGenConfig).toValue(new ChangeDetectorGenConfig(true, true, false, false)),
-  TemplateCompiler,
-  bind(ElementSchemaRegistry).toValue(new MockSchemaRegistry({}, {}))
-];
+export var TEST_BINDINGS = [bind(ElementSchemaRegistry).toValue(new MockSchemaRegistry({}, {}))];

--- a/modules/angular2/test/compiler/util_spec.ts
+++ b/modules/angular2/test/compiler/util_spec.ts
@@ -12,6 +12,7 @@ import {
   TestComponentBuilder
 } from 'angular2/test_lib';
 
+import {IS_DART} from '../platform';
 import {escapeSingleQuoteString, escapeDoubleQuoteString} from 'angular2/src/compiler/util';
 
 export function main() {
@@ -25,6 +26,12 @@ export function main() {
 
       it('should escape newlines',
          () => { expect(escapeSingleQuoteString('\n')).toEqual(`'\\n'`); });
+
+      if (IS_DART) {
+        it('should escape $', () => { expect(escapeSingleQuoteString('$')).toEqual(`'\\$'`); });
+      } else {
+        it('should not escape $', () => { expect(escapeSingleQuoteString('$')).toEqual(`'$'`); });
+      }
     });
 
     describe('escapeDoubleQuoteString', () => {
@@ -36,6 +43,12 @@ export function main() {
 
       it('should escape newlines',
          () => { expect(escapeDoubleQuoteString('\n')).toEqual(`"\\n"`); });
+
+      if (IS_DART) {
+        it('should escape $', () => { expect(escapeDoubleQuoteString('$')).toEqual(`"\\$"`); });
+      } else {
+        it('should not escape $', () => { expect(escapeDoubleQuoteString('$')).toEqual(`"$"`); });
+      }
     });
 
   });

--- a/modules/angular2/test/core/compiler/integration_spec.ts
+++ b/modules/angular2/test/core/compiler/integration_spec.ts
@@ -384,11 +384,7 @@ export function main() {
            tcb.overrideView(
                   MyComp, new ViewMetadata({
                     template: '<p no-duplicate></p>',
-                    directives: [
-                      DuplicateDir,
-                      DuplicateDir,
-                      [DuplicateDir, [DuplicateDir, bind(DuplicateDir).toClass(DuplicateDir)]]
-                    ]
+                    directives: [DuplicateDir, DuplicateDir, [DuplicateDir, [DuplicateDir]]]
                   }))
                .createAsync(MyComp)
                .then((rootTC) => {

--- a/modules/angular2/test/core/reflection/reflector_spec.ts
+++ b/modules/angular2/test/core/reflection/reflector_spec.ts
@@ -251,7 +251,7 @@ export function main() {
       describe("moduleId", () => {
         it("should return the moduleId for a type", () => {
           expect(reflector.moduleId(TestObjWith00Args))
-              .toEqual('angular2/test/core/reflection/reflector_spec');
+              .toEqual('base/dist/dart/angular2/test/core/reflection/reflector_spec');
         });
 
         it("should return an empty array otherwise", () => {


### PR DESCRIPTION
- use `$implicit` variable value correctly
- handle `ng-non-bindable` correctly
- add some more assertions
- make `CompiledTemplate` const
- fix default values for `@Directive.moduleId` 

BREAKING CHANGE:
- `Compiler.compileInHost` and all methods of `DynamicComponentLoader` don’t take `Binding` any more, only `Type`s. This is in preparation for the new compiler which does not support this.

Part of #3605
