### PR TITLE
chore(browserstack): deactivate failing Android browsers

### DIFF
--- a/browser-providers.conf.js
+++ b/browser-providers.conf.js
@@ -251,13 +251,13 @@ var sauceAliases = {
 var browserstackAliases = {
   'ALL': Object.keys(customLaunchers).filter(function(item) {return customLaunchers[item].base == 'BrowserStack';}),
   'DESKTOP': ['BS_CHROME', 'BS_FIREFOX', 'BS_IE9', 'BS_IE10', 'BS_IE11', 'BS_EDGE', 'BS_SAFARI7', 'BS_SAFARI8', 'BS_SAFARI9'],
-  'MOBILE': ['BS_ANDROID4.1', 'BS_ANDROID4.2', 'BS_ANDROID4.3', 'BS_ANDROID4.4', 'BS_ANDROID5', 'BS_IOS7', 'BS_IOS8', 'BS_IOS9'],
-  'ANDROID': ['BS_ANDROID4.1', 'BS_ANDROID4.2', 'BS_ANDROID4.3', 'BS_ANDROID4.4', 'BS_ANDROID5'],
+  'MOBILE': ['BS_ANDROID4.3', 'BS_ANDROID4.4', 'BS_IOS7', 'BS_IOS8', 'BS_IOS9'],
+  'ANDROID': ['BS_ANDROID4.3', 'BS_ANDROID4.4'],
   'IE': ['BS_IE9', 'BS_IE10', 'BS_IE11'],
   'IOS': ['BS_IOS7', 'BS_IOS8', 'BS_IOS9'],
   'SAFARI': ['BS_SAFARI7', 'BS_SAFARI8', 'BS_SAFARI9'],
-  'CI': ['BS_CHROME', 'BS_ANDROID5', 'BS_SAFARI7', 'BS_SAFARI8', 'BS_SAFARI9', 'BS_IOS7', 'BS_IOS8', 'BS_IOS9',
-    'BS_FIREFOX', 'BS_IE9', 'BS_IE10', 'BS_IE11', 'BS_EDGE', 'BS_ANDROID4.1', 'BS_ANDROID4.2', 'BS_ANDROID4.3', 'BS_ANDROID4.4']
+  'CI': ['BS_CHROME', 'BS_SAFARI7', 'BS_SAFARI8', 'BS_SAFARI9', 'BS_IOS7', 'BS_IOS8', 'BS_IOS9',
+    'BS_FIREFOX', 'BS_IE9', 'BS_IE10', 'BS_IE11', 'BS_EDGE', 'BS_ANDROID4.3', 'BS_ANDROID4.4']
 };
 
 module.exports = {


### PR DESCRIPTION
Android 5.0 is not yet supported for Local Testing.
Android 4.1 and 4.2 use ARM emulation which is very slow. They are being moved to x86, to be reactivated later.
