### PR TITLE
chore(saucelabs): fix badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
   - KARMA_BROWSERS=DartiumWithWebPlatform
   - E2E_BROWSERS=Dartium
   - LOGS_DIR=/tmp/angular-build/logs
-  - SAUCE_USERNAME=angular2-ci
-  - SAUCE_ACCESS_KEY=693ebc16208a-0b5b-1614-8d66-a2662f4e
+  - SAUCE_USERNAME=angular-ci
+  - SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987
   - ARCH=linux-x64
   # Token for tsd to increase github rate limit
   # See https://github.com/DefinitelyTyped/tsd#tsdrc
@@ -55,6 +55,7 @@ before_install:
 - ./scripts/ci/install_dart.sh ${DART_CHANNEL} ${ARCH}
 - sh -e /etc/init.d/xvfb start
 - if [[ -e SKIP_TRAVIS_TESTS ]]; then { cat SKIP_TRAVIS_TESTS ; exit 0; } fi
+- '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ] && SAUCE_USERNAME="angular2-ci" && SAUCE_ACCESS_KEY="693ebc16208a-0b5b-1614-8d66-a2662f4e" || true'
 
 install:
   # Update npm

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -715,9 +715,8 @@ gulp.task('test.unit.js/ci', function (done) {
 
 gulp.task('test.unit.js.sauce/ci', function (done) {
   karma.server.start({configFile: __dirname + '/karma-js.conf.js',
-    singleRun: true, browserNoActivityTimeout: 240000, captureTimeout: 120000, browsers: sauceConf.aliases.CI,
-    reporters: process.env.TRAVIS_PULL_REQUEST == 'false' && process.env.TRAVIS_BRANCH == 'master' ?
-    ['dots', 'saucelabs'] : ['dots']},
+    singleRun: true, browserNoActivityTimeout: 240000, captureTimeout: 120000,
+    reporters: ['dots', 'saucelabs'], browsers: sauceConf.aliases.CI},
     function(err) {done(); process.exit(err ? 1 : 0);});
 });
 


### PR DESCRIPTION
Apparently, the SL badge can only be a report on the latest campaign.
The tricks used in #4400 only makes it grey.

/cc @pkozlowski-opensource 
