### PR TITLE
refactor(http): remove unused facade imports

### DIFF
--- a/modules/angular2/src/http/backends/mock_backend.ts
+++ b/modules/angular2/src/http/backends/mock_backend.ts
@@ -4,7 +4,7 @@ import {Response} from '../static_response';
 import {ReadyStates} from '../enums';
 import {Connection, ConnectionBackend} from '../interfaces';
 import {isPresent} from 'angular2/src/core/facade/lang';
-import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
+import {BaseException} from 'angular2/src/core/facade/exceptions';
 var Rx = require('@reactivex/rxjs/dist/cjs/Rx');
 let {Subject, ReplaySubject} = Rx;
 

--- a/modules/angular2/src/http/enums.ts
+++ b/modules/angular2/src/http/enums.ts
@@ -1,5 +1,3 @@
-import {StringMapWrapper} from 'angular2/src/core/facade/collection';
-
 /**
  * Supported http methods.
  */

--- a/modules/angular2/src/http/http.ts
+++ b/modules/angular2/src/http/http.ts
@@ -1,4 +1,4 @@
-import {isString, isPresent, isBlank} from 'angular2/src/core/facade/lang';
+import {isString, isPresent} from 'angular2/src/core/facade/lang';
 import {makeTypeError} from 'angular2/src/core/facade/exceptions';
 import {Injectable} from 'angular2/angular2';
 import {RequestOptionsArgs, Connection, ConnectionBackend} from './interfaces';

--- a/modules/angular2/src/http/interfaces.ts
+++ b/modules/angular2/src/http/interfaces.ts
@@ -1,6 +1,5 @@
 import {ReadyStates, RequestMethods, ResponseTypes} from './enums';
 import {Headers} from './headers';
-import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 import {EventEmitter} from 'angular2/src/core/facade/async';
 import {Request} from './static_request';
 import {URLSearchParams} from './url_search_params';

--- a/modules/angular2/src/http/static_request.ts
+++ b/modules/angular2/src/http/static_request.ts
@@ -2,13 +2,7 @@ import {RequestMethods} from './enums';
 import {RequestArgs} from './interfaces';
 import {Headers} from './headers';
 import {normalizeMethodName} from './http_utils';
-import {
-  RegExpWrapper,
-  CONST_EXPR,
-  isPresent,
-  isJsObject,
-  StringWrapper
-} from 'angular2/src/core/facade/lang';
+import {isPresent, StringWrapper} from 'angular2/src/core/facade/lang';
 
 // TODO(jeffbcross): properly implement body accessors
 /**

--- a/modules/angular2/src/http/static_response.ts
+++ b/modules/angular2/src/http/static_response.ts
@@ -1,5 +1,5 @@
 import {ResponseTypes} from './enums';
-import {CONST_EXPR, isString, isPresent, Json} from 'angular2/src/core/facade/lang';
+import {isString, Json} from 'angular2/src/core/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
 import {Headers} from './headers';
 import {ResponseOptions} from './base_response_options';

--- a/modules/angular2/src/http/url_search_params.ts
+++ b/modules/angular2/src/http/url_search_params.ts
@@ -1,10 +1,5 @@
-import {CONST_EXPR, isPresent, isBlank, StringWrapper} from 'angular2/src/core/facade/lang';
-import {
-  Map,
-  MapWrapper,
-  ListWrapper,
-  isListLikeIterable
-} from 'angular2/src/core/facade/collection';
+import {isPresent, StringWrapper} from 'angular2/src/core/facade/lang';
+import {Map, ListWrapper, isListLikeIterable} from 'angular2/src/core/facade/collection';
 
 function paramParser(rawParams: string = ''): Map<string, string[]> {
   var map = new Map<string, string[]>();


### PR DESCRIPTION
I'm working on bundling and trying to see what / why `http` uses from facades. Spotted several unnecessary imports while doing this work, hence this PR.
