### PR TITLE
feat(renderer): use a comment instead of an element when stamping out…

### DIFF
--- a/modules/angular2/src/core/debug/debug_element_view_listener.ts
+++ b/modules/angular2/src/core/debug/debug_element_view_listener.ts
@@ -19,7 +19,7 @@ var _allViewsById = new Map<number, AppView>();
 var _nextId = 0;
 
 function _setElementId(element, indices: number[]) {
-  if (isPresent(element)) {
+  if (isPresent(element) && DOM.isElementNode(element)) {
     DOM.setData(element, NG_ID_PROPERTY, indices.join(NG_ID_SEPARATOR));
   }
 }

--- a/modules/angular2/src/core/render/dom/dom_renderer.ts
+++ b/modules/angular2/src/core/render/dom/dom_renderer.ts
@@ -194,9 +194,7 @@ export abstract class DomRenderer extends Renderer implements NodeFactory<Node> 
 
   dehydrateView(viewRef: RenderViewRef) { resolveInternalDomView(viewRef).dehydrate(); }
 
-  createTemplateAnchor(attrNameAndValues: string[]): Node {
-    return this.createElement('script', attrNameAndValues);
-  }
+  createTemplateAnchor(attrNameAndValues: string[]): Node { return DOM.createComment('template'); }
   abstract createElement(name: string, attrNameAndValues: string[]): Node;
   abstract mergeElement(existing: Node, attrNameAndValues: string[]);
   abstract createShadowRoot(host: Node, templateId: string): Node;

--- a/modules/angular2/test/core/linker/integration_spec.ts
+++ b/modules/angular2/test/core/linker/integration_spec.ts
@@ -475,6 +475,19 @@ export function main() {
                });
          }));
 
+      it('should use a comment while stamping out `<template>` elements.',
+         inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
+           tcb.overrideView(MyComp, new ViewMetadata({template: '<template></template>'}))
+
+               .createAsync(MyComp)
+               .then((fixture) => {
+                 var childNodesOfWrapper = DOM.childNodes(fixture.debugElement.nativeElement);
+                 expect(childNodesOfWrapper.length).toBe(1);
+                 expect(DOM.isCommentNode(childNodesOfWrapper[0])).toBe(true);
+                 async.done();
+               });
+         }));
+
       it('should support template directives via `template` attribute.',
          inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
            tcb.overrideView(

--- a/modules/benchmarks/e2e_test/naive_infinite_scroll_spec.ts
+++ b/modules/benchmarks/e2e_test/naive_infinite_scroll_spec.ts
@@ -9,7 +9,7 @@ describe('ng2 naive infinite scroll benchmark', function() {
   it('should not throw errors', function() {
     browser.get(URL);
     var expectedRowCount = 18;
-    var expectedCellsPerRow = 28;
+    var expectedCellsPerRow = 27;
     var allScrollItems = 'scroll-app #testArea scroll-item';
     var cells = `${ allScrollItems } .row *`;
     var stageButtons = `${ allScrollItems } .row stage-buttons button`;


### PR DESCRIPTION
… `<template>` elements

Closes #4805
