### PR TITLE
docs(onDestroy): fix broken backticks

### DIFF
--- a/modules/angular2/src/core/linker/interfaces.ts
+++ b/modules/angular2/src/core/linker/interfaces.ts
@@ -225,7 +225,7 @@ export interface DoCheck { doCheck(); }
  * }
  *
  * bootstrap(App).catch(err => console.error(err));
- * * ```
+ * ```
  */
 export interface OnDestroy { onDestroy(); }
 


### PR DESCRIPTION
This was causing a warning in the angular.io dgeni processing.
