### PR TITLE
chore(gulpfile): fix link to clang formatting

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -281,7 +281,7 @@ gulp.task('check-format', function() {
 gulp.task('enforce-format', function() {
   return doCheckFormat().on('warning', function(e) {
     console.log("ERROR: You forgot to run clang-format on your change.");
-    console.log("See https://github.com/angular/angular/blob/master/DEVELOPER.md#formatting");
+    console.log("See https://github.com/angular/angular/blob/master/DEVELOPER.md#clang-format");
     process.exit(1);
   });
 });


### PR DESCRIPTION
Seems like the anchor tag wasn't updated here.
