### PR TITLE
chore(build): copy bundles so they can be used with e2e tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -985,11 +985,19 @@ gulp.task('broccoli.js.dev', ['build.tools'], function(done) {
 });
 
 gulp.task('!broccoli.js.dev', function() {
-  return angularBuilder.rebuildBrowserDevTree();
+  return angularBuilder.rebuildBrowserDevTree().then(function () {
+    // TODO: this is not ideal
+    return gulp.src('dist/js/bundle/*')
+      .pipe(gulp.dest('dist/js/dev/es5/bundle'));
+  });
 });
 
 gulp.task('!broccoli.js.prod', function() {
-  return angularBuilder.rebuildBrowserProdTree();
+  return angularBuilder.rebuildBrowserProdTree().then(function () {
+    // TODO: this is not ideal
+    return gulp.src('dist/js/bundle/*')
+      .pipe(gulp.dest('dist/js/prod/es5/bundle'));
+  });
 });
 
 gulp.task('build.js.dev', ['build/clean.js'], function(done) {

--- a/tools/broccoli/trees/browser_tree.ts
+++ b/tools/broccoli/trees/browser_tree.ts
@@ -167,7 +167,8 @@ module.exports = function makeBrowserTree(options, destinationPath) {
     return funnels;
   }
 
-  var htmlTree = new Funnel(modulesTree, {include: ['*/src/**/*.html'], destDir: '/'});
+  var htmlTree = new Funnel(modulesTree,
+                            {include: ['*/src/**/*.html', '**/examples/**/*.html'], destDir: '/'});
   htmlTree = replace(htmlTree, {
     files: ['examples*/**/*.html'],
     patterns: [

--- a/tools/broccoli/trees/dart_tree.ts
+++ b/tools/broccoli/trees/dart_tree.ts
@@ -15,6 +15,7 @@ import replace from '../broccoli-replace';
 
 var global_excludes = [
   'angular2/http*',
+  'angular2/examples/*/ts/**/*',
   'angular2/src/http/**/*',
   'angular2/test/http/**/*',
   'examples/src/http/**/*',

--- a/tools/broccoli/trees/node_tree.ts
+++ b/tools/broccoli/trees/node_tree.ts
@@ -26,7 +26,8 @@ module.exports = function makeNodeTree(destinationPath) {
       'angular2/test/core/compiler/xhr_impl_spec.ts',
       'angular2/test/core/forms/**',
       'angular2/test/tools/tools_spec.ts',
-      'angular1_router/**'
+      'angular1_router/**',
+      'angular2/examples/**/!(*_spec.ts)',
     ]
   });
 


### PR DESCRIPTION
Also updates trees to properly compile/copy examples from `angular2/examples` to the correct directories.

/cc @rkirov 
