### PR TITLE
feat(Headers): implement `toJSON`

### DIFF
--- a/modules/angular2/src/http/headers.ts
+++ b/modules/angular2/src/http/headers.ts
@@ -1,4 +1,11 @@
-import {isPresent, isBlank, isJsObject, isType, StringWrapper} from 'angular2/src/facade/lang';
+import {
+  isPresent,
+  isBlank,
+  isJsObject,
+  isType,
+  StringWrapper,
+  Json
+} from 'angular2/src/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
 import {
   isListLikeIterable,
@@ -119,6 +126,11 @@ export class Headers {
    * Returns values of all headers.
    */
   values(): string[][] { return MapWrapper.values(this._headersMap); }
+
+  /**
+   * Returns string of all headers.
+   */
+  toJSON(): string { return Json.stringify(this.values()); }
 
   /**
    * Returns list of header values for a given name.


### PR DESCRIPTION
closes #4391

overwriting toString would make it easier to serialize headers
on the client I need to reconstruct server responses 

``` typescript
/// <server>
let req = Object.assign({}, res, {
  headers: res.headers.values()
});
/// </server>

 |
 |
index.html
 |
 ▼

/// <client>
let res = Object.assign({}, req, {
  body: req._body,
  headers: new Headers(req.headers)
});
/// </client>
```
- [ ] tests
