### PR TITLE
refactor(application): rename Binding into Provider

### DIFF
--- a/modules/angular2/src/core/application.ts
+++ b/modules/angular2/src/core/application.ts
@@ -11,19 +11,19 @@ export {platform} from './application_common';
 export {
   PlatformRef,
   ApplicationRef,
-  applicationCommonBindings,
+  applicationCommonProviders,
   createNgZone,
   platformCommon,
-  platformBindings
+  platformProviders
 } from './application_ref';
 
 /// See [commonBootstrap] for detailed documentation.
 export function bootstrap(appComponentType: /*Type*/ any,
-                          appBindings: Array<Type | Provider | any[]> = null):
+                          appProviders: Array<Type | Provider | any[]> = null):
     Promise<ComponentRef> {
-  var bindings = [compilerProviders()];
-  if (isPresent(appBindings)) {
-    bindings.push(appBindings);
+  var providers = [compilerProviders()];
+  if (isPresent(appProviders)) {
+    providers.push(appProviders);
   }
-  return commonBootstrap(appComponentType, bindings);
+  return commonBootstrap(appComponentType, providers);
 }

--- a/modules/angular2/src/core/application_common.ts
+++ b/modules/angular2/src/core/application_common.ts
@@ -38,13 +38,13 @@ import {EXCEPTION_PROVIDER} from './platform_bindings';
 import {AnimationBuilder} from 'angular2/src/animate/animation_builder';
 import {BrowserDetails} from 'angular2/src/animate/browser_details';
 import {wtfInit} from './profile/wtf_init';
-import {platformCommon, PlatformRef, applicationCommonBindings} from './application_ref';
+import {platformCommon, PlatformRef, applicationCommonProviders} from './application_ref';
 
 /**
  * A default set of providers which apply only to an Angular application running on
  * the UI thread.
  */
-export function applicationDomBindings(): Array<Type | Provider | any[]> {
+export function applicationDomProviders(): Array<Type | Provider | any[]> {
   if (isBlank(DOM)) {
     throw "Must set a root DOM adapter first.";
   }
@@ -66,6 +66,8 @@ export function applicationDomBindings(): Array<Type | Provider | any[]> {
     FORM_PROVIDERS
   ];
 }
+
+export const applicationDomBindings = applicationDomProviders;
 
 /**
  * Initialize the Angular 'platform' on the page.
@@ -100,8 +102,8 @@ export function applicationDomBindings(): Array<Type | Provider | any[]> {
  * DOM access. Web-worker applications should call `platform` from
  * `src/web_workers/worker/application_common` instead.
  */
-export function platform(bindings?: Array<Type | Provider | any[]>): PlatformRef {
-  return platformCommon(bindings, () => {
+export function platform(providers?: Array<Type | Provider | any[]>): PlatformRef {
+  return platformCommon(providers, () => {
     BrowserDomAdapter.makeCurrent();
     wtfInit();
     BrowserGetTestability.init();
@@ -219,12 +221,12 @@ export function platform(bindings?: Array<Type | Provider | any[]>): PlatformRef
  * Returns a `Promise` of {@link ComponentRef}.
  */
 export function commonBootstrap(appComponentType: /*Type*/ any,
-                                appBindings: Array<Type | Provider | any[]> = null):
+                                appProviders: Array<Type | Provider | any[]> = null):
     Promise<ComponentRef> {
   var p = platform();
-  var bindings = [applicationCommonBindings(), applicationDomBindings()];
-  if (isPresent(appBindings)) {
-    bindings.push(appBindings);
+  var bindings = [applicationCommonProviders(), applicationDomProviders()];
+  if (isPresent(appProviders)) {
+    bindings.push(appProviders);
   }
   return p.application(bindings).bootstrap(appComponentType);
 }

--- a/modules/angular2/src/core/application_tokens.ts
+++ b/modules/angular2/src/core/application_tokens.ts
@@ -40,7 +40,7 @@ function _appIdRandomProviderFactory() {
 }
 
 /**
- * Bindings that will generate a random APP_ID_TOKEN.
+ * Providers that will generate a random APP_ID_TOKEN.
  */
 export const APP_ID_RANDOM_PROVIDER: Provider =
     CONST_EXPR(new Provider(APP_ID, {useFactory: _appIdRandomProviderFactory, deps: []}));


### PR DESCRIPTION
while creating the server version I noticed bindings are still
mentioned
