### PR TITLE
refactor(http): remove useless constant

### DIFF
--- a/modules/angular2/src/http/interfaces.ts
+++ b/modules/angular2/src/http/interfaces.ts
@@ -3,10 +3,7 @@ import {Headers} from './headers';
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 import {EventEmitter} from 'angular2/src/core/facade/async';
 import {Request} from './static_request';
-import {URLSearchParamsUnionFixer, URLSearchParams} from './url_search_params';
-
-// Work around Dartanalyzer problem :(
-const URLSearchParams_UnionFixer = URLSearchParamsUnionFixer;
+import {URLSearchParams} from './url_search_params';
 
 /**
  * Abstract class from which real backends are derived.

--- a/modules/angular2/src/http/url_search_params.ts
+++ b/modules/angular2/src/http/url_search_params.ts
@@ -22,9 +22,6 @@ function paramParser(rawParams: string = ''): Map<string, string[]> {
   return map;
 }
 
-// TODO(caitp): This really should not be needed. Issue with ts2dart.
-export const URLSearchParamsUnionFixer: string = CONST_EXPR("UnionFixer");
-
 /**
  * Map-like representation of url search parameters, based on
  * [URLSearchParams](https://url.spec.whatwg.org/#urlsearchparams) in the url living standard,


### PR DESCRIPTION
Since the http module supports only TypeScript now, this workaround seems useless.
Related to my question https://github.com/angular/angular/issues/4347
