### PR TITLE
fix(test): command compiler attr merge test in IE

### DIFF
--- a/modules/angular2/test/core/compiler/command_compiler_spec.ts
+++ b/modules/angular2/test/core/compiler/command_compiler_spec.ts
@@ -222,7 +222,7 @@ export function main() {
            inject([AsyncTestCompleter], (async) => {
              var rootComp = createComp({
                type: RootCompTypeMeta,
-               template: '<div class="origclass" style="origstyle" role="origrole" attr1>'
+               template: '<div class="origclass" style="color: red;" role="origrole" attr1>'
              });
              var dir = CompileDirectiveMetadata.create({
                selector: 'div',
@@ -246,7 +246,7 @@ export function main() {
                          'role',
                          'newrole',
                          'style',
-                         'origstyle newstyle'
+                         'color: red; newstyle'
                        ],
                        [],
                        [],


### PR DESCRIPTION
All IEs ignore invalid value in style attribute, making the test to fail.
`var root = DOM.createTemplate('<div class="origclass" style="origstyle" role="origrole" attr1>');` does return `<template><div class="origclass" style="" role="origrole" attr1></template>`

Switching to a valid style value makes the test successful.
