### PR TITLE
docs(directives): Fixed the mistake of leading number

### DIFF
--- a/modules/angular2/src/core/metadata/directives.ts
+++ b/modules/angular2/src/core/metadata/directives.ts
@@ -198,7 +198,7 @@ import {ViewEncapsulation} from 'angular2/src/core/metadata/view';
  * ```
  *
  * This directive would be instantiated with a {@link QueryList} which contains `Dependency` 4 and
- * 6. Here, `Dependency` 5 would not be included, because it is not a direct child.
+ * `Dependency` 6. Here, `Dependency` 5 would not be included, because it is not a direct child.
  *
  * ### Injecting a live collection of descendant directives
  *


### PR DESCRIPTION
The leading number with a dot and space in the Markdown will be compiled to `ol > li` and be restarted from 1.

The `4 and 6.` in the docs mistakenly add a new line before the `6.` cause a misunderstand by the markdown engine.
