### PR TITLE
refactor(dart/transform): Simplify logging class

### DIFF
--- a/modules_dart/transform/lib/src/transform/common/logging.dart
+++ b/modules_dart/transform/lib/src/transform/common/logging.dart
@@ -4,7 +4,6 @@ import 'dart:async';
 
 import 'package:analyzer/analyzer.dart';
 import 'package:barback/barback.dart';
-import 'package:code_transformers/messages/build_logger.dart';
 import 'package:source_span/source_span.dart';
 
 typedef _SimpleCallback();
@@ -14,9 +13,9 @@ final _key = #loggingZonedLoggerKey;
 
 /// Executes {@link fn} inside a new {@link Zone} with its own logger.
 Future<dynamic> initZoned(Transform t, _SimpleCallback fn) =>
-    setZoned(new BuildLogger(t), fn);
+    setZoned(t.logger, fn);
 
-Future<dynamic> setZoned(BuildLogger logger, _SimpleCallback fn) async {
+Future<dynamic> setZoned(TransformLogger logger, _SimpleCallback fn) async {
   return runZoned(() async {
     try {
       return await fn();
@@ -46,8 +45,8 @@ Future<dynamic> setZoned(BuildLogger logger, _SimpleCallback fn) async {
 }
 
 /// The logger for the current {@link Zone}.
-BuildLogger get logger {
-  var current = Zone.current[_key] as BuildLogger;
+TransformLogger get logger {
+  var current = Zone.current[_key] as TransformLogger;
   return current == null ? new PrintLogger() : current;
 }
 
@@ -69,25 +68,25 @@ Future logElapsedAsync(Future asyncOperation(),
   return result;
 }
 
-class PrintLogger implements BuildLogger {
-  @override
-  final String detailsUri = '';
-  @override
-  final bool convertErrorsToWarnings = false;
-
+class PrintLogger implements TransformLogger {
   void _printWithPrefix(prefix, msg) => print('$prefix: $msg');
+
+  @override
   void info(msg, {AssetId asset, SourceSpan span}) =>
       _printWithPrefix('INFO', msg);
+
+  @override
   void fine(msg, {AssetId asset, SourceSpan span}) =>
       _printWithPrefix('FINE', msg);
+
+  @override
   void warning(msg, {AssetId asset, SourceSpan span}) =>
       _printWithPrefix('WARN', msg);
+
+  @override
   void error(msg, {AssetId asset, SourceSpan span}) {
     throw new PrintLoggerError(msg, asset, span);
   }
-
-  Future writeOutput() => null;
-  Future addLogFilesFromAsset(AssetId id, [int nextNumber = 1]) => null;
 }
 
 class PrintLoggerError extends Error {

--- a/modules_dart/transform/test/transform/common/recording_logger.dart
+++ b/modules_dart/transform/test/transform/common/recording_logger.dart
@@ -1,33 +1,27 @@
 library angular2.test.transform.common.read_file;
 
 import 'package:barback/barback.dart';
-import 'package:code_transformers/messages/build_logger.dart';
 import 'package:source_span/source_span.dart';
 
-class RecordingLogger implements BuildLogger {
-  @override
-  final String detailsUri = '';
-  @override
-  final bool convertErrorsToWarnings = false;
-
+class RecordingLogger implements TransformLogger {
   bool hasErrors = false;
 
   List<String> logs = [];
 
   void _record(prefix, msg) => logs.add('$prefix: $msg');
 
+  @override
   void info(msg, {AssetId asset, SourceSpan span}) => _record('INFO', msg);
 
+  @override
   void fine(msg, {AssetId asset, SourceSpan span}) => _record('FINE', msg);
 
+  @override
   void warning(msg, {AssetId asset, SourceSpan span}) => _record('WARN', msg);
 
+  @override
   void error(msg, {AssetId asset, SourceSpan span}) {
     hasErrors = true;
     _record('ERROR', msg);
   }
-
-  Future writeOutput() => throw new UnimplementedError();
-  Future addLogFilesFromAsset(AssetId id, [int nextNumber = 1]) =>
-      throw new UnimplementedError();
 }

--- a/modules_dart/transform/test/transform/directive_processor/all_tests.dart
+++ b/modules_dart/transform/test/transform/directive_processor/all_tests.dart
@@ -13,7 +13,6 @@ import 'package:angular2/src/transform/common/logging.dart' as log;
 import 'package:angular2/src/transform/common/model/reflection_info_model.pb.dart';
 import 'package:angular2/src/transform/common/ng_meta.dart';
 import 'package:barback/barback.dart';
-import 'package:code_transformers/messages/build_logger.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:guinness/guinness.dart';
 import '../common/read_file.dart';
@@ -427,7 +426,7 @@ Future<NgMeta> _testCreateModel(String inputPath,
     {List<AnnotationDescriptor> customDescriptors: const [],
     AssetId assetId,
     AssetReader reader,
-    BuildLogger logger}) {
+    TransformLogger logger}) {
   if (logger == null) logger = new RecordingLogger();
   return log.setZoned(logger, () async {
     var inputId = _assetIdForPath(inputPath);


### PR DESCRIPTION
Use `TransformLogger` for the transformer rather than `BuildLogger`,
which has additional funtionality (and complexity) that is unused.
