### PR TITLE
fix(dart/transform): Handle empty .ng_deps.dart files

### DIFF
--- a/modules_dart/transform/lib/src/transform/directive_metadata_linker/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/directive_metadata_linker/transformer.dart
@@ -64,7 +64,8 @@ class DirectiveMetadataLinker extends Transformer
             transform
                 .addOutput(new Asset.fromString(depsAssetId, formattedCode));
           } else {
-            transform.addOutput(new Asset.fromString(depsAssetId, ''));
+            transform.addOutput(
+                new Asset.fromString(depsAssetId, _emptyNgDepsContents));
           }
         }
       });
@@ -74,3 +75,5 @@ class DirectiveMetadataLinker extends Transformer
 
 AssetId _depsAssetId(AssetId primaryId) =>
     new AssetId(primaryId.package, toDepsExtension(primaryId.path));
+
+const _emptyNgDepsContents = 'initReflector() {}';

--- a/modules_dart/transform/test/transform/integration/all_tests.dart
+++ b/modules_dart/transform/test/transform/integration/all_tests.dart
@@ -130,6 +130,16 @@ void allTests() {
         outputs: {
       'a|web/bar.ng_deps.dart':
           'directive_chain_files/expected/bar.ng_deps.dart'
+    }),
+    new IntegrationTestConfig(
+        'should handle empty ng_deps files that define directive aliases.',
+        inputs: {
+      'a|web/foo.dart': 'empty_ng_deps_files/foo.dart',
+      'a|web/bar.dart': 'empty_ng_deps_files/bar.dart'
+    },
+        outputs: {
+      'a|web/foo.ng_deps.dart': 'empty_ng_deps_files/expected/foo.ng_deps.dart',
+      'a|web/bar.ng_deps.dart': 'empty_ng_deps_files/expected/bar.ng_deps.dart'
     })
   ];
 

--- a/modules_dart/transform/test/transform/integration/empty_ng_deps_files/bar.dart
+++ b/modules_dart/transform/test/transform/integration/empty_ng_deps_files/bar.dart
@@ -1,0 +1,3 @@
+library bar;
+
+const directiveAlias = const [];

--- a/modules_dart/transform/test/transform/integration/empty_ng_deps_files/expected/bar.ng_deps.dart
+++ b/modules_dart/transform/test/transform/integration/empty_ng_deps_files/expected/bar.ng_deps.dart
@@ -1,0 +1,1 @@
+initReflector() {}

--- a/modules_dart/transform/test/transform/integration/empty_ng_deps_files/expected/foo.ng_deps.dart
+++ b/modules_dart/transform/test/transform/integration/empty_ng_deps_files/expected/foo.ng_deps.dart
@@ -1,0 +1,27 @@
+library bar.ng_deps.dart;
+
+import 'foo.template.dart' as _templates;
+
+import 'foo.dart';
+import 'package:angular2/src/core/reflection/reflection.dart' as _ngRef;
+import 'package:angular2/src/core/metadata.dart';
+import 'package:angular2/src/core/metadata.ng_deps.dart' as i0;
+import 'bar.dart';
+import 'bar.ng_deps.dart' as i1;
+export 'foo.dart';
+
+var _visited = false;
+void initReflector() {
+  if (_visited) return;
+  _visited = true;
+  _ngRef.reflector
+    ..registerType(
+        MyComponent,
+        new _ngRef.ReflectionInfo(const [
+          const Component(selector: '[soup]'),
+          const View(directives: const [directiveAlias], template: ''),
+          _templates.HostMyComponentTemplate
+        ], const [], () => new MyComponent()));
+  i0.initReflector();
+  i1.initReflector();
+}

--- a/modules_dart/transform/test/transform/integration/empty_ng_deps_files/foo.dart
+++ b/modules_dart/transform/test/transform/integration/empty_ng_deps_files/foo.dart
@@ -1,0 +1,8 @@
+library bar;
+
+import 'package:angular2/src/core/metadata.dart';
+import 'bar.dart';
+
+@Component(selector: '[soup]')
+@View(template: '', directives: const [directiveAlias])
+class MyComponent {}


### PR DESCRIPTION
Handle the situation where a `.dart` file generates a `.ng_meta.json`
file but does not register any reflective information.

An example of this would be a file that defines a const list that looks
like a directive alias. The transformer keeps track of this, and creates
a `.ng_meta.json` file but never creates a `.ng_deps.dart` file, which
can result in other files being linked to it and it not defining an
`initReflector` method.
