### PR TITLE
docs(Router): fix invalid TypeScript syntax in example

### DIFF
--- a/modules/angular2/src/router/instruction.ts
+++ b/modules/angular2/src/router/instruction.ts
@@ -26,7 +26,7 @@ import {Url} from './url_parser';
  *
  * @Component({ template: 'user: {{id}}' })
  * class UserCmp {
- *   string: id;
+ *   id: string;
  *   constructor(params: RouteParams) {
  *     this.id = params.get('id');
  *   }


### PR DESCRIPTION
TypeScript code in example does not compile
