### PR TITLE
docs(developer.md): add PUB_CACHE variable to setup instructions

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -95,6 +95,14 @@ export DART_SDK="$DART_EDITOR_DIR/dart-sdk"
 PATH+=":$DART_SDK/bin"
 ```
 
+And specify where the pub’s dependencies are downloaded. By default, this directory is located under .pub_cache 
+in your home directory (on Mac and Linux), or in AppData\Roaming\Pub\Cache (on Windows).
+
+```shell
+# PUB_CACHE: location of pub dependencies
+export PUB_CACHE="/Users/<user>/.pub-cache"
+```
+
 ## Installing NPM Modules and Dart Packages
 
 Next, install the JavaScript modules and Dart packages needed to build and test Angular:


### PR DESCRIPTION
If PUB_CACHE is not set the pub dependencies are downloaded to a default
folder during the build because `gulp build` also runs `pub get`.

Running the tests locally PUB_CACHE is set to a subdirectory of the SDK
 when the `env_dart.sh` script is sourced.

Therefore `build/pubbuild.dart` fails as it can't find the dependencies.
