### PR TITLE
chore(package.json): fix package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular",
+  "name": "angular2-sources",
   "version": "2.0.0-alpha.39",
   "branchPattern": "2.0.*",
   "description": "Angular 2 - a web framework for modern web apps",


### PR DESCRIPTION
This package is not published to npm - instead our build process generates a directory which we publish, and we use a different, templated package.json when we do so.
There is a risk that someone runs `npm publish` in this directory, which will create a new version of angular 1, and contain a scary source tree.
So this package.json may as well have a name that doesn't exist on npm, and if we did publish by accident, it would be a package name that matches the contents.
