### PR TITLE
docs(http): add language annotations and fix method value to enum

### DIFF
--- a/modules/angular2/src/http/base_request_options.ts
+++ b/modules/angular2/src/http/base_request_options.ts
@@ -115,7 +115,7 @@ export class RequestOptions {
  *
  * ### Example ([live demo](http://plnkr.co/edit/LEKVSx?p=preview))
  *
- * ```
+ * ```typescript
  * import {bind, bootstrap} from 'angular2/angular2';
  * import {HTTP_BINDINGS, Http, BaseRequestOptions, RequestOptions} from 'angular2/http';
  * import {App} from './myapp';

--- a/modules/angular2/src/http/base_response_options.ts
+++ b/modules/angular2/src/http/base_response_options.ts
@@ -114,7 +114,7 @@ export class ResponseOptions {
  *
  * ### Example ([live demo](http://plnkr.co/edit/qv8DLT?p=preview))
  *
- * ```
+ * ```typescript
  * import {bind, bootstrap} from 'angular2/angular2';
  * import {HTTP_BINDINGS, Headers, Http, BaseResponseOptions, ResponseOptions} from 'angular2/http';
  * import {App} from './myapp';

--- a/modules/angular2/src/http/http.ts
+++ b/modules/angular2/src/http/http.ts
@@ -52,7 +52,7 @@ function mergeOptions(defaultOpts, providedOpts, method, url): RequestOptions {
  *
  * #Example
  *
- * ```
+ * ```typescript
  * import {Http, HTTP_BINDINGS} from 'angular2/http';
  * @Component({selector: 'http-app', viewBindings: [HTTP_BINDINGS]})
  * @View({templateUrl: 'people.html'})
@@ -86,7 +86,7 @@ function mergeOptions(defaultOpts, providedOpts, method, url): RequestOptions {
  *
  * #Example
  *
- * ```
+ * ```typescript
  * import {MockBackend, BaseRequestOptions, Http} from 'angular2/http';
  * var injector = Injector.resolveAndCreate([
  *   BaseRequestOptions,

--- a/modules/angular2/src/http/static_request.ts
+++ b/modules/angular2/src/http/static_request.ts
@@ -24,16 +24,16 @@ import {
  * One such example is when creating services that wrap higher-level services, like {@link Http},
  * where it may be useful to generate a `Request` with arbitrary headers and search params.
  *
- * ```
+ * ```typescript
  * import {Injectable, Injector} from 'angular2/angular2';
- * import {HTTP_BINDINGS, Http, Request} from 'angular2/http';
+ * import {HTTP_BINDINGS, Http, Request, RequestMethods} from 'angular2/http';
  *
  * @Injectable()
  * class AutoAuthenticator {
  *   constructor(public http:Http) {}
  *   request(url:string) {
  *     return this.http.request(new Request({
- *       method: 0, //GET.
+ *       method: RequestMethods.Get,
  *       url: url,
  *       search: 'password=123'
  *     }));


### PR DESCRIPTION
Added TypeScript syntax highlighting where I found type annotations.

Since https://github.com/angular/angular/pull/4331 will allow using strings as method names I think the method value in the example inside `static_request.ts` will be more readable by importing and using `RequestMethod` instead of a numeric value.
