### PR TITLE
chore(browserstack): use patched karma launcher

### DIFF
--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -52,7 +52,8 @@ module.exports = function(config) {
       project: 'Angular2',
       startTunnel: false,
       retryLimit: 1,
-      timeout: 600
+      timeout: 600,
+      pollingTimeout: 10000
     },
 
     browsers: ['Chrome'],

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -11850,6 +11850,7 @@
     },
     "karma-browserstack-launcher": {
       "version": "0.1.6",
+      "resolved": "git://github.com/mlaval/karma-browserstack-launcher.git#f3be494790d9ffb5dadb7fbf728ec770207a68d5",
       "dependencies": {
         "browserstack": {
           "version": "1.2.0"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8158,154 +8158,154 @@
     },
     "gulp-clang-format": {
       "version": "1.0.23",
-      "from": "gulp-clang-format@1.0.23",
+      "from": "https://registry.npmjs.org/gulp-clang-format/-/gulp-clang-format-1.0.23.tgz",
       "resolved": "https://registry.npmjs.org/gulp-clang-format/-/gulp-clang-format-1.0.23.tgz",
       "dependencies": {
         "gulp-diff": {
           "version": "1.0.0",
-          "from": "gulp-diff@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/gulp-diff/-/gulp-diff-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/gulp-diff/-/gulp-diff-1.0.0.tgz",
           "dependencies": {
             "diff": {
               "version": "2.2.0",
-              "from": "diff@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/diff/-/diff-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.0.tgz"
             },
             "through2": {
               "version": "2.0.0",
-              "from": "through2@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.4",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.3",
-                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <4.1.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "cli-color": {
               "version": "1.1.0",
-              "from": "cli-color@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/cli-color/-/cli-color-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.1.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 },
                 "d": {
                   "version": "0.1.1",
-                  "from": "d@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                 },
                 "es5-ext": {
                   "version": "0.10.8",
-                  "from": "es5-ext@>=0.10.8 <0.11.0",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
                   "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
                   "dependencies": {
                     "es6-symbol": {
                       "version": "3.0.1",
-                      "from": "es6-symbol@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz"
                     }
                   }
                 },
                 "es6-iterator": {
                   "version": "2.0.0",
-                  "from": "es6-iterator@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
                   "dependencies": {
                     "es6-symbol": {
                       "version": "3.0.1",
-                      "from": "es6-symbol@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz"
                     }
                   }
                 },
                 "memoizee": {
                   "version": "0.3.9",
-                  "from": "memoizee@>=0.3.9 <0.4.0",
+                  "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.9.tgz",
                   "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.9.tgz",
                   "dependencies": {
                     "es6-weak-map": {
                       "version": "0.1.4",
-                      "from": "es6-weak-map@>=0.1.4 <0.2.0",
+                      "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                       "dependencies": {
                         "es6-iterator": {
                           "version": "0.1.3",
-                          "from": "es6-iterator@>=0.1.3 <0.2.0",
+                          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                         },
                         "es6-symbol": {
                           "version": "2.0.1",
-                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                         }
                       }
                     },
                     "event-emitter": {
                       "version": "0.3.4",
-                      "from": "event-emitter@>=0.3.3 <0.4.0",
+                      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
                       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
                     },
                     "lru-queue": {
                       "version": "0.1.0",
-                      "from": "lru-queue@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
                     },
                     "next-tick": {
                       "version": "0.2.2",
-                      "from": "next-tick@>=0.2.2 <0.3.0",
+                      "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                     }
                   }
                 },
                 "timers-ext": {
                   "version": "0.1.0",
-                  "from": "timers-ext@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
                   "dependencies": {
                     "next-tick": {
                       "version": "0.2.2",
-                      "from": "next-tick@>=0.2.2 <0.3.0",
+                      "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                     }
                   }
@@ -8314,42 +8314,42 @@
             },
             "event-stream": {
               "version": "3.3.2",
-              "from": "event-stream@>=3.1.5 <4.0.0",
+              "from": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
               "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
               "dependencies": {
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.1 <2.4.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 },
                 "duplexer": {
                   "version": "0.1.1",
-                  "from": "duplexer@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                 },
                 "from": {
                   "version": "0.1.3",
-                  "from": "from@>=0.0.0 <1.0.0",
+                  "from": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
                 },
                 "map-stream": {
                   "version": "0.1.0",
-                  "from": "map-stream@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
                 },
                 "pause-stream": {
                   "version": "0.0.11",
-                  "from": "pause-stream@0.0.11",
+                  "from": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
                   "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
                 },
                 "split": {
                   "version": "0.3.3",
-                  "from": "split@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
                 },
                 "stream-combiner": {
                   "version": "0.0.4",
-                  "from": "stream-combiner@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
                 }
               }
@@ -8358,159 +8358,159 @@
         },
         "gulp-util": {
           "version": "3.0.7",
-          "from": "gulp-util@>=3.0.4 <4.0.0",
+          "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
           "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
           "dependencies": {
             "array-differ": {
               "version": "1.0.0",
-              "from": "array-differ@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
             },
             "array-uniq": {
               "version": "1.0.2",
-              "from": "array-uniq@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
             },
             "beeper": {
               "version": "1.1.0",
-              "from": "beeper@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
             },
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "dateformat": {
               "version": "1.0.11",
-              "from": "dateformat@>=1.0.11 <2.0.0",
+              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
               "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "5.0.0",
-                  "from": "get-stdin@*",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.0.tgz"
                 },
                 "meow": {
                   "version": "3.5.0",
-                  "from": "meow@*",
+                  "from": "https://registry.npmjs.org/meow/-/meow-3.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.5.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "loud-rejection": {
                       "version": "1.0.0",
-                      "from": "loud-rejection@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz"
                     },
                     "normalize-package-data": {
                       "version": "2.3.5",
-                      "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                      "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.4",
-                          "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                          "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
-                          "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.0",
-                              "from": "builtin-modules@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
                             }
                           }
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
-                          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                          "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
-                              "from": "spdx-correct@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                 }
                               }
                             },
                             "spdx-expression-parse": {
                               "version": "1.0.1",
-                              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.1.tgz",
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.4",
-                                  "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                                  "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                 }
                               }
@@ -8521,32 +8521,32 @@
                     },
                     "object-assign": {
                       "version": "4.0.1",
-                      "from": "object-assign@>=4.0.1 <5.0.0",
+                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                     },
                     "read-pkg-up": {
                       "version": "1.0.1",
-                      "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                       "dependencies": {
                         "find-up": {
                           "version": "1.0.0",
-                          "from": "find-up@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
                           "dependencies": {
                             "path-exists": {
                               "version": "2.0.0",
-                              "from": "path-exists@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "1.0.0",
-                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "1.0.0",
-                                  "from": "pinkie@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                 }
                               }
@@ -8555,32 +8555,32 @@
                         },
                         "read-pkg": {
                           "version": "1.1.0",
-                          "from": "read-pkg@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                           "dependencies": {
                             "load-json-file": {
                               "version": "1.0.1",
-                              "from": "load-json-file@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
                               "dependencies": {
                                 "graceful-fs": {
                                   "version": "4.1.2",
-                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
                                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                                 },
                                 "parse-json": {
                                   "version": "2.2.0",
-                                  "from": "parse-json@>=2.2.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                   "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                   "dependencies": {
                                     "error-ex": {
                                       "version": "1.3.0",
-                                      "from": "error-ex@>=1.2.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                       "dependencies": {
                                         "is-arrayish": {
                                           "version": "0.2.1",
-                                          "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                          "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
                                           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                         }
                                       }
@@ -8589,29 +8589,29 @@
                                 },
                                 "pify": {
                                   "version": "2.3.0",
-                                  "from": "pify@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "1.0.0",
-                                  "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "1.0.0",
-                                      "from": "pinkie@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-bom": {
                                   "version": "2.0.0",
-                                  "from": "strip-bom@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                   "dependencies": {
                                     "is-utf8": {
                                       "version": "0.2.0",
-                                      "from": "is-utf8@>=0.2.0 <0.3.0",
+                                      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
                                       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
                                     }
                                   }
@@ -8620,27 +8620,27 @@
                             },
                             "path-type": {
                               "version": "1.0.0",
-                              "from": "path-type@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
                                   "version": "4.1.2",
-                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
                                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                                 },
                                 "pify": {
                                   "version": "2.3.0",
-                                  "from": "pify@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "1.0.0",
-                                  "from": "pinkie-promise@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "1.0.0",
-                                      "from": "pinkie@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                     }
                                   }
@@ -8653,27 +8653,27 @@
                     },
                     "redent": {
                       "version": "1.0.0",
-                      "from": "redent@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                       "dependencies": {
                         "indent-string": {
                           "version": "2.1.0",
-                          "from": "indent-string@>=2.1.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                           "dependencies": {
                             "repeating": {
                               "version": "2.0.0",
-                              "from": "repeating@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                     }
                                   }
@@ -8684,12 +8684,12 @@
                         },
                         "strip-indent": {
                           "version": "1.0.1",
-                          "from": "strip-indent@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                           "dependencies": {
                             "get-stdin": {
                               "version": "4.0.1",
-                              "from": "get-stdin@>=4.0.1 <5.0.0",
+                              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                             }
                           }
@@ -8698,7 +8698,7 @@
                     },
                     "trim-newlines": {
                       "version": "1.0.0",
-                      "from": "trim-newlines@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                     }
                   }
@@ -8707,22 +8707,22 @@
             },
             "fancy-log": {
               "version": "1.1.0",
-              "from": "fancy-log@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz"
             },
             "gulplog": {
               "version": "1.0.0",
-              "from": "gulplog@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
               "dependencies": {
                 "glogg": {
                   "version": "1.0.0",
-                  "from": "glogg@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
                   "dependencies": {
                     "sparkles": {
                       "version": "1.0.0",
-                      "from": "sparkles@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
                     }
                   }
@@ -8731,128 +8731,128 @@
             },
             "has-gulplog": {
               "version": "0.1.0",
-              "from": "has-gulplog@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
               "dependencies": {
                 "sparkles": {
                   "version": "1.0.0",
-                  "from": "sparkles@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
                 }
               }
             },
             "lodash._reescape": {
               "version": "3.0.0",
-              "from": "lodash._reescape@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
             },
             "lodash._reevaluate": {
               "version": "3.0.0",
-              "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
             },
             "lodash._reinterpolate": {
               "version": "3.0.0",
-              "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
             },
             "lodash.template": {
               "version": "3.6.2",
-              "from": "lodash.template@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
               "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
               "dependencies": {
                 "lodash._basecopy": {
                   "version": "3.0.1",
-                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                 },
                 "lodash._basetostring": {
                   "version": "3.0.1",
-                  "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
                 },
                 "lodash._basevalues": {
                   "version": "3.0.0",
-                  "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
                 },
                 "lodash._isiterateecall": {
                   "version": "3.0.9",
-                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                 },
                 "lodash.escape": {
                   "version": "3.0.0",
-                  "from": "lodash.escape@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
                 },
                 "lodash.keys": {
                   "version": "3.1.2",
-                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
                       "version": "3.9.1",
-                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
                     "lodash.isarguments": {
                       "version": "3.0.4",
-                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                     },
                     "lodash.isarray": {
                       "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                     }
                   }
                 },
                 "lodash.restparam": {
                   "version": "3.6.1",
-                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                 },
                 "lodash.templatesettings": {
                   "version": "3.1.0",
-                  "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
                 }
               }
             },
             "multipipe": {
               "version": "0.1.2",
-              "from": "multipipe@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
               "dependencies": {
                 "duplexer2": {
                   "version": "0.0.2",
-                  "from": "duplexer2@0.0.2",
+                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -8863,76 +8863,76 @@
             },
             "object-assign": {
               "version": "3.0.0",
-              "from": "object-assign@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
             },
             "replace-ext": {
               "version": "0.0.1",
-              "from": "replace-ext@0.0.1",
+              "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "through2": {
               "version": "2.0.0",
-              "from": "through2@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.4",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.3",
-                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <4.1.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "vinyl": {
               "version": "0.5.3",
-              "from": "vinyl@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
               "dependencies": {
                 "clone": {
                   "version": "1.0.2",
-                  "from": "clone@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
                 },
                 "clone-stats": {
                   "version": "0.0.1",
-                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
                 }
               }
@@ -8941,52 +8941,52 @@
         },
         "pkginfo": {
           "version": "0.3.1",
-          "from": "pkginfo@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
         },
         "stream-combiner2": {
           "version": "1.1.1",
-          "from": "stream-combiner2@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
           "dependencies": {
             "duplexer2": {
               "version": "0.1.2",
-              "from": "duplexer2@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.2.tgz"
             },
             "readable-stream": {
               "version": "2.0.4",
-              "from": "readable-stream@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.3",
-                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -8995,7 +8995,7 @@
         },
         "stream-equal": {
           "version": "0.1.6",
-          "from": "stream-equal@0.1.6",
+          "from": "https://registry.npmjs.org/stream-equal/-/stream-equal-0.1.6.tgz",
           "resolved": "https://registry.npmjs.org/stream-equal/-/stream-equal-0.1.6.tgz"
         }
       }
@@ -18161,12 +18161,12 @@
     },
     "karma-browserstack-launcher": {
       "version": "0.1.6",
-      "from": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-0.1.6.tgz",
-      "resolved": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-0.1.6.tgz",
+      "from": "mlaval/karma-browserstack-launcher#global_poll",
+      "resolved": "git://github.com/mlaval/karma-browserstack-launcher.git#f3be494790d9ffb5dadb7fbf728ec770207a68d5",
       "dependencies": {
         "browserstack": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/browserstack/-/browserstack-1.2.0.tgz",
+          "from": "browserstack@1.2.0",
           "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.2.0.tgz"
         }
       }
@@ -20566,17 +20566,17 @@
     },
     "systemjs": {
       "version": "0.18.10",
-      "from": "systemjs@0.18.10",
+      "from": "https://registry.npmjs.org/systemjs/-/systemjs-0.18.10.tgz",
       "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.18.10.tgz",
       "dependencies": {
         "es6-module-loader": {
           "version": "0.17.8",
-          "from": "es6-module-loader@>=0.17.4 <0.18.0",
+          "from": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.17.8.tgz",
           "resolved": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.17.8.tgz"
         },
         "when": {
           "version": "3.7.4",
-          "from": "when@>=3.7.2 <4.0.0",
+          "from": "https://registry.npmjs.org/when/-/when-3.7.4.tgz",
           "resolved": "https://registry.npmjs.org/when/-/when-3.7.4.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "jpm": "1.0.0",
     "js-yaml": "^3.2.7",
     "karma": "^0.13.10",
-    "karma-browserstack-launcher": "^0.1.6",
+    "karma-browserstack-launcher": "mlaval/karma-browserstack-launcher#global_poll",
     "karma-chrome-launcher": "^0.2.0",
     "karma-dart": "^0.3.0",
     "karma-jasmine": "^0.3.6",


### PR DESCRIPTION
This should solve the `Error: 403 Forbidden (Rate Limit Exceeded)` errors in the Browser Stack job.

The patch comes from https://github.com/karma-runner/karma-browserstack-launcher/pull/40 by @shirish87
