### PR TITLE
feat(dart/transform): Introduce @angularEntrypoint

### DIFF
--- a/modules/angular2/angular2.dart
+++ b/modules/angular2/angular2.dart
@@ -9,6 +9,7 @@ export 'package:angular2/core.dart'
     hide forwardRef, resolveForwardRef, ForwardRefFn;
 export 'package:angular2/common.dart';
 export 'package:angular2/instrumentation.dart';
+export 'package:angular2/src/core/angular_entrypoint.dart' show AngularEntrypoint;
 export 'package:angular2/src/core/application_tokens.dart'
     hide APP_COMPONENT_REF_PROMISE, APP_ID_RANDOM_PROVIDER;
 export 'package:angular2/src/platform/dom/dom_tokens.dart';

--- a/modules/angular2/bootstrap.ts
+++ b/modules/angular2/bootstrap.ts
@@ -3,3 +3,4 @@
  * @deprecated
  */
 export {bootstrap} from 'angular2/platform/browser';
+export {AngularEntrypoint} from 'angular2/src/core/angular_entrypoint';

--- a/modules/angular2/bootstrap_static.ts
+++ b/modules/angular2/bootstrap_static.ts
@@ -3,3 +3,4 @@
  * @deprecated
  */
 export {bootstrapStatic} from 'angular2/platform/browser_static';
+export {AngularEntrypoint} from 'angular2/src/core/angular_entrypoint';

--- a/modules/angular2/platform/browser.ts
+++ b/modules/angular2/platform/browser.ts
@@ -1,3 +1,4 @@
+export {AngularEntrypoint} from 'angular2/src/core/angular_entrypoint';
 export {
   BROWSER_PROVIDERS,
   ELEMENT_PROBE_BINDINGS,

--- a/modules/angular2/platform/browser_static.ts
+++ b/modules/angular2/platform/browser_static.ts
@@ -1,3 +1,4 @@
+export {AngularEntrypoint} from 'angular2/src/core/angular_entrypoint';
 export {
   BROWSER_PROVIDERS,
   ELEMENT_PROBE_BINDINGS,
@@ -10,13 +11,13 @@ export {
   disableDebugTools
 } from 'angular2/src/platform/browser_common';
 
-import {Type, isPresent, CONST_EXPR} from 'angular2/src/facade/lang';
+import {Type, isPresent} from 'angular2/src/facade/lang';
 import {Promise} from 'angular2/src/facade/promise';
 import {
   BROWSER_PROVIDERS,
   BROWSER_APP_COMMON_PROVIDERS
 } from 'angular2/src/platform/browser_common';
-import {ComponentRef, platform, reflector} from 'angular2/core';
+import {ComponentRef, platform} from 'angular2/core';
 
 /**
  * An array of providers that should be passed into `application()` when bootstrapping a component

--- a/modules/angular2/src/core/angular_entrypoint.ts
+++ b/modules/angular2/src/core/angular_entrypoint.ts
@@ -1,0 +1,22 @@
+import {CONST} from 'angular2/src/facade/lang';
+
+/**
+ * Marks a function or method as an Angular 2 entrypoint. Only necessary in Dart code.
+ *
+ * The optional `name` parameter will be reflected in logs when the entry point is processed.
+ *
+ * See [the wiki][] for detailed documentation.
+ * [the wiki]: https://github.com/angular/angular/wiki/Angular-2-Dart-Transformer#entry_points
+ *
+ * ## Example
+ *
+ * ```
+ * @AngularEntrypoint("name-for-debug")
+ * void main() {
+ *   bootstrap(MyComponent);
+ * }
+ */
+@CONST()
+export class AngularEntrypoint {
+  constructor(public name?: String) {}
+}

--- a/modules/angular2/test/public_api_spec.ts
+++ b/modules/angular2/test/public_api_spec.ts
@@ -76,6 +76,8 @@ var NG_ALL = [
   'AbstractControlDirective.valid',
   'AbstractControlDirective.value',
   'AbstractControlDirective.path',
+  'AngularEntrypoint',
+  'AngularEntrypoint.name',
   'AppRootUrl',
   'AppRootUrl.value',
   'AppRootUrl.value=',

--- a/modules_dart/payload/hello_world/web/index.dart
+++ b/modules_dart/payload/hello_world/web/index.dart
@@ -1,9 +1,10 @@
 library hello_world.index;
 
-import "package:angular2/bootstrap.dart" show bootstrap;
+import "package:angular2/bootstrap.dart" show AngularEntrypoint, bootstrap;
 import "package:angular2/angular2.dart"
     show Component, Directive, ElementRef, Injectable, Renderer;
 
+@AngularEntrypoint("Hello World Entrypoint")
 main() {
   bootstrap(HelloCmp);
 }

--- a/modules_dart/transform/lib/src/transform/common/annotation_matcher.dart
+++ b/modules_dart/transform/lib/src/transform/common/annotation_matcher.dart
@@ -22,7 +22,7 @@ const _INJECTABLES = const [
 
 const _DIRECTIVES = const [
   const ClassDescriptor(
-      'Directive', 'package:angular2/src/core/metadatada/directive.dart',
+      'Directive', 'package:angular2/src/core/metadata/directive.dart',
       superClass: 'Injectable'),
   const ClassDescriptor('Directive', 'package:angular2/src/core/metadata.dart',
       superClass: 'Injectable'),
@@ -57,6 +57,19 @@ const _VIEWS = const [
   const ClassDescriptor('View', 'package:angular2/src/core/metadata.dart'),
 ];
 
+const _ENTRYPOINTS = const [
+  const ClassDescriptor('AngularEntrypoint', 'package:angular2/angular2.dart'),
+  const ClassDescriptor('AngularEntrypoint', 'package:angular2/bootstrap.dart'),
+  const ClassDescriptor(
+      'AngularEntrypoint', 'package:angular2/bootstrap_static.dart'),
+  const ClassDescriptor(
+      'AngularEntrypoint', 'package:angular2/platform/browser.dart'),
+  const ClassDescriptor(
+      'AngularEntrypoint', 'package:angular2/platform/browser_static.dart'),
+  const ClassDescriptor(
+      'AngularEntrypoint', 'package:angular2/src/core/angular_entrypoint.dart'),
+];
+
 /// Checks if a given [Annotation] matches any of the given
 /// [ClassDescriptors].
 class AnnotationMatcher extends ClassMatcherBase {
@@ -67,7 +80,8 @@ class AnnotationMatcher extends ClassMatcherBase {
       ..addAll(_COMPONENTS)
       ..addAll(_DIRECTIVES)
       ..addAll(_INJECTABLES)
-      ..addAll(_VIEWS));
+      ..addAll(_VIEWS)
+      ..addAll(_ENTRYPOINTS));
   }
 
   bool _implementsWithWarning(Annotation annotation, AssetId assetId,
@@ -94,4 +108,8 @@ class AnnotationMatcher extends ClassMatcherBase {
   /// Checks if an [Annotation] node implements [View].
   bool isView(Annotation annotation, AssetId assetId) =>
       _implementsWithWarning(annotation, assetId, _VIEWS);
+
+  /// Checks if an [Annotation] node implements [AngularEntrypoint]
+  bool isEntrypoint(Annotation annotation, AssetId assetId) =>
+      _implementsWithWarning(annotation, assetId, _ENTRYPOINTS);
 }

--- a/modules_dart/transform/lib/src/transform/reflection_remover/entrypoint_matcher.dart
+++ b/modules_dart/transform/lib/src/transform/reflection_remover/entrypoint_matcher.dart
@@ -1,0 +1,59 @@
+library angular2.transform.reflection_remover.entrypoint_matcher;
+
+import 'package:analyzer/analyzer.dart';
+import 'package:barback/barback.dart';
+
+import 'package:angular2/src/transform/common/annotation_matcher.dart';
+import 'package:angular2/src/transform/common/naive_eval.dart';
+
+/// Determines if a [FunctionDeclaration] or [MethodDeclaration] is an
+/// `AngularEntrypoint`.
+class EntrypointMatcher {
+  final AssetId _assetId;
+  final AnnotationMatcher _annotationMatcher;
+
+  EntrypointMatcher(this._assetId, this._annotationMatcher) {
+    if (_assetId == null) {
+      throw new ArgumentError.notNull('AssetId');
+    }
+    if (_annotationMatcher == null) {
+      throw new ArgumentError.notNull('AnnotationMatcher');
+    }
+  }
+
+  bool isEntrypoint(AnnotatedNode node) {
+    if (node == null ||
+        (node is! FunctionDeclaration && node is! MethodDeclaration)) {
+      return false;
+    }
+    return node.metadata
+        .any((a) => _annotationMatcher.isEntrypoint(a, _assetId));
+  }
+
+  /// Gets the name assigned to the `AngularEntrypoint`.
+  ///
+  /// This method assumes the name is the first argument to `AngularEntrypoint`;
+  String getName(AnnotatedNode node) {
+    final annotation = node.metadata.firstWhere(
+        (a) => _annotationMatcher.isEntrypoint(a, _assetId),
+        orElse: () => null);
+    if (annotation == null) return null;
+    if (annotation.arguments == null ||
+        annotation.arguments.arguments == null ||
+        annotation.arguments.arguments.isEmpty) {
+      return _defaultEntrypointName;
+    }
+    final entryPointName = naiveEval(annotation.arguments.arguments.first);
+    if (entryPointName == NOT_A_CONSTANT) {
+      throw new ArgumentError(
+          'Could not evaluate "${node}" as parameter to @AngularEntrypoint');
+    }
+    if (entryPointName is! String) {
+      throw new ArgumentError('Unexpected type "${entryPointName.runtimeType}" '
+          'as first parameter to @AngularEntrypoint');
+    }
+    return entryPointName;
+  }
+}
+
+const _defaultEntrypointName = "(no name provided)";

--- a/modules_dart/transform/lib/src/transform/reflection_remover/remove_reflection_capabilities.dart
+++ b/modules_dart/transform/lib/src/transform/reflection_remover/remove_reflection_capabilities.dart
@@ -2,11 +2,14 @@ library angular2.transform.reflection_remover.remove_reflection_capabilities;
 
 import 'dart:async';
 import 'package:analyzer/analyzer.dart';
-import 'package:angular2/src/transform/common/asset_reader.dart';
-import 'package:angular2/src/transform/common/mirror_mode.dart';
 import 'package:barback/barback.dart';
 
+import 'package:angular2/src/transform/common/annotation_matcher.dart';
+import 'package:angular2/src/transform/common/asset_reader.dart';
+import 'package:angular2/src/transform/common/mirror_mode.dart';
+
 import 'codegen.dart';
+import 'entrypoint_matcher.dart';
 import 'rewriter.dart';
 
 /// Finds the call to the Angular2 `ReflectionCapabilities` constructor
@@ -15,14 +18,15 @@ import 'rewriter.dart';
 ///
 /// This only searches the code in `reflectionEntryPoint`, not `part`s,
 /// `import`s, `export`s, etc.
-Future<String> removeReflectionCapabilities(
-    AssetReader reader, AssetId reflectionEntryPoint,
+Future<String> removeReflectionCapabilities(AssetReader reader,
+    AssetId reflectionEntryPoint, AnnotationMatcher annotationMatcher,
     {MirrorMode mirrorMode: MirrorMode.none,
     bool writeStaticInit: true}) async {
   var code = await reader.readAsString(reflectionEntryPoint);
 
   var codegen = new Codegen(reflectionEntryPoint);
   return new Rewriter(code, codegen,
+          new EntrypointMatcher(reflectionEntryPoint, annotationMatcher),
           mirrorMode: mirrorMode, writeStaticInit: writeStaticInit)
       .rewrite(parseCompilationUnit(code, name: reflectionEntryPoint.path));
 }

--- a/modules_dart/transform/lib/src/transform/reflection_remover/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/reflection_remover/transformer.dart
@@ -52,8 +52,11 @@ class ReflectionRemover extends Transformer implements LazyTransformer {
       }
 
       var transformedCode = await removeReflectionCapabilities(
-          new AssetReader.fromTransform(transform), primaryId,
-          mirrorMode: mirrorMode, writeStaticInit: writeStaticInit);
+          new AssetReader.fromTransform(transform),
+          primaryId,
+          options.annotationMatcher,
+          mirrorMode: mirrorMode,
+          writeStaticInit: writeStaticInit);
       transform.addOutput(new Asset.fromString(primaryId, transformedCode));
     }, log: transform.logger);
   }

--- a/modules_dart/transform/test/transform/reflection_remover/abstract_method_annotation_files/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/abstract_method_annotation_files/index.dart
@@ -1,0 +1,8 @@
+library web_foo;
+
+import 'package:angular2/bootstrap.dart';
+
+abstract class TestBootstrapper {
+  @AngularEntrypoint()
+  void testBootstrap();
+}

--- a/modules_dart/transform/test/transform/reflection_remover/all_tests.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/all_tests.dart
@@ -1,62 +1,123 @@
 library angular2.test.transform.reflection_remover;
 
 import 'package:analyzer/analyzer.dart';
-import 'package:angular2/src/transform/common/mirror_mode.dart';
-import 'package:angular2/src/transform/reflection_remover/codegen.dart';
-import 'package:angular2/src/transform/reflection_remover/rewriter.dart';
 import 'package:barback/barback.dart';
 import 'package:guinness/guinness.dart';
 
-import 'reflection_remover_files/expected/index.dart' as expected;
-import 'debug_mirrors_files/expected/index.dart' as debug_mirrors;
-import 'log_mirrors_files/expected/index.dart' as log_mirrors;
-import 'verbose_files/expected/index.dart' as verbose_mirrors;
-import 'bootstrap_files/expected/index.dart' as bootstrap_expected;
+import 'package:angular2/src/transform/common/annotation_matcher.dart';
+import 'package:angular2/src/transform/common/mirror_mode.dart';
+import 'package:angular2/src/transform/reflection_remover/codegen.dart';
+import 'package:angular2/src/transform/reflection_remover/entrypoint_matcher.dart';
+import 'package:angular2/src/transform/reflection_remover/rewriter.dart';
+
 import '../common/read_file.dart';
+import 'bootstrap_files/expected/index.dart' as bootstrap_expected;
+import 'debug_mirrors_files/expected/index.dart' as debug_mirrors;
+import 'function_annotation_files/expected/index.dart'
+    as func_annotation_expected;
+import 'log_mirrors_files/expected/index.dart' as log_mirrors;
+import 'method_annotation_files/expected/index.dart'
+    as method_annotation_expected;
+import 'reflection_remover_files/expected/index.dart' as expected;
+import 'verbose_files/expected/index.dart' as verbose_mirrors;
 
 main() => allTests();
 
 void allTests() {
-  var assetId = new AssetId('a', 'web/index.dart');
-  var codegen = new Codegen(assetId);
-  var code = readFile('reflection_remover/index.dart').replaceAll('\r\n', '\n');
-  var bootstrapCode = readFile('reflection_remover/bootstrap_files/index.dart')
-      .replaceAll('\r\n', '\n');
+  var entrypointMatcher, assetId, codegen, code;
+
+  beforeEach(() {
+    assetId = new AssetId('a', 'web/index.dart');
+    codegen = new Codegen(assetId);
+    code = readFile('reflection_remover/index.dart').replaceAll('\r\n', '\n');
+    entrypointMatcher = new EntrypointMatcher(assetId, new AnnotationMatcher());
+  });
 
   it(
       'should remove uses of mirrors & '
       'insert calls to generated code by default.', () {
-    var output =
-        new Rewriter(code, codegen).rewrite(parseCompilationUnit(code));
+    var output = new Rewriter(code, codegen, entrypointMatcher)
+        .rewrite(parseCompilationUnit(code));
     expect(output).toEqual(expected.code);
   });
 
   it(
       'should replace uses of mirrors with the debug implementation & '
       'insert calls to generated code in `MirrorMode.debug`.', () {
-    var output = new Rewriter(code, codegen, mirrorMode: MirrorMode.debug)
-        .rewrite(parseCompilationUnit(code));
+    var output = new Rewriter(code, codegen, entrypointMatcher,
+        mirrorMode: MirrorMode.debug).rewrite(parseCompilationUnit(code));
     expect(output).toEqual(debug_mirrors.code);
   });
 
   it(
       'should replace uses of mirrors with the verbose implementation '
       'in `MirrorMode.verbose`.', () {
-    var output = new Rewriter(code, codegen, mirrorMode: MirrorMode.verbose)
-        .rewrite(parseCompilationUnit(code));
+    var output = new Rewriter(code, codegen, entrypointMatcher,
+        mirrorMode: MirrorMode.verbose).rewrite(parseCompilationUnit(code));
     expect(output).toEqual(verbose_mirrors.code);
   });
 
   it('should not initialize the reflector when `writeStaticInit` is `false`.',
       () {
-    var output = new Rewriter(code, codegen, writeStaticInit: false)
-        .rewrite(parseCompilationUnit(code));
+    var output = new Rewriter(code, codegen, entrypointMatcher,
+        writeStaticInit: false).rewrite(parseCompilationUnit(code));
     expect(output).toEqual(log_mirrors.code);
   });
 
   it('should rewrite bootstrap.', () {
-    var output = new Rewriter(bootstrapCode, codegen, writeStaticInit: true)
-        .rewrite(parseCompilationUnit(bootstrapCode));
+    final bootstrapCode =
+        readFile('reflection_remover/bootstrap_files/index.dart')
+            .replaceAll('\r\n', '\n');
+    var output = new Rewriter(bootstrapCode, codegen, entrypointMatcher,
+        writeStaticInit: true).rewrite(parseCompilationUnit(bootstrapCode));
     expect(output).toEqual(bootstrap_expected.code);
+  });
+
+  describe('AngularEntrypoint annotation', () {
+    it('should add a call to `initReflector` at the beginning of the function',
+        () {
+      code = readFile('reflection_remover/function_annotation_files/index.dart')
+          .replaceAll('\r\n', '\n');
+      final output = new Rewriter(code, codegen, entrypointMatcher)
+          .rewrite(parseCompilationUnit(code));
+      expect(output).toEqual(func_annotation_expected.code);
+    });
+
+    it('should `throw` for entrypoints implemented as arrow functions', () {
+      code = readFile('reflection_remover/arrow_annotation_files/index.dart')
+          .replaceAll('\r\n', '\n');
+      expect(() {
+        new Rewriter(code, codegen, entrypointMatcher)
+            .rewrite(parseCompilationUnit(code));
+      }).toThrowWith(anInstanceOf: ArgumentError);
+    });
+
+    it('should `throw` for native functions annotated as entry points', () {
+      code = readFile('reflection_remover/native_annotation_files/index.dart')
+          .replaceAll('\r\n', '\n');
+      expect(() {
+        new Rewriter(code, codegen, entrypointMatcher)
+            .rewrite(parseCompilationUnit(code));
+      }).toThrowWith(anInstanceOf: ArgumentError);
+    });
+
+    it('should `throw` for abstract functions annotated as entry points', () {
+      code = readFile(
+              'reflection_remover/abstract_method_annotation_files/index.dart')
+          .replaceAll('\r\n', '\n');
+      expect(() {
+        new Rewriter(code, codegen, entrypointMatcher)
+            .rewrite(parseCompilationUnit(code));
+      }).toThrowWith(anInstanceOf: ArgumentError);
+    });
+
+    it('should add a call to `initReflector` at the beginning of the method',
+        () {
+      code = readFile('reflection_remover/method_annotation_files/index.dart')
+          .replaceAll('\r\n', '\n');
+      final output = new Rewriter(code, codegen, entrypointMatcher)
+          .rewrite(parseCompilationUnit(code));
+      expect(output).toEqual(method_annotation_expected.code);
+    });
   });
 }

--- a/modules_dart/transform/test/transform/reflection_remover/arrow_annotation_files/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/arrow_annotation_files/index.dart
@@ -1,0 +1,8 @@
+library web_foo;
+
+import 'package:angular2/bootstrap.dart';
+import 'package:angular2/src/core/reflection/reflection.dart';
+import 'package:angular2/src/core/reflection/reflection_capabilities.dart';
+
+@AngularEntrypoint()
+main() => bootstrap(MyComponent);

--- a/modules_dart/transform/test/transform/reflection_remover/function_annotation_files/expected/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/function_annotation_files/expected/index.dart
@@ -1,0 +1,23 @@
+library angular2.test.transform.reflection_remover.function_annotation_files;
+
+// This file is intentionally formatted as a string to avoid having the
+// automatic transformer prettify it.
+//
+// This file represents transformed user code. Because this code will be
+// linked to output by a source map, we cannot change line numbers from the
+// original code and we therefore add our generated code on the same line as
+// those we are removing.
+
+const code = """
+library web_foo;
+
+import 'package:angular2/bootstrap_static.dart';import 'index.ng_deps.dart' as ngStaticInit;
+import 'package:angular2/src/core/reflection/reflection.dart';
+/*import 'package:angular2/src/core/reflection/reflection_capabilities.dart';*/
+
+@AngularEntrypoint()
+void main() {ngStaticInit.initReflector();
+  ngStaticInit.initReflector();/*reflector.reflectionCapabilities = new ReflectionCapabilities();*/
+  bootstrapStatic(MyComponent);
+}
+""";

--- a/modules_dart/transform/test/transform/reflection_remover/function_annotation_files/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/function_annotation_files/index.dart
@@ -1,0 +1,11 @@
+library web_foo;
+
+import 'package:angular2/bootstrap.dart';
+import 'package:angular2/src/core/reflection/reflection.dart';
+import 'package:angular2/src/core/reflection/reflection_capabilities.dart';
+
+@AngularEntrypoint()
+void main() {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  bootstrap(MyComponent);
+}

--- a/modules_dart/transform/test/transform/reflection_remover/method_annotation_files/expected/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/method_annotation_files/expected/index.dart
@@ -1,0 +1,20 @@
+library angular2.test.transform.reflection_remover.method_annotation_files;
+
+// This file is intentionally formatted as a string to avoid having the
+// automatic transformer prettify it.
+//
+// This file represents transformed user code. Because this code will be
+// linked to output by a source map, we cannot change line numbers from the
+// original code and we therefore add our generated code on the same line as
+// those we are removing.
+
+const code = """
+library web_foo;
+
+import 'package:angular2/bootstrap_static.dart';import 'index.ng_deps.dart' as ngStaticInit;
+
+class TestBootstrapper {
+  @AngularEntrypoint("Method entrypoint")
+  void testBootstrap() {ngStaticInit.initReflector();}
+}
+""";

--- a/modules_dart/transform/test/transform/reflection_remover/method_annotation_files/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/method_annotation_files/index.dart
@@ -1,0 +1,8 @@
+library web_foo;
+
+import 'package:angular2/bootstrap.dart';
+
+class TestBootstrapper {
+  @AngularEntrypoint("Method entrypoint")
+  void testBootstrap() {}
+}

--- a/modules_dart/transform/test/transform/reflection_remover/native_annotation_files/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/native_annotation_files/index.dart
@@ -1,0 +1,8 @@
+library web_foo;
+
+import 'package:angular2/bootstrap.dart';
+import 'package:angular2/src/core/reflection/reflection.dart';
+import 'package:angular2/src/core/reflection/reflection_capabilities.dart';
+
+@AngularEntrypoint()
+main() native "MainMethod";


### PR DESCRIPTION
@yjbanov, this is the annotation declaration as I imagine it -- any objections? One result of this being Dart-only is that the examples in `playground/` cannot use it, since the annotation is not available to the .ts code.

Is the idea behind this annotation that the user will no longer need to specify `entry_points` to the transformer?

---

Add an annotation which the transformer uses to determine where to:
- Insert calls to `initReflector`
- Rewrite `import '.../bootstrap.dart'` => `bootstrap_static.dart`
- Rewrite `bootstrap(Type)` => `bootstrapStatic(Type)`

Closes #4865
