### PR TITLE
fix(test_lib): don't mock out XHR via MockXHR by default in tests

### DIFF
--- a/modules/angular2/src/test_lib/test_injector.ts
+++ b/modules/angular2/src/test_lib/test_injector.ts
@@ -30,7 +30,6 @@ import {
 
 import {MockDirectiveResolver} from 'angular2/src/mock/directive_resolver_mock';
 import {MockViewResolver} from 'angular2/src/mock/view_resolver_mock';
-import {MockXHR} from 'angular2/src/core/compiler/xhr_mock';
 import {MockLocationStrategy} from 'angular2/src/mock/mock_location_strategy';
 import {LocationStrategy} from 'angular2/src/router/location_strategy';
 import {MockNgZone} from 'angular2/src/mock/ng_zone_mock';
@@ -116,7 +115,7 @@ function _getAppBindings() {
     PipeResolver,
     provide(ExceptionHandler, {asValue: new ExceptionHandler(DOM)}),
     provide(LocationStrategy, {asClass: MockLocationStrategy}),
-    provide(XHR, {asClass: MockXHR}),
+    XHR,
     TestComponentBuilder,
     provide(NgZone, {asClass: MockNgZone}),
     provide(AnimationBuilder, {asClass: MockAnimationBuilder}),

--- a/modules/angular2/test/core/compiler/test_bindings.ts
+++ b/modules/angular2/test/core/compiler/test_bindings.ts
@@ -1,6 +1,10 @@
 import {provide, Provider} from 'angular2/src/core/di';
 import {MockSchemaRegistry} from './schema_registry_mock';
 import {ElementSchemaRegistry} from 'angular2/src/core/compiler/schema/element_schema_registry';
+import {MockXHR} from 'angular2/src/core/compiler/xhr_mock';
+import {XHR} from 'angular2/src/core/compiler/xhr';
 
-export var TEST_PROVIDERS =
-    [provide(ElementSchemaRegistry, {asValue: new MockSchemaRegistry({}, {})})];
+export var TEST_PROVIDERS = [
+  provide(ElementSchemaRegistry, {asValue: new MockSchemaRegistry({}, {})}),
+  provide(XHR, {asClass: MockXHR})
+];


### PR DESCRIPTION
This is useful for the compiler tests, but otherwise it's not useful.

Additionally if an application has external templates (as is common) then
we should actually fetch these templates in tests.

Fixes #4539
