### PR TITLE
docs(SlicePipe): fix ng-for example

### DIFF
--- a/modules/angular2/src/core/pipes/slice_pipe.ts
+++ b/modules/angular2/src/core/pipes/slice_pipe.ts
@@ -50,7 +50,7 @@ import {Pipe} from '../metadata';
  *
  * Assuming `var collection = ['a', 'b', 'c', 'd']`, this `ng-for` directive:
  *
- *     <li *ng-for="var i in collection | slice:1:3">{{i}}</li>
+ *     <li *ng-for="var i of collection | slice:1:3">{{i}}</li>
  *
  * produces the following:
  *


### PR DESCRIPTION
I have never seen that `in` on the `ng-for` and it doesn't seems to work.
