### PR TITLE
fix(coreDirectives): Added an Error Message for invalid selectors on …

### DIFF
--- a/modules/angular2/src/core/compiler/selector.ts
+++ b/modules/angular2/src/core/compiler/selector.ts
@@ -32,6 +32,10 @@ export class CssSelector {
   notSelectors: CssSelector[] = [];
 
   static parse(selector: string): CssSelector[] {
+    if (StringWrapper.equals(selector, '')) {
+      throw new BaseException('Selectors must not be an empty string');
+    }
+
     var results: CssSelector[] = [];
     var _addResult = (res: CssSelector[], cssSel) => {
       if (cssSel.notSelectors.length > 0 && isBlank(cssSel.element) &&

--- a/modules/angular2/test/core/compiler/selector_spec.ts
+++ b/modules/angular2/test/core/compiler/selector_spec.ts
@@ -233,6 +233,11 @@ export function main() {
   });
 
   describe('CssSelector.parse', () => {
+    it('should throw an error if the selector is an empty string', () => {
+      expect(function() { CssSelector.parse(''); })
+          .toThrowError('Selectors must not be an empty string');
+    });
+
     it('should detect element names', () => {
       var cssSelector = CssSelector.parse('sometag')[0];
       expect(cssSelector.element).toEqual('sometag');


### PR DESCRIPTION
…component annotation

If the component selector is an empty string or not a string an error
will be thrown.

Closes #3464
Closes #3759
