### PR TITLE
fix(lang): avoid infinite loop when calling assert()

### DIFF
--- a/modules/angular2/src/core/facade/lang.ts
+++ b/modules/angular2/src/core/facade/lang.ts
@@ -37,18 +37,15 @@ export function getTypeNameForDebugging(type: Type): string {
 export var Math = _global.Math;
 export var Date = _global.Date;
 
-var assertionsEnabled_ = typeof _global['assert'] !== 'undefined';
 export function assertionsEnabled(): boolean {
-  return assertionsEnabled_;
+  return false;
 }
 
 // TODO: remove calls to assert in production environment
 // Note: Can't just export this and import in in other files
 // as `assert` is a reserved keyword in Dart
 _global.assert = function assert(condition) {
-  if (assertionsEnabled_) {
-    _global['assert'].call(condition);
-  }
+  // TODO: to be fixed properly via #2830, noop for now
 };
 
 // This function is needed only to properly support Dart's const expressions


### PR DESCRIPTION
The current code doesn't function properly:
- assert are never activated
- even if activated would result in infinite loop

Since the code is broken and blocks other use-cases
this commit turns assert into noop. A proper solution
for asserts will be part of #2830

Fixes #4981
