### PR TITLE
fix(dart/transform): Write correct ng_deps without deferred imports

### DIFF
--- a/modules_dart/transform/lib/src/transform/common/code/ng_deps_code.dart
+++ b/modules_dart/transform/lib/src/transform/common/code/ng_deps_code.dart
@@ -140,15 +140,13 @@ abstract class NgDepsWriterMixin
       ..prefix = REFLECTOR_PREFIX);
 
     // We do not support `partUris`, so skip outputting them.
-    for (var importModel in model.imports) {
-      // Ignore deferred imports here so as to not load the deferred libraries
-      // code in the current library causing much of the code to not be
-      // deferred. Instead `DeferredRewriter` will rewrite the code as to load
-      // `ng_deps` in a deferred way.
-      if (importModel.isDeferred) return;
 
-      writeImportModel(importModel);
-    }
+    // Ignore deferred imports here so as to not load the deferred libraries
+    // code in the current library causing much of the code to not be
+    // deferred. Instead `DeferredRewriter` will rewrite the code as to load
+    // `ng_deps` in a deferred way.
+    model.imports.where((i) => !i.isDeferred).forEach(writeImportModel);
+
     writeExportModel(new ExportModel()..uri = model.sourceFile);
     model.exports.forEach(writeExportModel);
 

--- a/modules_dart/transform/test/transform/common/code/ng_deps_code_tests.dart
+++ b/modules_dart/transform/test/transform/common/code/ng_deps_code_tests.dart
@@ -1,0 +1,51 @@
+library angular2.test.transform.common.code.ng_deps_code_tests;
+
+import 'package:analyzer/analyzer.dart';
+import 'package:angular2/src/transform/common/code/ng_deps_code.dart';
+import 'package:angular2/src/transform/common/model/import_export_model.pb.dart';
+import 'package:angular2/src/transform/common/model/ng_deps_model.pb.dart';
+import 'package:guinness/guinness.dart';
+
+main() => allTests();
+
+void allTests() {
+  describe('writeNgDepsModel', () {
+    it('should output parsable code', () async {
+      final ngDeps = new NgDepsModel()
+        ..libraryUri = 'test.foo'
+        ..imports.add(new ImportModel()
+          ..uri = 'bar.dart'
+          ..prefix = 'dep');
+
+      final buf = new StringBuffer();
+      final writer = new NgDepsWriter(buf);
+      writer.writeNgDepsModel(ngDeps);
+
+      var compilationUnit = parseCompilationUnit(buf.toString());
+
+      expect(compilationUnit).toBeNotNull();
+      expect(compilationUnit.declarations).toBeNotNull();
+      expect(compilationUnit.declarations.length > 0).toBeTrue();
+    });
+
+    it('should output parsable code with deferred imports', () async {
+      // Regression test for i/4587.
+      final ngDeps = new NgDepsModel()
+        ..libraryUri = 'test.foo'
+        ..imports.add(new ImportModel()
+          ..uri = 'bar.dart'
+          ..isDeferred = true
+          ..prefix = 'dep');
+
+      final buf = new StringBuffer();
+      final writer = new NgDepsWriter(buf);
+      writer.writeNgDepsModel(ngDeps);
+
+      var compilationUnit = parseCompilationUnit(buf.toString());
+
+      expect(compilationUnit).toBeNotNull();
+      expect(compilationUnit.declarations).toBeNotNull();
+      expect(compilationUnit.declarations.length > 0).toBeTrue();
+    });
+  });
+}

--- a/modules_dart/transform/test/transform/transform.server.spec.dart
+++ b/modules_dart/transform/test/transform/transform.server.spec.dart
@@ -5,6 +5,7 @@ import 'package:unittest/unittest.dart' hide expect;
 import 'package:unittest/vm_config.dart';
 
 import 'common/async_string_writer_tests.dart' as asyncStringWriter;
+import 'common/code/ng_deps_code_tests.dart' as ngDepsCode;
 import 'common/ng_meta_test.dart' as ngMetaTest;
 import 'common/url_resolver_tests.dart' as urlResolver;
 import 'bind_generator/all_tests.dart' as bindGenerator;
@@ -20,6 +21,7 @@ import 'stylesheet_compiler/all_tests.dart' as stylesheetCompiler;
 main() {
   useVMConfiguration();
   describe('AsyncStringWriter', asyncStringWriter.allTests);
+  describe('NgDepsCode', ngDepsCode.allTests);
   describe('NgMeta', ngMetaTest.allTests);
   describe('Bind Generator', bindGenerator.allTests);
   describe('Directive Metadata Linker', directiveMeta.allTests);


### PR DESCRIPTION
Previously, the presence of a `deferred` import would cause us to output
incomplete `.ng_deps.dart` code.

Closes #4587
