### PR TITLE
fix(dom/events): do not throw an exception if Hammer.js is not loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ pubspec.lock
 modules/.settings
 .vscode
 modules/.vscode
+angular.iml
 
 # Don't check in secret files
 *secret.js

--- a/modules/angular2/src/core/render/dom/events/hammer_gestures.dart
+++ b/modules/angular2/src/core/render/dom/events/hammer_gestures.dart
@@ -2,7 +2,6 @@ library angular.events;
 
 import 'dart:html';
 import './hammer_common.dart';
-import 'package:angular2/src/facade/exceptions.dart' show BaseException;
 import "package:angular2/src/core/di.dart" show Injectable;
 
 import 'dart:js' as js;
@@ -12,12 +11,7 @@ class HammerGesturesPlugin extends HammerGesturesPluginCommon {
   bool supports(String eventName) {
     if (!super.supports(eventName)) return false;
 
-    if (!js.context.hasProperty('Hammer')) {
-      throw new BaseException(
-          'Hammer.js is not loaded, can not bind ${eventName} event');
-    }
-
-    return true;
+    return js.context.hasProperty('Hammer');
   }
 
   addEventListener(Element element, String eventName, Function handler) {

--- a/modules/angular2/src/core/render/dom/events/hammer_gestures.ts
+++ b/modules/angular2/src/core/render/dom/events/hammer_gestures.ts
@@ -8,11 +8,7 @@ export class HammerGesturesPlugin extends HammerGesturesPluginCommon {
   supports(eventName: string): boolean {
     if (!super.supports(eventName)) return false;
 
-    if (!isPresent(window['Hammer'])) {
-      throw new BaseException(`Hammer.js is not loaded, can not bind ${eventName} event`);
-    }
-
-    return true;
+    return isPresent(window['Hammer']);
   }
 
   addEventListener(element: HTMLElement, eventName: string, handler: Function) {

--- a/modules/angular2/test/core/render/dom/events/hammer_gestures_spec.dart
+++ b/modules/angular2/test/core/render/dom/events/hammer_gestures_spec.dart
@@ -1,0 +1,15 @@
+library angular2.render.dom.events.hammer_gestures.test;
+
+import 'package:angular2/testing_internal.dart';
+import 'package:angular2/src/core/render/dom/events/hammer_gestures.dart';
+
+main() {
+  describe('HammerGesturesSupport', () {
+
+    it('should return false if Hammer.js is not loaded', () {
+      HammerGesturesPlugin h = new HammerGesturesPlugin();
+      expect(h.supports('press'), false);
+    });
+
+  });
+}

--- a/modules/angular2/test/core/render/dom/events/hammer_gestures_spec.ts
+++ b/modules/angular2/test/core/render/dom/events/hammer_gestures_spec.ts
@@ -1,0 +1,29 @@
+import {
+  AsyncTestCompleter,
+  beforeEach,
+  ddescribe,
+  describe,
+  el,
+  expect,
+  iit,
+  inject,
+  it,
+  xit,
+  beforeEachBindings,
+  SpyObject
+} from 'angular2/testing_internal';
+
+import {HammerGesturesPlugin} from 'angular2/src/core/render/dom/events/hammer_gestures';
+
+export function main() {
+  if (typeof window !== 'undefined') {
+    describe('HammerGesturesSupport', () => {
+
+      it('should return false if Hammer.js is not loaded', () => {
+        const h = new HammerGesturesPlugin();
+        expect(h.supports('press')).toEqual(false);
+      });
+
+    });
+  }
+}


### PR DESCRIPTION
Close #4363
