### PR TITLE
fix(url_resolver): always replace `package:` in Dart, even if it came…

### DIFF
--- a/modules/angular2/src/core/compiler/url_resolver.dart
+++ b/modules/angular2/src/core/compiler/url_resolver.dart
@@ -1,6 +1,10 @@
 library angular2.src.services.url_resolver;
 
-import 'package:angular2/src/core/di.dart' show Injectable;
+import 'package:angular2/src/core/di.dart' show Injectable, Provider;
+
+UrlResolver createWithoutPackagePrefix() {
+  return new UrlResolver.withUrlPrefix(null);
+}
 
 @Injectable()
 class UrlResolver {
@@ -28,14 +32,15 @@ class UrlResolver {
    */
   String resolve(String baseUrl, String url) {
     Uri uri = Uri.parse(url);
-
-    if (uri.scheme == 'package') {
-      return '$_packagePrefix/${uri.path}';
+    if (!uri.isAbsolute) {
+      Uri baseUri = Uri.parse(baseUrl);
+      uri = baseUri.resolveUri(uri);
     }
 
-    if (uri.isAbsolute) return uri.toString();
-
-    Uri baseUri = Uri.parse(baseUrl);
-    return baseUri.resolveUri(uri).toString();
+    if (_packagePrefix != null && uri.scheme == 'package') {
+      return '$_packagePrefix/${uri.path}';
+    } else {
+      return uri.toString();
+    }
   }
 }

--- a/modules/angular2/src/core/compiler/url_resolver.ts
+++ b/modules/angular2/src/core/compiler/url_resolver.ts
@@ -3,6 +3,11 @@ import {isPresent, isBlank, RegExpWrapper, normalizeBlank} from 'angular2/src/co
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 import {ListWrapper} from 'angular2/src/core/facade/collection';
 
+export function createWithoutPackagePrefix(): UrlResolver {
+  return new UrlResolver();
+}
+
+
 /**
  * Used by the {@link Compiler} when resolving HTML and CSS template URLs.
  *

--- a/modules/angular2/test/core/compiler/test_bindings.ts
+++ b/modules/angular2/test/core/compiler/test_bindings.ts
@@ -3,8 +3,10 @@ import {MockSchemaRegistry} from './schema_registry_mock';
 import {ElementSchemaRegistry} from 'angular2/src/core/compiler/schema/element_schema_registry';
 import {MockXHR} from 'angular2/src/core/compiler/xhr_mock';
 import {XHR} from 'angular2/src/core/compiler/xhr';
+import {UrlResolver, createWithoutPackagePrefix} from 'angular2/src/core/compiler/url_resolver';
 
 export var TEST_PROVIDERS = [
   provide(ElementSchemaRegistry, {useValue: new MockSchemaRegistry({}, {})}),
-  provide(XHR, {useClass: MockXHR})
+  provide(XHR, {useClass: MockXHR}),
+  provide(UrlResolver, {useFactory: createWithoutPackagePrefix})
 ];


### PR DESCRIPTION
… from `baseUrl`.
