### PR TITLE
[Change Detector] Implement Short-Circuit

### DIFF
--- a/modules/angular2/src/core/change_detection/abstract_change_detector.ts
+++ b/modules/angular2/src/core/change_detection/abstract_change_detector.ts
@@ -26,8 +26,8 @@ class _Context {
 }
 
 export class AbstractChangeDetector<T> implements ChangeDetector {
-  lightDomChildren: any[] = [];
-  shadowDomChildren: any[] = [];
+  contentChildren: any[] = [];
+  viewChildren: any[] = [];
   parent: ChangeDetector;
   ref: ChangeDetectorRef;
 
@@ -50,21 +50,21 @@ export class AbstractChangeDetector<T> implements ChangeDetector {
     this.ref = new ChangeDetectorRef_(this);
   }
 
-  addChild(cd: ChangeDetector): void {
-    this.lightDomChildren.push(cd);
+  addContentChild(cd: ChangeDetector): void {
+    this.contentChildren.push(cd);
     cd.parent = this;
   }
 
-  removeChild(cd: ChangeDetector): void { ListWrapper.remove(this.lightDomChildren, cd); }
+  removeContentChild(cd: ChangeDetector): void { ListWrapper.remove(this.contentChildren, cd); }
 
-  addShadowDomChild(cd: ChangeDetector): void {
-    this.shadowDomChildren.push(cd);
+  addViewChild(cd: ChangeDetector): void {
+    this.viewChildren.push(cd);
     cd.parent = this;
   }
 
-  removeShadowDomChild(cd: ChangeDetector): void { ListWrapper.remove(this.shadowDomChildren, cd); }
+  removeViewChild(cd: ChangeDetector): void { ListWrapper.remove(this.viewChildren, cd); }
 
-  remove(): void { this.parent.removeChild(this); }
+  remove(): void { this.parent.removeContentChild(this); }
 
   handleEvent(eventName: string, elIndex: number, locals: Locals): boolean {
     var res = this.handleEventInternal(eventName, elIndex, locals);
@@ -86,10 +86,10 @@ export class AbstractChangeDetector<T> implements ChangeDetector {
 
     this.detectChangesInRecords(throwOnChange);
 
-    this._detectChangesInLightDomChildren(throwOnChange);
+    this._detectChangesContentChildren(throwOnChange);
     if (!throwOnChange) this.afterContentLifecycleCallbacks();
 
-    this._detectChangesInShadowDomChildren(throwOnChange);
+    this._detectChangesInViewChildren(throwOnChange);
     if (!throwOnChange) this.afterViewLifecycleCallbacks();
 
     if (this.mode === ChangeDetectionStrategy.CheckOnce)
@@ -130,7 +130,7 @@ export class AbstractChangeDetector<T> implements ChangeDetector {
 
   // This method is not intended to be overridden. Subclasses should instead provide an
   // implementation of `hydrateDirectives`.
-  hydrate(context: T, locals: Locals, directives: any, pipes: any): void {
+  hydrate(context: T, locals: Locals, directives: any, pipes: Pipes): void {
     this.mode = ChangeDetectionUtil.changeDetectionMode(this.strategy);
     this.context = context;
 
@@ -183,16 +183,16 @@ export class AbstractChangeDetector<T> implements ChangeDetector {
   afterViewLifecycleCallbacksInternal(): void {}
 
   /** @internal */
-  _detectChangesInLightDomChildren(throwOnChange: boolean): void {
-    var c = this.lightDomChildren;
+  _detectChangesContentChildren(throwOnChange: boolean): void {
+    var c = this.contentChildren;
     for (var i = 0; i < c.length; ++i) {
       c[i].runDetectChanges(throwOnChange);
     }
   }
 
   /** @internal */
-  _detectChangesInShadowDomChildren(throwOnChange: boolean): void {
-    var c = this.shadowDomChildren;
+  _detectChangesInViewChildren(throwOnChange: boolean): void {
+    var c = this.viewChildren;
     for (var i = 0; i < c.length; ++i) {
       c[i].runDetectChanges(throwOnChange);
     }

--- a/modules/angular2/src/core/change_detection/binding_record.ts
+++ b/modules/angular2/src/core/change_detection/binding_record.ts
@@ -47,7 +47,6 @@ export class BindingRecord {
     return isBlank(this.directiveRecord) || this.directiveRecord.isDefaultChangeDetection();
   }
 
-
   static createDirectiveDoCheck(directiveRecord: DirectiveRecord): BindingRecord {
     return new BindingRecord(DIRECTIVE_LIFECYCLE, null, 0, null, null, "DoCheck", directiveRecord);
   }

--- a/modules/angular2/src/core/change_detection/change_detection_util.ts
+++ b/modules/angular2/src/core/change_detection/change_detection_util.ts
@@ -126,8 +126,6 @@ export class ChangeDetectionUtil {
   static operation_greater_then(left, right): any { return left > right; }
   static operation_less_or_equals_then(left, right): any { return left <= right; }
   static operation_greater_or_equals_then(left, right): any { return left >= right; }
-  static operation_logical_and(left, right): any { return left && right; }
-  static operation_logical_or(left, right): any { return left || right; }
   static cond(cond, trueVal, falseVal): any { return cond ? trueVal : falseVal; }
 
   static mapFn(keys: any[]): any {

--- a/modules/angular2/src/core/change_detection/coalesce.ts
+++ b/modules/angular2/src/core/change_detection/coalesce.ts
@@ -1,4 +1,4 @@
-import {isPresent, isBlank, looseIdentical, StringWrapper} from 'angular2/src/core/facade/lang';
+import {isPresent, isBlank, looseIdentical} from 'angular2/src/core/facade/lang';
 import {ListWrapper, Map} from 'angular2/src/core/facade/collection';
 import {RecordType, ProtoRecord} from './proto_record';
 
@@ -13,51 +13,158 @@ import {RecordType, ProtoRecord} from './proto_record';
  *
  * @internal
  */
-export function coalesce(records: ProtoRecord[]): ProtoRecord[] {
-  var res: ProtoRecord[] = [];
-  var indexMap: Map<number, number> = new Map<number, number>();
+export function coalesce(srcRecords: ProtoRecord[]): ProtoRecord[] {
+  let dstRecords = [];
+  let excludedIdxs = [];
+  let indexMap: Map<number, number> = new Map<number, number>();
+  let skipDepth = 0;
+  let skipSources: ProtoRecord[] = ListWrapper.createFixedSize(srcRecords.length);
 
-  for (var i = 0; i < records.length; ++i) {
-    var r = records[i];
-    var record = _replaceIndices(r, res.length + 1, indexMap);
-    var matchingRecord = _findMatching(record, res);
+  for (let protoIndex = 0; protoIndex < srcRecords.length; protoIndex++) {
+    let skipRecord = skipSources[protoIndex];
+    if (isPresent(skipRecord)) {
+      skipDepth--;
+      skipRecord.fixedArgs[0] = dstRecords.length;
+    }
 
-    if (isPresent(matchingRecord) && record.lastInBinding) {
-      res.push(_selfRecord(record, matchingRecord.selfIndex, res.length + 1));
-      indexMap.set(r.selfIndex, matchingRecord.selfIndex);
-      matchingRecord.referencedBySelf = true;
+    let src = srcRecords[protoIndex];
+    let dst = _cloneAndUpdateIndexes(src, dstRecords, indexMap);
 
-    } else if (isPresent(matchingRecord) && !record.lastInBinding) {
-      if (record.argumentToPureFunction) {
-        matchingRecord.argumentToPureFunction = true;
-      }
-
-      indexMap.set(r.selfIndex, matchingRecord.selfIndex);
-
+    if (dst.isSkipRecord()) {
+      dstRecords.push(dst);
+      skipDepth++;
+      skipSources[dst.fixedArgs[0]] = dst;
     } else {
-      res.push(record);
-      indexMap.set(r.selfIndex, record.selfIndex);
+      let record = _mayBeAddRecord(dst, dstRecords, excludedIdxs, skipDepth > 0);
+      indexMap.set(src.selfIndex, record.selfIndex);
     }
   }
 
-  return res;
+  return _optimizeSkips(dstRecords);
 }
 
-function _selfRecord(r: ProtoRecord, contextIndex: number, selfIndex: number): ProtoRecord {
+/**
+ * - Conditional skip of 1 record followed by an unconditional skip of N are replaced by  a
+ *   conditional skip of N with the negated condition,
+ * - Skips of 0 records are removed
+ */
+function _optimizeSkips(srcRecords: ProtoRecord[]): ProtoRecord[] {
+  let dstRecords = [];
+  let skipSources = ListWrapper.createFixedSize(srcRecords.length);
+  let indexMap: Map<number, number> = new Map<number, number>();
+
+  for (let protoIndex = 0; protoIndex < srcRecords.length; protoIndex++) {
+    let skipRecord = skipSources[protoIndex];
+    if (isPresent(skipRecord)) {
+      skipRecord.fixedArgs[0] = dstRecords.length;
+    }
+
+    let src = srcRecords[protoIndex];
+
+    if (src.isSkipRecord()) {
+      if (src.isConditionalSkipRecord() && src.fixedArgs[0] === protoIndex + 2 &&
+          protoIndex < srcRecords.length - 1 &&
+          srcRecords[protoIndex + 1].mode === RecordType.SkipRecords) {
+        src.mode = src.mode === RecordType.SkipRecordsIf ? RecordType.SkipRecordsIfNot :
+                                                           RecordType.SkipRecordsIf;
+        src.fixedArgs[0] = srcRecords[protoIndex + 1].fixedArgs[0];
+        protoIndex++;
+      }
+
+      if (src.fixedArgs[0] > protoIndex + 1) {
+        let dst = _cloneAndUpdateIndexes(src, dstRecords, indexMap);
+        dstRecords.push(dst);
+        skipSources[dst.fixedArgs[0]] = dst;
+      }
+
+    } else {
+      let dst = _cloneAndUpdateIndexes(src, dstRecords, indexMap);
+      dstRecords.push(dst);
+      indexMap.set(src.selfIndex, dst.selfIndex);
+    }
+  }
+
+  return dstRecords;
+}
+
+/**
+ * Add a new record or re-use one of the existing records.
+ */
+function _mayBeAddRecord(record: ProtoRecord, dstRecords: ProtoRecord[], excludedIdxs: number[],
+                         excluded: boolean): ProtoRecord {
+  let match = _findFirstMatch(record, dstRecords, excludedIdxs);
+
+  if (isPresent(match)) {
+    if (record.lastInBinding) {
+      dstRecords.push(_createSelfRecord(record, match.selfIndex, dstRecords.length + 1));
+      match.referencedBySelf = true;
+    } else {
+      if (record.argumentToPureFunction) {
+        match.argumentToPureFunction = true;
+      }
+    }
+
+    return match;
+  }
+
+  if (excluded) {
+    excludedIdxs.push(record.selfIndex);
+  }
+
+  dstRecords.push(record);
+  return record;
+}
+
+/**
+ * Returns the first `ProtoRecord` that matches the record.
+ */
+function _findFirstMatch(record: ProtoRecord, dstRecords: ProtoRecord[],
+                         excludedIdxs: number[]): ProtoRecord {
+  return ListWrapper.find(
+      dstRecords,
+      // TODO(vicb): optimize notReusableIndexes.indexOf (sorted array)
+      rr => excludedIdxs.indexOf(rr.selfIndex) == -1 && rr.mode !== RecordType.DirectiveLifecycle &&
+            _haveSameDirIndex(rr, record) && rr.mode === record.mode &&
+            looseIdentical(rr.funcOrValue, record.funcOrValue) &&
+            rr.contextIndex === record.contextIndex && looseIdentical(rr.name, record.name) &&
+            ListWrapper.equals(rr.args, record.args));
+}
+
+/**
+ * Clone the `ProtoRecord` and changes the indexes for the ones in the destination array for:
+ * - the arguments,
+ * - the context,
+ * - self
+ */
+function _cloneAndUpdateIndexes(record: ProtoRecord, dstRecords: ProtoRecord[],
+                                indexMap: Map<number, number>): ProtoRecord {
+  let args = record.args.map(src => _srcToDstSelfIndex(indexMap, src));
+  let contextIndex = _srcToDstSelfIndex(indexMap, record.contextIndex);
+  let selfIndex = dstRecords.length + 1;
+
+  return new ProtoRecord(record.mode, record.name, record.funcOrValue, args, record.fixedArgs,
+                         contextIndex, record.directiveIndex, selfIndex, record.bindingRecord,
+                         record.lastInBinding, record.lastInDirective,
+                         record.argumentToPureFunction, record.referencedBySelf,
+                         record.propertyBindingIndex);
+}
+
+/**
+ * Returns the index in the destination array corresponding to the index in the src array.
+ * When the element is not present in the destination array, return the source index.
+ */
+function _srcToDstSelfIndex(indexMap: Map<number, number>, srcIdx: number): number {
+  var dstIdx = indexMap.get(srcIdx);
+  return isPresent(dstIdx) ? dstIdx : srcIdx;
+}
+
+function _createSelfRecord(r: ProtoRecord, contextIndex: number, selfIndex: number): ProtoRecord {
   return new ProtoRecord(RecordType.Self, "self", null, [], r.fixedArgs, contextIndex,
                          r.directiveIndex, selfIndex, r.bindingRecord, r.lastInBinding,
                          r.lastInDirective, false, false, r.propertyBindingIndex);
 }
 
-function _findMatching(r: ProtoRecord, rs: ProtoRecord[]) {
-  return ListWrapper.find(
-      rs, (rr) => rr.mode !== RecordType.DirectiveLifecycle && _sameDirIndex(rr, r) &&
-                  rr.mode === r.mode && looseIdentical(rr.funcOrValue, r.funcOrValue) &&
-                  rr.contextIndex === r.contextIndex && StringWrapper.equals(rr.name, r.name) &&
-                  ListWrapper.equals(rr.args, r.args));
-}
-
-function _sameDirIndex(a: ProtoRecord, b: ProtoRecord): boolean {
+function _haveSameDirIndex(a: ProtoRecord, b: ProtoRecord): boolean {
   var di1 = isBlank(a.directiveIndex) ? null : a.directiveIndex.directiveIndex;
   var ei1 = isBlank(a.directiveIndex) ? null : a.directiveIndex.elementIndex;
 
@@ -65,18 +172,4 @@ function _sameDirIndex(a: ProtoRecord, b: ProtoRecord): boolean {
   var ei2 = isBlank(b.directiveIndex) ? null : b.directiveIndex.elementIndex;
 
   return di1 === di2 && ei1 === ei2;
-}
-
-function _replaceIndices(r: ProtoRecord, selfIndex: number, indexMap: Map<any, any>) {
-  var args = r.args.map(a => _map(indexMap, a));
-  var contextIndex = _map(indexMap, r.contextIndex);
-  return new ProtoRecord(r.mode, r.name, r.funcOrValue, args, r.fixedArgs, contextIndex,
-                         r.directiveIndex, selfIndex, r.bindingRecord, r.lastInBinding,
-                         r.lastInDirective, r.argumentToPureFunction, r.referencedBySelf,
-                         r.propertyBindingIndex);
-}
-
-function _map(indexMap: Map<any, any>, value: number) {
-  var r = indexMap.get(value);
-  return isPresent(r) ? r : value;
 }

--- a/modules/angular2/src/core/change_detection/coalesce.ts
+++ b/modules/angular2/src/core/change_detection/coalesce.ts
@@ -3,14 +3,15 @@ import {ListWrapper, Map} from 'angular2/src/core/facade/collection';
 import {RecordType, ProtoRecord} from './proto_record';
 
 /**
- * Removes "duplicate" records. It assuming that record evaluation does not
- * have side-effects.
+ * Removes "duplicate" records. It assumes that record evaluation does not have side-effects.
  *
- * Records that are not last in bindings are removed and all the indices
- * of the records that depend on them are updated.
+ * Records that are not last in bindings are removed and all the indices of the records that depend
+ * on them are updated.
  *
- * Records that are last in bindings CANNOT be removed, and instead are
- * replaced with very cheap SELF records.
+ * Records that are last in bindings CANNOT be removed, and instead are replaced with very cheap
+ * SELF records.
+ *
+ * @internal
  */
 export function coalesce(records: ProtoRecord[]): ProtoRecord[] {
   var res: ProtoRecord[] = [];

--- a/modules/angular2/src/core/change_detection/codegen_name_util.ts
+++ b/modules/angular2/src/core/change_detection/codegen_name_util.ts
@@ -23,7 +23,7 @@ export const CONTEXT_ACCESSOR = "context";
 export const CONTEXT_INDEX = 0;
 const _FIELD_PREFIX = 'this.';
 
-var _whiteSpaceRegExp = RegExpWrapper.create("\\W", "g");
+var _whiteSpaceRegExp = /\W/g;
 
 /**
  * Returns `s` with all non-identifier characters removed.

--- a/modules/angular2/src/core/change_detection/dynamic_change_detector.ts
+++ b/modules/angular2/src/core/change_detection/dynamic_change_detector.ts
@@ -299,7 +299,6 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     }
   }
 
-  /** @internal */
   private _calculateCurrValue(proto: ProtoRecord, values: any[], locals: Locals) {
     switch (proto.mode) {
       case RecordType.Self:
@@ -367,7 +366,6 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     }
   }
 
-  /** @internal */
   private _pipeCheck(proto: ProtoRecord, throwOnChange: boolean, values: any[]) {
     var context = this._readContext(proto, values);
     var selectedPipe = this._pipeFor(proto, context);
@@ -406,7 +404,6 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     }
   }
 
-  /** @internal */
   private _pipeFor(proto: ProtoRecord, context) {
     var storedPipe = this._readPipe(proto);
     if (isPresent(storedPipe)) return storedPipe;
@@ -416,7 +413,6 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     return pipe;
   }
 
-  /** @internal */
   private _readContext(proto: ProtoRecord, values: any[]) {
     if (proto.contextIndex == -1) {
       return this._getDirectiveFor(proto.directiveIndex);
@@ -424,29 +420,22 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     return values[proto.contextIndex];
   }
 
-  /** @internal */
   private _readSelf(proto: ProtoRecord, values: any[]) { return values[proto.selfIndex]; }
 
-  /** @internal */
   private _writeSelf(proto: ProtoRecord, value, values: any[]) { values[proto.selfIndex] = value; }
 
-  /** @internal */
   private _readPipe(proto: ProtoRecord) { return this.localPipes[proto.selfIndex]; }
 
-  /** @internal */
   private _writePipe(proto: ProtoRecord, value) { this.localPipes[proto.selfIndex] = value; }
 
-  /** @internal */
   private _setChanged(proto: ProtoRecord, value: boolean) {
     if (proto.argumentToPureFunction) this.changes[proto.selfIndex] = value;
   }
 
-  /** @internal */
   private _pureFuncAndArgsDidNotChange(proto: ProtoRecord): boolean {
     return proto.isPureFunction() && !this._argsChanged(proto);
   }
 
-  /** @internal */
   private _argsChanged(proto: ProtoRecord): boolean {
     var args = proto.args;
     for (var i = 0; i < args.length; ++i) {
@@ -457,12 +446,10 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
     return false;
   }
 
-  /** @internal */
   private _argsOrContextChanged(proto: ProtoRecord): boolean {
     return this._argsChanged(proto) || this.changes[proto.contextIndex];
   }
 
-  /** @internal */
   private _readArgs(proto: ProtoRecord, values: any[]) {
     var res = ListWrapper.createFixedSize(proto.args.length);
     var args = proto.args;

--- a/modules/angular2/src/core/change_detection/interfaces.ts
+++ b/modules/angular2/src/core/change_detection/interfaces.ts
@@ -22,10 +22,10 @@ export interface ChangeDetector {
   mode: ChangeDetectionStrategy;
   ref: ChangeDetectorRef;
 
-  addChild(cd: ChangeDetector): void;
-  addShadowDomChild(cd: ChangeDetector): void;
-  removeChild(cd: ChangeDetector): void;
-  removeShadowDomChild(cd: ChangeDetector): void;
+  addContentChild(cd: ChangeDetector): void;
+  addViewChild(cd: ChangeDetector): void;
+  removeContentChild(cd: ChangeDetector): void;
+  removeViewChild(cd: ChangeDetector): void;
   remove(): void;
   hydrate(context: any, locals: Locals, directives: any, pipes: any): void;
   dehydrate(): void;

--- a/modules/angular2/src/core/change_detection/proto_change_detector.ts
+++ b/modules/angular2/src/core/change_detection/proto_change_detector.ts
@@ -80,9 +80,7 @@ export function createEventRecords(definition: ChangeDetectorDefinition): EventB
 }
 
 export class ProtoRecordBuilder {
-  records: ProtoRecord[];
-
-  constructor() { this.records = []; }
+  records: ProtoRecord[] = [];
 
   add(b: BindingRecord, variableNames: string[], bindingIndex: number) {
     var oldLast = ListWrapper.last(this.records);
@@ -265,8 +263,7 @@ class _ConvertAstIntoProtoRecords implements AstVisitor {
     return this._addRecord(RecordType.Chain, "chain", null, args, null, 0);
   }
 
-  /** @internal */
-  _visitAll(asts: any[]) {
+  private _visitAll(asts: any[]) {
     var res = ListWrapper.createFixedSize(asts.length);
     for (var i = 0; i < asts.length; ++i) {
       res[i] = asts[i].visit(this);
@@ -274,8 +271,10 @@ class _ConvertAstIntoProtoRecords implements AstVisitor {
     return res;
   }
 
-  /** @internal */
-  _addRecord(type, name, funcOrValue, args, fixedArgs, context) {
+  /**
+   * Adds a `ProtoRecord` and returns its selfIndex.
+   */
+  private _addRecord(type, name, funcOrValue, args, fixedArgs, context): number {
     var selfIndex = this._records.length + 1;
     if (context instanceof DirectiveIndex) {
       this._records.push(new ProtoRecord(type, name, funcOrValue, args, fixedArgs, -1, context,

--- a/modules/angular2/src/core/change_detection/proto_record.ts
+++ b/modules/angular2/src/core/change_detection/proto_record.ts
@@ -18,7 +18,10 @@ export enum RecordType {
   CollectionLiteral,
   SafeMethodInvoke,
   DirectiveLifecycle,
-  Chain
+  Chain,
+  SkipRecordsIf,     // Skip records when the condition is true
+  SkipRecordsIfNot,  // Skip records when the condition is false
+  SkipRecords        // Skip records unconditionally
 }
 
 export class ProtoRecord {
@@ -41,6 +44,16 @@ export class ProtoRecord {
   }
 
   isPipeRecord(): boolean { return this.mode === RecordType.Pipe; }
+
+  isConditionalSkipRecord(): boolean {
+    return this.mode === RecordType.SkipRecordsIfNot || this.mode === RecordType.SkipRecordsIf;
+  }
+
+  isUnconditionalSkipRecord(): boolean { return this.mode === RecordType.SkipRecords; }
+
+  isSkipRecord(): boolean {
+    return this.isConditionalSkipRecord() || this.isUnconditionalSkipRecord();
+  }
 
   isLifeCycleRecord(): boolean { return this.mode === RecordType.DirectiveLifecycle; }
 }

--- a/modules/angular2/src/core/linker/view_manager_utils.ts
+++ b/modules/angular2/src/core/linker/view_manager_utils.ts
@@ -102,7 +102,7 @@ export class AppViewManagerUtils {
       currentView.init(protoView.changeDetectorFactory(currentView), elementInjectors,
                        rootElementInjectors, preBuiltObjects, views, elementRefs, viewContainers);
       if (isPresent(parentView) && protoView.type === viewModule.ViewType.COMPONENT) {
-        parentView.changeDetector.addShadowDomChild(currentView.changeDetector);
+        parentView.changeDetector.addViewChild(currentView.changeDetector);
       }
       elementOffset += protoView.elementBinders.length;
       textOffset += protoView.textBindingCount;
@@ -122,7 +122,7 @@ export class AppViewManagerUtils {
       contextView = parentView;
       contextBoundElementIndex = boundElementIndex;
     }
-    parentView.changeDetector.addChild(view.changeDetector);
+    parentView.changeDetector.addContentChild(view.changeDetector);
     var viewContainer = parentView.viewContainers[boundElementIndex];
     if (isBlank(viewContainer)) {
       viewContainer = new viewModule.AppViewContainer();

--- a/modules/angular2/test/core/change_detection/change_detector_config.ts
+++ b/modules/angular2/test/core/change_detection/change_detector_config.ts
@@ -417,7 +417,14 @@ var _availableDefinitions = [
   'a.sayHi("Jim")',
   'passThrough([12])',
   'invalidFn(1)',
-  'age'
+  'age',
+  'true ? city : zipcode',
+  'false ? city : zipcode',
+  'getTrue() && getTrue()',
+  'getFalse() && getTrue()',
+  'getFalse() || getFalse()',
+  'getTrue() || getFalse()',
+  'name == "Victor" ? (true ? address.city : address.zipcode) : address.zipcode'
 ];
 
 var _availableEventDefinitions = [
@@ -427,7 +434,8 @@ var _availableEventDefinitions = [
   // '(event)="\$event=1"',
   '(event)="a=a+1; a=a+1;"',
   '(event)="false"',
-  '(event)="true"'
+  '(event)="true"',
+  '(event)="true ? a = a + 1 : a = a + 1"',
 ];
 
 var _availableHostEventDefinitions = ['(host-event)="onEvent(\$event)"'];

--- a/modules/angular2/test/core/change_detection/change_detector_spec.ts
+++ b/modules/angular2/test/core/change_detection/change_detector_spec.ts
@@ -634,7 +634,7 @@ export function main() {
               it('should be called before processing view children', () => {
                 var parent = _createWithoutHydrate('directNoDispatcher').changeDetector;
                 var child = _createWithoutHydrate('directNoDispatcher').changeDetector;
-                parent.addShadowDomChild(child);
+                parent.addViewChild(child);
 
                 var orderOfOperations = [];
 
@@ -753,7 +753,7 @@ export function main() {
               it('should be called after processing view children', () => {
                 var parent = _createWithoutHydrate('directNoDispatcher').changeDetector;
                 var child = _createWithoutHydrate('directNoDispatcher').changeDetector;
-                parent.addShadowDomChild(child);
+                parent.addViewChild(child);
 
                 var orderOfOperations = [];
 
@@ -902,32 +902,32 @@ export function main() {
           child = _createChangeDetector('"str"').changeDetector;
         });
 
-        it('should add light dom children', () => {
-          parent.addChild(child);
+        it('should add content children', () => {
+          parent.addContentChild(child);
 
-          expect(parent.lightDomChildren.length).toEqual(1);
-          expect(parent.lightDomChildren[0]).toBe(child);
+          expect(parent.contentChildren.length).toEqual(1);
+          expect(parent.contentChildren[0]).toBe(child);
         });
 
-        it('should add shadow dom children', () => {
-          parent.addShadowDomChild(child);
+        it('should add view children', () => {
+          parent.addViewChild(child);
 
-          expect(parent.shadowDomChildren.length).toEqual(1);
-          expect(parent.shadowDomChildren[0]).toBe(child);
+          expect(parent.viewChildren.length).toEqual(1);
+          expect(parent.viewChildren[0]).toBe(child);
         });
 
-        it('should remove light dom children', () => {
-          parent.addChild(child);
-          parent.removeChild(child);
+        it('should remove content children', () => {
+          parent.addContentChild(child);
+          parent.removeContentChild(child);
 
-          expect(parent.lightDomChildren).toEqual([]);
+          expect(parent.contentChildren).toEqual([]);
         });
 
-        it('should remove shadow dom children', () => {
-          parent.addShadowDomChild(child);
-          parent.removeShadowDomChild(child);
+        it('should remove view children', () => {
+          parent.addViewChild(child);
+          parent.removeViewChild(child);
 
-          expect(parent.shadowDomChildren.length).toEqual(0);
+          expect(parent.viewChildren.length).toEqual(0);
         });
       });
 
@@ -1142,7 +1142,7 @@ export function main() {
         function changeDetector(mode, parent) {
           var val = _createChangeDetector('10');
           val.changeDetector.mode = mode;
-          if (isPresent(parent)) parent.addChild(val.changeDetector);
+          if (isPresent(parent)) parent.addContentChild(val.changeDetector);
           return val.changeDetector;
         }
 

--- a/modules/angular2/test/core/change_detection/coalesce_spec.ts
+++ b/modules/angular2/test/core/change_detection/coalesce_spec.ts
@@ -16,28 +16,29 @@ import {DirectiveIndex} from 'angular2/src/core/change_detection/directive_recor
 
 export function main() {
   function r(funcOrValue, args, contextIndex, selfIndex,
-             {lastInBinding, mode, name, directiveIndex, argumentToPureFunction}: {
+             {lastInBinding, mode, name, directiveIndex, argumentToPureFunction, fixedArgs}: {
                lastInBinding?: any,
                mode?: any,
                name?: any,
                directiveIndex?: any,
-               argumentToPureFunction?: boolean
+               argumentToPureFunction?: boolean,
+               fixedArgs?: any[]
              } = {}) {
     if (isBlank(lastInBinding)) lastInBinding = false;
     if (isBlank(mode)) mode = RecordType.PropertyRead;
     if (isBlank(name)) name = "name";
     if (isBlank(directiveIndex)) directiveIndex = null;
     if (isBlank(argumentToPureFunction)) argumentToPureFunction = false;
+    if (isBlank(fixedArgs)) fixedArgs = null;
 
-    return new ProtoRecord(mode, name, funcOrValue, args, null, contextIndex, directiveIndex,
+    return new ProtoRecord(mode, name, funcOrValue, args, fixedArgs, contextIndex, directiveIndex,
                            selfIndex, null, lastInBinding, false, argumentToPureFunction, false, 0);
   }
 
   describe("change detection - coalesce", () => {
     it("should work with an empty list", () => { expect(coalesce([])).toEqual([]); });
 
-    it("should remove non-terminal duplicate records" +
-           " and update the context indices referencing them",
+    it("should remove non-terminal duplicate records and update the context indices referencing them",
        () => {
          var rs = coalesce(
              [r("user", [], 0, 1), r("first", [], 1, 2), r("user", [], 0, 3), r("last", [], 3, 4)]);
@@ -52,8 +53,7 @@ export function main() {
       expect(rs).toEqual([r("dup", [], 0, 1), r("user", [], 0, 2), r("first", [2], 2, 3)]);
     });
 
-    it("should remove non-terminal duplicate records" +
-           " and update the args indices referencing them",
+    it("should remove non-terminal duplicate records and update the args indices referencing them",
        () => {
          var rs = coalesce([
            r("user1", [], 0, 1),
@@ -131,6 +131,105 @@ export function main() {
       ]);
       expect(rs)
           .toEqual([r("user", [], 0, 1, {argumentToPureFunction: true}), r("name", [], 1, 2)]);
+    });
+
+    describe('short-circuit', () => {
+      it('should not use short-circuitable records', () => {
+        var records = [
+          r("sknot", [], 0, 1, {mode: RecordType.SkipRecordsIfNot, fixedArgs: [3]}),
+          r("a", [], 0, 2),
+          r("sk", [], 0, 3, {mode: RecordType.SkipRecords, fixedArgs: [4]}),
+          r("b", [], 0, 4),
+          r("cond", [2, 4], 0, 5),
+          r("a", [], 0, 6),
+          r("b", [], 0, 7),
+        ];
+
+        expect(coalesce(records)).toEqual(records);
+      });
+
+      it('should not use short-circuitable records from nested short-circuits', () => {
+        var records = [
+          r("sknot outer", [], 0, 1, {mode: RecordType.SkipRecordsIfNot, fixedArgs: [7]}),
+          r("sknot inner", [], 0, 2, {mode: RecordType.SkipRecordsIfNot, fixedArgs: [4]}),
+          r("a", [], 0, 3),
+          r("sk inner", [], 0, 4, {mode: RecordType.SkipRecords, fixedArgs: [5]}),
+          r("b", [], 0, 5),
+          r("cond-inner", [3, 5], 0, 6),
+          r("sk outer", [], 0, 7, {mode: RecordType.SkipRecords, fixedArgs: [8]}),
+          r("c", [], 0, 8),
+          r("cond-outer", [6, 8], 0, 9),
+          r("a", [], 0, 10),
+          r("b", [], 0, 11),
+          r("c", [], 0, 12),
+        ];
+
+        expect(coalesce(records)).toEqual(records);
+      });
+
+      it('should collapse the true branch', () => {
+        var rs = coalesce([
+          r("a", [], 0, 1),
+          r("sknot", [], 0, 2, {mode: RecordType.SkipRecordsIfNot, fixedArgs: [4]}),
+          r("a", [], 0, 3),
+          r("sk", [], 0, 4, {mode: RecordType.SkipRecords, fixedArgs: [6]}),
+          r("a", [], 0, 5),
+          r("b", [], 5, 6),
+          r("cond", [3, 6], 0, 7),
+        ]);
+
+        expect(rs).toEqual([
+          r("a", [], 0, 1),
+          r("sknot", [], 0, 2, {mode: RecordType.SkipRecordsIf, fixedArgs: [3]}),
+          r("b", [], 1, 3),
+          r("cond", [1, 3], 0, 4),
+        ]);
+      });
+
+      it('should collapse the false branch', () => {
+        var rs = coalesce([
+          r("a", [], 0, 1),
+          r("sknot", [], 0, 2, {mode: RecordType.SkipRecordsIfNot, fixedArgs: [5]}),
+          r("a", [], 0, 3),
+          r("b", [], 3, 4),
+          r("sk", [], 0, 5, {mode: RecordType.SkipRecords, fixedArgs: [6]}),
+          r("a", [], 0, 6),
+          r("cond", [4, 6], 0, 7),
+        ]);
+
+        expect(rs).toEqual([
+          r("a", [], 0, 1),
+          r("sknot", [], 0, 2, {mode: RecordType.SkipRecordsIfNot, fixedArgs: [3]}),
+          r("b", [], 1, 3),
+          r("cond", [3, 1], 0, 4),
+        ]);
+      });
+
+      it('should optimize skips', () => {
+        var rs = coalesce([
+          // skipIfNot(1) + skip(N) -> skipIf(+N)
+          r("sknot", [], 0, 1, {mode: RecordType.SkipRecordsIfNot, fixedArgs: [2]}),
+          r("sk", [], 0, 2, {mode: RecordType.SkipRecords, fixedArgs: [3]}),
+          r("a", [], 0, 3),
+          // skipIf(1) + skip(N) -> skipIfNot(N)
+          r("skif", [], 0, 4, {mode: RecordType.SkipRecordsIf, fixedArgs: [5]}),
+          r("sk", [], 0, 5, {mode: RecordType.SkipRecords, fixedArgs: [6]}),
+          r("b", [], 0, 6),
+          // remove empty skips
+          r("sknot", [], 0, 7, {mode: RecordType.SkipRecordsIfNot, fixedArgs: [7]}),
+          r("skif", [], 0, 8, {mode: RecordType.SkipRecordsIf, fixedArgs: [8]}),
+          r("sk", [], 0, 9, {mode: RecordType.SkipRecords, fixedArgs: [9]}),
+          r("end", [], 0, 10),
+        ]);
+
+        expect(rs).toEqual([
+          r("sknot", [], 0, 1, {mode: RecordType.SkipRecordsIf, fixedArgs: [2]}),
+          r("a", [], 0, 2),
+          r("skif", [], 0, 3, {mode: RecordType.SkipRecordsIfNot, fixedArgs: [4]}),
+          r("b", [], 0, 4),
+          r("end", [], 0, 5),
+        ]);
+      });
     });
   });
 }

--- a/modules/benchmarks/src/change_detection/change_detection_benchmark.ts
+++ b/modules/benchmarks/src/change_detection/change_detection_benchmark.ts
@@ -285,7 +285,7 @@ function setUpChangeDetection(protoChangeDetectorFactory: Function, iterations, 
   for (var i = 0; i < iterations; ++i) {
     var cd = proto.instantiate(dispatcher);
     cd.hydrate(object, null, new FakeDirectives(targetObj), null);
-    parentCd.addChild(cd);
+    parentCd.addContentChild(cd);
   }
   return parentCd;
 }


### PR DESCRIPTION
closes #4790 

**Records**

Records generated for `exp ? a : b.c` :
- `exp` 
- short-circruit - context = `exp`, fixed args = `[1, 2]` (nb of records in the true and false branch)
- `a`
- `b`
- `c` (context = `b`)
- cond =  `exp ? a : b.c` 

Either `a` or `b.c` get evaluated and the last `cond` always returns the evaluated value

**Coalesce**
- any branch can be collapsed if it only contains records that have been evaluated before,
- if both branches are collapsed, the short-circuit record is removed altogether,
- records in short-circuit can not be re-used (they might not be fresh).

**Support**

Ternary operator, `&&`, `||`.

Note: most important changes are in the feat commits.
