### PR TITLE
feat(dart/transform): Do not declare outputs

### DIFF
--- a/modules_dart/transform/lib/src/transform/bind_generator/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/bind_generator/transformer.dart
@@ -16,7 +16,7 @@ import 'generator.dart';
 ///
 /// These setters are registered in the same `setupReflection` function with
 /// the `registerType` calls.
-class BindGenerator extends Transformer implements DeclaringTransformer {
+class BindGenerator extends Transformer {
   final TransformerOptions options;
 
   BindGenerator(this.options);
@@ -25,18 +25,11 @@ class BindGenerator extends Transformer implements DeclaringTransformer {
   bool isPrimary(AssetId id) => id.path.endsWith(DEPS_EXTENSION);
 
   @override
-  declareOutputs(DeclaringTransform transform) {
-    transform.consumePrimary();
-    transform.declareOutput(transform.primaryId);
-  }
-
-  @override
   Future apply(Transform transform) async {
     await log.initZoned(transform, () async {
       var primaryId = transform.primaryInput.id;
       var reader = new AssetReader.fromTransform(transform);
       var transformedCode = await createNgSettersAndGetters(reader, primaryId);
-      transform.consumePrimary();
       transform.addOutput(new Asset.fromString(
           primaryId, formatter.format(transformedCode, uri: primaryId.path)));
     });

--- a/modules_dart/transform/lib/src/transform/deferred_rewriter/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/deferred_rewriter/transformer.dart
@@ -13,7 +13,7 @@ import 'rewriter.dart';
 /// Transformer responsible for rewriting deferred library loads to enable
 /// initializing the reflector in a deferred way to keep the code with the
 /// deferred library.
-class DeferredRewriter extends Transformer implements DeclaringTransformer {
+class DeferredRewriter extends Transformer {
   final TransformerOptions options;
 
   DeferredRewriter(this.options);
@@ -23,22 +23,13 @@ class DeferredRewriter extends Transformer implements DeclaringTransformer {
       id.extension.endsWith('dart') && !id.path.endsWith(DEPS_EXTENSION);
 
   @override
-  declareOutputs(DeclaringTransform transform) {
-    transform.consumePrimary();
-    transform.declareOutput(transform.primaryId);
-  }
-
-  @override
   Future apply(Transform transform) async {
     await log.initZoned(transform, () async {
       var asset = transform.primaryInput;
       var reader = new AssetReader.fromTransform(transform);
       var transformedCode = await rewriteDeferredLibraries(reader, asset.id);
-      transform.consumePrimary();
       if (transformedCode != null) {
         transform.addOutput(new Asset.fromString(asset.id, transformedCode));
-      } else {
-        transform.addOutput(asset);
       }
     });
   }

--- a/modules_dart/transform/lib/src/transform/directive_metadata_linker/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/directive_metadata_linker/transformer.dart
@@ -20,21 +20,11 @@ import 'ng_meta_linker.dart';
 ///
 /// See `common/ng_meta.dart` for the JSON format of these files are serialized
 /// to.
-class DirectiveMetadataLinker extends Transformer
-    implements DeclaringTransformer {
+class DirectiveMetadataLinker extends Transformer {
   final _encoder = const JsonEncoder.withIndent('  ');
 
   @override
   bool isPrimary(AssetId id) => id.path.endsWith(META_EXTENSION);
-
-  @override
-  declareOutputs(DeclaringTransform transform) {
-    // TODO(kegluenq): We should consume this, but doing so causes barback to
-    // incorrectly determine what assets are available in this phase.
-    // transform.consumePrimary();
-    transform.declareOutput(transform.primaryId);
-    transform.declareOutput(_depsAssetId(transform.primaryId));
-  }
 
   @override
   Future apply(Transform transform) {
@@ -43,8 +33,6 @@ class DirectiveMetadataLinker extends Transformer
 
       return linkDirectiveMetadata(
           new AssetReader.fromTransform(transform), primaryId).then((ngMeta) {
-        // See above
-        // transform.consumePrimary();
         if (ngMeta != null) {
           if (!ngMeta.types.isEmpty || !ngMeta.aliases.isEmpty) {
             transform.addOutput(new Asset.fromString(

--- a/modules_dart/transform/lib/src/transform/directive_processor/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/directive_processor/transformer.dart
@@ -21,7 +21,7 @@ import 'rewriter.dart';
 ///
 /// This transformer is the first phase in a two-phase transform. It should
 /// be followed by {@link DirectiveLinker}.
-class DirectiveProcessor extends Transformer implements DeclaringTransformer {
+class DirectiveProcessor extends Transformer {
   final TransformerOptions options;
   final _encoder = const JsonEncoder.withIndent('  ');
 
@@ -29,14 +29,6 @@ class DirectiveProcessor extends Transformer implements DeclaringTransformer {
 
   @override
   bool isPrimary(AssetId id) => id.extension.endsWith('dart');
-
-  /// We don't always output these, but providing a superset of our outputs
-  /// should be safe. Barback will just have to wait until `apply` finishes to
-  /// determine that one or the other will not be emitted.
-  @override
-  declareOutputs(DeclaringTransform transform) {
-    transform.declareOutput(_ngMetaAssetId(transform.primaryId));
-  }
 
   @override
   Future apply(Transform transform) async {

--- a/modules_dart/transform/lib/src/transform/inliner_for_test/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/inliner_for_test/transformer.dart
@@ -17,7 +17,7 @@ import 'package:barback/barback.dart';
 import 'package:dart_style/dart_style.dart';
 
 /// Processes .dart files and inlines `templateUrl` and styleUrls` values.
-class InlinerForTest extends Transformer implements DeclaringTransformer {
+class InlinerForTest extends Transformer {
   final DartFormatter _formatter;
   final AnnotationMatcher _annotationMatcher;
 
@@ -29,16 +29,9 @@ class InlinerForTest extends Transformer implements DeclaringTransformer {
   bool isPrimary(AssetId id) => id.extension.endsWith('dart');
 
   @override
-  declareOutputs(DeclaringTransform transform) {
-    transform.consumePrimary();
-    transform.declareOutput(transform.primaryId);
-  }
-
-  @override
   Future apply(Transform transform) async {
     return initZoned(transform, () async {
       var primaryId = transform.primaryInput.id;
-      transform.consumePrimary();
       var inlinedCode = await inline(new AssetReader.fromTransform(transform),
           primaryId, _annotationMatcher);
       if (inlinedCode == null || inlinedCode.isEmpty) {

--- a/modules_dart/transform/lib/src/transform/reflection_remover/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/reflection_remover/transformer.dart
@@ -19,7 +19,7 @@ import 'remove_reflection_capabilities.dart';
 /// have already been run and that a .ng_deps.dart file has been generated for
 /// {@link options.entryPoint}. The instantiation of {@link ReflectionCapabilities} is
 /// replaced by calling `setupReflection` in that .ng_deps.dart file.
-class ReflectionRemover extends Transformer implements DeclaringTransformer {
+class ReflectionRemover extends Transformer {
   final TransformerOptions options;
 
   ReflectionRemover(this.options);
@@ -27,12 +27,6 @@ class ReflectionRemover extends Transformer implements DeclaringTransformer {
   @override
   bool isPrimary(AssetId id) => options.entryPointGlobs != null &&
       options.entryPointGlobs.any((g) => g.matches(id.path));
-
-  @override
-  declareOutputs(DeclaringTransform transform) {
-    transform.consumePrimary();
-    transform.declareOutput(transform.primaryId);
-  }
 
   @override
   Future apply(Transform transform) async {
@@ -51,7 +45,6 @@ class ReflectionRemover extends Transformer implements DeclaringTransformer {
       var transformedCode = await removeReflectionCapabilities(
           new AssetReader.fromTransform(transform), primaryId,
           mirrorMode: mirrorMode, writeStaticInit: writeStaticInit);
-      transform.consumePrimary();
       transform.addOutput(new Asset.fromString(primaryId, transformedCode));
     });
   }

--- a/modules_dart/transform/lib/src/transform/stylesheet_compiler/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/stylesheet_compiler/transformer.dart
@@ -12,18 +12,12 @@ import 'package:barback/barback.dart';
 import 'processor.dart';
 
 /// Pre-compiles CSS stylesheet files to Dart code for Angular 2.
-class StylesheetCompiler extends Transformer implements DeclaringTransformer {
+class StylesheetCompiler extends Transformer {
   StylesheetCompiler();
 
   @override
   bool isPrimary(AssetId id) {
     return id.path.endsWith(CSS_EXTENSION);
-  }
-
-  @override
-  declareOutputs(DeclaringTransform transform) {
-    transform.declareOutput(nonShimmedStylesheetAssetId(transform.primaryId));
-    transform.declareOutput(shimmedStylesheetAssetId(transform.primaryId));
   }
 
   @override

--- a/modules_dart/transform/lib/src/transform/template_compiler/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/template_compiler/transformer.dart
@@ -18,20 +18,13 @@ import 'generator.dart';
 /// extracting information about what reflection is necessary to render and
 /// use that template. It then generates code in place of those reflective
 /// accesses.
-class TemplateCompiler extends Transformer implements DeclaringTransformer {
+class TemplateCompiler extends Transformer {
   final TransformerOptions options;
 
   TemplateCompiler(this.options);
 
   @override
   bool isPrimary(AssetId id) => id.path.endsWith(DEPS_EXTENSION);
-
-  @override
-  declareOutputs(DeclaringTransform transform) {
-    transform.consumePrimary();
-    transform.declareOutput(transform.primaryId);
-    transform.declareOutput(templatesAssetId(transform.primaryId));
-  }
 
   @override
   Future apply(Transform transform) async {
@@ -41,7 +34,6 @@ class TemplateCompiler extends Transformer implements DeclaringTransformer {
       var reader = new AssetReader.fromTransform(transform);
       var outputs = await processTemplates(reader, primaryId,
           reflectPropertiesAsAttributes: options.reflectPropertiesAsAttributes);
-      transform.consumePrimary();
       var ngDepsCode = '';
       var templatesCode = '';
       if (outputs != null) {

--- a/modules_dart/transform/test/transform/stylesheet_compiler/all_tests.dart
+++ b/modules_dart/transform/test/transform/stylesheet_compiler/all_tests.dart
@@ -41,17 +41,6 @@ allTests() {
         .toBe(false);
   });
 
-  it('should declare outputs', () {
-    var transform = new FakeDeclaringTransform()
-      ..primaryId = new AssetId('somepackage', 'lib/style.css');
-    subject.declareOutputs(transform);
-    expect(transform.outputs.length).toBe(2);
-    expect(transform.outputs[0].toString())
-        .toEqual('somepackage|lib/style.css.dart');
-    expect(transform.outputs[1].toString())
-        .toEqual('somepackage|lib/style.css.shim.dart');
-  });
-
   it('should compile stylesheets', () async {
     var cssFile = new Asset.fromString(
         new AssetId('somepackage', 'lib/style.css'), SIMPLE_CSS);


### PR DESCRIPTION
@yjbanov , let's discuss!

Experience shows that for large projects, declaring transformer outputs
can cause ~10x slowdown. Remove output declarations to avoid this.
