### PR TITLE
chore(typings): remove StringMap

### DIFF
--- a/docs/typescript-definition-package/templates/angular2/angular2.d.ts.template.html
+++ b/docs/typescript-definition-package/templates/angular2/angular2.d.ts.template.html
@@ -2,7 +2,6 @@
 {% block staticDeclarations %}
 
 interface Map<K,V> {}
-interface StringMap<K,V> extends Map<K,V> {}
 
 {% for alias, module in doc.moduleDocs %}
 declare module {$ module.namespace $} {

--- a/modules/angular2/manual_typings/globals.d.ts
+++ b/modules/angular2/manual_typings/globals.d.ts
@@ -5,10 +5,6 @@
 /// <reference path="../typings/zone/zone.d.ts"/>
 declare var assert: any;
 
-// FIXME: K must be string!
-// FIXME: should have an index signature, `[k: string]: V;`
-interface StringMap<K extends string, V> {}
-
 interface BrowserNodeGlobal {
   Object: typeof Object;
   Array: typeof Array;

--- a/modules/angular2/src/animate/animation.ts
+++ b/modules/angular2/src/animate/animation.ts
@@ -96,7 +96,7 @@ export class Animation {
    * Applies the provided styles to the element
    * @param styles
    */
-  applyStyles(styles: StringMap<string, any>): void {
+  applyStyles(styles: {[key: string]: any}): void {
     StringMapWrapper.forEach(styles, (value, key) => {
       var dashCaseKey = camelCaseToDashCase(key);
       if (isPresent(DOM.getStyle(this.element, dashCaseKey))) {

--- a/modules/angular2/src/animate/css_animation_builder.ts
+++ b/modules/angular2/src/animate/css_animation_builder.ts
@@ -61,7 +61,7 @@ export class CssAnimationBuilder {
    * @param from
    * @param to
    */
-  setStyles(from: StringMap<string, any>, to: StringMap<string, any>): CssAnimationBuilder {
+  setStyles(from: {[key: string]: any}, to: {[key: string]: any}): CssAnimationBuilder {
     return this.setFromStyles(from).setToStyles(to);
   }
 
@@ -69,7 +69,7 @@ export class CssAnimationBuilder {
    * Sets the initial styles for the animation
    * @param from
    */
-  setFromStyles(from: StringMap<string, any>): CssAnimationBuilder {
+  setFromStyles(from: {[key: string]: any}): CssAnimationBuilder {
     this.data.fromStyles = from;
     return this;
   }
@@ -78,7 +78,7 @@ export class CssAnimationBuilder {
    * Sets the destination styles for the animation
    * @param to
    */
-  setToStyles(to: StringMap<string, any>): CssAnimationBuilder {
+  setToStyles(to: {[key: string]: any}): CssAnimationBuilder {
     this.data.toStyles = to;
     return this;
   }

--- a/modules/angular2/src/animate/css_animation_options.ts
+++ b/modules/angular2/src/animate/css_animation_options.ts
@@ -1,9 +1,9 @@
 export class CssAnimationOptions {
   /** initial styles for the element */
-  fromStyles: StringMap<string, any>;
+  fromStyles: {[key: string]: any};
 
   /** destination styles for the element */
-  toStyles: StringMap<string, any>;
+  toStyles: {[key: string]: any};
 
   /** classes to be added to the element */
   classesToAdd: string[] = [];

--- a/modules/angular2/src/core/change_detection/abstract_change_detector.ts
+++ b/modules/angular2/src/core/change_detection/abstract_change_detector.ts
@@ -278,7 +278,7 @@ export class AbstractChangeDetector<T> implements ChangeDetector {
     this.dispatcher.logBindingUpdate(this._currentBinding(), value);
   }
 
-  addChange(changes: StringMap<string, any>, oldValue: any, newValue: any): StringMap<string, any> {
+  addChange(changes: {[key: string]: any}, oldValue: any, newValue: any): {[key: string]: any} {
     if (isBlank(changes)) {
       changes = {};
     }

--- a/modules/angular2/src/core/change_detection/change_detection_util.ts
+++ b/modules/angular2/src/core/change_detection/change_detection_util.ts
@@ -124,7 +124,7 @@ export class ChangeDetectionUtil {
   static cond(cond, trueVal, falseVal): any { return cond ? trueVal : falseVal; }
 
   static mapFn(keys: any[]): any {
-    function buildMap(values): StringMap<any, any> {
+    function buildMap(values): {[k: /*any*/ string]: any} {
       var res = StringMapWrapper.create();
       for (var i = 0; i < keys.length; ++i) {
         StringMapWrapper.set(res, keys[i], values[i]);

--- a/modules/angular2/src/core/compiler/directive_metadata.ts
+++ b/modules/angular2/src/core/compiler/directive_metadata.ts
@@ -113,9 +113,9 @@ export class CompileDirectiveMetadata {
     lifecycleHooks?: LifecycleHooks[],
     template?: CompileTemplateMetadata
   } = {}): CompileDirectiveMetadata {
-    var hostListeners = {};
-    var hostProperties = {};
-    var hostAttributes = {};
+    var hostListeners: {[key: string]: string} = {};
+    var hostProperties: {[key: string]: string} = {};
+    var hostAttributes: {[key: string]: string} = {};
     if (isPresent(host)) {
       StringMapWrapper.forEach(host, (value: string, key: string) => {
         var matches = RegExpWrapper.firstMatch(HOST_REG_EXP, key);
@@ -128,7 +128,7 @@ export class CompileDirectiveMetadata {
         }
       });
     }
-    var inputsMap = {};
+    var inputsMap: {[key: string]: string} = {};
     if (isPresent(inputs)) {
       inputs.forEach((bindConfig: string) => {
         // canonical syntax: `dirProp: elProp`
@@ -137,7 +137,7 @@ export class CompileDirectiveMetadata {
         inputsMap[parts[0]] = parts[1];
       });
     }
-    var outputsMap = {};
+    var outputsMap: {[key: string]: string} = {};
     if (isPresent(outputs)) {
       outputs.forEach((bindConfig: string) => {
         // canonical syntax: `dirProp: elProp`

--- a/modules/angular2/src/core/compiler/directive_metadata.ts
+++ b/modules/angular2/src/core/compiler/directive_metadata.ts
@@ -34,12 +34,12 @@ export class CompileTypeMetadata {
     this.isHost = normalizeBool(isHost);
   }
 
-  static fromJson(data: StringMap<string, any>): CompileTypeMetadata {
+  static fromJson(data: {[key: string]: any}): CompileTypeMetadata {
     return new CompileTypeMetadata(
         {name: data['name'], moduleUrl: data['moduleUrl'], isHost: data['isHost']});
   }
 
-  toJson(): StringMap<string, any> {
+  toJson(): {[key: string]: any} {
     return {
       // Note: Runtime type can't be serialized...
       'name': this.name,
@@ -72,7 +72,7 @@ export class CompileTemplateMetadata {
     this.ngContentSelectors = isPresent(ngContentSelectors) ? ngContentSelectors : [];
   }
 
-  static fromJson(data: StringMap<string, any>): CompileTemplateMetadata {
+  static fromJson(data: {[key: string]: any}): CompileTemplateMetadata {
     return new CompileTemplateMetadata({
       encapsulation: isPresent(data['encapsulation']) ?
                          VIEW_ENCAPSULATION_VALUES[data['encapsulation']] :
@@ -85,7 +85,7 @@ export class CompileTemplateMetadata {
     });
   }
 
-  toJson(): StringMap<string, any> {
+  toJson(): {[key: string]: any} {
     return {
       'encapsulation':
           isPresent(this.encapsulation) ? serializeEnum(this.encapsulation) : this.encapsulation,
@@ -109,7 +109,7 @@ export class CompileDirectiveMetadata {
     changeDetection?: ChangeDetectionStrategy,
     inputs?: string[],
     outputs?: string[],
-    host?: StringMap<string, string>,
+    host?: {[key: string]: string},
     lifecycleHooks?: LifecycleHooks[],
     template?: CompileTemplateMetadata
   } = {}): CompileDirectiveMetadata {
@@ -169,11 +169,11 @@ export class CompileDirectiveMetadata {
   selector: string;
   exportAs: string;
   changeDetection: ChangeDetectionStrategy;
-  inputs: StringMap<string, string>;
-  outputs: StringMap<string, string>;
-  hostListeners: StringMap<string, string>;
-  hostProperties: StringMap<string, string>;
-  hostAttributes: StringMap<string, string>;
+  inputs: {[key: string]: string};
+  outputs: {[key: string]: string};
+  hostListeners: {[key: string]: string};
+  hostProperties: {[key: string]: string};
+  hostAttributes: {[key: string]: string};
   lifecycleHooks: LifecycleHooks[];
   template: CompileTemplateMetadata;
   constructor({type, isComponent, dynamicLoadable, selector, exportAs, changeDetection, inputs,
@@ -184,11 +184,11 @@ export class CompileDirectiveMetadata {
     selector?: string,
     exportAs?: string,
     changeDetection?: ChangeDetectionStrategy,
-    inputs?: StringMap<string, string>,
-    outputs?: StringMap<string, string>,
-    hostListeners?: StringMap<string, string>,
-    hostProperties?: StringMap<string, string>,
-    hostAttributes?: StringMap<string, string>,
+    inputs?: {[key: string]: string},
+    outputs?: {[key: string]: string},
+    hostListeners?: {[key: string]: string},
+    hostProperties?: {[key: string]: string},
+    hostAttributes?: {[key: string]: string},
     lifecycleHooks?: LifecycleHooks[],
     template?: CompileTemplateMetadata
   } = {}) {
@@ -207,7 +207,7 @@ export class CompileDirectiveMetadata {
     this.template = template;
   }
 
-  static fromJson(data: StringMap<string, any>): CompileDirectiveMetadata {
+  static fromJson(data: {[key: string]: any}): CompileDirectiveMetadata {
     return new CompileDirectiveMetadata({
       isComponent: data['isComponent'],
       dynamicLoadable: data['dynamicLoadable'],
@@ -229,7 +229,7 @@ export class CompileDirectiveMetadata {
     });
   }
 
-  toJson(): StringMap<string, any> {
+  toJson(): {[key: string]: any} {
     return {
       'isComponent': this.isComponent,
       'dynamicLoadable': this.dynamicLoadable,

--- a/modules/angular2/src/core/compiler/template_parser.ts
+++ b/modules/angular2/src/core/compiler/template_parser.ts
@@ -436,8 +436,8 @@ class TemplateParseVisitor implements HtmlAstVisitor {
     return directiveAsts;
   }
 
-  private _createDirectiveHostPropertyAsts(elementName: string,
-                                           hostProps: StringMap<string, string>, sourceInfo: string,
+  private _createDirectiveHostPropertyAsts(elementName: string, hostProps: {[key: string]: string},
+                                           sourceInfo: string,
                                            targetPropertyAsts: BoundElementPropertyAst[]) {
     if (isPresent(hostProps)) {
       StringMapWrapper.forEach(hostProps, (expression, propName) => {
@@ -448,8 +448,8 @@ class TemplateParseVisitor implements HtmlAstVisitor {
     }
   }
 
-  private _createDirectiveHostEventAsts(hostListeners: StringMap<string, string>,
-                                        sourceInfo: string, targetEventAsts: BoundEventAst[]) {
+  private _createDirectiveHostEventAsts(hostListeners: {[key: string]: string}, sourceInfo: string,
+                                        targetEventAsts: BoundEventAst[]) {
     if (isPresent(hostListeners)) {
       StringMapWrapper.forEach(hostListeners, (expression, propName) => {
         this._parseEvent(propName, expression, sourceInfo, [], targetEventAsts);
@@ -457,7 +457,7 @@ class TemplateParseVisitor implements HtmlAstVisitor {
     }
   }
 
-  private _createDirectivePropertyAsts(directiveProperties: StringMap<string, string>,
+  private _createDirectivePropertyAsts(directiveProperties: {[key: string]: string},
                                        boundProps: BoundElementOrDirectiveProperty[],
                                        targetBoundDirectiveProps: BoundDirectivePropertyAst[]) {
     if (isPresent(directiveProperties)) {

--- a/modules/angular2/src/core/dom/dom_adapter.ts
+++ b/modules/angular2/src/core/dom/dom_adapter.ts
@@ -27,7 +27,7 @@ export abstract class DomAdapter {
    * Maps attribute names to their corresponding property names for cases
    * where attribute name doesn't match property name.
    */
-  attrToPropMap: StringMap<string, string>;
+  attrToPropMap: {[key: string]: string};
 
   abstract parse(templateHtml: string);
   abstract query(selector: string): any;

--- a/modules/angular2/src/core/dom/generic_browser_adapter.ts
+++ b/modules/angular2/src/core/dom/generic_browser_adapter.ts
@@ -23,7 +23,7 @@ export abstract class GenericBrowserDomAdapter extends DomAdapter {
           }
         }
       }
-      var transEndEventNames = {
+      var transEndEventNames: {[key: string]: string} = {
         WebkitTransition: 'webkitTransitionEnd',
         MozTransition: 'transitionend',
         OTransition: 'oTransitionEnd otransitionend',

--- a/modules/angular2/src/core/dom/parse5_adapter.ts
+++ b/modules/angular2/src/core/dom/parse5_adapter.ts
@@ -115,9 +115,9 @@ export class Parse5DomAdapter extends DomAdapter {
     return result;
   }
   on(el, evt, listener) {
-    var listenersMap: StringMap<any, any> = el._eventListenersMap;
+    var listenersMap: {[k: /*any*/ string]: any} = el._eventListenersMap;
     if (isBlank(listenersMap)) {
-      var listenersMap: StringMap<any, any> = StringMapWrapper.create();
+      var listenersMap: {[k: /*any*/ string]: any} = StringMapWrapper.create();
       el._eventListenersMap = listenersMap;
     }
     var listeners = StringMapWrapper.get(listenersMap, evt);
@@ -492,7 +492,7 @@ export class Parse5DomAdapter extends DomAdapter {
     var rules = [];
     for (var i = 0; i < parsedRules.length; i++) {
       var parsedRule = parsedRules[i];
-      var rule: StringMap<string, any> = StringMapWrapper.create();
+      var rule: {[key: string]: any} = StringMapWrapper.create();
       StringMapWrapper.set(rule, "cssText", css);
       StringMapWrapper.set(rule, "style", {content: "", cssText: ""});
       if (parsedRule.type == "rule") {

--- a/modules/angular2/src/core/dom/parse5_adapter.ts
+++ b/modules/angular2/src/core/dom/parse5_adapter.ts
@@ -17,7 +17,7 @@ import {
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 import {SelectorMatcher, CssSelector} from 'angular2/src/core/compiler/selector';
 
-var _attrToPropMap = {
+var _attrToPropMap: {[key: string]: string} = {
   'class': 'className',
   'innerHtml': 'innerHTML',
   'readonly': 'readOnly',

--- a/modules/angular2/src/core/facade/collection.ts
+++ b/modules/angular2/src/core/facade/collection.ts
@@ -9,7 +9,6 @@ import {
 
 export var Map = global.Map;
 export var Set = global.Set;
-export var StringMap = global.Object;
 
 // Safari and Internet Explorer do not support the iterable parameter to the
 // Map constructor.  We work around that by manually adding the items.
@@ -79,14 +78,14 @@ var _arrayFromMap: {(m: Map<any, any>, getValues: boolean): any[]} = (function()
 
 export class MapWrapper {
   static clone<K, V>(m: Map<K, V>): Map<K, V> { return createMapFromMap(m); }
-  static createFromStringMap<T>(stringMap: StringMap<string, T>): Map<string, T> {
+  static createFromStringMap<T>(stringMap: {[key: string]: T}): Map<string, T> {
     var result = new Map<string, T>();
     for (var prop in stringMap) {
       result.set(prop, stringMap[prop]);
     }
     return result;
   }
-  static toStringMap<T>(m: Map<string, T>): StringMap<string, T> {
+  static toStringMap<T>(m: Map<string, T>): {[key: string]: T} {
     var r = {};
     m.forEach((v, k) => r[k] = v);
     return r;
@@ -106,28 +105,28 @@ export class MapWrapper {
  * Wraps Javascript Objects
  */
 export class StringMapWrapper {
-  static create(): StringMap<any, any> {
+  static create(): {[k: /*any*/ string]: any} {
     // Note: We are not using Object.create(null) here due to
     // performance!
     // http://jsperf.com/ng2-object-create-null
     return {};
   }
-  static contains(map: StringMap<string, any>, key: string): boolean {
+  static contains(map: {[key: string]: any}, key: string): boolean {
     return map.hasOwnProperty(key);
   }
-  static get<V>(map: StringMap<string, V>, key: string): V {
+  static get<V>(map: {[key: string]: V}, key: string): V {
     return map.hasOwnProperty(key) ? map[key] : undefined;
   }
-  static set<V>(map: StringMap<string, V>, key: string, value: V) { map[key] = value; }
-  static keys(map: StringMap<string, any>): string[] { return Object.keys(map); }
-  static isEmpty(map: StringMap<string, any>): boolean {
+  static set<V>(map: {[key: string]: V}, key: string, value: V) { map[key] = value; }
+  static keys(map: {[key: string]: any}): string[] { return Object.keys(map); }
+  static isEmpty(map: {[key: string]: any}): boolean {
     for (var prop in map) {
       return false;
     }
     return true;
   }
-  static delete (map: StringMap<string, any>, key: string) { delete map[key]; }
-  static forEach<K, V>(map: StringMap<string, V>, callback: /*(V, K) => void*/ Function) {
+  static delete (map: {[key: string]: any}, key: string) { delete map[key]; }
+  static forEach<K, V>(map: {[key: string]: V}, callback: /*(V, K) => void*/ Function) {
     for (var prop in map) {
       if (map.hasOwnProperty(prop)) {
         callback(map[prop], prop);
@@ -135,7 +134,7 @@ export class StringMapWrapper {
     }
   }
 
-  static merge<V>(m1: StringMap<string, V>, m2: StringMap<string, V>): StringMap<string, V> {
+  static merge<V>(m1: {[key: string]: V}, m2: {[key: string]: V}): {[key: string]: V} {
     var m = {};
 
     for (var attr in m1) {
@@ -153,7 +152,7 @@ export class StringMapWrapper {
     return m;
   }
 
-  static equals<V>(m1: StringMap<string, V>, m2: StringMap<string, V>): boolean {
+  static equals<V>(m1: {[key: string]: V}, m2: {[key: string]: V}): boolean {
     var k1 = Object.keys(m1);
     var k2 = Object.keys(m2);
     if (k1.length != k2.length) {

--- a/modules/angular2/src/core/facade/collection.ts
+++ b/modules/angular2/src/core/facade/collection.ts
@@ -86,7 +86,7 @@ export class MapWrapper {
     return result;
   }
   static toStringMap<T>(m: Map<string, T>): {[key: string]: T} {
-    var r = {};
+    var r: {[key: string]: T} = {};
     m.forEach((v, k) => r[k] = v);
     return r;
   }
@@ -135,7 +135,7 @@ export class StringMapWrapper {
   }
 
   static merge<V>(m1: {[key: string]: V}, m2: {[key: string]: V}): {[key: string]: V} {
-    var m = {};
+    var m: {[key: string]: V} = {};
 
     for (var attr in m1) {
       if (m1.hasOwnProperty(attr)) {

--- a/modules/angular2/src/core/forms/directives/abstract_control_directive.ts
+++ b/modules/angular2/src/core/forms/directives/abstract_control_directive.ts
@@ -8,7 +8,7 @@ export class AbstractControlDirective {
 
   get valid(): boolean { return isPresent(this.control) ? this.control.valid : null; }
 
-  get errors(): StringMap<string, any> {
+  get errors(): {[key: string]: any} {
     return isPresent(this.control) ? this.control.errors : null;
   }
 

--- a/modules/angular2/src/core/forms/directives/ng_control_name.ts
+++ b/modules/angular2/src/core/forms/directives/ng_control_name.ts
@@ -1,6 +1,5 @@
 import {CONST_EXPR} from 'angular2/src/core/facade/lang';
 import {EventEmitter, ObservableWrapper} from 'angular2/src/core/facade/async';
-import {StringMap} from 'angular2/src/core/facade/collection';
 import {OnChanges, OnDestroy} from 'angular2/lifecycle_hooks';
 import {SimpleChange} from 'angular2/src/core/change_detection';
 import {Query, Directive} from 'angular2/src/core/metadata';
@@ -97,7 +96,7 @@ export class NgControlName extends NgControl implements OnChanges,
     this.valueAccessor = selectValueAccessor(this, valueAccessors);
   }
 
-  onChanges(changes: StringMap<string, SimpleChange>) {
+  onChanges(changes: {[key: string]: SimpleChange}) {
     if (!this._added) {
       this.formDirective.addControl(this);
       this._added = true;

--- a/modules/angular2/src/core/forms/directives/ng_form.ts
+++ b/modules/angular2/src/core/forms/directives/ng_form.ts
@@ -98,7 +98,7 @@ export class NgForm extends ControlContainer implements Form {
 
   get path(): string[] { return []; }
 
-  get controls(): StringMap<string, AbstractControl> { return this.form.controls; }
+  get controls(): {[key: string]: AbstractControl} { return this.form.controls; }
 
   addControl(dir: NgControl): void {
     this._later(_ => {

--- a/modules/angular2/src/core/forms/directives/ng_form_control.ts
+++ b/modules/angular2/src/core/forms/directives/ng_form_control.ts
@@ -84,7 +84,7 @@ export class NgFormControl extends NgControl implements OnChanges {
     this.valueAccessor = selectValueAccessor(this, valueAccessors);
   }
 
-  onChanges(changes: StringMap<string, SimpleChange>): void {
+  onChanges(changes: {[key: string]: SimpleChange}): void {
     if (!this._added) {
       setUpControl(this.form, this);
       this.form.updateValidity();

--- a/modules/angular2/src/core/forms/directives/ng_model.ts
+++ b/modules/angular2/src/core/forms/directives/ng_model.ts
@@ -55,7 +55,7 @@ export class NgModel extends NgControl implements OnChanges {
     this.valueAccessor = selectValueAccessor(this, valueAccessors);
   }
 
-  onChanges(changes: StringMap<string, SimpleChange>) {
+  onChanges(changes: {[key: string]: SimpleChange}) {
     if (!this._added) {
       setUpControl(this._control, this);
       this._control.updateValidity();

--- a/modules/angular2/src/core/forms/directives/shared.ts
+++ b/modules/angular2/src/core/forms/directives/shared.ts
@@ -51,7 +51,7 @@ export function setProperty(renderer: Renderer, elementRef: ElementRef, propName
   renderer.setElementProperty(elementRef, propName, propValue);
 }
 
-export function isPropertyUpdated(changes: StringMap<string, any>, viewModel: any): boolean {
+export function isPropertyUpdated(changes: {[key: string]: any}, viewModel: any): boolean {
   if (!StringMapWrapper.contains(changes, "model")) return false;
   var change = changes["model"];
 

--- a/modules/angular2/src/core/forms/form_builder.ts
+++ b/modules/angular2/src/core/forms/form_builder.ts
@@ -97,7 +97,7 @@ export class FormBuilder {
   }
 
   _reduceControls(controlsConfig: any): {[key: string]: modelModule.AbstractControl} {
-    var controls = {};
+    var controls: {[key: string]: modelModule.AbstractControl} = {};
     StringMapWrapper.forEach(controlsConfig, (controlConfig, controlName) => {
       controls[controlName] = this._createControl(controlConfig);
     });

--- a/modules/angular2/src/core/forms/form_builder.ts
+++ b/modules/angular2/src/core/forms/form_builder.ts
@@ -66,8 +66,8 @@ import * as modelModule from './model';
  */
 @Injectable()
 export class FormBuilder {
-  group(controlsConfig: StringMap<string, any>,
-        extra: StringMap<string, any> = null): modelModule.ControlGroup {
+  group(controlsConfig: {[key: string]: any},
+        extra: {[key: string]: any} = null): modelModule.ControlGroup {
     var controls = this._reduceControls(controlsConfig);
     var optionals = isPresent(extra) ? StringMapWrapper.get(extra, "optionals") : null;
     var validator = isPresent(extra) ? StringMapWrapper.get(extra, "validator") : null;
@@ -96,7 +96,7 @@ export class FormBuilder {
     }
   }
 
-  _reduceControls(controlsConfig: any): StringMap<string, modelModule.AbstractControl> {
+  _reduceControls(controlsConfig: any): {[key: string]: modelModule.AbstractControl} {
     var controls = {};
     StringMapWrapper.forEach(controlsConfig, (controlConfig, controlName) => {
       controls[controlName] = this._createControl(controlConfig);

--- a/modules/angular2/src/core/forms/model.ts
+++ b/modules/angular2/src/core/forms/model.ts
@@ -1,6 +1,6 @@
 import {StringWrapper, isPresent, isBlank, normalizeBool} from 'angular2/src/core/facade/lang';
 import {Observable, EventEmitter, ObservableWrapper} from 'angular2/src/core/facade/async';
-import {StringMap, StringMapWrapper, ListWrapper} from 'angular2/src/core/facade/collection';
+import {StringMapWrapper, ListWrapper} from 'angular2/src/core/facade/collection';
 import {Validators} from './validators';
 
 /**
@@ -43,7 +43,7 @@ function _find(control: AbstractControl, path: Array<string | number>| string) {
 export class AbstractControl {
   _value: any;
   _status: string;
-  _errors: StringMap<string, any>;
+  _errors: {[key: string]: any};
   _pristine: boolean = true;
   _touched: boolean = false;
   _parent: ControlGroup | ControlArray;
@@ -58,7 +58,7 @@ export class AbstractControl {
 
   get valid(): boolean { return this._status === VALID; }
 
-  get errors(): StringMap<string, any> { return this._errors; }
+  get errors(): {[key: string]: any} { return this._errors; }
 
   get pristine(): boolean { return this._pristine; }
 
@@ -199,11 +199,10 @@ export class Control extends AbstractControl {
  * ### Example ([live demo](http://plnkr.co/edit/23DESOpbNnBpBHZt1BR4?p=preview))
  */
 export class ControlGroup extends AbstractControl {
-  private _optionals: StringMap<string, boolean>;
+  private _optionals: {[key: string]: boolean};
 
-  constructor(public controls: StringMap<string, AbstractControl>,
-              optionals: StringMap<string, boolean> = null,
-              validator: Function = Validators.group) {
+  constructor(public controls: {[key: string]: AbstractControl},
+              optionals: {[key: string]: boolean} = null, validator: Function = Validators.group) {
     super(validator);
     this._optionals = isPresent(optionals) ? optionals : {};
     this._valueChanges = new EventEmitter();

--- a/modules/angular2/src/core/forms/validators.ts
+++ b/modules/angular2/src/core/forms/validators.ts
@@ -17,11 +17,11 @@ export const NG_VALIDATORS: OpaqueToken = CONST_EXPR(new OpaqueToken("NgValidato
  * ```
  */
 export class Validators {
-  static required(control: modelModule.Control): StringMap<string, boolean> {
+  static required(control: modelModule.Control): {[key: string]: boolean} {
     return isBlank(control.value) || control.value == "" ? {"required": true} : null;
   }
 
-  static nullValidator(c: any): StringMap<string, boolean> { return null; }
+  static nullValidator(c: any): {[key: string]: boolean} { return null; }
 
   static compose(validators: Function[]): Function {
     if (isBlank(validators)) return Validators.nullValidator;
@@ -35,7 +35,7 @@ export class Validators {
     };
   }
 
-  static group(group: modelModule.ControlGroup): StringMap<string, boolean> {
+  static group(group: modelModule.ControlGroup): {[key: string]: boolean} {
     var res = {};
     StringMapWrapper.forEach(group.controls, (control, name) => {
       if (group.contains(name) && isPresent(control.errors)) {
@@ -45,7 +45,7 @@ export class Validators {
     return StringMapWrapper.isEmpty(res) ? null : res;
   }
 
-  static array(array: modelModule.ControlArray): StringMap<string, boolean> {
+  static array(array: modelModule.ControlArray): {[key: string]: boolean} {
     var res = {};
     array.controls.forEach((control) => {
       if (isPresent(control.errors)) {
@@ -55,7 +55,7 @@ export class Validators {
     return StringMapWrapper.isEmpty(res) ? null : res;
   }
 
-  static _mergeErrors(control: modelModule.AbstractControl, res: StringMap<string, any[]>): void {
+  static _mergeErrors(control: modelModule.AbstractControl, res: {[key: string]: any[]}): void {
     StringMapWrapper.forEach(control.errors, (value, error) => {
       if (!StringMapWrapper.contains(res, error)) {
         res[error] = [];

--- a/modules/angular2/src/core/forms/validators.ts
+++ b/modules/angular2/src/core/forms/validators.ts
@@ -29,14 +29,14 @@ export class Validators {
     return function(control: modelModule.Control) {
       var res = ListWrapper.reduce(validators, (res, validator) => {
         var errors = validator(control);
-        return isPresent(errors) ? StringMapWrapper.merge(res, errors) : res;
+        return isPresent(errors) ? StringMapWrapper.merge(<any>res, <any>errors) : res;
       }, {});
       return StringMapWrapper.isEmpty(res) ? null : res;
     };
   }
 
-  static group(group: modelModule.ControlGroup): {[key: string]: boolean} {
-    var res = {};
+  static group(group: modelModule.ControlGroup): {[key: string]: any[]} {
+    var res: {[key: string]: any[]} = {};
     StringMapWrapper.forEach(group.controls, (control, name) => {
       if (group.contains(name) && isPresent(control.errors)) {
         Validators._mergeErrors(control, res);
@@ -45,8 +45,8 @@ export class Validators {
     return StringMapWrapper.isEmpty(res) ? null : res;
   }
 
-  static array(array: modelModule.ControlArray): {[key: string]: boolean} {
-    var res = {};
+  static array(array: modelModule.ControlArray): {[key: string]: any[]} {
+    var res: {[key: string]: any[]} = {};
     array.controls.forEach((control) => {
       if (isPresent(control.errors)) {
         Validators._mergeErrors(control, res);

--- a/modules/angular2/src/core/linker/directive_resolver.ts
+++ b/modules/angular2/src/core/linker/directive_resolver.ts
@@ -1,7 +1,7 @@
 import {resolveForwardRef, Injectable} from 'angular2/src/core/di';
 import {Type, isPresent, isBlank, stringify} from 'angular2/src/core/facade/lang';
 import {BaseException} from 'angular2/src/core/facade/exceptions';
-import {ListWrapper, StringMap, StringMapWrapper} from 'angular2/src/core/facade/collection';
+import {ListWrapper, StringMapWrapper} from 'angular2/src/core/facade/collection';
 import {
   DirectiveMetadata,
   ComponentMetadata,
@@ -43,8 +43,7 @@ export class DirectiveResolver {
   }
 
   private _mergeWithPropertyMetadata(dm: DirectiveMetadata,
-                                     propertyMetadata:
-                                         StringMap<string, any[]>): DirectiveMetadata {
+                                     propertyMetadata: {[key: string]: any[]}): DirectiveMetadata {
     var inputs = [];
     var outputs = [];
     var host = {};
@@ -102,8 +101,7 @@ export class DirectiveResolver {
   }
 
   private _merge(dm: DirectiveMetadata, inputs: string[], outputs: string[],
-                 host: StringMap<string, string>,
-                 queries: StringMap<string, any>): DirectiveMetadata {
+                 host: {[key: string]: string}, queries: {[key: string]: any}): DirectiveMetadata {
     var mergedInputs = isPresent(dm.inputs) ? ListWrapper.concat(dm.inputs, inputs) : inputs;
     var mergedOutputs = isPresent(dm.outputs) ? ListWrapper.concat(dm.outputs, outputs) : outputs;
     var mergedHost = isPresent(dm.host) ? StringMapWrapper.merge(dm.host, host) : host;

--- a/modules/angular2/src/core/linker/directive_resolver.ts
+++ b/modules/angular2/src/core/linker/directive_resolver.ts
@@ -46,8 +46,8 @@ export class DirectiveResolver {
                                      propertyMetadata: {[key: string]: any[]}): DirectiveMetadata {
     var inputs = [];
     var outputs = [];
-    var host = {};
-    var queries = {};
+    var host: {[key: string]: string} = {};
+    var queries: {[key: string]: any} = {};
 
     StringMapWrapper.forEach(propertyMetadata, (metadata: any[], propName: string) => {
       metadata.forEach(a => {

--- a/modules/angular2/src/core/linker/interfaces.ts
+++ b/modules/angular2/src/core/linker/interfaces.ts
@@ -1,4 +1,4 @@
-import {StringMap, MapWrapper} from 'angular2/src/core/facade/collection';
+import {MapWrapper} from 'angular2/src/core/facade/collection';
 import {SimpleChange} from 'angular2/src/core/change_detection/change_detection_util';
 
 /**
@@ -77,7 +77,7 @@ export var LIFECYCLE_HOOKS_VALUES = [
  * bootstrap(App).catch(err => console.error(err));
  * ```
  */
-export interface OnChanges { onChanges(changes: StringMap<string, SimpleChange>); }
+export interface OnChanges { onChanges(changes: {[key: string]: SimpleChange}); }
 
 /**
  * Implement this interface to execute custom initialization logic after your directive's

--- a/modules/angular2/src/core/linker/proto_view_factory.ts
+++ b/modules/angular2/src/core/linker/proto_view_factory.ts
@@ -55,9 +55,9 @@ export class ProtoViewFactory {
     var result = this._cache.get(compiledTemplate.id);
     if (isBlank(result)) {
       var templateData = compiledTemplate.getData(this._appId);
-      result =
-          new AppProtoView(templateData.commands, ViewType.HOST, true,
-                           templateData.changeDetectorFactory, null, new ProtoPipes(new Map()));
+      var emptyMap: {[key: string]: PipeBinding} = {};
+      result = new AppProtoView(templateData.commands, ViewType.HOST, true,
+                                templateData.changeDetectorFactory, null, new ProtoPipes(emptyMap));
       this._cache.set(compiledTemplate.id, result);
     }
     return result;

--- a/modules/angular2/src/core/linker/view.ts
+++ b/modules/angular2/src/core/linker/view.ts
@@ -3,7 +3,6 @@ import {
   MapWrapper,
   Map,
   StringMapWrapper,
-  StringMap
 } from 'angular2/src/core/facade/collection';
 import {
   AST,
@@ -263,7 +262,7 @@ export class AppView implements ChangeDispatcher, RenderEventDispatcher {
   get ownBindersCount(): number { return this.proto.elementBinders.length; }
 }
 
-function _localsToStringMap(locals: Locals): StringMap<string, any> {
+function _localsToStringMap(locals: Locals): {[key: string]: any} {
   var res = {};
   var c = locals;
   while (isPresent(c)) {

--- a/modules/angular2/src/core/metadata.ts
+++ b/modules/angular2/src/core/metadata.ts
@@ -151,11 +151,11 @@ export interface DirectiveFactory {
     outputs?: string[],
     properties?: string[],
     events?: string[],
-    host?: StringMap<string, string>,
+    host?: {[key: string]: string},
     bindings?: any[],
     exportAs?: string,
     moduleId?: string,
-    queries?: StringMap<string, any>
+    queries?: {[key: string]: any}
   }): DirectiveDecorator;
   new (obj: {
     selector?: string,
@@ -163,11 +163,11 @@ export interface DirectiveFactory {
     outputs?: string[],
     properties?: string[],
     events?: string[],
-    host?: StringMap<string, string>,
+    host?: {[key: string]: string},
     bindings?: any[],
     exportAs?: string,
     moduleId?: string,
-    queries?: StringMap<string, any>
+    queries?: {[key: string]: any}
   }): DirectiveMetadata;
 }
 
@@ -221,11 +221,11 @@ export interface ComponentFactory {
     outputs?: string[],
     properties?: string[],
     events?: string[],
-    host?: StringMap<string, string>,
+    host?: {[key: string]: string},
     bindings?: any[],
     exportAs?: string,
     moduleId?: string,
-    queries?: StringMap<string, any>,
+    queries?: {[key: string]: any},
     viewBindings?: any[],
     changeDetection?: ChangeDetectionStrategy,
   }): ComponentDecorator;
@@ -235,11 +235,11 @@ export interface ComponentFactory {
     outputs?: string[],
     properties?: string[],
     events?: string[],
-    host?: StringMap<string, string>,
+    host?: {[key: string]: string},
     bindings?: any[],
     exportAs?: string,
     moduleId?: string,
-    queries?: StringMap<string, any>,
+    queries?: {[key: string]: any},
     viewBindings?: any[],
     changeDetection?: ChangeDetectionStrategy,
   }): ComponentMetadata;

--- a/modules/angular2/src/core/metadata/directives.ts
+++ b/modules/angular2/src/core/metadata/directives.ts
@@ -632,7 +632,7 @@ export class DirectiveMetadata extends InjectableMetadata {
    * }
    * ```
    */
-  host: StringMap<string, string>;
+  host: {[key: string]: string};
 
   /**
    * Defines the set of injectable objects that are visible to a Directive and its light DOM
@@ -748,7 +748,7 @@ export class DirectiveMetadata extends InjectableMetadata {
    * }
    * ```
    */
-  queries: StringMap<string, any>;
+  queries: {[key: string]: any};
 
   constructor({selector, inputs, outputs, properties, events, host, bindings, exportAs, moduleId,
                queries}: {
@@ -757,11 +757,11 @@ export class DirectiveMetadata extends InjectableMetadata {
     outputs?: string[],
     properties?: string[],
     events?: string[],
-    host?: StringMap<string, string>,
+    host?: {[key: string]: string},
     bindings?: any[],
     exportAs?: string,
     moduleId?: string,
-    queries?: StringMap<string, any>
+    queries?: {[key: string]: any}
   } = {}) {
     super();
     this.selector = selector;
@@ -883,12 +883,12 @@ export class ComponentMetadata extends DirectiveMetadata {
     outputs?: string[],
     properties?: string[],
     events?: string[],
-    host?: StringMap<string, string>,
+    host?: {[key: string]: string},
     bindings?: any[],
     exportAs?: string,
     moduleId?: string,
     viewBindings?: any[],
-    queries?: StringMap<string, any>,
+    queries?: {[key: string]: any},
     changeDetection?: ChangeDetectionStrategy,
   } = {}) {
     super({

--- a/modules/angular2/src/core/pipes/date_pipe.ts
+++ b/modules/angular2/src/core/pipes/date_pipe.ts
@@ -81,7 +81,7 @@ var defaultLocale: string = 'en-US';
 @Pipe({name: 'date'})
 @Injectable()
 export class DatePipe implements PipeTransform {
-  static _ALIASES = {
+  static _ALIASES: {[key: string]: String} = {
     'medium': 'yMMMdjms',
     'short': 'yMdjm',
     'fullDate': 'yMMMMEEEEd',

--- a/modules/angular2/src/core/pipes/pipes.ts
+++ b/modules/angular2/src/core/pipes/pipes.ts
@@ -14,7 +14,7 @@ import * as cd from 'angular2/src/core/change_detection/pipes';
 
 export class ProtoPipes {
   static fromBindings(bindings: PipeBinding[]): ProtoPipes {
-    var config = {};
+    var config: {[key: string]: PipeBinding} = {};
     bindings.forEach(b => config[b.name] = b);
     return new ProtoPipes(config);
   }

--- a/modules/angular2/src/core/pipes/pipes.ts
+++ b/modules/angular2/src/core/pipes/pipes.ts
@@ -23,7 +23,7 @@ export class ProtoPipes {
       /**
       * Map of {@link PipeMetadata} names to {@link PipeMetadata} implementations.
       */
-      public config: StringMap<string, PipeBinding>) {
+      public config: {[key: string]: PipeBinding}) {
     this.config = config;
   }
 
@@ -37,7 +37,7 @@ export class ProtoPipes {
 
 
 export class Pipes implements cd.Pipes {
-  _config: StringMap<string, cd.SelectedPipe> = {};
+  _config: {[key: string]: cd.SelectedPipe} = {};
 
   constructor(public proto: ProtoPipes, public injector: Injector) {}
 

--- a/modules/angular2/src/core/reflection/platform_reflection_capabilities.ts
+++ b/modules/angular2/src/core/reflection/platform_reflection_capabilities.ts
@@ -7,7 +7,7 @@ export interface PlatformReflectionCapabilities {
   interfaces(type: Type): any[];
   parameters(type: any): any[][];
   annotations(type: any): any[];
-  propMetadata(typeOrFunc: any): StringMap<string, any[]>;
+  propMetadata(typeOrFunc: any): {[key: string]: any[]};
   getter(name: string): GetterFn;
   setter(name: string): SetterFn;
   method(name: string): MethodFn;

--- a/modules/angular2/src/core/reflection/reflection_capabilities.ts
+++ b/modules/angular2/src/core/reflection/reflection_capabilities.ts
@@ -134,7 +134,7 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
     return [];
   }
 
-  propMetadata(typeOrFunc: any): StringMap<string, any[]> {
+  propMetadata(typeOrFunc: any): {[key: string]: any[]} {
     // Prefer the direct API.
     if (isPresent((<any>typeOrFunc).propMetadata)) {
       var propMetadata = (<any>typeOrFunc).propMetadata;

--- a/modules/angular2/src/core/reflection/reflector.ts
+++ b/modules/angular2/src/core/reflection/reflector.ts
@@ -6,7 +6,6 @@ import {
   MapWrapper,
   Set,
   SetWrapper,
-  StringMap,
   StringMapWrapper
 } from 'angular2/src/core/facade/collection';
 import {SetterFn, GetterFn, MethodFn} from './types';
@@ -16,7 +15,7 @@ export {PlatformReflectionCapabilities} from './platform_reflection_capabilities
 
 export class ReflectionInfo {
   constructor(public annotations?: any[], public parameters?: any[][], public factory?: Function,
-              public interfaces?: any[], public propMetadata?: StringMap<string, any[]>) {}
+              public interfaces?: any[], public propMetadata?: {[key: string]: any[]}) {}
 }
 
 export class Reflector {
@@ -61,17 +60,11 @@ export class Reflector {
     this._injectableInfo.set(type, typeInfo);
   }
 
-  registerGetters(getters: StringMap<string, GetterFn>): void {
-    _mergeMaps(this._getters, getters);
-  }
+  registerGetters(getters: {[key: string]: GetterFn}): void { _mergeMaps(this._getters, getters); }
 
-  registerSetters(setters: StringMap<string, SetterFn>): void {
-    _mergeMaps(this._setters, setters);
-  }
+  registerSetters(setters: {[key: string]: SetterFn}): void { _mergeMaps(this._setters, setters); }
 
-  registerMethods(methods: StringMap<string, MethodFn>): void {
-    _mergeMaps(this._methods, methods);
-  }
+  registerMethods(methods: {[key: string]: MethodFn}): void { _mergeMaps(this._methods, methods); }
 
   factory(type: Type): Function {
     if (this._containsReflectionInfo(type)) {
@@ -100,7 +93,7 @@ export class Reflector {
     }
   }
 
-  propMetadata(typeOrFunc: /*Type*/ any): StringMap<string, any[]> {
+  propMetadata(typeOrFunc: /*Type*/ any): {[key: string]: any[]} {
     if (this._injectableInfo.has(typeOrFunc)) {
       var res = this._getReflectionInfo(typeOrFunc).propMetadata;
       return isPresent(res) ? res : {};
@@ -154,6 +147,6 @@ export class Reflector {
   importUri(type: Type): string { return this.reflectionCapabilities.importUri(type); }
 }
 
-function _mergeMaps(target: Map<any, any>, config: StringMap<string, Function>): void {
+function _mergeMaps(target: Map<any, any>, config: {[key: string]: Function}): void {
   StringMapWrapper.forEach(config, (v, k) => target.set(k, v));
 }

--- a/modules/angular2/src/core/render/dom/events/key_events.ts
+++ b/modules/angular2/src/core/render/dom/events/key_events.ts
@@ -12,7 +12,7 @@ import {NgZone} from 'angular2/src/core/zone/ng_zone';
 import {Injectable} from 'angular2/src/core/di';
 
 var modifierKeys = ['alt', 'control', 'meta', 'shift'];
-var modifierKeyGetters: StringMap<string, Function> = {
+var modifierKeyGetters: {[key: string]: Function} = {
   'alt': (event) => event.altKey,
   'control': (event) => event.ctrlKey,
   'meta': (event) => event.metaKey,
@@ -38,7 +38,7 @@ export class KeyEventsPlugin extends EventManagerPlugin {
     });
   }
 
-  static parseEventName(eventName: string): StringMap<string, string> {
+  static parseEventName(eventName: string): {[key: string]: string} {
     var parts = eventName.toLowerCase().split('.');
 
     var domEventName = ListWrapper.removeAt(parts, 0);

--- a/modules/angular2/src/core/zone/ng_zone.ts
+++ b/modules/angular2/src/core/zone/ng_zone.ts
@@ -251,7 +251,7 @@ export class NgZone {
     var errorHandling;
 
     if (enableLongStackTrace) {
-      errorHandling = StringMapWrapper.merge(Zone.longStackTraceZone,
+      errorHandling = StringMapWrapper.merge(<any>Zone.longStackTraceZone,
                                              {onError: function(e) { ngZone._onError(this, e); }});
     } else {
       errorHandling = {onError: function(e) { ngZone._onError(this, e); }};

--- a/modules/angular2/src/http/enums.ts
+++ b/modules/angular2/src/http/enums.ts
@@ -1,4 +1,4 @@
-import {StringMap, StringMapWrapper} from 'angular2/src/core/facade/collection';
+import {StringMapWrapper} from 'angular2/src/core/facade/collection';
 
 /**
  * Supported http methods.

--- a/modules/angular2/src/http/headers.ts
+++ b/modules/angular2/src/http/headers.ts
@@ -44,7 +44,7 @@ export class Headers {
     if (headers instanceof Headers) {
       this._headersMap = (<Headers>headers)._headersMap;
     } else /*if (headers instanceof StringMap)*/ {
-      this._headersMap = MapWrapper.createFromStringMap<string[]>(headers);
+      this._headersMap = MapWrapper.createFromStringMap<string[]>(<{[key: string]: any}>headers);
       MapWrapper.forEach(this._headersMap, (v, k) => {
         if (!isListLikeIterable(v)) {
           var list = [];

--- a/modules/angular2/src/http/headers.ts
+++ b/modules/angular2/src/http/headers.ts
@@ -5,7 +5,6 @@ import {
   Map,
   MapWrapper,
   ListWrapper,
-  StringMap
 } from 'angular2/src/core/facade/collection';
 
 /**
@@ -36,7 +35,7 @@ import {
  */
 export class Headers {
   _headersMap: Map<string, string[]>;
-  constructor(headers?: Headers | StringMap<string, any>) {
+  constructor(headers?: Headers | {[key: string]: any}) {
     if (isBlank(headers)) {
       this._headersMap = new Map<string, string[]>();
       return;
@@ -44,7 +43,7 @@ export class Headers {
 
     if (headers instanceof Headers) {
       this._headersMap = (<Headers>headers)._headersMap;
-    } else if (headers instanceof StringMap) {
+    } else /*if (headers instanceof StringMap)*/ {
       this._headersMap = MapWrapper.createFromStringMap<string[]>(headers);
       MapWrapper.forEach(this._headersMap, (v, k) => {
         if (!isListLikeIterable(v)) {

--- a/modules/angular2/src/router/instruction.ts
+++ b/modules/angular2/src/router/instruction.ts
@@ -1,10 +1,4 @@
-import {
-  Map,
-  MapWrapper,
-  StringMap,
-  StringMapWrapper,
-  ListWrapper
-} from 'angular2/src/core/facade/collection';
+import {Map, MapWrapper, StringMapWrapper, ListWrapper} from 'angular2/src/core/facade/collection';
 import {isPresent, isBlank, normalizeBlank, Type} from 'angular2/src/core/facade/lang';
 import {Promise} from 'angular2/src/core/facade/async';
 
@@ -43,7 +37,7 @@ import {Url} from './url_parser';
  * ```
  */
 export class RouteParams {
-  constructor(public params: StringMap<string, string>) {}
+  constructor(public params: {[key: string]: string}) {}
 
   get(param: string): string { return normalizeBlank(StringMapWrapper.get(this.params, param)); }
 }
@@ -78,7 +72,7 @@ export class RouteParams {
  */
 export class Instruction {
   constructor(public component: ComponentInstruction, public child: Instruction,
-              public auxInstruction: StringMap<string, Instruction>) {}
+              public auxInstruction: {[key: string]: Instruction}) {}
 
   /**
    * Returns a new instruction that shares the state of the existing instruction, but with
@@ -153,7 +147,7 @@ export class ComponentInstruction {
    * @private
    */
   constructor(public urlPath: string, public urlParams: string[],
-              private _recognizer: PathRecognizer, public params: StringMap<string, any> = null) {}
+              private _recognizer: PathRecognizer, public params: {[key: string]: any} = null) {}
 
   /**
    * Returns the component type of the represented route, or `null` if this instruction

--- a/modules/angular2/src/router/path_recognizer.ts
+++ b/modules/angular2/src/router/path_recognizer.ts
@@ -8,23 +8,17 @@ import {
 } from 'angular2/src/core/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 
-import {
-  Map,
-  MapWrapper,
-  StringMap,
-  StringMapWrapper,
-  ListWrapper
-} from 'angular2/src/core/facade/collection';
+import {Map, MapWrapper, StringMapWrapper, ListWrapper} from 'angular2/src/core/facade/collection';
 
 import {RouteHandler} from './route_handler';
 import {Url, RootUrl, serializeParams} from './url_parser';
 import {ComponentInstruction} from './instruction';
 
 class TouchMap {
-  map: StringMap<string, string> = {};
-  keys: StringMap<string, boolean> = {};
+  map: {[key: string]: string} = {};
+  keys: {[key: string]: boolean} = {};
 
-  constructor(map: StringMap<string, any>) {
+  constructor(map: {[key: string]: any}) {
     if (isPresent(map)) {
       StringMapWrapper.forEach(map, (value, key) => {
         this.map[key] = isPresent(value) ? value.toString() : null;
@@ -38,8 +32,8 @@ class TouchMap {
     return this.map[key];
   }
 
-  getUnused(): StringMap<string, any> {
-    var unused: StringMap<string, any> = StringMapWrapper.create();
+  getUnused(): {[key: string]: any} {
+    var unused: {[key: string]: any} = StringMapWrapper.create();
     var keys = StringMapWrapper.keys(this.keys);
     ListWrapper.forEach(keys, (key) => { unused[key] = StringMapWrapper.get(this.map, key); });
     return unused;
@@ -96,7 +90,7 @@ class StarSegment implements Segment {
 var paramMatcher = /^:([^\/]+)$/g;
 var wildcardMatcher = /^\*([^\/]+)$/g;
 
-function parsePathString(route: string): StringMap<string, any> {
+function parsePathString(route: string): {[key: string]: any} {
   // normalize route as not starting with a "/". Recognition will
   // also normalize.
   if (StringWrapper.startsWith(route, "/")) {
@@ -278,7 +272,7 @@ export class PathRecognizer {
   }
 
 
-  generate(params: StringMap<string, any>): ComponentInstruction {
+  generate(params: {[key: string]: any}): ComponentInstruction {
     var paramTokens = new TouchMap(params);
 
     var path = [];
@@ -298,7 +292,7 @@ export class PathRecognizer {
   }
 
   private _getInstruction(urlPath: string, urlParams: string[], _recognizer: PathRecognizer,
-                          params: StringMap<string, any>): ComponentInstruction {
+                          params: {[key: string]: any}): ComponentInstruction {
     var hashKey = urlPath + '?' + urlParams.join('?');
     if (this._cache.has(hashKey)) {
       return this._cache.get(hashKey);

--- a/modules/angular2/src/router/route_recognizer.ts
+++ b/modules/angular2/src/router/route_recognizer.ts
@@ -9,13 +9,7 @@ import {
   Type
 } from 'angular2/src/core/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
-import {
-  Map,
-  MapWrapper,
-  ListWrapper,
-  StringMap,
-  StringMapWrapper
-} from 'angular2/src/core/facade/collection';
+import {Map, MapWrapper, ListWrapper, StringMapWrapper} from 'angular2/src/core/facade/collection';
 
 import {PathRecognizer, PathMatch} from './path_recognizer';
 import {Route, AsyncRoute, AuxRoute, Redirect, RouteDefinition} from './route_config_impl';

--- a/modules/angular2/src/router/route_registry.ts
+++ b/modules/angular2/src/router/route_registry.ts
@@ -1,13 +1,7 @@
 import {PathMatch} from './path_recognizer';
 import {RouteRecognizer} from './route_recognizer';
 import {Instruction, ComponentInstruction, PrimaryInstruction} from './instruction';
-import {
-  ListWrapper,
-  Map,
-  MapWrapper,
-  StringMap,
-  StringMapWrapper
-} from 'angular2/src/core/facade/collection';
+import {ListWrapper, Map, MapWrapper, StringMapWrapper} from 'angular2/src/core/facade/collection';
 import {Promise, PromiseWrapper} from 'angular2/src/core/facade/async';
 import {
   isPresent,

--- a/modules/angular2/src/router/route_registry.ts
+++ b/modules/angular2/src/router/route_registry.ts
@@ -155,7 +155,7 @@ export class RouteRegistry {
     }
 
     var componentRecognizer = this._rules.get(parentComponent);
-    var auxInstructions = {};
+    var auxInstructions: {[key: string]: Instruction} = {};
 
     var promises = instruction.auxUrls.map((auxSegment: Url) => {
       var match = componentRecognizer.recognizeAuxiliary(auxSegment);

--- a/modules/angular2/src/router/router_link.ts
+++ b/modules/angular2/src/router/router_link.ts
@@ -1,5 +1,5 @@
 import {Directive} from '../core/metadata';
-import {StringMap, StringMapWrapper} from 'angular2/src/core/facade/collection';
+import {StringMapWrapper} from 'angular2/src/core/facade/collection';
 
 import {Router} from './router';
 import {Location} from './location';

--- a/modules/angular2/src/router/url_parser.ts
+++ b/modules/angular2/src/router/url_parser.ts
@@ -1,4 +1,4 @@
-import {StringMap, StringMapWrapper} from 'angular2/src/core/facade/collection';
+import {StringMapWrapper} from 'angular2/src/core/facade/collection';
 import {
   isPresent,
   isBlank,
@@ -14,7 +14,7 @@ import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptio
 export class Url {
   constructor(public path: string, public child: Url = null,
               public auxiliary: Url[] = CONST_EXPR([]),
-              public params: StringMap<string, any> = null) {}
+              public params: {[key: string]: any} = null) {}
 
   toString(): string {
     return this.path + this._matrixParamsToString() + this._auxToString() + this._childString();
@@ -41,7 +41,7 @@ export class Url {
 
 export class RootUrl extends Url {
   constructor(path: string, child: Url = null, auxiliary: Url[] = CONST_EXPR([]),
-              params: StringMap<string, any> = null) {
+              params: {[key: string]: any} = null) {
     super(path, child, auxiliary, params);
   }
 
@@ -149,7 +149,7 @@ export class UrlParser {
     return new Url(path, child, aux, matrixParams);
   }
 
-  parseQueryParams(): StringMap<string, any> {
+  parseQueryParams(): {[key: string]: any} {
     var params = {};
     this.capture('?');
     this.parseParam(params);
@@ -160,7 +160,7 @@ export class UrlParser {
     return params;
   }
 
-  parseMatrixParams(): StringMap<string, any> {
+  parseMatrixParams(): {[key: string]: any} {
     var params = {};
     while (this._remaining.length > 0 && this.peekStartsWith(';')) {
       this.capture(';');
@@ -169,7 +169,7 @@ export class UrlParser {
     return params;
   }
 
-  parseParam(params: StringMap<string, any>): void {
+  parseParam(params: {[key: string]: any}): void {
     var key = matchUrlSegment(this._remaining);
     if (isBlank(key)) {
       return;
@@ -206,7 +206,7 @@ export class UrlParser {
 
 export var parser = new UrlParser();
 
-export function serializeParams(paramMap: StringMap<string, any>): string[] {
+export function serializeParams(paramMap: {[key: string]: any}): string[] {
   var params = [];
   if (isPresent(paramMap)) {
     StringMapWrapper.forEach(paramMap, (value, key) => {

--- a/modules/angular2/src/web_workers/shared/client_message_broker.ts
+++ b/modules/angular2/src/web_workers/shared/client_message_broker.ts
@@ -41,7 +41,7 @@ export class ClientMessageBroker {
     this._sink = messageBus.to(channel);
     var source = messageBus.from(channel);
     ObservableWrapper.subscribe(source,
-                                (message: StringMap<string, any>) => this._handleMessage(message));
+                                (message: {[key: string]: any}) => this._handleMessage(message));
   }
 
   private _generateMessageId(name: string): string {
@@ -99,7 +99,7 @@ export class ClientMessageBroker {
     return promise;
   }
 
-  private _handleMessage(message: StringMap<string, any>): void {
+  private _handleMessage(message: {[key: string]: any}): void {
     var data = new MessageData(message);
     // TODO(jteplitz602): replace these strings with messaging constants #3685
     if (StringWrapper.equals(data.type, "result") || StringWrapper.equals(data.type, "error")) {
@@ -121,7 +121,7 @@ class MessageData {
   value: any;
   id: string;
 
-  constructor(data: StringMap<string, any>) {
+  constructor(data: {[key: string]: any}) {
     this.type = StringMapWrapper.get(data, "type");
     this.id = this._getValueIfPresent(data, "id");
     this.value = this._getValueIfPresent(data, "value");
@@ -130,7 +130,7 @@ class MessageData {
   /**
    * Returns the value from the StringMap if present. Otherwise returns null
    */
-  _getValueIfPresent(data: StringMap<string, any>, key: string) {
+  _getValueIfPresent(data: {[key: string]: any}, key: string) {
     if (StringMapWrapper.contains(data, key)) {
       return StringMapWrapper.get(data, key);
     } else {

--- a/modules/angular2/src/web_workers/shared/post_message_bus.ts
+++ b/modules/angular2/src/web_workers/shared/post_message_bus.ts
@@ -5,7 +5,7 @@ import {
 } from "angular2/src/web_workers/shared/message_bus";
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 import {EventEmitter} from 'angular2/src/core/facade/async';
-import {StringMap, StringMapWrapper} from 'angular2/src/core/facade/collection';
+import {StringMapWrapper} from 'angular2/src/core/facade/collection';
 import {Injectable} from "angular2/src/core/di";
 import {NgZone} from 'angular2/src/core/zone/ng_zone';
 
@@ -34,7 +34,7 @@ export class PostMessageBus implements MessageBus {
 
 export class PostMessageBusSink implements MessageBusSink {
   private _zone: NgZone;
-  private _channels: StringMap<string, _Channel> = StringMapWrapper.create();
+  private _channels: {[key: string]: _Channel} = StringMapWrapper.create();
   private _messageBuffer: Array<Object> = [];
 
   constructor(private _postMessageTarget: PostMessageTarget) {}
@@ -83,7 +83,7 @@ export class PostMessageBusSink implements MessageBusSink {
 
 export class PostMessageBusSource implements MessageBusSource {
   private _zone: NgZone;
-  private _channels: StringMap<string, _Channel> = StringMapWrapper.create();
+  private _channels: {[key: string]: _Channel} = StringMapWrapper.create();
 
   constructor(eventTarget?: EventTarget) {
     if (eventTarget) {

--- a/modules/angular2/src/web_workers/shared/render_view_with_fragments_store.ts
+++ b/modules/angular2/src/web_workers/shared/render_view_with_fragments_store.ts
@@ -112,7 +112,7 @@ export class RenderViewWithFragmentsStore {
     }
   }
 
-  serializeViewWithFragments(view: RenderViewWithFragments): StringMap<string, any> {
+  serializeViewWithFragments(view: RenderViewWithFragments): {[key: string]: any} {
     if (view == null) {
       return null;
     }
@@ -130,7 +130,7 @@ export class RenderViewWithFragmentsStore {
     }
   }
 
-  deserializeViewWithFragments(obj: StringMap<string, any>): RenderViewWithFragments {
+  deserializeViewWithFragments(obj: {[key: string]: any}): RenderViewWithFragments {
     if (obj == null) {
       return null;
     }

--- a/modules/angular2/src/web_workers/shared/serializer.ts
+++ b/modules/angular2/src/web_workers/shared/serializer.ts
@@ -7,13 +7,7 @@ import {
 } from "angular2/src/core/facade/lang";
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 
-import {
-  ListWrapper,
-  Map,
-  StringMap,
-  StringMapWrapper,
-  MapWrapper
-} from "angular2/src/core/facade/collection";
+import {ListWrapper, Map, StringMapWrapper, MapWrapper} from "angular2/src/core/facade/collection";
 import {
   RenderProtoViewRef,
   RenderViewRef,
@@ -144,7 +138,7 @@ export class Serializer {
    * If the values need to be deserialized pass in their type
    * and they will be deserialized before being placed in the map
    */
-  objectToMap(obj: StringMap<string, any>, type?: Type, data?: any): Map<string, any> {
+  objectToMap(obj: {[key: string]: any}, type?: Type, data?: any): Map<string, any> {
     if (isPresent(type)) {
       var map = new Map<string, any>();
       StringMapWrapper.forEach(obj,
@@ -157,14 +151,14 @@ export class Serializer {
 
   allocateRenderViews(fragmentCount: number) { this._renderViewStore.allocate(fragmentCount); }
 
-  private _serializeWorkerElementRef(elementRef: RenderElementRef): StringMap<string, any> {
+  private _serializeWorkerElementRef(elementRef: RenderElementRef): {[key: string]: any} {
     return {
       'renderView': this.serialize(elementRef.renderView, RenderViewRef),
       'boundElementIndex': elementRef.boundElementIndex
     };
   }
 
-  private _deserializeWorkerElementRef(map: StringMap<string, any>): RenderElementRef {
+  private _deserializeWorkerElementRef(map: {[key: string]: any}): RenderElementRef {
     return new WebWorkerElementRef(this.deserialize(map['renderView'], RenderViewRef),
                                    map['boundElementIndex']);
   }
@@ -174,7 +168,7 @@ function serializeTemplateCmd(cmd: RenderTemplateCmd): Object {
   return cmd.visit(RENDER_TEMPLATE_CMD_SERIALIZER, null);
 }
 
-function deserializeTemplateCmd(data: StringMap<string, any>): RenderTemplateCmd {
+function deserializeTemplateCmd(data: {[key: string]: any}): RenderTemplateCmd {
   return RENDER_TEMPLATE_CMD_DESERIALIZERS[data['deserializerIndex']](data);
 }
 
@@ -232,18 +226,18 @@ class RenderTemplateCmdSerializer implements RenderCommandVisitor {
 var RENDER_TEMPLATE_CMD_SERIALIZER = new RenderTemplateCmdSerializer();
 
 var RENDER_TEMPLATE_CMD_DESERIALIZERS = [
-  (data: StringMap<string, any>) =>
+  (data: {[key: string]: any}) =>
       new WebWorkerTextCmd(data['isBound'], data['ngContentIndex'], data['value']),
-  (data: StringMap<string, any>) => new WebWorkerNgContentCmd(data['ngContentIndex']),
-  (data: StringMap<string, any>) =>
+  (data: {[key: string]: any}) => new WebWorkerNgContentCmd(data['ngContentIndex']),
+  (data: {[key: string]: any}) =>
       new WebWorkerBeginElementCmd(data['isBound'], data['ngContentIndex'], data['name'],
                                    data['attrNameAndValues'], data['eventTargetAndNames']),
-  (data: StringMap<string, any>) => new WebWorkerEndElementCmd(),
-  (data: StringMap<string, any>) => new WebWorkerBeginComponentCmd(
+  (data: {[key: string]: any}) => new WebWorkerEndElementCmd(),
+  (data: {[key: string]: any}) => new WebWorkerBeginComponentCmd(
       data['isBound'], data['ngContentIndex'], data['name'], data['attrNameAndValues'],
       data['eventTargetAndNames'], data['nativeShadow'], data['templateId']),
-  (data: StringMap<string, any>) => new WebWorkerEndComponentCmd(),
-  (data: StringMap<string, any>) => new WebWorkerEmbeddedTemplateCmd(
+  (data: {[key: string]: any}) => new WebWorkerEndComponentCmd(),
+  (data: {[key: string]: any}) => new WebWorkerEmbeddedTemplateCmd(
       data['isBound'], data['ngContentIndex'], data['name'], data['attrNameAndValues'],
       data['eventTargetAndNames'], data['isMerged'],
       (<any[]>data['children']).map(childData => deserializeTemplateCmd(childData))),

--- a/modules/angular2/src/web_workers/shared/service_message_broker.ts
+++ b/modules/angular2/src/web_workers/shared/service_message_broker.ts
@@ -61,7 +61,7 @@ export class ServiceMessageBroker {
     });
   }
 
-  private _handleMessage(map: StringMap<string, any>): void {
+  private _handleMessage(map: {[key: string]: any}): void {
     var message = new ReceivedMessage(map);
     if (this._methods.has(message.method)) {
       this._methods.get(message.method)(message);
@@ -83,7 +83,7 @@ export class ReceivedMessage {
   id: string;
   type: string;
 
-  constructor(data: StringMap<string, any>) {
+  constructor(data: {[key: string]: any}) {
     this.method = data['method'];
     this.args = data['args'];
     this.id = data['id'];

--- a/modules/angular2/src/web_workers/ui/event_serializer.ts
+++ b/modules/angular2/src/web_workers/ui/event_serializer.ts
@@ -1,4 +1,4 @@
-import {StringMap, Set} from 'angular2/src/core/facade/collection';
+import {Set} from 'angular2/src/core/facade/collection';
 import {isPresent} from 'angular2/src/core/facade/lang';
 
 const MOUSE_EVENT_PROPERTIES = [
@@ -37,28 +37,28 @@ const EVENT_PROPERTIES = ['type', 'bubbles', 'cancelable'];
 const NODES_WITH_VALUE =
     new Set(["input", "select", "option", "button", "li", "meter", "progress", "param"]);
 
-export function serializeGenericEvent(e: Event): StringMap<string, any> {
+export function serializeGenericEvent(e: Event): {[key: string]: any} {
   return serializeEvent(e, EVENT_PROPERTIES);
 }
 
 // TODO(jteplitz602): Allow users to specify the properties they need rather than always
 // adding value and files #3374
-export function serializeEventWithTarget(e: Event): StringMap<string, any> {
+export function serializeEventWithTarget(e: Event): {[key: string]: any} {
   var serializedEvent = serializeEvent(e, EVENT_PROPERTIES);
   return addTarget(e, serializedEvent);
 }
 
-export function serializeMouseEvent(e: MouseEvent): StringMap<string, any> {
+export function serializeMouseEvent(e: MouseEvent): {[key: string]: any} {
   return serializeEvent(e, MOUSE_EVENT_PROPERTIES);
 }
 
-export function serializeKeyboardEvent(e: KeyboardEvent): StringMap<string, any> {
+export function serializeKeyboardEvent(e: KeyboardEvent): {[key: string]: any} {
   var serializedEvent = serializeEvent(e, KEYBOARD_EVENT_PROPERTIES);
   return addTarget(e, serializedEvent);
 }
 
 // TODO(jteplitz602): #3374. See above.
-function addTarget(e: Event, serializedEvent: StringMap<string, any>): StringMap<string, any> {
+function addTarget(e: Event, serializedEvent: {[key: string]: any}): {[key: string]: any} {
   if (NODES_WITH_VALUE.has((<HTMLElement>e.target).tagName.toLowerCase())) {
     var target = <HTMLInputElement>e.target;
     serializedEvent['target'] = {'value': target.value};
@@ -69,7 +69,7 @@ function addTarget(e: Event, serializedEvent: StringMap<string, any>): StringMap
   return serializedEvent;
 }
 
-function serializeEvent(e: any, properties: string[]): StringMap<string, any> {
+function serializeEvent(e: any, properties: string[]): {[key: string]: any} {
   var serialized = {};
   for (var i = 0; i < properties.length; i++) {
     var prop = properties[i];

--- a/modules/angular2/src/web_workers/worker/application_common.ts
+++ b/modules/angular2/src/web_workers/worker/application_common.ts
@@ -84,7 +84,7 @@ class PrintLogger {
   logGroupEnd() {}
 }
 
-function webWorkerBindings(appComponentType, bus: MessageBus, initData: StringMap<string, any>):
+function webWorkerBindings(appComponentType, bus: MessageBus, initData: {[key: string]: any}):
     Array<Type | Binding | any[]> {
   return [
     compilerBindings(),
@@ -118,7 +118,7 @@ export function bootstrapWebWorkerCommon(appComponentType: Type, bus: MessageBus
 
     var subscription: any;
     var emitter = bus.from(SETUP_CHANNEL);
-    subscription = ObservableWrapper.subscribe(emitter, (message: StringMap<string, any>) => {
+    subscription = ObservableWrapper.subscribe(emitter, (message: {[key: string]: any}) => {
       var bindings =
           [applicationCommonBindings(), webWorkerBindings(appComponentType, bus, message)];
       if (isPresent(appBindings)) {

--- a/modules/angular2/src/web_workers/worker/event_deserializer.ts
+++ b/modules/angular2/src/web_workers/worker/event_deserializer.ts
@@ -1,8 +1,6 @@
-import {StringMap} from "angular2/src/core/facade/collection";
-
 // no deserialization is necessary in TS.
 // This is only here to match dart interface
-export function deserializeGenericEvent(serializedEvent: StringMap<string, any>):
-    StringMap<string, any> {
+export function deserializeGenericEvent(serializedEvent: {[key: string]: any}):
+    {[key: string]: any} {
   return serializedEvent;
 }

--- a/modules/angular2/src/web_workers/worker/event_dispatcher.ts
+++ b/modules/angular2/src/web_workers/worker/event_dispatcher.ts
@@ -38,7 +38,7 @@ class RenderEventData {
   eventName: string;
   locals: Map<string, any>;
 
-  constructor(message: StringMap<string, any>, serializer: Serializer) {
+  constructor(message: {[key: string]: any}, serializer: Serializer) {
     this.viewRef = serializer.deserialize(message['viewRef'], RenderViewRef);
     this.elementIndex = message['elementIndex'];
     this.eventName = message['eventName'];

--- a/modules/angular2/test/core/change_detection/change_detector_config.ts
+++ b/modules/angular2/test/core/change_detection/change_detector_config.ts
@@ -176,7 +176,7 @@ class _ExpressionWithLocals {
    * Map from test id to _ExpressionWithLocals.
    * Tests in this map define an expression and local values which those expressions refer to.
    */
-  static availableDefinitions: StringMap<string, _ExpressionWithLocals> = {
+  static availableDefinitions: {[key: string]: _ExpressionWithLocals} = {
     'valueFromLocals': new _ExpressionWithLocals(
         'key', new Locals(null, MapWrapper.createFromPairs([['key', 'value']]))),
     'functionFromLocals': new _ExpressionWithLocals(
@@ -241,7 +241,7 @@ class _ExpressionWithMode {
    * Map from test id to _ExpressionWithMode.
    * Definitions in this map define conditions which allow testing various change detector modes.
    */
-  static availableDefinitions: StringMap<string, _ExpressionWithMode> = {
+  static availableDefinitions: {[key: string]: _ExpressionWithMode} = {
     'emptyUsingDefaultStrategy':
         new _ExpressionWithMode(ChangeDetectionStrategy.Default, false, false),
     'emptyUsingOnPushStrategy':
@@ -316,7 +316,7 @@ class _DirectiveUpdating {
    * Definitions in this map define definitions which allow testing directive updating.
    */
   static availableDefinitions:
-      StringMap<string, _DirectiveUpdating> = {
+      {[key: string]: _DirectiveUpdating} = {
         'directNoDispatcher': new _DirectiveUpdating(
             [_DirectiveUpdating.updateA('42', _DirectiveUpdating.basicRecords[0])],
             [_DirectiveUpdating.basicRecords[0]]),

--- a/modules/angular2/test/core/compiler/runtime_metadata_spec.ts
+++ b/modules/angular2/test/core/compiler/runtime_metadata_spec.ts
@@ -117,7 +117,7 @@ class DirectiveWithoutModuleId {
 class ComponentWithEverything implements OnChanges,
     OnInit, DoCheck, OnDestroy, AfterContentInit, AfterContentChecked, AfterViewInit,
     AfterViewChecked {
-  onChanges(changes: StringMap<string, SimpleChange>): void {}
+  onChanges(changes: {[key: string]: SimpleChange}): void {}
   onInit(): void {}
   doCheck(): void {}
   onDestroy(): void {}

--- a/modules/angular2/test/core/compiler/schema_registry_mock.ts
+++ b/modules/angular2/test/core/compiler/schema_registry_mock.ts
@@ -1,10 +1,9 @@
 import {ElementSchemaRegistry} from 'angular2/src/core/compiler/schema/element_schema_registry';
-import {StringMap} from 'angular2/src/core/facade/collection';
 import {isPresent} from 'angular2/src/core/facade/lang';
 
 export class MockSchemaRegistry implements ElementSchemaRegistry {
-  constructor(public existingProperties: StringMap<string, boolean>,
-              public attrPropMapping: StringMap<string, string>) {}
+  constructor(public existingProperties: {[key: string]: boolean},
+              public attrPropMapping: {[key: string]: string}) {}
   hasProperty(tagName: string, property: string): boolean {
     var result = this.existingProperties[property];
     return isPresent(result) ? result : true;

--- a/modules/angular2/test/core/compiler/template_compiler_spec.ts
+++ b/modules/angular2/test/core/compiler/template_compiler_spec.ts
@@ -325,10 +325,10 @@ function testableStylesModule(sourceModule: SourceModule): SourceModule {
 
 // Attention: read by eval!
 export function humanizeTemplate(template: CompiledTemplate,
-                                 humanizedTemplates: Map<number, StringMap<string, any>> = null):
-    StringMap<string, any> {
+                                 humanizedTemplates: Map<number, {[key: string]: any}> = null):
+    {[key: string]: any} {
   if (isBlank(humanizedTemplates)) {
-    humanizedTemplates = new Map<number, StringMap<string, any>>();
+    humanizedTemplates = new Map<number, {[key: string]: any}>();
   }
   var result = humanizedTemplates.get(template.id);
   if (isPresent(result)) {
@@ -369,7 +369,7 @@ function testChangeDetector(changeDetectorFactory: Function): string[] {
 
 class CommandHumanizer implements CommandVisitor {
   constructor(private result: any[],
-              private humanizedTemplates: Map<number, StringMap<string, any>>) {}
+              private humanizedTemplates: Map<number, {[key: string]: any}>) {}
   visitText(cmd: TextCmd, context: any): any {
     this.result.push(`#text(${cmd.value})`);
     return null;

--- a/modules/angular2/test/core/facade/collection_spec.ts
+++ b/modules/angular2/test/core/facade/collection_spec.ts
@@ -109,33 +109,33 @@ export function main() {
          () => { expect(StringMapWrapper.equals({}, {})).toBe(true); });
 
       it('should return true when comparing the same map', () => {
-        var m1 = {'a': 1, 'b': 2, 'c': 3};
+        var m1: {[key: string]: number} = {'a': 1, 'b': 2, 'c': 3};
         expect(StringMapWrapper.equals(m1, m1)).toBe(true);
       });
 
       it('should return true when comparing different maps with the same keys and values', () => {
-        var m1 = {'a': 1, 'b': 2, 'c': 3};
-        var m2 = {'a': 1, 'b': 2, 'c': 3};
+        var m1: {[key: string]: number} = {'a': 1, 'b': 2, 'c': 3};
+        var m2: {[key: string]: number} = {'a': 1, 'b': 2, 'c': 3};
         expect(StringMapWrapper.equals(m1, m2)).toBe(true);
       });
 
       it('should return false when comparing maps with different numbers of keys', () => {
-        var m1 = {'a': 1, 'b': 2, 'c': 3};
-        var m2 = {'a': 1, 'b': 2, 'c': 3, 'd': 4};
+        var m1: {[key: string]: number} = {'a': 1, 'b': 2, 'c': 3};
+        var m2: {[key: string]: number} = {'a': 1, 'b': 2, 'c': 3, 'd': 4};
         expect(StringMapWrapper.equals(m1, m2)).toBe(false);
         expect(StringMapWrapper.equals(m2, m1)).toBe(false);
       });
 
       it('should return false when comparing maps with different keys', () => {
-        var m1 = {'a': 1, 'b': 2, 'c': 3};
-        var m2 = {'a': 1, 'b': 2, 'CC': 3};
+        var m1: {[key: string]: number} = {'a': 1, 'b': 2, 'c': 3};
+        var m2: {[key: string]: number} = {'a': 1, 'b': 2, 'CC': 3};
         expect(StringMapWrapper.equals(m1, m2)).toBe(false);
         expect(StringMapWrapper.equals(m2, m1)).toBe(false);
       });
 
       it('should return false when comparing maps with different values', () => {
-        var m1 = {'a': 1, 'b': 2, 'c': 3};
-        var m2 = {'a': 1, 'b': 20, 'c': 3};
+        var m1: {[key: string]: number} = {'a': 1, 'b': 2, 'c': 3};
+        var m2: {[key: string]: number} = {'a': 1, 'b': 20, 'c': 3};
         expect(StringMapWrapper.equals(m1, m2)).toBe(false);
         expect(StringMapWrapper.equals(m2, m1)).toBe(false);
       });

--- a/modules/angular2/test/core/facade/collection_spec.ts
+++ b/modules/angular2/test/core/facade/collection_spec.ts
@@ -1,11 +1,6 @@
 import {describe, it, expect, beforeEach, ddescribe, iit, xit} from 'angular2/test_lib';
 
-import {
-  ListWrapper,
-  StringMap,
-  StringMapWrapper,
-  MapWrapper
-} from 'angular2/src/core/facade/collection';
+import {ListWrapper, StringMapWrapper, MapWrapper} from 'angular2/src/core/facade/collection';
 
 export function main() {
   describe('ListWrapper', () => {

--- a/modules/angular2/test/router/route_recognizer_spec.ts
+++ b/modules/angular2/test/router/route_recognizer_spec.ts
@@ -10,7 +10,7 @@ import {
   SpyObject
 } from 'angular2/test_lib';
 
-import {Map, StringMap, StringMapWrapper} from 'angular2/src/core/facade/collection';
+import {Map, StringMapWrapper} from 'angular2/src/core/facade/collection';
 
 import {RouteRecognizer} from 'angular2/src/router/route_recognizer';
 import {ComponentInstruction} from 'angular2/src/router/instruction';

--- a/modules/angular2/test/test_lib/utils_spec.ts
+++ b/modules/angular2/test/test_lib/utils_spec.ts
@@ -187,7 +187,7 @@ export function main() {
       }
     ];
 
-    browsers.forEach((browser) => {
+    browsers.forEach((browser: {[key: string]: any}) => {
       it(`should detect ${StringMapWrapper.get(browser, 'name')}`, () => {
         var bd = new BrowserDetection(<string>StringMapWrapper.get(browser, 'ua'));
         expect(bd.isFirefox).toBe(StringMapWrapper.get(browser, 'isFirefox'));

--- a/modules/angular2/test/web_workers/shared/web_worker_test_util.ts
+++ b/modules/angular2/test/web_workers/shared/web_worker_test_util.ts
@@ -1,4 +1,4 @@
-import {StringMap, StringMapWrapper, ListWrapper} from 'angular2/src/core/facade/collection';
+import {StringMapWrapper, ListWrapper} from 'angular2/src/core/facade/collection';
 import {
   MessageBusSink,
   MessageBusSource,
@@ -13,11 +13,11 @@ import {NgZone} from 'angular2/src/core/zone/ng_zone';
  * Such that whatever goes into one's sink comes out the others source.
  */
 export function createPairedMessageBuses(): PairedMessageBuses {
-  var firstChannels: StringMap<string, MockEventEmitter> = {};
+  var firstChannels: {[key: string]: MockEventEmitter} = {};
   var workerMessageBusSink = new MockMessageBusSink(firstChannels);
   var uiMessageBusSource = new MockMessageBusSource(firstChannels);
 
-  var secondChannels: StringMap<string, MockEventEmitter> = {};
+  var secondChannels: {[key: string]: MockEventEmitter} = {};
   var uiMessageBusSink = new MockMessageBusSink(secondChannels);
   var workerMessageBusSource = new MockMessageBusSource(secondChannels);
 
@@ -30,7 +30,7 @@ export class PairedMessageBuses {
 }
 
 export class MockMessageBusSource implements MessageBusSource {
-  constructor(private _channels: StringMap<string, MockEventEmitter>) {}
+  constructor(private _channels: {[key: string]: MockEventEmitter}) {}
 
   initChannel(channel: string, runInZone = true) {
     if (!StringMapWrapper.contains(this._channels, channel)) {
@@ -49,7 +49,7 @@ export class MockMessageBusSource implements MessageBusSource {
 }
 
 export class MockMessageBusSink implements MessageBusSink {
-  constructor(private _channels: StringMap<string, MockEventEmitter>) {}
+  constructor(private _channels: {[key: string]: MockEventEmitter}) {}
 
   initChannel(channel: string, runInZone = true) {
     if (!StringMapWrapper.contains(this._channels, channel)) {

--- a/modules/benchpress/src/measure_values.ts
+++ b/modules/benchpress/src/measure_values.ts
@@ -1,9 +1,9 @@
 import {Date, DateWrapper} from 'angular2/src/core/facade/lang';
-import {StringMap, Map} from 'angular2/src/core/facade/collection';
+import {Map} from 'angular2/src/core/facade/collection';
 
 export class MeasureValues {
   constructor(public runIndex: number, public timeStamp: Date,
-              public values: StringMap<string, any>) {}
+              public values: {[key: string]: any}) {}
 
   toJson() {
     return {

--- a/modules/benchpress/src/metric.ts
+++ b/modules/benchpress/src/metric.ts
@@ -1,7 +1,6 @@
 import {bind, Binding} from 'angular2/src/core/di';
 import {Promise, PromiseWrapper} from 'angular2/src/core/facade/async';
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
-import {StringMap} from 'angular2/src/core/facade/collection';
 
 /**
  * A metric is measures values
@@ -21,11 +20,11 @@ export abstract class Metric {
    * since the begin call.
    * @param restart: Whether to restart right after this.
    */
-  endMeasure(restart: boolean): Promise<StringMap<string, any>> { throw new BaseException('NYI'); }
+  endMeasure(restart: boolean): Promise<{[key: string]: any}> { throw new BaseException('NYI'); }
 
   /**
    * Describes the metrics provided by this metric implementation.
    * (e.g. units, ...)
    */
-  describe(): StringMap<string, any> { throw new BaseException('NYI'); }
+  describe(): {[key: string]: any} { throw new BaseException('NYI'); }
 }

--- a/modules/benchpress/src/metric/multi_metric.ts
+++ b/modules/benchpress/src/metric/multi_metric.ts
@@ -1,5 +1,5 @@
 import {bind, Binding, Injector, OpaqueToken} from 'angular2/src/core/di';
-import {ListWrapper, StringMapWrapper, StringMap} from 'angular2/src/core/facade/collection';
+import {ListWrapper, StringMapWrapper} from 'angular2/src/core/facade/collection';
 import {Promise, PromiseWrapper} from 'angular2/src/core/facade/async';
 
 import {Metric} from '../metric';
@@ -29,7 +29,7 @@ export class MultiMetric extends Metric {
    * since the begin call.
    * @param restart: Whether to restart right after this.
    */
-  endMeasure(restart: boolean): Promise<StringMap<string, any>> {
+  endMeasure(restart: boolean): Promise<{[key: string]: any}> {
     return PromiseWrapper.all(
                              ListWrapper.map(this._metrics, (metric) => metric.endMeasure(restart)))
         .then((values) => { return mergeStringMaps(values); });
@@ -39,7 +39,7 @@ export class MultiMetric extends Metric {
    * Describes the metrics provided by this metric implementation.
    * (e.g. units, ...)
    */
-  describe(): StringMap<string, any> {
+  describe(): {[key: string]: any} {
     return mergeStringMaps(this._metrics.map((metric) => metric.describe()));
   }
 }

--- a/modules/benchpress/src/metric/perflog_metric.ts
+++ b/modules/benchpress/src/metric/perflog_metric.ts
@@ -8,7 +8,7 @@ import {
   NumberWrapper
 } from 'angular2/src/core/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
-import {ListWrapper, StringMap, StringMapWrapper} from 'angular2/src/core/facade/collection';
+import {ListWrapper, StringMapWrapper} from 'angular2/src/core/facade/collection';
 import {bind, Binding, OpaqueToken} from 'angular2/src/core/di';
 
 import {WebDriverExtension, PerfLogFeatures} from '../web_driver_extension';
@@ -24,7 +24,7 @@ export class PerflogMetric extends Metric {
   // TODO(tbosch): use static values when our transpiler supports them
   static get SET_TIMEOUT(): OpaqueToken { return _SET_TIMEOUT; }
 
-  private _remainingEvents: Array<StringMap<string, any>>;
+  private _remainingEvents: Array<{[key: string]: any}>;
   private _measureCount: number;
   _perfLogFeatures: PerfLogFeatures;
 
@@ -35,7 +35,7 @@ export class PerflogMetric extends Metric {
    * @param microMetrics Name and description of metrics provided via console.time / console.timeEnd
    **/
   constructor(private _driverExtension: WebDriverExtension, private _setTimeout: Function,
-              private _microMetrics: StringMap<string, any>, private _forceGc: boolean,
+              private _microMetrics: {[key: string]: any}, private _forceGc: boolean,
               private _captureFrames: boolean) {
     super();
 
@@ -44,7 +44,7 @@ export class PerflogMetric extends Metric {
     this._perfLogFeatures = _driverExtension.perfLogFeatures();
   }
 
-  describe(): StringMap<string, any> {
+  describe(): {[key: string]: any} {
     var res = {
       'scriptTime': 'script execution time in ms, including gc and render',
       'pureScriptTime': 'script execution time in ms, without gc nor render'
@@ -89,7 +89,7 @@ export class PerflogMetric extends Metric {
     return resultPromise.then((_) => this._beginMeasure());
   }
 
-  endMeasure(restart: boolean): Promise<StringMap<string, any>> {
+  endMeasure(restart: boolean): Promise<{[key: string]: any}> {
     if (this._forceGc) {
       return this._endPlainMeasureAndMeasureForceGc(restart);
     } else {
@@ -117,7 +117,7 @@ export class PerflogMetric extends Metric {
     return this._driverExtension.timeBegin(this._markName(this._measureCount++));
   }
 
-  _endMeasure(restart: boolean): Promise<StringMap<string, any>> {
+  _endMeasure(restart: boolean): Promise<{[key: string]: any}> {
     var markName = this._markName(this._measureCount - 1);
     var nextMarkName = restart ? this._markName(this._measureCount++) : null;
     return this._driverExtension.timeEnd(markName, nextMarkName)
@@ -171,7 +171,7 @@ export class PerflogMetric extends Metric {
     }
   }
 
-  _aggregateEvents(events: Array<StringMap<string, any>>, markName): StringMap<string, any> {
+  _aggregateEvents(events: Array<{[key: string]: any}>, markName): {[key: string]: any} {
     var result = {'scriptTime': 0, 'pureScriptTime': 0};
     if (this._perfLogFeatures.gc) {
       result['gcTime'] = 0;
@@ -199,8 +199,8 @@ export class PerflogMetric extends Metric {
     var frameCaptureStartEvent = null;
     var frameCaptureEndEvent = null;
 
-    var intervalStarts: StringMap<string, any> = {};
-    var intervalStartCount: StringMap<string, number> = {};
+    var intervalStarts: {[key: string]: any} = {};
+    var intervalStartCount: {[key: string]: number} = {};
     events.forEach((event) => {
       var ph = event['ph'];
       var name = event['name'];
@@ -307,7 +307,7 @@ export class PerflogMetric extends Metric {
     return result;
   }
 
-  _addFrameMetrics(result: StringMap<string, any>, frameTimes: any[]) {
+  _addFrameMetrics(result: {[key: string]: any}, frameTimes: any[]) {
     result['frameTime.mean'] =
         ListWrapper.reduce(frameTimes, (a, b) => a + b, 0) / frameTimes.length;
     var firstFrame = frameTimes[0];

--- a/modules/benchpress/src/sample_description.ts
+++ b/modules/benchpress/src/sample_description.ts
@@ -1,4 +1,4 @@
-import {StringMapWrapper, ListWrapper, StringMap} from 'angular2/src/core/facade/collection';
+import {StringMapWrapper, ListWrapper} from 'angular2/src/core/facade/collection';
 import {bind, Binding, OpaqueToken} from 'angular2/src/core/di';
 import {Validator} from './validator';
 import {Metric} from './metric';
@@ -10,10 +10,10 @@ import {Options} from './common_options';
 export class SampleDescription {
   // TODO(tbosch): use static values when our transpiler supports them
   static get BINDINGS(): Binding[] { return _BINDINGS; }
-  description: StringMap<string, any>;
+  description: {[key: string]: any};
 
-  constructor(public id: string, descriptions: Array<StringMap<string, any>>,
-              public metrics: StringMap<string, any>) {
+  constructor(public id: string, descriptions: Array<{[key: string]: any}>,
+              public metrics: {[key: string]: any}) {
     this.description = {};
     ListWrapper.forEach(descriptions, (description) => {
       StringMapWrapper.forEach(description, (value, prop) => this.description[prop] = value);

--- a/modules/benchpress/src/sampler.ts
+++ b/modules/benchpress/src/sampler.ts
@@ -1,6 +1,5 @@
 import {isPresent, isBlank, Date, DateWrapper} from 'angular2/src/core/facade/lang';
 import {Promise, PromiseWrapper} from 'angular2/src/core/facade/async';
-import {StringMapWrapper, StringMap, ListWrapper} from 'angular2/src/core/facade/collection';
 import {bind, Binding, OpaqueToken} from 'angular2/src/core/di';
 
 import {Metric} from './metric';
@@ -78,7 +77,7 @@ export class Sampler {
         .then((measureValues) => this._report(lastState, measureValues));
   }
 
-  _report(state: SampleState, metricValues: StringMap<string, any>): Promise<SampleState> {
+  _report(state: SampleState, metricValues: {[key: string]: any}): Promise<SampleState> {
     var measureValues = new MeasureValues(state.completeSample.length, this._now(), metricValues);
     var completeSample = state.completeSample.concat([measureValues]);
     var validSample = this._validator.validate(completeSample);

--- a/modules/benchpress/src/validator.ts
+++ b/modules/benchpress/src/validator.ts
@@ -1,5 +1,4 @@
 import {bind, Binding} from 'angular2/src/core/di';
-import {StringMap} from 'angular2/src/core/facade/collection';
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 
 import {MeasureValues} from './measure_values';
@@ -23,5 +22,5 @@ export abstract class Validator {
    * Returns a Map that describes the properties of the validator
    * (e.g. sample size, ...)
    */
-  describe(): StringMap<string, any> { throw new BaseException('NYI'); }
+  describe(): {[key: string]: any} { throw new BaseException('NYI'); }
 }

--- a/modules/benchpress/src/validator/regression_slope_validator.ts
+++ b/modules/benchpress/src/validator/regression_slope_validator.ts
@@ -1,4 +1,4 @@
-import {ListWrapper, StringMap} from 'angular2/src/core/facade/collection';
+import {ListWrapper} from 'angular2/src/core/facade/collection';
 import {bind, Binding, OpaqueToken} from 'angular2/src/core/di';
 
 import {Validator} from '../validator';
@@ -26,7 +26,7 @@ export class RegressionSlopeValidator extends Validator {
     this._metric = metric;
   }
 
-  describe(): StringMap<string, any> {
+  describe(): {[key: string]: any} {
     return {'sampleSize': this._sampleSize, 'regressionSlopeMetric': this._metric};
   }
 

--- a/modules/benchpress/src/validator/size_validator.ts
+++ b/modules/benchpress/src/validator/size_validator.ts
@@ -1,4 +1,4 @@
-import {ListWrapper, StringMap} from 'angular2/src/core/facade/collection';
+import {ListWrapper} from 'angular2/src/core/facade/collection';
 import {bind, Binding, OpaqueToken} from 'angular2/src/core/di';
 
 import {Validator} from '../validator';
@@ -20,7 +20,7 @@ export class SizeValidator extends Validator {
     this._sampleSize = size;
   }
 
-  describe(): StringMap<string, any> { return {'sampleSize': this._sampleSize}; }
+  describe(): {[key: string]: any} { return {'sampleSize': this._sampleSize}; }
 
   validate(completeSample: MeasureValues[]): MeasureValues[] {
     if (completeSample.length >= this._sampleSize) {

--- a/modules/benchpress/src/web_driver_extension.ts
+++ b/modules/benchpress/src/web_driver_extension.ts
@@ -3,7 +3,7 @@ import {bind, Binding, Injector, OpaqueToken} from 'angular2/src/core/di';
 import {isBlank, isPresent} from 'angular2/src/core/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 import {Promise, PromiseWrapper} from 'angular2/src/core/facade/async';
-import {ListWrapper, StringMap} from 'angular2/src/core/facade/collection';
+import {ListWrapper} from 'angular2/src/core/facade/collection';
 
 import {Options} from './common_options';
 
@@ -61,7 +61,7 @@ export abstract class WebDriverExtension {
 
   perfLogFeatures(): PerfLogFeatures { throw new BaseException('NYI'); }
 
-  supports(capabilities: StringMap<string, any>): boolean { return true; }
+  supports(capabilities: {[key: string]: any}): boolean { return true; }
 }
 
 export class PerfLogFeatures {

--- a/modules/benchpress/src/webdriver/chrome_driver_extension.ts
+++ b/modules/benchpress/src/webdriver/chrome_driver_extension.ts
@@ -1,5 +1,5 @@
 import {bind, Binding} from 'angular2/src/core/di';
-import {ListWrapper, StringMapWrapper, StringMap} from 'angular2/src/core/facade/collection';
+import {ListWrapper, StringMapWrapper} from 'angular2/src/core/facade/collection';
 import {
   Json,
   isPresent,
@@ -84,8 +84,8 @@ export class ChromeDriverExtension extends WebDriverExtension {
         });
   }
 
-  private _convertPerfRecordsToEvents(chromeEvents: Array<StringMap<string, any>>,
-                                      normalizedEvents: Array<StringMap<string, any>> = null) {
+  private _convertPerfRecordsToEvents(chromeEvents: Array<{[key: string]: any}>,
+                                      normalizedEvents: Array<{[key: string]: any}> = null) {
     if (isBlank(normalizedEvents)) {
       normalizedEvents = [];
     }
@@ -214,14 +214,14 @@ export class ChromeDriverExtension extends WebDriverExtension {
     return new PerfLogFeatures({render: true, gc: true, frameCapture: true});
   }
 
-  supports(capabilities: StringMap<string, any>): boolean {
+  supports(capabilities: {[key: string]: any}): boolean {
     return this._majorChromeVersion != -1 &&
            StringWrapper.equals(capabilities['browserName'].toLowerCase(), 'chrome');
   }
 }
 
-function normalizeEvent(chromeEvent: StringMap<string, any>, data: StringMap<string, any>):
-    StringMap<string, any> {
+function normalizeEvent(chromeEvent: {[key: string]: any}, data: {[key: string]: any}):
+    {[key: string]: any} {
   var ph = chromeEvent['ph'];
   if (StringWrapper.equals(ph, 'S')) {
     ph = 'b';

--- a/modules/benchpress/src/webdriver/firefox_driver_extension.ts
+++ b/modules/benchpress/src/webdriver/firefox_driver_extension.ts
@@ -38,7 +38,7 @@ export class FirefoxDriverExtension extends WebDriverExtension {
 
   perfLogFeatures(): PerfLogFeatures { return new PerfLogFeatures({render: true, gc: true}); }
 
-  supports(capabilities: StringMap<string, any>): boolean {
+  supports(capabilities: {[key: string]: any}): boolean {
     return StringWrapper.equals(capabilities['browserName'].toLowerCase(), 'firefox');
   }
 }

--- a/modules/benchpress/src/webdriver/ios_driver_extension.ts
+++ b/modules/benchpress/src/webdriver/ios_driver_extension.ts
@@ -1,5 +1,5 @@
 import {bind, Binding} from 'angular2/src/core/di';
-import {ListWrapper, StringMap} from 'angular2/src/core/facade/collection';
+import {ListWrapper} from 'angular2/src/core/facade/collection';
 import {
   Json,
   isPresent,
@@ -91,7 +91,7 @@ export class IOsDriverExtension extends WebDriverExtension {
 
   perfLogFeatures(): PerfLogFeatures { return new PerfLogFeatures({render: true}); }
 
-  supports(capabilities: StringMap<string, any>): boolean {
+  supports(capabilities: {[key: string]: any}): boolean {
     return StringWrapper.equals(capabilities['browserName'].toLowerCase(), 'safari');
   }
 }

--- a/modules/benchpress/test/metric/multi_metric_spec.ts
+++ b/modules/benchpress/test/metric/multi_metric_spec.ts
@@ -11,7 +11,7 @@ import {
   xit,
 } from 'angular2/test_lib';
 
-import {ListWrapper, StringMap} from 'angular2/src/core/facade/collection';
+import {ListWrapper} from 'angular2/src/core/facade/collection';
 import {PromiseWrapper, Promise} from 'angular2/src/core/facade/async';
 
 import {Metric, MultiMetric, bind, Injector} from 'benchpress/common';
@@ -70,13 +70,13 @@ class MockMetric extends Metric {
 
   beginMeasure(): Promise<string> { return PromiseWrapper.resolve(`${this._id}_beginMeasure`); }
 
-  endMeasure(restart: boolean): Promise<StringMap<string, any>> {
+  endMeasure(restart: boolean): Promise<{[key: string]: any}> {
     var result = {};
     result[this._id] = {'restart': restart};
     return PromiseWrapper.resolve(result);
   }
 
-  describe(): StringMap<string, string> {
+  describe(): {[key: string]: string} {
     var result = {};
     result[this._id] = 'describe';
     return result;

--- a/modules/benchpress/test/metric/multi_metric_spec.ts
+++ b/modules/benchpress/test/metric/multi_metric_spec.ts
@@ -77,7 +77,7 @@ class MockMetric extends Metric {
   }
 
   describe(): {[key: string]: string} {
-    var result = {};
+    var result: {[key: string]: string} = {};
     result[this._id] = 'describe';
     return result;
   }

--- a/modules/benchpress/test/reporter/multi_reporter_spec.ts
+++ b/modules/benchpress/test/reporter/multi_reporter_spec.ts
@@ -11,7 +11,7 @@ import {
   xit,
 } from 'angular2/test_lib';
 
-import {ListWrapper, StringMap} from 'angular2/src/core/facade/collection';
+import {ListWrapper} from 'angular2/src/core/facade/collection';
 import {PromiseWrapper, Promise} from 'angular2/src/core/facade/async';
 import {DateWrapper} from 'angular2/src/core/facade/lang';
 
@@ -65,12 +65,12 @@ export function main() {
 class MockReporter extends Reporter {
   constructor(private _id: string) { super(); }
 
-  reportMeasureValues(values: MeasureValues): Promise<StringMap<string, any>> {
+  reportMeasureValues(values: MeasureValues): Promise<{[key: string]: any}> {
     return PromiseWrapper.resolve({'id': this._id, 'values': values});
   }
 
   reportSample(completeSample: MeasureValues[],
-               validSample: MeasureValues[]): Promise<StringMap<string, any>> {
+               validSample: MeasureValues[]): Promise<{[key: string]: any}> {
     return PromiseWrapper.resolve(
         {'id': this._id, 'completeSample': completeSample, 'validSample': validSample});
   }

--- a/modules/benchpress/test/web_driver_extension_spec.ts
+++ b/modules/benchpress/test/web_driver_extension_spec.ts
@@ -11,7 +11,7 @@ import {
   xit,
 } from 'angular2/test_lib';
 
-import {StringMap, ListWrapper} from 'angular2/src/core/facade/collection';
+import {ListWrapper} from 'angular2/src/core/facade/collection';
 import {isPresent, StringWrapper} from 'angular2/src/core/facade/lang';
 import {PromiseWrapper} from 'angular2/src/core/facade/async';
 
@@ -57,7 +57,7 @@ class MockExtension extends WebDriverExtension {
     this.id = id;
   }
 
-  supports(capabilities: StringMap<string, any>): boolean {
+  supports(capabilities: {[key: string]: any}): boolean {
     return StringWrapper.equals(capabilities['browser'], this.id);
   }
 }

--- a/modules/examples/src/model_driven_forms/index.ts
+++ b/modules/examples/src/model_driven_forms/index.ts
@@ -18,7 +18,7 @@ import {RegExpWrapper, print, isPresent} from 'angular2/src/core/facade/lang';
 /**
  * Custom validator.
  */
-function creditCardValidator(c): StringMap<string, boolean> {
+function creditCardValidator(c): {[key: string]: boolean} {
   if (isPresent(c.value) && RegExpWrapper.test(/^\d{16}$/g, c.value)) {
     return null;
   } else {

--- a/modules/examples/src/template_driven_forms/index.ts
+++ b/modules/examples/src/template_driven_forms/index.ts
@@ -35,7 +35,7 @@ class CheckoutModel {
 /**
  * Custom validator.
  */
-function creditCardValidator(c): StringMap<string, boolean> {
+function creditCardValidator(c): {[key: string]: boolean} {
   if (isPresent(c.value) && RegExpWrapper.test(/^\d{16}$/g, c.value)) {
     return null;
   } else {

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -10026,7 +10026,7 @@
       }
     },
     "ts2dart": {
-      "version": "0.7.10",
+      "version": "0.7.11",
       "dependencies": {
         "source-map": {
           "version": "0.4.4",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -15496,9 +15496,9 @@
       }
     },
     "ts2dart": {
-      "version": "0.7.10",
-      "from": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.7.10.tgz",
-      "resolved": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.7.10.tgz",
+      "version": "0.7.11",
+      "from": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.7.11.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "temp": "^0.8.1",
     "ternary-stream": "^1.2.3",
     "through2": "^0.6.1",
-    "ts2dart": "^0.7.10",
+    "ts2dart": "^0.7.11",
     "tsd": "^0.6.5-beta",
     "tslint": "^2.5.0",
     "typescript": "^1.6.2",


### PR DESCRIPTION
This was a poorly typed attempt to mimic TypeScript's index signatures,
which we can use instead.
This eliminates a very strange type that we were exposing to users, but
not re-exporting through our public API.

Fixes #4483
