### PR TITLE
fix(dart/transform): Run DeferredRewriter in the correct phase

### DIFF
--- a/modules_dart/transform/lib/src/transform/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/transformer.dart
@@ -30,10 +30,11 @@ class AngularTransformerGroup extends TransformerGroup {
       [new DirectiveProcessor(options)]
     ];
     phases.addAll([
-      [new DeferredRewriter(options), new DirectiveMetadataLinker()],
+      [new DirectiveMetadataLinker()],
       [new BindGenerator(options)],
       [new TemplateCompiler(options)],
       [new StylesheetCompiler()],
+      [new DeferredRewriter(options)]
     ]);
     return new AngularTransformerGroup._(phases,
         formatCode: options.formatCode);

--- a/modules_dart/transform/test/transform/integration/deferred_files/bar.dart
+++ b/modules_dart/transform/test/transform/integration/deferred_files/bar.dart
@@ -1,0 +1,17 @@
+library bar;
+
+import 'package:angular2/src/core/metadata.dart';
+
+import 'deps/my_dep.dart' deferred as dep;
+
+@Component(selector: '[soup]')
+@View(template: '')
+class MyComponent {
+  void doDeferredThing() {
+    dep.loadLibrary().then((_) {
+      dep.doImmediateThing();
+    });
+  }
+}
+
+void execImmediate() {}

--- a/modules_dart/transform/test/transform/integration/deferred_files/expected/bar.dart
+++ b/modules_dart/transform/test/transform/integration/deferred_files/expected/bar.dart
@@ -1,0 +1,17 @@
+library bar;
+
+import 'package:angular2/src/core/metadata.dart';
+
+import 'deps/my_dep.dart' deferred as dep;
+
+@Component(selector: '[soup]')
+@View(template: '')
+class MyComponent {
+  void doDeferredThing() {
+    dep.loadLibrary().then((_) {
+      dep.doImmediateThing();
+    });
+  }
+}
+
+void execImmediate() {}

--- a/modules_dart/transform/test/transform/integration/deferred_files/expected/bar.ng_deps.dart
+++ b/modules_dart/transform/test/transform/integration/deferred_files/expected/bar.ng_deps.dart
@@ -1,0 +1,24 @@
+library bar.ng_deps.dart;
+
+import 'bar.template.dart' as _templates;
+
+import 'bar.dart';
+import 'package:angular2/src/core/reflection/reflection.dart' as _ngRef;
+import 'package:angular2/src/core/metadata.dart';
+import 'package:angular2/src/core/metadata.ng_deps.dart' as i0;
+export 'bar.dart';
+
+var _visited = false;
+void initReflector() {
+  if (_visited) return;
+  _visited = true;
+  _ngRef.reflector
+    ..registerType(
+        MyComponent,
+        new _ngRef.ReflectionInfo(const [
+          const Component(selector: '[soup]'),
+          const View(template: ''),
+          _templates.HostMyComponentTemplate
+        ], const [], () => new MyComponent()));
+  i0.initReflector();
+}

--- a/modules_dart/transform/test/transform/integration/deferred_files/expected/output.dart
+++ b/modules_dart/transform/test/transform/integration/deferred_files/expected/output.dart
@@ -1,0 +1,18 @@
+library angular2.test.transform.integration.deferred;
+
+// This stored as a constant because we need to be careful to avoid modifying
+// source lines for files we rewrite.
+// That is, we expect that modifications we make to input files do not change
+// line numbers, and storing this expected output as code would allow it to be
+// formatted, breaking our tests.
+const indexContents = '''
+library web_foo;
+
+import 'index.ng_deps.dart' as ngStaticInit;import 'bar.ng_deps.dart' deferred as bar;
+
+void main() {
+  bar.loadLibrary().then((_) {bar.initReflector();}).then((_) {
+    bar.execImmediate();
+  });
+}
+''';

--- a/modules_dart/transform/test/transform/integration/deferred_files/index.dart
+++ b/modules_dart/transform/test/transform/integration/deferred_files/index.dart
@@ -1,0 +1,9 @@
+library web_foo;
+
+import 'bar.dart' deferred as bar;
+
+void main() {
+  bar.loadLibrary().then((_) {
+    bar.execImmediate();
+  });
+}


### PR DESCRIPTION
`DeferredRewriter` depends on the presence of `.ng_deps.dart` files,
which do not yet exist in the phase where it was previously run.

Update the transformer phases to fix this and add an integration test to
prevent regression.
