### PR TITLE
chore(build): upgrade systemjs-builder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1061,7 +1061,8 @@ gulp.task('!build.js.cjs', function() {
 
 
 var bundleConfig = {
-  paths: {"*": "dist/js/prod/es5/*.js"},
+  baseURL: 'dist/js/prod/es5',
+  defaultJSExtensions: true,
   // Files that end up empty after transpilation confuse system-builder
   // and need to be explitily listed here.
   // TODO: upgrade system builder and find a way to declare all input as cjs.
@@ -1119,10 +1120,9 @@ gulp.task('!bundle.js.min', ['build.js.prod'], function() {
 // development build
 gulp.task('!bundle.js.dev', ['build.js.dev'], function() {
   var devBundleConfig = merge(true, bundleConfig);
-  devBundleConfig.paths =
-      merge(true, devBundleConfig.paths, {
-       "*": "dist/js/dev/es5/*.js"
-      });
+  devBundleConfig = merge(true, devBundleConfig, {
+    baseURL: 'dist/js/dev/es5'
+  });
   return bundler.bundle(
       devBundleConfig,
       'angular2/angular2',
@@ -1139,8 +1139,9 @@ gulp.task('!bundle.js.dev', ['build.js.dev'], function() {
 
 // WebWorker build
 gulp.task("!bundle.web_worker.js.dev", ["build.js.dev"], function() {
-  var devBundleConfig = merge(true, bundleConfig);
-  devBundleConfig.paths = merge(true, devBundleConfig.paths, {"*": "dist/js/dev/es5/*.js"});
+  var devBundleConfig = merge(true, bundleConfig, {
+    baseURL: 'dist/js/dev/es5'
+  });
   return bundler.bundle(
       devBundleConfig,
       'angular2/web_worker/ui',
@@ -1156,8 +1157,9 @@ gulp.task("!bundle.web_worker.js.dev", ["build.js.dev"], function() {
 });
 
 gulp.task('!router.bundle.js.dev', ['build.js.dev'], function() {
-  var devBundleConfig = merge(true, bundleConfig);
-  devBundleConfig.paths = merge(true, devBundleConfig.paths, {"*": "dist/js/dev/es5/*.js"});
+  var devBundleConfig = merge(true, bundleConfig,{
+    baseURL: 'dist/js/dev/es5'
+  });
   return bundler.bundle(
     devBundleConfig,
     'angular2/router - angular2/angular2',
@@ -1166,8 +1168,9 @@ gulp.task('!router.bundle.js.dev', ['build.js.dev'], function() {
 });
 
 gulp.task('!test.bundle.js.dev', ['build.js.dev'], function() {
-  var devBundleConfig = merge(true, bundleConfig);
-  devBundleConfig.paths = merge(true, devBundleConfig.paths, {"*": "dist/js/dev/es5/*.js"});
+  var devBundleConfig = merge(true, bundleConfig,{
+    baseURL: 'dist/js/dev/es5'
+  });
   return bundler.bundle(
     devBundleConfig,
     'angular2/test + angular2/mock - angular2/angular2',
@@ -1181,8 +1184,9 @@ gulp.task('!test.bundle.js.dev', ['build.js.dev'], function() {
 // use System loader polyfills (like system.js and es6 loader).
 // see: https://github.com/systemjs/builder (SFX bundles).
 gulp.task('!bundle.js.sfx.dev', ['build.js.dev'], function() {
-  var devBundleConfig = merge(true, bundleConfig);
-  devBundleConfig.paths = merge(true, devBundleConfig.paths, {'*': 'dist/js/dev/es5/*.js'});
+  var devBundleConfig = merge(true, bundleConfig,{
+    baseURL: 'dist/js/dev/es5'
+  });
   return bundler.bundle(devBundleConfig, 'angular2/angular2_sfx',
                         './dist/build/angular2.sfx.dev.js', {sourceMaps: true},
                         /* self-executing */ true)

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -10551,10 +10551,47 @@
       }
     },
     "systemjs-builder": {
-      "version": "0.10.6",
+      "version": "0.14.7",
       "dependencies": {
+        "algorithms": {
+          "version": "0.9.1"
+        },
+        "es6-template-strings": {
+          "version": "2.0.0",
+          "dependencies": {
+            "es5-ext": {
+              "version": "0.10.8",
+              "dependencies": {
+                "es6-iterator": {
+                  "version": "2.0.0",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1"
+                    }
+                  }
+                },
+                "es6-symbol": {
+                  "version": "3.0.0",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1"
+                    }
+                  }
+                }
+              }
+            },
+            "esniff": {
+              "version": "1.0.0",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1"
+                }
+              }
+            }
+          }
+        },
         "glob": {
-          "version": "5.0.5",
+          "version": "5.0.15",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
@@ -10581,7 +10618,7 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.0",
+          "version": "0.5.1",
           "dependencies": {
             "minimist": {
               "version": "0.0.8"
@@ -10589,31 +10626,29 @@
           }
         },
         "rsvp": {
-          "version": "3.0.18"
+          "version": "3.1.0"
         },
         "source-map": {
-          "version": "0.4.2",
+          "version": "0.4.4",
           "dependencies": {
             "amdefine": {
-              "version": "0.1.0"
+              "version": "1.0.0"
             }
           }
         },
         "systemjs": {
-          "version": "0.16.11",
+          "version": "0.19.3",
           "dependencies": {
             "es6-module-loader": {
-              "version": "0.16.6",
-              "dependencies": {
-                "when": {
-                  "version": "3.7.3"
-                }
-              }
+              "version": "0.17.8"
+            },
+            "when": {
+              "version": "3.7.3"
             }
           }
         },
         "traceur": {
-          "version": "0.0.88",
+          "version": "0.0.91",
           "dependencies": {
             "commander": {
               "version": "2.6.0"
@@ -10652,7 +10687,7 @@
                   "version": "0.1.32",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.0"
+                      "version": "1.0.0"
                     }
                   }
                 }
@@ -10661,7 +10696,7 @@
           }
         },
         "uglify-js": {
-          "version": "2.4.21",
+          "version": "2.4.24",
           "dependencies": {
             "async": {
               "version": "0.2.10"
@@ -10670,7 +10705,7 @@
               "version": "0.1.34",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.0"
+                  "version": "1.0.0"
                 }
               }
             },
@@ -10681,7 +10716,7 @@
               "version": "3.5.4",
               "dependencies": {
                 "camelcase": {
-                  "version": "1.0.2"
+                  "version": "1.2.1"
                 },
                 "decamelize": {
                   "version": "1.0.0"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@reactivex/rxjs": {
       "version": "0.0.0-prealpha.3",
-      "from": "https://registry.npmjs.org/@reactivex/rxjs/-/rxjs-0.0.0-prealpha.3.tgz",
+      "from": "@reactivex/rxjs@0.0.0-prealpha.3",
       "resolved": "https://registry.npmjs.org/@reactivex/rxjs/-/rxjs-0.0.0-prealpha.3.tgz"
     },
     "angular": {
@@ -16299,139 +16299,192 @@
       }
     },
     "systemjs-builder": {
-      "version": "0.10.6",
-      "from": "https://registry.npmjs.org/systemjs-builder/-/systemjs-builder-0.10.6.tgz",
-      "resolved": "https://registry.npmjs.org/systemjs-builder/-/systemjs-builder-0.10.6.tgz",
+      "version": "0.14.7",
+      "from": "systemjs-builder@0.14.7",
+      "resolved": "https://registry.npmjs.org/systemjs-builder/-/systemjs-builder-0.14.7.tgz",
       "dependencies": {
+        "algorithms": {
+          "version": "0.9.1",
+          "from": "algorithms@>=0.9.1 <0.10.0",
+          "resolved": "https://registry.npmjs.org/algorithms/-/algorithms-0.9.1.tgz"
+        },
+        "es6-template-strings": {
+          "version": "2.0.0",
+          "from": "es6-template-strings@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/es6-template-strings/-/es6-template-strings-2.0.0.tgz",
+          "dependencies": {
+            "es5-ext": {
+              "version": "0.10.8",
+              "from": "es5-ext@>=0.10.7 <0.11.0",
+              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
+              "dependencies": {
+                "es6-iterator": {
+                  "version": "2.0.0",
+                  "from": "es6-iterator@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    }
+                  }
+                },
+                "es6-symbol": {
+                  "version": "3.0.0",
+                  "from": "es6-symbol@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.0.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "esniff": {
+              "version": "1.0.0",
+              "from": "esniff@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/esniff/-/esniff-1.0.0.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "d@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
         "glob": {
-          "version": "5.0.5",
-          "from": "https://registry.npmjs.org/glob/-/glob-5.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.5.tgz",
+          "version": "5.0.15",
+          "from": "glob@>=5.0.14 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "from": "inflight@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "once": {
               "version": "1.3.2",
-              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         },
         "mkdirp": {
-          "version": "0.5.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "rsvp": {
-          "version": "3.0.18",
-          "from": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+          "version": "3.1.0",
+          "from": "rsvp@>=3.0.20 <4.0.0",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.1.0.tgz"
         },
         "source-map": {
-          "version": "0.4.2",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.4 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+              "version": "1.0.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
         },
         "systemjs": {
-          "version": "0.16.11",
-          "from": "https://registry.npmjs.org/systemjs/-/systemjs-0.16.11.tgz",
-          "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.16.11.tgz",
+          "version": "0.19.3",
+          "from": "systemjs@0.19.3",
+          "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.19.3.tgz",
           "dependencies": {
             "es6-module-loader": {
-              "version": "0.16.6",
-              "from": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.16.6.tgz",
-              "resolved": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.16.6.tgz",
-              "dependencies": {
-                "when": {
-                  "version": "3.7.3",
-                  "from": "https://registry.npmjs.org/when/-/when-3.7.3.tgz",
-                  "resolved": "https://registry.npmjs.org/when/-/when-3.7.3.tgz"
-                }
-              }
+              "version": "0.17.8",
+              "from": "es6-module-loader@>=0.17.4 <0.18.0",
+              "resolved": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.17.8.tgz"
+            },
+            "when": {
+              "version": "3.7.3",
+              "from": "when@>=3.7.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/when/-/when-3.7.3.tgz"
             }
           }
         },
         "traceur": {
-          "version": "0.0.88",
-          "from": "https://registry.npmjs.org/traceur/-/traceur-0.0.88.tgz",
-          "resolved": "https://registry.npmjs.org/traceur/-/traceur-0.0.88.tgz",
+          "version": "0.0.91",
+          "from": "traceur@0.0.91",
+          "resolved": "https://registry.npmjs.org/traceur/-/traceur-0.0.91.tgz",
           "dependencies": {
             "commander": {
               "version": "2.6.0",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+              "from": "commander@>=2.6.0 <2.7.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
             },
             "glob": {
               "version": "4.3.5",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "from": "glob@>=4.3.0 <4.4.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "once": {
                   "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -16440,23 +16493,23 @@
             },
             "semver": {
               "version": "2.3.2",
-              "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+              "from": "semver@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
             },
             "source-map-support": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+              "from": "source-map-support@>=0.2.8 <0.3.0",
               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.32",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                  "from": "source-map@0.1.32",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 }
@@ -16465,55 +16518,55 @@
           }
         },
         "uglify-js": {
-          "version": "2.4.21",
-          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.21.tgz",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.21.tgz",
+          "version": "2.4.24",
+          "from": "uglify-js@>=2.4.23 <3.0.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "from": "async@>=0.2.6 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.1.34",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "from": "source-map@0.1.34",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
               "version": "3.5.4",
-              "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+              "from": "yargs@>=3.5.4 <3.6.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
               "dependencies": {
                 "camelcase": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                  "version": "1.2.1",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "decamelize": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                 },
                 "window-size": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                  "from": "window-size@0.1.0",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.2",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                  "from": "wordwrap@0.0.2",
                   "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                 }
               }
@@ -16621,34 +16674,34 @@
     },
     "ts2dart": {
       "version": "0.7.11",
-      "from": "ts2dart@0.7.11",
+      "from": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.7.11.tgz",
       "resolved": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.7.11.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.2 <0.5.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
         },
         "source-map-support": {
           "version": "0.3.2",
-          "from": "source-map-support@>=0.3.1 <0.4.0",
+          "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.2.tgz",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.2.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
-              "from": "source-map@0.1.32",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "strip-ansi": "^2.0.1",
     "symlink-or-copy": "^1.0.1",
     "systemjs": "^0.18.10",
-    "systemjs-builder": "^0.10.3",
+    "systemjs-builder": "0.14.7",
     "temp": "^0.8.1",
     "ternary-stream": "^1.2.3",
     "through2": "^0.6.1",

--- a/tools/build/bundle.js
+++ b/tools/build/bundle.js
@@ -13,9 +13,9 @@ module.exports.bundle = function(buildConfig, moduleName, outputFile, outputConf
   var builder = new Builder();
   builder.config(buildConfig);
   if (sfx) {
-    return builder.buildSFX(moduleName, outputFile, outputConfig);
+    return builder.buildStatic(moduleName, outputFile, outputConfig);
   } else {
-    return builder.build(moduleName, outputFile, outputConfig);
+    return builder.bundle(moduleName, outputFile, outputConfig);
   }
 };
 


### PR DESCRIPTION
upgrade systemjs-builder to 0.14.x

BREAKING CHANGE:

URLs are now first-class module names. All names are normalized into URLs into the registry as part of the normalization process. See https://github.com/systemjs/systemjs/releases/tag/0.17.0 and https://github.com/whatwg/loader/issues/52 for more details.

blocked pending @rkirov fixing e2e tests and bundles.
