### PR TITLE
fix(dart/transform): Gracefully handle empty .ng_meta.json files

### DIFF
--- a/modules_dart/transform/lib/src/transform/template_compiler/compile_data_creator.dart
+++ b/modules_dart/transform/lib/src/transform/template_compiler/compile_data_creator.dart
@@ -22,8 +22,8 @@ import 'package:barback/barback.dart';
 Future<CompileDataResults> createCompileData(
     AssetReader reader, AssetId assetId) async {
   return logElapsedAsync(() async {
-    return (await _CompileDataCreator.create(reader, assetId))
-        .createCompileData();
+    final creator = await _CompileDataCreator.create(reader, assetId);
+    return creator != null ? creator.createCompileData() : null;
   }, operationName: 'createCompileData', assetId: assetId);
 }
 

--- a/modules_dart/transform/lib/src/transform/template_compiler/generator.dart
+++ b/modules_dart/transform/lib/src/transform/template_compiler/generator.dart
@@ -28,6 +28,7 @@ import 'compile_data_creator.dart';
 Future<Outputs> processTemplates(AssetReader reader, AssetId assetId,
     {bool reflectPropertiesAsAttributes: false}) async {
   var viewDefResults = await createCompileData(reader, assetId);
+  if (viewDefResults == null) return null;
   final directiveMetadatas = viewDefResults.ngMeta.types.values;
   if (directiveMetadatas.isNotEmpty) {
     var processor = new reg.Processor();

--- a/modules_dart/transform/test/transform/template_compiler/all_tests.dart
+++ b/modules_dart/transform/test/transform/template_compiler/all_tests.dart
@@ -318,6 +318,34 @@ void allTests() {
     expect(ngDeps.setters).toContain('text');
     expect(ngDeps.setters.length).toEqual(1);
   });
+
+  it('should gracefully handle null .ng_meta.json files', () async {
+    final dne =
+        new AssetId('package', 'lib/file_that_does_not_exist.ng_meta.json');
+
+    var didThrow = false;
+    await process(dne).then((out) {
+      expect(out).toBeNull();
+    }).catchError((_) {
+      didThrow = true;
+    });
+
+    expect(didThrow).toBeFalse();
+  });
+
+  it('should gracefully handle empty .ng_meta.json files', () async {
+    final emptyId = new AssetId('package', 'lib/empty.ng_meta.json');
+    reader.addAsset(emptyId, '');
+
+    var didThrow = false;
+    await process(emptyId).then((out) {
+      expect(out).toBeNull();
+    }).catchError((_) {
+      didThrow = true;
+    });
+
+    expect(didThrow).toBeFalse();
+  });
 }
 
 void _formatThenExpectEquals(String actual, String expected) {


### PR DESCRIPTION
Fix the `template_compiler` step to gracefully handle null & empty
.ng_meta.json files.
