### PR TITLE
refactor: remove useless imports

### DIFF
--- a/modules/angular2/src/core/application_common.ts
+++ b/modules/angular2/src/core/application_common.ts
@@ -1,12 +1,9 @@
 import {FORM_BINDINGS} from 'angular2/src/core/forms';
-import {bind, Binding, Injector, OpaqueToken} from 'angular2/src/core/di';
+import {bind, Binding} from 'angular2/src/core/di';
 import {
-  NumberWrapper,
   Type,
   isBlank,
   isPresent,
-  assertionsEnabled,
-  print,
   stringify
 } from 'angular2/src/core/facade/lang';
 import {BrowserDomAdapter} from 'angular2/src/core/dom/browser_adapter';
@@ -14,7 +11,7 @@ import {BrowserGetTestability} from 'angular2/src/core/testability/browser_testa
 import {DOM} from 'angular2/src/core/dom/dom_adapter';
 import {ViewLoader} from 'angular2/src/core/render/dom/compiler/view_loader';
 import {StyleInliner} from 'angular2/src/core/render/dom/compiler/style_inliner';
-import {Promise, PromiseWrapper, PromiseCompleter} from 'angular2/src/core/facade/async';
+import {Promise} from 'angular2/src/core/facade/async';
 import {XHR} from 'angular2/src/core/render/xhr';
 import {XHRImpl} from 'angular2/src/core/render/xhr_impl';
 import {
@@ -27,10 +24,9 @@ import {HammerGesturesPlugin} from 'angular2/src/core/render/dom/events/hammer_g
 import {AppRootUrl} from 'angular2/src/core/services/app_root_url';
 import {AnchorBasedAppRootUrl} from 'angular2/src/core/services/anchor_based_app_root_url';
 import {
-  ComponentRef,
-  DynamicComponentLoader
+  ComponentRef
 } from 'angular2/src/core/compiler/dynamic_component_loader';
-import {TestabilityRegistry, Testability} from 'angular2/src/core/testability/testability';
+import {Testability} from 'angular2/src/core/testability/testability';
 import {Renderer, RenderCompiler} from 'angular2/src/core/render/api';
 import {
   DomRenderer,

--- a/modules/angular2/src/core/compiler/view.ts
+++ b/modules/angular2/src/core/compiler/view.ts
@@ -6,12 +6,9 @@ import {
   StringMap
 } from 'angular2/src/core/facade/collection';
 import {
-  AST,
   ChangeDetector,
-  ChangeDetectorRef,
   ChangeDispatcher,
   DirectiveIndex,
-  DirectiveRecord,
   BindingTarget,
   Locals,
   ProtoChangeDetector
@@ -25,7 +22,7 @@ import {
   DirectiveBinding
 } from './element_injector';
 import {ElementBinder} from './element_binder';
-import {isPresent, isBlank} from 'angular2/src/core/facade/lang';
+import {isPresent} from 'angular2/src/core/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 import * as renderApi from 'angular2/src/core/render/api';
 import {RenderEventDispatcher} from 'angular2/src/core/render/api';

--- a/modules/angular2/src/core/compiler/view_resolver.ts
+++ b/modules/angular2/src/core/compiler/view_resolver.ts
@@ -3,7 +3,7 @@ import {ViewMetadata} from '../metadata/view';
 
 import {Type, stringify, isBlank} from 'angular2/src/core/facade/lang';
 import {BaseException} from 'angular2/src/core/facade/exceptions';
-import {Map, MapWrapper, ListWrapper} from 'angular2/src/core/facade/collection';
+import {Map} from 'angular2/src/core/facade/collection';
 
 import {reflector} from 'angular2/src/core/reflection/reflection';
 

--- a/modules/angular2/src/core/reflection/reflection_capabilities.ts
+++ b/modules/angular2/src/core/reflection/reflection_capabilities.ts
@@ -1,5 +1,5 @@
 import {Type, isPresent, isFunction, global, stringify} from 'angular2/src/core/facade/lang';
-import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
+import {BaseException} from 'angular2/src/core/facade/exceptions';
 import {ListWrapper} from 'angular2/src/core/facade/collection';
 import {GetterFn, SetterFn, MethodFn} from './types';
 import {PlatformReflectionCapabilities} from 'platform_reflection_capabilities';


### PR DESCRIPTION
While exploring the codebase I removed some useless imports.
