### PR TITLE
fix(router): resolve isRouteActive for parent routes

### DIFF
--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -117,12 +117,13 @@ export class Router {
    */
   isRouteActive(instruction: Instruction): boolean {
     var router = this;
-    while (isPresent(router.parent) && isPresent(instruction.child)) {
+    while (isPresent(router.parent)) {
       router = router.parent;
-      instruction = instruction.child;
+      instruction = isPresent(instruction.child) ? instruction.child : instruction;
     }
-    return isPresent(this._currentInstruction) &&
-           this._currentInstruction.component == instruction.component;
+    var currentInstruction =
+        isPresent(this._currentInstruction) ? this._currentInstruction : router._currentInstruction;
+    return isPresent(currentInstruction) && currentInstruction.component == instruction.component;
   }
 
 

--- a/modules/angular2/test/router/integration/router_link_spec.ts
+++ b/modules/angular2/test/router/integration/router_link_spec.ts
@@ -324,6 +324,24 @@ export function main() {
                });
          }));
 
+      it('should be added to links inside a router-outlet',
+         inject([AsyncTestCompleter], (async) => {
+           router.config([new Route({path: '/sample', component: SampleCmp, name: 'Sample'})])
+               .then((_) => compile())
+               .then((_) => {
+                 var element = fixture.debugElement.nativeElement;
+
+                 fixture.detectChanges();
+                 router.subscribe((_) => {
+                   fixture.detectChanges();
+                   var link = DOM.querySelector(element, '.link-inside-router-outlet');
+                   expect(link).toHaveCssClass('router-link-active');
+                   async.done();
+                 });
+
+                 router.navigate(['./Sample']);
+               });
+         }));
 
       describe("router link dsl", () => {
         it('should generate link hrefs with params', inject([AsyncTestCompleter], (async) => {
@@ -516,4 +534,14 @@ class AmbiguousBookCmp {
   new AuxRoute({path: '/aside', component: Hello2Cmp, name: 'Aside'})
 ])
 class AuxLinkCmp {
+}
+
+@Component({selector: 'sample-cmp'})
+@View({
+  template: `<div class="sample-cmp">
+    <a [router-link]="['../Sample']" class="link-inside-router-outlet">Link to parent</a>
+  </div>`,
+  directives: ROUTER_DIRECTIVES
+})
+class SampleCmp {
 }


### PR DESCRIPTION
Router.isRouteActive is not resolving routes like ['../RouteDefinedInParentComponent']

I just used the resolved router reference in the loop to evaluate the predicate instead of 'this'
