### PR TITLE
fix(compiler): attribute case when parsing HTML in IE9

### DIFF
--- a/modules/angular2/src/core/compiler/html_parser.ts
+++ b/modules/angular2/src/core/compiler/html_parser.ts
@@ -45,7 +45,9 @@ function parseText(text: Text, indexInParent: number, parentSourceInfo: string):
 function parseAttr(element: Element, parentSourceInfo: string, attrName: string, attrValue: string):
     HtmlAttrAst {
   // TODO(tbosch): add source row/column source info from parse5 / package:html
-  return new HtmlAttrAst(attrName, attrValue, `${parentSourceInfo}[${attrName}=${attrValue}]`);
+  var lowerCaseAttrName = attrName.toLowerCase();
+  return new HtmlAttrAst(lowerCaseAttrName, attrValue,
+                         `${parentSourceInfo}[${lowerCaseAttrName}=${attrValue}]`);
 }
 
 function parseElement(element: Element, indexInParent: number, parentSourceInfo: string):

--- a/modules/angular2/test/core/compiler/html_parser_spec.ts
+++ b/modules/angular2/test/core/compiler/html_parser_spec.ts
@@ -81,6 +81,14 @@ export function main() {
               ]);
         });
 
+        it('should parse and lower case attributes on regular elements', () => {
+          expect(humanizeDom(parser.parse('<div FoO="bar"></div>', 'TestComp')))
+              .toEqual([
+                [HtmlElementAst, 'div', 'TestComp > div:nth-child(0)'],
+                [HtmlAttrAst, 'foo', 'bar', 'TestComp > div:nth-child(0)[foo=bar]']
+              ]);
+        });
+
         it('should parse attributes on template elements', () => {
           expect(humanizeDom(parser.parse('<template k="v"></template>', 'TestComp')))
               .toEqual([


### PR DESCRIPTION
Investigating a test failure in IE9, I found an interesting issue about parsing attributes.
Consider the following code snippet:

```
myElem = document.createElement('div');
myElem.innerHTML = '<input type="text" ng-control="min" maxlength="3" ABC="4" efGH="5"></input>';
myElem.outerHTML
```

Output in Chrome:
`<div><input type="text" ng-control="min" maxlength="3" abc="4" efgh="5"></div>`
Output in Firefox:
`<div><input type="text" ng-control="min" maxlength="3" ABC="4" efGH="5" /></div>`
Output in IE9:
`<div><input maxLength="3" type="text" ng-control="min" efGH="5" ABC="4"></div>`

As you can see, IE9 and Firefox keep the case, and IE9 even **modifies** it in the particular case of `maxlength`.
Hence the proposal to lower case all attributes names to harmonize the behaviors.
