### PR TITLE
fix(shims): Don't rely on prefixed requestAnimationFrame

### DIFF
--- a/modules/angular2/src/test_lib/shims_for_IE.js
+++ b/modules/angular2/src/test_lib/shims_for_IE.js
@@ -112,23 +112,17 @@ if (!window.console.assert) window.console.assert = function () { };
 
 (function() {
     var lastTime = 0;
-    var vendors = ['ms', 'moz', 'webkit', 'o'];
-    for(var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
-        window.requestAnimationFrame = window[vendors[x]+'RequestAnimationFrame'];
-        window.cancelAnimationFrame = window[vendors[x]+'CancelAnimationFrame'] 
-                                   || window[vendors[x]+'CancelRequestAnimationFrame'];
-    }
- 
+
     if (!window.requestAnimationFrame)
         window.requestAnimationFrame = function(callback, element) {
-            var currTime = new Date().getTime();
+            var currTime = Date.now();
             var timeToCall = Math.max(0, 16 - (currTime - lastTime));
-            var id = window.setTimeout(function() { callback(currTime + timeToCall); }, 
+            var id = window.setTimeout(function() { callback(currTime + timeToCall); },
               timeToCall);
             lastTime = currTime + timeToCall;
             return id;
         };
- 
+
     if (!window.cancelAnimationFrame)
         window.cancelAnimationFrame = function(id) {
             clearTimeout(id);


### PR DESCRIPTION
The `ms` & `moz` prefixes are not needed. `ms` was never available in a public
IE release (IE 10 has an unprefixed version) and Firefox has unprefixed
rAF since v24 - current version is 41. Even more, Firefox versions below 22
don't have cancelAnimationFrame so it's better to not use the prefixed version
at all to avoid surprises.

The `o` prefix is also useless - Opera Presto never had rAF and the
Chromium-based Opera doesn't use the `o` prefix.

Also, switched from `new Date().getTime()` to `Date.now()` as it's supported
everywhere (even in Android 2.3) except IE<9 and it avoids a useless date
object construction.

See http://caniuse.com/#feat=requestanimationframe for more info.

Refs 4f56a01b3b9ac7edf8ebaa1e86425808920c2370
