### PR TITLE
fix(core): reexport PLATFORM_DIRECTIVES and PLATFORM_PIPES in dart

### DIFF
--- a/modules/angular2/core.dart
+++ b/modules/angular2/core.dart
@@ -18,3 +18,4 @@ export 'package:angular2/src/common/directives.dart';
 export 'package:angular2/src/common/forms.dart';
 export 'package:angular2/src/core/debug.dart';
 export 'package:angular2/src/core/change_detection.dart';
+export 'package:angular2/src/core/platform_directives_and_pipes.dart';

--- a/modules/angular2/src/core/util.dart
+++ b/modules/angular2/src/core/util.dart
@@ -1,0 +1,4 @@
+library angular2.src.core.util;
+
+// the ts version is needed only for TS, we don't need a Dart implementation
+// because there are no decorators in Dart.

--- a/modules/angular2/src/facade/browser.dart
+++ b/modules/angular2/src/facade/browser.dart
@@ -5,11 +5,11 @@
 library angular2.src.facade.browser;
 
 import 'dart:js' show context;
+import 'dart:html' show Location, window;
 
 export 'dart:html'
     show
         document,
-        location,
         window,
         Element,
         Node,
@@ -20,6 +20,8 @@ export 'dart:html'
         History,
         Location,
         EventListener;
+
+Location get location => window.location;
 
 final _gc = context['gc'];
 

--- a/modules/angular2/src/facade/collection.dart
+++ b/modules/angular2/src/facade/collection.dart
@@ -1,8 +1,8 @@
 library facade.collection;
 
-import 'dart:collection' show IterableBase, Iterator;
+import 'dart:collection' show IterableBase;
 import 'dart:convert' show JsonEncoder;
-export 'dart:core' show Map, List, Set;
+export 'dart:core' show Iterator, Map, List, Set;
 import 'dart:math' show max, min;
 
 var jsonEncoder = new JsonEncoder();

--- a/modules/angular2/src/facade/facade.dart
+++ b/modules/angular2/src/facade/facade.dart
@@ -1,0 +1,7 @@
+library angular2.src.facade.facade;
+
+// Public API for Facade
+export "lang.dart" show Type;
+export "async.dart" show Stream, EventEmitter;
+export "exceptions.dart" show WrappedException;
+export "exception_handler.dart" show ExceptionHandler;


### PR DESCRIPTION
Looks like we missed this in the original PR.
