### PR TITLE
chore(saucelabs): add Edge

### DIFF
--- a/modules/angular2/test/core/reflection/reflector_spec.ts
+++ b/modules/angular2/test/core/reflection/reflector_spec.ts
@@ -1,4 +1,12 @@
-import {describe, it, iit, ddescribe, expect, beforeEach} from 'angular2/testing_internal';
+import {
+  describe,
+  it,
+  iit,
+  ddescribe,
+  expect,
+  beforeEach,
+  browserDetection
+} from 'angular2/testing_internal';
 import {Reflector, ReflectionInfo} from 'angular2/src/core/reflection/reflection';
 import {ReflectionCapabilities} from 'angular2/src/core/reflection/reflection_capabilities';
 import {
@@ -94,34 +102,38 @@ export function main() {
         expect(obj.b).toEqual(2);
       });
 
-      it("should check args from no to max", () => {
-        var f = t => reflector.factory(t);
-        var checkArgs = (obj, args) => expect(obj.args).toEqual(args);
+      // Makes Edge to disconnect when running the full unit test campaign
+      // TODO: remove when issue is solved: https://github.com/angular/angular/issues/4756
+      if (!browserDetection.isEdge) {
+        it("should check args from no to max", () => {
+          var f = t => reflector.factory(t);
+          var checkArgs = (obj, args) => expect(obj.args).toEqual(args);
 
-        // clang-format off
-        checkArgs(f(TestObjWith00Args)(), []);
-        checkArgs(f(TestObjWith01Args)(1), [1]);
-        checkArgs(f(TestObjWith02Args)(1, 2), [1, 2]);
-        checkArgs(f(TestObjWith03Args)(1, 2, 3), [1, 2, 3]);
-        checkArgs(f(TestObjWith04Args)(1, 2, 3, 4), [1, 2, 3, 4]);
-        checkArgs(f(TestObjWith05Args)(1, 2, 3, 4, 5), [1, 2, 3, 4, 5]);
-        checkArgs(f(TestObjWith06Args)(1, 2, 3, 4, 5, 6), [1, 2, 3, 4, 5, 6]);
-        checkArgs(f(TestObjWith07Args)(1, 2, 3, 4, 5, 6, 7), [1, 2, 3, 4, 5, 6, 7]);
-        checkArgs(f(TestObjWith08Args)(1, 2, 3, 4, 5, 6, 7, 8), [1, 2, 3, 4, 5, 6, 7, 8]);
-        checkArgs(f(TestObjWith09Args)(1, 2, 3, 4, 5, 6, 7, 8, 9), [1, 2, 3, 4, 5, 6, 7, 8, 9]);
-        checkArgs(f(TestObjWith10Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        checkArgs(f(TestObjWith11Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-        checkArgs(f(TestObjWith12Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-        checkArgs(f(TestObjWith13Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
-        checkArgs(f(TestObjWith14Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
-        checkArgs(f(TestObjWith15Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-        checkArgs(f(TestObjWith16Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
-        checkArgs(f(TestObjWith17Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]);
-        checkArgs(f(TestObjWith18Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]);
-        checkArgs(f(TestObjWith19Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
-        checkArgs(f(TestObjWith20Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
-        // clang-format on
-      });
+          // clang-format off
+          checkArgs(f(TestObjWith00Args)(), []);
+          checkArgs(f(TestObjWith01Args)(1), [1]);
+          checkArgs(f(TestObjWith02Args)(1, 2), [1, 2]);
+          checkArgs(f(TestObjWith03Args)(1, 2, 3), [1, 2, 3]);
+          checkArgs(f(TestObjWith04Args)(1, 2, 3, 4), [1, 2, 3, 4]);
+          checkArgs(f(TestObjWith05Args)(1, 2, 3, 4, 5), [1, 2, 3, 4, 5]);
+          checkArgs(f(TestObjWith06Args)(1, 2, 3, 4, 5, 6), [1, 2, 3, 4, 5, 6]);
+          checkArgs(f(TestObjWith07Args)(1, 2, 3, 4, 5, 6, 7), [1, 2, 3, 4, 5, 6, 7]);
+          checkArgs(f(TestObjWith08Args)(1, 2, 3, 4, 5, 6, 7, 8), [1, 2, 3, 4, 5, 6, 7, 8]);
+          checkArgs(f(TestObjWith09Args)(1, 2, 3, 4, 5, 6, 7, 8, 9), [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+          checkArgs(f(TestObjWith10Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+          checkArgs(f(TestObjWith11Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+          checkArgs(f(TestObjWith12Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+          checkArgs(f(TestObjWith13Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+          checkArgs(f(TestObjWith14Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+          checkArgs(f(TestObjWith15Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+          checkArgs(f(TestObjWith16Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+          checkArgs(f(TestObjWith17Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]);
+          checkArgs(f(TestObjWith18Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]);
+          checkArgs(f(TestObjWith19Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
+          checkArgs(f(TestObjWith20Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+          // clang-format on
+        });
+      }
 
       it("should throw when more than 20 arguments",
          () => { expect(() => reflector.factory(TestObjWith21Args)).toThrowError(); });

--- a/modules/angular2/test/pipes/slice_pipe_spec.ts
+++ b/modules/angular2/test/pipes/slice_pipe_spec.ts
@@ -6,7 +6,8 @@ import {
   xit,
   expect,
   beforeEach,
-  afterEach
+  afterEach,
+  browserDetection
 } from 'angular2/testing_internal';
 
 import {SlicePipe} from 'angular2/src/core/pipes';
@@ -68,15 +69,19 @@ export function main() {
         expect(pipe.transform(str, [99])).toEqual('');
       });
 
-      it('should return entire input if START is negative and greater than input length', () => {
-        expect(pipe.transform(list, [-99])).toEqual([1, 2, 3, 4, 5]);
-        expect(pipe.transform(str, [-99])).toEqual('tuvwxyz');
-      });
+      // Makes Edge to disconnect when running the full unit test campaign
+      // TODO: remove when issue is solved: https://github.com/angular/angular/issues/4756
+      if (!browserDetection.isEdge) {
+        it('should return entire input if START is negative and greater than input length', () => {
+          expect(pipe.transform(list, [-99])).toEqual([1, 2, 3, 4, 5]);
+          expect(pipe.transform(str, [-99])).toEqual('tuvwxyz');
+        });
 
-      it('should not modify the input list', () => {
-        expect(pipe.transform(list, [2])).toEqual([3, 4, 5]);
-        expect(list).toEqual([1, 2, 3, 4, 5]);
-      });
+        it('should not modify the input list', () => {
+          expect(pipe.transform(list, [2])).toEqual([3, 4, 5]);
+          expect(list).toEqual([1, 2, 3, 4, 5]);
+        });
+      }
 
     });
 

--- a/sauce.conf.js
+++ b/sauce.conf.js
@@ -89,6 +89,12 @@ var customLaunchers = {
     platform: 'Windows 8.1',
     version: '11'
   },
+  'SL_EDGE': {
+    base: 'SauceLabs',
+    browserName: 'microsoftedge',
+    platform: 'Windows 10',
+    version: '20.10240'
+  },
   'SL_ANDROID4.1': {
     base: 'SauceLabs',
     browserName: 'android',
@@ -123,7 +129,7 @@ var customLaunchers = {
 
 var aliases = {
   'ALL': Object.keys(customLaunchers).filter(function(item) {return customLaunchers[item].base == 'SauceLabs';}),
-  'DESKTOP': ['SL_CHROME', 'SL_FIREFOX', 'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_SAFARI7', 'SL_SAFARI8', 'SL_SAFARI8.1'],
+  'DESKTOP': ['SL_CHROME', 'SL_FIREFOX', 'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_EDGE', 'SL_SAFARI7', 'SL_SAFARI8', 'SL_SAFARI8.1'],
   'MOBILE': ['SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4', 'SL_ANDROID5.1', 'SL_IOS7', 'SL_IOS8', 'SL_IOS9'],
   'ANDROID': ['SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4', 'SL_ANDROID5.1'],
   'IE': ['SL_IE9', 'SL_IE10', 'SL_IE11'],
@@ -132,7 +138,7 @@ var aliases = {
   'BETA': ['SL_CHROMEBETA', 'SL_FIREFOXBETA'],
   'DEV': ['SL_CHROMEDEV', 'SL_FIREFOXDEV'],
   'CI': ['SL_CHROME', 'SL_ANDROID5.1', 'SL_SAFARI7', 'SL_SAFARI8', 'SL_SAFARI8.1', 'SL_IOS7', 'SL_IOS8', 'SL_IOS9',
-         'SL_FIREFOX', 'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4',
+         'SL_FIREFOX', 'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_EDGE', 'SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4',
          'SL_CHROMEDEV', 'SL_FIREFOXBETA']
 };
 


### PR DESCRIPTION
For some reason, 3 tests need to be skipped in Edge in order to be able to run the full campaign, see #4756. 
But it also means that 2000+ tests can be already run in Edge as part of CI.
