### PR TITLE
refactor(compiler): don’t require `id` in metadata

### DIFF
--- a/modules/angular2/src/compiler/directive_metadata.ts
+++ b/modules/angular2/src/compiler/directive_metadata.ts
@@ -22,27 +22,22 @@ import {LifecycleHooks, LIFECYCLE_HOOKS_VALUES} from 'angular2/src/core/compiler
 var HOST_REG_EXP = /^(?:(?:\[([^\]]+)\])|(?:\(([^\)]+)\)))$/g;
 
 export class CompileTypeMetadata {
-  id: number;
   runtime: Type;
   name: string;
   moduleId: string;
-  constructor({id, runtime, name, moduleId}:
-                  {id?: number, runtime?: Type, name?: string, moduleId?: string} = {}) {
-    this.id = id;
+  constructor({runtime, name, moduleId}: {runtime?: Type, name?: string, moduleId?: string} = {}) {
     this.runtime = runtime;
     this.name = name;
     this.moduleId = moduleId;
   }
 
   static fromJson(data: StringMap<string, any>): CompileTypeMetadata {
-    return new CompileTypeMetadata(
-        {id: data['id'], name: data['name'], moduleId: data['moduleId']});
+    return new CompileTypeMetadata({name: data['name'], moduleId: data['moduleId']});
   }
 
   toJson(): StringMap<string, any> {
     return {
       // Note: Runtime type can't be serialized...
-      'id': this.id,
       'name': this.name,
       'moduleId': this.moduleId
     };
@@ -253,12 +248,8 @@ export function createHostComponentMeta(componentType: CompileTypeMetadata,
                                         componentSelector: string): CompileDirectiveMetadata {
   var template = CssSelector.parse(componentSelector)[0].getMatchingElementTemplate();
   return CompileDirectiveMetadata.create({
-    type: new CompileTypeMetadata({
-      runtime: Object,
-      id: (componentType.id * -1) - 1,
-      name: `Host${componentType.name}`,
-      moduleId: componentType.moduleId
-    }),
+    type: new CompileTypeMetadata(
+        {runtime: Object, name: `Host${componentType.name}`, moduleId: componentType.moduleId}),
     template: new CompileTemplateMetadata(
         {template: template, templateUrl: '', styles: [], styleUrls: [], ngContentSelectors: []}),
     changeDetection: ChangeDetectionStrategy.Default,

--- a/modules/angular2/src/compiler/runtime_metadata.ts
+++ b/modules/angular2/src/compiler/runtime_metadata.ts
@@ -25,7 +25,6 @@ var HOST_REG_EXP = /^(?:(?:\[([^\]]+)\])|(?:\(([^\)]+)\)))$/g;
 
 @Injectable()
 export class RuntimeMetadataResolver {
-  private _directiveCounter = 0;
   private _cache: Map<Type, cpl.CompileDirectiveMetadata> = new Map();
 
   constructor(private _directiveResolver: DirectiveResolver, private _viewResolver: ViewResolver) {}
@@ -55,12 +54,8 @@ export class RuntimeMetadataResolver {
         exportAs: directiveAnnotation.exportAs,
         isComponent: isPresent(templateMeta),
         dynamicLoadable: true,
-        type: new cpl.CompileTypeMetadata({
-          id: this._directiveCounter++,
-          name: stringify(directiveType),
-          moduleId: moduleId,
-          runtime: directiveType
-        }),
+        type: new cpl.CompileTypeMetadata(
+            {name: stringify(directiveType), moduleId: moduleId, runtime: directiveType}),
         template: templateMeta,
         changeDetection: changeDetectionStrategy,
         properties: directiveAnnotation.properties,
@@ -89,8 +84,8 @@ export class RuntimeMetadataResolver {
 
 function removeDuplicatedDirectives(directives: cpl.CompileDirectiveMetadata[]):
     cpl.CompileDirectiveMetadata[] {
-  var directivesMap: Map<number, cpl.CompileDirectiveMetadata> = new Map();
-  directives.forEach((dirMeta) => { directivesMap.set(dirMeta.type.id, dirMeta); });
+  var directivesMap: Map<Type, cpl.CompileDirectiveMetadata> = new Map();
+  directives.forEach((dirMeta) => { directivesMap.set(dirMeta.type.runtime, dirMeta); });
   return MapWrapper.values(directivesMap);
 }
 

--- a/modules/angular2/src/compiler/template_parser.ts
+++ b/modules/angular2/src/compiler/template_parser.ts
@@ -95,7 +95,7 @@ export class TemplateParser {
 class TemplateParseVisitor implements HtmlAstVisitor {
   selectorMatcher: SelectorMatcher;
   errors: string[] = [];
-  directivesIndexByTypeId: Map<number, number> = new Map();
+  directivesIndex: Map<CompileDirectiveMetadata, number> = new Map();
   constructor(directives: CompileDirectiveMetadata[], private _exprParser: Parser,
               private _schemaRegistry: ElementSchemaRegistry) {
     this.selectorMatcher = new SelectorMatcher();
@@ -103,7 +103,7 @@ class TemplateParseVisitor implements HtmlAstVisitor {
                                  (directive: CompileDirectiveMetadata, index: number) => {
                                    var selector = CssSelector.parse(directive.selector);
                                    this.selectorMatcher.addSelectables(selector, directive);
-                                   this.directivesIndexByTypeId.set(directive.type.id, index);
+                                   this.directivesIndex.set(directive, index);
                                  });
   }
 
@@ -397,8 +397,7 @@ class TemplateParseVisitor implements HtmlAstVisitor {
                        } else if (!dir1Comp && dir2Comp) {
                          return 1;
                        } else {
-                         return this.directivesIndexByTypeId.get(dir1.type.id) -
-                                this.directivesIndexByTypeId.get(dir2.type.id);
+                         return this.directivesIndex.get(dir1) - this.directivesIndex.get(dir2);
                        }
                      });
     return directives;

--- a/modules/angular2/src/compiler/util.ts
+++ b/modules/angular2/src/compiler/util.ts
@@ -59,11 +59,11 @@ export function codeGenMapArray(argNames: string[], callback: string): string {
   }
 }
 
-export function codeGenReplaceAll(pattern: string, value: string): string {
+export function codeGenReplaceAll(pattern: string, expression: string): string {
   if (IS_DART) {
-    return `.replaceAll('${pattern}', '${value}')`;
+    return `.replaceAll('${pattern}', ${expression})`;
   } else {
-    return `.replace(/${pattern}/g, '${value}')`;
+    return `.replace(/${pattern}/g, ${expression})`;
   }
 }
 
@@ -75,6 +75,14 @@ export function codeGenValueFn(params: string[], value: string): string {
   }
 }
 
+export function codeGenToString(expr: string): string {
+  if (IS_DART) {
+    return `'\${${expr}}'`;
+  } else {
+    // JS automatically convets to string...
+    return expr;
+  }
+}
 
 export function splitAtColon(input: string, defaultValues: string[]): string[] {
   var parts = StringWrapper.split(input.trim(), /\s*:\s*/g);

--- a/modules/angular2/test/compiler/directive_metadata_spec.ts
+++ b/modules/angular2/test/compiler/directive_metadata_spec.ts
@@ -28,7 +28,7 @@ export function main() {
     var fullDirectiveMeta: CompileDirectiveMetadata;
 
     beforeEach(() => {
-      fullTypeMeta = new CompileTypeMetadata({id: 23, name: 'SomeType', moduleId: 'someUrl'});
+      fullTypeMeta = new CompileTypeMetadata({name: 'SomeType', moduleId: 'someUrl'});
       fullTemplateMeta = new CompileTemplateMetadata({
         encapsulation: ViewEncapsulation.Emulated,
         template: '<a></a>',

--- a/modules/angular2/test/compiler/style_compiler_spec.ts
+++ b/modules/angular2/test/compiler/style_compiler_spec.ts
@@ -42,7 +42,8 @@ const IMPORT_ABS_MODULE_NAME_WITH_IMPORT =
 export function main() {
   describe('StyleCompiler', () => {
     var xhr: SpyXHR;
-    var typeMeta;
+    var templateId;
+    var appId;
 
     beforeEachBindings(() => {
       xhr = <any>new SpyXHR();
@@ -52,7 +53,8 @@ export function main() {
     var compiler: StyleCompiler;
 
     beforeEach(inject([StyleCompiler], (_compiler) => {
-      typeMeta = new CompileTypeMetadata({id: 23, moduleId: 'someUrl'});
+      templateId = 23;
+      appId = 'app1';
       compiler = _compiler;
     }));
 
@@ -81,8 +83,9 @@ export function main() {
           return PromiseWrapper.resolve(response);
         });
         return compiler.compileComponentRuntime(
-            typeMeta, new CompileTemplateMetadata(
-                          {styles: styles, styleUrls: styleAbsUrls, encapsulation: encapsulation}));
+            appId, templateId,
+            new CompileTemplateMetadata(
+                {styles: styles, styleUrls: styleAbsUrls, encapsulation: encapsulation}));
       }
 
       describe('no shim', () => {
@@ -121,8 +124,8 @@ export function main() {
              compile(['div {\ncolor: red;\n}', 'span {\ncolor: blue;\n}'], [], encapsulation)
                  .then(styles => {
                    compareStyles(styles, [
-                     'div[_ngcontent-23] {\ncolor: red;\n}',
-                     'span[_ngcontent-23] {\ncolor: blue;\n}'
+                     'div[_ngcontent-app1-23] {\ncolor: red;\n}',
+                     'span[_ngcontent-app1-23] {\ncolor: blue;\n}'
                    ]);
                    async.done();
                  });
@@ -132,8 +135,8 @@ export function main() {
              compile(['div {\ncolor: red;\n}'], [IMPORT_ABS_MODULE_NAME], encapsulation)
                  .then(styles => {
                    compareStyles(styles, [
-                     'div[_ngcontent-23] {\ncolor: red;\n}',
-                     'span[_ngcontent-23] {\ncolor: blue;\n}'
+                     'div[_ngcontent-app1-23] {\ncolor: red;\n}',
+                     'span[_ngcontent-app1-23] {\ncolor: blue;\n}'
                    ]);
                    async.done();
                  });
@@ -143,9 +146,9 @@ export function main() {
              compile(['div {\ncolor: red;\n}'], [IMPORT_ABS_MODULE_NAME_WITH_IMPORT], encapsulation)
                  .then(styles => {
                    compareStyles(styles, [
-                     'div[_ngcontent-23] {\ncolor: red;\n}',
-                     'a[_ngcontent-23] {\ncolor: green;\n}',
-                     'span[_ngcontent-23] {\ncolor: blue;\n}'
+                     'div[_ngcontent-app1-23] {\ncolor: red;\n}',
+                     'a[_ngcontent-app1-23] {\ncolor: green;\n}',
+                     'span[_ngcontent-app1-23] {\ncolor: blue;\n}'
                    ]);
                    async.done();
                  });
@@ -198,8 +201,9 @@ export function main() {
       function compile(styles: string[], styleAbsUrls: string[], encapsulation: ViewEncapsulation):
           Promise<string[]> {
         var sourceExpression = compiler.compileComponentCodeGen(
-            typeMeta, new CompileTemplateMetadata(
-                          {styles: styles, styleUrls: styleAbsUrls, encapsulation: encapsulation}));
+            `'${appId}'`, `${templateId}`,
+            new CompileTemplateMetadata(
+                {styles: styles, styleUrls: styleAbsUrls, encapsulation: encapsulation}));
         var sourceWithImports = testableExpression(sourceExpression).getSourceWithImports();
         return evalModule(sourceWithImports.source, sourceWithImports.imports, null);
       };
@@ -207,7 +211,7 @@ export function main() {
       describe('no shim', () => {
         var encapsulation = ViewEncapsulation.None;
 
-        it('should compile plain css ruless', inject([AsyncTestCompleter], (async) => {
+        it('should compile plain css rules', inject([AsyncTestCompleter], (async) => {
              compile(['div {color: red}', 'span {color: blue}'], [], encapsulation)
                  .then(styles => {
                    expect(styles).toEqual(['div {color: red}', 'span {color: blue}']);
@@ -240,8 +244,8 @@ export function main() {
              compile(['div {\ncolor: red;\n}', 'span {\ncolor: blue;\n}'], [], encapsulation)
                  .then(styles => {
                    compareStyles(styles, [
-                     'div[_ngcontent-23] {\ncolor: red;\n}',
-                     'span[_ngcontent-23] {\ncolor: blue;\n}'
+                     'div[_ngcontent-app1-23] {\ncolor: red;\n}',
+                     'span[_ngcontent-app1-23] {\ncolor: blue;\n}'
                    ]);
                    async.done();
                  });
@@ -251,8 +255,8 @@ export function main() {
              compile(['div {color: red}'], [IMPORT_ABS_MODULE_NAME], encapsulation)
                  .then(styles => {
                    compareStyles(styles, [
-                     'div[_ngcontent-23] {\ncolor: red;\n}',
-                     'span[_ngcontent-23] {\ncolor: blue;\n}'
+                     'div[_ngcontent-app1-23] {\ncolor: red;\n}',
+                     'span[_ngcontent-app1-23] {\ncolor: blue;\n}'
                    ]);
                    async.done();
                  });

--- a/modules/angular2/test/compiler/template_parser_spec.ts
+++ b/modules/angular2/test/compiler/template_parser_spec.ts
@@ -322,11 +322,11 @@ export function main() {
         it('should locate directives components first and ordered by the directives array in the View',
            () => {
              var dirA = CompileDirectiveMetadata.create(
-                 {selector: '[a]', type: new CompileTypeMetadata({name: 'DirA', id: 3})});
+                 {selector: '[a]', type: new CompileTypeMetadata({name: 'DirA'})});
              var dirB = CompileDirectiveMetadata.create(
-                 {selector: '[b]', type: new CompileTypeMetadata({name: 'DirB', id: 2})});
+                 {selector: '[b]', type: new CompileTypeMetadata({name: 'DirB'})});
              var dirC = CompileDirectiveMetadata.create(
-                 {selector: '[c]', type: new CompileTypeMetadata({name: 'DirC', id: 1})});
+                 {selector: '[c]', type: new CompileTypeMetadata({name: 'DirC'})});
              var comp = CompileDirectiveMetadata.create({
                selector: 'div',
                isComponent: true,


### PR DESCRIPTION
The output of the compiler has to be the same
given the same input. Requiring a unique id for
every type already during compilation makes it
hard to parallelize compilation. 

Part of #3605
