### PR TITLE
chore(package.json): remove typings bundles

### DIFF
--- a/modules/angular2/package.json
+++ b/modules/angular2/package.json
@@ -13,13 +13,5 @@
     "zone.js": "<%= packageJson.dependencies['zone.js'] %>"
   },
   "devDependencies": <%= JSON.stringify(packageJson.defaultDevDependencies) %>,
-  "typings": "./angular2.d.ts",
-  "typescript": {
-    "definitions": [
-      "bundles/typings/angular2/angular2.d.ts",
-      "bundles/typings/angular2/http.d.ts",
-      "bundles/typings/angular2/router.d.ts",
-      "bundles/typings/angular2/testing.d.ts"
-    ]
-  }
+  "typings": "./angular2.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular",
+  "name": "angular-srcs",
   "version": "2.0.0-alpha.42",
   "branchPattern": "2.0.*",
   "description": "Angular 2 - a web framework for modern web apps",


### PR DESCRIPTION
This was used for 'tsd link', but now that our typings are laid out in the node_module, users should no longer need that.
Also fix the project name in root package.json. There is a risk that someone runs npm publish in this directory, which will create a new version of angular 1, and contain a scary source tree.
So this package.json may as well have a name that doesn't exist on npm, and if we did publish by accident, it would be a package name that matches the contents.
