### PR TITLE
Bundles build cleanup

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1067,19 +1067,16 @@ gulp.task('!bundle.js.sfx.dev', ['build.js.dev'], function() {
 gulp.task('!bundle.js.prod.deps', ['!bundle.js.prod'], function() {
   return merge2(
     addDevDependencies('angular2.min.js'),
-    bundler.modify(
-        ['node_modules/reflect-metadata/Reflect.js', 'dist/build/http.js'],
-        'http.js'
-    )).pipe(gulp.dest('dist/js/bundle'));
+    bundler.modify(['dist/build/http.js'], 'http.js')
+  )
+    .pipe(gulp.dest('dist/js/bundle'));
 });
 
 gulp.task('!bundle.js.min.deps', ['!bundle.js.min'], function() {
   return merge2(
     addDevDependencies('angular2.min.js'),
-    bundler.modify(
-        ['node_modules/reflect-metadata/Reflect.js', 'dist/build/http.min.js'],
-        'http.min.js'
-    ))
+    bundler.modify(['dist/build/http.min.js'], 'http.min.js')
+  )
     .pipe(uglify())
     .pipe(gulp.dest('dist/js/bundle'));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -981,7 +981,8 @@ gulp.task('!bundle.js.prod', ['build.js.prod'], function() {
 
   return q.all([
     bundler.bundle(bundleConfig, 'angular2/angular2', './dist/build/angular2.js', bundlerConfig),
-    bundler.bundle(bundleConfig, 'angular2/http - angular2/angular2', './dist/build/http.js', bundlerConfig)
+    bundler.bundle(bundleConfig, 'angular2/http - angular2/angular2', './dist/build/http.js', bundlerConfig),
+    bundler.bundle(bundleConfig, 'angular2/router - angular2/angular2', './dist/build/router.js', bundlerConfig)
   ]);
 });
 
@@ -995,7 +996,7 @@ gulp.task('!bundle.js.min', ['build.js.prod'], function() {
   return q.all([
     bundler.bundle(bundleConfig, 'angular2/angular2', './dist/build/angular2.min.js', bundlerConfig),
     bundler.bundle(bundleConfig, 'angular2/http - angular2/angular2', './dist/build/http.min.js', bundlerConfig),
-    bundler.bundle(bundleConfig, 'angular2/router - angular2/angular2', './dist/js/bundle/router.dev.min.js', bundlerConfig)
+    bundler.bundle(bundleConfig, 'angular2/router - angular2/angular2', './dist/js/build/router.min.js', bundlerConfig)
   ]);
 });
 
@@ -1012,7 +1013,8 @@ gulp.task('!bundle.js.dev', ['build.js.dev'], function() {
 
   return q.all([
     bundler.bundle(devBundleConfig, 'angular2/angular2', './dist/build/angular2.dev.js', bundlerConfig),
-    bundler.bundle(devBundleConfig, 'angular2/http - angular2/angular2', './dist/build/http.dev.js', bundlerConfig)
+    bundler.bundle(devBundleConfig, 'angular2/http - angular2/angular2', './dist/build/http.dev.js', bundlerConfig),
+    bundler.bundle(bundleConfig, 'angular2/router - angular2/angular2', './dist/build/router.dev.js', bundlerConfig)
   ]);
 });
 
@@ -1032,16 +1034,6 @@ gulp.task("!bundle.web_worker.js.dev", ["build.js.dev"], function() {
           './dist/build/web_worker/worker.dev.js',
           { sourceMaps: true});
       });
-});
-
-gulp.task('!router.bundle.js.dev', ['build.js.dev'], function() {
-  var devBundleConfig = merge(true, bundleConfig);
-  devBundleConfig.paths = merge(true, devBundleConfig.paths, {"*": "dist/js/dev/es5/*.js"});
-  return bundler.bundle(
-    devBundleConfig,
-    'angular2/router - angular2/angular2',
-    './dist/js/bundle/router.dev.js',
-    { sourceMaps: true });
 });
 
 gulp.task('!bundle.testing', ['build.js.dev'], function() {
@@ -1154,8 +1146,7 @@ gulp.task('!bundle.copy', [
   '!bundle.js.dev.deps',
   '!bundle.js.min.deps',
   '!bundle.web_worker.js.dev.deps',
-  '!bundle.js.sfx.dev.deps',
-  '!router.bundle.js.dev'
+  '!bundle.js.sfx.dev.deps'
 ],
           function() {
             return merge2(gulp.src('dist/js/bundle/**').pipe(gulp.dest('dist/js/prod/es5/bundle')),
@@ -1168,7 +1159,6 @@ gulp.task('bundles.js', [
   '!bundle.js.min.deps',
   '!bundle.web_worker.js.dev.deps',
   '!bundle.js.sfx.dev.deps',
-  '!router.bundle.js.dev',
   '!bundle.testing',
   '!bundle.copy']);
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1066,8 +1066,9 @@ gulp.task('!bundle.js.sfx.dev', ['build.js.dev'], function() {
 
 gulp.task('!bundle.js.prod.deps', ['!bundle.js.prod'], function() {
   return merge2(
-    addDevDependencies('angular2.min.js'),
-    bundler.modify(['dist/build/http.js'], 'http.js')
+    addDevDependencies('angular2.js'),
+    bundler.modify(['dist/build/http.js'], 'http.js'),
+    bundler.modify(['dist/build/router.js'], 'router.js')
   )
     .pipe(gulp.dest('dist/js/bundle'));
 });
@@ -1075,7 +1076,8 @@ gulp.task('!bundle.js.prod.deps', ['!bundle.js.prod'], function() {
 gulp.task('!bundle.js.min.deps', ['!bundle.js.min'], function() {
   return merge2(
     addDevDependencies('angular2.min.js'),
-    bundler.modify(['dist/build/http.min.js'], 'http.min.js')
+    bundler.modify(['dist/build/http.min.js'], 'http.min.js'),
+    bundler.modify(['dist/build/router.min.js'], 'router.min.js')
   )
     .pipe(uglify())
     .pipe(gulp.dest('dist/js/bundle'));
@@ -1109,10 +1111,12 @@ function addDevDependencies(outputFile) {
 }
 
 gulp.task('!bundle.js.dev.deps', ['!bundle.js.dev'], function() {
-  var bundle = addDevDependencies('angular2.dev.js');
-  return merge2(bundle, bundler.modify(
-    ['dist/build/http.dev.js'], 'http.dev.js')
-      .pipe(gulp.dest('dist/js/bundle')));
+  return merge2(
+    addDevDependencies('angular2.dev.js'),
+    bundler.modify(['dist/build/http.dev.js'], 'http.dev.js'),
+    bundler.modify(['dist/build/router.dev.js'], 'router.dev.js')
+  )
+    .pipe(gulp.dest('dist/js/bundle'));
 });
 
 gulp.task('!bundle.js.sfx.dev.deps', ['!bundle.js.sfx.dev'], function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1065,11 +1065,8 @@ gulp.task('!bundle.js.sfx.dev', ['build.js.dev'], function() {
 });
 
 gulp.task('!bundle.js.prod.deps', ['!bundle.js.prod'], function() {
-  return merge2(bundler.modify(
-      ['node_modules/zone.js/dist/zone-microtask.js', 'node_modules/reflect-metadata/Reflect.js',
-      'dist/build/angular2.js'],
-      'angular2.js'
-    ),
+  return merge2(
+    addDevDependencies('angular2.min.js'),
     bundler.modify(
         ['node_modules/reflect-metadata/Reflect.js', 'dist/build/http.js'],
         'http.js'
@@ -1077,11 +1074,8 @@ gulp.task('!bundle.js.prod.deps', ['!bundle.js.prod'], function() {
 });
 
 gulp.task('!bundle.js.min.deps', ['!bundle.js.min'], function() {
-  return merge2(bundler.modify(
-      ['node_modules/zone.js/dist/zone-microtask.min.js',
-      'node_modules/reflect-metadata/Reflect.js', 'dist/build/angular2.min.js'],
-      'angular2.min.js'
-    ),
+  return merge2(
+    addDevDependencies('angular2.min.js'),
     bundler.modify(
         ['node_modules/reflect-metadata/Reflect.js', 'dist/build/http.min.js'],
         'http.min.js'


### PR DESCRIPTION
There is a series of commits here that unifies gulp tasks for angular2, http and router bundles, harmonizing things are removing code duplication.

I'm doing those changes in preparation for producing CJS bundles - before I introduce those I want to make sure that our bundles creation pipeline is as simple and as unified as possible (still several changes to do here, but hey, baby steps...).
