### PR TITLE
feat(Location): add search() method which returns an Object

### DIFF
--- a/modules/angular2/src/core/facade/decode.dart
+++ b/modules/angular2/src/core/facade/decode.dart
@@ -1,0 +1,11 @@
+library angular2.src.core.facade.decode;
+
+import 'dart:core' show String, Uri;
+
+String tryDecodeURIComponent(String encodedComponent) {
+  try {
+    return Uri.decodeComponent(encodedComponent);
+  } catch(exception, stackTrace) {
+    // Ignore any invalid uri component
+  }
+}

--- a/modules/angular2/src/core/facade/decode.ts
+++ b/modules/angular2/src/core/facade/decode.ts
@@ -1,0 +1,10 @@
+/**
+ * Tries to decode the URI component without throwing an exception.
+ */
+export function tryDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch (e) {
+    // Ignore any invalid uri component
+  }
+}

--- a/modules/angular2/src/mock/location_mock.ts
+++ b/modules/angular2/src/mock/location_mock.ts
@@ -24,6 +24,8 @@ export class SpyLocation implements Location {
 
   path(): string { return this._path; }
 
+  search(): any { return this._query; }
+
   simulateUrlPop(pathname: string) {
     ObservableWrapper.callEmit(this._subject, {'url': pathname, 'pop': true});
   }

--- a/modules/angular2/src/mock/mock_location_strategy.ts
+++ b/modules/angular2/src/mock/mock_location_strategy.ts
@@ -11,6 +11,7 @@ import {LocationStrategy} from 'angular2/src/router/location_strategy';
 export class MockLocationStrategy extends LocationStrategy {
   internalBaseHref: string = '/';
   internalPath: string = '/';
+  internalSearch: string = '';
   internalTitle: string = '';
   urlChanges: string[] = [];
   /** @internal */
@@ -24,6 +25,8 @@ export class MockLocationStrategy extends LocationStrategy {
 
   path(): string { return this.internalPath; }
 
+  search(): any { return this.internalSearch; }
+
   prepareExternalUrl(internal: string): string {
     if (internal.startsWith('/') && this.internalBaseHref.endsWith('/')) {
       return this.internalBaseHref + internal.substring(1);
@@ -34,8 +37,10 @@ export class MockLocationStrategy extends LocationStrategy {
   pushState(ctx: any, title: string, path: string, query: string): void {
     this.internalTitle = title;
 
-    var url = path + (query.length > 0 ? ('?' + query) : '');
+    query = query.length > 0 ? ('?' + query) : '';
+    var url = path + query;
     this.internalPath = url;
+    this.internalSearch = query;
 
     var externalUrl = this.prepareExternalUrl(url);
     this.urlChanges.push(externalUrl);

--- a/modules/angular2/src/router/hash_location_strategy.ts
+++ b/modules/angular2/src/router/hash_location_strategy.ts
@@ -77,6 +77,8 @@ export class HashLocationStrategy extends LocationStrategy {
            normalizeQueryParams(this._platformLocation.search);
   }
 
+  search(): string { return this._platformLocation.search; }
+
   prepareExternalUrl(internal: string): string {
     var url = joinWithSlash(this._baseHref, internal);
     return url.length > 0 ? ('#' + url) : url;

--- a/modules/angular2/src/router/location_strategy.ts
+++ b/modules/angular2/src/router/location_strategy.ts
@@ -20,6 +20,7 @@ import {OpaqueToken} from 'angular2/core';
 export abstract class LocationStrategy {
   abstract path(): string;
   abstract prepareExternalUrl(internal: string): string;
+  abstract search(): any;
   abstract pushState(state: any, title: string, url: string, queryParams: string): void;
   abstract replaceState(state: any, title: string, url: string, queryParams: string): void;
   abstract forward(): void;

--- a/modules/angular2/src/router/path_location_strategy.ts
+++ b/modules/angular2/src/router/path_location_strategy.ts
@@ -88,6 +88,8 @@ export class PathLocationStrategy extends LocationStrategy {
     return this._platformLocation.pathname + normalizeQueryParams(this._platformLocation.search);
   }
 
+  search(): string { return this._platformLocation.search; }
+
   pushState(state: any, title: string, url: string, queryParams: string) {
     var externalUrl = this.prepareExternalUrl(url + normalizeQueryParams(queryParams));
     this._platformLocation.pushState(state, title, externalUrl);

--- a/modules/angular2/test/router/location_spec.ts
+++ b/modules/angular2/test/router/location_spec.ts
@@ -84,5 +84,24 @@ export function main() {
       location.go('/home', "key=value");
       expect(location.path()).toEqual("/home?key=value");
     });
+
+    it('should provide query params as an Object', () => {
+      var locationStrategy = new MockLocationStrategy();
+      var location = new Location(locationStrategy);
+
+      location.go('/home', "key=value");
+      expect(location.search()['key']).toEqual("value");
+
+      // should parse various formats cleanly
+      location.go('/home', "opinion=angular+is+awesome!");
+      expect(location.search()['opinion']).toEqual("angular is awesome!");
+
+      location.go(
+          '/home',
+          "opinion=Jeff+Cross is good as a worldwide news+reporter&random=other:formatting");
+      expect(location.search()['opinion'])
+          .toEqual("Jeff Cross is good as a worldwide news reporter");
+      expect(location.search()['random']).toEqual("other:formatting");
+    });
   });
 }


### PR DESCRIPTION
The utility function `tryDecodeURIComponent` may be better placed in a different file. This uses the same strategy and implementation found in Angular 1.x. Lemme know if any refactoring or moving around is needed.

closes https://github.com/angular/angular/issues/4824
