### PR TITLE
route_recognizer: bad alias message, "CamelCase"

### DIFF
--- a/modules/angular2/src/router/route_recognizer.ts
+++ b/modules/angular2/src/router/route_recognizer.ts
@@ -47,7 +47,7 @@ export class RouteRecognizer {
     if (isPresent(config.as) && config.as[0].toUpperCase() != config.as[0]) {
       var suggestedAlias = config.as[0].toUpperCase() + config.as.substring(1);
       throw new BaseException(
-          `Route '${config.path}' with alias '${config.as}' does not begin with an uppercase letter. Route aliases should be CamelCase like '${suggestedAlias}'.`);
+          `Route '${config.path}' with alias '${config.as}' does not begin with an uppercase letter. Route aliases should be TitleCase like '${suggestedAlias}'.`);
     }
 
     if (config instanceof AuxRoute) {


### PR DESCRIPTION
Changed alias message to say "TitleCase" instead of "CamelCase"

Fixes #5190
