### PR TITLE
chore(saucelabs): add latest Safaris

### DIFF
--- a/modules/angular2/test/core/render/dom/compiler/shadow_css_spec.ts
+++ b/modules/angular2/test/core/render/dom/compiler/shadow_css_spec.ts
@@ -62,7 +62,8 @@ export function main() {
         isPresent(DOM.defaultDoc().body.style.animationName)) {
       it('should handle keyframes rules', () => {
         var css = '@keyframes foo {0% {transform: translate(-50%) scaleX(0);}}';
-        var passRe = /@keyframes foo {\s*0% {\s*transform:translate\(-50%\) scaleX\(0\);\s*}\s*}/g;
+        var passRe =
+            /@(-webkit-)*keyframes foo {\s*0% {\s*transform:translate\(-50%\) scaleX\(0\);\s*}\s*}/g;
         expect(RegExpWrapper.test(passRe, s(css, 'a'))).toEqual(true);
       });
     }

--- a/sauce.conf.js
+++ b/sauce.conf.js
@@ -47,6 +47,12 @@ var customLaunchers = {
     platform: 'OS X 10.10',
     version: '8'
   },
+  'SL_SAFARI8.1': {
+    base: 'SauceLabs',
+    browserName: 'safari',
+    platform: 'OS X 10.11',
+    version: '8.1'
+  },
   'SL_IOS7': {
     base: 'SauceLabs',
     browserName: 'iphone',
@@ -117,16 +123,16 @@ var customLaunchers = {
 
 var aliases = {
   'ALL': Object.keys(customLaunchers).filter(function(item) {return customLaunchers[item].base == 'SauceLabs';}),
-  'DESKTOP': ['SL_CHROME', 'SL_FIREFOX', 'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_SAFARI7', 'SL_SAFARI8'],
+  'DESKTOP': ['SL_CHROME', 'SL_FIREFOX', 'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_SAFARI7', 'SL_SAFARI8', 'SL_SAFARI8.1'],
   'MOBILE': ['SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4', 'SL_ANDROID5.1', 'SL_IOS7', 'SL_IOS8', 'SL_IOS9'],
   'ANDROID': ['SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4', 'SL_ANDROID5.1'],
   'IE': ['SL_IE9', 'SL_IE10', 'SL_IE11'],
   'IOS': ['SL_IOS7', 'SL_IOS8', 'SL_IOS9'],
-  'SAFARI': ['SL_SAFARI7', 'SL_SAFARI8'],
+  'SAFARI': ['SL_SAFARI7', 'SL_SAFARI8', 'SL_SAFARI8.1'],
   'BETA': ['SL_CHROMEBETA', 'SL_FIREFOXBETA'],
   'DEV': ['SL_CHROMEDEV', 'SL_FIREFOXDEV'],
-  'CI': ['SL_CHROME', 'SL_ANDROID5.1', 'SL_SAFARI7', 'SL_SAFARI8', 'SL_IOS7', 'SL_IOS8', 'SL_FIREFOX',
-         'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4',
+  'CI': ['SL_CHROME', 'SL_ANDROID5.1', 'SL_SAFARI7', 'SL_SAFARI8', 'SL_SAFARI8.1', 'SL_IOS7', 'SL_IOS8', 'SL_IOS9',
+         'SL_FIREFOX', 'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4',
          'SL_CHROMEDEV', 'SL_FIREFOXDEV']
 };
 


### PR DESCRIPTION
Add the latest versions of Safari to SauceLabs.

About the change in the shadow CSS spec, both output `@-webkit-keyframes` when `@keyframes` is given as input.
