### PR TITLE
Router: limit imports of private APIs

### DIFF
--- a/modules/angular2/router.ts
+++ b/modules/angular2/router.ts
@@ -28,9 +28,8 @@ import {RouterOutlet} from './src/router/router_outlet';
 import {RouterLink} from './src/router/router_link';
 import {RouteRegistry} from './src/router/route_registry';
 import {Location} from './src/router/location';
-import {provide, OpaqueToken, Provider} from 'angular2/angular2';
+import {ApplicationRef, provide, OpaqueToken, Provider} from 'angular2/angular2';
 import {CONST_EXPR} from './src/core/facade/lang';
-import {ApplicationRef} from './src/core/application_ref';
 import {BaseException} from 'angular2/src/core/facade/exceptions';
 
 

--- a/modules/angular2/router.ts
+++ b/modules/angular2/router.ts
@@ -28,7 +28,7 @@ import {RouterOutlet} from './src/router/router_outlet';
 import {RouterLink} from './src/router/router_link';
 import {RouteRegistry} from './src/router/route_registry';
 import {Location} from './src/router/location';
-import {provide, OpaqueToken, Provider} from './core';
+import {provide, OpaqueToken, Provider} from 'angular2/angular2';
 import {CONST_EXPR} from './src/core/facade/lang';
 import {ApplicationRef} from './src/core/application_ref';
 import {BaseException} from 'angular2/src/core/facade/exceptions';

--- a/modules/angular2/src/router/hash_location_strategy.ts
+++ b/modules/angular2/src/router/hash_location_strategy.ts
@@ -1,5 +1,5 @@
 import {DOM} from 'angular2/src/core/dom/dom_adapter';
-import {Injectable} from 'angular2/src/core/di';
+import {Injectable} from 'angular2/angular2';
 import {LocationStrategy} from './location_strategy';
 import {EventListener, History, Location} from 'angular2/src/core/facade/browser';
 

--- a/modules/angular2/src/router/location.ts
+++ b/modules/angular2/src/router/location.ts
@@ -3,7 +3,7 @@ import {StringWrapper, isPresent, CONST_EXPR} from 'angular2/src/core/facade/lan
 import {EventEmitter, ObservableWrapper} from 'angular2/src/core/facade/async';
 import {isBlank} from 'angular2/src/core/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
-import {OpaqueToken, Injectable, Optional, Inject} from 'angular2/src/core/di';
+import {OpaqueToken, Injectable, Optional, Inject} from 'angular2/angular2';
 
 /**
  * The `APP_BASE_HREF` token represents the base href to be used with the

--- a/modules/angular2/src/router/path_location_strategy.ts
+++ b/modules/angular2/src/router/path_location_strategy.ts
@@ -1,5 +1,5 @@
 import {DOM} from 'angular2/src/core/dom/dom_adapter';
-import {Injectable} from 'angular2/src/core/di';
+import {Injectable} from 'angular2/angular2';
 import {EventListener, History, Location} from 'angular2/src/core/facade/browser';
 import {LocationStrategy} from './location_strategy';
 

--- a/modules/angular2/src/router/route_data.ts
+++ b/modules/angular2/src/router/route_data.ts
@@ -1,4 +1,4 @@
-import {OpaqueToken} from 'angular2/src/core/di';
+import {OpaqueToken} from 'angular2/angular2';
 import {CONST_EXPR} from 'angular2/src/core/facade/lang';
 
 export const ROUTE_DATA: OpaqueToken = CONST_EXPR(new OpaqueToken('routeData'));

--- a/modules/angular2/src/router/route_registry.ts
+++ b/modules/angular2/src/router/route_registry.ts
@@ -24,7 +24,7 @@ import {
   RouteDefinition
 } from './route_config_impl';
 import {reflector} from 'angular2/src/core/reflection/reflection';
-import {Injectable} from 'angular2/src/core/di';
+import {Injectable} from 'angular2/angular2';
 import {normalizeRouteConfig, assertComponentExists} from './route_config_nomalizer';
 import {parser, Url, pathSegmentsToUrl} from './url_parser';
 

--- a/modules/angular2/src/router/router_outlet.ts
+++ b/modules/angular2/src/router/router_outlet.ts
@@ -3,9 +3,16 @@ import {StringMapWrapper} from 'angular2/src/core/facade/collection';
 import {isBlank, isPresent} from 'angular2/src/core/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 
-import {Directive, Attribute} from 'angular2/src/core/metadata';
-import {DynamicComponentLoader, ComponentRef, ElementRef} from 'angular2/src/core/linker';
-import {Injector, provide, Dependency} from 'angular2/angular2';
+import {
+  Directive,
+  Attribute,
+  DynamicComponentLoader,
+  ComponentRef,
+  ElementRef,
+  Injector,
+  provide,
+  Dependency
+} from 'angular2/angular2';
 
 import * as routerMod from './router';
 import {ComponentInstruction, RouteParams} from './instruction';

--- a/modules/angular2/src/router/router_outlet.ts
+++ b/modules/angular2/src/router/router_outlet.ts
@@ -5,7 +5,7 @@ import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptio
 
 import {Directive, Attribute} from 'angular2/src/core/metadata';
 import {DynamicComponentLoader, ComponentRef, ElementRef} from 'angular2/src/core/linker';
-import {Injector, provide, Dependency} from 'angular2/src/core/di';
+import {Injector, provide, Dependency} from 'angular2/angular2';
 
 import * as routerMod from './router';
 import {ComponentInstruction, RouteParams} from './instruction';


### PR DESCRIPTION
This PR is similar to #4648 but this time focusing on router. After this change router imports for "private" / shared APIs is limited to:
- facades
- reflection
- DOM
- decorator helpers

I'm slightly worried that this change might go against what @jeffbcross is trying to do in #4027 so what we might to is to import from `angular2/core` instead of `angular2/angular2`
