### PR TITLE
fix(forms): handle maxlength attribute in IE9

### DIFF
--- a/modules/angular2/src/common/forms/directives/validators.ts
+++ b/modules/angular2/src/common/forms/directives/validators.ts
@@ -1,5 +1,5 @@
 import {forwardRef, Provider, OpaqueToken} from 'angular2/src/core/di';
-import {CONST_EXPR} from 'angular2/src/facade/lang';
+import {CONST_EXPR, isPresent} from 'angular2/src/facade/lang';
 import {Attribute, Directive} from 'angular2/src/core/metadata';
 import {Validators, NG_VALIDATORS} from '../validators';
 import {Control} from '../model';
@@ -71,8 +71,11 @@ const MAX_LENGTH_VALIDATOR = CONST_EXPR(
 export class MaxLengthValidator implements Validator {
   private _validator: Function;
 
-  constructor(@Attribute("maxlength") minLength: string) {
-    this._validator = Validators.maxLength(NumberWrapper.parseInt(minLength, 10));
+  constructor(@Attribute("maxlength") maxLength: string,
+              @Attribute("maxLength") maxLengthWithCamelCase: string) {
+    // In IE9, maxlength attribute is always camel-cased
+    this._validator = Validators.maxLength(
+        NumberWrapper.parseInt(isPresent(maxLength) ? maxLength : maxLengthWithCamelCase, 10));
   }
 
   validate(c: Control): {[key: string]: any} { return this._validator(c); }

--- a/modules/angular2/test/compiler/html_parser_spec.ts
+++ b/modules/angular2/test/compiler/html_parser_spec.ts
@@ -82,10 +82,15 @@ export function main() {
         });
 
         it('should parse attributes on svg elements case sensitive', () => {
-          expect(humanizeDom(parser.parse('<svg viewBox="0"></svg>', 'TestComp')))
+          expect(humanizeDom(parser.parse('<svg viewBox="0 0 0 0"></svg>', 'TestComp')))
               .toEqual([
                 [HtmlElementAst, 'svg', 'TestComp > svg:nth-child(0)'],
-                [HtmlAttrAst, 'viewBox', '0', 'TestComp > svg:nth-child(0)[viewBox=0]']
+                [
+                  HtmlAttrAst,
+                  'viewBox',
+                  '0 0 0 0',
+                  'TestComp > svg:nth-child(0)[viewBox=0 0 0 0]'
+                ]
               ]);
         });
 


### PR DESCRIPTION
A more specific fix than #4743 to solve the maxlength case issue in IE9.

It also fixes the test with `viewBox` in IE9 where it is "auto expanded".
