### PR TITLE
chore(docs): rename @private to @internal

### DIFF
--- a/docs/angular.io-package/processors/addJadeDataDocsProcessor.js
+++ b/docs/angular.io-package/processors/addJadeDataDocsProcessor.js
@@ -35,7 +35,7 @@ module.exports = function addJadeDataDocsProcessor() {
       */
 
       _.forEach(docs, function(doc) {
-        if (doc.docType === 'module' && !doc.private && doc.exports.length) {
+        if (doc.docType === 'module' && !doc.internal && doc.exports.length) {
           modules.push(doc);
 
           // GET DATA FOR INDEX PAGE OF MODULE SECTION

--- a/docs/docs-package/processors/generateNavigationDoc.js
+++ b/docs/docs-package/processors/generateNavigationDoc.js
@@ -27,7 +27,7 @@ module.exports = function generateNavigationDoc() {
           modulesDoc.value.sections.push(moduleNavItem);
 
           _.forEach(doc.exports, function(exportDoc) {
-            if (!exportDoc.private) {
+            if (!exportDoc.internal) {
               var exportNavItem = {
                 path: exportDoc.path,
                 partial: exportDoc.outputPath,

--- a/docs/typescript-definition-package/processors/code_gen.js
+++ b/docs/typescript-definition-package/processors/code_gen.js
@@ -49,7 +49,7 @@ DtsSerializer.prototype = {
   },
 
   member: function(buffer, ast) {
-    if (ast.private) return;
+    if (ast.private || ast.internal) return;
 
     buffer.push('\n');
     this.comment(buffer, ast.content);

--- a/docs/typescript-definition-package/processors/createTypeDefinitionFile.spec.js
+++ b/docs/typescript-definition-package/processors/createTypeDefinitionFile.spec.js
@@ -25,22 +25,22 @@ describe('createTypeDefinitionFile processor', function() {
 
 
 
-  describe('classes with private constructors', function() {
-    
+  describe('classes with @internal constructors', function() {
+
     it('should convert heritage from `implements` into `extends`', function() {
-      
+
       // Create some mock docs for testing
       var docs = [
         {
           id: 'angular2/angular2',
           exports: [
-            { docType: 'class', heritage: 'implements Xyz', constructorDoc: { private: true }  }
+            { docType: 'class', heritage: 'implements Xyz', constructorDoc: { internal: true }  }
           ]
         }
       ];
 
       docs = processor.$process(docs);
-      
+
       expect(docs.length).toEqual(1);
       expect(docs[0].docType).toEqual('type-definition');
 
@@ -49,5 +49,5 @@ describe('createTypeDefinitionFile processor', function() {
       expect(moduleDoc.exports[0].heritage).toEqual('extends Xyz');
     });
   });
-	
+
 });

--- a/docs/typescript-package/index.js
+++ b/docs/typescript-package/index.js
@@ -1,9 +1,10 @@
 var basePackage = require('dgeni-packages/base');
+var jsdocPackage = require('dgeni-packages/jsdoc');
 var Package = require('dgeni').Package;
 var path = require('canonical-path');
 
 // Define the dgeni package for generating the docs
-module.exports = new Package('typescript-parsing', [basePackage])
+module.exports = new Package('typescript-parsing', [basePackage, jsdocPackage])
 
 // Register the services and file readers
 .factory(require('./services/modules'))
@@ -37,6 +38,9 @@ module.exports = new Package('typescript-parsing', [basePackage])
   log.level = 'warn';
 })
 
+.config(function(parseTagsProcessor) {
+  parseTagsProcessor.tagDefinitions.push({ name: 'internal', transforms: function() { return true; } });
+})
 
 // Configure ids and paths
 .config(function(computeIdsProcessor, computePathsProcessor, EXPORT_DOC_TYPES) {

--- a/docs/typescript-package/services/convertPrivateClassesToInterfaces.js
+++ b/docs/typescript-package/services/convertPrivateClassesToInterfaces.js
@@ -4,8 +4,8 @@ module.exports = function convertPrivateClassesToInterfaces() {
   return function(exportDocs, addInjectableReference) {
     _.forEach(exportDocs, function(exportDoc) {
 
-      // Search for classes with a constructor marked as `@private`
-      if (exportDoc.docType === 'class' && exportDoc.constructorDoc && exportDoc.constructorDoc.private) {
+      // Search for classes with a constructor marked as `@internal`
+      if (exportDoc.docType === 'class' && exportDoc.constructorDoc && exportDoc.constructorDoc.internal) {
 
         // Convert this class to an interface with no constructor
         exportDoc.docType = 'interface';

--- a/docs/typescript-package/services/convertPrivateClassesToInterfaces.spec.js
+++ b/docs/typescript-package/services/convertPrivateClassesToInterfaces.spec.js
@@ -11,13 +11,13 @@ describe('readTypeScriptModules', function() {
     convertPrivateClassesToInterfaces = injector.get('convertPrivateClassesToInterfaces');
   });
 
-  it('should convert private class docs to interface docs', function() {
+  it('should convert @internal class docs to interface docs', function() {
     var docs = [
       {
         docType: 'class',
         name: 'privateClass',
         id: 'privateClass',
-        constructorDoc: { private: true }
+        constructorDoc: { internal: true }
       }
     ];
     convertPrivateClassesToInterfaces(docs, false);
@@ -25,7 +25,7 @@ describe('readTypeScriptModules', function() {
   });
 
 
-  it('should not touch non-private class docs', function() {
+  it('should not touch non-internal class docs', function() {
     var docs = [
       {
         docType: 'class',
@@ -45,7 +45,7 @@ describe('readTypeScriptModules', function() {
         docType: 'class',
         name: 'privateClass',
         id: 'privateClass',
-        constructorDoc: { private: true },
+        constructorDoc: { internal: true },
         heritage: 'implements parentInterface'
       }
     ];
@@ -60,7 +60,7 @@ describe('readTypeScriptModules', function() {
         docType: 'class',
         name: 'privateClass',
         id: 'privateClass',
-        constructorDoc: { private: true },
+        constructorDoc: { internal: true },
         heritage: 'implements parentInterface'
       }
     ];

--- a/modules/angular2/src/core/application_ref.ts
+++ b/modules/angular2/src/core/application_ref.ts
@@ -113,7 +113,7 @@ export function createNgZone(): NgZone {
 var _platform: PlatformRef;
 
 /**
- * @private
+ * @internal
  */
 export function platformCommon(bindings?: Array<Type | Binding | any[]>, initializer?: () => void):
     PlatformRef {
@@ -145,12 +145,12 @@ export function platformCommon(bindings?: Array<Type | Binding | any[]>, initial
  */
 export class PlatformRef {
   /**
-   * @private
+   * @internal
    */
   _applications: ApplicationRef[] = [];
 
   /**
-   * @private
+   * @internal
    */
   constructor(private _injector: Injector, private _dispose: () => void) {}
 
@@ -251,7 +251,7 @@ export class PlatformRef {
   }
 
   /**
-   * @private
+   * @internal
    */
   _applicationDisposed(app: ApplicationRef): void { ListWrapper.remove(this._applications, app); }
 }
@@ -266,7 +266,7 @@ export class ApplicationRef {
   private _rootComponents: ComponentRef[] = [];
 
   /**
-   * @private
+   * @internal
    */
   constructor(private _platform: PlatformRef, private _zone: NgZone, private _injector: Injector) {}
 

--- a/modules/angular2/src/core/application_tokens.ts
+++ b/modules/angular2/src/core/application_tokens.ts
@@ -2,7 +2,7 @@ import {OpaqueToken, Binding} from 'angular2/src/core/di';
 import {CONST_EXPR, Math, StringWrapper} from 'angular2/src/core/facade/lang';
 
 /**
- *  @private
+ *  @internal
  */
 export const APP_COMPONENT_REF_PROMISE = CONST_EXPR(new OpaqueToken('Promise<ComponentRef>'));
 

--- a/modules/angular2/src/core/change_detection/change_detector_ref.ts
+++ b/modules/angular2/src/core/change_detection/change_detector_ref.ts
@@ -6,7 +6,7 @@ import {ChangeDetectionStrategy} from './constants';
  */
 export class ChangeDetectorRef {
   /**
-   * @private
+   * @internal
    */
   constructor(private _cd: ChangeDetector) {}
 

--- a/modules/angular2/src/core/change_detection/parser/locals.ts
+++ b/modules/angular2/src/core/change_detection/parser/locals.ts
@@ -3,7 +3,7 @@ import {BaseException} from 'angular2/src/core/facade/exceptions';
 import {ListWrapper, MapWrapper} from 'angular2/src/core/facade/collection';
 
 /**
- * @private
+ * @internal
  */
 export class Locals {
   constructor(public parent: Locals, public current: Map<any, any>) {}

--- a/modules/angular2/src/core/compiler/runtime_compiler.ts
+++ b/modules/angular2/src/core/compiler/runtime_compiler.ts
@@ -10,7 +10,7 @@ import {Promise, PromiseWrapper} from 'angular2/src/core/facade/async';
 @Injectable()
 export class RuntimeCompiler extends Compiler {
   /**
-   * @private
+   * @internal
    */
   constructor(_protoViewFactory: ProtoViewFactory, private _templateCompiler: TemplateCompiler) {
     super(_protoViewFactory);

--- a/modules/angular2/src/core/compiler/url_resolver.ts
+++ b/modules/angular2/src/core/compiler/url_resolver.ts
@@ -145,7 +145,7 @@ function _buildFromEncodedParts(opt_scheme?: string, opt_userInfo?: string, opt_
  *    $7 = Related           fragment without #
  * </pre>
  * @type {!RegExp}
- * @private
+ * @internal
  */
 var _splitRe =
     RegExpWrapper.create('^' +

--- a/modules/angular2/src/core/debug/debug_element.ts
+++ b/modules/angular2/src/core/debug/debug_element.ts
@@ -17,7 +17,7 @@ export class DebugElement {
   _elementInjector: ElementInjector;
 
   /**
-   * @private
+   * @internal
    */
   constructor(private _parentView: AppView, private _boundElementIndex: number) {
     this._elementInjector = this._parentView.elementInjectors[this._boundElementIndex];

--- a/modules/angular2/src/core/di/binding.ts
+++ b/modules/angular2/src/core/di/binding.ts
@@ -31,7 +31,7 @@ import {
 import {resolveForwardRef} from './forward_ref';
 
 /**
- * @private
+ * @internal
  */
 export class Dependency {
   constructor(public key: Key, public optional: boolean, public lowerBoundVisibility: any,
@@ -257,7 +257,7 @@ export class Binding {
  */
 export class ResolvedBinding {
   /**
-   * @private
+   * @internal
    */
   constructor(
       /**
@@ -266,23 +266,23 @@ export class ResolvedBinding {
       public key: Key,
 
       /**
-       * @private
+       * @internal
        * Factory function which can return an instance of an object represented by a key.
        */
       public resolvedFactories: ResolvedFactory[],
 
       /**
-       * @private
+       * @internal
        * Indicates if the binding is a multi-binding or a regular binding.
        */
       public multiBinding: boolean) {}
 
-  /** @private */
+  /** @internal */
   get resolvedFactory(): ResolvedFactory { return this.resolvedFactories[0]; }
 }
 
 /**
- * @private
+ * @internal
  * An internal resolved representation of a factory function created by resolving {@link Binding}.
  */
 export class ResolvedFactory {

--- a/modules/angular2/src/core/di/exceptions.ts
+++ b/modules/angular2/src/core/di/exceptions.ts
@@ -32,16 +32,16 @@ function constructResolvingPath(keys: any[]): string {
  * Base class for all errors arising from misconfigured bindings.
  */
 export class AbstractBindingError extends BaseException {
-  /** @private */
+  /** @internal */
   message: string;
 
-  /** @private */
+  /** @internal */
   keys: Key[];
 
-  /** @private */
+  /** @internal */
   injectors: Injector[];
 
-  /** @private */
+  /** @internal */
   constructResolvingMessage: Function;
 
   constructor(injector: Injector, key: Key, constructResolvingMessage: Function) {
@@ -135,13 +135,13 @@ export class CyclicDependencyError extends AbstractBindingError {
  * ```
  */
 export class InstantiationError extends WrappedException {
-  /** @private */
+  /** @internal */
   keys: Key[];
 
-  /** @private */
+  /** @internal */
   injectors: Injector[];
 
-  /** @private */
+  /** @internal */
   constructor(injector: Injector, originalException, originalStack, key: Key) {
     super("DI Exception", originalException, originalStack, null);
     this.keys = [key];

--- a/modules/angular2/src/core/di/injector.ts
+++ b/modules/angular2/src/core/di/injector.ts
@@ -387,7 +387,7 @@ export class BindingWithVisibility {
 }
 
 /**
- * @private
+ * @internal
  * Used to provide dependencies that cannot be easily expressed as bindings.
  */
 export interface DependencyProvider {
@@ -537,7 +537,7 @@ export class Injector {
   }
 
   /**
-   * @private
+   * @internal
    */
   debugContext(): any { return this._debugContext(); }
 
@@ -592,7 +592,7 @@ export class Injector {
   }
 
   /**
-   * @private
+   * @internal
    */
   getAt(index: number): any { return this._strategy.getObjAtIndex(index); }
 
@@ -613,7 +613,7 @@ export class Injector {
   get parent(): Injector { return this._parent; }
 
   /**
-   * @private
+   * @internal
    * Internal. Do not use.
    * We return `any` not to export the InjectorStrategy type.
    */

--- a/modules/angular2/src/core/di/key.ts
+++ b/modules/angular2/src/core/di/key.ts
@@ -46,7 +46,7 @@ export class Key {
 }
 
 /**
- * @private
+ * @internal
  */
 export class KeyRegistry {
   private _allKeys = new Map<Object, Key>();

--- a/modules/angular2/src/core/di/type_literal.ts
+++ b/modules/angular2/src/core/di/type_literal.ts
@@ -1,5 +1,5 @@
 /**
- * @private
+ * @internal
  * Type literals is a Dart-only feature. This is here only so we can x-compile
  * to multiple languages.
  */

--- a/modules/angular2/src/core/life_cycle/life_cycle.ts
+++ b/modules/angular2/src/core/life_cycle/life_cycle.ts
@@ -40,7 +40,7 @@ export class LifeCycle {
   _runningTick: boolean = false;
 
   /**
-   * @private
+   * @internal
    */
   constructor(changeDetector: ChangeDetector = null, enforceNoNewChanges: boolean = false) {
     this._changeDetectors = [];
@@ -51,7 +51,7 @@ export class LifeCycle {
   }
 
   /**
-   * @private
+   * @internal
    */
   registerWith(zone: NgZone, changeDetector: ChangeDetector = null) {
     if (isPresent(changeDetector)) {

--- a/modules/angular2/src/core/linker/compiler.ts
+++ b/modules/angular2/src/core/linker/compiler.ts
@@ -18,7 +18,7 @@ import {CompiledHostTemplate} from 'angular2/src/core/linker/template_commands';
 @Injectable()
 export class Compiler {
   /**
-   * @private
+   * @internal
    */
   constructor(private _protoViewFactory: ProtoViewFactory) {}
 

--- a/modules/angular2/src/core/linker/dynamic_component_loader.ts
+++ b/modules/angular2/src/core/linker/dynamic_component_loader.ts
@@ -32,7 +32,7 @@ export class ComponentRef {
   componentType: Type;
 
   /**
-   * @private
+   * @internal
    *
    * The injector provided {@link DynamicComponentLoader#loadAsRoot}.
    *
@@ -42,7 +42,7 @@ export class ComponentRef {
   injector: Injector;
 
   /**
-   * @private
+   * @internal
    *
    * TODO(i): refactor into public/private fields
    */
@@ -60,7 +60,7 @@ export class ComponentRef {
   get hostView(): HostViewRef { return this.location.parentView; }
 
   /**
-   * @private
+   * @internal
    *
    * Returns the type of this Component instance.
    *
@@ -69,7 +69,7 @@ export class ComponentRef {
   get hostComponentType(): Type { return this.componentType; }
 
   /**
-   * @private
+   * @internal
    *
    * The instance of the component.
    *
@@ -91,7 +91,7 @@ export class ComponentRef {
 @Injectable()
 export class DynamicComponentLoader {
   /**
-   * @private
+   * @internal
    */
   constructor(private _compiler: Compiler, private _viewManager: AppViewManager) {}
 

--- a/modules/angular2/src/core/linker/element_ref.ts
+++ b/modules/angular2/src/core/linker/element_ref.ts
@@ -14,7 +14,7 @@ import {RenderViewRef, RenderElementRef, Renderer} from 'angular2/src/core/rende
  */
 export class ElementRef implements RenderElementRef {
   /**
-   * @private
+   * @internal
    *
    * Reference to the {@link ViewRef} that this `ElementRef` is part of.
    */
@@ -22,7 +22,7 @@ export class ElementRef implements RenderElementRef {
 
 
   /**
-   * @private
+   * @internal
    *
    * Index of the element inside the {@link ViewRef}.
    *
@@ -30,7 +30,7 @@ export class ElementRef implements RenderElementRef {
    */
   boundElementIndex: number;
   /**
-   * @private
+   * @internal
    */
   constructor(parentView: ViewRef, boundElementIndex: number, private _renderer: Renderer) {
     this.parentView = parentView;
@@ -38,7 +38,7 @@ export class ElementRef implements RenderElementRef {
   }
 
   /**
-   * @private
+   * @internal
    */
   get renderView(): RenderViewRef { return this.parentView.render; }
 

--- a/modules/angular2/src/core/linker/interfaces.ts
+++ b/modules/angular2/src/core/linker/interfaces.ts
@@ -2,7 +2,7 @@ import {MapWrapper} from 'angular2/src/core/facade/collection';
 import {SimpleChange} from 'angular2/src/core/change_detection/change_detection_util';
 
 /**
- * @private
+ * @internal
  */
 export enum LifecycleHooks {
   OnInit,
@@ -16,7 +16,7 @@ export enum LifecycleHooks {
 }
 
 /**
- * @private
+ * @internal
  */
 export var LIFECYCLE_HOOKS_VALUES = [
   LifecycleHooks.OnInit,

--- a/modules/angular2/src/core/linker/query_list.dart
+++ b/modules/angular2/src/core/linker/query_list.dart
@@ -27,12 +27,12 @@ class QueryList<T> extends Object
     return this._results.map(fn).toList();
   }
 
-  /** @private */
+  /** @internal */
   void reset(List<T> newList) {
     _results = newList;
   }
 
-  /** @private */
+  /** @internal */
   void notifyOnChanges() {
     _emitter.add(this);
   }

--- a/modules/angular2/src/core/linker/query_list.ts
+++ b/modules/angular2/src/core/linker/query_list.ts
@@ -46,10 +46,10 @@ export class QueryList<T> {
   toString(): string { return this._results.toString(); }
 
   /**
-   * @private
+   * @internal
    */
   reset(res: T[]): void { this._results = res; }
 
-  /** @private */
+  /** @internal */
   notifyOnChanges(): void { this._emitter.next(this); }
 }

--- a/modules/angular2/src/core/linker/template_ref.ts
+++ b/modules/angular2/src/core/linker/template_ref.ts
@@ -30,7 +30,7 @@ export class TemplateRef {
   elementRef: ElementRef;
 
   /**
-   * @private
+   * @internal
    */
   constructor(elementRef: ElementRef) { this.elementRef = elementRef; }
 
@@ -42,7 +42,7 @@ export class TemplateRef {
   }
 
   /**
-   * @private
+   * @internal
    *
    * Reference to the ProtoView used for creating Embedded Views that are based on the compiled
    * Embedded Template.

--- a/modules/angular2/src/core/linker/view_container_ref.ts
+++ b/modules/angular2/src/core/linker/view_container_ref.ts
@@ -31,11 +31,11 @@ import {ViewRef, HostViewRef, ProtoViewRef, internalView} from './view_ref';
  */
 export class ViewContainerRef {
   /**
-   * @private
+   * @internal
    */
   constructor(
       /**
-       * @private
+       * @internal
        */
       public viewManager: avmModule.AppViewManager,
 

--- a/modules/angular2/src/core/linker/view_manager.ts
+++ b/modules/angular2/src/core/linker/view_manager.ts
@@ -35,7 +35,7 @@ import {ProtoViewFactory} from './proto_view_factory';
 export class AppViewManager {
   private _protoViewFactory: ProtoViewFactory;
   /**
-   * @private
+   * @internal
    */
   constructor(private _viewPool: AppViewPool, private _viewListener: AppViewListener,
               private _utils: AppViewManagerUtils, private _renderer: Renderer,

--- a/modules/angular2/src/core/linker/view_ref.ts
+++ b/modules/angular2/src/core/linker/view_ref.ts
@@ -25,7 +25,7 @@ export function internalProtoView(protoViewRef: ProtoViewRef): viewModule.AppPro
  */
 export interface HostViewRef {
   /**
-   * @private
+   * @internal
    */
   changeDetectorRef: ChangeDetectorRef;
 }
@@ -87,26 +87,26 @@ export class ViewRef implements HostViewRef {
   private _changeDetectorRef: ChangeDetectorRef = null;
 
   /**
-   * @private
+   * @internal
    */
   constructor(public _view: viewModule.AppView) {}
 
   /**
-   * @private
+   * @internal
    *
    * Return `RenderViewRef`
    */
   get render(): RenderViewRef { return this._view.render; }
 
   /**
-   * @private
+   * @internal
    *
    * Return `RenderFragmentRef`
    */
   get renderFragment(): RenderFragmentRef { return this._view.renderFragment; }
 
   /**
-   * @private
+   * @internal
    *
    * Return `ChangeDetectorRef`
    */
@@ -167,7 +167,7 @@ export class ViewRef implements HostViewRef {
  */
 export class ProtoViewRef {
   /**
-   * @private
+   * @internal
    */
   constructor(public _protoView: viewModule.AppProtoView) {}
 }

--- a/modules/angular2/src/core/render/api.ts
+++ b/modules/angular2/src/core/render/api.ts
@@ -16,7 +16,7 @@ import {Map} from 'angular2/src/core/facade/collection';
 // TODO(i): refactor this to an interface
 export class RenderProtoViewRef {
   /**
-   * @private
+   * @internal
    */
   constructor() {}
 }
@@ -169,7 +169,7 @@ export interface RenderElementRef {
  */
 export class Renderer {
   /**
-   * @private
+   * @internal
    *
    * Private constructor is required so that this class gets converted into an interface in our
    * public api.

--- a/modules/angular2/src/core/render/dom/dom_renderer.ts
+++ b/modules/angular2/src/core/render/dom/dom_renderer.ts
@@ -39,7 +39,7 @@ export class DomRenderer implements Renderer, NodeFactory<Node> {
   private _document;
 
   /**
-   * @private
+   * @internal
    */
   constructor(private _eventManager: EventManager,
               private _domSharedStylesHost: DomSharedStylesHost, private _animate: AnimationBuilder,

--- a/modules/angular2/src/core/zone/ng_zone.ts
+++ b/modules/angular2/src/core/zone/ng_zone.ts
@@ -111,7 +111,7 @@ export class NgZone {
   _pendingTimeouts: number[] = [];
 
   /**
-   * @private
+   * @internal
    * @param {bool} enableLongStackTrace whether to enable long stack trace. They should only be
    *               enabled in development mode as they significantly impact perf.
    */
@@ -136,7 +136,7 @@ export class NgZone {
   }
 
   /**
-   * @private <!-- TODO: refactor to make TS private -->
+   * @internal <!-- TODO: refactor to make TS private -->
    *
    * Sets the zone hook that is called just before a browser task that is handled by Angular
    * executes.
@@ -150,7 +150,7 @@ export class NgZone {
   }
 
   /**
-   * @private <!-- TODO: refactor to make TS private -->
+   * @internal <!-- TODO: refactor to make TS private -->
    *
    * Sets the zone hook that is called immediately after Angular zone is done processing the current
    * task and any microtasks scheduled from that task.
@@ -166,7 +166,7 @@ export class NgZone {
   }
 
   /**
-   * @private <!-- TODO: refactor to make TS private -->
+   * @internal <!-- TODO: refactor to make TS private -->
    *
    * Sets the zone hook that is called immediately after the `onTurnDone` callback is called and any
    * microstasks scheduled from within that callback are drained.
@@ -192,7 +192,7 @@ export class NgZone {
   }
 
   /**
-   * @private <!-- TODO: refactor to make TS private -->
+   * @internal <!-- TODO: refactor to make TS private -->
    *
    * Sets the zone hook that is called when an error is thrown in the Angular zone.
    *

--- a/modules/angular2/src/http/backends/jsonp_backend.ts
+++ b/modules/angular2/src/http/backends/jsonp_backend.ts
@@ -21,7 +21,7 @@ export class JSONPConnection implements Connection {
   private _finished: boolean = false;
 
   /**
-   * @private
+   * @internal
    */
   constructor(req: Request, private _dom: BrowserJsonp,
               private baseResponseOptions?: ResponseOptions) {
@@ -103,7 +103,7 @@ export class JSONPConnection implements Connection {
 @Injectable()
 export class JSONPBackend implements ConnectionBackend {
   /**
-   * @private
+   * @internal
    */
   constructor(private _browserJSONP: BrowserJsonp, private _baseResponseOptions: ResponseOptions) {}
   createConnection(request: Request): JSONPConnection {

--- a/modules/angular2/src/http/base_response_options.ts
+++ b/modules/angular2/src/http/base_response_options.ts
@@ -46,11 +46,11 @@ export class ResponseOptions {
    */
   headers: Headers;
   /**
-   * @private
+   * @internal
    */
   statusText: string;
   /**
-   * @private
+   * @internal
    */
   type: ResponseTypes;
   url: string;

--- a/modules/angular2/src/router/instruction.ts
+++ b/modules/angular2/src/router/instruction.ts
@@ -144,7 +144,7 @@ export class ComponentInstruction {
   reuse: boolean = false;
 
   /**
-   * @private
+   * @internal
    */
   constructor(public urlPath: string, public urlParams: string[],
               private _recognizer: PathRecognizer, public params: {[key: string]: any} = null) {}

--- a/modules/angular2/src/router/router_outlet.ts
+++ b/modules/angular2/src/router/router_outlet.ts
@@ -32,7 +32,7 @@ export class RouterOutlet {
   private _currentInstruction: ComponentInstruction = null;
 
   /**
-   * @private
+   * @internal
    */
   constructor(private _elementRef: ElementRef, private _loader: DynamicComponentLoader,
               private _parentRouter: routerMod.Router, @Attribute('name') nameAttr: string) {

--- a/modules/angular2/src/test_lib/test_component_builder.ts
+++ b/modules/angular2/src/test_lib/test_component_builder.ts
@@ -28,7 +28,7 @@ export class RootTestComponent {
   debugElement: DebugElement;
 
   /**
-   * @private
+   * @internal
    */
   constructor(componentRef: ComponentRef) {
     this.debugElement = new DebugElement(internalView(<ViewRef>componentRef.hostView), 0);

--- a/modules/angular2/src/web_workers/shared/client_message_broker.ts
+++ b/modules/angular2/src/web_workers/shared/client_message_broker.ts
@@ -17,7 +17,7 @@ export {Type} from "angular2/src/core/facade/lang";
 @Injectable()
 export class ClientMessageBrokerFactory {
   /**
-   * @private
+   * @internal
    */
   constructor(private _messageBus: MessageBus, public _serializer: Serializer) {}
 
@@ -35,7 +35,7 @@ export class ClientMessageBroker {
   private _sink: EventEmitter;
 
   /**
-   * @private
+   * @internal
    */
   constructor(messageBus: MessageBus, public _serializer: Serializer, public channel) {
     this._sink = messageBus.to(channel);

--- a/modules/angular2/src/web_workers/shared/service_message_broker.ts
+++ b/modules/angular2/src/web_workers/shared/service_message_broker.ts
@@ -13,7 +13,7 @@ import {
 @Injectable()
 export class ServiceMessageBrokerFactory {
   /**
-   * @private
+   * @internal
    */
   constructor(private _messageBus: MessageBus, public _serializer: Serializer) {}
 
@@ -37,7 +37,7 @@ export class ServiceMessageBroker {
   private _methods: Map<string, Function> = new Map<string, Function>();
 
   /**
-   * @private
+   * @internal
    */
   constructor(messageBus: MessageBus, private _serializer: Serializer, public channel) {
     this._sink = messageBus.to(channel);


### PR DESCRIPTION
The latter is understood by TypeScript's --stripInternal option, so this lets us
rely more on the tooling provided by typescript team.

Part of #3082 
