### PR TITLE
chore(build): deploy build artifacts to build repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,7 @@ after_script:
 - node tools/analytics/build-analytics start ci after_script
 - ./scripts/ci/print-logs.sh
 - ./scripts/ci/after-script.sh
+- ./scripts/ci/publish-build-artifacts.sh
 - node tools/analytics/build-analytics success ci after_script
 - if [[ $TRAVIS_TEST_RESULT -eq 0 ]]; then node tools/analytics/build-analytics success ci job; else node tools/analytics/build-analytics error ci job; fi
 

--- a/scripts/ci/presubmit-queue-setup.sh
+++ b/scripts/ci/presubmit-queue-setup.sh
@@ -2,7 +2,7 @@
 set -e -o pipefail
 
 if [ "$TRAVIS_REPO_SLUG" = "angular/angular" ]; then
-  if [[ $TRAVIS_BRANCH == "presubmit-"* ]]; then
+  if [[ $TRAVIS_BRANCH == "presubmit-"* || $MODE == "build_only" ]]; then
 
     echo '*********************'
     echo '** PRESUBMIT SETUP **'
@@ -14,8 +14,10 @@ if [ "$TRAVIS_REPO_SLUG" = "angular/angular" ]; then
     git config user.name "`git --no-pager show -s --format='%cN' HEAD`"
     git config user.email "`git --no-pager show -s --format='%cE' HEAD`"
 
-    git remote add upstream https://github.com/angular/angular.git
-    git fetch upstream master
-    git rebase upstream/master
+    if [[ $TRAVIS_BRANCH == "presubmit-"* ]]; then
+      git remote add upstream https://github.com/angular/angular.git
+      git fetch upstream master
+      git rebase upstream/master
+    fi
   fi
 fi

--- a/scripts/ci/publish-build-artifacts.sh
+++ b/scripts/ci/publish-build-artifacts.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e -x
+
+DART_BUILD_ARTIFACTS_DIR="dist/dart/angular2"
+JS_BUILD_ARTIFACTS_DIR="dist/js/prod/es5/angular2"
+
+DART_BUILD_BRANCH="builds-dart"
+JS_BUILD_BRANCH="builds-js"
+
+REPO_URL="https://github.com/angular/angular.git"
+# Use the below URL for testing when using SSH authentication
+# REPO_URL="git@github.com:angular/angular.git"
+
+SHA=`git rev-parse HEAD`
+SHORT_SHA=`git rev-parse --short HEAD`
+COMMIT_MSG=`git log --oneline | head -n1`
+
+function publishRepo {
+  LANG=$1
+  ARTIFACTS_DIR=$2
+
+  BUILD_BRANCH="builds-${LANG}"
+  REPO_DIR="tmp/${BUILD_BRANCH}"
+
+  echo "Pushing build artifacts to angular/$BUILD_BRANCH"
+
+  # create local repo folder and clone build repo into it
+  rm -rf $REPO_DIR
+  mkdir -p $REPO_DIR
+  (
+    cd $REPO_DIR && \
+    git init && \
+    git remote add origin $REPO_URL && \
+    git fetch origin $BUILD_BRANCH && \
+    git checkout origin/$BUILD_BRANCH && \
+    git checkout -b $BUILD_BRANCH
+  )
+
+  # copy over build artifacts into the repo directory
+  rm -rf $REPO_DIR/*
+  cp -R $ARTIFACTS_DIR/* $REPO_DIR/
+  cp .gitignore $REPO_DIR/
+  echo `date` > $REPO_DIR/BUILD_INFO
+  echo $SHA >> $REPO_DIR/BUILD_INFO
+
+  (
+    cd $REPO_DIR && \
+    git add --all && \
+    git commit -m "${COMMIT_MSG}" && \
+    git push origin $BUILD_BRANCH && \
+    git tag "2.0.0-build.${SHORT_SHA}.${LANG}" && \
+    git push origin --tags
+  )
+}
+
+if [ "$TRAVIS_REPO_SLUG" = "angular/angular" && "$MODE" == "build_only" ]; then
+  publishRepo "js" "${JS_BUILD_ARTIFACTS_DIR}"
+  publishRepo "dart" "${DART_BUILD_ARTIFACTS_DIR}"
+  echo "Finished publishing build artifacts"
+fi


### PR DESCRIPTION
Add a script that runs after presubmit is successful. The script pushes ES5 and Dart build artifacts to `https://github.com/angular/angular2builds.js` and `https://github.com/angular/angular2builds.dart` respectively.

Fixes #5100
