### PR TITLE
chore: remove devDependencies from package.json published to npm

### DIFF
--- a/tools/broccoli/trees/dart_tree.ts
+++ b/tools/broccoli/trees/dart_tree.ts
@@ -128,14 +128,7 @@ function getTemplatedPubspecsTree() {
     license: BASE_PACKAGE_JSON.license,
     contributors: BASE_PACKAGE_JSON.contributors,
     dependencies: BASE_PACKAGE_JSON.dependencies,
-    devDependencies: {
-      "yargs": BASE_PACKAGE_JSON.devDependencies['yargs'],
-      "gulp-sourcemaps": BASE_PACKAGE_JSON.devDependencies['gulp-sourcemaps'],
-      "gulp-traceur": BASE_PACKAGE_JSON.devDependencies['gulp-traceur'],
-      "gulp": BASE_PACKAGE_JSON.devDependencies['gulp'],
-      "gulp-rename": BASE_PACKAGE_JSON.devDependencies['gulp-rename'],
-      "through2": BASE_PACKAGE_JSON.devDependencies['through2']
-    }
+    devDependencies: {}
   };
   // Generate pubspec.yaml from templates.
   var pubspecs = modulesFunnel(['**/pubspec.yaml']);

--- a/tools/broccoli/trees/node_tree.ts
+++ b/tools/broccoli/trees/node_tree.ts
@@ -67,14 +67,7 @@ module.exports = function makeNodeTree(destinationPath) {
     contributors: BASE_PACKAGE_JSON.contributors,
     dependencies: BASE_PACKAGE_JSON.dependencies,
     devDependencies: BASE_PACKAGE_JSON.devDependencies,
-    defaultDevDependencies: {
-      "yargs": BASE_PACKAGE_JSON.devDependencies['yargs'],
-      "gulp-sourcemaps": BASE_PACKAGE_JSON.devDependencies['gulp-sourcemaps'],
-      "gulp-traceur": BASE_PACKAGE_JSON.devDependencies['gulp-traceur'],
-      "gulp": BASE_PACKAGE_JSON.devDependencies['gulp'],
-      "gulp-rename": BASE_PACKAGE_JSON.devDependencies['gulp-rename'],
-      "through2": BASE_PACKAGE_JSON.devDependencies['through2']
-    }
+    defaultDevDependencies: {}
   };
 
   var packageJsons = new Funnel(modulesTree, {include: ['**/package.json']});


### PR DESCRIPTION
This is a follow up PR related to #4454 - since we are dropping es6 output and all the convenience script to transpile e6->es5 we don't need devDependencies in the published npm package
