### PR TITLE
refactor(dart/transform): Separate log & zone code

### DIFF
--- a/modules_dart/transform/lib/src/transform/common/class_matcher_base.dart
+++ b/modules_dart/transform/lib/src/transform/common/class_matcher_base.dart
@@ -4,7 +4,7 @@ import 'package:analyzer/src/generated/ast.dart';
 import 'package:barback/barback.dart' show AssetId;
 import 'package:code_transformers/assets.dart';
 import 'package:path/path.dart' as path;
-import 'logging.dart' show logger;
+import 'logging.dart' show log;
 
 /// Checks if a given [Identifier] matches any of the given [ClassDescriptor]s.
 abstract class ClassMatcherBase {
@@ -53,7 +53,7 @@ abstract class ClassMatcherBase {
     if (superClass == null) {
       if (missingSuperClassWarning != null &&
           missingSuperClassWarning.isNotEmpty) {
-        logger.warning(missingSuperClassWarning);
+        log.warning(missingSuperClassWarning);
       }
       return false;
     }
@@ -87,7 +87,7 @@ ImportDirective _getMatchingImport(
       return false;
     } else {
       importMatch =
-          descriptor.assetId == uriToAssetId(assetId, uriString, logger, null);
+          descriptor.assetId == uriToAssetId(assetId, uriString, log, null);
     }
 
     if (!importMatch) return false;

--- a/modules_dart/transform/lib/src/transform/common/code/parameter_code.dart
+++ b/modules_dart/transform/lib/src/transform/common/code/parameter_code.dart
@@ -68,7 +68,7 @@ class ParameterVisitor extends SimpleAstVisitor<ParameterModel> {
   @override
   ParameterModel visitFieldFormalParameter(FieldFormalParameter node) {
     if (node.parameters != null) {
-      logger.error('Parameters in ctor not supported '
+      log.error('Parameters in ctor not supported '
           '(${node.toSource()})');
     }
     var type = node.type;
@@ -82,7 +82,7 @@ class ParameterVisitor extends SimpleAstVisitor<ParameterModel> {
   @override
   ParameterModel visitFunctionTypedFormalParameter(
       FunctionTypedFormalParameter node) {
-    logger.error('Function typed formal parameters not supported '
+    log.error('Function typed formal parameters not supported '
         '(${node.toSource()})');
     return _visitNormalFormalParameter(node.metadata, null, node.identifier);
   }

--- a/modules_dart/transform/lib/src/transform/common/code/reflection_info_code.dart
+++ b/modules_dart/transform/lib/src/transform/common/code/reflection_info_code.dart
@@ -56,7 +56,7 @@ class ReflectionInfoVisitor extends RecursiveAstVisitor<ReflectionInfoModel> {
     if (numCtorsFound > 1) {
       var ctorName = ctor.name;
       if (ctorName != null) {
-        logger.warning('Found ${numCtorsFound} constructors for class '
+        log.warning('Found ${numCtorsFound} constructors for class '
             '${node.name}; using constructor ${ctorName}.');
       }
     }
@@ -88,7 +88,7 @@ class ReflectionInfoVisitor extends RecursiveAstVisitor<ReflectionInfoModel> {
       });
       if (componentDirectives != null && componentDirectives.isNotEmpty) {
         if (viewDirectives != null) {
-          logger.warning(
+          log.warning(
               'Cannot specify view parameters on @Component when a @View '
               'is present. Component name: ${model.name}',
               asset: assetId);
@@ -166,7 +166,7 @@ class ReflectionInfoVisitor extends RecursiveAstVisitor<ReflectionInfoModel> {
     if (directivesNode == null) return const [];
 
     if (directivesNode.expression is! ListLiteral) {
-      logger.warning('Angular 2 expects a list literal for `directives` '
+      log.warning('Angular 2 expects a list literal for `directives` '
           'but found a ${directivesNode.expression.runtimeType}');
       return const [];
     }
@@ -179,7 +179,7 @@ class ReflectionInfoVisitor extends RecursiveAstVisitor<ReflectionInfoModel> {
       } else if (dep is Identifier) {
         directives.add(new PrefixedDirective()..name = '${dep}');
       } else {
-        logger.warning('Found unexpected value $dep in `directives`.');
+        log.warning('Found unexpected value $dep in `directives`.');
       }
     }
     return directives;

--- a/modules_dart/transform/lib/src/transform/common/directive_metadata_reader.dart
+++ b/modules_dart/transform/lib/src/transform/common/directive_metadata_reader.dart
@@ -182,7 +182,7 @@ class _DirectiveMetadataVisitor extends Object
       if (_type != null && _type.name != null && _type.name.isNotEmpty) {
         name = _type.name;
       }
-      logger.warning(
+      log.warning(
           'Cannot specify view parameters on @Component when a @View '
           'is present. Component name: ${name}',
           asset: _assetId);

--- a/modules_dart/transform/lib/src/transform/common/ng_meta.dart
+++ b/modules_dart/transform/lib/src/transform/common/ng_meta.dart
@@ -79,7 +79,7 @@ class NgMeta {
         var ngDepsJsonMap = json[key];
         if (ngDepsJsonMap == null) continue;
         if (ngDepsJsonMap is! Map) {
-          logger.warning(
+          log.warning(
               'Unexpected value $ngDepsJsonMap for key "$key" in NgMeta.');
           continue;
         }
@@ -87,7 +87,7 @@ class NgMeta {
       } else {
         var entry = json[key];
         if (entry is! Map) {
-          logger.warning('Unexpected value $entry for key "$key" in NgMeta.');
+          log.warning('Unexpected value $entry for key "$key" in NgMeta.');
           continue;
         }
         if (entry[_KIND_KEY] == _TYPE_VALUE) {
@@ -128,7 +128,7 @@ class NgMeta {
     var seen = new Set();
     helper(name) {
       if (!seen.add(name)) {
-        logger.warning('Circular alias dependency for "$name".');
+        log.warning('Circular alias dependency for "$name".');
         return;
       }
       if (types.containsKey(name)) {
@@ -136,7 +136,7 @@ class NgMeta {
       } else if (aliases.containsKey(name)) {
         aliases[name].forEach(helper);
       } else {
-        logger.warning('Unknown alias: "$name".');
+        log.warning('Unknown alias: "$name".');
       }
     }
     helper(alias);

--- a/modules_dart/transform/lib/src/transform/common/xhr_impl.dart
+++ b/modules_dart/transform/lib/src/transform/common/xhr_impl.dart
@@ -20,7 +20,7 @@ class XhrImpl implements XHR {
   Future<String> get(String url) async {
     final assetId = fromUri(url);
     if (!url.startsWith('asset:')) {
-      logger.warning('XhrImpl received unexpected url: $url');
+      log.warning('XhrImpl received unexpected url: $url');
     }
 
     if (!await _reader.hasInput(assetId)) {

--- a/modules_dart/transform/lib/src/transform/common/zone.dart
+++ b/modules_dart/transform/lib/src/transform/common/zone.dart
@@ -1,0 +1,65 @@
+library angular2.src.transform.common.zone;
+
+import 'dart:async';
+
+import 'package:analyzer/analyzer.dart';
+import 'package:barback/barback.dart';
+import 'package:source_span/source_span.dart';
+
+import 'package:angular2/src/core/compiler/template_compiler.dart';
+
+typedef _SimpleCallback();
+
+// Keys used to store zone local values on the current zone.
+final _loggerKey = #loggingZonedLoggerKey;
+final _templateCompilerKey = #templateCompilerKey;
+
+/// Executes `fn` inside a new `Zone` with the provided zone-local values.
+Future<dynamic> exec(_SimpleCallback fn,
+    {TransformLogger log, TemplateCompiler templateCompiler}) async {
+  return runZoned(() async {
+    try {
+      return await fn();
+    } on AnalyzerError catch (e) {
+      // Do not worry about printing the stack trace, barback will handle
+      // that on its own when it catches the rethrown exception.
+      log.error('  Failed with ${e.runtimeType}\n${_friendlyError(e.error)}');
+      rethrow;
+    } on AnalyzerErrorGroup catch (eGroup) {
+      // See above re: stack trace.
+      var numErrors = eGroup.errors.length;
+      if (numErrors == 1) {
+        log.error(_friendlyError(eGroup.errors[0].error));
+      } else {
+        var buf = new StringBuffer();
+        buf.writeln('  Failed with ${numErrors} errors');
+        for (var i = 0; i < numErrors; ++i) {
+          buf.writeln(
+              'Error ${i + 1}: ${_friendlyError(eGroup.errors[i].error)}');
+        }
+        log.error('$buf');
+      }
+      rethrow;
+    }
+  }, zoneValues: {_loggerKey: log, _templateCompilerKey: templateCompiler});
+}
+
+/// The [TransformLogger] for the current {@link Zone}.
+TransformLogger get log => Zone.current[_loggerKey] as TransformLogger;
+
+/// The [TemplateCompiler] for the current zone.
+TemplateCompiler get templateCompiler => Zone.current[_templateCompilerKey] as TemplateCompiler;
+
+/// Generate a human-readable error message from `error`.
+String _friendlyError(AnalysisError error) {
+  if (error.source != null) {
+    var file =
+        new SourceFile(error.source.contents.data, url: error.source.fullName);
+
+    return file
+        .span(error.offset, error.offset + error.length)
+        .message(error.message, color: false);
+  } else {
+    return '<unknown location>: ${error.message}';
+  }
+}

--- a/modules_dart/transform/lib/src/transform/deferred_rewriter/rewriter.dart
+++ b/modules_dart/transform/lib/src/transform/deferred_rewriter/rewriter.dart
@@ -99,11 +99,11 @@ class _FindDeferredLibraries extends Object with RecursiveAstVisitor<Object> {
 
   bool hasDeferredLibrariesToRewrite() {
     if (deferredImports.isEmpty) {
-      logger.fine('There are no deferred library imports.');
+      log.fine('There are no deferred library imports.');
       return false;
     }
     if (loadLibraryInvocations.isEmpty) {
-      logger.fine(
+      log.fine(
           'There are no loadLibrary invocations that need to be rewritten.');
       return false;
     }

--- a/modules_dart/transform/lib/src/transform/deferred_rewriter/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/deferred_rewriter/transformer.dart
@@ -2,11 +2,12 @@ library angular2.transform.deferred_rewriter.transformer;
 
 import 'dart:async';
 
+import 'package:barback/barback.dart';
+
 import 'package:angular2/src/transform/common/asset_reader.dart';
-import 'package:angular2/src/transform/common/logging.dart' as log;
 import 'package:angular2/src/transform/common/names.dart';
 import 'package:angular2/src/transform/common/options.dart';
-import 'package:barback/barback.dart';
+import 'package:angular2/src/transform/common/zone.dart' as zone;
 
 import 'rewriter.dart';
 
@@ -24,14 +25,14 @@ class DeferredRewriter extends Transformer {
 
   @override
   Future apply(Transform transform) async {
-    await log.initZoned(transform, () async {
+    return zone.exec(() async {
       var asset = transform.primaryInput;
       var reader = new AssetReader.fromTransform(transform);
       var transformedCode = await rewriteDeferredLibraries(reader, asset.id);
       if (transformedCode != null) {
         transform.addOutput(new Asset.fromString(asset.id, transformedCode));
       }
-    });
+    }, log: transform.logger);
   }
 }
 

--- a/modules_dart/transform/lib/src/transform/directive_metadata_linker/ng_deps_linker.dart
+++ b/modules_dart/transform/lib/src/transform/directive_metadata_linker/ng_deps_linker.dart
@@ -84,7 +84,7 @@ Future<Map<String, String>> _processNgImports(NgDepsModel model,
         retVal[directive.uri] = summaryJsonUri;
       }
     }, onError: (err, stack) {
-      logger.warning('Error while looking for $summaryJsonUri. '
+      log.warning('Error while looking for $summaryJsonUri. '
           'Message: $err\n'
           'Stack: $stack');
     });

--- a/modules_dart/transform/lib/src/transform/directive_metadata_linker/ng_meta_linker.dart
+++ b/modules_dart/transform/lib/src/transform/directive_metadata_linker/ng_meta_linker.dart
@@ -77,7 +77,7 @@ Future _linkRecursive(NgMeta ngMeta, AssetReader reader, AssetId assetId,
       }
     } catch (err, st) {
       // Log and continue.
-      logger.warning('Failed to fetch $uri. Message: $err.\n$st');
+      log.warning('Failed to fetch $uri. Message: $err.\n$st');
     }
   }));
 }

--- a/modules_dart/transform/lib/src/transform/directive_metadata_linker/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/directive_metadata_linker/transformer.dart
@@ -3,10 +3,11 @@ library angular2.transform.directive_metadata_linker.transformer;
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:angular2/src/transform/common/asset_reader.dart';
-import 'package:angular2/src/transform/common/logging.dart' as log;
-import 'package:angular2/src/transform/common/names.dart';
 import 'package:barback/barback.dart';
+
+import 'package:angular2/src/transform/common/asset_reader.dart';
+import 'package:angular2/src/transform/common/names.dart';
+import 'package:angular2/src/transform/common/zone.dart' as zone;
 
 import 'ng_meta_linker.dart';
 
@@ -37,7 +38,7 @@ class DirectiveMetadataLinker extends Transformer {
 
   @override
   Future apply(Transform transform) {
-    return log.initZoned(transform, () {
+    return zone.exec(() {
       var primaryId = transform.primaryInput.id;
 
       return linkDirectiveMetadata(
@@ -53,7 +54,7 @@ class DirectiveMetadataLinker extends Transformer {
           }
         }
       });
-    });
+    }, log: transform.logger);
   }
 }
 

--- a/modules_dart/transform/lib/src/transform/directive_processor/inliner.dart
+++ b/modules_dart/transform/lib/src/transform/directive_processor/inliner.dart
@@ -54,11 +54,11 @@ Future<String> _getAllDeclarations(AssetReader reader, AssetId assetId,
   var asyncWriter = new AsyncStringWriter(code.substring(0, partsStart));
   visitor.parts.forEach((partDirective) {
     var uri = stringLiteralToString(partDirective.uri);
-    var partAssetId = uriToAssetId(assetId, uri, logger, null /* span */,
+    var partAssetId = uriToAssetId(assetId, uri, log, null /* span */,
         errorOnAbsolute: false);
     asyncWriter.asyncPrint(reader.readAsString(partAssetId).then((partCode) {
       if (partCode == null || partCode.isEmpty) {
-        logger.warning('Empty part at "${partDirective.uri}. Ignoring.',
+        log.warning('Empty part at "${partDirective.uri}. Ignoring.',
             asset: partAssetId);
         return '';
       }
@@ -66,7 +66,7 @@ Future<String> _getAllDeclarations(AssetReader reader, AssetId assetId,
       var parsedDirectives = parseDirectives(partCode, name: uri).directives;
       return partCode.substring(parsedDirectives.last.end);
     }).catchError((err, stackTrace) {
-      logger.warning(
+      log.warning(
           'Failed while reading part at ${partDirective.uri}. Ignoring.\n'
           'Error: $err\n'
           'Stack Trace: $stackTrace',

--- a/modules_dart/transform/lib/src/transform/directive_processor/rewriter.dart
+++ b/modules_dart/transform/lib/src/transform/directive_processor/rewriter.dart
@@ -3,6 +3,9 @@ library angular2.transform.directive_processor.rewriter;
 import 'dart:async';
 
 import 'package:analyzer/analyzer.dart';
+import 'package:barback/barback.dart' show AssetId;
+
+import 'package:angular2/src/core/compiler/template_compiler.dart';
 import 'package:angular2/src/transform/common/annotation_matcher.dart';
 import 'package:angular2/src/transform/common/asset_reader.dart';
 import 'package:angular2/src/transform/common/code/ng_deps_code.dart';
@@ -11,8 +14,7 @@ import 'package:angular2/src/transform/common/interface_matcher.dart';
 import 'package:angular2/src/transform/common/logging.dart';
 import 'package:angular2/src/transform/common/ng_compiler.dart';
 import 'package:angular2/src/transform/common/ng_meta.dart';
-import 'package:barback/barback.dart' show AssetId;
-import 'package:angular2/src/core/compiler/template_compiler.dart';
+import 'package:angular2/src/transform/common/zone.dart' as zone;
 
 import 'inliner.dart';
 
@@ -35,7 +37,10 @@ Future<NgMeta> createNgMeta(AssetReader reader, AssetId assetId,
   return logElapsedAsync(() async {
     var ngMeta = new NgMeta(ngDeps: ngDepsVisitor.model);
 
-    var templateCompiler = createTemplateCompiler(reader);
+    var templateCompiler = zone.templateCompiler;
+    if (templateCompiler == null) {
+      templateCompiler = createTemplateCompiler(reader);
+    }
     var ngMetaVisitor = new _NgMetaVisitor(ngMeta, assetId, annotationMatcher,
         _interfaceMatcher, templateCompiler);
     parsedCode.accept(ngMetaVisitor);
@@ -91,7 +96,7 @@ class _NgMetaVisitor extends Object with SimpleAstVisitor<Object> {
             compileDirectiveMetadata;
       }
     }).catchError((err) {
-      logger.error('ERROR: $err');
+      log.error('ERROR: $err');
     }));
     return null;
   }

--- a/modules_dart/transform/lib/src/transform/directive_processor/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/directive_processor/transformer.dart
@@ -3,12 +3,13 @@ library angular2.transform.directive_processor.transformer;
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:barback/barback.dart';
+
 import 'package:angular2/src/core/dom/html_adapter.dart';
 import 'package:angular2/src/transform/common/asset_reader.dart';
-import 'package:angular2/src/transform/common/logging.dart' as log;
 import 'package:angular2/src/transform/common/names.dart';
 import 'package:angular2/src/transform/common/options.dart';
-import 'package:barback/barback.dart';
+import 'package:angular2/src/transform/common/zone.dart' as zone;
 
 import 'rewriter.dart';
 
@@ -32,7 +33,7 @@ class DirectiveProcessor extends Transformer {
   @override
   Future apply(Transform transform) async {
     Html5LibDomAdapter.makeCurrent();
-    await log.initZoned(transform, () async {
+    return zone.exec(() async {
       var primaryId = transform.primaryInput.id;
       var reader = new AssetReader.fromTransform(transform);
       var ngMeta =
@@ -42,7 +43,7 @@ class DirectiveProcessor extends Transformer {
       }
       transform.addOutput(new Asset.fromString(
           _ngSummaryAssetId(primaryId), _encoder.convert(ngMeta.toJson())));
-    });
+    }, log: transform.logger);
   }
 }
 

--- a/modules_dart/transform/lib/src/transform/inliner_for_test/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/inliner_for_test/transformer.dart
@@ -4,18 +4,19 @@ import 'dart:async';
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/src/generated/ast.dart';
+import 'package:barback/barback.dart';
+import 'package:dart_style/dart_style.dart';
+
 import 'package:angular2/src/core/compiler/xhr.dart' show XHR;
 import 'package:angular2/src/transform/common/annotation_matcher.dart';
 import 'package:angular2/src/transform/common/asset_reader.dart';
 import 'package:angular2/src/transform/common/naive_eval.dart';
 import 'package:angular2/src/transform/common/async_string_writer.dart';
-import 'package:angular2/src/transform/common/logging.dart';
 import 'package:angular2/src/transform/common/options.dart';
 import 'package:angular2/src/transform/common/url_resolver.dart';
 import 'package:angular2/src/transform/common/xhr_impl.dart';
+import 'package:angular2/src/transform/common/zone.dart' as zone;
 import 'package:angular2/src/transform/directive_processor/inliner.dart';
-import 'package:barback/barback.dart';
-import 'package:dart_style/dart_style.dart';
 
 /// Processes .dart files and inlines `templateUrl` and styleUrls` values.
 class InlinerForTest extends Transformer {
@@ -31,7 +32,7 @@ class InlinerForTest extends Transformer {
 
   @override
   Future apply(Transform transform) async {
-    return initZoned(transform, () async {
+    return zone.exec(() async {
       var primaryId = transform.primaryInput.id;
       var inlinedCode = await inline(new AssetReader.fromTransform(transform),
           primaryId, _annotationMatcher);
@@ -43,7 +44,7 @@ class InlinerForTest extends Transformer {
         }
         transform.addOutput(new Asset.fromString(primaryId, inlinedCode));
       }
-    });
+    }, log: transform.logger);
   }
 }
 
@@ -144,7 +145,7 @@ class _ViewPropInliner extends RecursiveAstVisitor<Object> {
   void _populateStyleUrls(NamedExpression node) {
     var urls = naiveEval(node.expression);
     if (urls is! List) {
-      logger.warning('styleUrls is not a List of Strings (${node.expression})');
+      zone.log.warning('styleUrls is not a List of Strings (${node.expression})');
       return;
     }
     _writer.print(_code.substring(_lastIndex, node.offset));
@@ -156,7 +157,7 @@ class _ViewPropInliner extends RecursiveAstVisitor<Object> {
         _writer.asyncPrint(_readOrEmptyString(url));
         _writer.print("''', ");
       } else {
-        logger.warning('style url is not a String (${url})');
+        zone.log.warning('style url is not a String (${url})');
       }
     }
     _writer.println(']');
@@ -165,7 +166,7 @@ class _ViewPropInliner extends RecursiveAstVisitor<Object> {
   void _populateTemplateUrl(NamedExpression node) {
     var url = naiveEval(node.expression);
     if (url is! String) {
-      logger.warning('template url is not a String (${node.expression})');
+      zone.log.warning('template url is not a String (${node.expression})');
       return;
     }
     _writer.print(_code.substring(_lastIndex, node.offset));
@@ -181,7 +182,7 @@ class _ViewPropInliner extends RecursiveAstVisitor<Object> {
     final resolvedUri = _urlResolver.resolve(_baseUri.toString(), url);
 
     return _xhr.get(resolvedUri).catchError((_) {
-      logger.error('$_baseUri: could not read $url');
+      zone.log.error('$_baseUri: could not read $url');
       return '';
     });
   }

--- a/modules_dart/transform/lib/src/transform/reflection_remover/rewriter.dart
+++ b/modules_dart/transform/lib/src/transform/reflection_remover/rewriter.dart
@@ -91,7 +91,7 @@ class _RewriterVisitor extends Object with RecursiveAstVisitor<Object> {
   Object visitInstanceCreationExpression(InstanceCreationExpression node) {
     if (_rewriter._mirrorMatcher.isNewReflectionCapabilities(node) &&
         !reflectionCapabilityAssignments.contains(node.parent)) {
-      logger.error('Unexpected format in creation of '
+      log.error('Unexpected format in creation of '
           '${REFLECTION_CAPABILITIES_NAME}');
     }
     return super.visitInstanceCreationExpression(node);
@@ -132,7 +132,7 @@ class _RewriterVisitor extends Object with RecursiveAstVisitor<Object> {
       var args = node.argumentList.arguments;
       int numArgs = node.argumentList.arguments.length;
       if (numArgs < 1 || numArgs > 2) {
-        logger.warning('`bootstrap` does not support $numArgs arguments. '
+        log.warning('`bootstrap` does not support $numArgs arguments. '
             'Found bootstrap${node.argumentList}. Transform may not succeed.');
       }
 
@@ -168,7 +168,7 @@ class _RewriterVisitor extends Object with RecursiveAstVisitor<Object> {
   _rewriteReflectionCapabilitiesImport(ImportDirective node) {
     buf.write(_rewriter._code.substring(_currentIndex, node.offset));
     if ('${node.prefix}' == _rewriter._codegen.prefix) {
-      logger.warning(
+      log.warning(
           'Found import prefix "${_rewriter._codegen.prefix}" in source file.'
           ' Transform may not succeed.');
     }

--- a/modules_dart/transform/lib/src/transform/reflection_remover/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/reflection_remover/transformer.dart
@@ -1,12 +1,14 @@
 library angular2.transform.reflection_remover.transformer;
 
 import 'dart:async';
+
+import 'package:barback/barback.dart';
+
 import 'package:angular2/src/transform/common/asset_reader.dart';
-import 'package:angular2/src/transform/common/logging.dart' as log;
 import 'package:angular2/src/transform/common/mirror_mode.dart';
 import 'package:angular2/src/transform/common/names.dart';
 import 'package:angular2/src/transform/common/options.dart';
-import 'package:barback/barback.dart';
+import 'package:angular2/src/transform/common/zone.dart' as zone;
 
 import 'remove_reflection_capabilities.dart';
 
@@ -30,14 +32,14 @@ class ReflectionRemover extends Transformer {
 
   @override
   Future apply(Transform transform) async {
-    await log.initZoned(transform, () async {
+    return zone.exec(() async {
       var primaryId = transform.primaryInput.id;
       var mirrorMode = options.mirrorMode;
       var writeStaticInit = options.initReflector;
       if (options.modeName == TRANSFORM_DYNAMIC_MODE) {
         mirrorMode = MirrorMode.debug;
         writeStaticInit = false;
-        log.logger.info('Running in "${options.modeName}", '
+        zone.log.info('Running in "${options.modeName}", '
             'mirrorMode: ${mirrorMode}, '
             'writeStaticInit: ${writeStaticInit}.');
       }
@@ -46,6 +48,6 @@ class ReflectionRemover extends Transformer {
           new AssetReader.fromTransform(transform), primaryId,
           mirrorMode: mirrorMode, writeStaticInit: writeStaticInit);
       transform.addOutput(new Asset.fromString(primaryId, transformedCode));
-    });
+    }, log: transform.logger);
   }
 }

--- a/modules_dart/transform/lib/src/transform/stylesheet_compiler/processor.dart
+++ b/modules_dart/transform/lib/src/transform/stylesheet_compiler/processor.dart
@@ -2,12 +2,13 @@ library angular2.transform.stylesheet_compiler.processor;
 
 import 'dart:async';
 
+import 'package:angular2/src/core/compiler/source_module.dart';
 import 'package:angular2/src/transform/common/asset_reader.dart';
 import 'package:angular2/src/transform/common/code/source_module.dart';
 import 'package:angular2/src/transform/common/logging.dart';
 import 'package:angular2/src/transform/common/names.dart';
 import 'package:angular2/src/transform/common/ng_compiler.dart';
-import 'package:angular2/src/core/compiler/source_module.dart';
+import 'package:angular2/src/transform/common/zone.dart' as zone;
 
 import 'package:barback/barback.dart';
 
@@ -20,7 +21,10 @@ AssetId nonShimmedStylesheetAssetId(AssetId cssAssetId) => new AssetId(
 Future<Iterable<Asset>> processStylesheet(
     AssetReader reader, AssetId stylesheetId) async {
   final stylesheetUrl = '${stylesheetId.package}|${stylesheetId.path}';
-  final templateCompiler = createTemplateCompiler(reader);
+  var templateCompiler = zone.templateCompiler;
+  if (templateCompiler == null) {
+    templateCompiler = createTemplateCompiler(reader);
+  }
   final cssText = await reader.readAsString(stylesheetId);
   return logElapsedAsync(() async {
     final sourceModules =

--- a/modules_dart/transform/lib/src/transform/stylesheet_compiler/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/stylesheet_compiler/transformer.dart
@@ -2,12 +2,12 @@ library angular2.transform.stylesheet_compiler.transformer;
 
 import 'dart:async';
 
+import 'package:barback/barback.dart';
+
 import 'package:angular2/src/core/dom/html_adapter.dart';
 import 'package:angular2/src/transform/common/asset_reader.dart';
-import 'package:angular2/src/transform/common/logging.dart' as log;
 import 'package:angular2/src/transform/common/names.dart';
-
-import 'package:barback/barback.dart';
+import 'package:angular2/src/transform/common/zone.dart' as zone;
 
 import 'processor.dart';
 
@@ -22,13 +22,13 @@ class StylesheetCompiler extends Transformer {
 
   @override
   Future apply(Transform transform) async {
-    await log.initZoned(transform, () async {
+    final reader = new AssetReader.fromTransform(transform);
+    return zone.exec(() async {
       Html5LibDomAdapter.makeCurrent();
-      var reader = new AssetReader.fromTransform(transform);
       var outputs = await processStylesheet(reader, transform.primaryInput.id);
       outputs.forEach((Asset compiledStylesheet) {
         transform.addOutput(compiledStylesheet);
       });
-    });
+    }, log: transform.logger);
   }
 }

--- a/modules_dart/transform/lib/src/transform/template_compiler/compile_data_creator.dart
+++ b/modules_dart/transform/lib/src/transform/template_compiler/compile_data_creator.dart
@@ -73,7 +73,7 @@ class _CompileDataCreator {
               compileDirectiveMetadata, <CompileDirectiveMetadata>[]);
           for (var dep in reflectable.directives) {
             if (!ngMetaMap.containsKey(dep.prefix)) {
-              logger.warning(
+              log.warning(
                   'Missing prefix "${dep.prefix}" '
                   'needed by "${dep}" from metadata map',
                   asset: entryPoint);
@@ -86,7 +86,7 @@ class _CompileDataCreator {
             } else if (depNgMeta.aliases.containsKey(dep.name)) {
               compileDatum.directives.addAll(depNgMeta.flatten(dep.name));
             } else {
-              logger.warning('Could not find Directive entry for $dep. '
+              log.warning('Could not find Directive entry for $dep. '
                   'Please be aware that Dart transformers have limited support for '
                   'reusable, pre-defined lists of Directives (aka '
                   '"directive aliases"). See https://goo.gl/d8XPt0 for details.');
@@ -166,7 +166,7 @@ class _CompileDataCreator {
               ngMeta.addAll(newMetadata);
             }
           } catch (ex, stackTrace) {
-            logger.warning('Failed to decode: $ex, $stackTrace',
+            log.warning('Failed to decode: $ex, $stackTrace',
                 asset: metaAssetId);
           }
         }

--- a/modules_dart/transform/lib/src/transform/template_compiler/generator.dart
+++ b/modules_dart/transform/lib/src/transform/template_compiler/generator.dart
@@ -2,6 +2,9 @@ library angular2.transform.template_compiler.generator;
 
 import 'dart:async';
 
+import 'package:barback/barback.dart';
+import 'package:path/path.dart' as path;
+
 import 'package:angular2/src/core/change_detection/interfaces.dart';
 import 'package:angular2/src/core/facade/lang.dart';
 import 'package:angular2/src/core/reflection/reflection.dart';
@@ -13,8 +16,7 @@ import 'package:angular2/src/transform/common/model/import_export_model.pb.dart'
 import 'package:angular2/src/transform/common/model/ng_deps_model.pb.dart';
 import 'package:angular2/src/transform/common/names.dart';
 import 'package:angular2/src/transform/common/ng_compiler.dart';
-import 'package:barback/barback.dart';
-import 'package:path/path.dart' as path;
+import 'package:angular2/src/transform/common/zone.dart' as zone;
 
 import 'reflection/processor.dart' as reg;
 import 'reflection/reflection_capabilities.dart';
@@ -40,9 +42,12 @@ Future<Outputs> processTemplates(AssetReader reader, AssetId assetId,
     viewDefResults.ngMeta.ngDeps.methods
         .addAll(processor.methodNames.map((e) => e.sanitizedName));
   }
-  var templateCompiler = createTemplateCompiler(reader,
-      changeDetectionConfig: new ChangeDetectorGenConfig(assertionsEnabled(),
-          assertionsEnabled(), reflectPropertiesAsAttributes, false));
+  var templateCompiler = zone.templateCompiler;
+  if (templateCompiler == null) {
+    templateCompiler = createTemplateCompiler(reader,
+        changeDetectionConfig: new ChangeDetectorGenConfig(assertionsEnabled(),
+            assertionsEnabled(), reflectPropertiesAsAttributes, false));
+  }
 
   final compileData =
       viewDefResults.viewDefinitions.values.toList(growable: false);

--- a/modules_dart/transform/lib/src/transform/template_compiler/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/template_compiler/transformer.dart
@@ -2,14 +2,15 @@ library angular2.transform.template_compiler.transformer;
 
 import 'dart:async';
 
+import 'package:barback/barback.dart';
+
 import 'package:angular2/src/core/dom/html_adapter.dart';
 import 'package:angular2/src/transform/common/asset_reader.dart';
 import 'package:angular2/src/transform/common/code/ng_deps_code.dart';
 import 'package:angular2/src/transform/common/formatter.dart';
-import 'package:angular2/src/transform/common/logging.dart' as log;
 import 'package:angular2/src/transform/common/names.dart';
 import 'package:angular2/src/transform/common/options.dart';
-import 'package:barback/barback.dart';
+import 'package:angular2/src/transform/common/zone.dart' as zone;
 
 import 'generator.dart';
 
@@ -32,7 +33,7 @@ class TemplateCompiler extends Transformer {
 
   @override
   Future apply(Transform transform) async {
-    await log.initZoned(transform, () async {
+    return zone.exec(() async {
       Html5LibDomAdapter.makeCurrent();
       var primaryId = transform.primaryInput.id;
       var reader = new AssetReader.fromTransform(transform);
@@ -55,7 +56,7 @@ class TemplateCompiler extends Transformer {
           new Asset.fromString(ngDepsAssetId(primaryId), ngDepsCode));
       transform.addOutput(
           new Asset.fromString(templatesAssetId(primaryId), templatesCode));
-    });
+    }, log: transform.logger);
   }
 }
 

--- a/modules_dart/transform/test/transform/deferred_rewriter/all_tests.dart
+++ b/modules_dart/transform/test/transform/deferred_rewriter/all_tests.dart
@@ -1,11 +1,13 @@
 library angular2.test.transform.deferred_rewriter.all_tests;
 
 import 'package:barback/barback.dart';
-import 'package:angular2/src/transform/deferred_rewriter/transformer.dart';
-import 'package:angular2/src/transform/common/logging.dart' as log;
 import 'package:dart_style/dart_style.dart';
 import 'package:guinness/guinness.dart';
 import 'package:path/path.dart' as path;
+
+import 'package:angular2/src/transform/common/zone.dart' as zone;
+import 'package:angular2/src/transform/deferred_rewriter/transformer.dart';
+
 import '../common/read_file.dart';
 import '../common/recording_logger.dart';
 
@@ -35,7 +37,7 @@ void allTests() {
 
 void _testRewriteDeferredLibraries(String name, String inputPath) {
   it(name, () {
-    return log.setZoned(new RecordingLogger(), () async {
+    return zone.exec(() async {
       var inputId = _assetIdForPath(inputPath);
       var reader = new TestAssetReader();
       var expectedPath = path.join(
@@ -50,7 +52,7 @@ void _testRewriteDeferredLibraries(String name, String inputPath) {
       } else {
         expect(formatter.format(output)).toEqual(formatter.format(input));
       }
-    });
+    }, log: new RecordingLogger());
   });
 }
 

--- a/modules_dart/transform/test/transform/directive_metadata_linker/all_tests.dart
+++ b/modules_dart/transform/test/transform/directive_metadata_linker/all_tests.dart
@@ -3,14 +3,15 @@ library angular2.test.transform.directive_metadata_linker.all_tests;
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:angular2/src/transform/common/asset_reader.dart';
-import 'package:angular2/src/transform/common/logging.dart' as log;
-import 'package:angular2/src/transform/common/names.dart';
-import 'package:angular2/src/transform/common/model/import_export_model.pb.dart';
-import 'package:angular2/src/transform/directive_metadata_linker/ng_meta_linker.dart';
 import 'package:barback/barback.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:guinness/guinness.dart';
+
+import 'package:angular2/src/transform/common/asset_reader.dart';
+import 'package:angular2/src/transform/common/names.dart';
+import 'package:angular2/src/transform/common/model/import_export_model.pb.dart';
+import 'package:angular2/src/transform/common/zone.dart' as zone;
+import 'package:angular2/src/transform/directive_metadata_linker/ng_meta_linker.dart';
 
 import '../common/ng_meta_helper.dart';
 import '../common/read_file.dart';
@@ -172,6 +173,6 @@ void allTests() {
 }
 
 Future<NgMeta> _testLink(AssetReader reader, AssetId assetId) {
-  return log.setZoned(
-      new RecordingLogger(), () => linkDirectiveMetadata(reader, assetId));
+  return zone.exec(() => linkDirectiveMetadata(reader, assetId),
+      log: new RecordingLogger());
 }

--- a/modules_dart/transform/test/transform/directive_processor/all_tests.dart
+++ b/modules_dart/transform/test/transform/directive_processor/all_tests.dart
@@ -2,20 +2,22 @@ library angular2.test.transform.directive_processor.all_tests;
 
 import 'dart:async';
 
-import 'package:angular2/src/core/change_detection/change_detection.dart';
-import 'package:angular2/src/core/linker/interfaces.dart' show LifecycleHooks;
-import 'package:angular2/src/core/dom/html_adapter.dart';
-import 'package:angular2/src/transform/directive_processor/rewriter.dart';
-import 'package:angular2/src/transform/common/annotation_matcher.dart';
-import 'package:angular2/src/transform/common/code/ng_deps_code.dart';
-import 'package:angular2/src/transform/common/asset_reader.dart';
-import 'package:angular2/src/transform/common/logging.dart' as log;
-import 'package:angular2/src/transform/common/model/ng_deps_model.pb.dart';
-import 'package:angular2/src/transform/common/model/reflection_info_model.pb.dart';
-import 'package:angular2/src/transform/common/ng_meta.dart';
 import 'package:barback/barback.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:guinness/guinness.dart';
+
+import 'package:angular2/src/core/change_detection/change_detection.dart';
+import 'package:angular2/src/core/dom/html_adapter.dart';
+import 'package:angular2/src/core/linker/interfaces.dart' show LifecycleHooks;
+import 'package:angular2/src/transform/common/annotation_matcher.dart';
+import 'package:angular2/src/transform/common/asset_reader.dart';
+import 'package:angular2/src/transform/common/code/ng_deps_code.dart';
+import 'package:angular2/src/transform/common/model/ng_deps_model.pb.dart';
+import 'package:angular2/src/transform/common/model/reflection_info_model.pb.dart';
+import 'package:angular2/src/transform/common/ng_meta.dart';
+import 'package:angular2/src/transform/common/zone.dart' as zone;
+import 'package:angular2/src/transform/directive_processor/rewriter.dart';
+
 import '../common/read_file.dart';
 import '../common/recording_logger.dart';
 
@@ -568,7 +570,7 @@ Future<NgMeta> _testCreateModel(String inputPath,
     AssetReader reader,
     TransformLogger logger}) {
   if (logger == null) logger = new RecordingLogger();
-  return log.setZoned(logger, () async {
+  return zone.exec(() async {
     var inputId = _assetIdForPath(inputPath);
     if (reader == null) {
       reader = new TestAssetReader();
@@ -580,7 +582,7 @@ Future<NgMeta> _testCreateModel(String inputPath,
 
     var annotationMatcher = new AnnotationMatcher()..addAll(customDescriptors);
     return createNgMeta(reader, inputId, annotationMatcher);
-  });
+  }, log: logger);
 }
 
 AssetId _assetIdForPath(String path) =>

--- a/modules_dart/transform/test/transform/inliner_for_test/all_tests.dart
+++ b/modules_dart/transform/test/transform/inliner_for_test/all_tests.dart
@@ -2,15 +2,16 @@ library angular2.test.transform.inliner_for_test.all_tests;
 
 import 'dart:async';
 
-import 'package:angular2/src/transform/common/annotation_matcher.dart';
-import 'package:angular2/src/transform/common/asset_reader.dart';
-import 'package:angular2/src/transform/common/logging.dart' as log;
-import 'package:angular2/src/transform/common/options.dart';
-import 'package:angular2/src/transform/inliner_for_test/transformer.dart';
 import 'package:barback/barback.dart';
 import 'package:code_transformers/tests.dart';
 import 'package:guinness/guinness.dart';
 import 'package:dart_style/dart_style.dart';
+
+import 'package:angular2/src/transform/common/annotation_matcher.dart';
+import 'package:angular2/src/transform/common/asset_reader.dart';
+import 'package:angular2/src/transform/common/options.dart';
+import 'package:angular2/src/transform/common/zone.dart' as zone;
+import 'package:angular2/src/transform/inliner_for_test/transformer.dart';
 
 import '../common/read_file.dart';
 import '../common/recording_logger.dart';
@@ -118,8 +119,8 @@ void allTests() {
 }
 
 Future<String> _testInline(AssetReader reader, AssetId assetId) {
-  return log.setZoned(
-      new RecordingLogger(), () => inline(reader, assetId, annotationMatcher));
+  return zone.exec(() => inline(reader, assetId, annotationMatcher),
+      log: new RecordingLogger());
 }
 
 AssetId _assetId(String path) => new AssetId('a', 'inliner_for_test/$path');

--- a/modules_dart/transform/test/transform/template_compiler/all_tests.dart
+++ b/modules_dart/transform/test/transform/template_compiler/all_tests.dart
@@ -4,14 +4,15 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:barback/barback.dart';
-import 'package:angular2/src/core/change_detection/codegen_name_util.dart'
-    show CONTEXT_ACCESSOR;
-import 'package:angular2/src/core/dom/html_adapter.dart';
-import 'package:angular2/src/transform/common/logging.dart' as log;
-import 'package:angular2/src/transform/template_compiler/generator.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:path/path.dart' as path;
 import 'package:guinness/guinness.dart';
+
+import 'package:angular2/src/core/change_detection/codegen_name_util.dart'
+    show CONTEXT_ACCESSOR;
+import 'package:angular2/src/core/dom/html_adapter.dart';
+import 'package:angular2/src/transform/template_compiler/generator.dart';
+import 'package:angular2/src/transform/common/zone.dart' as zone;
 
 import '../common/compile_directive_metadata/ng_for.ng_meta.dart' as ngMeta;
 import '../common/ng_meta_helper.dart';
@@ -76,7 +77,7 @@ void allTests() {
 
   Future<String> process(AssetId assetId) {
     logger = new RecordingLogger();
-    return log.setZoned(logger, () => processTemplates(reader, assetId));
+    return zone.exec(() => processTemplates(reader, assetId), log: logger);
   }
 
   // TODO(tbosch): This is just a temporary test that makes sure that the dart


### PR DESCRIPTION
- Move zone-related code out of logger.dart and into zone.dart.
- Rename `logger` => `log`.
- Add the ability to specify a zone-local `TemplateCompiler`.
