### PR TITLE
chore(pub): upgrade observe dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: angular
 environment:
   sdk: '>=1.12.0-dev.5.10 <2.0.0'
 dependencies:
-  observe: '0.13.1'
+  observe: '^0.13.1'
 dev_dependencies:
   guinness: '^0.1.17'
   intl: '^0.12.4'


### PR DESCRIPTION
observe 0.13.1 depends on an old version of analyzer, which depends on dart:profiler, which is deprecated and will be deleted in dart 1.13
