### PR TITLE
perf(dart/transform): Restrict visibility/mutability of codegen

### DIFF
--- a/modules/angular2/src/core/compiler/change_detector_compiler.ts
+++ b/modules/angular2/src/core/compiler/change_detector_compiler.ts
@@ -64,7 +64,7 @@ export class ChangeDetectionCompiler {
       // and have the same API for calling them!
       if (IS_DART) {
         codegen = new Codegen(PREGEN_PROTO_CHANGE_DETECTOR_MODULE);
-        var className = definition.id;
+        var className = `_${definition.id}`;
         var typeRef = (index === 0 && componentType.isHost) ?
                           'dynamic' :
                           `${moduleRef(componentType.moduleUrl)}${componentType.name}`;

--- a/modules/angular2/src/core/compiler/util.ts
+++ b/modules/angular2/src/core/compiler/util.ts
@@ -46,8 +46,11 @@ function escapeString(input: string, re: RegExp): string {
 }
 
 export function codeGenExportVariable(name: string, isConst: boolean = false): string {
-  var declaration = IS_DART && isConst ? `const ${name}` : `var ${name}`;
-  return IS_DART ? `${declaration} = ` : `${declaration} = exports['${name}'] = `;
+  if (IS_DART) {
+    return isConst ? `const ${name} = ` : `final ${name} = `;
+  } else {
+    return `var ${name} = exports['${name}'] = `;
+  }
 }
 
 export function codeGenConcatArray(expression: string): string {


### PR DESCRIPTION
For exported, generated templates, declare with `final` so `dart2js`
knows they will never be reassigned.

For non-exported, generated change detector classes, prefix the
classname with `_` to mark them as internal.
