### PR TITLE
chore: test CSS calc() expressions

### DIFF
--- a/modules/angular2/test/core/compiler/shadow_css_spec.ts
+++ b/modules/angular2/test/core/compiler/shadow_css_spec.ts
@@ -164,5 +164,11 @@ export function main() {
         expect(css).toEqual(styleStr);
       });
     }
+
+    it('should leave calc() unchanged', () => {
+      var styleStr = 'a {height:calc(100% - 55px);}';
+      var css = s(styleStr, 'a');
+      expect(css).toEqual(styleStr);
+    });
   });
 }


### PR DESCRIPTION
A bug in csslib caused our CSS shimmer in the transformer to mangle CSS output (#4730), while other parsers worked fine. This bug has been fixed in csslib v0.12.2. The test is to make sure we parse `calc()` expressions consistently between DOM, parse5 and csslib, in case we accidentally pull in the wrong version of something or there's a regression.
