### PR TITLE
docs(metadata): Fix a small naming problem

### DIFF
--- a/modules/angular2/src/core/metadata.ts
+++ b/modules/angular2/src/core/metadata.ts
@@ -1047,7 +1047,7 @@ export var Attribute: AttributeFactory = makeParamDecorator(AttributeMetadata);
  *   <div #findme>...</div>
  * </seeker>
  *
- * @Component({ selector: 'foo' })
+ * @Component({ selector: 'seeker' })
  * class seeker {
  *   constructor(@Query('findme') elList: QueryList<ElementRef>) {...}
  * }
@@ -1064,8 +1064,8 @@ export var Attribute: AttributeFactory = makeParamDecorator(AttributeMetadata);
  *   <div #find-me-too>...</div>
  * </seeker>
  *
- *  @Component({
- *   selector: 'foo'
+ * @Component({
+ *   selector: 'seeker'
  * })
  * class Seeker {
  *   constructor(@Query('findMe, findMeToo') elList: QueryList<ElementRef>) {...}


### PR DESCRIPTION
Change the selector name form "foo" to "seeker".
