### PR TITLE
docs(http): use http.request('/foo') instead of http('/foo')

### DIFF
--- a/modules/angular2/src/http/backends/xhr_backend.ts
+++ b/modules/angular2/src/http/backends/xhr_backend.ts
@@ -101,7 +101,7 @@ export class XHRConnection implements Connection {
  * })
  * class MyComponent {
  *   constructor(http:Http) {
- *     http('people.json').subscribe(res => this.people = res.json());
+ *     http.request('people.json').subscribe(res => this.people = res.json());
  *   }
  * }
  * ```


### PR DESCRIPTION
`http('/foo')` is not valid anymore, so I'm replacing it with `http.request('/foo')`.
