### PR TITLE
quicker-start with npm install

### DIFF
--- a/docs/typescript-definition-package/index.js
+++ b/docs/typescript-definition-package/index.js
@@ -50,7 +50,7 @@ module.exports = new Package('angular-v2-docs', [jsdocPackage, nunjucksPackage, 
   createTypeDefinitionFile.typeDefinitions = [
     {
       id: 'angular2/angular2',
-      references: ['../es6-shim/es6-shim.d.ts'],
+      references: [],
       modules: {
         'angular2/angular2': {namespace: 'ng', id: 'angular2/angular2'},
         'angular2/web_worker/worker': {namespace: 'ngWorker', id: 'angular2/web_worker/worker'},
@@ -71,7 +71,7 @@ module.exports = new Package('angular-v2-docs', [jsdocPackage, nunjucksPackage, 
     },
     {
       id: 'angular2/test_lib',
-      references: ['./angular2.d.ts', '../jasmine/jasmine.d.ts'],
+      references: ['./angular2.d.ts'],
       remapTypes: { Type: 'ng.Type', Binding: 'ng.Binding', ViewMetadata: 'ng.ViewMetadata', Injector: 'ng.Injector',
                     Predicate: 'ng.Predicate', ElementRef: 'ng.ElementRef', DebugElement: 'ng.DebugElement',
                     InjectableReference: 'ng.InjectableReference', ComponentRef: 'ng.ComponentRef' },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -446,7 +446,7 @@ function runKarma(configFile, done) {
 
 gulp.task('test.js', function(done) {
   runSequence('test.unit.tools/ci', 'test.transpiler.unittest', 'test.unit.js/ci',
-              'test.unit.cjs/ci', 'test.typings', sequenceComplete(done));
+              'test.unit.cjs/ci', 'test.typings', 'test.typings.npm', sequenceComplete(done));
 });
 
 gulp.task('test.dart', function(done) {
@@ -771,14 +771,54 @@ gulp.task('!pre.test.typings', ['docs/typings'], function() {
 });
 
 // -----------------
+// Tests for the typings we deliver for TS users
+//
+// There are currently two mechanisms for this.
+// The first is the legacy, bundled .d.ts file produced by dgeni.
+// This is tested by 'test.typings'.
+//
+// The second is individual .d.ts files produced by the compiler,
+// distributed in our npm package, and loaded from node_modules by
+// the typescript compiler.
+// This is tested by 'test.typings.npm'.
+//
+// During the transition, we support both packaging/delivery types.
+// TODO(alexeagle): remove the dgeni bundle when users have switched
+
 gulp.task('test.typings', ['!pre.test.typings'], function() {
-  return gulp.src(['typing_spec/*.ts', 'dist/docs/typings/angular2/*.d.ts', 'dist/docs/typings/http.d.ts'])
+  return gulp.src(['typing_spec/*.ts', 'dist/docs/typings/angular2/*.d.ts',
+                   'dist/docs/typings/http.d.ts',
+                   'dist/docs/typings/es6-shim/es6-shim.d.ts',
+                   'dist/docs/typings/jasmine/jasmine.d.ts'])
       .pipe(tsc({target: 'ES5', module: 'commonjs',
                  experimentalDecorators: true,
                  noImplicitAny: true,
                  // Don't use the version of typescript that gulp-typescript depends on, we need 1.5
                  // see https://github.com/ivogabe/gulp-typescript#typescript-version
                  typescript: require('typescript')}));
+});
+
+// Make sure the two typings tests are isolated, by running this one in a tempdir
+var tmpdir = path.join(os.tmpdir(), 'test.typings',  new Date().getTime().toString());
+gulp.task('!pre.test.typings.layoutNodeModule', function() {
+  return gulp
+    .src(['dist/js/dev/es5/angular2/**/*'], {base: 'dist/js/dev/es5'})
+    .pipe(gulp.dest(path.join(tmpdir, 'node_modules')));
+});
+gulp.task('!pre.test.typings.copyTypingsSpec', function() {
+  return gulp
+    .src(['typing_spec/basic_spec.ts'], {base: 'typing_spec'})
+    .pipe(gulp.dest(path.join(tmpdir)));
+});
+gulp.task('test.typings.npm', [
+  '!pre.test.typings.layoutNodeModule',
+  '!pre.test.typings.copyTypingsSpec'
+], function() {
+  return gulp.src([tmpdir + '/**'])
+    .pipe(tsc({target: 'ES5', module: 'commonjs',
+      experimentalDecorators: true,
+      noImplicitAny: true,
+      typescript: require('typescript')}));
 });
 
 // -----------------

--- a/modules/angular2/manual_typings/globals-es6.d.ts
+++ b/modules/angular2/manual_typings/globals-es6.d.ts
@@ -1,0 +1,31 @@
+/**
+ * Declarations angular depends on for compilation to ES6.
+ * This file is also used to propagate our transitive typings
+ * to users.
+ */
+
+/// <reference path="../typings/zone/zone.d.ts"/>
+/// <reference path="../typings/hammerjs/hammerjs.d.ts"/>
+/// <reference path="../typings/jasmine/jasmine.d.ts"/>
+/// <reference path="../typings/angular-protractor/angular-protractor.d.ts"/>
+declare var assert: any;
+
+interface BrowserNodeGlobal {
+  Object: typeof Object;
+  Array: typeof Array;
+  Map: typeof Map;
+  Set: typeof Set;
+  Date: typeof Date;
+  RegExp: typeof RegExp;
+  JSON: typeof JSON;
+  Math: typeof Math;
+  assert(condition: any): void;
+  Reflect: any;
+  zone: Zone;
+  getAngularTestability: Function;
+  getAllAngularTestabilities: Function;
+  setTimeout: Function;
+  clearTimeout: Function;
+  setInterval: Function;
+  clearInterval: Function;
+}

--- a/modules/angular2/manual_typings/globals.d.ts
+++ b/modules/angular2/manual_typings/globals.d.ts
@@ -1,26 +1,7 @@
 /**
- * This file contains declarations of global symbols we reference in our code
+ * Declarations angular depends on for compilation to ES6.
+ * This file is also used to propagate our transitive typings
+ * to users.
  */
-
-/// <reference path="../typings/zone/zone.d.ts"/>
-declare var assert: any;
-
-interface BrowserNodeGlobal {
-  Object: typeof Object;
-  Array: typeof Array;
-  Map: typeof Map;
-  Set: typeof Set;
-  Date: typeof Date;
-  RegExp: typeof RegExp;
-  JSON: typeof JSON;
-  Math: typeof Math;
-  assert(condition): void;
-  Reflect: any;
-  zone: Zone;
-  getAngularTestability: Function;
-  getAllAngularTestabilities: Function;
-  setTimeout: Function;
-  clearTimeout: Function;
-  setInterval: Function;
-  clearInterval: Function;
-}
+/// <reference path="../typings/es6-shim/es6-shim.d.ts"/>
+/// <reference path="./globals-es6.d.ts"/>

--- a/modules/angular2/package.json
+++ b/modules/angular2/package.json
@@ -13,6 +13,7 @@
     "zone.js": "<%= packageJson.dependencies['zone.js'] %>"
   },
   "devDependencies": <%= JSON.stringify(packageJson.defaultDevDependencies) %>,
+  "typings": "./angular2.d.ts",
   "typescript": {
     "definitions": [
       "bundles/typings/angular2/angular2.d.ts",

--- a/modules/angular2/src/core/application_ref.ts
+++ b/modules/angular2/src/core/application_ref.ts
@@ -204,6 +204,7 @@ export abstract class PlatformRef {
 }
 
 export class PlatformRef_ extends PlatformRef {
+  /** @internal */
   _applications: ApplicationRef[] = [];
 
   constructor(private _injector: Injector, private _dispose: () => void) { super(); }
@@ -256,6 +257,7 @@ export class PlatformRef_ extends PlatformRef {
     this._dispose();
   }
 
+  /** @internal */
   _applicationDisposed(app: ApplicationRef): void { ListWrapper.remove(this._applications, app); }
 }
 

--- a/modules/angular2/src/core/application_ref.ts
+++ b/modules/angular2/src/core/application_ref.ts
@@ -117,9 +117,6 @@ export function createNgZone(): NgZone {
 
 var _platform: PlatformRef;
 
-/**
- * @internal
- */
 export function platformCommon(bindings?: Array<Type | Binding | any[]>, initializer?: () => void):
     PlatformRef {
   if (isPresent(_platform)) {

--- a/modules/angular2/src/core/change_detection/abstract_change_detector.ts
+++ b/modules/angular2/src/core/change_detection/abstract_change_detector.ts
@@ -178,6 +178,7 @@ export class AbstractChangeDetector<T> implements ChangeDetector {
 
   afterViewLifecycleCallbacksInternal(): void {}
 
+  /** @internal */
   _detectChangesInLightDomChildren(throwOnChange: boolean): void {
     var c = this.lightDomChildren;
     for (var i = 0; i < c.length; ++i) {
@@ -185,6 +186,7 @@ export class AbstractChangeDetector<T> implements ChangeDetector {
     }
   }
 
+  /** @internal */
   _detectChangesInShadowDomChildren(throwOnChange: boolean): void {
     var c = this.shadowDomChildren;
     for (var i = 0; i < c.length; ++i) {

--- a/modules/angular2/src/core/change_detection/change_detection_jit_generator.ts
+++ b/modules/angular2/src/core/change_detection/change_detection_jit_generator.ts
@@ -109,17 +109,20 @@ export class ChangeDetectorJITGenerator {
     `;
   }
 
+  /** @internal */
   _genPropertyBindingTargets(): string {
     var targets = this._logic.genPropertyBindingTargets(this.propertyBindingTargets,
                                                         this.genConfig.genDebugInfo);
     return `${this.typeName}.gen_propertyBindingTargets = ${targets};`;
   }
 
+  /** @internal */
   _genDirectiveIndices(): string {
     var indices = this._logic.genDirectiveIndices(this.directiveRecords);
     return `${this.typeName}.gen_directiveIndices = ${indices};`;
   }
 
+  /** @internal */
   _maybeGenHandleEventInternal(): string {
     if (this.eventBindings.length > 0) {
       var handlers = this.eventBindings.map(eb => this._genEventBinding(eb)).join("\n");
@@ -136,6 +139,7 @@ export class ChangeDetectorJITGenerator {
     }
   }
 
+  /** @internal */
   _genEventBinding(eb: EventBinding): string {
     var recs = eb.records.map(r => this._genEventBindingEval(eb, r)).join("\n");
     return `
@@ -144,6 +148,7 @@ export class ChangeDetectorJITGenerator {
     }`;
   }
 
+  /** @internal */
   _genEventBindingEval(eb: EventBinding, r: ProtoRecord): string {
     if (r.lastInBinding) {
       var evalRecord = this._logic.genEventBindingEvalValue(eb, r);
@@ -155,6 +160,7 @@ export class ChangeDetectorJITGenerator {
     }
   }
 
+  /** @internal */
   _genMarkPathToRootAsCheckOnce(r: ProtoRecord): string {
     var br = r.bindingRecord;
     if (br.isDefaultChangeDetection()) {
@@ -164,11 +170,13 @@ export class ChangeDetectorJITGenerator {
     }
   }
 
+  /** @internal */
   _genUpdatePreventDefault(eb: EventBinding, r: ProtoRecord): string {
     var local = this._names.getEventLocalName(eb, r.selfIndex);
     return `if (${local} === false) { ${this._names.getPreventDefaultAccesor()} = true};`;
   }
 
+  /** @internal */
   _maybeGenDehydrateDirectives(): string {
     var destroyPipesCode = this._names.genPipeOnDestroy();
     if (destroyPipesCode) {
@@ -182,6 +190,7 @@ export class ChangeDetectorJITGenerator {
     }`;
   }
 
+  /** @internal */
   _maybeGenHydrateDirectives(): string {
     var hydrateDirectivesCode = this._logic.genHydrateDirectives(this.directiveRecords);
     var hydrateDetectorsCode = this._logic.genHydrateDetectors(this.directiveRecords);
@@ -192,6 +201,7 @@ export class ChangeDetectorJITGenerator {
     }`;
   }
 
+  /** @internal */
   _maybeGenAfterContentLifecycleCallbacks(): string {
     var notifications = this._logic.genContentLifecycleCallbacks(this.directiveRecords);
     if (notifications.length > 0) {
@@ -206,6 +216,7 @@ export class ChangeDetectorJITGenerator {
     }
   }
 
+  /** @internal */
   _maybeGenAfterViewLifecycleCallbacks(): string {
     var notifications = this._logic.genViewLifecycleCallbacks(this.directiveRecords);
     if (notifications.length > 0) {
@@ -220,6 +231,7 @@ export class ChangeDetectorJITGenerator {
     }
   }
 
+  /** @internal */
   _genRecord(r: ProtoRecord): string {
     var rec;
     if (r.isLifeCycleRecord()) {
@@ -236,6 +248,7 @@ export class ChangeDetectorJITGenerator {
     `;
   }
 
+  /** @internal */
   _genDirectiveLifecycle(r: ProtoRecord): string {
     if (r.name === "DoCheck") {
       return this._genOnCheck(r);
@@ -248,6 +261,7 @@ export class ChangeDetectorJITGenerator {
     }
   }
 
+  /** @internal */
   _genPipeCheck(r: ProtoRecord): string {
     var context = this._names.getLocalName(r.contextIndex);
     var argString = r.args.map((arg) => this._names.getLocalName(arg)).join(", ");
@@ -288,6 +302,7 @@ export class ChangeDetectorJITGenerator {
     }
   }
 
+  /** @internal */
   _genReferenceCheck(r: ProtoRecord): string {
     var oldValue = this._names.getFieldName(r.selfIndex);
     var newValue = this._names.getLocalName(r.selfIndex);
@@ -318,10 +333,12 @@ export class ChangeDetectorJITGenerator {
     }
   }
 
+  /** @internal */
   _genChangeMarker(r: ProtoRecord): string {
     return r.argumentToPureFunction ? `${this._names.getChangeName(r.selfIndex)} = true` : ``;
   }
 
+  /** @internal */
   _genUpdateDirectiveOrElement(r: ProtoRecord): string {
     if (!r.lastInBinding) return "";
 
@@ -348,6 +365,7 @@ export class ChangeDetectorJITGenerator {
     }
   }
 
+  /** @internal */
   _genThrowOnChangeCheck(oldValue: string, newValue: string): string {
     if (this.genConfig.genCheckNoChanges) {
       return `
@@ -360,6 +378,7 @@ export class ChangeDetectorJITGenerator {
     }
   }
 
+  /** @internal */
   _genCheckNoChanges(): string {
     if (this.genConfig.genCheckNoChanges) {
       return `${this.typeName}.prototype.checkNoChanges = function() { this.runDetectChanges(true); }`;
@@ -368,6 +387,7 @@ export class ChangeDetectorJITGenerator {
     }
   }
 
+  /** @internal */
   _genAddToChanges(r: ProtoRecord): string {
     var newValue = this._names.getLocalName(r.selfIndex);
     var oldValue = this._names.getFieldName(r.selfIndex);
@@ -375,6 +395,7 @@ export class ChangeDetectorJITGenerator {
     return `${CHANGES_LOCAL} = this.addChange(${CHANGES_LOCAL}, ${oldValue}, ${newValue});`;
   }
 
+  /** @internal */
   _maybeFirstInBinding(r: ProtoRecord): string {
     var prev = ChangeDetectionUtil.protoByIndex(this.records, r.selfIndex - 1);
     var firstInBindng = isBlank(prev) || prev.bindingRecord !== r.bindingRecord;
@@ -383,6 +404,7 @@ export class ChangeDetectorJITGenerator {
                '';
   }
 
+  /** @internal */
   _maybeGenLastInDirective(r: ProtoRecord): string {
     if (!r.lastInDirective) return "";
     return `
@@ -392,21 +414,25 @@ export class ChangeDetectorJITGenerator {
     `;
   }
 
+  /** @internal */
   _genOnCheck(r: ProtoRecord): string {
     var br = r.bindingRecord;
     return `if (!throwOnChange) ${this._names.getDirectiveName(br.directiveRecord.directiveIndex)}.doCheck();`;
   }
 
+  /** @internal */
   _genOnInit(r: ProtoRecord): string {
     var br = r.bindingRecord;
     return `if (!throwOnChange && !${this._names.getAlreadyCheckedName()}) ${this._names.getDirectiveName(br.directiveRecord.directiveIndex)}.onInit();`;
   }
 
+  /** @internal */
   _genOnChange(r: ProtoRecord): string {
     var br = r.bindingRecord;
     return `if (!throwOnChange && ${CHANGES_LOCAL}) ${this._names.getDirectiveName(br.directiveRecord.directiveIndex)}.onChanges(${CHANGES_LOCAL});`;
   }
 
+  /** @internal */
   _genNotifyOnPushDetectors(r: ProtoRecord): string {
     var br = r.bindingRecord;
     if (!r.lastInDirective || br.isDefaultChangeDetection()) return "";

--- a/modules/angular2/src/core/change_detection/codegen_logic_util.ts
+++ b/modules/angular2/src/core/change_detection/codegen_logic_util.ts
@@ -111,6 +111,7 @@ export class CodegenLogicUtil {
     return `${getLocalName(protoRec.selfIndex)} = ${rhs};`;
   }
 
+  /** @internal */
   _observe(exp: string, rec: ProtoRecord): string {
     // This is an experimental feature. Works only in Dart.
     if (this._changeDetection === ChangeDetectionStrategy.OnPushObserve) {
@@ -138,6 +139,7 @@ export class CodegenLogicUtil {
     return `[${bs.join(", ")}]`;
   }
 
+  /** @internal */
   _genInterpolation(protoRec: ProtoRecord): string {
     var iVals = [];
     for (var i = 0; i < protoRec.args.length; ++i) {

--- a/modules/angular2/src/core/change_detection/codegen_name_util.ts
+++ b/modules/angular2/src/core/change_detection/codegen_name_util.ts
@@ -40,8 +40,10 @@ export class CodegenNameUtil {
   /**
    * Record names sanitized for use as fields.
    * See [sanitizeName] for details.
+   * @internal
    */
   _sanitizedNames: string[];
+  /** @internal */
   _sanitizedEventNames = new Map<EventBinding, string[]>();
 
   constructor(private _records: ProtoRecord[], private _eventBindings: EventBinding[],
@@ -62,6 +64,7 @@ export class CodegenNameUtil {
     }
   }
 
+  /** @internal */
   _addFieldPrefix(name: string): string { return `${_FIELD_PREFIX}${name}`; }
 
   getDispatcherName(): string { return this._addFieldPrefix(_DISPATCHER_ACCESSOR); }

--- a/modules/angular2/src/core/change_detection/differs/default_iterable_differ.ts
+++ b/modules/angular2/src/core/change_detection/differs/default_iterable_differ.ts
@@ -151,6 +151,8 @@ export class DefaultIterableDiffer implements IterableDiffer {
    * currentKey, and clear all of the queues (additions, moves, removals).
    * Set the previousIndexes of moved and added items to their currentIndexes
    * Reset the list of additions, moves and removals
+   *
+   * @internal
    */
   _reset() {
     if (this.isDirty) {
@@ -185,6 +187,8 @@ export class DefaultIterableDiffer implements IterableDiffer {
    *   item.
    * - `item` is the current item in the collection
    * - `index` is the position of the item in the collection
+   *
+   * @internal
    */
   _mismatch(record: CollectionChangeRecord, item, index: number): CollectionChangeRecord {
     // The previous record after which we will append the current one.
@@ -241,6 +245,8 @@ export class DefaultIterableDiffer implements IterableDiffer {
    * at the end. Which will show up as the two 'a's switching position. This is incorrect, since a
    * better way to think of it is as insert of 'b' rather then switch 'a' with 'b' and then add 'a'
    * at the end.
+   *
+   * @internal
    */
   _verifyReinsertion(record: CollectionChangeRecord, item, index: number): CollectionChangeRecord {
     var reinsertRecord: CollectionChangeRecord =
@@ -258,6 +264,8 @@ export class DefaultIterableDiffer implements IterableDiffer {
    * Get rid of any excess {@link CollectionChangeRecord}s from the previous collection
    *
    * - `record` The first excess {@link CollectionChangeRecord}.
+   *
+   * @internal
    */
   _truncate(record: CollectionChangeRecord) {
     // Anything after that needs to be removed;
@@ -284,6 +292,7 @@ export class DefaultIterableDiffer implements IterableDiffer {
     }
   }
 
+  /** @internal */
   _reinsertAfter(record: CollectionChangeRecord, prevRecord: CollectionChangeRecord,
                  index: number): CollectionChangeRecord {
     if (this._unlinkedRecords !== null) {
@@ -308,6 +317,7 @@ export class DefaultIterableDiffer implements IterableDiffer {
     return record;
   }
 
+  /** @internal */
   _moveAfter(record: CollectionChangeRecord, prevRecord: CollectionChangeRecord,
              index: number): CollectionChangeRecord {
     this._unlink(record);
@@ -316,6 +326,7 @@ export class DefaultIterableDiffer implements IterableDiffer {
     return record;
   }
 
+  /** @internal */
   _addAfter(record: CollectionChangeRecord, prevRecord: CollectionChangeRecord,
             index: number): CollectionChangeRecord {
     this._insertAfter(record, prevRecord, index);
@@ -333,6 +344,7 @@ export class DefaultIterableDiffer implements IterableDiffer {
     return record;
   }
 
+  /** @internal */
   _insertAfter(record: CollectionChangeRecord, prevRecord: CollectionChangeRecord,
                index: number): CollectionChangeRecord {
     // todo(vicb)
@@ -366,10 +378,12 @@ export class DefaultIterableDiffer implements IterableDiffer {
     return record;
   }
 
+  /** @internal */
   _remove(record: CollectionChangeRecord): CollectionChangeRecord {
     return this._addToRemovals(this._unlink(record));
   }
 
+  /** @internal */
   _unlink(record: CollectionChangeRecord): CollectionChangeRecord {
     if (this._linkedRecords !== null) {
       this._linkedRecords.remove(record);
@@ -396,6 +410,7 @@ export class DefaultIterableDiffer implements IterableDiffer {
     return record;
   }
 
+  /** @internal */
   _addToMoves(record: CollectionChangeRecord, toIndex: number): CollectionChangeRecord {
     // todo(vicb)
     // assert(record._nextMoved === null);
@@ -417,6 +432,7 @@ export class DefaultIterableDiffer implements IterableDiffer {
     return record;
   }
 
+  /** @internal */
   _addToRemovals(record: CollectionChangeRecord): CollectionChangeRecord {
     if (this._unlinkedRecords === null) {
       this._unlinkedRecords = new _DuplicateMap();
@@ -477,14 +493,23 @@ export class CollectionChangeRecord {
   currentIndex: number = null;
   previousIndex: number = null;
 
+  /** @internal */
   _nextPrevious: CollectionChangeRecord = null;
+  /** @internal */
   _prev: CollectionChangeRecord = null;
+  /** @internal */
   _next: CollectionChangeRecord = null;
+  /** @internal */
   _prevDup: CollectionChangeRecord = null;
+  /** @internal */
   _nextDup: CollectionChangeRecord = null;
+  /** @internal */
   _prevRemoved: CollectionChangeRecord = null;
+  /** @internal */
   _nextRemoved: CollectionChangeRecord = null;
+  /** @internal */
   _nextAdded: CollectionChangeRecord = null;
+  /** @internal */
   _nextMoved: CollectionChangeRecord = null;
 
   constructor(public item: any) {}
@@ -499,7 +524,9 @@ export class CollectionChangeRecord {
 
 // A linked list of CollectionChangeRecords with the same CollectionChangeRecord.item
 class _DuplicateItemRecordList {
+  /** @internal */
   _head: CollectionChangeRecord = null;
+  /** @internal */
   _tail: CollectionChangeRecord = null;
 
   /**

--- a/modules/angular2/src/core/change_detection/differs/default_keyvalue_differ.ts
+++ b/modules/angular2/src/core/change_detection/differs/default_keyvalue_differ.ts
@@ -129,6 +129,7 @@ export class DefaultKeyValueDiffer implements KeyValueDiffer {
     return this.isDirty;
   }
 
+  /** @internal */
   _reset() {
     if (this.isDirty) {
       var record: KVChangeRecord;
@@ -176,6 +177,7 @@ export class DefaultKeyValueDiffer implements KeyValueDiffer {
     }
   }
 
+  /** @internal */
   _truncate(lastRecord: KVChangeRecord, record: KVChangeRecord) {
     while (record !== null) {
       if (lastRecord === null) {
@@ -201,11 +203,13 @@ export class DefaultKeyValueDiffer implements KeyValueDiffer {
     }
   }
 
+  /** @internal */
   _isInRemovals(record: KVChangeRecord) {
     return record === this._removalsHead || record._nextRemoved !== null ||
            record._prevRemoved !== null;
   }
 
+  /** @internal */
   _addToRemovals(record: KVChangeRecord) {
     // todo(vicb) assert
     // assert(record._next == null);
@@ -222,6 +226,7 @@ export class DefaultKeyValueDiffer implements KeyValueDiffer {
     }
   }
 
+  /** @internal */
   _removeFromSeq(prev: KVChangeRecord, record: KVChangeRecord) {
     var next = record._next;
     if (prev === null) {
@@ -236,6 +241,7 @@ export class DefaultKeyValueDiffer implements KeyValueDiffer {
     //})());
   }
 
+  /** @internal */
   _removeFromRemovals(record: KVChangeRecord) {
     // todo(vicb) assert
     // assert(record._next == null);
@@ -257,6 +263,7 @@ export class DefaultKeyValueDiffer implements KeyValueDiffer {
     record._prevRemoved = record._nextRemoved = null;
   }
 
+  /** @internal */
   _addToAdditions(record: KVChangeRecord) {
     // todo(vicb): assert
     // assert(record._next == null);
@@ -272,6 +279,7 @@ export class DefaultKeyValueDiffer implements KeyValueDiffer {
     }
   }
 
+  /** @internal */
   _addToChanges(record: KVChangeRecord) {
     // todo(vicb) assert
     // assert(record._nextAdded == null);
@@ -315,6 +323,7 @@ export class DefaultKeyValueDiffer implements KeyValueDiffer {
            "removals: " + removals.join(', ') + "\n";
   }
 
+  /** @internal */
   _forEach(obj, fn: Function) {
     if (obj instanceof Map) {
       (<Map<any, any>>obj).forEach(<any>fn);
@@ -329,11 +338,17 @@ export class KVChangeRecord {
   previousValue: any = null;
   currentValue: any = null;
 
+  /** @internal */
   _nextPrevious: KVChangeRecord = null;
+  /** @internal */
   _next: KVChangeRecord = null;
+  /** @internal */
   _nextAdded: KVChangeRecord = null;
+  /** @internal */
   _nextRemoved: KVChangeRecord = null;
+  /** @internal */
   _prevRemoved: KVChangeRecord = null;
+  /** @internal */
   _nextChanged: KVChangeRecord = null;
 
   constructor(public key: any) {}

--- a/modules/angular2/src/core/change_detection/dynamic_change_detector.ts
+++ b/modules/angular2/src/core/change_detection/dynamic_change_detector.ts
@@ -49,6 +49,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     return preventDefault;
   }
 
+  /** @internal */
   _processEventBinding(eb: EventBinding, locals: Locals): any {
     var values = ListWrapper.createFixedSize(eb.records.length);
     values[0] = this.values[0];
@@ -67,6 +68,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     throw new BaseException("Cannot be reached");
   }
 
+  /** @internal */
   _markPathAsCheckOnce(proto: ProtoRecord): void {
     if (!proto.bindingRecord.isDefaultChangeDetection()) {
       var dir = proto.bindingRecord.directiveRecord;
@@ -74,6 +76,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     }
   }
 
+  /** @internal */
   _matchingEventBindings(eventName: string, elIndex: number): EventBinding[] {
     return ListWrapper.filter(this._eventBindings,
                               eb => eb.eventName == eventName && eb.elIndex === elIndex);
@@ -103,6 +106,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     ListWrapper.fill(this.prevContexts, ChangeDetectionUtil.uninitialized);
   }
 
+  /** @internal */
   _destroyPipes() {
     for (var i = 0; i < this.localPipes.length; ++i) {
       if (isPresent(this.localPipes[i])) {
@@ -156,6 +160,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     }
   }
 
+  /** @internal */
   _firstInBinding(r: ProtoRecord): boolean {
     var prev = ChangeDetectionUtil.protoByIndex(this._records, r.selfIndex - 1);
     return isBlank(prev) || prev.bindingRecord !== r.bindingRecord;
@@ -188,6 +193,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     }
   }
 
+  /** @internal */
   _updateDirectiveOrElement(change, bindingRecord) {
     if (isBlank(bindingRecord.directiveRecord)) {
       super.notifyDispatcher(change.currentValue);
@@ -201,6 +207,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     }
   }
 
+  /** @internal */
   _addChange(bindingRecord: BindingRecord, change, changes) {
     if (bindingRecord.callOnChanges()) {
       return super.addChange(changes, change.previousValue, change.currentValue);
@@ -209,10 +216,13 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     }
   }
 
+  /** @internal */
   _getDirectiveFor(directiveIndex) { return this.directives.getDirectiveFor(directiveIndex); }
 
+  /** @internal */
   _getDetectorFor(directiveIndex) { return this.directives.getDetectorFor(directiveIndex); }
 
+  /** @internal */
   _check(proto: ProtoRecord, throwOnChange: boolean, values: any[], locals: Locals): SimpleChange {
     if (proto.isPipeRecord()) {
       return this._pipeCheck(proto, throwOnChange, values);
@@ -221,6 +231,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     }
   }
 
+  /** @internal */
   _referenceCheck(proto: ProtoRecord, throwOnChange: boolean, values: any[], locals: Locals) {
     if (this._pureFuncAndArgsDidNotChange(proto)) {
       this._setChanged(proto, false);
@@ -259,6 +270,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     }
   }
 
+  /** @internal */
   _calculateCurrValue(proto: ProtoRecord, values: any[], locals: Locals) {
     switch (proto.mode) {
       case RecordType.Self:
@@ -326,6 +338,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     }
   }
 
+  /** @internal */
   _pipeCheck(proto: ProtoRecord, throwOnChange: boolean, values: any[]) {
     var context = this._readContext(proto, values);
     var selectedPipe = this._pipeFor(proto, context);
@@ -364,6 +377,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     }
   }
 
+  /** @internal */
   _pipeFor(proto: ProtoRecord, context) {
     var storedPipe = this._readPipe(proto);
     if (isPresent(storedPipe)) return storedPipe;
@@ -373,6 +387,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     return pipe;
   }
 
+  /** @internal */
   _readContext(proto: ProtoRecord, values: any[]) {
     if (proto.contextIndex == -1) {
       return this._getDirectiveFor(proto.directiveIndex);
@@ -383,22 +398,29 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     return values[proto.contextIndex];
   }
 
+  /** @internal */
   _readSelf(proto: ProtoRecord, values: any[]) { return values[proto.selfIndex]; }
 
+  /** @internal */
   _writeSelf(proto: ProtoRecord, value, values: any[]) { values[proto.selfIndex] = value; }
 
+  /** @internal */
   _readPipe(proto: ProtoRecord) { return this.localPipes[proto.selfIndex]; }
 
+  /** @internal */
   _writePipe(proto: ProtoRecord, value) { this.localPipes[proto.selfIndex] = value; }
 
+  /** @internal */
   _setChanged(proto: ProtoRecord, value: boolean) {
     if (proto.argumentToPureFunction) this.changes[proto.selfIndex] = value;
   }
 
+  /** @internal */
   _pureFuncAndArgsDidNotChange(proto: ProtoRecord): boolean {
     return proto.isPureFunction() && !this._argsChanged(proto);
   }
 
+  /** @internal */
   _argsChanged(proto: ProtoRecord): boolean {
     var args = proto.args;
     for (var i = 0; i < args.length; ++i) {
@@ -409,10 +431,12 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     return false;
   }
 
+  /** @internal */
   _argsOrContextChanged(proto: ProtoRecord): boolean {
     return this._argsChanged(proto) || this.changes[proto.contextIndex];
   }
 
+  /** @internal */
   _readArgs(proto: ProtoRecord, values: any[]) {
     var res = ListWrapper.createFixedSize(proto.args.length);
     var args = proto.args;

--- a/modules/angular2/src/core/change_detection/jit_proto_change_detector.ts
+++ b/modules/angular2/src/core/change_detection/jit_proto_change_detector.ts
@@ -5,6 +5,7 @@ import {ProtoChangeDetector, ChangeDetector, ChangeDetectorDefinition} from './i
 import {ChangeDetectorJITGenerator} from './change_detection_jit_generator';
 
 export class JitProtoChangeDetector implements ProtoChangeDetector {
+  /** @internal */
   _factory: Function;
 
   constructor(private definition: ChangeDetectorDefinition) {
@@ -15,6 +16,7 @@ export class JitProtoChangeDetector implements ProtoChangeDetector {
 
   instantiate(dispatcher: any): ChangeDetector { return this._factory(dispatcher); }
 
+  /** @internal */
   _createFactory(definition: ChangeDetectorDefinition) {
     return new ChangeDetectorJITGenerator(definition, 'util', 'AbstractChangeDetector').generate();
   }

--- a/modules/angular2/src/core/change_detection/parser/locals.ts
+++ b/modules/angular2/src/core/change_detection/parser/locals.ts
@@ -2,9 +2,6 @@ import {isPresent} from 'angular2/src/core/facade/lang';
 import {BaseException} from 'angular2/src/core/facade/exceptions';
 import {ListWrapper, MapWrapper} from 'angular2/src/core/facade/collection';
 
-/**
- * @internal
- */
 export class Locals {
   constructor(public parent: Locals, public current: Map<any, any>) {}
 

--- a/modules/angular2/src/core/change_detection/parser/parser.ts
+++ b/modules/angular2/src/core/change_detection/parser/parser.ts
@@ -58,9 +58,11 @@ class ParseException extends BaseException {
 
 @Injectable()
 export class Parser {
+  /** @internal */
   _reflector: Reflector;
 
-  constructor(public _lexer: Lexer, providedReflector: Reflector = null) {
+  constructor(/** @internal */
+              public _lexer: Lexer, providedReflector: Reflector = null) {
     this._reflector = isPresent(providedReflector) ? providedReflector : reflector;
   }
 

--- a/modules/angular2/src/core/change_detection/proto_change_detector.ts
+++ b/modules/angular2/src/core/change_detection/proto_change_detector.ts
@@ -38,9 +38,13 @@ import {coalesce} from './coalesce';
 import {ProtoRecord, RecordType} from './proto_record';
 
 export class DynamicProtoChangeDetector implements ProtoChangeDetector {
+  /** @internal */
   _propertyBindingRecords: ProtoRecord[];
+  /** @internal */
   _propertyBindingTargets: BindingTarget[];
+  /** @internal */
   _eventBindingRecords: EventBinding[];
+  /** @internal */
   _directiveIndices: DirectiveIndex[];
 
   constructor(private _definition: ChangeDetectorDefinition) {
@@ -96,6 +100,7 @@ export class ProtoRecordBuilder {
     }
   }
 
+  /** @internal */
   _setArgumentToPureFunction(startIndex: number): void {
     for (var i = startIndex; i < this.records.length; ++i) {
       var rec = this.records[i];
@@ -111,6 +116,7 @@ export class ProtoRecordBuilder {
     }
   }
 
+  /** @internal */
   _appendRecords(b: BindingRecord, variableNames: string[], bindingIndex: number) {
     if (b.isDirectiveLifecycle()) {
       this.records.push(new ProtoRecord(RecordType.DirectiveLifecycle, b.lifecycleEvent, null, [],

--- a/modules/angular2/src/core/compiler/selector.ts
+++ b/modules/angular2/src/core/compiler/selector.ts
@@ -312,6 +312,7 @@ export class SelectorMatcher {
     return result;
   }
 
+  /** @internal */
   _matchTerminal(map: Map<string, SelectorContext[]>, name, cssSelector: CssSelector,
                  matchedCallback: (c: CssSelector, a: any) => void): boolean {
     if (isBlank(map) || isBlank(name)) {
@@ -335,6 +336,7 @@ export class SelectorMatcher {
     return result;
   }
 
+  /** @internal */
   _matchPartial(map: Map<string, SelectorMatcher>, name, cssSelector: CssSelector,
                 matchedCallback /*: (c: CssSelector, a: any) => void*/): boolean {
     if (isBlank(map) || isBlank(name)) {

--- a/modules/angular2/src/core/compiler/shadow_css.ts
+++ b/modules/angular2/src/core/compiler/shadow_css.ts
@@ -162,6 +162,7 @@ export class ShadowCss {
     return this._scopeCssText(cssText, selector, hostSelector);
   }
 
+  /** @internal */
   _insertDirectives(cssText: string): string {
     cssText = this._insertPolyfillDirectivesInCssText(cssText);
     return this._insertPolyfillRulesInCssText(cssText);
@@ -181,6 +182,7 @@ export class ShadowCss {
    * scopeName menu-item {
    *
   **/
+  /** @internal */
   _insertPolyfillDirectivesInCssText(cssText: string): string {
     // Difference with webcomponents.js: does not handle comments
     return StringWrapper.replaceAllMapped(cssText, _cssContentNextSelectorRe,
@@ -202,6 +204,7 @@ export class ShadowCss {
    * scopeName menu-item {...}
    *
   **/
+  /** @internal */
   _insertPolyfillRulesInCssText(cssText: string): string {
     // Difference with webcomponents.js: does not handle comments
     return StringWrapper.replaceAllMapped(cssText, _cssContentRuleRe, function(m) {
@@ -220,6 +223,7 @@ export class ShadowCss {
    *
    *  scopeName .foo { ... }
   */
+  /** @internal */
   _scopeCssText(cssText: string, scopeSelector: string, hostSelector: string): string {
     var unscoped = this._extractUnscopedRulesFromCssText(cssText);
     cssText = this._insertPolyfillHostInCssText(cssText);
@@ -249,6 +253,7 @@ export class ShadowCss {
    * menu-item {...}
    *
   **/
+  /** @internal */
   _extractUnscopedRulesFromCssText(cssText: string): string {
     // Difference with webcomponents.js: does not handle comments
     var r = '', m;
@@ -269,6 +274,7 @@ export class ShadowCss {
    *
    * scopeName.foo > .bar
   */
+  /** @internal */
   _convertColonHost(cssText: string): string {
     return this._convertColonRule(cssText, _cssColonHostRe, this._colonHostPartReplacer);
   }
@@ -288,11 +294,13 @@ export class ShadowCss {
    *
    * scopeName.foo .bar { ... }
   */
+  /** @internal */
   _convertColonHostContext(cssText: string): string {
     return this._convertColonRule(cssText, _cssColonHostContextRe,
                                   this._colonHostContextPartReplacer);
   }
 
+  /** @internal */
   _convertColonRule(cssText: string, regExp: RegExp, partReplacer: Function): string {
     // p1 = :host, p2 = contents of (), p3 rest of rule
     return StringWrapper.replaceAllMapped(cssText, regExp, function(m) {
@@ -311,6 +319,7 @@ export class ShadowCss {
     });
   }
 
+  /** @internal */
   _colonHostContextPartReplacer(host: string, part: string, suffix: string): string {
     if (StringWrapper.contains(part, _polyfillHost)) {
       return this._colonHostPartReplacer(host, part, suffix);
@@ -319,6 +328,7 @@ export class ShadowCss {
     }
   }
 
+  /** @internal */
   _colonHostPartReplacer(host: string, part: string, suffix: string): string {
     return host + StringWrapper.replace(part, _polyfillHost, '') + suffix;
   }
@@ -327,6 +337,7 @@ export class ShadowCss {
    * Convert combinators like ::shadow and pseudo-elements like ::content
    * by replacing with space.
   */
+  /** @internal */
   _convertShadowDOMSelectors(cssText: string): string {
     for (var i = 0; i < _shadowDOMSelectorsRe.length; i++) {
       cssText = StringWrapper.replaceAll(cssText, _shadowDOMSelectorsRe[i], ' ');
@@ -335,6 +346,7 @@ export class ShadowCss {
   }
 
   // change a selector like 'div' to 'name div'
+  /** @internal */
   _scopeRules(cssRules, scopeSelector: string, hostSelector: string): string {
     var cssText = '';
     if (isPresent(cssRules)) {
@@ -370,6 +382,7 @@ export class ShadowCss {
     return cssText;
   }
 
+  /** @internal */
   _ieSafeCssTextFromKeyFrameRule(rule): string {
     var cssText = '@keyframes ' + rule.name + ' {';
     for (var i = 0; i < rule.cssRules.length; i++) {
@@ -380,6 +393,7 @@ export class ShadowCss {
     return cssText;
   }
 
+  /** @internal */
   _scopeSelector(selector: string, scopeSelector: string, hostSelector: string,
                  strict: boolean): string {
     var r = [], parts = selector.split(',');
@@ -396,11 +410,13 @@ export class ShadowCss {
     return r.join(', ');
   }
 
+  /** @internal */
   _selectorNeedsScoping(selector: string, scopeSelector: string): boolean {
     var re = this._makeScopeMatcher(scopeSelector);
     return !isPresent(RegExpWrapper.firstMatch(re, selector));
   }
 
+  /** @internal */
   _makeScopeMatcher(scopeSelector: string): RegExp {
     var lre = /\[/g;
     var rre = /\]/g;
@@ -409,12 +425,14 @@ export class ShadowCss {
     return RegExpWrapper.create('^(' + scopeSelector + ')' + _selectorReSuffix, 'm');
   }
 
+  /** @internal */
   _applySelectorScope(selector: string, scopeSelector: string, hostSelector: string): string {
     // Difference from webcomponentsjs: scopeSelector could not be an array
     return this._applySimpleSelectorScope(selector, scopeSelector, hostSelector);
   }
 
   // scope via name and [is=name]
+  /** @internal */
   _applySimpleSelectorScope(selector: string, scopeSelector: string, hostSelector: string): string {
     if (isPresent(RegExpWrapper.firstMatch(_polyfillHostRe, selector))) {
       var replaceBy = this.strictStyling ? `[${hostSelector}]` : scopeSelector;
@@ -427,6 +445,7 @@ export class ShadowCss {
 
   // return a selector with [name] suffix on each simple selector
   // e.g. .foo.bar > .zot becomes .foo[name].bar[name] > .zot[name]
+  /** @internal */
   _applyStrictSelectorScope(selector: string, scopeSelector: string): string {
     var isRe = /\[is=([^\]]*)\]/g;
     scopeSelector = StringWrapper.replaceAllMapped(scopeSelector, isRe, (m) => m[1]);
@@ -452,12 +471,14 @@ export class ShadowCss {
     return scoped;
   }
 
+  /** @internal */
   _insertPolyfillHostInCssText(selector: string): string {
     selector = StringWrapper.replaceAll(selector, _colonHostContextRe, _polyfillHostContext);
     selector = StringWrapper.replaceAll(selector, _colonHostRe, _polyfillHost);
     return selector;
   }
 
+  /** @internal */
   _propertiesFromRule(rule): string {
     var cssText = rule.style.cssText;
     // TODO(sorvell): Safari cssom incorrectly removes quotes from the content

--- a/modules/angular2/src/core/debug/debug_element.ts
+++ b/modules/angular2/src/core/debug/debug_element.ts
@@ -77,6 +77,7 @@ export abstract class DebugElement {
 }
 
 export class DebugElement_ extends DebugElement {
+  /** @internal */
   _elementInjector: ElementInjector;
 
   constructor(private _parentView: AppView, private _boundElementIndex: number) {
@@ -134,6 +135,7 @@ export class DebugElement_ extends DebugElement {
 
   getLocal(name: string): any { return this._parentView.locals.get(name); }
 
+  /** @internal */
   _getChildElements(view: AppView, parentBoundElementIndex: number): DebugElement[] {
     var els = [];
     var parentElementBinder = null;

--- a/modules/angular2/src/core/di/binding.ts
+++ b/modules/angular2/src/core/di/binding.ts
@@ -30,9 +30,6 @@ import {
 } from './exceptions';
 import {resolveForwardRef} from './forward_ref';
 
-/**
- * @internal
- */
 export class Dependency {
   constructor(public key: Key, public optional: boolean, public lowerBoundVisibility: any,
               public upperBoundVisibility: any, public properties: any[]) {}
@@ -280,7 +277,6 @@ export class ResolvedBinding_ implements ResolvedBinding {
 }
 
 /**
- * @internal
  * An internal resolved representation of a factory function created by resolving {@link Binding}.
  */
 export class ResolvedFactory {

--- a/modules/angular2/src/core/di/binding.ts
+++ b/modules/angular2/src/core/di/binding.ts
@@ -183,6 +183,7 @@ export class Binding {
    */
   dependencies: Object[];
 
+  /** @internal */
   _multi: boolean;
 
   constructor(token, {toClass, toValue, toAlias, toFactory, deps, multi}: {

--- a/modules/angular2/src/core/di/injector.ts
+++ b/modules/angular2/src/core/di/injector.ts
@@ -196,6 +196,7 @@ export class ProtoInjectorDynamicStrategy implements ProtoInjectorStrategy {
 }
 
 export class ProtoInjector {
+  /** @internal */
   _strategy: ProtoInjectorStrategy;
   numberOfBindings: number;
 
@@ -522,16 +523,24 @@ export class Injector {
     return new Injector(proto, null, null);
   }
 
+  /** @internal */
   _strategy: InjectorStrategy;
+  /** @internal */
   _isHost: boolean = false;
+  /** @internal */
   _constructionCounter: number = 0;
-
+  /** @internal */
+  public _proto: any /* ProtoInjector */;
+  /** @internal */
+  public _parent: Injector;
   /**
    * Private
    */
-  constructor(public _proto: any /* ProtoInjector */, public _parent: Injector = null,
+  constructor(_proto: any /* ProtoInjector */, _parent: Injector = null,
               private _depProvider: any /* DependencyProvider */ = null,
               private _debugContext: Function = null) {
+    this._proto = _proto;
+    this._parent = _parent;
     this._strategy = _proto._strategy.createInjectorStrategy(this);
   }
 
@@ -739,6 +748,7 @@ export class Injector {
     return this._instantiateBinding(binding, Visibility.PublicAndPrivate);
   }
 
+  /** @internal */
   _new(binding: ResolvedBinding, visibility: Visibility): any {
     if (this._constructionCounter++ > this._strategy.getMaxNumberOfObjects()) {
       throw new CyclicDependencyError(this, binding.key);
@@ -899,6 +909,7 @@ export class Injector {
     }
   }
 
+  /** @internal */
   _throwOrNull(key: Key, optional: boolean): any {
     if (optional) {
       return null;
@@ -907,11 +918,13 @@ export class Injector {
     }
   }
 
+  /** @internal */
   _getByKeySelf(key: Key, optional: boolean, bindingVisibility: Visibility): any {
     var obj = this._strategy.getObjByKeyId(key.id, bindingVisibility);
     return (obj !== UNDEFINED) ? obj : this._throwOrNull(key, optional);
   }
 
+  /** @internal */
   _getByKeyHost(key: Key, optional: boolean, bindingVisibility: Visibility,
                 lowerBoundVisibility: Object): any {
     var inj = this;
@@ -938,11 +951,13 @@ export class Injector {
     return this._throwOrNull(key, optional);
   }
 
+  /** @internal */
   _getPrivateDependency(key: Key, optional: boolean, inj: Injector): any {
     var obj = inj._parent._strategy.getObjByKeyId(key.id, Visibility.Private);
     return (obj !== UNDEFINED) ? obj : this._throwOrNull(key, optional);
   }
 
+  /** @internal */
   _getByKeyDefault(key: Key, optional: boolean, bindingVisibility: Visibility,
                    lowerBoundVisibility: Object): any {
     var inj = this;

--- a/modules/angular2/src/core/di/injector.ts
+++ b/modules/angular2/src/core/di/injector.ts
@@ -387,7 +387,6 @@ export class BindingWithVisibility {
 }
 
 /**
- * @internal
  * Used to provide dependencies that cannot be easily expressed as bindings.
  */
 export interface DependencyProvider {

--- a/modules/angular2/src/core/di/type_literal.ts
+++ b/modules/angular2/src/core/di/type_literal.ts
@@ -1,5 +1,4 @@
 /**
- * @internal
  * Type literals is a Dart-only feature. This is here only so we can x-compile
  * to multiple languages.
  */

--- a/modules/angular2/src/core/directives/ng_for.ts
+++ b/modules/angular2/src/core/directives/ng_for.ts
@@ -41,6 +41,7 @@ import {isPresent, isBlank} from 'angular2/src/core/facade/lang';
  */
 @Directive({selector: '[ng-for][ng-for-of]', inputs: ['ngForOf', 'ngForTemplate']})
 export class NgFor implements DoCheck {
+  /** @internal */
   _ngForOf: any;
   private _differ: IterableDiffer;
 

--- a/modules/angular2/src/core/directives/ng_style.ts
+++ b/modules/angular2/src/core/directives/ng_style.ts
@@ -62,7 +62,9 @@ import {isPresent, isBlank, print} from 'angular2/src/core/facade/lang';
  */
 @Directive({selector: '[ng-style]', inputs: ['rawStyle: ng-style']})
 export class NgStyle implements DoCheck {
+  /** @internal */
   _rawStyle;
+  /** @internal */
   _differ: KeyValueDiffer;
 
   constructor(private _differs: KeyValueDiffers, private _ngEl: ElementRef,

--- a/modules/angular2/src/core/directives/ng_switch.ts
+++ b/modules/angular2/src/core/directives/ng_switch.ts
@@ -62,6 +62,7 @@ export class NgSwitch {
     this._switchValue = value;
   }
 
+  /** @internal */
   _onWhenValueChanged(oldWhen, newWhen, view: SwitchView): void {
     this._deregisterView(oldWhen, view);
     this._registerView(newWhen, view);
@@ -85,6 +86,7 @@ export class NgSwitch {
     }
   }
 
+  /** @internal */
   _emptyAllActiveViews(): void {
     var activeContainers = this._activeViews;
     for (var i = 0; i < activeContainers.length; i++) {
@@ -93,6 +95,7 @@ export class NgSwitch {
     this._activeViews = [];
   }
 
+  /** @internal */
   _activateViews(views: SwitchView[]): void {
     // TODO(vicb): assert(this._activeViews.length === 0);
     if (isPresent(views)) {
@@ -103,6 +106,7 @@ export class NgSwitch {
     }
   }
 
+  /** @internal */
   _registerView(value, view: SwitchView): void {
     var views = this._valueViews.get(value);
     if (isBlank(views)) {
@@ -112,6 +116,7 @@ export class NgSwitch {
     views.push(view);
   }
 
+  /** @internal */
   _deregisterView(value, view: SwitchView): void {
     // `_WHEN_DEFAULT` is used a marker for non-registered whens
     if (value === _WHEN_DEFAULT) return;
@@ -142,7 +147,9 @@ export class NgSwitch {
 @Directive({selector: '[ng-switch-when]', inputs: ['ngSwitchWhen']})
 export class NgSwitchWhen {
   // `_WHEN_DEFAULT` is used as a marker for a not yet initialized value
+  /** @internal */
   _value: any = _WHEN_DEFAULT;
+  /** @internal */
   _view: SwitchView;
 
   constructor(viewContainer: ViewContainerRef, templateRef: TemplateRef,

--- a/modules/angular2/src/core/directives/observable_list_diff.ts
+++ b/modules/angular2/src/core/directives/observable_list_diff.ts
@@ -2,3 +2,4 @@
 
 // I need to be here to make TypeScript think this is a module.
 import {} from 'angular2/src/core/facade/lang';
+export var workaround_empty_observable_list_diff: any;

--- a/modules/angular2/src/core/dom/parse5_adapter.ts
+++ b/modules/angular2/src/core/dom/parse5_adapter.ts
@@ -368,6 +368,7 @@ export class Parse5DomAdapter extends DomAdapter {
   hasClass(element, classname: string): boolean {
     return ListWrapper.contains(this.classList(element), classname);
   }
+  /** @internal */
   _readStyleAttribute(element) {
     var styleMap = {};
     var attributes = element.attribs;
@@ -383,6 +384,7 @@ export class Parse5DomAdapter extends DomAdapter {
     }
     return styleMap;
   }
+  /** @internal */
   _writeStyleAttribute(element, styleMap) {
     var styleAttrValue = "";
     for (var key in styleMap) {
@@ -486,6 +488,7 @@ export class Parse5DomAdapter extends DomAdapter {
       el.href = baseUrl + '/../' + href;
     }
   }
+  /** @internal */
   _buildRules(parsedRules, css?) {
     var rules = [];
     for (var i = 0; i < parsedRules.length; i++) {

--- a/modules/angular2/src/core/facade/async.ts
+++ b/modules/angular2/src/core/facade/async.ts
@@ -1,4 +1,3 @@
-///<reference path="../../../typings/tsd.d.ts" />
 import {global, isPresent} from 'angular2/src/core/facade/lang';
 // TODO(jeffbcross): use ES6 import once typings are available
 var Subject = require('@reactivex/rxjs/dist/cjs/Subject');
@@ -56,14 +55,18 @@ export class PromiseWrapper {
   }
 }
 
-export class TimerWrapper {
-  static setTimeout(fn: Function, millis: number): number { return global.setTimeout(fn, millis); }
-  static clearTimeout(id: number): void { global.clearTimeout(id); }
+export namespace NodeJS {
+  export interface Timer {}
+}
 
-  static setInterval(fn: Function, millis: number): number {
+export class TimerWrapper {
+  static setTimeout(fn: (...args: any[]) => void, millis: number): NodeJS.Timer { return global.setTimeout(fn, millis); }
+  static clearTimeout(id: NodeJS.Timer): void { global.clearTimeout(id); }
+
+  static setInterval(fn: (...args: any[]) => void, millis: number): NodeJS.Timer {
     return global.setInterval(fn, millis);
   }
-  static clearInterval(id: number): void { global.clearInterval(id); }
+  static clearInterval(id: NodeJS.Timer): void { global.clearInterval(id); }
 }
 
 export class ObservableWrapper {

--- a/modules/angular2/src/core/facade/async.ts
+++ b/modules/angular2/src/core/facade/async.ts
@@ -60,7 +60,9 @@ export namespace NodeJS {
 }
 
 export class TimerWrapper {
-  static setTimeout(fn: (...args: any[]) => void, millis: number): NodeJS.Timer { return global.setTimeout(fn, millis); }
+  static setTimeout(fn: (...args: any[]) => void, millis: number): NodeJS.Timer {
+    return global.setTimeout(fn, millis);
+  }
   static clearTimeout(id: NodeJS.Timer): void { global.clearTimeout(id); }
 
   static setInterval(fn: (...args: any[]) => void, millis: number): NodeJS.Timer {
@@ -132,6 +134,7 @@ export class Observable {
  * Once a reference implementation of the spec is available, switch to it.
  */
 export class EventEmitter extends Observable {
+  /** @internal */
   _subject = new Subject();
 
   observer(generator: any): any {

--- a/modules/angular2/src/core/facade/collection.ts
+++ b/modules/angular2/src/core/facade/collection.ts
@@ -259,7 +259,7 @@ export class ListWrapper {
   static toString<T>(l: T[]): string { return l.toString(); }
   static toJSON<T>(l: T[]): string { return JSON.stringify(l); }
 
-  static maximum<T>(list: T[], predicate: (T) => number): T {
+  static maximum<T>(list: T[], predicate: (t: T) => number): T {
     if (list.length == 0) {
       return null;
     }

--- a/modules/angular2/src/core/facade/exception_handler.ts
+++ b/modules/angular2/src/core/facade/exception_handler.ts
@@ -78,15 +78,18 @@ export class ExceptionHandler {
     if (this._rethrowException) throw exception;
   }
 
+  /** @internal */
   _extractMessage(exception: any): string {
     return exception instanceof WrappedException ? exception.wrapperMessage : exception.toString();
   }
 
+  /** @internal */
   _longStackTrace(stackTrace: any): any {
     return isListLikeIterable(stackTrace) ? (<any[]>stackTrace).join("\n\n-----async gap-----\n") :
                                             stackTrace.toString();
   }
 
+  /** @internal */
   _findContext(exception: any): any {
     try {
       if (!(exception instanceof WrappedException)) return null;
@@ -98,6 +101,7 @@ export class ExceptionHandler {
     }
   }
 
+  /** @internal */
   _findOriginalException(exception: any): any {
     if (!(exception instanceof WrappedException)) return null;
 
@@ -109,6 +113,7 @@ export class ExceptionHandler {
     return e;
   }
 
+  /** @internal */
   _findOriginalStack(exception: any): any {
     if (!(exception instanceof WrappedException)) return null;
 

--- a/modules/angular2/src/core/facade/exceptions.ts
+++ b/modules/angular2/src/core/facade/exceptions.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../../manual_typings/globals.d.ts" />
-
 import {ExceptionHandler} from './exception_handler';
 
 export {ExceptionHandler} from './exception_handler';

--- a/modules/angular2/src/core/facade/lang.ts
+++ b/modules/angular2/src/core/facade/lang.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../../manual_typings/globals.d.ts" />
-
 // TODO(jteplitz602): Load WorkerGlobalScope from lib.webworker.d.ts file #3492
 declare var WorkerGlobalScope;
 var globalScope: BrowserNodeGlobal;
@@ -196,7 +194,7 @@ export class StringJoiner {
 export class NumberParseError extends Error {
   name: string;
 
-  constructor(public message: string) { super(message); }
+  constructor(public message: string) { super(); }
 
   toString(): string { return this.message; }
 }
@@ -251,7 +249,7 @@ export class RegExpWrapper {
     flags = flags.replace(/g/g, '');
     return new _global.RegExp(regExpStr, flags + 'g');
   }
-  static firstMatch(regExp: RegExp, input: string): string[] {
+  static firstMatch(regExp: RegExp, input: string): RegExpExecArray {
     // Reset multimatch regex state
     regExp.lastIndex = 0;
     return regExp.exec(input);
@@ -277,7 +275,7 @@ export class RegExpMatcherWrapper {
   static next(matcher: {
     re: RegExp;
     input: string
-  }): string[] {
+  }): RegExpExecArray {
     return matcher.re.exec(matcher.input);
   }
 }

--- a/modules/angular2/src/core/forms/directives/ng_control_group.ts
+++ b/modules/angular2/src/core/forms/directives/ng_control_group.ts
@@ -58,6 +58,7 @@ const controlGroupBinding =
 })
 export class NgControlGroup extends ControlContainer implements OnInit,
     OnDestroy {
+  /** @internal */
   _parent: ControlContainer;
   constructor(@Host() @SkipSelf() _parent: ControlContainer) {
     super();

--- a/modules/angular2/src/core/forms/directives/ng_control_name.ts
+++ b/modules/angular2/src/core/forms/directives/ng_control_name.ts
@@ -80,11 +80,13 @@ const controlNameBinding =
 })
 export class NgControlName extends NgControl implements OnChanges,
     OnDestroy {
+  /** @internal */
   _parent: ControlContainer;
   update = new EventEmitter();
   model: any;
   viewModel: any;
   validators: Function[];
+  /** @internal */
   _added = false;
 
   constructor(@Host() @SkipSelf() parent: ControlContainer,

--- a/modules/angular2/src/core/forms/directives/ng_form.ts
+++ b/modules/angular2/src/core/forms/directives/ng_form.ts
@@ -157,10 +157,12 @@ export class NgForm extends ControlContainer implements Form {
     return false;
   }
 
+  /** @internal */
   _findContainer(path: string[]): ControlGroup {
     path.pop();
     return ListWrapper.isEmpty(path) ? this.form : <ControlGroup>this.form.find(path);
   }
 
+  /** @internal */
   _later(fn): void { PromiseWrapper.then(PromiseWrapper.resolve(null), fn, (_) => {}); }
 }

--- a/modules/angular2/src/core/forms/directives/ng_form_control.ts
+++ b/modules/angular2/src/core/forms/directives/ng_form_control.ts
@@ -72,6 +72,7 @@ const formControlBinding =
 export class NgFormControl extends NgControl implements OnChanges {
   form: Control;
   update = new EventEmitter();
+  /** @internal */
   _added = false;
   model: any;
   viewModel: any;

--- a/modules/angular2/src/core/forms/directives/ng_form_model.ts
+++ b/modules/angular2/src/core/forms/directives/ng_form_model.ts
@@ -140,6 +140,7 @@ export class NgFormModel extends ControlContainer implements Form,
     return false;
   }
 
+  /** @internal */
   _updateDomValue() {
     this.directives.forEach(dir => {
       var ctrl: any = this.form.find(dir.path);

--- a/modules/angular2/src/core/forms/directives/ng_model.ts
+++ b/modules/angular2/src/core/forms/directives/ng_model.ts
@@ -41,7 +41,9 @@ const formControlBinding = CONST_EXPR(new Binding(NgControl, {toAlias: forwardRe
   exportAs: 'form'
 })
 export class NgModel extends NgControl implements OnChanges {
+  /** @internal */
   _control = new Control();
+  /** @internal */
   _added = false;
   update = new EventEmitter();
   model: any;

--- a/modules/angular2/src/core/forms/form_builder.ts
+++ b/modules/angular2/src/core/forms/form_builder.ts
@@ -96,6 +96,7 @@ export class FormBuilder {
     }
   }
 
+  /** @internal */
   _reduceControls(controlsConfig: any): {[key: string]: modelModule.AbstractControl} {
     var controls: {[key: string]: modelModule.AbstractControl} = {};
     StringMapWrapper.forEach(controlsConfig, (controlConfig, controlName) => {
@@ -104,6 +105,7 @@ export class FormBuilder {
     return controls;
   }
 
+  /** @internal */
   _createControl(controlConfig: any): modelModule.AbstractControl {
     if (controlConfig instanceof modelModule.Control ||
         controlConfig instanceof modelModule.ControlGroup ||

--- a/modules/angular2/src/core/forms/model.ts
+++ b/modules/angular2/src/core/forms/model.ts
@@ -41,13 +41,19 @@ function _find(control: AbstractControl, path: Array<string | number>| string) {
  * Omitting from external API doc as this is really an abstract internal concept.
  */
 export class AbstractControl {
+  /** @internal */
   _value: any;
+  /** @internal */
   _status: string;
+  /** @internal */
   _errors: {[key: string]: any};
+  /** @internal */
   _pristine: boolean = true;
+  /** @internal */
   _touched: boolean = false;
+  /** @internal */
   _parent: ControlGroup | ControlArray;
-
+  /** @internal */
   _valueChanges: EventEmitter;
 
   constructor(public validator: Function) {}
@@ -128,6 +134,7 @@ export class AbstractControl {
     return isPresent(this.getError(errorCode, path));
   }
 
+  /** @internal */
   _updateValue(): void {}
 }
 
@@ -148,6 +155,7 @@ export class AbstractControl {
  * ### Example ([live demo](http://plnkr.co/edit/23DESOpbNnBpBHZt1BR4?p=preview))
  */
 export class Control extends AbstractControl {
+  /** @internal */
   _onChange: Function;
 
   constructor(value: any = null, validator: Function = Validators.nullValidator) {
@@ -234,12 +242,15 @@ export class ControlGroup extends AbstractControl {
     return c && this._included(controlName);
   }
 
+  /** @internal */
   _setParentForControls() {
     StringMapWrapper.forEach(this.controls, (control, name) => { control.setParent(this); });
   }
 
+  /** @internal */
   _updateValue() { this._value = this._reduceValue(); }
 
+  /** @internal */
   _reduceValue() {
     return this._reduceChildren({}, (acc, control, name) => {
       acc[name] = control.value;
@@ -247,6 +258,7 @@ export class ControlGroup extends AbstractControl {
     });
   }
 
+  /** @internal */
   _reduceChildren(initValue: any, fn: Function) {
     var res = initValue;
     StringMapWrapper.forEach(this.controls, (control, name) => {
@@ -257,6 +269,7 @@ export class ControlGroup extends AbstractControl {
     return res;
   }
 
+  /** @internal */
   _included(controlName: string): boolean {
     var isOptional = StringMapWrapper.contains(this._optionals, controlName);
     return !isOptional || StringMapWrapper.get(this._optionals, controlName);
@@ -331,8 +344,10 @@ export class ControlArray extends AbstractControl {
    */
   get length(): number { return this.controls.length; }
 
+  /** @internal */
   _updateValue(): void { this._value = this.controls.map((control) => control.value); }
 
+  /** @internal */
   _setParentForControls(): void {
     this.controls.forEach((control) => { control.setParent(this); });
   }

--- a/modules/angular2/src/core/life_cycle/life_cycle.ts
+++ b/modules/angular2/src/core/life_cycle/life_cycle.ts
@@ -54,8 +54,11 @@ export abstract class LifeCycle {
 export class LifeCycle_ extends LifeCycle {
   static _tickScope: WtfScopeFn = wtfCreateScope('LifeCycle#tick()');
 
+  /** @internal */
   _changeDetectors: ChangeDetector[];
+  /** @internal */
   _enforceNoNewChanges: boolean;
+  /** @internal */
   _runningTick: boolean = false;
 
   constructor(changeDetector: ChangeDetector = null, enforceNoNewChanges: boolean = false) {

--- a/modules/angular2/src/core/linker/component_url_mapper.ts
+++ b/modules/angular2/src/core/linker/component_url_mapper.ts
@@ -24,6 +24,7 @@ export class ComponentUrlMapper {
 }
 
 export class RuntimeComponentUrlMapper extends ComponentUrlMapper {
+  /** @internal */
   _componentUrls = new Map<Type, string>();
 
   constructor() { super(); }

--- a/modules/angular2/src/core/linker/element_injector.ts
+++ b/modules/angular2/src/core/linker/element_injector.ts
@@ -78,6 +78,7 @@ export class StaticKeys {
 }
 
 export class TreeNode<T extends TreeNode<any>> {
+  /** @internal */
   _parent: T;
   constructor(parent: T) {
     if (isPresent(parent)) {
@@ -102,6 +103,7 @@ export class DirectiveDependency extends Dependency {
     this._verify();
   }
 
+  /** @internal */
   _verify(): void {
     var count = 0;
     if (isPresent(this.queryDecorator)) count++;
@@ -288,12 +290,15 @@ export class ProtoElementInjector {
     resolvedViewBindings.forEach(b => bd.push(new BindingWithVisibility(b, Visibility.Private)));
   }
 
+  /** @internal */
+  public _firstBindingIsComponent: boolean;
 
 
   constructor(public parent: ProtoElementInjector, public index: number,
               bwv: BindingWithVisibility[], public distanceToParent: number,
-              public _firstBindingIsComponent: boolean,
+              _firstBindingIsComponent: boolean,
               public directiveVariableBindings: Map<string, number>) {
+    this._firstBindingIsComponent = _firstBindingIsComponent;
     var length = bwv.length;
     this.protoInjector = new ProtoInjector(bwv);
     this.eventEmitterAccessors = ListWrapper.createFixedSize(length);
@@ -327,10 +332,12 @@ export class ElementInjector extends TreeNode<ElementInjector> implements Depend
 
   private _injector: Injector;
   private _strategy: _ElementInjectorStrategy;
+  /** @internal */
+  public _proto: ProtoElementInjector;
 
-  constructor(public _proto: ProtoElementInjector, parent: ElementInjector) {
+  constructor(_proto: ProtoElementInjector, parent: ElementInjector) {
     super(parent);
-
+    this._proto = _proto;
     this._injector =
         new Injector(this._proto.protoInjector, null, this, () => this._debugContext());
 

--- a/modules/angular2/src/core/linker/interfaces.ts
+++ b/modules/angular2/src/core/linker/interfaces.ts
@@ -1,9 +1,6 @@
 import {MapWrapper} from 'angular2/src/core/facade/collection';
 import {SimpleChange} from 'angular2/src/core/change_detection/change_detection_util';
 
-/**
- * @internal
- */
 export enum LifecycleHooks {
   OnInit,
   OnDestroy,

--- a/modules/angular2/src/core/linker/view_manager.ts
+++ b/modules/angular2/src/core/linker/view_manager.ts
@@ -219,6 +219,7 @@ export class AppViewManager_ extends AppViewManager {
     return this._utils.getComponentInstance(hostView, boundElementIndex);
   }
 
+  /** @internal */
   _createRootHostViewScope: WtfScopeFn = wtfCreateScope('AppViewManager#createRootHostView()');
 
   createRootHostView(hostProtoViewRef: ProtoViewRef, overrideSelector: string,
@@ -239,6 +240,7 @@ export class AppViewManager_ extends AppViewManager {
     return wtfLeave(s, hostView.ref);
   }
 
+  /** @internal */
   _destroyRootHostViewScope: WtfScopeFn = wtfCreateScope('AppViewManager#destroyRootHostView()');
 
   destroyRootHostView(hostViewRef: HostViewRef) {
@@ -254,6 +256,7 @@ export class AppViewManager_ extends AppViewManager {
     wtfLeave(s);
   }
 
+  /** @internal */
   _createEmbeddedViewInContainerScope: WtfScopeFn =
       wtfCreateScope('AppViewManager#createEmbeddedViewInContainer()');
 
@@ -269,6 +272,7 @@ export class AppViewManager_ extends AppViewManager {
                                                    templateRef.elementRef, null));
   }
 
+  /** @internal */
   _createHostViewInContainerScope: WtfScopeFn =
       wtfCreateScope('AppViewManager#createHostViewInContainer()');
 
@@ -289,6 +293,7 @@ export class AppViewManager_ extends AppViewManager {
   /**
    *
    * See {@link AppViewManager#destroyViewInContainer}.
+   * @internal
    */
   _createViewInContainer(viewContainerLocation: ElementRef, index: number,
                          protoView: viewModule.AppProtoView, context: ElementRef,
@@ -320,6 +325,7 @@ export class AppViewManager_ extends AppViewManager {
     return view.ref;
   }
 
+  /** @internal */
   _attachRenderView(parentView: viewModule.AppView, boundElementIndex: number, index: number,
                     view: viewModule.AppView) {
     var elementRef = parentView.elementRefs[boundElementIndex];
@@ -331,6 +337,7 @@ export class AppViewManager_ extends AppViewManager {
     }
   }
 
+  /** @internal */
   _destroyViewInContainerScope = wtfCreateScope('AppViewMananger#destroyViewInContainer()');
 
   destroyViewInContainer(viewContainerLocation: ElementRef, index: number) {
@@ -341,6 +348,7 @@ export class AppViewManager_ extends AppViewManager {
     wtfLeave(s);
   }
 
+  /** @internal */
   _attachViewInContainerScope = wtfCreateScope('AppViewMananger#attachViewInContainer()');
 
   // TODO(i): refactor detachViewInContainer+attachViewInContainer to moveViewInContainer
@@ -361,6 +369,7 @@ export class AppViewManager_ extends AppViewManager {
     return wtfLeave(s, viewRef);
   }
 
+  /** @internal */
   _detachViewInContainerScope = wtfCreateScope('AppViewMananger#detachViewInContainer()');
 
   // TODO(i): refactor detachViewInContainer+attachViewInContainer to moveViewInContainer
@@ -375,6 +384,7 @@ export class AppViewManager_ extends AppViewManager {
     return wtfLeave(s, view.ref);
   }
 
+  /** @internal */
   _createMainView(protoView: viewModule.AppProtoView,
                   renderViewWithFragments: RenderViewWithFragments): viewModule.AppView {
     var mergedParentView =
@@ -384,6 +394,7 @@ export class AppViewManager_ extends AppViewManager {
     return mergedParentView;
   }
 
+  /** @internal */
   _createPooledView(protoView: viewModule.AppProtoView): viewModule.AppView {
     var view = this._viewPool.getView(protoView);
     if (isBlank(view)) {
@@ -394,6 +405,7 @@ export class AppViewManager_ extends AppViewManager {
     return view;
   }
 
+  /** @internal */
   _destroyPooledView(view: viewModule.AppView) {
     var wasReturned = this._viewPool.returnView(view);
     if (!wasReturned) {
@@ -402,6 +414,7 @@ export class AppViewManager_ extends AppViewManager {
     }
   }
 
+  /** @internal */
   _destroyViewInContainer(parentView: viewModule.AppView, boundElementIndex: number,
                           index: number) {
     var viewContainer = parentView.viewContainers[boundElementIndex];
@@ -422,6 +435,7 @@ export class AppViewManager_ extends AppViewManager {
     }
   }
 
+  /** @internal */
   _viewDehydrateRecurse(view: viewModule.AppView) {
     if (view.hydrated()) {
       this._utils.dehydrateView(view);

--- a/modules/angular2/src/core/linker/view_manager_utils.ts
+++ b/modules/angular2/src/core/linker/view_manager_utils.ts
@@ -172,6 +172,7 @@ export class AppViewManagerUtils {
                       contextView.locals);
   }
 
+  /** @internal */
   _hydrateView(initView: viewModule.AppView, imperativelyCreatedInjector: Injector,
                hostElementInjector: eli.ElementInjector, context: Object, parentLocals: Locals) {
     var viewIdx = initView.viewOffset;
@@ -213,6 +214,7 @@ export class AppViewManagerUtils {
     }
   }
 
+  /** @internal */
   _populateViewLocals(view: viewModule.AppView, elementInjector: eli.ElementInjector,
                       boundElementIdx: number): void {
     if (isPresent(elementInjector.getDirectiveVariableBindings())) {
@@ -226,6 +228,7 @@ export class AppViewManagerUtils {
     }
   }
 
+  /** @internal */
   _setUpEventEmitters(view: viewModule.AppView, elementInjector: eli.ElementInjector,
                       boundElementIndex: number) {
     var emitters = elementInjector.getEventEmitterAccessors();

--- a/modules/angular2/src/core/linker/view_pool.ts
+++ b/modules/angular2/src/core/linker/view_pool.ts
@@ -9,7 +9,9 @@ export const APP_VIEW_POOL_CAPACITY = CONST_EXPR(new OpaqueToken('AppViewPool.vi
 
 @Injectable()
 export class AppViewPool {
+  /** @internal */
   _poolCapacityPerProtoView: number;
+  /** @internal */
   _pooledViewsPerProtoView = new Map<viewModule.AppProtoView, Array<viewModule.AppView>>();
 
   constructor(@Inject(APP_VIEW_POOL_CAPACITY) poolCapacityPerProtoView) {

--- a/modules/angular2/src/core/linker/view_ref.ts
+++ b/modules/angular2/src/core/linker/view_ref.ts
@@ -98,8 +98,12 @@ export abstract class ViewRef implements HostViewRef {
 
 export class ViewRef_ extends ViewRef {
   private _changeDetectorRef: ChangeDetectorRef = null;
-
-  constructor(public _view: viewModule.AppView) { super(); }
+  /** @internal */
+  public _view: viewModule.AppView;
+  constructor(_view: viewModule.AppView) {
+    super();
+    this._view = _view;
+  }
 
   /**
    * Return `RenderViewRef`
@@ -166,5 +170,10 @@ export class ViewRef_ extends ViewRef {
 export abstract class ProtoViewRef {}
 
 export class ProtoViewRef_ extends ProtoViewRef {
-  constructor(public _protoView: viewModule.AppProtoView) { super(); }
+  /** @internal */
+  public _protoView: viewModule.AppProtoView;
+  constructor(_protoView: viewModule.AppProtoView) {
+    super();
+    this._protoView = _protoView;
+  }
 }

--- a/modules/angular2/src/core/linker/view_resolver.ts
+++ b/modules/angular2/src/core/linker/view_resolver.ts
@@ -11,6 +11,7 @@ import {reflector} from 'angular2/src/core/reflection/reflection';
 
 @Injectable()
 export class ViewResolver {
+  /** @internal */
   _cache = new Map<Type, ViewMetadata>();
 
   resolve(component: Type): ViewMetadata {
@@ -24,6 +25,7 @@ export class ViewResolver {
     return view;
   }
 
+  /** @internal */
   _resolve(component: Type): ViewMetadata {
     var compMeta: ComponentMetadata;
     var viewMeta: ViewMetadata;
@@ -87,6 +89,7 @@ export class ViewResolver {
     return null;
   }
 
+  /** @internal */
   _throwMixingViewAndComponent(propertyName: string, component: Type): void {
     throw new BaseException(
         `Component '${stringify(component)}' cannot have both '${propertyName}' and '@View' set at the same time"`);

--- a/modules/angular2/src/core/metadata/directives.ts
+++ b/modules/angular2/src/core/metadata/directives.ts
@@ -957,6 +957,7 @@ export class ComponentMetadata extends DirectiveMetadata {
 @CONST()
 export class PipeMetadata extends InjectableMetadata {
   name: string;
+  /** @internal */
   _pure: boolean;
 
   constructor({name, pure}: {name: string, pure: boolean}) {

--- a/modules/angular2/src/core/pipes/async_pipe.ts
+++ b/modules/angular2/src/core/pipes/async_pipe.ts
@@ -63,14 +63,19 @@ var _observableStrategy = new ObservableStrategy();
 @Pipe({name: 'async', pure: false})
 @Injectable()
 export class AsyncPipe implements PipeTransform, PipeOnDestroy {
+  /** @internal */
   _latestValue: Object = null;
+  /** @internal */
   _latestReturnedValue: Object = null;
 
+  /** @internal */
   _subscription: Object = null;
+  /** @internal */
   _obj: Observable | Promise<any> = null;
   private _strategy: any = null;
-
-  constructor(public _ref: ChangeDetectorRef) {}
+  /** @internal */
+  public _ref: ChangeDetectorRef;
+  constructor(_ref: ChangeDetectorRef) { this._ref = _ref; }
 
   onDestroy(): void {
     if (isPresent(this._subscription)) {
@@ -99,6 +104,7 @@ export class AsyncPipe implements PipeTransform, PipeOnDestroy {
     }
   }
 
+  /** @internal */
   _subscribe(obj: Observable | Promise<any>): void {
     this._obj = obj;
     this._strategy = this._selectStrategy(obj);
@@ -106,6 +112,7 @@ export class AsyncPipe implements PipeTransform, PipeOnDestroy {
         this._strategy.createSubscription(obj, value => this._updateLatestValue(obj, value));
   }
 
+  /** @internal */
   _selectStrategy(obj: Observable | Promise<any>): any {
     if (isPromise(obj)) {
       return _promiseStrategy;
@@ -116,6 +123,7 @@ export class AsyncPipe implements PipeTransform, PipeOnDestroy {
     }
   }
 
+  /** @internal */
   _dispose(): void {
     this._strategy.dispose(this._subscription);
     this._latestValue = null;
@@ -124,6 +132,7 @@ export class AsyncPipe implements PipeTransform, PipeOnDestroy {
     this._obj = null;
   }
 
+  /** @internal */
   _updateLatestValue(async: any, value: Object) {
     if (async === this._obj) {
       this._latestValue = value;

--- a/modules/angular2/src/core/pipes/pipes.ts
+++ b/modules/angular2/src/core/pipes/pipes.ts
@@ -37,6 +37,7 @@ export class ProtoPipes {
 
 
 export class Pipes implements cd.Pipes {
+  /** @internal */
   _config: {[key: string]: cd.SelectedPipe} = {};
 
   constructor(public proto: ProtoPipes, public injector: Injector) {}

--- a/modules/angular2/src/core/profile/wtf_impl.ts
+++ b/modules/angular2/src/core/profile/wtf_impl.ts
@@ -13,13 +13,13 @@ interface Trace {
   endTimeRange(range: Range);
 }
 
-interface Range {}
+export interface Range {}
 
 interface Events {
   createScope(signature: string, flags: any): Scope;
 }
 
-interface Scope {
+export interface Scope {
   (...args): any;
 }
 

--- a/modules/angular2/src/core/profile/wtf_impl.ts
+++ b/modules/angular2/src/core/profile/wtf_impl.ts
@@ -19,9 +19,7 @@ interface Events {
   createScope(signature: string, flags: any): Scope;
 }
 
-export interface Scope {
-  (...args): any;
-}
+export interface Scope { (...args): any; }
 
 var trace: Trace;
 var events: Events;

--- a/modules/angular2/src/core/reflection/reflection_capabilities.ts
+++ b/modules/angular2/src/core/reflection/reflection_capabilities.ts
@@ -9,7 +9,7 @@ import {
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 import {ListWrapper} from 'angular2/src/core/facade/collection';
 import {GetterFn, SetterFn, MethodFn} from './types';
-import {PlatformReflectionCapabilities} from 'platform_reflection_capabilities';
+import {PlatformReflectionCapabilities} from './platform_reflection_capabilities';
 
 export class ReflectionCapabilities implements PlatformReflectionCapabilities {
   private _reflect: any;

--- a/modules/angular2/src/core/reflection/reflection_capabilities.ts
+++ b/modules/angular2/src/core/reflection/reflection_capabilities.ts
@@ -83,6 +83,7 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
         `Cannot create a factory for '${stringify(t)}' because its constructor has more than 20 arguments`);
   }
 
+  /** @internal */
   _zipTypesAndAnnotaions(paramTypes, paramAnnotations): any[][] {
     var result;
 

--- a/modules/angular2/src/core/reflection/reflector.ts
+++ b/modules/angular2/src/core/reflection/reflector.ts
@@ -19,10 +19,15 @@ export class ReflectionInfo {
 }
 
 export class Reflector {
+  /** @internal */
   _injectableInfo = new Map<any, ReflectionInfo>();
+  /** @internal */
   _getters = new Map<string, GetterFn>();
+  /** @internal */
   _setters = new Map<string, SetterFn>();
+  /** @internal */
   _methods = new Map<string, MethodFn>();
+  /** @internal */
   _usedKeys: Set<any>;
   reflectionCapabilities: PlatformReflectionCapabilities;
 
@@ -135,6 +140,7 @@ export class Reflector {
     }
   }
 
+  /** @internal */
   _getReflectionInfo(typeOrFunc) {
     if (isPresent(this._usedKeys)) {
       this._usedKeys.add(typeOrFunc);
@@ -142,6 +148,7 @@ export class Reflector {
     return this._injectableInfo.get(typeOrFunc);
   }
 
+  /** @internal */
   _containsReflectionInfo(typeOrFunc) { return this._injectableInfo.has(typeOrFunc); }
 
   importUri(type: Type): string { return this.reflectionCapabilities.importUri(type); }

--- a/modules/angular2/src/core/render/dom/dom_renderer.ts
+++ b/modules/angular2/src/core/render/dom/dom_renderer.ts
@@ -195,6 +195,7 @@ export class DomRenderer_ extends DomRenderer {
     return this._componentCmds.get(templateId);
   }
 
+  /** @internal */
   _createRootHostViewScope: WtfScopeFn = wtfCreateScope('DomRenderer#createRootHostView()');
   createRootHostView(hostProtoViewRef: RenderProtoViewRef, fragmentCount: number,
                      hostElementSelector: string): RenderViewWithFragments {
@@ -207,6 +208,7 @@ export class DomRenderer_ extends DomRenderer {
     return wtfLeave(s, this._createView(hostProtoViewRef, element));
   }
 
+  /** @internal */
   _createViewScope = wtfCreateScope('DomRenderer#createView()');
   createView(protoViewRef: RenderProtoViewRef, fragmentCount: number): RenderViewWithFragments {
     var s = this._createViewScope();
@@ -256,6 +258,7 @@ export class DomRenderer_ extends DomRenderer {
     }
   }
 
+  /** @internal */
   _detachFragmentScope = wtfCreateScope('DomRenderer#detachFragment()');
   detachFragment(fragmentRef: RenderFragmentRef) {
     var s = this._detachFragmentScope();

--- a/modules/angular2/src/core/render/dom/events/event_manager.ts
+++ b/modules/angular2/src/core/render/dom/events/event_manager.ts
@@ -29,6 +29,7 @@ export class EventManager {
 
   getZone(): NgZone { return this._zone; }
 
+  /** @internal */
   _findPluginFor(eventName: string): EventManagerPlugin {
     var plugins = this._plugins;
     for (var i = 0; i < plugins.length; i++) {

--- a/modules/angular2/src/core/render/dom/events/hammer_gestures.ts
+++ b/modules/angular2/src/core/render/dom/events/hammer_gestures.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../../../../typings/hammerjs/hammerjs.d.ts"/>
-
 import {HammerGesturesPluginCommon} from './hammer_common';
 import {isPresent} from 'angular2/src/core/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';

--- a/modules/angular2/src/core/render/dom/events/key_events.ts
+++ b/modules/angular2/src/core/render/dom/events/key_events.ts
@@ -90,8 +90,8 @@ export class KeyEventsPlugin extends EventManagerPlugin {
     return fullKey;
   }
 
-  static eventCallback(element: HTMLElement, fullKey: any, handler: (e: Event) => any, zone: NgZone):
-      (event: KeyboardEvent) => void {
+  static eventCallback(element: HTMLElement, fullKey: any, handler: (e: Event) => any,
+                       zone: NgZone): (event: KeyboardEvent) => void {
     return (event) => {
       if (StringWrapper.equals(KeyEventsPlugin.getEventFullKey(event), fullKey)) {
         zone.run(() => handler(event));

--- a/modules/angular2/src/core/render/dom/events/key_events.ts
+++ b/modules/angular2/src/core/render/dom/events/key_events.ts
@@ -90,7 +90,7 @@ export class KeyEventsPlugin extends EventManagerPlugin {
     return fullKey;
   }
 
-  static eventCallback(element: HTMLElement, fullKey: any, handler: (Event) => any, zone: NgZone):
+  static eventCallback(element: HTMLElement, fullKey: any, handler: (e: Event) => any, zone: NgZone):
       (event: KeyboardEvent) => void {
     return (event) => {
       if (StringWrapper.equals(KeyEventsPlugin.getEventFullKey(event), fullKey)) {

--- a/modules/angular2/src/core/render/dom/shared_styles_host.ts
+++ b/modules/angular2/src/core/render/dom/shared_styles_host.ts
@@ -5,7 +5,9 @@ import {DOCUMENT} from './dom_tokens';
 
 @Injectable()
 export class SharedStylesHost {
+  /** @internal */
   _styles: string[] = [];
+  /** @internal */
   _stylesSet = new Set<string>();
 
   constructor() {}
@@ -34,6 +36,7 @@ export class DomSharedStylesHost extends SharedStylesHost {
     super();
     this._hostNodes.add(doc.head);
   }
+  /** @internal */
   _addStylesToHost(styles: string[], host: Node) {
     for (var i = 0; i < styles.length; i++) {
       var style = styles[i];

--- a/modules/angular2/src/core/testability/testability.ts
+++ b/modules/angular2/src/core/testability/testability.ts
@@ -14,12 +14,15 @@ import {PromiseWrapper} from 'angular2/src/core/facade/async';
  */
 @Injectable()
 export class Testability {
+  /** @internal */
   _pendingCount: number = 0;
+  /** @internal */
   _callbacks: Function[] = [];
+  /** @internal */
   _isAngularEventPending: boolean = false;
+  constructor(_ngZone: NgZone) { this._watchAngularEvents(_ngZone); }
 
-  constructor(public _ngZone: NgZone) { this._watchAngularEvents(_ngZone); }
-
+  /** @internal */
   _watchAngularEvents(_ngZone: NgZone): void {
     _ngZone.overrideOnTurnStart(() => { this._isAngularEventPending = true; });
     _ngZone.overrideOnEventDone(() => {
@@ -44,6 +47,7 @@ export class Testability {
 
   isStable(): boolean { return this._pendingCount == 0 && !this._isAngularEventPending; }
 
+  /** @internal */
   _runCallbacksIfReady(): void {
     if (!this.isStable()) {
       return;  // Not ready
@@ -76,6 +80,7 @@ export class Testability {
 
 @Injectable()
 export class TestabilityRegistry {
+  /** @internal */
   _applications = new Map<any, Testability>();
 
   constructor() { testabilityGetter.addToWindow(this); }

--- a/modules/angular2/src/core/util/decorators.ts
+++ b/modules/angular2/src/core/util/decorators.ts
@@ -236,7 +236,7 @@ if (!(Reflect && Reflect.getMetadata)) {
   throw 'reflect-metadata shim is required when using class decorators';
 }
 
-export function makeDecorator(annotationCls, chainFn: (fn: Function) => void = null): (...args) =>
+export function makeDecorator(annotationCls, chainFn: (fn: Function) => void = null): (...args: any[]) =>
     (cls: any) => any {
   function DecoratorFactory(objOrType): (cls: any) => any {
     var annotationInstance = new (<any>annotationCls)(objOrType);

--- a/modules/angular2/src/core/util/decorators.ts
+++ b/modules/angular2/src/core/util/decorators.ts
@@ -236,8 +236,8 @@ if (!(Reflect && Reflect.getMetadata)) {
   throw 'reflect-metadata shim is required when using class decorators';
 }
 
-export function makeDecorator(annotationCls, chainFn: (fn: Function) => void = null): (...args: any[]) =>
-    (cls: any) => any {
+export function makeDecorator(annotationCls, chainFn: (fn: Function) => void = null):
+    (...args: any[]) => (cls: any) => any {
   function DecoratorFactory(objOrType): (cls: any) => any {
     var annotationInstance = new (<any>annotationCls)(objOrType);
     if (this instanceof annotationCls) {

--- a/modules/angular2/src/core/zone/ng_zone.ts
+++ b/modules/angular2/src/core/zone/ng_zone.ts
@@ -3,7 +3,10 @@ import {normalizeBlank, isPresent, global} from 'angular2/src/core/facade/lang';
 import {wtfLeave, wtfCreateScope, WtfScopeFn} from '../profile/profile';
 
 
-export interface NgZoneZone extends Zone { _innerZone: boolean; }
+export interface NgZoneZone extends Zone {
+  /** @internal */
+  _innerZone: boolean;
+}
 
 /**
  * An injectable service for executing work inside or outside of the Angular zone.
@@ -78,36 +81,50 @@ export interface NgZoneZone extends Zone { _innerZone: boolean; }
  * ```
  */
 export class NgZone {
+  /** @internal */
   _runScope: WtfScopeFn = wtfCreateScope(`NgZone#run()`);
+  /** @internal */
   _microtaskScope: WtfScopeFn = wtfCreateScope(`NgZone#microtask()`);
 
   // Code executed in _mountZone does not trigger the onTurnDone.
+  /** @internal */
   _mountZone;
   // _innerZone is the child of _mountZone. Any code executed in this zone will trigger the
   // onTurnDone hook at the end of the current VM turn.
+  /** @internal */
   _innerZone;
 
+  /** @internal */
   _onTurnStart: () => void;
+  /** @internal */
   _onTurnDone: () => void;
+  /** @internal */
   _onEventDone: () => void;
+  /** @internal */
   _onErrorHandler: (error: any, stack: any) => void;
 
   // Number of microtasks pending from _innerZone (& descendants)
+  /** @internal */
   _pendingMicrotasks: number = 0;
   // Whether some code has been executed in the _innerZone (& descendants) in the current turn
+  /** @internal */
   _hasExecutedCodeInInnerZone: boolean = false;
   // run() call depth in _mountZone. 0 at the end of a macrotask
   // zone.run(() => {         // top-level call
   //   zone.run(() => {});    // nested call -> in-turn
   // });
+  /** @internal */
   _nestedRun: number = 0;
 
   // TODO(vicb): implement this class properly for node.js environment
   // This disabled flag is only here to please cjs tests
+  /** @internal */
   _disabled: boolean;
 
+  /** @internal */
   _inVmTurnDone: boolean = false;
 
+  /** @internal */
   _pendingTimeouts: number[] = [];
 
   /**
@@ -227,6 +244,7 @@ export class NgZone {
     }
   }
 
+  /** @internal */
   _createInnerZone(zone, enableLongStackTrace) {
     var microtaskScope = this._microtaskScope;
     var ngZone = this;
@@ -315,6 +333,7 @@ export class NgZone {
         });
   }
 
+  /** @internal */
   _onError(zone, e): void {
     if (isPresent(this._onErrorHandler)) {
       var trace = [normalizeBlank(e.stack)];

--- a/modules/angular2/src/http/headers.ts
+++ b/modules/angular2/src/http/headers.ts
@@ -35,6 +35,7 @@ import {
  * ```
  */
 export class Headers {
+  /** @internal */
   _headersMap: Map<string, string[]>;
   constructor(headers?: Headers | {[key: string]: any}) {
     if (headers instanceof Headers) {

--- a/modules/angular2/src/mock/location_mock.ts
+++ b/modules/angular2/src/mock/location_mock.ts
@@ -4,8 +4,11 @@ import {Location} from 'angular2/src/router/location';
 
 export class SpyLocation implements Location {
   urlChanges: string[] = [];
+  /** @internal */
   _path: string = '';
+  /** @internal */
   _subject: EventEmitter = new EventEmitter();
+  /** @internal */
   _baseHref: string = '';
 
   setInitialPath(url: string) { this._path = url; }

--- a/modules/angular2/src/mock/mock_location_strategy.ts
+++ b/modules/angular2/src/mock/mock_location_strategy.ts
@@ -7,6 +7,7 @@ export class MockLocationStrategy extends LocationStrategy {
   internalPath: string = '/';
   internalTitle: string = '';
   urlChanges: string[] = [];
+  /** @internal */
   _subject: EventEmitter = new EventEmitter();
   constructor() { super(); }
 

--- a/modules/angular2/src/mock/ng_zone_mock.ts
+++ b/modules/angular2/src/mock/ng_zone_mock.ts
@@ -1,6 +1,7 @@
 import {NgZone} from 'angular2/src/core/zone/ng_zone';
 
 export class MockNgZone extends NgZone {
+  /** @internal */
   _onEventDone: () => void;
 
   constructor() { super({enableLongStackTrace: false}); }

--- a/modules/angular2/src/mock/view_resolver_mock.ts
+++ b/modules/angular2/src/mock/view_resolver_mock.ts
@@ -6,9 +6,13 @@ import {ViewMetadata} from '../core/metadata';
 import {ViewResolver} from 'angular2/src/core/linker/view_resolver';
 
 export class MockViewResolver extends ViewResolver {
+  /** @internal */
   _views = new Map<Type, ViewMetadata>();
+  /** @internal */
   _inlineTemplates = new Map<Type, string>();
+  /** @internal */
   _viewCache = new Map<Type, ViewMetadata>();
+  /** @internal */
   _directiveOverrides = new Map<Type, Map<Type, Type>>();
 
   constructor() { super(); }
@@ -103,6 +107,8 @@ export class MockViewResolver extends ViewResolver {
   }
 
   /**
+   * @internal
+   *
    * Once a component has been compiled, the AppProtoView is stored in the compiler cache.
    *
    * Then it should not be possible to override the component configuration after the component

--- a/modules/angular2/src/router/async_route_handler.ts
+++ b/modules/angular2/src/router/async_route_handler.ts
@@ -3,6 +3,7 @@ import {Promise, PromiseWrapper} from 'angular2/src/core/facade/async';
 import {isPresent, Type} from 'angular2/src/core/facade/lang';
 
 export class AsyncRouteHandler implements RouteHandler {
+  /** @internal */
   _resolvedComponent: Promise<any> = null;
   componentType: Type;
 

--- a/modules/angular2/src/router/location.ts
+++ b/modules/angular2/src/router/location.ts
@@ -80,7 +80,9 @@ export const APP_BASE_HREF: OpaqueToken = CONST_EXPR(new OpaqueToken('appBaseHre
  */
 @Injectable()
 export class Location {
+  /** @internal */
   _subject: EventEmitter = new EventEmitter();
+  /** @internal */
   _baseHref: string;
 
   constructor(public platformStrategy: LocationStrategy,

--- a/modules/angular2/src/router/route_recognizer.ts
+++ b/modules/angular2/src/router/route_recognizer.ts
@@ -99,6 +99,7 @@ export class RouteRecognizer {
     return solutions;
   }
 
+  /** @internal */
   _redirect(urlParse: Url): Url {
     for (var i = 0; i < this.redirects.length; i += 1) {
       let redirector = this.redirects[i];

--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -204,6 +204,7 @@ export class Router {
     });
   }
 
+  /** @internal */
   _navigate(instruction: Instruction, _skipLocationChange: boolean): Promise<any> {
     return this._settleInstruction(instruction)
         .then((_) => this._canReuse(instruction))
@@ -230,6 +231,7 @@ export class Router {
   // guaranteed that the `componentType`s for the terminal async routes have been loaded by the time
   // we begin navigation. The method below simply traverses instructions and resolves any components
   // for which `componentType` is not present
+  /** @internal */
   _settleInstruction(instruction: Instruction): Promise<any> {
     var unsettledInstructions: Array<Promise<any>> = [];
     if (isBlank(instruction.component.componentType)) {
@@ -257,6 +259,7 @@ export class Router {
   /*
    * Recursively set reuse flags
    */
+  /** @internal */
   _canReuse(instruction: Instruction): Promise<any> {
     if (isBlank(this._outlet)) {
       return _resolveToFalse;
@@ -335,8 +338,10 @@ export class Router {
   }
 
 
+  /** @internal */
   _startNavigating(): void { this.navigating = true; }
 
+  /** @internal */
   _finishNavigating(): void { this.navigating = false; }
 
 
@@ -454,6 +459,7 @@ export class Router {
 }
 
 export class RootRouter extends Router {
+  /** @internal */
   _location: Location;
 
   constructor(registry: RouteRegistry, location: Location, primaryComponent: Type) {

--- a/modules/angular2/src/router/sync_route_handler.ts
+++ b/modules/angular2/src/router/sync_route_handler.ts
@@ -3,6 +3,7 @@ import {Promise, PromiseWrapper} from 'angular2/src/core/facade/async';
 import {Type} from 'angular2/src/core/facade/lang';
 
 export class SyncRouteHandler implements RouteHandler {
+  /** @internal */
   _resolvedComponent: Promise<any> = null;
 
   constructor(public componentType: Type, public data?: Object) {

--- a/modules/angular2/src/router/url_parser.ts
+++ b/modules/angular2/src/router/url_parser.ts
@@ -22,6 +22,7 @@ export class Url {
 
   segmentToString(): string { return this.path + this._matrixParamsToString(); }
 
+  /** @internal */
   _auxToString(): string {
     return this.auxiliary.length > 0 ?
                ('(' + this.auxiliary.map(sibling => sibling.toString()).join('//') + ')') :
@@ -36,6 +37,7 @@ export class Url {
     return ';' + serializeParams(this.params).join(';');
   }
 
+  /** @internal */
   _childString(): string { return isPresent(this.child) ? ('/' + this.child.toString()) : ''; }
 }
 

--- a/modules/angular2/src/test_lib/e2e_util.ts
+++ b/modules/angular2/src/test_lib/e2e_util.ts
@@ -1,7 +1,3 @@
-/// <reference path="../../typings/node/node.d.ts" />
-/// <reference path="../../typings/angular-protractor/angular-protractor.d.ts" />
-/// <reference path="../../typings/jasmine/jasmine"/>
-
 import * as webdriver from 'selenium-webdriver';
 
 export var browser: protractor.IBrowser = global['browser'];

--- a/modules/angular2/src/test_lib/fake_async.ts
+++ b/modules/angular2/src/test_lib/fake_async.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/jasmine/jasmine.d.ts"/>
-
 import {global} from 'angular2/src/core/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 import {ListWrapper} from 'angular2/src/core/facade/collection';

--- a/modules/angular2/src/test_lib/test_component_builder.ts
+++ b/modules/angular2/src/test_lib/test_component_builder.ts
@@ -30,7 +30,9 @@ export abstract class RootTestComponent {
 }
 
 export class RootTestComponent_ extends RootTestComponent {
+  /** @internal */
   _componentRef: ComponentRef;
+  /** @internal */
   _componentParentView: AppView;
 
   constructor(componentRef: ComponentRef) {
@@ -55,15 +57,21 @@ var _nextRootElementId = 0;
  */
 @Injectable()
 export class TestComponentBuilder {
+  /** @internal */
   _bindingsOverrides = new Map<Type, any[]>();
+  /** @internal */
   _directiveOverrides = new Map<Type, Map<Type, Type>>();
+  /** @internal */
   _templateOverrides = new Map<Type, string>();
+  /** @internal */
   _viewBindingsOverrides = new Map<Type, any[]>();
+  /** @internal */
   _viewOverrides = new Map<Type, ViewMetadata>();
 
 
   constructor(private _injector: Injector) {}
 
+  /** @internal */
   _clone(): TestComponentBuilder {
     var clone = new TestComponentBuilder(this._injector);
     clone._viewOverrides = MapWrapper.clone(this._viewOverrides);

--- a/modules/angular2/src/test_lib/test_lib.ts
+++ b/modules/angular2/src/test_lib/test_lib.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/jasmine/jasmine.d.ts"/>
-
 import {DOM} from 'angular2/src/core/dom/dom_adapter';
 import {StringMapWrapper} from 'angular2/src/core/facade/collection';
 import {global, isFunction, Math} from 'angular2/src/core/facade/lang';

--- a/modules/angular2/src/test_lib/test_lib.ts
+++ b/modules/angular2/src/test_lib/test_lib.ts
@@ -392,6 +392,7 @@ export class SpyObject {
     return object;
   }
 
+  /** @internal */
   _createGuinnessCompatibleSpy(name): GuinessCompatibleSpy {
     var newSpy: GuinessCompatibleSpy = <any>jasmine.createSpy(name);
     newSpy.andCallFake = <any>newSpy.and.callFake;

--- a/modules/angular2/src/test_lib/utils.ts
+++ b/modules/angular2/src/test_lib/utils.ts
@@ -9,6 +9,7 @@ import {
 } from 'angular2/src/core/facade/lang';
 
 export class Log {
+  /** @internal */
   _result: any[];
 
   constructor() { this._result = []; }

--- a/modules/angular2/src/web_workers/shared/client_message_broker.ts
+++ b/modules/angular2/src/web_workers/shared/client_message_broker.ts
@@ -1,4 +1,3 @@
-/// <reference path="../../../manual_typings/globals.d.ts" />
 import {MessageBus} from "angular2/src/web_workers/shared/message_bus";
 import {print, isPresent, DateWrapper, stringify} from "angular2/src/core/facade/lang";
 import {

--- a/modules/angular2/src/web_workers/shared/client_message_broker.ts
+++ b/modules/angular2/src/web_workers/shared/client_message_broker.ts
@@ -22,7 +22,12 @@ export abstract class ClientMessageBrokerFactory {
 
 @Injectable()
 export class ClientMessageBrokerFactory_ extends ClientMessageBrokerFactory {
-  constructor(private _messageBus: MessageBus, public _serializer: Serializer) { super(); }
+  /** @internal */
+  public _serializer: Serializer;
+  constructor(private _messageBus: MessageBus, _serializer: Serializer) {
+    super();
+    this._serializer = _serializer;
+  }
 
   /**
    * Initializes the given channel and attaches a new {@link ClientMessageBroker} to it.
@@ -40,10 +45,13 @@ export abstract class ClientMessageBroker {
 export class ClientMessageBroker_ extends ClientMessageBroker {
   private _pending: Map<string, PromiseCompleter<any>> = new Map<string, PromiseCompleter<any>>();
   private _sink: EventEmitter;
+  /** @internal */
+  public _serializer: Serializer;
 
-  constructor(messageBus: MessageBus, public _serializer: Serializer, public channel) {
+  constructor(messageBus: MessageBus, _serializer: Serializer, public channel) {
     super();
     this._sink = messageBus.to(channel);
+    this._serializer = _serializer;
     var source = messageBus.from(channel);
     ObservableWrapper.subscribe(source,
                                 (message: {[key: string]: any}) => this._handleMessage(message));

--- a/modules/angular2/src/web_workers/shared/service_message_broker.ts
+++ b/modules/angular2/src/web_workers/shared/service_message_broker.ts
@@ -19,7 +19,13 @@ export abstract class ServiceMessageBrokerFactory {
 
 @Injectable()
 export class ServiceMessageBrokerFactory_ extends ServiceMessageBrokerFactory {
-  constructor(private _messageBus: MessageBus, public _serializer: Serializer) { super(); }
+  /** @internal */
+  public _serializer: Serializer;
+
+  constructor(private _messageBus: MessageBus, _serializer: Serializer) {
+    super();
+    this._serializer = _serializer;
+  }
 
   createMessageBroker(channel: string, runInZone: boolean = true): ServiceMessageBroker {
     this._messageBus.initChannel(channel, runInZone);

--- a/modules/angular2/test/core/zone/ng_zone_spec.ts
+++ b/modules/angular2/test/core/zone/ng_zone_spec.ts
@@ -23,7 +23,7 @@ var needsLongerTimers = browserDetection.isSlow || browserDetection.isEdge;
 var resultTimer = 1000;
 var testTimeout = browserDetection.isEdge ? 1200 : 100;
 // Schedules a macrotask (using a timer)
-function macroTask(fn: Function, timer = 1): void {
+function macroTask(fn: (...args: any[]) => void, timer = 1): void {
   // adds longer timers for passing tests in IE and Edge
   _zone.runOutsideAngular(() => TimerWrapper.setTimeout(fn, needsLongerTimers ? timer : 1));
 }

--- a/modules/examples/src/web_workers/images/index_common.ts
+++ b/modules/examples/src/web_workers/images/index_common.ts
@@ -39,7 +39,7 @@ export class ImageDemo {
     }
   }
 
-  private _filter(i: number): Function {
+  private _filter(i: number): (...args: any[]) => void {
     return () => {
       var imageData = this._bitmapService.convertToImageData(this.images[i].buffer);
       imageData = this._bitmapService.applySepia(imageData);

--- a/tools/broccoli/trees/browser_tree.ts
+++ b/tools/broccoli/trees/browser_tree.ts
@@ -231,10 +231,9 @@ module.exports = function makeBrowserTree(options, destinationPath) {
 
   htmlTree = mergeTrees([htmlTree, scripts, polymer, react]);
 
-  var typingsTree = new Funnel('modules', {
-    include: ['angular2/typings/**/*.d.ts',
-              'angular2/manual_typings/*.d.ts'],
-    destDir: '/'});
+  var typingsTree = new Funnel(
+      'modules',
+      {include: ['angular2/typings/**/*.d.ts', 'angular2/manual_typings/*.d.ts'], destDir: '/'});
 
   // Add a line to the end of our top-level .d.ts file.
   // This HACK for transitive typings is a workaround for

--- a/tools/broccoli/trees/browser_tree.ts
+++ b/tools/broccoli/trees/browser_tree.ts
@@ -118,6 +118,7 @@ module.exports = function makeBrowserTree(options, destinationPath) {
     mapRoot: '',  // force sourcemaps to use relative path
     noEmitOnError: false,
     rootDir: '.',
+    rootFilePaths: ['angular2/manual_typings/globals-es6.d.ts'],
     sourceMap: true,
     sourceRoot: '.',
     target: 'ES6'
@@ -126,7 +127,8 @@ module.exports = function makeBrowserTree(options, destinationPath) {
   // Use TypeScript to transpile the *.ts files to ES5
   var typescriptOptions = {
     allowNonTsExtensions: false,
-    declaration: false,
+    declaration: true,
+    stripInternal: true,
     emitDecoratorMetadata: true,
     experimentalDecorators: true,
     mapRoot: '',  // force sourcemaps to use relative path
@@ -134,6 +136,7 @@ module.exports = function makeBrowserTree(options, destinationPath) {
     moduleResolution: 1 /* classic */,
     noEmitOnError: true,
     rootDir: '.',
+    rootFilePaths: ['angular2/manual_typings/globals.d.ts'],
     sourceMap: true,
     sourceRoot: '.',
     target: 'ES5'
@@ -228,8 +231,29 @@ module.exports = function makeBrowserTree(options, destinationPath) {
 
   htmlTree = mergeTrees([htmlTree, scripts, polymer, react]);
 
-  es5Tree = mergeTrees([es5Tree, htmlTree, assetsTree, clientModules]);
-  es6Tree = mergeTrees([es6Tree, htmlTree, assetsTree, clientModules]);
+  var typingsTree = new Funnel('modules', {
+    include: ['angular2/typings/**/*.d.ts',
+              'angular2/manual_typings/*.d.ts'],
+    destDir: '/'});
+
+  // Add a line to the end of our top-level .d.ts file.
+  // This HACK for transitive typings is a workaround for
+  // https://github.com/Microsoft/TypeScript/issues/5097
+  //
+  // This allows users to get our top-level dependencies like es6-shim.d.ts
+  // to appear when they compile against angular2.
+  //
+  // This carries the risk that the user brings their own copy of that file
+  // (or any other symbols exported here) and they will get a compiler error
+  // because of the duplicate definitions.
+  // TODO(alexeagle): remove this when typescript releases a fix
+  es5Tree = replace(es5Tree, {
+    files: ['angular2/angular2.d.ts'],
+    patterns: [{match: /$/, replacement: 'import "./manual_typings/globals.d.ts";\n'}]
+  });
+
+  es5Tree = mergeTrees([es5Tree, htmlTree, assetsTree, clientModules, typingsTree]);
+  es6Tree = mergeTrees([es6Tree, htmlTree, assetsTree, clientModules, typingsTree]);
 
   var mergedTree = mergeTrees([stew.mv(es6Tree, '/es6'), stew.mv(es5Tree, '/es5')]);
 

--- a/tools/broccoli/trees/node_tree.ts
+++ b/tools/broccoli/trees/node_tree.ts
@@ -41,7 +41,7 @@ module.exports = function makeNodeTree(destinationPath) {
     moduleResolution: 1 /* classic */,
     noEmitOnError: true,
     rootDir: '.',
-    rootFilePaths: ['angular2/manual_typings/globals.d.ts'],
+    rootFilePaths: ['angular2/manual_typings/globals.d.ts', 'angular2/typings/es6-shim/es6-shim.d.ts'],
     sourceMap: true,
     sourceRoot: '.',
     target: 'ES5'

--- a/tools/broccoli/trees/node_tree.ts
+++ b/tools/broccoli/trees/node_tree.ts
@@ -41,7 +41,8 @@ module.exports = function makeNodeTree(destinationPath) {
     moduleResolution: 1 /* classic */,
     noEmitOnError: true,
     rootDir: '.',
-    rootFilePaths: ['angular2/manual_typings/globals.d.ts', 'angular2/typings/es6-shim/es6-shim.d.ts'],
+    rootFilePaths:
+        ['angular2/manual_typings/globals.d.ts', 'angular2/typings/es6-shim/es6-shim.d.ts'],
     sourceMap: true,
     sourceRoot: '.',
     target: 'ES5'

--- a/typing_spec/basic_spec.ts
+++ b/typing_spec/basic_spec.ts
@@ -1,5 +1,3 @@
-///<reference path="../dist/docs/typings/angular2/angular2.d.ts"/>
-
 import {Component, bootstrap, View} from 'angular2/angular2'
 
 @Component({


### PR DESCRIPTION
We have the prerequisite typings cleanups all merged, and no longer relying on dgeni magic. This PR implements the remaining bits to deliver our typings to users through the `npm install` distribution with no additional commands required.

cc @mprobst @rkirov 
