### PR TITLE
chore(test): failures in browsers which do no support Symbol.iterator

### DIFF
--- a/modules/angular2/src/testing/shims_for_IE.js
+++ b/modules/angular2/src/testing/shims_for_IE.js
@@ -128,3 +128,7 @@ if (!window.console.assert) window.console.assert = function () { };
             clearTimeout(id);
         };
 }());
+
+// Workaround for https://github.com/angular/angular/issues/5067
+// TODO: remove as part of the issue resolution
+if (!window.Symbol) window.Symbol = {iterator: '_es6-shim iterator_'};


### PR DESCRIPTION
Temporary workaround for issue #5067
It should prevent test failure until the issue is properly fixed.
