### PR TITLE
docs(http) remove .toRx() from http calls

### DIFF
--- a/modules/angular2/http.ts
+++ b/modules/angular2/http.ts
@@ -69,7 +69,7 @@ export {URLSearchParams} from './src/http/url_search_params';
  * export class App {
  *   people: Object[];
  *   constructor(http:Http) {
- *     http.get('people.json').toRx().subscribe(res => {
+ *     http.get('people.json').subscribe(res => {
  *       this.people = res.json();
  *     });
  *   }
@@ -195,7 +195,7 @@ export const HTTP_BINDINGS: any[] = [
  * export class App {
  *   people: Array<Object>;
  *   constructor(jsonp:Jsonp) {
- *     jsonp.request('people.json').toRx().subscribe(res => {
+ *     jsonp.request('people.json').subscribe(res => {
  *       this.people = res.json();
  *     })
  *   }

--- a/modules/angular2/src/http/backends/mock_backend.ts
+++ b/modules/angular2/src/http/backends/mock_backend.ts
@@ -47,8 +47,8 @@ export class MockConnection implements Connection {
    *
    * ```
    * var connection;
-   * backend.connections.toRx().subscribe(c => connection = c);
-   * http.request('data.json').toRx().subscribe(res => console.log(res.text()));
+   * backend.connections.subscribe(c => connection = c);
+   * http.request('data.json').subscribe(res => console.log(res.text()));
    * connection.mockRespond(new Response('fake response')); //logs 'fake response'
    * ```
    *
@@ -108,8 +108,8 @@ export class MockConnection implements Connection {
  *   var http = injector.get(Http);
  *   var backend = injector.get(MockBackend);
  *   //Assign any newly-created connection to local variable
- *   backend.connections.toRx().subscribe(c => connection = c);
- *   http.request('data.json').toRx().subscribe((res) => {
+ *   backend.connections.subscribe(c => connection = c);
+ *   http.request('data.json').subscribe((res) => {
  *     expect(res.text()).toBe('awesome');
  *     async.done();
  *   });
@@ -142,8 +142,8 @@ export class MockBackend implements ConnectionBackend {
    *     }, [MockBackend, BaseRequestOptions]]);
    *   var backend = injector.get(MockBackend);
    *   var http = injector.get(Http);
-   *   backend.connections.toRx().subscribe(c => connection = c);
-   *   http.request('something.json').toRx().subscribe(res => {
+   *   backend.connections.subscribe(c => connection = c);
+   *   http.request('something.json').subscribe(res => {
    *     text = res.text();
    *   });
    *   connection.mockRespond(new Response({body: 'Something'}));

--- a/modules/angular2/src/http/backends/xhr_backend.ts
+++ b/modules/angular2/src/http/backends/xhr_backend.ts
@@ -101,7 +101,7 @@ export class XHRConnection implements Connection {
  * })
  * class MyComponent {
  *   constructor(http:Http) {
- *     http('people.json').toRx().subscribe(res => this.people = res.json());
+ *     http('people.json').subscribe(res => this.people = res.json());
  *   }
  * }
  * ```

--- a/modules/angular2/src/http/static_request.ts
+++ b/modules/angular2/src/http/static_request.ts
@@ -42,7 +42,7 @@ import {
  *
  * var injector = Injector.resolveAndCreate([HTTP_BINDINGS, AutoAuthenticator]);
  * var authenticator = injector.get(AutoAuthenticator);
- * authenticator.request('people.json').toRx().subscribe(res => {
+ * authenticator.request('people.json').subscribe(res => {
  *   //URL should have included '?password=123'
  *   console.log('people', res.json());
  * });

--- a/modules/angular2/src/http/static_response.ts
+++ b/modules/angular2/src/http/static_response.ts
@@ -15,7 +15,7 @@ import {isJsObject} from './http_utils';
  * #Example
  *
  * ```
- * http.request('my-friends.txt').toRx().subscribe(response => this.friends = response.text());
+ * http.request('my-friends.txt').subscribe(response => this.friends = response.text());
  * ```
  *
  * The Response's interface is inspired by the Response constructor defined in the [Fetch


### PR DESCRIPTION
There were still some `http.get('/something').toRx()` in the docs, so I removed them.

Also, I noticed this `http('people.json')` [is not valid anymore](http://plnkr.co/edit/DCwXIYjlqGOFq72XyLuR?p=preview), if someone can confirm this is no longer supported I'll fix it too (in a different PR).
