### PR TITLE
Update modules/angular2/package.json

### DIFF
--- a/modules/angular2/package.json
+++ b/modules/angular2/package.json
@@ -18,7 +18,10 @@
     "definitions": [
       "bundles/typings/angular2/angular2.d.ts",
       "bundles/typings/angular2/http.d.ts",
-      "bundles/typings/angular2/router.d.ts"
+      "bundles/typings/angular2/router.d.ts",
+      "bundles/typings/angular2/test_lib.d.ts",
+      "bundles/typings/jasmine/jasmine.d.ts",
+      "bundles/typings/es6-shim/es6-shim.d.ts"
     ]
   }
 }


### PR DESCRIPTION
Add missing typescript defintions contained in the bundles (necessary to use `tsd link`).
