### PR TITLE
refactor(http): use Rx Observables in XHR backend

### DIFF
--- a/modules/angular2/src/http/http.ts
+++ b/modules/angular2/src/http/http.ts
@@ -34,18 +34,8 @@ function mergeOptions(defaultOpts, providedOpts, method, url): RequestOptions {
  * Performs http requests using `XMLHttpRequest` as the default backend.
  *
  * `Http` is available as an injectable class, with methods to perform http requests. Calling
- * `request` returns an {@link EventEmitter} which will emit a single {@link Response} when a
+ * `request` returns an {@link Observable} which will emit a single {@link Response} when a
  * response is received.
- *
- *
- * ## Breaking Change
- *
- * Previously, methods of `Http` would return an RxJS Observable directly. For now,
- * the `toRx()` method of {@link EventEmitter} needs to be called in order to get the RxJS
- * Subject. `EventEmitter` does not provide combinators like `map`, and has different semantics for
- * subscribing/observing. This is temporary; the result of all `Http` method calls will be either an
- * Observable
- * or Dart Stream when [issue #2794](https://github.com/angular/angular/issues/2794) is resolved.
  *
  * #Example
  *
@@ -56,8 +46,6 @@ function mergeOptions(defaultOpts, providedOpts, method, url): RequestOptions {
  * class PeopleComponent {
  *   constructor(http: Http) {
  *     http.get('people.json')
- *       //Get the RxJS Subject
- *       .toRx()
  *       // Call map on the response observable to get the parsed people object
  *       .map(res => res.json())
  *       // Subscribe to the observable to get the parsed people object and attach it to the
@@ -67,9 +55,6 @@ function mergeOptions(defaultOpts, providedOpts, method, url): RequestOptions {
  * }
  * ```
  *
- * To use the {@link EventEmitter} returned by `Http`, simply pass a generator (See "interface
- *Generator" in the Async Generator spec: https://github.com/jhusain/asyncgenerator) to the
- *`observer` method of the returned emitter, with optional methods of `next`, `throw`, and `return`.
  *
  * #Example
  *
@@ -95,7 +80,7 @@ function mergeOptions(defaultOpts, providedOpts, method, url): RequestOptions {
  *       [MockBackend, BaseRequestOptions])
  * ]);
  * var http = injector.get(Http);
- * http.get('request-from-mock-backend.json').toRx().subscribe((res:Response) => doSomething(res));
+ * http.get('request-from-mock-backend.json').subscribe((res:Response) => doSomething(res));
  * ```
  *
  **/

--- a/modules/angular2/src/http/interfaces.ts
+++ b/modules/angular2/src/http/interfaces.ts
@@ -26,7 +26,6 @@ export class Connection {
   readyState: ReadyStates;
   request: Request;
   response: EventEmitter;  // TODO: generic of <Response>;
-  dispose(): void { throw new BaseException('Abstract!'); }
 }
 
 /**

--- a/modules/angular2/test/http/backends/jsonp_backend_spec.ts
+++ b/modules/angular2/test/http/backends/jsonp_backend_spec.ts
@@ -38,11 +38,16 @@ class MockBrowserJsonp extends BrowserJsonp {
 
   addEventListener(type: string, cb: (data: any) => any) { this.callbacks.set(type, cb); }
 
+  removeEventListener(type: string, cb: Function) { this.callbacks.delete(type); }
+
   dispatchEvent(type: string, argument?: any) {
     if (!isPresent(argument)) {
       argument = {};
     }
-    this.callbacks.get(type)(argument);
+    let cb = this.callbacks.get(type);
+    if (isPresent(cb)) {
+      cb(argument);
+    }
   }
 
   build(url: string) {
@@ -89,7 +94,7 @@ export function main() {
          inject([AsyncTestCompleter], async => {
            let connection = new JSONPConnection(sampleRequest, new MockBrowserJsonp(),
                                                 new ResponseOptions({type: ResponseTypes.Error}));
-           ObservableWrapper.subscribe<Response>(connection.response, res => {
+           connection.response.subscribe(res => {
              expect(res.type).toBe(ResponseTypes.Error);
              async.done();
            });
@@ -104,17 +109,17 @@ export function main() {
            let errorSpy = spy.spy('error');
            let returnSpy = spy.spy('cancelled');
 
-           ObservableWrapper.subscribe(connection.response, loadSpy, errorSpy, returnSpy);
-           connection.dispose();
-           expect(connection.readyState).toBe(ReadyStates.Cancelled);
+           let request = connection.response.subscribe(loadSpy, errorSpy, returnSpy);
+           request.unsubscribe();
 
            connection.finished('Fake data');
            existingScripts[0].dispatchEvent('load');
 
            TimerWrapper.setTimeout(() => {
+             expect(connection.readyState).toBe(ReadyStates.Cancelled);
              expect(loadSpy).not.toHaveBeenCalled();
              expect(errorSpy).not.toHaveBeenCalled();
-             expect(returnSpy).toHaveBeenCalled();
+             expect(returnSpy).not.toHaveBeenCalled();
              async.done();
            }, 10);
          }));
@@ -122,8 +127,7 @@ export function main() {
       it('should report error if loaded without invoking callback',
          inject([AsyncTestCompleter], async => {
            let connection = new JSONPConnection(sampleRequest, new MockBrowserJsonp());
-           ObservableWrapper.subscribe(
-               connection.response,
+           connection.response.subscribe(
                res => {
                  expect("response listener called").toBe(false);
                  async.done();
@@ -139,15 +143,15 @@ export function main() {
       it('should report error if script contains error', inject([AsyncTestCompleter], async => {
            let connection = new JSONPConnection(sampleRequest, new MockBrowserJsonp());
 
-           ObservableWrapper.subscribe(connection.response,
-                                       res => {
-                                         expect("response listener called").toBe(false);
-                                         async.done();
-                                       },
-                                       err => {
-                                         expect(err['message']).toBe('Oops!');
-                                         async.done();
-                                       });
+           connection.response.subscribe(
+               res => {
+                 expect("response listener called").toBe(false);
+                 async.done();
+               },
+               err => {
+                 expect(err['message']).toBe('Oops!');
+                 async.done();
+               });
 
            existingScripts[0].dispatchEvent('error', ({message: "Oops!"}));
          }));
@@ -159,14 +163,15 @@ export function main() {
               let base = new BaseRequestOptions();
               let req = new Request(
                   base.merge(new RequestOptions({url: 'https://google.com', method: method})));
-              expect(() => new JSONPConnection(req, new MockBrowserJsonp())).toThrowError();
+              expect(() => new JSONPConnection(req, new MockBrowserJsonp()).response.subscribe())
+                  .toThrowError();
             });
       });
 
       it('should respond with data passed to callback', inject([AsyncTestCompleter], async => {
            let connection = new JSONPConnection(sampleRequest, new MockBrowserJsonp());
 
-           ObservableWrapper.subscribe<Response>(connection.response, res => {
+           connection.response.subscribe(res => {
              expect(res.json()).toEqual(({fake_payload: true, blob_id: 12345}));
              async.done();
            });

--- a/modules/examples/src/http/http_comp.ts
+++ b/modules/examples/src/http/http_comp.ts
@@ -1,6 +1,5 @@
 import {Component, View, NgFor} from 'angular2/angular2';
-import {Http, Response} from 'angular2/http';
-import {ObservableWrapper} from 'angular2/src/core/facade/async';
+import {Http} from 'angular2/http';
 
 @Component({selector: 'http-app'})
 @View({
@@ -16,8 +15,5 @@ import {ObservableWrapper} from 'angular2/src/core/facade/async';
 })
 export class HttpCmp {
   people: Object;
-  constructor(http: Http) {
-    ObservableWrapper.subscribe<Response>(http.get('./people.json'),
-                                          res => this.people = res.json());
-  }
+  constructor(http: Http) { http.get('./people.json').subscribe(res => this.people = res.json()); }
 }

--- a/modules/examples/src/jsonp/jsonp_comp.ts
+++ b/modules/examples/src/jsonp/jsonp_comp.ts
@@ -17,7 +17,6 @@ import {ObservableWrapper} from 'angular2/src/core/facade/async';
 export class JsonpCmp {
   people: Object;
   constructor(jsonp: Jsonp) {
-    ObservableWrapper.subscribe<Response>(jsonp.get('./people.json?callback=JSONP_CALLBACK'),
-                                          res => this.people = res.json());
+    jsonp.get('./people.json?callback=JSONP_CALLBACK').subscribe(res => this.people = res.json());
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Http now returns Rx Observables directly, so calling .toRx() is no longer necessary. Additionally, Http calls are now cold, so backend requests will not fire unless .subscribe() is called.

Refactors XHR and JSONP backends to use RxJS Observables instead of EventEmitter implementation.

closes #4043 and closes #2974
