### PR TITLE
refactor(router): remove unused facade imports

### DIFF
--- a/modules/angular2/src/router/async_route_handler.ts
+++ b/modules/angular2/src/router/async_route_handler.ts
@@ -1,5 +1,5 @@
 import {RouteHandler} from './route_handler';
-import {Promise, PromiseWrapper} from 'angular2/src/core/facade/async';
+import {Promise} from 'angular2/src/core/facade/async';
 import {isPresent, Type} from 'angular2/src/core/facade/lang';
 
 export class AsyncRouteHandler implements RouteHandler {

--- a/modules/angular2/src/router/instruction.ts
+++ b/modules/angular2/src/router/instruction.ts
@@ -1,4 +1,4 @@
-import {Map, MapWrapper, StringMapWrapper, ListWrapper} from 'angular2/src/core/facade/collection';
+import {StringMapWrapper} from 'angular2/src/core/facade/collection';
 import {unimplemented} from 'angular2/src/core/facade/exceptions';
 import {isPresent, isBlank, normalizeBlank, Type, CONST_EXPR} from 'angular2/src/core/facade/lang';
 import {Promise} from 'angular2/src/core/facade/async';

--- a/modules/angular2/src/router/path_recognizer.ts
+++ b/modules/angular2/src/router/path_recognizer.ts
@@ -1,14 +1,6 @@
-import {
-  RegExp,
-  RegExpWrapper,
-  RegExpMatcherWrapper,
-  StringWrapper,
-  isPresent,
-  isBlank
-} from 'angular2/src/core/facade/lang';
-import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
-
-import {Map, MapWrapper, StringMapWrapper} from 'angular2/src/core/facade/collection';
+import {RegExpWrapper, StringWrapper, isPresent, isBlank} from 'angular2/src/core/facade/lang';
+import {BaseException} from 'angular2/src/core/facade/exceptions';
+import {Map, StringMapWrapper} from 'angular2/src/core/facade/collection';
 
 import {RouteHandler} from './route_handler';
 import {Url, RootUrl, serializeParams} from './url_parser';

--- a/modules/angular2/src/router/route_config_impl.ts
+++ b/modules/angular2/src/router/route_config_impl.ts
@@ -1,4 +1,4 @@
-import {CONST, Type, isPresent} from 'angular2/src/core/facade/lang';
+import {CONST, Type} from 'angular2/src/core/facade/lang';
 import {RouteDefinition} from './route_definition';
 export {RouteDefinition} from './route_definition';
 

--- a/modules/angular2/src/router/route_config_nomalizer.ts
+++ b/modules/angular2/src/router/route_config_nomalizer.ts
@@ -1,7 +1,7 @@
 import {AsyncRoute, AuxRoute, Route, Redirect, RouteDefinition} from './route_config_decorator';
 import {ComponentDefinition} from './route_definition';
 import {isType, Type} from 'angular2/src/core/facade/lang';
-import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
+import {BaseException} from 'angular2/src/core/facade/exceptions';
 
 
 /**

--- a/modules/angular2/src/router/route_definition.ts
+++ b/modules/angular2/src/router/route_definition.ts
@@ -1,4 +1,4 @@
-import {CONST, Type} from 'angular2/src/core/facade/lang';
+import {Type} from 'angular2/src/core/facade/lang';
 
 /**
  * `RouteDefinition` defines a route within a {@link RouteConfig} decorator.

--- a/modules/angular2/src/router/route_handler.ts
+++ b/modules/angular2/src/router/route_handler.ts
@@ -1,4 +1,4 @@
-import {Promise, PromiseWrapper} from 'angular2/src/core/facade/async';
+import {Promise} from 'angular2/src/core/facade/async';
 import {Type} from 'angular2/src/core/facade/lang';
 
 export interface RouteHandler {

--- a/modules/angular2/src/router/route_lifecycle_reflector.ts
+++ b/modules/angular2/src/router/route_lifecycle_reflector.ts
@@ -1,4 +1,4 @@
-import {Type, isPresent} from 'angular2/src/core/facade/lang';
+import {Type} from 'angular2/src/core/facade/lang';
 import {RouteLifecycleHook, CanActivate} from './lifecycle_annotations_impl';
 import {reflector} from 'angular2/src/core/reflection/reflection';
 

--- a/modules/angular2/src/router/route_recognizer.ts
+++ b/modules/angular2/src/router/route_recognizer.ts
@@ -1,14 +1,5 @@
-import {
-  RegExp,
-  RegExpWrapper,
-  StringWrapper,
-  isBlank,
-  isPresent,
-  isType,
-  isStringMap,
-  Type
-} from 'angular2/src/core/facade/lang';
-import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
+import {StringWrapper, isBlank, isPresent, Type} from 'angular2/src/core/facade/lang';
+import {BaseException} from 'angular2/src/core/facade/exceptions';
 import {Map, MapWrapper, ListWrapper, StringMapWrapper} from 'angular2/src/core/facade/collection';
 
 import {PathRecognizer, PathMatch} from './path_recognizer';

--- a/modules/angular2/src/router/route_registry.ts
+++ b/modules/angular2/src/router/route_registry.ts
@@ -1,7 +1,7 @@
 import {PathMatch} from './path_recognizer';
 import {RouteRecognizer} from './route_recognizer';
 import {Instruction, ComponentInstruction, PrimaryInstruction} from './instruction';
-import {ListWrapper, Map, MapWrapper, StringMapWrapper} from 'angular2/src/core/facade/collection';
+import {ListWrapper, Map} from 'angular2/src/core/facade/collection';
 import {Promise, PromiseWrapper} from 'angular2/src/core/facade/async';
 import {
   isPresent,
@@ -9,12 +9,10 @@ import {
   isType,
   isString,
   isStringMap,
-  isFunction,
-  StringWrapper,
   Type,
   getTypeNameForDebugging
 } from 'angular2/src/core/facade/lang';
-import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
+import {BaseException} from 'angular2/src/core/facade/exceptions';
 import {
   RouteConfig,
   AsyncRoute,

--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -4,16 +4,9 @@ import {
   EventEmitter,
   ObservableWrapper
 } from 'angular2/src/core/facade/async';
-import {Map, StringMapWrapper, MapWrapper, ListWrapper} from 'angular2/src/core/facade/collection';
-import {
-  isBlank,
-  isString,
-  StringWrapper,
-  isPresent,
-  Type,
-  isArray
-} from 'angular2/src/core/facade/lang';
-import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
+import {Map, StringMapWrapper, ListWrapper} from 'angular2/src/core/facade/collection';
+import {isBlank, isString, StringWrapper, isPresent, Type} from 'angular2/src/core/facade/lang';
+import {BaseException} from 'angular2/src/core/facade/exceptions';
 import {RouteRegistry} from './route_registry';
 import {
   ComponentInstruction,

--- a/modules/angular2/src/router/router_outlet.ts
+++ b/modules/angular2/src/router/router_outlet.ts
@@ -1,7 +1,7 @@
 import {Promise, PromiseWrapper} from 'angular2/src/core/facade/async';
 import {StringMapWrapper} from 'angular2/src/core/facade/collection';
 import {isBlank, isPresent} from 'angular2/src/core/facade/lang';
-import {BaseException, WrappedException} from 'angular2/src/core/facade/exceptions';
+import {BaseException} from 'angular2/src/core/facade/exceptions';
 
 import {
   Directive,


### PR DESCRIPTION
I'm working on bundling and trying to see what / why router uses from facades. Spotted several unnecessary imports while doing this work, hence this PR.
