### PR TITLE
fix(build): reorder bundling step

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -976,12 +976,14 @@ gulp.task('!bundle.js.prod', ['build.js.prod'], function() {
   var bundlerConfig = {
     sourceMaps: true
   };
-
-  return q.all([
-    bundler.bundle(bundleConfig, 'angular2/angular2', './dist/build/angular2.js', bundlerConfig),
-    bundler.bundle(bundleConfig, 'angular2/http - angular2/angular2', './dist/build/http.js', bundlerConfig),
-    bundler.bundle(bundleConfig, 'angular2/router - angular2/angular2', './dist/build/router.js', bundlerConfig)
-  ]);
+  
+  return bundler.bundle(bundleConfig, 'angular2/angular2', './dist/build/angular2.js', bundlerConfig)
+    .then(function(){
+      return q.all([
+        bundler.bundle(bundleConfig, 'angular2/http - angular2/angular2', './dist/build/http.js', bundlerConfig),
+        bundler.bundle(bundleConfig, 'angular2/router - angular2/angular2', './dist/build/router.js', bundlerConfig)
+      ]);
+    });
 });
 
 // minified production build
@@ -990,12 +992,14 @@ gulp.task('!bundle.js.min', ['build.js.prod'], function() {
     sourceMaps: true,
     minify: true
   };
-
-  return q.all([
-    bundler.bundle(bundleConfig, 'angular2/angular2', './dist/build/angular2.min.js', bundlerConfig),
-    bundler.bundle(bundleConfig, 'angular2/http - angular2/angular2', './dist/build/http.min.js', bundlerConfig),
-    bundler.bundle(bundleConfig, 'angular2/router - angular2/angular2', './dist/js/build/router.min.js', bundlerConfig)
-  ]);
+  
+  return bundler.bundle(bundleConfig, 'angular2/angular2', './dist/build/angular2.min.js', bundlerConfig)
+    .then(function(){
+      return q.all([
+        bundler.bundle(bundleConfig, 'angular2/http - angular2/angular2', './dist/build/http.min.js', bundlerConfig),
+        bundler.bundle(bundleConfig, 'angular2/router - angular2/angular2', './dist/js/build/router.min.js', bundlerConfig)
+      ]);
+    });
 });
 
 // development build
@@ -1009,11 +1013,13 @@ gulp.task('!bundle.js.dev', ['build.js.dev'], function() {
        "*": "dist/js/dev/es5/*.js"
       });
 
-  return q.all([
-    bundler.bundle(devBundleConfig, 'angular2/angular2', './dist/build/angular2.dev.js', bundlerConfig),
-    bundler.bundle(devBundleConfig, 'angular2/http - angular2/angular2', './dist/build/http.dev.js', bundlerConfig),
-    bundler.bundle(bundleConfig, 'angular2/router - angular2/angular2', './dist/build/router.dev.js', bundlerConfig)
-  ]);
+  return bundler.bundle(devBundleConfig, 'angular2/angular2', './dist/build/angular2.dev.js', bundlerConfig)
+    .then(function(){
+      return q.all([
+        bundler.bundle(devBundleConfig, 'angular2/http - angular2/angular2', './dist/build/http.dev.js', bundlerConfig),
+        bundler.bundle(bundleConfig, 'angular2/router - angular2/angular2', './dist/build/router.dev.js', bundlerConfig)
+      ]);
+    });
 });
 
 // WebWorker build


### PR DESCRIPTION
Previously, each bundle gulp task would kick off 3 bundle processes in parallel, and the tasks themselves are kicked off in parallel. This leads to 9+ bundle / source-mapping / minification tasks running in parallel, and causes CI to be quite flaky, exhibiting errors like:

```
Security context: 0x21ef97b37399 <JS Object>
    2: _serializeMappings(aka SourceMapGenerator_serializeMappings) [/home/travis/build/angular/angular/node_modules/systemjs-builder/node_modules/source-map/lib/source-map/source-map-generator.js:~289] [pc=0x244e65cef4ed] (this=0x2c83a9f9e379 <a SourceMapGenerator with map 0x2b2aab242ed1>)
    3: toJSON(aka SourceMapGenerator_toJSON) [/home/travis/build/angular/angular/node_modules/systemjs-bu...
FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - process out of memory
```

This reorders each task slightly so the main bundle step completes before the aux modules get bundled.
