### PR TITLE
style(lint): new tslint rule to enforce privates to start with _

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -285,6 +285,7 @@ gulp.task('lint', ['build.tools'], function() {
   var tslintConfig = {
     "rules": {
       "requireInternalWithUnderscore": true,
+      "requirePrivateWithUnderscore": true,
       "requireParameterType": true,
       "requireReturnType": true,
       "semicolon": true,

--- a/modules/angular2/src/common/pipes/slice_pipe.ts
+++ b/modules/angular2/src/common/pipes/slice_pipe.ts
@@ -79,5 +79,5 @@ export class SlicePipe implements PipeTransform {
     return ListWrapper.slice(value, start, end);
   }
 
-  private supports(obj: any): boolean { return isString(obj) || isArray(obj); }
+  public supports(obj: any): boolean { return isString(obj) || isArray(obj); }
 }

--- a/modules/angular2/src/core/change_detection/change_detection_jit_generator.ts
+++ b/modules/angular2/src/core/change_detection/change_detection_jit_generator.ts
@@ -32,13 +32,13 @@ export class ChangeDetectorJITGenerator {
   private _logic: CodegenLogicUtil;
   private _names: CodegenNameUtil;
   private _endOfBlockIdxs: number[];
-  private id: string;
-  private changeDetectionStrategy: ChangeDetectionStrategy;
-  private records: ProtoRecord[];
-  private propertyBindingTargets: BindingTarget[];
-  private eventBindings: EventBinding[];
-  private directiveRecords: any[];
-  private genConfig: ChangeDetectorGenConfig;
+  private _id: string;
+  private _changeDetectionStrategy: ChangeDetectionStrategy;
+  private _records: ProtoRecord[];
+  private _propertyBindingTargets: BindingTarget[];
+  private _eventBindings: EventBinding[];
+  private _directiveRecords: any[];
+  private _genConfig: ChangeDetectorGenConfig;
   typeName: string;
 
   constructor(definition: ChangeDetectorDefinition, private changeDetectionUtilVarName: string,
@@ -47,20 +47,20 @@ export class ChangeDetectorJITGenerator {
     var propertyBindingRecords = createPropertyRecords(definition);
     var eventBindingRecords = createEventRecords(definition);
     var propertyBindingTargets = definition.bindingRecords.map(b => b.target);
-    this.id = definition.id;
-    this.changeDetectionStrategy = definition.strategy;
-    this.genConfig = definition.genConfig;
+    this._id = definition.id;
+    this._changeDetectionStrategy = definition.strategy;
+    this._genConfig = definition.genConfig;
 
-    this.records = propertyBindingRecords;
-    this.propertyBindingTargets = propertyBindingTargets;
-    this.eventBindings = eventBindingRecords;
-    this.directiveRecords = definition.directiveRecords;
-    this._names = new CodegenNameUtil(this.records, this.eventBindings, this.directiveRecords,
+    this._records = propertyBindingRecords;
+    this._propertyBindingTargets = propertyBindingTargets;
+    this._eventBindings = eventBindingRecords;
+    this._directiveRecords = definition.directiveRecords;
+    this._names = new CodegenNameUtil(this._records, this._eventBindings, this._directiveRecords,
                                       this.changeDetectionUtilVarName);
     this._logic =
         new CodegenLogicUtil(this._names, this.changeDetectionUtilVarName,
-                             this.changeDetectorStateVarName, this.changeDetectionStrategy);
-    this.typeName = sanitizeName(`ChangeDetector_${this.id}`);
+                             this.changeDetectorStateVarName, this._changeDetectionStrategy);
+    this.typeName = sanitizeName(`ChangeDetector_${this._id}`);
   }
 
   generate(): Function {
@@ -79,9 +79,9 @@ export class ChangeDetectorJITGenerator {
     return `
       var ${this.typeName} = function ${this.typeName}(dispatcher) {
         ${this.abstractChangeDetectorVarName}.call(
-            this, ${JSON.stringify(this.id)}, dispatcher, ${this.records.length},
+            this, ${JSON.stringify(this._id)}, dispatcher, ${this._records.length},
             ${this.typeName}.gen_propertyBindingTargets, ${this.typeName}.gen_directiveIndices,
-            ${codify(this.changeDetectionStrategy)});
+            ${codify(this._changeDetectionStrategy)});
         this.dehydrateDirectives(false);
       }
 
@@ -92,7 +92,7 @@ export class ChangeDetectorJITGenerator {
         var ${IS_CHANGED_LOCAL} = false;
         var ${CHANGES_LOCAL} = null;
 
-        ${this._genAllRecords(this.records)}
+        ${this._genAllRecords(this._records)}
       }
 
       ${this._maybeGenHandleEventInternal()}
@@ -113,21 +113,21 @@ export class ChangeDetectorJITGenerator {
 
   /** @internal */
   _genPropertyBindingTargets(): string {
-    var targets = this._logic.genPropertyBindingTargets(this.propertyBindingTargets,
-                                                        this.genConfig.genDebugInfo);
+    var targets = this._logic.genPropertyBindingTargets(this._propertyBindingTargets,
+                                                        this._genConfig.genDebugInfo);
     return `${this.typeName}.gen_propertyBindingTargets = ${targets};`;
   }
 
   /** @internal */
   _genDirectiveIndices(): string {
-    var indices = this._logic.genDirectiveIndices(this.directiveRecords);
+    var indices = this._logic.genDirectiveIndices(this._directiveRecords);
     return `${this.typeName}.gen_directiveIndices = ${indices};`;
   }
 
   /** @internal */
   _maybeGenHandleEventInternal(): string {
-    if (this.eventBindings.length > 0) {
-      var handlers = this.eventBindings.map(eb => this._genEventBinding(eb)).join("\n");
+    if (this._eventBindings.length > 0) {
+      var handlers = this._eventBindings.map(eb => this._genEventBinding(eb)).join("\n");
       return `
         ${this.typeName}.prototype.handleEventInternal = function(eventName, elIndex, locals) {
           var ${this._names.getPreventDefaultAccesor()} = false;
@@ -212,8 +212,8 @@ export class ChangeDetectorJITGenerator {
 
   /** @internal */
   _maybeGenHydrateDirectives(): string {
-    var hydrateDirectivesCode = this._logic.genHydrateDirectives(this.directiveRecords);
-    var hydrateDetectorsCode = this._logic.genHydrateDetectors(this.directiveRecords);
+    var hydrateDirectivesCode = this._logic.genHydrateDirectives(this._directiveRecords);
+    var hydrateDetectorsCode = this._logic.genHydrateDetectors(this._directiveRecords);
     if (!hydrateDirectivesCode && !hydrateDetectorsCode) return '';
     return `${this.typeName}.prototype.hydrateDirectives = function(directives) {
       ${hydrateDirectivesCode}
@@ -223,7 +223,7 @@ export class ChangeDetectorJITGenerator {
 
   /** @internal */
   _maybeGenAfterContentLifecycleCallbacks(): string {
-    var notifications = this._logic.genContentLifecycleCallbacks(this.directiveRecords);
+    var notifications = this._logic.genContentLifecycleCallbacks(this._directiveRecords);
     if (notifications.length > 0) {
       var directiveNotifications = notifications.join("\n");
       return `
@@ -238,7 +238,7 @@ export class ChangeDetectorJITGenerator {
 
   /** @internal */
   _maybeGenAfterViewLifecycleCallbacks(): string {
-    var notifications = this._logic.genViewLifecycleCallbacks(this.directiveRecords);
+    var notifications = this._logic.genViewLifecycleCallbacks(this._directiveRecords);
     if (notifications.length > 0) {
       var directiveNotifications = notifications.join("\n");
       return `
@@ -409,7 +409,7 @@ export class ChangeDetectorJITGenerator {
 
     var newValue = this._names.getLocalName(r.selfIndex);
     var oldValue = this._names.getFieldName(r.selfIndex);
-    var notifyDebug = this.genConfig.logBindingUpdate ? `this.logBindingUpdate(${newValue});` : "";
+    var notifyDebug = this._genConfig.logBindingUpdate ? `this.logBindingUpdate(${newValue});` : "";
 
     var br = r.bindingRecord;
     if (br.target.isDirective()) {
@@ -453,7 +453,7 @@ export class ChangeDetectorJITGenerator {
 
   /** @internal */
   _maybeFirstInBinding(r: ProtoRecord): string {
-    var prev = ChangeDetectionUtil.protoByIndex(this.records, r.selfIndex - 1);
+    var prev = ChangeDetectionUtil.protoByIndex(this._records, r.selfIndex - 1);
     var firstInBinding = isBlank(prev) || prev.bindingRecord !== r.bindingRecord;
     return firstInBinding && !r.bindingRecord.isDirectiveLifecycle() ?
                `${this._names.getPropertyBindingIndex()} = ${r.propertyBindingIndex};` :

--- a/modules/angular2/src/core/render/view_factory.ts
+++ b/modules/angular2/src/core/render/view_factory.ts
@@ -284,7 +284,7 @@ class RenderViewBuilder<N> implements RenderCommandVisitor {
 }
 
 class Component<N> {
-  private contentNodesByNgContentIndex: N[][] = [];
+  private _contentNodesByNgContentIndex: N[][] = [];
 
   constructor(public hostElement: N, public shadowRoot: N, public isRoot: boolean,
               public template: RenderComponentTemplate) {}
@@ -294,15 +294,15 @@ class Component<N> {
         context.factory.appendChild(this.hostElement, node);
       }
     } else {
-      while (this.contentNodesByNgContentIndex.length <= ngContentIndex) {
-        this.contentNodesByNgContentIndex.push([]);
+      while (this._contentNodesByNgContentIndex.length <= ngContentIndex) {
+        this._contentNodesByNgContentIndex.push([]);
       }
-      this.contentNodesByNgContentIndex[ngContentIndex].push(node);
+      this._contentNodesByNgContentIndex[ngContentIndex].push(node);
     }
   }
   project(ngContentIndex: number): N[] {
-    return ngContentIndex < this.contentNodesByNgContentIndex.length ?
-               this.contentNodesByNgContentIndex[ngContentIndex] :
+    return ngContentIndex < this._contentNodesByNgContentIndex.length ?
+               this._contentNodesByNgContentIndex[ngContentIndex] :
                [];
   }
 }

--- a/modules/angular2/src/mock/directive_resolver_mock.ts
+++ b/modules/angular2/src/mock/directive_resolver_mock.ts
@@ -5,13 +5,13 @@ import {DirectiveResolver} from 'angular2/src/core/linker/directive_resolver';
 
 export class MockDirectiveResolver extends DirectiveResolver {
   private _providerOverrides = new Map<Type, any[]>();
-  private viewProviderOverrides = new Map<Type, any[]>();
+  private _viewProviderOverrides = new Map<Type, any[]>();
 
   resolve(type: Type): DirectiveMetadata {
     var dm = super.resolve(type);
 
     var providerOverrides = this._providerOverrides.get(type);
-    var viewProviderOverrides = this.viewProviderOverrides.get(type);
+    var viewProviderOverrides = this._viewProviderOverrides.get(type);
 
     var providers = dm.providers;
     if (isPresent(providerOverrides)) {
@@ -61,7 +61,7 @@ export class MockDirectiveResolver extends DirectiveResolver {
    * @deprecated
    */
   setViewBindingsOverride(type: Type, viewBindings: any[]): void {
-    this.viewProviderOverrides.set(type, viewBindings);
+    this._viewProviderOverrides.set(type, viewBindings);
   }
 
   setProvidersOverride(type: Type, bindings: any[]): void {
@@ -69,6 +69,6 @@ export class MockDirectiveResolver extends DirectiveResolver {
   }
 
   setViewProvidersOverride(type: Type, viewBindings: any[]): void {
-    this.viewProviderOverrides.set(type, viewBindings);
+    this._viewProviderOverrides.set(type, viewBindings);
   }
 }

--- a/modules/angular2/src/upgrade/upgrade_ng1_adapter.ts
+++ b/modules/angular2/src/upgrade/upgrade_ng1_adapter.ts
@@ -64,16 +64,16 @@ export class UpgradeNg1ComponentAdapterBuilder {
       throw new Error('Only support single directive definition for: ' + this.name);
     }
     var directive = directives[0];
-    if (directive.replace) this.notSupported('replace');
-    if (directive.terminal) this.notSupported('terminal');
+    if (directive.replace) this._notSupported('replace');
+    if (directive.terminal) this._notSupported('terminal');
     var link = directive.link;
     if (typeof link == 'object') {
-      if ((<angular.IDirectivePrePost>link).post) this.notSupported('link.post');
+      if ((<angular.IDirectivePrePost>link).post) this._notSupported('link.post');
     }
     return directive;
   }
 
-  private notSupported(feature: string) {
+  private _notSupported(feature: string) {
     throw new Error(`Upgraded directive '${this.name}' does not support '${feature}'.`);
   }
 
@@ -199,7 +199,7 @@ class UpgradeNg1ComponentAdapter implements OnChanges, DoCheck {
     if (link) {
       var attrs: angular.IAttributes = NOT_SUPPORTED;
       var transcludeFn: angular.ITranscludeFunction = NOT_SUPPORTED;
-      var linkController = this.resolveRequired($element, directive.require);
+      var linkController = this._resolveRequired($element, directive.require);
       (<angular.IDirectiveLinkFn>directive.link)(componentScope, $element, attrs, linkController,
                                                  transcludeFn);
     }
@@ -257,7 +257,7 @@ class UpgradeNg1ComponentAdapter implements OnChanges, DoCheck {
     this.destinationObj[this.propertyMap[name]] = value;
   }
 
-  private resolveRequired($element: angular.IAugmentedJQuery, require: string | string[]): any {
+  private _resolveRequired($element: angular.IAugmentedJQuery, require: string | string[]): any {
     if (!require) {
       return undefined;
     } else if (typeof require == 'string') {
@@ -289,7 +289,7 @@ class UpgradeNg1ComponentAdapter implements OnChanges, DoCheck {
     } else if (require instanceof Array) {
       var deps = [];
       for (var i = 0; i < require.length; i++) {
-        deps.push(this.resolveRequired($element, require[i]));
+        deps.push(this._resolveRequired($element, require[i]));
       }
       return deps;
     }

--- a/tools/tslint/requirePrivateWithUnderscoreRule.ts
+++ b/tools/tslint/requirePrivateWithUnderscoreRule.ts
@@ -1,0 +1,33 @@
+import {RuleFailure} from 'tslint/lib/lint';
+import {AbstractRule} from 'tslint/lib/rules';
+import {RuleWalker} from 'tslint/lib/language/walker';
+import * as ts from 'tslint/node_modules/typescript';
+
+export class Rule extends AbstractRule {
+  public apply(sourceFile: ts.SourceFile): RuleFailure[] {
+    const typedefWalker = new TypedefWalker(sourceFile, this.getOptions());
+    return this.applyWithWalker(typedefWalker);
+  }
+}
+
+class TypedefWalker extends RuleWalker {
+  protected visitPropertyDeclaration(node: ts.PropertyDeclaration): void {
+    this.assertUnderscoreIsPrivate(node);
+    super.visitPropertyDeclaration(node);
+  }
+
+  public visitMethodDeclaration(node: ts.MethodDeclaration): void {
+    this.assertUnderscoreIsPrivate(node);
+    super.visitMethodDeclaration(node);
+  }
+
+  private assertUnderscoreIsPrivate(node: ts.Declaration) {
+    if (node.name.getText().charAt(0) === '_') return;
+
+    if (node.modifiers && node.modifiers.flags & ts.NodeFlags.Private) {
+      this.addFailure(
+          this.createFailure(node.getStart(), node.getWidth(),
+                             `expected private member ${node.name.getText()} to start with _`));
+    }
+  }
+}


### PR DESCRIPTION
As a convention from AtScript, private functions and members must start with _ (underscore). A new tslint rule was created to enforce that. All the places that broke this new rule were also fixed (Added underscore).
