### PR TITLE
refactor(dart/transform): Remove reflection_entry_points

### DIFF
--- a/modules_dart/transform/lib/src/transform/common/options.dart
+++ b/modules_dart/transform/lib/src/transform/common/options.dart
@@ -19,8 +19,6 @@ const INIT_REFLECTOR_PARAM = 'init_reflector';
 const INLINE_VIEWS_PARAM = 'inline_views';
 const MIRROR_MODE_PARAM = 'mirror_mode';
 const OPTIMIZATION_PHASES_PARAM = 'optimization_phases';
-const PRECOMPILE_PARAM = 'precompile';
-const REFLECTION_ENTRY_POINT_PARAM = 'reflection_entry_points';
 
 /// Provides information necessary to transform an Angular2 app.
 class TransformerOptions {

--- a/modules_dart/transform/lib/src/transform/common/options_reader.dart
+++ b/modules_dart/transform/lib/src/transform/common/options_reader.dart
@@ -127,10 +127,6 @@ const CUSTOM_ANNOTATIONS_ERROR = '''
           superClass: ...''';
 
 void _warnDeprecated(Map config) {
-  if (config.containsKey(REFLECTION_ENTRY_POINT_PARAM)) {
-    print('${REFLECTION_ENTRY_POINT_PARAM} is no longer necessary for '
-        'Angular 2 apps. Please remove it from your pubspec.');
-  }
   if (config.containsKey(GENERATE_CHANGE_DETECTORS_PARAM)) {
     print('${GENERATE_CHANGE_DETECTORS_PARAM} is no longer necessary for '
         'Angular 2 apps. Please remove it from your pubspec.');


### PR DESCRIPTION
I will not commit this until the new template compiler is committed.

NOTE: `_warnDeprecated` is currently empty but the new template compiler changes will populate it again -- leaving it now will make the merge easier.

`reflection_entry_points` was deprecated on Aug 26 and is no longer used
by the transformer. Remove its deprecation message.

Closes #3856
