### PR TITLE
docs(Http): add type annotations to clarify API

### DIFF
--- a/modules/examples/src/http/http_comp.ts
+++ b/modules/examples/src/http/http_comp.ts
@@ -17,7 +17,7 @@ export class HttpCmp {
   people: Array<Object>;
   constructor(http: Http) {
     http.get('./people.json')
-        .map((res: Response) => res.json())
-        .subscribe((people: Array<Object>) => this.people = people);
+      .map((res: Response) => res.json())
+      .subscribe((people: Array<Object>) => this.people = people);
   }
 }

--- a/modules/examples/src/http/http_comp.ts
+++ b/modules/examples/src/http/http_comp.ts
@@ -1,5 +1,5 @@
 import {Component, View, NgFor} from 'angular2/angular2';
-import {Http} from 'angular2/http';
+import {Http, Response} from 'angular2/http';
 
 @Component({selector: 'http-app'})
 @View({
@@ -14,8 +14,10 @@ import {Http} from 'angular2/http';
   `
 })
 export class HttpCmp {
-  people: Object;
+  people: Array<Object>;
   constructor(http: Http) {
-    http.get('./people.json').map(res => res.json()).subscribe(res => this.people = res);
+    http.get('./people.json')
+      .map((res: Response) => res.json())
+      .subscribe((people: Array<Object>) => this.people = people);
   }
 }

--- a/modules/examples/src/http/http_comp.ts
+++ b/modules/examples/src/http/http_comp.ts
@@ -17,7 +17,7 @@ export class HttpCmp {
   people: Array<Object>;
   constructor(http: Http) {
     http.get('./people.json')
-      .map((res: Response) => res.json())
-      .subscribe((people: Array<Object>) => this.people = people);
+        .map((res: Response) => res.json())
+        .subscribe((people: Array<Object>) => this.people = people);
   }
 }


### PR DESCRIPTION
IMHO this tiny example is easier to read when some type annotations are added and the parameter names are more concise.
