### PR TITLE
fix(http): refactor 'require' statements to 'import' declarations for Rx

### DIFF
--- a/modules/angular2/src/http/backends/mock_backend.ts
+++ b/modules/angular2/src/http/backends/mock_backend.ts
@@ -5,8 +5,7 @@ import {ReadyStates} from '../enums';
 import {Connection, ConnectionBackend} from '../interfaces';
 import {isPresent} from 'angular2/src/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
-var Rx = require('@reactivex/rxjs/dist/cjs/Rx');
-let {Subject, ReplaySubject} = Rx;
+import {Subject, ReplaySubject} from '@reactivex/rxjs/dist/cjs/Rx';
 
 /**
  *

--- a/modules/angular2/test/http/http_spec.ts
+++ b/modules/angular2/test/http/http_spec.ts
@@ -29,9 +29,7 @@ import {
   Http,
   Jsonp
 } from 'angular2/http';
-
-var Rx = require('@reactivex/rxjs/dist/cjs/Rx');
-let {Observable, Subject} = Rx;
+import {Observable, Subject} from '@reactivex/rxjs/dist/cjs/Rx';
 
 class SpyObserver extends SpyObject {
   onNext: Function;


### PR DESCRIPTION
Looks like this is some old leftover code from the times when Rx didn't distribute typings via npm.
