### PR TITLE
chore(bundles): publish UMD bundles

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1132,6 +1132,50 @@ gulp.task('!bundle.web_worker.js.dev.deps', ['!bundle.web_worker.js.dev'], funct
                 addDevDependencies("web_worker/worker.dev.js")));
 });
 
+gulp.task('bundles.js.umd', ['build.js.dev'], function() {
+
+  function rxExternalImport(context, request, callback) {
+      // Use globally defined RxJS
+    if(/^@reactivex/.test(request)) {
+        var rxImport = request.substring('@reactivex/rxjs/dist/cjs/'.length);
+        return callback(null, "var Rx" + (rxImport === 'Rx' ? '' : '.' + rxImport));
+    }
+    callback();
+  }
+
+
+  var webpack = q.denodeify(require('webpack'));
+  var resolveOptions = {
+    root: __dirname + '/dist/js/dev/es5',
+    packageAlias: '' //this option is added to ignore "broken" package.json in our dist folder
+  };
+
+  var externalOptions = [{
+    'angular2/angular2': 'var ng'
+  }, rxExternalImport];
+
+  return q.all([
+    webpack({
+      entry: ['angular2/angular2.js'],
+      resolve: resolveOptions,
+      externals: [rxExternalImport],
+      output: {filename: 'dist/js/bundle/angular2.umd.dev.js', library: 'ng', libraryTarget: 'umd'}
+    }),
+    webpack({
+      entry: ['angular2/http.js'],
+      resolve: resolveOptions,
+      externals: externalOptions,
+      output: {filename: 'dist/js/bundle/http.umd.dev.js', library: 'ngHttp', libraryTarget: 'umd'}
+    }),
+    webpack({
+      entry: ['angular2/router.js'],
+      resolve: resolveOptions,
+      externals: externalOptions,
+      output: {filename: 'dist/js/bundle/router.umd.dev.js', library: 'ngRouter', libraryTarget: 'umd'}
+    })
+  ]);
+});
+
 // We need to duplicate the deps of bundles.js so that this task runs after
 // all the bundle files are created.
 gulp.task('!bundle.copy', [
@@ -1152,6 +1196,7 @@ gulp.task('bundles.js', [
   '!bundle.js.min.deps',
   '!bundle.web_worker.js.dev.deps',
   '!bundle.js.sfx.dev.deps',
+  'bundles.js.umd',
   '!bundle.testing',
   '!bundle.copy']);
 

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -13949,6 +13949,275 @@
         }
       }
     },
+    "webpack": {
+      "version": "1.12.3",
+      "dependencies": {
+        "async": {
+          "version": "1.5.0"
+        },
+        "clone": {
+          "version": "1.0.2"
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.2"
+            }
+          }
+        },
+        "esprima": {
+          "version": "2.7.0"
+        },
+        "interpret": {
+          "version": "0.6.6"
+        },
+        "loader-utils": {
+          "version": "0.2.11",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3"
+            },
+            "json5": {
+              "version": "0.4.0"
+            }
+          }
+        },
+        "memory-fs": {
+          "version": "0.2.0"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8"
+            }
+          }
+        },
+        "node-libs-browser": {
+          "version": "0.5.3",
+          "dependencies": {
+            "assert": {
+              "version": "1.3.0"
+            },
+            "browserify-zlib": {
+              "version": "0.1.4",
+              "dependencies": {
+                "pako": {
+                  "version": "0.2.8"
+                }
+              }
+            },
+            "buffer": {
+              "version": "3.5.1",
+              "dependencies": {
+                "ieee754": {
+                  "version": "1.1.6"
+                },
+                "is-array": {
+                  "version": "1.0.1"
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "1.1.0",
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4"
+                }
+              }
+            },
+            "constants-browserify": {
+              "version": "0.0.1"
+            },
+            "crypto-browserify": {
+              "version": "3.2.8",
+              "dependencies": {
+                "pbkdf2-compat": {
+                  "version": "2.0.1"
+                },
+                "ripemd160": {
+                  "version": "0.2.0"
+                },
+                "sha.js": {
+                  "version": "2.2.6"
+                }
+              }
+            },
+            "domain-browser": {
+              "version": "1.1.4"
+            },
+            "events": {
+              "version": "1.1.0"
+            },
+            "http-browserify": {
+              "version": "1.7.0",
+              "dependencies": {
+                "Base64": {
+                  "version": "0.2.1"
+                },
+                "inherits": {
+                  "version": "2.0.1"
+                }
+              }
+            },
+            "https-browserify": {
+              "version": "0.0.0"
+            },
+            "os-browserify": {
+              "version": "0.1.2"
+            },
+            "path-browserify": {
+              "version": "0.0.0"
+            },
+            "process": {
+              "version": "0.11.2"
+            },
+            "punycode": {
+              "version": "1.3.2"
+            },
+            "querystring-es3": {
+              "version": "0.2.1"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1"
+                },
+                "isarray": {
+                  "version": "0.0.1"
+                },
+                "inherits": {
+                  "version": "2.0.1"
+                }
+              }
+            },
+            "stream-browserify": {
+              "version": "1.0.0",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1"
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31"
+            },
+            "timers-browserify": {
+              "version": "1.4.1"
+            },
+            "tty-browserify": {
+              "version": "0.0.0"
+            },
+            "url": {
+              "version": "0.10.3",
+              "dependencies": {
+                "querystring": {
+                  "version": "0.2.0"
+                }
+              }
+            },
+            "util": {
+              "version": "0.10.3",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1"
+                }
+              }
+            },
+            "vm-browserify": {
+              "version": "0.0.4",
+              "dependencies": {
+                "indexof": {
+                  "version": "0.0.1"
+                }
+              }
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3"
+            },
+            "minimist": {
+              "version": "0.0.10"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "tapable": {
+          "version": "0.1.9"
+        },
+        "uglify-js": {
+          "version": "2.5.0",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10"
+            },
+            "source-map": {
+              "version": "0.5.3"
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2"
+            },
+            "yargs": {
+              "version": "3.5.4",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1"
+                },
+                "decamelize": {
+                  "version": "1.1.1"
+                },
+                "window-size": {
+                  "version": "0.1.0"
+                },
+                "wordwrap": {
+                  "version": "0.0.2"
+                }
+              }
+            }
+          }
+        },
+        "watchpack": {
+          "version": "0.2.9",
+          "dependencies": {
+            "async": {
+              "version": "0.9.2"
+            },
+            "graceful-fs": {
+              "version": "4.1.2"
+            }
+          }
+        },
+        "webpack-core": {
+          "version": "0.6.8",
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "source-list-map": {
+              "version": "0.1.5"
+            }
+          }
+        }
+      }
+    },
     "which": {
       "version": "1.2.0",
       "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20019,34 +20019,34 @@
     },
     "ts2dart": {
       "version": "0.7.14",
-      "from": "ts2dart@0.7.14",
+      "from": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.7.14.tgz",
       "resolved": "https://registry.npmjs.org/ts2dart/-/ts2dart-0.7.14.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.2 <0.5.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
         },
         "source-map-support": {
           "version": "0.3.3",
-          "from": "source-map-support@>=0.3.1 <0.4.0",
+          "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
-              "from": "source-map@0.1.32",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
@@ -21400,6 +21400,425 @@
           "version": "0.2.10",
           "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        }
+      }
+    },
+    "webpack": {
+      "version": "1.12.3",
+      "from": "webpack@*",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.12.3.tgz",
+      "dependencies": {
+        "async": {
+          "version": "1.5.0",
+          "from": "async@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+        },
+        "clone": {
+          "version": "1.0.2",
+          "from": "clone@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "from": "enhanced-resolve@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.2",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+            }
+          }
+        },
+        "esprima": {
+          "version": "2.7.0",
+          "from": "esprima@>=2.5.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.0.tgz"
+        },
+        "interpret": {
+          "version": "0.6.6",
+          "from": "interpret@>=0.6.4 <0.7.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+        },
+        "loader-utils": {
+          "version": "0.2.11",
+          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.11.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "json5": {
+              "version": "0.4.0",
+              "from": "json5@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+            }
+          }
+        },
+        "memory-fs": {
+          "version": "0.2.0",
+          "from": "memory-fs@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "node-libs-browser": {
+          "version": "0.5.3",
+          "from": "node-libs-browser@>=0.4.0 <=0.6.0",
+          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
+          "dependencies": {
+            "assert": {
+              "version": "1.3.0",
+              "from": "assert@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+            },
+            "browserify-zlib": {
+              "version": "0.1.4",
+              "from": "browserify-zlib@>=0.1.4 <0.2.0",
+              "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+              "dependencies": {
+                "pako": {
+                  "version": "0.2.8",
+                  "from": "pako@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+                }
+              }
+            },
+            "buffer": {
+              "version": "3.5.1",
+              "from": "buffer@>=3.0.3 <4.0.0",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.5.1.tgz",
+              "dependencies": {
+                "ieee754": {
+                  "version": "1.1.6",
+                  "from": "ieee754@>=1.1.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+                },
+                "is-array": {
+                  "version": "1.0.1",
+                  "from": "is-array@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "1.1.0",
+              "from": "console-browserify@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4",
+                  "from": "date-now@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                }
+              }
+            },
+            "constants-browserify": {
+              "version": "0.0.1",
+              "from": "constants-browserify@0.0.1",
+              "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+            },
+            "crypto-browserify": {
+              "version": "3.2.8",
+              "from": "crypto-browserify@>=3.2.6 <3.3.0",
+              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
+              "dependencies": {
+                "pbkdf2-compat": {
+                  "version": "2.0.1",
+                  "from": "pbkdf2-compat@2.0.1",
+                  "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+                },
+                "ripemd160": {
+                  "version": "0.2.0",
+                  "from": "ripemd160@0.2.0",
+                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+                },
+                "sha.js": {
+                  "version": "2.2.6",
+                  "from": "sha.js@2.2.6",
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+                }
+              }
+            },
+            "domain-browser": {
+              "version": "1.1.4",
+              "from": "domain-browser@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+            },
+            "events": {
+              "version": "1.1.0",
+              "from": "events@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz"
+            },
+            "http-browserify": {
+              "version": "1.7.0",
+              "from": "http-browserify@>=1.3.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+              "dependencies": {
+                "Base64": {
+                  "version": "0.2.1",
+                  "from": "Base64@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "https-browserify": {
+              "version": "0.0.0",
+              "from": "https-browserify@0.0.0",
+              "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+            },
+            "os-browserify": {
+              "version": "0.1.2",
+              "from": "os-browserify@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+            },
+            "path-browserify": {
+              "version": "0.0.0",
+              "from": "path-browserify@0.0.0",
+              "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+            },
+            "process": {
+              "version": "0.11.2",
+              "from": "process@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+            },
+            "punycode": {
+              "version": "1.3.2",
+              "from": "punycode@>=1.2.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+            },
+            "querystring-es3": {
+              "version": "0.2.1",
+              "from": "querystring-es3@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.13 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "stream-browserify": {
+              "version": "1.0.0",
+              "from": "stream-browserify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.25 <0.11.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "timers-browserify": {
+              "version": "1.4.1",
+              "from": "timers-browserify@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz"
+            },
+            "tty-browserify": {
+              "version": "0.0.0",
+              "from": "tty-browserify@0.0.0",
+              "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+            },
+            "url": {
+              "version": "0.10.3",
+              "from": "url@>=0.10.1 <0.11.0",
+              "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+              "dependencies": {
+                "querystring": {
+                  "version": "0.2.0",
+                  "from": "querystring@0.2.0",
+                  "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+                }
+              }
+            },
+            "util": {
+              "version": "0.10.3",
+              "from": "util@>=0.10.3 <0.11.0",
+              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "vm-browserify": {
+              "version": "0.0.4",
+              "from": "vm-browserify@0.0.4",
+              "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+              "dependencies": {
+                "indexof": {
+                  "version": "0.0.1",
+                  "from": "indexof@0.0.1",
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "minimist@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "from": "supports-color@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "from": "has-flag@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+            }
+          }
+        },
+        "tapable": {
+          "version": "0.1.9",
+          "from": "tapable@>=0.1.8 <0.2.0",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.9.tgz"
+        },
+        "uglify-js": {
+          "version": "2.5.0",
+          "from": "uglify-js@>=2.5.0 <2.6.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.5.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.5.3",
+              "from": "source-map@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            },
+            "yargs": {
+              "version": "3.5.4",
+              "from": "yargs@>=3.5.4 <3.6.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                },
+                "decamelize": {
+                  "version": "1.1.1",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "from": "window-size@0.1.0",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "watchpack": {
+          "version": "0.2.9",
+          "from": "watchpack@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+            },
+            "graceful-fs": {
+              "version": "4.1.2",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+            }
+          }
+        },
+        "webpack-core": {
+          "version": "0.6.8",
+          "from": "webpack-core@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "from": "source-map@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                }
+              }
+            },
+            "source-list-map": {
+              "version": "0.1.5",
+              "from": "source-list-map@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
+            }
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "tslint": "^3.0.0-dev.1",
     "typescript": "^1.6.2",
     "universal-analytics": "^0.3.9",
+    "webpack": "^1.12.3",
     "which": "~1",
     "yargs": "2.3.*"
   }


### PR DESCRIPTION
So, this is a PR that adds UMD bundles for core, router and http. RxJS is an external dependency here.

Now, even if those bundles make it possible to use CJS-based tools / workflows (WebPack and company) there are far from ideal:
- we can't bundle external deps (zone, reflect-metadata, RxJS)
- assuming that a person uses core + http + router we got bundles that are bigger as compared to System.register ones (well, currently it is even worst due to #5139)
- I believe that the resulting CJS-based workflow experience is actually _worse_ as compared to bundling  ng2

Given all those issues I'm more and more skeptical when it comes to value of those bundles. I've been debating this topic with @IgorMinar, @rkirov, @robwormald an many others and IMO it would make sense to bring this topic during one of the next team meetings. 

Anyway, PR / bundles are here.
