### PR TITLE
fix(ng-content): wildcard ng-content has to go last.

### DIFF
--- a/modules/angular2/src/core/compiler/template_parser.ts
+++ b/modules/angular2/src/core/compiler/template_parser.ts
@@ -655,12 +655,12 @@ class Component {
 
   findNgContentIndex(selector: CssSelector): number {
     var ngContentIndices = [];
-    if (isPresent(this.wildcardNgContentIndex)) {
-      ngContentIndices.push(this.wildcardNgContentIndex);
-    }
     this.ngContentIndexMatcher.match(
         selector, (selector, ngContentIndex) => { ngContentIndices.push(ngContentIndex); });
     ListWrapper.sort(ngContentIndices);
+    if (isPresent(this.wildcardNgContentIndex)) {
+      ngContentIndices.push(this.wildcardNgContentIndex);
+    }
     return ngContentIndices.length > 0 ? ngContentIndices[0] : null;
   }
 }

--- a/modules/angular2/test/core/compiler/template_parser_spec.ts
+++ b/modules/angular2/test/core/compiler/template_parser_spec.ts
@@ -754,6 +754,12 @@ There is no directive with "exportAs" set to "dirA" at TestComp > div:nth-child(
             .toEqual([['div', null], ['#text(hello)', 2], ['b', 1], ['a', 0]]);
       });
 
+      it('should project into wildcard ng-content last', () => {
+        expect(humanizeContentProjection(
+                   parse('<div>hello<a></a></div>', [createComp('div', ['*', 'a'])])))
+            .toEqual([['div', null], ['#text(hello)', 0], ['a', 1]]);
+      });
+
       it('should only project direct child nodes', () => {
         expect(humanizeContentProjection(
                    parse('<div><span><a></a></span><a></a></div>', [createComp('div', ['a'])])))


### PR DESCRIPTION
This was the case before the new compiler landed and should be preserved. 

Related to #4598
