### PR TITLE
refactor(tests): rename beforeEachBindings -> beforeEachProviders 

### DIFF
--- a/modules/angular2/src/testing/testing_internal.dart
+++ b/modules/angular2/src/testing/testing_internal.dart
@@ -46,7 +46,7 @@ void testSetup() {
   reflector.reflectionCapabilities = new ReflectionCapabilities();
   // beforeEach configuration:
   // - Priority 3: clear the bindings before each test,
-  // - Priority 2: collect the bindings before each test, see beforeEachBindings(),
+  // - Priority 2: collect the bindings before each test, see beforeEachProviders(),
   // - Priority 1: create the test injector to be used in beforeEach() and it()
 
   gns.beforeEach(() {
@@ -74,7 +74,7 @@ void testSetup() {
  *
  * Example:
  *
- *   beforeEachBindings(() => [
+ *   beforeEachProviders(() => [
  *     bind(Compiler).toClass(MockCompiler),
  *     bind(SomeToken).toValue(myValue),
  *   ]);

--- a/modules/angular2/src/testing/testing_internal.ts
+++ b/modules/angular2/src/testing/testing_internal.ts
@@ -104,16 +104,16 @@ export function beforeEach(fn: FunctionWithParamTokens | SyncTestFn): void {
  *
  * Example:
  *
- *   beforeEachBindings(() => [
+ *   beforeEachProviders(() => [
  *     provide(Compiler, {useClass: MockCompiler}),
  *     provide(SomeToken, {useValue: myValue}),
  *   ]);
  */
 export function beforeEachProviders(fn): void {
   jsmBeforeEach(() => {
-    var bindings = fn();
-    if (!bindings) return;
-    testProviders = [...testProviders, ...bindings];
+    var providers = fn();
+    if (!providers) return;
+    testProviders = [...testProviders, ...providers];
   });
 }
 

--- a/modules/angular2/test/common/directives/ng_class_spec.ts
+++ b/modules/angular2/test/common/directives/ng_class_spec.ts
@@ -3,7 +3,7 @@ import {
   AsyncTestCompleter,
   TestComponentBuilder,
   beforeEach,
-  beforeEachBindings,
+  beforeEachProviders,
   ddescribe,
   xdescribe,
   describe,
@@ -30,7 +30,7 @@ export function main() {
   describe('binding to CSS class list', () => {
 
     describe('viewpool support', () => {
-      beforeEachBindings(() => { return [provide(APP_VIEW_POOL_CAPACITY, {useValue: 100})]; });
+      beforeEachProviders(() => { return [provide(APP_VIEW_POOL_CAPACITY, {useValue: 100})]; });
 
       it('should clean up when the directive is destroyed',
          inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {

--- a/modules/angular2/test/common/directives/ng_for_spec.ts
+++ b/modules/angular2/test/common/directives/ng_for_spec.ts
@@ -2,7 +2,7 @@ import {
   AsyncTestCompleter,
   TestComponentBuilder,
   beforeEach,
-  beforeEachBindings,
+  beforeEachProviders,
   ddescribe,
   describe,
   el,

--- a/modules/angular2/test/common/directives/ng_style_spec.ts
+++ b/modules/angular2/test/common/directives/ng_style_spec.ts
@@ -2,7 +2,7 @@ import {
   AsyncTestCompleter,
   TestComponentBuilder,
   beforeEach,
-  beforeEachBindings,
+  beforeEachProviders,
   ddescribe,
   xdescribe,
   describe,

--- a/modules/angular2/test/compiler/change_definition_factory_spec.ts
+++ b/modules/angular2/test/compiler/change_definition_factory_spec.ts
@@ -10,7 +10,7 @@ import {
   it,
   xit,
   TestComponentBuilder,
-  beforeEachBindings
+  beforeEachProviders
 } from 'angular2/testing_internal';
 import {MapWrapper} from 'angular2/src/facade/collection';
 import {
@@ -39,7 +39,7 @@ import {TEST_PROVIDERS} from './test_bindings';
 
 export function main() {
   describe('ChangeDefinitionFactory', () => {
-    beforeEachBindings(() => TEST_PROVIDERS);
+    beforeEachProviders(() => TEST_PROVIDERS);
 
     var parser: TemplateParser;
     var dispatcher: TestDispatcher;

--- a/modules/angular2/test/compiler/change_detector_compiler_spec.ts
+++ b/modules/angular2/test/compiler/change_detector_compiler_spec.ts
@@ -10,7 +10,7 @@ import {
   afterEach,
   AsyncTestCompleter,
   inject,
-  beforeEachBindings
+  beforeEachProviders
 } from 'angular2/testing_internal';
 import {provide} from 'angular2/src/core/di';
 
@@ -56,7 +56,7 @@ var THIS_MODULE_REF = moduleRef(THIS_MODULE_URL);
 
 export function main() {
   describe('ChangeDetectorCompiler', () => {
-    beforeEachBindings(() => TEST_PROVIDERS);
+    beforeEachProviders(() => TEST_PROVIDERS);
 
     var parser: TemplateParser;
     var compiler: ChangeDetectionCompiler;
@@ -78,7 +78,7 @@ export function main() {
       }
 
       describe('no jit', () => {
-        beforeEachBindings(() => [
+        beforeEachProviders(() => [
           provide(ChangeDetectorGenConfig,
                   {useValue: new ChangeDetectorGenConfig(true, false, false)})
         ]);
@@ -89,7 +89,7 @@ export function main() {
       });
 
       describe('jit', () => {
-        beforeEachBindings(() => [
+        beforeEachProviders(() => [
           provide(ChangeDetectorGenConfig,
                   {useValue: new ChangeDetectorGenConfig(true, false, true)})
         ]);

--- a/modules/angular2/test/compiler/command_compiler_spec.ts
+++ b/modules/angular2/test/compiler/command_compiler_spec.ts
@@ -10,7 +10,7 @@ import {
   afterEach,
   AsyncTestCompleter,
   inject,
-  beforeEachBindings
+  beforeEachProviders
 } from 'angular2/testing_internal';
 
 import {
@@ -84,7 +84,7 @@ var compTypeTemplateId: Map<CompileTypeMetadata, string> = MapWrapper.createFrom
 
 export function main() {
   describe('CommandCompiler', () => {
-    beforeEachBindings(() => TEST_PROVIDERS);
+    beforeEachProviders(() => TEST_PROVIDERS);
 
     var parser: TemplateParser;
     var commandCompiler: CommandCompiler;

--- a/modules/angular2/test/compiler/runtime_compiler_spec.ts
+++ b/modules/angular2/test/compiler/runtime_compiler_spec.ts
@@ -10,7 +10,7 @@ import {
   afterEach,
   AsyncTestCompleter,
   inject,
-  beforeEachBindings
+  beforeEachProviders
 } from 'angular2/testing_internal';
 
 import {Component, View, provide} from 'angular2/core';
@@ -35,7 +35,7 @@ export function main() {
       var protoViewFactorySpy;
       var someProtoView;
 
-      beforeEachBindings(() => {
+      beforeEachProviders(() => {
         protoViewFactorySpy = new SpyProtoViewFactory();
         someProtoView = new AppProtoView(null, null, null, null, null, null, null);
         protoViewFactorySpy.spy('createHost').andReturn(someProtoView);

--- a/modules/angular2/test/compiler/style_compiler_spec.ts
+++ b/modules/angular2/test/compiler/style_compiler_spec.ts
@@ -10,7 +10,7 @@ import {
   afterEach,
   AsyncTestCompleter,
   inject,
-  beforeEachBindings
+  beforeEachProviders
 } from 'angular2/testing_internal';
 import {provide} from 'angular2/src/core/di';
 import {SpyXHR} from './spies';
@@ -43,7 +43,7 @@ export function main() {
   describe('StyleCompiler', () => {
     var xhr: SpyXHR;
 
-    beforeEachBindings(() => {
+    beforeEachProviders(() => {
       xhr = <any>new SpyXHR();
       return [TEST_PROVIDERS, provide(XHR, {useValue: xhr})];
     });

--- a/modules/angular2/test/compiler/template_normalizer_spec.ts
+++ b/modules/angular2/test/compiler/template_normalizer_spec.ts
@@ -10,7 +10,7 @@ import {
   it,
   xit,
   TestComponentBuilder,
-  beforeEachBindings
+  beforeEachProviders
 } from 'angular2/testing_internal';
 
 import {
@@ -29,7 +29,7 @@ export function main() {
     var dirType: CompileTypeMetadata;
     var dirTypeWithHttpUrl: CompileTypeMetadata;
 
-    beforeEachBindings(() => TEST_PROVIDERS);
+    beforeEachProviders(() => TEST_PROVIDERS);
 
     beforeEach(() => {
       dirType = new CompileTypeMetadata({moduleUrl: 'package:some/module/a.js', name: 'SomeComp'});

--- a/modules/angular2/test/compiler/template_preparser_spec.ts
+++ b/modules/angular2/test/compiler/template_preparser_spec.ts
@@ -10,7 +10,7 @@ import {
   afterEach,
   AsyncTestCompleter,
   inject,
-  beforeEachBindings
+  beforeEachProviders
 } from 'angular2/testing_internal';
 
 import {HtmlParser} from 'angular2/src/compiler/html_parser';

--- a/modules/angular2/test/core/debug/debug_element_spec.ts
+++ b/modules/angular2/test/core/debug/debug_element_spec.ts
@@ -8,7 +8,7 @@ import {
   expect,
   iit,
   inject,
-  beforeEachBindings,
+  beforeEachProviders,
   it,
   xit,
   TestComponentBuilder

--- a/modules/angular2/test/core/dom/dom_adapter_spec.ts
+++ b/modules/angular2/test/core/dom/dom_adapter_spec.ts
@@ -9,7 +9,7 @@ import {
   inject,
   it,
   xit,
-  beforeEachBindings,
+  beforeEachProviders,
   SpyObject,
   stringifyElement
 } from 'angular2/testing_internal';

--- a/modules/angular2/test/core/linker/compiler_spec.ts
+++ b/modules/angular2/test/core/linker/compiler_spec.ts
@@ -10,7 +10,7 @@ import {
   afterEach,
   AsyncTestCompleter,
   inject,
-  beforeEachBindings
+  beforeEachProviders
 } from 'angular2/testing_internal';
 
 import {Component, View, provide} from 'angular2/core';
@@ -33,7 +33,7 @@ export function main() {
     var someProtoView;
     var cht: CompiledHostTemplate;
 
-    beforeEachBindings(() => {
+    beforeEachProviders(() => {
       protoViewFactorySpy = new SpyProtoViewFactory();
       someProtoView = new AppProtoView(null, null, null, null, null, null, null);
       protoViewFactorySpy.spy('createHost').andReturn(someProtoView);

--- a/modules/angular2/test/core/linker/dynamic_component_loader_spec.ts
+++ b/modules/angular2/test/core/linker/dynamic_component_loader_spec.ts
@@ -9,7 +9,7 @@ import {
   expect,
   iit,
   inject,
-  beforeEachBindings,
+  beforeEachProviders,
   it,
   xit,
   TestComponentBuilder,

--- a/modules/angular2/test/core/linker/view_container_ref_spec.ts
+++ b/modules/angular2/test/core/linker/view_container_ref_spec.ts
@@ -9,7 +9,7 @@ import {
   expect,
   iit,
   inject,
-  beforeEachBindings,
+  beforeEachProviders,
   it,
   xit
 } from 'angular2/testing_internal';

--- a/modules/angular2/test/core/linker/view_manager_spec.ts
+++ b/modules/angular2/test/core/linker/view_manager_spec.ts
@@ -9,7 +9,7 @@ import {
   expect,
   iit,
   inject,
-  beforeEachBindings,
+  beforeEachProviders,
   it,
   xit
 } from 'angular2/testing_internal';

--- a/modules/angular2/test/core/linker/view_manager_utils_spec.ts
+++ b/modules/angular2/test/core/linker/view_manager_utils_spec.ts
@@ -9,7 +9,7 @@ import {
   expect,
   iit,
   inject,
-  beforeEachBindings,
+  beforeEachProviders,
   it,
   xit,
   Log,

--- a/modules/angular2/test/core/linker/view_pool_spec.ts
+++ b/modules/angular2/test/core/linker/view_pool_spec.ts
@@ -9,7 +9,7 @@ import {
   expect,
   iit,
   inject,
-  beforeEachBindings,
+  beforeEachProviders,
   it,
   xit,
   SpyObject,

--- a/modules/angular2/test/platform/dom/dom_renderer_integration_spec.ts
+++ b/modules/angular2/test/platform/dom/dom_renderer_integration_spec.ts
@@ -9,7 +9,7 @@ import {
   inject,
   it,
   xit,
-  beforeEachBindings,
+  beforeEachProviders,
   SpyObject,
 } from 'angular2/testing_internal';
 

--- a/modules/angular2/test/platform/dom/shared_styles_host_spec.ts
+++ b/modules/angular2/test/platform/dom/shared_styles_host_spec.ts
@@ -9,7 +9,7 @@ import {
   expect,
   iit,
   inject,
-  beforeEachBindings,
+  beforeEachProviders,
   it,
   xit,
   SpyObject,

--- a/modules/angular2/test/router/location_spec.ts
+++ b/modules/angular2/test/router/location_spec.ts
@@ -8,7 +8,7 @@ import {
   expect,
   inject,
   beforeEach,
-  beforeEachBindings,
+  beforeEachProviders,
   SpyObject
 } from 'angular2/testing_internal';
 

--- a/modules/angular2/test/testing/test_component_builder_spec.ts
+++ b/modules/angular2/test/testing/test_component_builder_spec.ts
@@ -8,7 +8,7 @@ import {
   expect,
   iit,
   inject,
-  beforeEachBindings,
+  beforeEachProviders,
   it,
   xit,
   TestComponentBuilder

--- a/modules/angular2/test/web_workers/debug_tools/multi_client_server_message_bus.server.spec.dart
+++ b/modules/angular2/test/web_workers/debug_tools/multi_client_server_message_bus.server.spec.dart
@@ -12,7 +12,7 @@ import "package:angular2/testing_internal.dart"
         expect,
         beforeEach,
         createTestInjector,
-        beforeEachBindings,
+        beforeEachProviders,
         SpyObject,
         proxy;
 import "package:angular2/src/web_workers/debug_tools/multi_client_server_message_bus.dart";

--- a/modules/angular2/test/web_workers/debug_tools/single_client_server_message_bus.server.spec.dart
+++ b/modules/angular2/test/web_workers/debug_tools/single_client_server_message_bus.server.spec.dart
@@ -11,7 +11,7 @@ import "package:angular2/testing_internal.dart"
         expect,
         beforeEach,
         createTestInjector,
-        beforeEachBindings,
+        beforeEachProviders,
         SpyObject,
         proxy;
 import "package:angular2/src/web_workers/debug_tools/single_client_server_message_bus.dart";

--- a/modules/angular2/test/web_workers/debug_tools/web_socket_message_bus_spec.dart
+++ b/modules/angular2/test/web_workers/debug_tools/web_socket_message_bus_spec.dart
@@ -9,7 +9,7 @@ import "package:angular2/testing_internal.dart"
         expect,
         beforeEach,
         createTestInjector,
-        beforeEachBindings,
+        beforeEachProviders,
         SpyObject,
         proxy;
 import "package:angular2/src/web_workers/debug_tools/web_socket_message_bus.dart";

--- a/modules/angular2/test/web_workers/shared/message_bus_spec.ts
+++ b/modules/angular2/test/web_workers/shared/message_bus_spec.ts
@@ -6,7 +6,7 @@ import {
   expect,
   beforeEach,
   createTestInjector,
-  beforeEachBindings,
+  beforeEachProviders,
   SpyObject,
   proxy
 } from 'angular2/testing_internal';

--- a/modules/angular2/test/web_workers/shared/service_message_broker_spec.ts
+++ b/modules/angular2/test/web_workers/shared/service_message_broker_spec.ts
@@ -6,7 +6,7 @@ import {
   expect,
   beforeEach,
   createTestInjector,
-  beforeEachBindings,
+  beforeEachProviders,
   SpyObject,
   proxy
 } from 'angular2/testing_internal';
@@ -32,7 +32,7 @@ export function main() {
   const RESULT = 20;
   const ID = "methodId";
 
-  beforeEachBindings(() => [
+  beforeEachProviders(() => [
     provide(ON_WEB_WORKER, {useValue: true}),
     RenderProtoViewRefStore,
     RenderViewWithFragmentsStore

--- a/modules/angular2/test/web_workers/worker/event_dispatcher_spec.ts
+++ b/modules/angular2/test/web_workers/worker/event_dispatcher_spec.ts
@@ -6,7 +6,7 @@ import {
   expect,
   beforeEach,
   createTestInjector,
-  beforeEachBindings,
+  beforeEachProviders,
   SpyObject,
   proxy
 } from 'angular2/testing_internal';
@@ -26,7 +26,7 @@ import {EVENT_CHANNEL} from 'angular2/src/web_workers/shared/messaging_api';
 
 export function main() {
   describe("EventDispatcher", () => {
-    beforeEachBindings(() => [
+    beforeEachProviders(() => [
       provide(ON_WEB_WORKER, {useValue: true}),
       RenderProtoViewRefStore,
       RenderViewWithFragmentsStore

--- a/modules/angular2/test/web_workers/worker/renderer_integration_spec.ts
+++ b/modules/angular2/test/web_workers/worker/renderer_integration_spec.ts
@@ -8,7 +8,7 @@ import {
   expect,
   beforeEach,
   createTestInjector,
-  beforeEachBindings,
+  beforeEachProviders,
   TestComponentBuilder
 } from "angular2/testing_internal";
 import {DOM} from 'angular2/src/platform/dom/dom_adapter';
@@ -100,7 +100,7 @@ export function main() {
     var uiInjector: Injector;
     var uiRenderViewStore: RenderViewWithFragmentsStore;
 
-    beforeEachBindings(() => {
+    beforeEachProviders(() => {
       var uiRenderProtoViewStore = new RenderProtoViewRefStore(false);
       uiRenderViewStore = new RenderViewWithFragmentsStore(false);
       uiInjector = createTestInjector([

--- a/modules/angular2/test/web_workers/worker/xhr_impl_spec.ts
+++ b/modules/angular2/test/web_workers/worker/xhr_impl_spec.ts
@@ -6,7 +6,7 @@ import {
   expect,
   beforeEach,
   createTestInjector,
-  beforeEachBindings
+  beforeEachProviders
 } from 'angular2/testing_internal';
 import {SpyMessageBroker} from './spies';
 import {Type} from 'angular2/src/facade/lang';


### PR DESCRIPTION
As I understand it, `beforeEachBindings` has been deprecated in favor of `beforeEachProviders`

Probably there are more files, but this one was the first that struck my eye.
