### PR TITLE
docs(chore): make styles consistent for API doc headings

### DIFF
--- a/modules/angular1_router/src/ng_outlet.ts
+++ b/modules/angular1_router/src/ng_outlet.ts
@@ -221,7 +221,7 @@ function ngOutletFillContentDirective($compile) {
  * ## Use
  * The directive uses a simple syntax: `ng-link="componentName({ param: paramValue })"`
  *
- * ## Example
+ * ### Example
  *
  * ```js
  * angular.module('myApp', ['ngComponentRouter'])

--- a/modules/angular2/router.ts
+++ b/modules/angular2/router.ts
@@ -37,7 +37,7 @@ import {BaseException} from 'angular2/src/core/facade/exceptions';
  * Token used to bind the component with the top-level {@link RouteConfig}s for the
  * application.
  *
- * ## Example ([live demo](http://plnkr.co/edit/iRUP8B5OUbxCWQ3AcIDm))
+ * ### Example ([live demo](http://plnkr.co/edit/iRUP8B5OUbxCWQ3AcIDm))
  *
  * ```
  * import {Component} from 'angular2/angular2';
@@ -66,7 +66,7 @@ export const ROUTER_PRIMARY_COMPONENT: OpaqueToken =
  * {@link RouterLink}, add this to your `directives` array in the {@link View} decorator of your
  * component.
  *
- * ## Example ([live demo](http://plnkr.co/edit/iRUP8B5OUbxCWQ3AcIDm))
+ * ### Example ([live demo](http://plnkr.co/edit/iRUP8B5OUbxCWQ3AcIDm))
  *
  * ```
  * import {Component} from 'angular2/angular2';
@@ -88,7 +88,7 @@ export const ROUTER_DIRECTIVES: any[] = CONST_EXPR([RouterOutlet, RouterLink]);
 /**
  * A list of {@link Provider}s. To use the router, you must add this to your application.
  *
- * ## Example ([live demo](http://plnkr.co/edit/iRUP8B5OUbxCWQ3AcIDm))
+ * ### Example ([live demo](http://plnkr.co/edit/iRUP8B5OUbxCWQ3AcIDm))
  *
  * ```
  * import {Component} from 'angular2/angular2';

--- a/modules/angular2/src/core/application_common.ts
+++ b/modules/angular2/src/core/application_common.ts
@@ -72,7 +72,7 @@ export function applicationDomBindings(): Array<Type | Provider | any[]> {
  *
  * See {@link PlatformRef} for details on the Angular platform.
  *
- * # Without specified providers
+ *##Without specified providers
  *
  * If no providers are specified, `platform`'s behavior depends on whether an existing
  * platform exists:
@@ -83,7 +83,7 @@ export function applicationDomBindings(): Array<Type | Provider | any[]> {
  * was created with). This is a convenience feature, allowing for multiple applications
  * to be loaded into the same platform without awareness of each other.
  *
- * # With specified providers
+ *##With specified providers
  *
  * It is also possible to specify providers to be made in the new platform. These providers
  * will be shared between all applications on the page. For example, an abstraction for
@@ -94,7 +94,7 @@ export function applicationDomBindings(): Array<Type | Provider | any[]> {
  * them if a platform did not exist already. If it did exist, however, an error will be
  * thrown.
  *
- * # DOM Applications
+ *##DOM Applications
  *
  * This version of `platform` initializes Angular to run in the UI thread, with direct
  * DOM access. Web-worker applications should call `platform` from
@@ -208,7 +208,7 @@ export function platform(bindings?: Array<Type | Provider | any[]>): PlatformRef
  * to that application.
  *
  *
- * # API
+ *##API
  * - `appComponentType`: The root component which should act as the application. This is
  *   a reference to a `Type` which is annotated with `@Component(...)`.
  * - `componentInjectableBindings`: An additional set of providers that can be added to the

--- a/modules/angular2/src/core/application_ref.ts
+++ b/modules/angular2/src/core/application_ref.ts
@@ -159,20 +159,20 @@ export abstract class PlatformRef {
   /**
    * Instantiate a new Angular application on the page.
    *
-   * # What is an application?
+   *##What is an application?
    *
    * Each Angular application has its own zone, change detection, compiler,
    * renderer, and other framework components. An application hosts one or more
    * root components, which can be initialized via `ApplicationRef.bootstrap()`.
    *
-   * # Application Bindings
+   *##Application Bindings
    *
    * Angular applications require numerous providers to be properly instantiated.
    * When using `application()` to create a new app on the page, these providers
    * must be provided. Fortunately, there are helper functions to configure
    * typical providers, as shown in the example below.
    *
-   * # Example
+   * ### Example
    * ```
    * var myAppBindings = [MyAppService];
    *
@@ -180,7 +180,7 @@ export abstract class PlatformRef {
    *   .application([applicationCommonBindings(), applicationDomBindings(), myAppBindings])
    *   .bootstrap(MyTopLevelComponent);
    * ```
-   * # See Also
+   *##See Also
    *
    * See the {@link bootstrap} documentation for more details.
    */
@@ -191,7 +191,7 @@ export abstract class PlatformRef {
    * are only available asynchronously. One such use case is to initialize an
    * application running in a web worker.
    *
-   * # Usage
+   *##Usage
    *
    * `bindingFn` is a function that will be called in the new application's zone.
    * It should return a `Promise` to a list of providers to be used for the
@@ -281,19 +281,19 @@ export abstract class ApplicationRef {
   /**
    * Bootstrap a new component at the root level of the application.
    *
-   * # Bootstrap process
+   *##Bootstrap process
    *
    * When bootstrapping a new root component into an application, Angular mounts the
    * specified application component onto DOM elements identified by the [componentType]'s
    * selector and kicks off automatic change detection to finish initializing the component.
    *
-   * # Optional Bindings
+   *##Optional Bindings
    *
    * Bindings for the given component can optionally be overridden via the `providers`
    * parameter. These providers will only apply for the root component being added and any
    * child components under it.
    *
-   * # Example
+   * ### Example
    * ```
    * var app = platform.application([applicationCommonBindings(), applicationDomBindings()];
    * app.bootstrap(FirstRootComponent);

--- a/modules/angular2/src/core/change_detection/differs/iterable_differs.ts
+++ b/modules/angular2/src/core/change_detection/differs/iterable_differs.ts
@@ -44,7 +44,7 @@ export class IterableDiffers {
          * which will only be applied to the injector for this component and its children.
          * This step is all that's required to make a new {@link IterableDiffer} available.
    *
-   * # Example
+   * ### Example
    *
    * ```
    * @Component({

--- a/modules/angular2/src/core/change_detection/differs/keyvalue_differs.ts
+++ b/modules/angular2/src/core/change_detection/differs/keyvalue_differs.ts
@@ -44,7 +44,7 @@ export class KeyValueDiffers {
          * which will only be applied to the injector for this component and its children.
          * This step is all that's required to make a new {@link KeyValueDiffer} available.
    *
-   * # Example
+   * ### Example
    *
    * ```
    * @Component({

--- a/modules/angular2/src/core/directives/ng_for.ts
+++ b/modules/angular2/src/core/directives/ng_for.ts
@@ -23,7 +23,7 @@ import {isPresent, isBlank} from 'angular2/src/core/facade/lang';
  * * When an item is removed, its template instance is removed from the DOM.
  * * When items are reordered, their respective templates are reordered in the DOM.
  *
- * # Example
+ * ### Example
  *
  * ```
  * <ul>
@@ -33,7 +33,7 @@ import {isPresent, isBlank} from 'angular2/src/core/facade/lang';
  * </ul>
  * ```
  *
- * # Syntax
+ *##Syntax
  *
  * - `<li *ng-for="#item of items; #i = index">...</li>`
  * - `<li template="ng-for #item of items; #i = index">...</li>`

--- a/modules/angular2/src/core/directives/ng_if.ts
+++ b/modules/angular2/src/core/directives/ng_if.ts
@@ -18,7 +18,7 @@ import {isBlank} from 'angular2/src/core/facade/lang';
  * </div>
  * ```
  *
- * # Syntax
+ *##Syntax
  *
  * - `<div *ng-if="condition">...</div>`
  * - `<div template="ng-if condition">...</div>`

--- a/modules/angular2/src/core/directives/ng_style.ts
+++ b/modules/angular2/src/core/directives/ng_style.ts
@@ -15,7 +15,7 @@ import {isPresent, isBlank, print} from 'angular2/src/core/facade/lang';
  * corresponding element styles are updated based on changes to this object. Style names to update
  * are taken from the object's keys, and values - from the corresponding object's values.
  *
- * # Syntax
+ *##Syntax
  *
  * - `<div [ng-style]="{'font-style': style}"></div>`
  * - `<div [ng-style]="styleExp"></div>` - here the `styleExp` must evaluate to an object

--- a/modules/angular2/src/core/directives/ng_switch.ts
+++ b/modules/angular2/src/core/directives/ng_switch.ts
@@ -29,7 +29,7 @@ export class SwitchView {
  * evaluated. If a matching expression is not found via a when attribute then an element with the
  * default attribute is displayed.
  *
- * # Example:
+ * ### Example
  *
  * ```
  * <ANY [ng-switch]="expression">

--- a/modules/angular2/src/core/facade/async.ts
+++ b/modules/angular2/src/core/facade/async.ts
@@ -49,7 +49,7 @@ export class Observable {
 /**
  * Use by directives and components to emit custom Events.
  *
- * ## Examples
+ * ### Examples
  *
  * In the following example, `Zippy` alternatively emits `open` and `close` events when its
  * title gets clicked:

--- a/modules/angular2/src/core/facade/exception_handler.ts
+++ b/modules/angular2/src/core/facade/exception_handler.ts
@@ -17,7 +17,7 @@ class _ArrayLogger {
  * intercept error handling,
  * write a custom exception handler that replaces this default as appropriate for your app.
  *
- * # Example
+ * ### Example
  *
  * ```javascript
  *

--- a/modules/angular2/src/core/forms.ts
+++ b/modules/angular2/src/core/forms.ts
@@ -47,7 +47,7 @@ import {CONST_EXPR, Type} from './facade/lang';
 /**
  * Shorthand set of providers used for building Angular forms.
  *
- * ### Example:
+ * ### Example
  *
  * ```typescript
  * bootstrap(MyApp, [FORM_PROVIDERS]);

--- a/modules/angular2/src/core/forms/directives.ts
+++ b/modules/angular2/src/core/forms/directives.ts
@@ -38,7 +38,7 @@ export {NgControlStatus} from './directives/ng_control_status';
  *
  *  This is a shorthand for importing them each individually.
  *
- * ### Example:
+ * ### Example
  *
  * ```typescript
  * @Component({

--- a/modules/angular2/src/core/forms/directives/checkbox_value_accessor.ts
+++ b/modules/angular2/src/core/forms/directives/checkbox_value_accessor.ts
@@ -13,7 +13,7 @@ const CHECKBOX_VALUE_ACCESSOR = CONST_EXPR(new Provider(
 /**
  * The accessor for writing a value and listening to changes on a checkbox input element.
  *
- *  # Example
+ *  ### Example
  *  ```
  *  <input type="checkbox" [ng-control]="rememberLogin">
  *  ```

--- a/modules/angular2/src/core/forms/directives/default_value_accessor.ts
+++ b/modules/angular2/src/core/forms/directives/default_value_accessor.ts
@@ -13,7 +13,7 @@ const DEFAULT_VALUE_ACCESSOR = CONST_EXPR(new Provider(
  * The default accessor for writing a value and listening to changes that is used by the
  * {@link NgModel}, {@link NgFormControl}, and {@link NgControlName} directives.
  *
- *  # Example
+ *  ### Example
  *  ```
  *  <input type="text" [(ng-model)]="searchQuery">
  *  ```

--- a/modules/angular2/src/core/forms/directives/ng_control_group.ts
+++ b/modules/angular2/src/core/forms/directives/ng_control_group.ts
@@ -17,7 +17,7 @@ const controlGroupBinding =
  *
  * This directive can only be used as a child of {@link NgForm} or {@link NgFormModel}.
  *
- * # Example
+ * ### Example
  *
  * In this example, we create the credentials and personal control groups.
  * We can work with each group separately: check its validity, get its value, listen to its changes.

--- a/modules/angular2/src/core/forms/directives/ng_control_name.ts
+++ b/modules/angular2/src/core/forms/directives/ng_control_name.ts
@@ -21,7 +21,7 @@ const controlNameBinding =
  *
  * This directive can only be used as a child of {@link NgForm} or {@link NgFormModel}.
 
- * # Example
+ * ### Example
  *
  * In this example, we create the login and password controls.
  * We can work with each control separately: check its validity, get its value, listen to its

--- a/modules/angular2/src/core/forms/directives/ng_form.ts
+++ b/modules/angular2/src/core/forms/directives/ng_form.ts
@@ -22,19 +22,19 @@ const formDirectiveProvider =
  * If `NgForm` is bound in a component, `<form>` elements in that component will be
  * upgraded to use the Angular form system.
  *
- * # Typical Use
+ *##Typical Use
  *
  * Include `FORM_DIRECTIVES` in the `directives` section of a {@link View} annotation
  * to use `NgForm` and its associated controls.
  *
- * # Structure
+ *##Structure
  *
  * An Angular form is a collection of `Control`s in some hierarchy.
  * `Control`s can be at the top level or can be organized in `ControlGroup`s
  * or `ControlArray`s. This hierarchy is reflected in the form's `value`, a
  * JSON object that mirrors the form structure.
  *
- * # Submission
+ *##Submission
  *
  * The `ng-submit` event signals when the user triggers a form submission.
  *

--- a/modules/angular2/src/core/forms/directives/ng_form_control.ts
+++ b/modules/angular2/src/core/forms/directives/ng_form_control.ts
@@ -42,7 +42,7 @@ const formControlBinding =
  * }
  *  ```
  *
- * # ng-model
+ *##ng-model
  *
  * We can also use `ng-model` to bind a domain model to the form.
  *

--- a/modules/angular2/src/core/forms/directives/ng_model.ts
+++ b/modules/angular2/src/core/forms/directives/ng_model.ts
@@ -16,7 +16,7 @@ const formControlBinding =
 /**
  * Binds a domain model to a form control.
  *
- * # Usage
+ *##Usage
  *
  * `ng-model` binds an existing domain model to a form control. For a
  * two-way binding, use `[(ng-model)]` to ensure the model updates in

--- a/modules/angular2/src/core/forms/directives/number_value_accessor.ts
+++ b/modules/angular2/src/core/forms/directives/number_value_accessor.ts
@@ -13,7 +13,7 @@ const NUMBER_VALUE_ACCESSOR = CONST_EXPR(new Provider(
  * The accessor for writing a number value and listening to changes that is used by the
  * {@link NgModel}, {@link NgFormControl}, and {@link NgControlName} directives.
  *
- *  # Example
+ *  ### Example
  *  ```
  *  <input type="number" [(ng-model)]="age">
  *  ```

--- a/modules/angular2/src/core/forms/directives/select_control_value_accessor.ts
+++ b/modules/angular2/src/core/forms/directives/select_control_value_accessor.ts
@@ -14,7 +14,7 @@ const SELECT_VALUE_ACCESSOR = CONST_EXPR(new Provider(
 /**
  * Marks `<option>` as dynamic, so Angular can be notified when options change.
  *
- * #Example:
+ * ### Example
  *
  * ```
  * <select ng-control="city">

--- a/modules/angular2/src/core/forms/form_builder.ts
+++ b/modules/angular2/src/core/forms/form_builder.ts
@@ -7,7 +7,7 @@ import * as modelModule from './model';
 /**
  * Creates a form object from a user-specified configuration.
  *
- * # Example
+ * ### Example
  *
  * ```
  * import {Component, bootstrap} from 'angular2/angular2';

--- a/modules/angular2/src/core/forms/model.ts
+++ b/modules/angular2/src/core/forms/model.ts
@@ -38,7 +38,7 @@ function _find(control: AbstractControl, path: Array<string | number>| string) {
 }
 
 /**
- * Omitting from external API doc as this is really an abstract internal concept.
+ *
  */
 export class AbstractControl {
   /** @internal */
@@ -145,7 +145,7 @@ export class AbstractControl {
  * `Control` is one of the three fundamental building blocks used to define forms in Angular, along
  * with {@link ControlGroup} and {@link ControlArray}.
  *
- * # Usage
+ *##Usage
  *
  * By default, a `Control` is created for every `<input>` or other form component.
  * With {@link NgFormControl} or {@link NgFormModel} an existing {@link Control} can be
@@ -287,7 +287,7 @@ export class ControlGroup extends AbstractControl {
  * along with {@link Control} and {@link ControlGroup}. {@link ControlGroup} can also contain
  * other controls, but is of fixed length.
  *
- * # Adding or removing controls
+ *##Adding or removing controls
  *
  * To change the controls in the array, use the `push`, `insert`, or `removeAt` methods
  * in `ControlArray` itself. These methods ensure the controls are properly tracked in the

--- a/modules/angular2/src/core/forms/validators.ts
+++ b/modules/angular2/src/core/forms/validators.ts
@@ -10,7 +10,7 @@ export const NG_VALIDATORS: OpaqueToken = CONST_EXPR(new OpaqueToken("NgValidato
 /**
  * Provides a set of validators used by form controls.
  *
- * # Example
+ * ### Example
  *
  * ```
  * var loginControl = new Control("", Validators.required)

--- a/modules/angular2/src/core/life_cycle/life_cycle.ts
+++ b/modules/angular2/src/core/life_cycle/life_cycle.ts
@@ -15,7 +15,7 @@ import {wtfLeave, wtfCreateScope, WtfScopeFn} from '../profile/profile';
  *
  * Each Angular application has a single `LifeCycle` instance.
  *
- * # Example
+ * ### Example
  *
  * This is a contrived example, since the bootstrap automatically runs inside of the `Zone`, which
  * invokes

--- a/modules/angular2/src/core/linker/dynamic_component_loader.ts
+++ b/modules/angular2/src/core/linker/dynamic_component_loader.ts
@@ -107,7 +107,7 @@ export abstract class DynamicComponentLoader {
    * Returns a promise for the {@link ComponentRef} representing the newly created Component.
    *
    *
-   * ## Example
+   * ### Example
    *
    * ```
    * @ng.Component({
@@ -167,7 +167,7 @@ export abstract class DynamicComponentLoader {
    * Returns a promise for the {@link ComponentRef} representing the newly created Component.
    *
    *
-   * ## Example
+   * ### Example
    *
    * ```
    * @ng.Component({
@@ -221,7 +221,7 @@ export abstract class DynamicComponentLoader {
    * Returns a promise for the {@link ComponentRef} representing the newly created Component.
    *
    *
-   * ## Example
+   * ### Example
    *
    * ```
    * @ng.Component({

--- a/modules/angular2/src/core/linker/view_manager.ts
+++ b/modules/angular2/src/core/linker/view_manager.ts
@@ -76,7 +76,7 @@ export abstract class AppViewManager {
    * Use {@link AppViewManager#destroyRootHostView} to destroy the created Component and it's Host
    * View.
    *
-   * ## Example
+   * ### Example
    *
    * ```
    * @ng.Component({

--- a/modules/angular2/src/core/linker/view_ref.ts
+++ b/modules/angular2/src/core/linker/view_ref.ts
@@ -43,7 +43,7 @@ export interface HostViewRef {
  * removing nested Views via a {@link ViewContainer}. Each View can contain many View Containers.
  * <!-- /TODO -->
  *
- * ## Example
+ * ### Example
  *
  * Given this template...
  *
@@ -139,7 +139,7 @@ export class ViewRef_ extends ViewRef {
  * {@link Compiler#compileInHost} API.
  *
  *
- * ## Example
+ * ### Example
  *
  * Given this template:
  *

--- a/modules/angular2/src/core/metadata.ts
+++ b/modules/angular2/src/core/metadata.ts
@@ -107,7 +107,7 @@ export interface ViewDecorator extends TypeDecorator {
 /**
  * {@link DirectiveMetadata} factory for creating annotations, decorators or DSL.
  *
- * ## Example as TypeScript Decorator
+ * ### Example as TypeScript Decorator
  *
  * ```
  * import {Directive} from "angular2/angular2";
@@ -120,7 +120,7 @@ export interface ViewDecorator extends TypeDecorator {
  * }
  * ```
  *
- * ## Example as ES5 DSL
+ * ### Example as ES5 DSL
  *
  * ```
  * var MyDirective = ng
@@ -132,7 +132,7 @@ export interface ViewDecorator extends TypeDecorator {
  *   })
  * ```
  *
- * ## Example as ES5 annotation
+ * ### Example as ES5 annotation
  *
  * ```
  * var MyDirective = function() {
@@ -176,7 +176,7 @@ export interface DirectiveFactory {
 /**
  * {@link ComponentMetadata} factory for creating annotations, decorators or DSL.
  *
- * ## Example as TypeScript Decorator
+ * ### Example as TypeScript Decorator
  *
  * ```
  * import {Component} from "angular2/angular2";
@@ -189,7 +189,7 @@ export interface DirectiveFactory {
  * }
  * ```
  *
- * ## Example as ES5 DSL
+ * ### Example as ES5 DSL
  *
  * ```
  * var MyComponent = ng
@@ -201,7 +201,7 @@ export interface DirectiveFactory {
  *   })
  * ```
  *
- * ## Example as ES5 annotation
+ * ### Example as ES5 annotation
  *
  * ```
  * var MyComponent = function() {
@@ -268,7 +268,7 @@ export interface ComponentFactory {
 /**
  * {@link ViewMetadata} factory for creating annotations, decorators or DSL.
  *
- * ## Example as TypeScript Decorator
+ * ### Example as TypeScript Decorator
  *
  * ```
  * import {Component, View} from "angular2/angular2";
@@ -282,7 +282,7 @@ export interface ComponentFactory {
  * }
  * ```
  *
- * ## Example as ES5 DSL
+ * ### Example as ES5 DSL
  *
  * ```
  * var MyComponent = ng
@@ -295,7 +295,7 @@ export interface ComponentFactory {
  *   })
  * ```
  *
- * ## Example as ES5 annotation
+ * ### Example as ES5 annotation
  *
  * ```
  * var MyComponent = function() {
@@ -332,7 +332,7 @@ export interface ViewFactory {
 /**
  * {@link AttributeMetadata} factory for creating annotations, decorators or DSL.
  *
- * ## Example as TypeScript Decorator
+ * ### Example as TypeScript Decorator
  *
  * ```
  * import {Attribute, Component} from "angular2/angular2";
@@ -345,7 +345,7 @@ export interface ViewFactory {
  * }
  * ```
  *
- * ## Example as ES5 DSL
+ * ### Example as ES5 DSL
  *
  * ```
  * var MyComponent = ng
@@ -357,7 +357,7 @@ export interface ViewFactory {
  *   })
  * ```
  *
- * ## Example as ES5 annotation
+ * ### Example as ES5 annotation
  *
  * ```
  * var MyComponent = function(title) {
@@ -449,7 +449,7 @@ export interface ViewChildFactory {
 /**
  * {@link PipeMetadata} factory for creating decorators.
  *
- * ## Example as TypeScript Decorator
+ * ### Example as TypeScript Decorator
  *
  * ```
  * import {Pipe} from "angular2/angular2";
@@ -528,7 +528,7 @@ export interface HostListenerFactory {
  * When the component class implements some {@link angular2/lifecycle_hooks} the callbacks are
  * called by the change detection at defined points in time during the life of the component.
  *
- * ## Example
+ * ### Example
  *
  * ```
  * @Component({
@@ -613,7 +613,7 @@ export var Component: ComponentFactory =
  * {@link DirectiveMetadata} directives only
  * - `bindingPropagation: BindingPropagation` to control change detection in a more granular way.
  *
- * ## Example
+ * ### Example
  *
  * The following example demonstrates how dependency injection resolves constructor arguments in
  * practice.
@@ -782,7 +782,7 @@ export var Component: ComponentFactory =
  * If none can be
  * found, the injector supplies `null` instead of throwing an error.
  *
- * ## Example
+ * ### Example
  *
  * Here we use a decorator directive to simply define basic tool-tip behavior.
  *
@@ -870,7 +870,7 @@ export var Component: ComponentFactory =
  * When the directive class implements some {@link angular2/lifecycle_hooks} the callbacks are
  * called by the change detection at defined points in time during the life of the directive.
  *
- * ## Example
+ * ### Example
  *
  * Let's suppose we want to implement the `unless` behavior, to conditionally include a template.
  *
@@ -942,7 +942,7 @@ export var Directive: DirectiveFactory = <DirectiveFactory>makeDecorator(Directi
  *
  * For details on the `@Component` annotation, see {@link ComponentMetadata}.
  *
- * ## Example
+ * ### Example
  *
  * ```
  * @Component({
@@ -975,7 +975,7 @@ export var View: ViewFactory =
  *
  * For details on the `@Component` annotation, see {@link ComponentMetadata}.
  *
- * ## Example
+ * ### Example
  *
  * ```
  * @Component({
@@ -1242,7 +1242,7 @@ export var ViewQuery: QueryFactory = makeParamDecorator(ViewQueryMetadata);
 /**
  * Declare reusable pipe function.
  *
- * ## Example
+ * ### Example
  *
  * ```
  * @Pipe({

--- a/modules/angular2/src/core/metadata/di.ts
+++ b/modules/angular2/src/core/metadata/di.ts
@@ -14,7 +14,7 @@ import {DependencyMetadata} from 'angular2/src/core/di/metadata';
  *
  * The directive can inject constant string literals of host element attributes.
  *
- * ## Example
+ * ### Example
  *
  * Suppose we have an `<input>` element and want to know its `type`.
  *

--- a/modules/angular2/src/core/metadata/directives.ts
+++ b/modules/angular2/src/core/metadata/directives.ts
@@ -67,7 +67,7 @@ import {ViewEncapsulation} from 'angular2/src/core/metadata/view';
  * {@link DirectiveMetadata} directives only
  * - `bindingPropagation: BindingPropagation` to control change detection in a more granular way.
  *
- * ## Example
+ * ### Example
  *
  * The following example demonstrates how dependency injection resolves constructor arguments in
  * practice.
@@ -236,7 +236,7 @@ import {ViewEncapsulation} from 'angular2/src/core/metadata/view';
  * If none can be
  * found, the injector supplies `null` instead of throwing an error.
  *
- * ## Example
+ * ### Example
  *
  * Here we use a decorator directive to simply define basic tool-tip behavior.
  *
@@ -324,7 +324,7 @@ import {ViewEncapsulation} from 'angular2/src/core/metadata/view';
  * When the directive class implements some {@link angular2/lifecycle_hooks} the callbacks are
  * called by the change detection at defined points in time during the life of the directive.
  *
- * ## Example
+ * ### Example
  *
  * Let's suppose we want to implement the `unless` behavior, to conditionally include a template.
  *
@@ -399,7 +399,7 @@ export class DirectiveMetadata extends InjectableMetadata {
    * - `selector1, selector2`: select if either `selector1` or `selector2` matches.
    *
    *
-   * ## Example
+   * ### Example
    *
    * Suppose we have a directive with an `input[type=text]` selector.
    *
@@ -802,7 +802,7 @@ export class DirectiveMetadata extends InjectableMetadata {
  * When the component class implements some {@link angular2/lifecycle_hooks} the callbacks are
  * called by the change detection at defined points in time during the life of the component.
  *
- * ## Example
+ * ### Example
  *
  * ```
  * @Component({
@@ -948,7 +948,7 @@ export class ComponentMetadata extends DirectiveMetadata {
 /**
  * Declare reusable pipe function.
  *
- * ## Example
+ * ### Example
  *
  * ```
  * @Pipe({

--- a/modules/angular2/src/core/metadata/view.ts
+++ b/modules/angular2/src/core/metadata/view.ts
@@ -44,7 +44,7 @@ export var VIEW_ENCAPSULATION_VALUES =
  *
  * For details on the `@Component` annotation, see {@link ComponentMetadata}.
  *
- * ## Example
+ * ### Example
  *
  * ```
  * @Component({
@@ -96,7 +96,7 @@ export class ViewMetadata {
    *
    * Directives must be listed explicitly to provide proper component encapsulation.
    *
-   * ## Example
+   * ### Example
    *
    * ```javascript
    * @Component({

--- a/modules/angular2/src/core/pipes/async_pipe.ts
+++ b/modules/angular2/src/core/pipes/async_pipe.ts
@@ -40,7 +40,7 @@ var _observableStrategy = new ObservableStrategy();
  * emitted.
  * When a new value is emitted, the `async` pipe marks the component to be checked for changes.
  *
- * # Example
+ * ### Example
  * The example below binds the `time` Observable to the view. Every 500ms, the `time` Observable
  * updates the view with the current time.
  *

--- a/modules/angular2/src/core/pipes/date_pipe.ts
+++ b/modules/angular2/src/core/pipes/date_pipe.ts
@@ -26,7 +26,7 @@ var defaultLocale: string = 'en-US';
  *
  * Formats a date value to a string based on the requested format.
  *
- * # Usage
+ *##Usage
  *
  *     expression | date[:format]
  *
@@ -67,7 +67,7 @@ var defaultLocale: string = 'en-US';
  *
  * Timezone of the formatted text will be the local system timezone of the end-users machine.
  *
- * # Examples
+ * ### Examples
  *
  * Assuming `dateObj` is (year: 2015, month: 6, day: 15, hour: 21, minute: 43, second: 11)
  * in the _local_ time and locale is 'en-US':

--- a/modules/angular2/src/core/pipes/json_pipe.ts
+++ b/modules/angular2/src/core/pipes/json_pipe.ts
@@ -6,7 +6,7 @@ import {Pipe} from 'angular2/src/core/metadata';
 /**
  * Implements json transforms to any object.
  *
- * # Example
+ * ### Example
  *
  * In this example we transform the user object to json.
  *

--- a/modules/angular2/src/core/pipes/lowercase_pipe.ts
+++ b/modules/angular2/src/core/pipes/lowercase_pipe.ts
@@ -8,7 +8,7 @@ import {InvalidPipeArgumentException} from './invalid_pipe_argument_exception';
 /**
  * Implements lowercase transforms to text.
  *
- * # Example
+ * ### Example
  *
  * In this example we transform the user text lowercase.
  *

--- a/modules/angular2/src/core/pipes/number_pipe.ts
+++ b/modules/angular2/src/core/pipes/number_pipe.ts
@@ -62,7 +62,7 @@ export class NumberPipe {
  * Formats a number as local text. i.e. group sizing and separator and other locale-specific
  * configurations are based on the active locale.
  *
- * # Usage
+ *##Usage
  *
  *     expression | number[:digitInfo]
  *
@@ -77,7 +77,7 @@ export class NumberPipe {
  * For more information on the acceptable range for each of these numbers and other
  * details see your native internationalization library.
  *
- * # Examples
+ * ### Examples
  *
  *     {{ 123 | number }}              // output is 123
  *     {{ 123.1 | number: '.2-3' }}    // output is 123.10
@@ -99,7 +99,7 @@ export class DecimalPipe extends NumberPipe implements PipeTransform {
  *
  * Formats a number as local percent.
  *
- * # Usage
+ *##Usage
  *
  *     expression | percent[:digitInfo]
  *
@@ -121,7 +121,7 @@ export class PercentPipe extends NumberPipe implements PipeTransform {
  *
  * Formats a number as local currency.
  *
- * # Usage
+ *##Usage
  *
  *     expression | currency[:currencyCode[:symbolDisplay[:digitInfo]]]
  *

--- a/modules/angular2/src/core/pipes/slice_pipe.ts
+++ b/modules/angular2/src/core/pipes/slice_pipe.ts
@@ -16,7 +16,7 @@ import {Pipe} from '../metadata';
  *
  * The ending index of the subset to return is specified by the optional `end` parameter.
  *
- * # Usage
+ *##Usage
  *
  *     expression | slice:start[:end]
  *
@@ -44,7 +44,7 @@ import {Pipe} from '../metadata';
  * When operating on a [List], the returned list is always a copy even when all
  * the elements are being returned.
  *
- * # Examples
+ * ### Examples
  *
  * ## List Example
  *

--- a/modules/angular2/src/core/pipes/uppercase_pipe.ts
+++ b/modules/angular2/src/core/pipes/uppercase_pipe.ts
@@ -7,7 +7,7 @@ import {InvalidPipeArgumentException} from './invalid_pipe_argument_exception';
 /**
  * Implements uppercase transforms to text.
  *
- * # Example
+ * ### Example
  *
  * In this example we transform the user text uppercase.
  *

--- a/modules/angular2/src/core/util/decorators.ts
+++ b/modules/angular2/src/core/util/decorators.ts
@@ -167,7 +167,7 @@ function applyParams(fnOrArray: (Function | any[]), key: string): Function {
  * }
  * ```
  *
- * ## Example with parameter annotations
+ * ### Example with parameter annotations
  *
  * ```
  * var MyService = ng.Class({
@@ -187,7 +187,7 @@ function applyParams(fnOrArray: (Function | any[]), key: string): Function {
  * }
  * ```
  *
- * ## Example with inheritance
+ * ### Example with inheritance
  *
  * ```
  * var Shape = ng.Class({

--- a/modules/angular2/src/http/backends/mock_backend.ts
+++ b/modules/angular2/src/http/backends/mock_backend.ts
@@ -43,7 +43,7 @@ export class MockConnection implements Connection {
    * Sends a mock response to the connection. This response is the value that is emitted to the
    * {@link EventEmitter} returned by {@link Http}.
    *
-   * #Example
+   * ### Example
    *
    * ```
    * var connection;
@@ -94,7 +94,7 @@ export class MockConnection implements Connection {
  * This class can be injected in tests, and should be used to override providers
  * to other backends, such as {@link XHRBackend}.
  *
- * #Example
+ * ### Example
  *
  * ```
  * import {MockBackend, DefaultOptions, Http} from 'angular2/http';
@@ -126,7 +126,7 @@ export class MockBackend implements ConnectionBackend {
    * of {@link MockConnection} instances that have been created by this backend. Can be subscribed
    * to in order to respond to connections.
    *
-   * #Example
+   * ### Example
    *
    * ```
    * import {MockBackend, Http, BaseRequestOptions} from 'angular2/http';

--- a/modules/angular2/src/http/backends/xhr_backend.ts
+++ b/modules/angular2/src/http/backends/xhr_backend.ts
@@ -88,7 +88,7 @@ export class XHRConnection implements Connection {
  * overridden if a different backend implementation should be used,
  * such as in a node backend.
  *
- * #Example
+ * ### Example
  *
  * ```
  * import {Http, MyNodeBackend, HTTP_PROVIDERS, BaseRequestOptions} from 'angular2/http';

--- a/modules/angular2/src/http/base_request_options.ts
+++ b/modules/angular2/src/http/base_request_options.ts
@@ -72,7 +72,7 @@ export class RequestOptions {
    * the `options` object. If these values should be merged, it should be done prior to calling
    * `merge` on the `RequestOptions` instance.
    *
-   * Example ([live demo](http://plnkr.co/edit/6w8XA8YTkDRcPYpdB9dk?p=preview))
+   * ### Example ([live demo](http://plnkr.co/edit/6w8XA8YTkDRcPYpdB9dk?p=preview))
    *
    * ```typescript
    * import {RequestOptions, Request, RequestMethods} from 'angular2/http';

--- a/modules/angular2/src/http/base_response_options.ts
+++ b/modules/angular2/src/http/base_response_options.ts
@@ -72,7 +72,7 @@ export class ResponseOptions {
    * This may be useful when sharing a base `ResponseOptions` object inside tests,
    * where certain properties may change from test to test.
    *
-   * Example ([live demo](http://plnkr.co/edit/1lXquqFfgduTFBWjNoRE?p=preview))
+   * ### Example ([live demo](http://plnkr.co/edit/1lXquqFfgduTFBWjNoRE?p=preview))
    *
    * ```typescript
    * import {ResponseOptions, Response} from 'angular2/http';

--- a/modules/angular2/src/http/http.ts
+++ b/modules/angular2/src/http/http.ts
@@ -36,7 +36,7 @@ function mergeOptions(defaultOpts, providedOpts, method, url): RequestOptions {
  * `request` returns an {@link Observable} which will emit a single {@link Response} when a
  * response is received.
  *
- * #Example
+ * ### Example
  *
  * ```typescript
  * import {Http, HTTP_PROVIDERS} from 'angular2/http';
@@ -58,7 +58,7 @@ function mergeOptions(defaultOpts, providedOpts, method, url): RequestOptions {
  * ```
  *
  *
- * #Example
+ * ### Example
  *
  * ```
  * http.get('people.json').observer({next: (value) => this.people = people});
@@ -68,7 +68,7 @@ function mergeOptions(defaultOpts, providedOpts, method, url): RequestOptions {
  * {@link XHRBackend} in this case), which could be mocked with dependency injection by replacing
  * the {@link XHRBackend} provider, as in the following example:
  *
- * #Example
+ * ### Example
  *
  * ```typescript
  * import {MockBackend, BaseRequestOptions, Http} from 'angular2/http';

--- a/modules/angular2/src/http/static_response.ts
+++ b/modules/angular2/src/http/static_response.ts
@@ -12,7 +12,7 @@ import {isJsObject} from './http_utils';
  * usually instantiated by end-users, it is the primary object interacted with when it comes time to
  * add data to a view.
  *
- * #Example
+ * ### Example
  *
  * ```
  * http.request('my-friends.txt').subscribe(response => this.friends = response.text());

--- a/modules/angular2/src/router/hash_location_strategy.ts
+++ b/modules/angular2/src/router/hash_location_strategy.ts
@@ -12,7 +12,7 @@ import {EventListener, History, Location} from 'angular2/src/core/facade/browser
  * For instance, if you call `location.go('/foo')`, the browser's URL will become
  * `example.com#/foo`.
  *
- * ## Example
+ * ### Example
  *
  * ```
  * import {Component, View} from 'angular2/angular2';

--- a/modules/angular2/src/router/instruction.ts
+++ b/modules/angular2/src/router/instruction.ts
@@ -12,7 +12,7 @@ import {Url} from './url_parser';
  *
  * You can inject `RouteParams` into the constructor of a component to use it.
  *
- * ## Example
+ * ### Example
  *
  * ```
  * import {bootstrap, Component} from 'angular2/angular2';
@@ -48,7 +48,7 @@ export class RouteParams {
  * `Instruction`s can be created using {@link Router#generate}, and can be used to
  * perform route changes with {@link Router#navigateByInstruction}.
  *
- * ## Example
+ * ### Example
  *
  * ```
  * import {bootstrap, Component} from 'angular2/angular2';

--- a/modules/angular2/src/router/interfaces.ts
+++ b/modules/angular2/src/router/interfaces.ts
@@ -21,7 +21,7 @@ var __ignore_me = global;
  * If `onActivate` returns a promise, the route change will wait until the promise settles to
  * instantiate and activate child components.
  *
- * ## Example
+ * ### Example
  * ```
  * import {Component} from 'angular2/angular2';
  * import {OnActivate, ComponentInstruction} from 'angular2/router';
@@ -52,7 +52,7 @@ export interface OnActivate {
  * representing the current route being navigated to, and the second parameter representing the
  * previous route or `null`.
  *
- * ## Example
+ * ### Example
  * ```
  * import {Component} from 'angular2/angular2';
  * import {CanReuse, OnReuse, ComponentInstruction} from 'angular2/router';
@@ -86,7 +86,7 @@ export interface OnReuse {
  *
  * If `onDeactivate` returns a promise, the route change will wait until the promise settles.
  *
- * ## Example
+ * ### Example
  * ```
  * import {Component} from 'angular2/angular2';
  * import {OnDeactivate, ComponentInstruction} from 'angular2/router';
@@ -121,7 +121,7 @@ export interface OnDeactivate {
  *
  * If `canReuse` throws or rejects, the navigation will be cancelled.
  *
- * ## Example
+ * ### Example
  * ```
  * import {Component} from 'angular2/angular2';
  * import {CanReuse, OnReuse, ComponentInstruction} from 'angular2/router';
@@ -159,7 +159,7 @@ export interface CanReuse {
  *
  * If `canDeactivate` throws or rejects, the navigation is also cancelled.
  *
- * ## Example
+ * ### Example
  * ```
  * import {Component} from 'angular2/angular2';
  * import {CanDeactivate, ComponentInstruction} from 'angular2/router';

--- a/modules/angular2/src/router/lifecycle_annotations.ts
+++ b/modules/angular2/src/router/lifecycle_annotations.ts
@@ -33,7 +33,7 @@ export {
  * If `CanActivate` returns or resolves to `true`, navigation continues, the component is
  * instantiated, and the {@link OnActivate} hook of that component is called if implemented.
  *
- * ## Example
+ * ### Example
  * ```
  * import {Component} from 'angular2/angular2';
  * import {CanActivate} from 'angular2/router';

--- a/modules/angular2/src/router/location.ts
+++ b/modules/angular2/src/router/location.ts
@@ -13,7 +13,7 @@ import {OpaqueToken, Injectable, Optional, Inject} from 'angular2/angular2';
  * representing the URL prefix that should be preserved when generating and recognizing
  * URLs.
  *
- * ## Example
+ * ### Example
  *
  * ```
  * import {Component} from 'angular2/angular2';
@@ -52,7 +52,7 @@ export const APP_BASE_HREF: OpaqueToken = CONST_EXPR(new OpaqueToken('appBaseHre
  * - `my/app/user/123` **is not** normalized
  * - `/my/app/user/123/` **is not** normalized
  *
- * ## Example
+ * ### Example
  *
  * ```
  * import {Component} from 'angular2/angular2';

--- a/modules/angular2/src/router/path_location_strategy.ts
+++ b/modules/angular2/src/router/path_location_strategy.ts
@@ -20,7 +20,7 @@ import {LocationStrategy, normalizeQueryParams} from './location_strategy';
  * `location.go('/foo')`, the browser's URL will become
  * `example.com/my/app/foo`.
  *
- * ## Example
+ * ### Example
  *
  * ```
  * import {Component, provide} from 'angular2/angular2';

--- a/modules/angular2/src/router/route_config_impl.ts
+++ b/modules/angular2/src/router/route_config_impl.ts
@@ -22,7 +22,7 @@ export class RouteConfig {
  * - `data` is an optional property of any type representing arbitrary route metadata for the given
  * route. It is injectable via the {@link ROUTE_DATA} token.
  *
- * ## Example
+ * ### Example
  * ```
  * import {RouteConfig} from 'angular2/router';
  *
@@ -62,7 +62,7 @@ export class Route implements RouteDefinition {
  * - `data` is an optional property of any type representing arbitrary route metadata for the given
  * route. It is injectable via the {@link ROUTE_DATA} token.
  *
- * ## Example
+ * ### Example
  * ```
  * import {RouteConfig, AuxRoute} from 'angular2/router';
  *
@@ -99,7 +99,7 @@ export class AuxRoute implements RouteDefinition {
  * - `data` is an optional property of any type representing arbitrary route metadata for the given
  * route. It is injectable via the {@link ROUTE_DATA} token.
  *
- * ## Example
+ * ### Example
  * ```
  * import {RouteConfig} from 'angular2/router';
  *
@@ -131,7 +131,7 @@ export class AsyncRoute implements RouteDefinition {
  * - `path` is a string that uses the route matcher DSL.
  * - `redirectTo` is a string representing the new URL to be matched against.
  *
- * ## Example
+ * ### Example
  * ```
  * import {RouteConfig} from 'angular2/router';
  *

--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -141,7 +141,7 @@ export class Router {
   /**
    * Dynamically update the routing configuration and trigger a navigation.
    *
-   * # Usage
+   *##Usage
    *
    * ```
    * router.config([
@@ -160,7 +160,7 @@ export class Router {
    * Navigate based on the provided Route Link DSL. It's preferred to navigate with this method
    * over `navigateByUrl`.
    *
-   * # Usage
+   *##Usage
    *
    * This method takes an array representing the Route Link DSL:
    * ```

--- a/modules/angular2/src/web_workers/worker/application_common.ts
+++ b/modules/angular2/src/web_workers/worker/application_common.ts
@@ -51,7 +51,7 @@ import {compilerProviders} from 'angular2/src/core/compiler/compiler';
  *
  * See {@link PlatformRef} for details on the Angular platform.
  *
- * # Without specified providers
+ *##Without specified providers
  *
  * If no providers are specified, `platform`'s behavior depends on whether an existing
  * platform exists:
@@ -62,7 +62,7 @@ import {compilerProviders} from 'angular2/src/core/compiler/compiler';
  * was created with). This is a convenience feature, allowing for multiple applications
  * to be loaded into the same platform without awareness of each other.
  *
- * # With specified providers
+ *##With specified providers
  *
  * It is also possible to specify providers to be made in the new platform. These providers
  * will be shared between all applications on the page. For example, an abstraction for
@@ -73,7 +73,7 @@ import {compilerProviders} from 'angular2/src/core/compiler/compiler';
  * them if a platform did not exist already. If it did exist, however, an error will be
  * thrown.
  *
- * # For Web Worker Appplications
+ *##For Web Worker Appplications
  *
  * This version of `platform` initializes Angular for use with applications
  * that do not directly touch the DOM, such as applications which run in a

--- a/modules/upgrade/src/upgrade_adapter.ts
+++ b/modules/upgrade/src/upgrade_adapter.ts
@@ -76,7 +76,7 @@ var upgradeCount: number = 0;
  * 9. The new application is running in Angular v2 zone, and therefore it no longer needs calls to
  *    `$apply()`.
  *
- * ## Example
+ * ### Example
  *
  * ```
  * var adapter = new UpgradeAdapter();
@@ -143,7 +143,7 @@ export class UpgradeAdapter {
    *   - Event:  `<comp (close)="doSomething()">`
    * - Content projection: yes
    *
-   * ## Example
+   * ### Example
    *
    * ```
    * var adapter = new UpgradeAdapter();
@@ -215,7 +215,7 @@ export class UpgradeAdapter {
    *   - `transclude`: supported.
    *
    *
-   * ## Example
+   * ### Example
    *
    * ```
    * var adapter = new UpgradeAdapter();
@@ -260,7 +260,7 @@ export class UpgradeAdapter {
    * [`bootstrap`](https://docs.angularjs.org/api/ng/function/angular.bootstrap) method. Unlike
    * AngularJS v1, this bootstrap is asynchronous.
    *
-   * ## Example
+   * ### Example
    *
    * ```
    * var adapter = new UpgradeAdapter();
@@ -374,7 +374,7 @@ export class UpgradeAdapter {
    * for this reason we provide an application global way of registering providers which is
    * consistent with single global injection in AngularJS v1.
    *
-   * ## Example
+   * ### Example
    *
    * ```
    * class Greeter {
@@ -409,7 +409,7 @@ export class UpgradeAdapter {
    * Allows AngularJS v1 service to be accessible from Angular v2.
    *
    *
-   * ## Example
+   * ### Example
    *
    * ```
    * class Login { ... }
@@ -449,7 +449,7 @@ export class UpgradeAdapter {
    * Allows Angular v2 service to be accessible from AngularJS v1.
    *
    *
-   * ## Example
+   * ### Example
    *
    * ```
    * class Example {


### PR DESCRIPTION
Fixes for doc headings (and deleting API content that says "internal only" for something that's now public)
