### PR TITLE
fix(di): allow dependencies as flat array

### DIFF
--- a/modules/angular2/src/core/di/binding.ts
+++ b/modules/angular2/src/core/di/binding.ts
@@ -576,7 +576,13 @@ function _extractToken(typeOrFunc, metadata /*any[] | any*/, params: any[][]): D
   var optional = false;
 
   if (!isArray(metadata)) {
-    return _createDependency(metadata, optional, null, null, depProps);
+    if (metadata instanceof InjectMetadata) {
+      var metaArrayWrapper = ListWrapper.createFixedSize(1);
+      metaArrayWrapper[0] = metadata;
+      metadata = metaArrayWrapper;
+    } else {
+      return _createDependency(metadata, optional, null, null, depProps);
+    }
   }
 
   var lowerBoundVisibility = null;

--- a/modules/angular2/test/core/di/injector_spec.ts
+++ b/modules/angular2/test/core/di/injector_spec.ts
@@ -642,6 +642,15 @@ export function main() {
       });
     });
 
+    it('should allow declaring dependencies with flat arrays', () => {
+      var resolved =
+          Injector.resolve([bind('token').toFactory(e => e, [new InjectMetadata("dep")])]);
+      var nestedResolved =
+          Injector.resolve([bind('token').toFactory(e => e, [[new InjectMetadata("dep")]])]);
+      expect(resolved[0].resolvedFactories[0].dependencies[0].key.token)
+          .toEqual(nestedResolved[0].resolvedFactories[0].dependencies[0].key.token);
+    });
+
     describe("displayName", () => {
       it("should work", () => {
         expect(Injector.resolveAndCreate([Engine, BrokenEngine]).displayName)


### PR DESCRIPTION
Fix https://github.com/angular/angular/issues/4224

According to my observations, the problem only occurs when the dependencies are defined with `Inject`. The only difference is that when the nested array is omitted the dependency is not resolved to the correct value.

Let me know if I've missed something.
