### PR TITLE
fix(test): "integration tests svg should support svg elements" fails …

### DIFF
--- a/modules/angular2/test/core/linker/integration_spec.ts
+++ b/modules/angular2/test/core/linker/integration_spec.ts
@@ -1758,7 +1758,15 @@ export function main() {
                        .toEqual('http://www.w3.org/2000/svg');
                    expect(DOM.getProperty(<Element>use, 'namespaceURI'))
                        .toEqual('http://www.w3.org/2000/svg');
-                   expect(DOM.getOuterHTML(<HTMLElement>use)).toContain('xmlns:xlink');
+
+                   if (!IS_DART) {
+                     var firstAttribute = DOM.getProperty(<Element>use, 'attributes')[0];
+                     expect(firstAttribute.name).toEqual('xlink:href');
+                     expect(firstAttribute.namespaceURI).toEqual('http://www.w3.org/1999/xlink');
+                   } else {
+                     // For Dart where '_Attr' has no instance getter 'namespaceURI'
+                     expect(DOM.getOuterHTML(<HTMLElement>use)).toContain('xmlns:xlink');
+                   }
 
                    async.done();
                  });


### PR DESCRIPTION
…in non-Chrome browsers

Fixes #4987 

If a Dart guru has a better idea to test the `namespaceURI` of the attribute, please let me know.
