### PR TITLE
chore: fix incremental test.unit.dart

### DIFF
--- a/tools/broccoli/broccoli-ts2dart.ts
+++ b/tools/broccoli/broccoli-ts2dart.ts
@@ -19,7 +19,7 @@ class TSToDartTranspiler implements DiffingBroccoliPlugin {
   }
 
   rebuild(treeDiff: DiffResult) {
-    let toEmit = [];
+    let toEmit = [path.resolve(this.inputPath, 'angular2/manual_typings/globals.d.ts')];
     let getDartFilePath = (path: string) => path.replace(/((\.js)|(\.ts))$/i, '.dart');
     treeDiff.addedPaths.concat(treeDiff.changedPaths)
         .forEach((changedPath) => {
@@ -43,7 +43,6 @@ class TSToDartTranspiler implements DiffingBroccoliPlugin {
       let dartOutputFilePath = getDartFilePath(removedPath);
       fs.unlinkSync(path.join(this.cachePath, dartOutputFilePath));
     });
-
     this.transpiler.transpile(toEmit, this.cachePath);
   }
 }


### PR DESCRIPTION
Always pass the global typings to ts2dart, independent of the result of the diffing

Closes #4881
