### PR TITLE
fix(typings): two errors not reported by our build:

### DIFF
--- a/modules/angular2/src/core/platform_bindings.ts
+++ b/modules/angular2/src/core/platform_bindings.ts
@@ -1,8 +1,9 @@
 import {provide} from 'angular2/src/core/di';
+import {Provider} from "angular2/src/core/di/provider";
 import {ExceptionHandler} from 'angular2/src/facade/exceptions';
 import {DOM} from 'angular2/src/core/dom/dom_adapter';
 
-export const EXCEPTION_PROVIDER =
+export const EXCEPTION_PROVIDER: Provider =
     provide(ExceptionHandler, {useFactory: () => new ExceptionHandler(DOM, false), deps: []});
 
 export const EXCEPTION_BINDING = EXCEPTION_PROVIDER;

--- a/modules/angular2/src/mock/animation_builder_mock.ts
+++ b/modules/angular2/src/mock/animation_builder_mock.ts
@@ -8,7 +8,7 @@ import {BrowserDetails} from 'angular2/src/animate/browser_details';
 @Injectable()
 export class MockAnimationBuilder extends AnimationBuilder {
   constructor() { super(null); }
-  css(): MockCssAnimationBuilder { return new MockCssAnimationBuilder(); }
+  css(): CssAnimationBuilder { return new MockCssAnimationBuilder(); }
 }
 
 class MockCssAnimationBuilder extends CssAnimationBuilder {


### PR DESCRIPTION
third_party/javascript/angular2/github/modules/angular2/src/core/platform_bindings.ts:5:14: Exported variable 'EXCEPTION_PROVIDER' has or is using name 'Provider' from external module third_party/javascript/angular2/github/modules/angular2/src/core/di/provider but cannot be named.
third_party/javascript/angular2/github/modules/angular2/src/core/platform_bindings.ts:8:14: Exported variable 'EXCEPTION_BINDING' has or is using name 'Provider' from external module third_party/javascript/angular2/github/modules/angular2/src/core/di/provider but cannot be named.
third_party/javascript/angular2/github/modules/angular2/src/mock/animation_builder_mock.ts:11:10: Return type of public method from exported class has or is using private name 'MockCssAnimationBuilder'.
