### PR TITLE
chore(build): more clean up for legacy typings bundle creation

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -145,12 +145,6 @@ You can selectively build either the JS or Dart versions as follows:
 * `$(npm bin)/gulp build.js`
 * `$(npm bin)/gulp build.dart`
 
-Also note that in order for the whole test suite to succeed you will need to generate the type definitions by running:
-
-```shell
-$(npm bin)/gulp docs/typings
-```
-
 To clean out the `dist` folder, run:
 
 ```shell

--- a/scripts/publish/npm_publish.sh
+++ b/scripts/publish/npm_publish.sh
@@ -7,7 +7,7 @@ cd $ROOT_DIR
 
 gulp clean
 # benchpress.bundle and bundles.js will implicitly build everything we need
-gulp benchpress.bundle bundles.js docs/typings
+gulp benchpress.bundle bundles.js
 
 NPM_DIR=$ROOT_DIR/dist/npm
 rm -fr $NPM_DIR
@@ -35,7 +35,6 @@ function publishModule {
     # Copy Bundles
     cp -r $ROOT_DIR/dist/js/bundle/$FILES $PUBLISH_DIR/bundles
     # Copy Typings
-    cp -r $ROOT_DIR/dist/docs/typings/angular2/$DTS_FILES $PUBLISH_DIR/bundles/typings/angular2
     cp -r $ROOT_DIR/modules/angular2/typings/es6-shim/$DTS_FILES $PUBLISH_DIR/bundles/typings/es6-shim
     cp -r $ROOT_DIR/modules/angular2/typings/jasmine/$DTS_FILES $PUBLISH_DIR/bundles/typings/jasmine
   fi


### PR DESCRIPTION
Related to 5f2eb3e078aeb8c3966e8fb279c332506021e58d

There were some left-overs from cleanup to the dgeni generated typings. Discovered while testing bundles and publishing to npm.

cc: @alexeagle 
