### PR TITLE
docs(Http): fix parameter name

### DIFF
--- a/modules/angular2/src/http/http.ts
+++ b/modules/angular2/src/http/http.ts
@@ -58,7 +58,7 @@ function mergeOptions(defaultOpts, providedOpts, method, url): RequestOptions {
  * #Example
  *
  * ```
- * http.get('people.json').observer({next: (value) => this.people = people});
+ * http.get('people.json').observer({next: (value) => this.people = value});
  * ```
  *
  * The default construct used to perform requests, `XMLHttpRequest`, is abstracted as a "Backend" (


### PR DESCRIPTION
The named parameter `value` should be used in the function body.
