### PR TITLE
fix(compiler): const is not supported in IE9 and IE10

### DIFF
--- a/modules/angular2/src/core/compiler/util.ts
+++ b/modules/angular2/src/core/compiler/util.ts
@@ -46,7 +46,7 @@ function escapeString(input: string, re: RegExp): string {
 }
 
 export function codeGenExportVariable(name: string, isConst: boolean = false): string {
-  var declaration = isConst ? `const ${name}` : `var ${name}`;
+  var declaration = IS_DART && isConst ? `const ${name}` : `var ${name}`;
   return IS_DART ? `${declaration} = ` : `${declaration} = exports['${name}'] = `;
 }
 


### PR DESCRIPTION
With the new compiler, 4 unit tests are failing in these browsers.
The reason is that they don't support `const`, see https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Instructions/const

As far as I can see, the TS compiler transforms all `const` into `var`.
@tbosch Would it be an issue to do the same in our compiler when targeting JS please?
