### PR TITLE
refactor(dart/transform): Remove generate_change_detectors

### DIFF
--- a/modules_dart/transform/lib/src/transform/common/options.dart
+++ b/modules_dart/transform/lib/src/transform/common/options.dart
@@ -8,13 +8,12 @@ import 'mirror_mode.dart';
 const CUSTOM_ANNOTATIONS_PARAM = 'custom_annotations';
 const ENTRY_POINT_PARAM = 'entry_points';
 const FORMAT_CODE_PARAM = 'format_code';
-// TODO(kegluenq): Remove this after 30 Oct (i/4433).
-const GENERATE_CHANGE_DETECTORS_PARAM = 'generate_change_detectors';
-const REFLECT_PROPERTIES_AS_ATTRIBUTES = 'reflectPropertiesAsAttributes';
+const REFLECT_PROPERTIES_AS_ATTRIBUTES = 'reflect_properties_as_attributes';
+// TODO(kegluenq): Remove this after 30 Nov (i/5108).
+const REFLECT_PROPERTIES_AS_ATTRIBUTES_OLD = 'reflectPropertiesAsAttributes';
 const INIT_REFLECTOR_PARAM = 'init_reflector';
 const INLINE_VIEWS_PARAM = 'inline_views';
 const MIRROR_MODE_PARAM = 'mirror_mode';
-const OPTIMIZATION_PHASES_PARAM = 'optimization_phases';
 
 /// Provides information necessary to transform an Angular2 app.
 class TransformerOptions {
@@ -35,6 +34,9 @@ class TransformerOptions {
   /// The [AnnotationMatcher] which is used to identify angular annotations.
   final AnnotationMatcher annotationMatcher;
 
+  /// Whether to reflect property values as attributes.
+  /// If this is `true`, the change detection code will echo set property values
+  /// as attributes on DOM elements, which may aid in application debugging.
   final bool reflectPropertiesAsAttributes;
 
   /// Whether to format generated code.

--- a/modules_dart/transform/lib/src/transform/common/options_reader.dart
+++ b/modules_dart/transform/lib/src/transform/common/options_reader.dart
@@ -13,6 +13,11 @@ TransformerOptions parseBarbackSettings(BarbackSettings settings) {
       _readBool(config, INIT_REFLECTOR_PARAM, defaultValue: true);
   var reflectPropertiesAsAttributes =
       _readBool(config, REFLECT_PROPERTIES_AS_ATTRIBUTES, defaultValue: false);
+  if (!config.containsKey(REFLECT_PROPERTIES_AS_ATTRIBUTES)) {
+    reflectPropertiesAsAttributes = _readBool(
+        config, REFLECT_PROPERTIES_AS_ATTRIBUTES_OLD,
+        defaultValue: false);
+  }
   var formatCode = _readBool(config, FORMAT_CODE_PARAM, defaultValue: false);
   String mirrorModeVal =
       config.containsKey(MIRROR_MODE_PARAM) ? config[MIRROR_MODE_PARAM] : '';
@@ -113,8 +118,9 @@ const CUSTOM_ANNOTATIONS_ERROR = '''
           superClass: ...''';
 
 void _warnDeprecated(Map config) {
-  if (config.containsKey(GENERATE_CHANGE_DETECTORS_PARAM)) {
-    print('${GENERATE_CHANGE_DETECTORS_PARAM} is no longer necessary for '
-        'Angular 2 apps. Please remove it from your pubspec.');
+  if (config.containsKey(REFLECT_PROPERTIES_AS_ATTRIBUTES_OLD)) {
+    print('${REFLECT_PROPERTIES_AS_ATTRIBUTES_OLD} has been renamed to '
+        '${REFLECT_PROPERTIES_AS_ATTRIBUTES}. Please update it in your '
+        'pubspec.');
   }
 }


### PR DESCRIPTION
The template compiler update removed the option to run the transformer
without generating change detectors and deprecated the
`generate_change_detectors` transformer parameter.

Now that it has been deprecated for several weeks, remove it from the
transformer code.

Forward `reflectPropertiesAsAttributes` => `reflect_properties_as_attributes`
and add a deprecation warning to `reflectPropertiesAsAttributes`.

Closes #4433
