### PR TITLE
fix(dart/transform): Handle export cycles

### DIFF
--- a/modules_dart/transform/test/transform/directive_metadata_extractor/all_tests.dart
+++ b/modules_dart/transform/test/transform/directive_metadata_extractor/all_tests.dart
@@ -193,6 +193,20 @@ void allTests() {
       expect(extracted.types['BazComponent'].selector).toEqual('[baz]');
     });
 
+    it('should handle `DirectiveMetadata` export cycles gracefully.', () async {
+      var extracted = await extractDirectiveMetadata(
+          reader,
+          new AssetId('a',
+              'directive_metadata_extractor/export_cycle_files/baz.ng_deps.dart'));
+      expect(extracted.types).toContain('FooComponent');
+      expect(extracted.types).toContain('BarComponent');
+      expect(extracted.types).toContain('BazComponent');
+
+      expect(extracted.types['FooComponent'].selector).toEqual('[foo]');
+      expect(extracted.types['BarComponent'].selector).toEqual('[bar]');
+      expect(extracted.types['BazComponent'].selector).toEqual('[baz]');
+    });
+
     it(
         'should include `DirectiveMetadata` from exported files '
         'expressed as absolute uris', () async {

--- a/modules_dart/transform/test/transform/directive_metadata_extractor/export_cycle_files/bar.ng_deps.dart
+++ b/modules_dart/transform/test/transform/directive_metadata_extractor/export_cycle_files/bar.ng_deps.dart
@@ -1,0 +1,19 @@
+library foo.ng_deps.dart;
+
+import 'bar.dart';
+import 'package:angular2/src/core/metadata.dart';
+
+export 'baz.dart';
+import 'baz.ng_deps.dart' as i0;
+
+var _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(
+        BarComponent,
+        new ReflectionInfo(const [const Component(selector: '[bar]')], const [],
+            () => new BarComponent()));
+  i0.initReflector(reflector);
+}

--- a/modules_dart/transform/test/transform/directive_metadata_extractor/export_cycle_files/baz.ng_deps.dart
+++ b/modules_dart/transform/test/transform/directive_metadata_extractor/export_cycle_files/baz.ng_deps.dart
@@ -1,0 +1,17 @@
+library foo.ng_deps.dart;
+
+import 'baz.dart';
+import 'package:angular2/src/core/metadata.dart';
+
+export 'foo.dart';
+
+var _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(
+        BazComponent,
+        new ReflectionInfo(const [const Component(selector: '[baz]')], const [],
+            () => new BazComponent()));
+}

--- a/modules_dart/transform/test/transform/directive_metadata_extractor/export_cycle_files/foo.ng_deps.dart
+++ b/modules_dart/transform/test/transform/directive_metadata_extractor/export_cycle_files/foo.ng_deps.dart
@@ -1,0 +1,19 @@
+library foo.ng_deps.dart;
+
+import 'foo.dart';
+import 'package:angular2/src/core/metadata.dart';
+
+export 'bar.dart';
+import 'bar.ng_deps.dart' as i0;
+
+var _visited = false;
+void initReflector(reflector) {
+  if (_visited) return;
+  _visited = true;
+  reflector
+    ..registerType(
+        FooComponent,
+        new ReflectionInfo(const [const Component(selector: '[foo]')], const [],
+            () => new FooComponent()));
+  i0.initReflector(reflector);
+}


### PR DESCRIPTION
Currently, an export cycle in dart inputs will cause the transformer to
hang indefinitely on the `DirectiveMetadataExtractor` step.

Closes #4370
