### PR TITLE
fix(compiler): do not match directives to variable names

### DIFF
--- a/modules/angular2/src/core/compiler/template_parser.ts
+++ b/modules/angular2/src/core/compiler/template_parser.ts
@@ -295,8 +295,7 @@ class TemplateParseVisitor implements HtmlAstVisitor {
       } else if (isPresent(
                      bindParts[2])) {  // match: var-name / var-name="iden" / #name / #name="iden"
         var identifier = bindParts[5];
-        this._parseVariable(identifier, attrValue, attr.sourceInfo, targetMatchableAttrs,
-                            targetVars);
+        this._parseVariable(identifier, attrValue, attr.sourceInfo, targetVars);
 
       } else if (isPresent(bindParts[3])) {  // match: on-event
         this._parseEvent(bindParts[5], attrValue, attr.sourceInfo, targetMatchableAttrs,
@@ -338,9 +337,8 @@ class TemplateParseVisitor implements HtmlAstVisitor {
   }
 
   private _parseVariable(identifier: string, value: string, sourceInfo: any,
-                         targetMatchableAttrs: string[][], targetVars: VariableAst[]) {
+                         targetVars: VariableAst[]) {
     targetVars.push(new VariableAst(dashCaseToCamelCase(identifier), value, sourceInfo));
-    targetMatchableAttrs.push([identifier, value]);
   }
 
   private _parseProperty(name: string, expression: string, sourceInfo: any,

--- a/modules/angular2/test/core/compiler/template_parser_spec.ts
+++ b/modules/angular2/test/core/compiler/template_parser_spec.ts
@@ -379,19 +379,6 @@ export function main() {
               ]);
         });
 
-        it('should locate directives in variable bindings', () => {
-          var dirA = CompileDirectiveMetadata.create(
-              {selector: '[a=b]', exportAs: 'b', type: new CompileTypeMetadata({name: 'DirA'})});
-          var dirB = CompileDirectiveMetadata.create(
-              {selector: '[b]', type: new CompileTypeMetadata({name: 'DirB'})});
-          expect(humanizeTemplateAsts(parse('<div #a="b">', [dirA, dirB])))
-              .toEqual([
-                [ElementAst, 'div', 'TestComp > div:nth-child(0)'],
-                [DirectiveAst, dirA, 'TestComp > div:nth-child(0)'],
-                [VariableAst, 'a', 'b', 'TestComp > div:nth-child(0)[#a=b]']
-              ]);
-        });
-
         it('should parse directive host properties', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: 'div',
@@ -537,9 +524,10 @@ export function main() {
         it('should assign variables to directives via exportAs', () => {
           var dirA = CompileDirectiveMetadata.create(
               {selector: '[a]', type: new CompileTypeMetadata({name: 'DirA'}), exportAs: 'dirA'});
-          expect(humanizeTemplateAsts(parse('<div #a="dirA"></div>', [dirA])))
+          expect(humanizeTemplateAsts(parse('<div a #a="dirA"></div>', [dirA])))
               .toEqual([
                 [ElementAst, 'div', 'TestComp > div:nth-child(0)'],
+                [AttrAst, 'a', '', 'TestComp > div:nth-child(0)[a=]'],
                 [DirectiveAst, dirA, 'TestComp > div:nth-child(0)'],
                 [VariableAst, 'a', 'dirA', 'TestComp > div:nth-child(0)[#a=dirA]']
               ]);
@@ -566,9 +554,10 @@ There is no directive with "exportAs" set to "dirA" at TestComp > div:nth-child(
             type: new CompileTypeMetadata({name: 'DirA'}),
             exportAs: 'dirA', template: new CompileTemplateMetadata({ngContentSelectors: []})
           });
-          expect(humanizeTemplateAsts(parse('<div #a></div>', [dirA])))
+          expect(humanizeTemplateAsts(parse('<div a #a></div>', [dirA])))
               .toEqual([
                 [ElementAst, 'div', 'TestComp > div:nth-child(0)'],
+                [AttrAst, 'a', '', 'TestComp > div:nth-child(0)[a=]'],
                 [VariableAst, 'a', '', 'TestComp > div:nth-child(0)[#a=]'],
                 [DirectiveAst, dirA, 'TestComp > div:nth-child(0)'],
                 [VariableAst, 'a', '', 'TestComp > div:nth-child(0)[#a=]']


### PR DESCRIPTION
According to @mhevery this change in the compiler was wrong. We should not match directive selectors to variables because variable name can be anything. A proper way to assign a directive to a variable is by using the explicit selector match _and_ a variable that's assigned explicitly (via `exportAs` or default to the root directive/component).
