### PR TITLE
fix(core): make .toRx() return Subject

### DIFF
--- a/modules/angular2/src/core/facade/async.ts
+++ b/modules/angular2/src/core/facade/async.ts
@@ -137,7 +137,7 @@ export class EventEmitter extends Observable {
                                    () => generator.return ? generator.return () : null);
   }
 
-  toRx(): any { return this; }
+  toRx(): any { return this._subject; }
 
   next(value: any) { this._subject.next(value); }
 


### PR DESCRIPTION
this was broken in the original great RxNext migration.
