### PR TITLE
refactor(angular_1_router): Angular 1.X component integration

### DIFF
--- a/modules/angular1_router/src/ng_outlet.ts
+++ b/modules/angular1_router/src/ng_outlet.ts
@@ -155,7 +155,8 @@ function ngOutletDirective($animate, $q: ng.IQService, $router) {
         }
 
         this.controller.$$routeParams = instruction.params;
-        this.controller.$$template = '<div ' + dashCase(componentName) + '></div>';
+        this.controller.$$template =
+            '<' + dashCase(componentName) + '></' + dashCase(componentName) + '>';
         this.controller.$$router = this.router.childRouter(instruction.componentType);
 
         let newScope = scope.$new();


### PR DESCRIPTION
With the latest update on angular 1.5, @shahata  introduced a more convenient way to create component (Through this PR angular/angular.js#12933). The thing is the default configuration of the components prevent the new router to use it as is.

The default value of the restrict is 'E' whereas the ngOutlet directive is expecting components with a restrict 'A'

This PR is just simple modification of the ngOutlet directive to make the default configuration of a component working with the new router.
