### PR TITLE
fix(JsonPipe): marks json pipe as not pure

### DIFF
--- a/modules/angular2/src/core/pipes/json_pipe.ts
+++ b/modules/angular2/src/core/pipes/json_pipe.ts
@@ -5,6 +5,7 @@ import {Pipe} from 'angular2/src/core/metadata';
 
 /**
  * Implements json transforms to any object.
+ * The json pipe runs all the time checking for changes on the transformed object.
  *
  * ### Example
  *
@@ -25,7 +26,7 @@ import {Pipe} from 'angular2/src/core/metadata';
  * ```
  */
 @CONST()
-@Pipe({name: 'json'})
+@Pipe({name: 'json', pure: false})
 @Injectable()
 export class JsonPipe implements PipeTransform {
   transform(value: any, args: any[] = null): string { return Json.stringify(value); }


### PR DESCRIPTION
Marked json pipe as not pure so that it runs all the time, reflecting changes on the object.

Closes #4821
