### PR TITLE
fix(render): keep bindings of components in content and view in the r…

### DIFF
--- a/modules/angular2/test/core/linker/projection_integration_spec.ts
+++ b/modules/angular2/test/core/linker/projection_integration_spec.ts
@@ -112,6 +112,26 @@ export function main() {
              });
        }));
 
+    it('should project content components',
+       inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
+         tcb.overrideView(
+                Simple,
+                new ViewMetadata(
+                    {template: 'SIMPLE({{0}}|<ng-content></ng-content>|{{2}})', directives: []}))
+             .overrideView(OtherComp, new ViewMetadata({template: '{{1}}', directives: []}))
+             .overrideView(MainComp, new ViewMetadata({
+                             template: '<simple><other></other></simple>',
+                             directives: [Simple, OtherComp]
+                           }))
+             .createAsync(MainComp)
+             .then((main) => {
+
+               main.detectChanges();
+               expect(main.debugElement.nativeElement).toHaveText('SIMPLE(0|1|2)');
+               async.done();
+             });
+       }));
+
     it('should not show the light dom even if there is no content tag',
        inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
          tcb.overrideView(MainComp,
@@ -450,6 +470,12 @@ export function main() {
 @Component({selector: 'main'})
 @View({template: '', directives: []})
 class MainComp {
+  text: string = '';
+}
+
+@Component({selector: 'other'})
+@View({template: '', directives: []})
+class OtherComp {
   text: string = '';
 }
 

--- a/modules/angular2/test/core/render/view_factory_spec.ts
+++ b/modules/angular2/test/core/render/view_factory_spec.ts
@@ -347,6 +347,28 @@ export function main() {
             .toEqual(['1.1', '1.2', '1.3', '1.4', '2.1', '2.2', '3.1', '3.1']);
       });
 
+      it('should store bound elements from the view before bound elements from content components',
+         () => {
+           componentTemplates.set(0, [
+             beginElement('a', ['id', '2.1'], [], true, null),
+             endElement(),
+           ]);
+           componentTemplates.set(1, [
+             beginElement('a', ['id', '3.1'], [], true, null),
+             endElement(),
+           ]);
+           var view = createRenderView(
+               [
+                 beginComponent('a-comp', ['id', '1.1'], [], false, null, 0),
+                 beginComponent('b-comp', ['id', '1.2'], [], false, null, 1),
+                 endComponent(),
+                 endComponent(),
+               ],
+               null, nodeFactory);
+
+           expect(mapAttrs(view.boundElements, 'id')).toEqual(['1.1', '1.2', '2.1', '3.1']);
+         });
+
       it('should store bound text nodes after the bound text nodes of the main template', () => {
         componentTemplates.set(0, [
           text('2.1', true, null),
@@ -373,6 +395,22 @@ export function main() {
             .toEqual(['1.1', '1.2', '1.3', '2.1', '2.2', '3.1', '3.1']);
       });
     });
+
+    it('should store bound text nodes from the view before bound text nodes from content components',
+       () => {
+         componentTemplates.set(0, [text('2.1', true, null)]);
+         componentTemplates.set(1, [text('3.1', true, null)]);
+         var view = createRenderView(
+             [
+               beginComponent('a-comp', [], [], false, null, 0),
+               beginComponent('b-comp', [], [], false, null, 1),
+               endComponent(),
+               endComponent(),
+             ],
+             null, nodeFactory);
+
+         expect(mapText(view.boundTextNodes)).toEqual(['2.1', '3.1']);
+       });
 
     describe('content projection', () => {
       it('should remove non projected nodes', () => {


### PR DESCRIPTION
…ight order

Bindings in the component view have to be first, before 
bindings of components in the light dom (i.e. have the same
order as used in the `ViewManagerUtils.createView()` method.

Fixes #4522
