### PR TITLE
chore(package.json): update RxJS to alpha 8

### DIFF
--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@reactivex/rxjs": {
-      "version": "5.0.0-alpha.7"
+      "version": "5.0.0-alpha.8"
     },
     "angular": {
       "version": "1.4.7"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "2.0.0-alpha.45",
   "dependencies": {
     "@reactivex/rxjs": {
-      "version": "5.0.0-alpha.7",
-      "from": "https://registry.npmjs.org/@reactivex/rxjs/-/rxjs-5.0.0-alpha.7.tgz",
-      "resolved": "https://registry.npmjs.org/@reactivex/rxjs/-/rxjs-5.0.0-alpha.7.tgz"
+      "version": "5.0.0-alpha.8",
+      "from": "@reactivex/rxjs@5.0.0-alpha.8",
+      "resolved": "http://registry.npmjs.org/@reactivex/rxjs/-/rxjs-5.0.0-alpha.8.tgz"
     },
     "angular": {
       "version": "1.4.7",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "gulp test.all.js && gulp test.all.dart"
   },
   "dependencies": {
-    "@reactivex/rxjs": "5.0.0-alpha.7",
+    "@reactivex/rxjs": "5.0.0-alpha.8",
     "reflect-metadata": "0.1.2",
     "zone.js": "0.5.8"
   },


### PR DESCRIPTION
Resolves some issues regarding typechecking with operators.
