### PR TITLE
Optimize unit tests

### DIFF
--- a/modules/angular2/src/common/forms/directives/checkbox_value_accessor.ts
+++ b/modules/angular2/src/common/forms/directives/checkbox_value_accessor.ts
@@ -5,7 +5,6 @@ import {Self, forwardRef, Provider} from 'angular2/src/core/di';
 
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from './control_value_accessor';
 import {CONST_EXPR} from 'angular2/src/facade/lang';
-import {setProperty} from './shared';
 
 const CHECKBOX_VALUE_ACCESSOR = CONST_EXPR(new Provider(
     NG_VALUE_ACCESSOR, {useExisting: forwardRef(() => CheckboxControlValueAccessor), multi: true}));
@@ -30,7 +29,9 @@ export class CheckboxControlValueAccessor implements ControlValueAccessor {
 
   constructor(private _renderer: Renderer, private _elementRef: ElementRef) {}
 
-  writeValue(value: any): void { setProperty(this._renderer, this._elementRef, "checked", value); }
+  writeValue(value: any): void {
+    this._renderer.setElementProperty(this._elementRef, 'checked', value);
+  }
   registerOnChange(fn: (_: any) => {}): void { this.onChange = fn; }
   registerOnTouched(fn: () => {}): void { this.onTouched = fn; }
 }

--- a/modules/angular2/src/common/forms/directives/default_value_accessor.ts
+++ b/modules/angular2/src/common/forms/directives/default_value_accessor.ts
@@ -4,7 +4,6 @@ import {Renderer} from 'angular2/src/core/render';
 import {Self, forwardRef, Provider} from 'angular2/src/core/di';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from './control_value_accessor';
 import {isBlank, CONST_EXPR} from 'angular2/src/facade/lang';
-import {setProperty} from './shared';
 
 const DEFAULT_VALUE_ACCESSOR = CONST_EXPR(new Provider(
     NG_VALUE_ACCESSOR, {useExisting: forwardRef(() => DefaultValueAccessor), multi: true}));
@@ -39,7 +38,7 @@ export class DefaultValueAccessor implements ControlValueAccessor {
 
   writeValue(value: any): void {
     var normalizedValue = isBlank(value) ? '' : value;
-    setProperty(this._renderer, this._elementRef, 'value', normalizedValue);
+    this._renderer.setElementProperty(this._elementRef, 'value', normalizedValue);
   }
 
   registerOnChange(fn: (_: any) => void): void { this.onChange = fn; }

--- a/modules/angular2/src/common/forms/directives/number_value_accessor.ts
+++ b/modules/angular2/src/common/forms/directives/number_value_accessor.ts
@@ -4,7 +4,6 @@ import {Renderer} from 'angular2/src/core/render';
 import {Self, forwardRef, Provider} from 'angular2/src/core/di';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from './control_value_accessor';
 import {isBlank, CONST_EXPR, NumberWrapper} from 'angular2/src/facade/lang';
-import {setProperty} from './shared';
 
 const NUMBER_VALUE_ACCESSOR = CONST_EXPR(new Provider(
     NG_VALUE_ACCESSOR, {useExisting: forwardRef(() => NumberValueAccessor), multi: true}));
@@ -34,7 +33,9 @@ export class NumberValueAccessor implements ControlValueAccessor {
 
   constructor(private _renderer: Renderer, private _elementRef: ElementRef) {}
 
-  writeValue(value: number): void { setProperty(this._renderer, this._elementRef, 'value', value); }
+  writeValue(value: number): void {
+    this._renderer.setElementProperty(this._elementRef, 'value', value);
+  }
 
   registerOnChange(fn: (_: number) => void): void {
     this.onChange = (value) => { fn(NumberWrapper.parseFloat(value)); };

--- a/modules/angular2/src/common/forms/directives/select_control_value_accessor.ts
+++ b/modules/angular2/src/common/forms/directives/select_control_value_accessor.ts
@@ -6,7 +6,6 @@ import {Query, Directive} from 'angular2/src/core/metadata';
 import {ObservableWrapper} from 'angular2/src/facade/async';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from './control_value_accessor';
 import {CONST_EXPR} from 'angular2/src/facade/lang';
-import {setProperty} from './shared';
 
 const SELECT_VALUE_ACCESSOR = CONST_EXPR(new Provider(
     NG_VALUE_ACCESSOR, {useExisting: forwardRef(() => SelectControlValueAccessor), multi: true}));
@@ -50,7 +49,7 @@ export class SelectControlValueAccessor implements ControlValueAccessor {
 
   writeValue(value: any): void {
     this.value = value;
-    setProperty(this._renderer, this._elementRef, "value", value);
+    this._renderer.setElementProperty(this._elementRef, 'value', value);
   }
 
   registerOnChange(fn: () => any): void { this.onChange = fn; }

--- a/modules/angular2/src/common/forms/directives/shared.ts
+++ b/modules/angular2/src/common/forms/directives/shared.ts
@@ -9,8 +9,6 @@ import {NgControlGroup} from './ng_control_group';
 import {Control, ControlGroup} from '../model';
 import {Validators} from '../validators';
 import {ControlValueAccessor} from './control_value_accessor';
-import {ElementRef, QueryList} from 'angular2/src/core/linker';
-import {Renderer} from 'angular2/src/core/render';
 import {DefaultValueAccessor} from './default_value_accessor';
 import {NumberValueAccessor} from './number_value_accessor';
 import {CheckboxControlValueAccessor} from './checkbox_value_accessor';
@@ -55,11 +53,6 @@ export function setUpControlGroup(control: ControlGroup, dir: NgControlGroup) {
 function _throwError(dir: AbstractControlDirective, message: string): void {
   var path = dir.path.join(" -> ");
   throw new BaseException(`${message} '${path}'`);
-}
-
-export function setProperty(renderer: Renderer, elementRef: ElementRef, propName: string,
-                            propValue: any) {
-  renderer.setElementProperty(elementRef, propName, propValue);
 }
 
 export function composeValidators(validators: /* Array<Validator|Function> */ any[]): Function {

--- a/modules/angular2/src/core/linker/element_injector.ts
+++ b/modules/angular2/src/core/linker/element_injector.ts
@@ -34,8 +34,8 @@ import {resolveProvider, ResolvedFactory, ResolvedProvider_} from 'angular2/src/
 
 import {AttributeMetadata, QueryMetadata} from '../metadata/di';
 
-import * as viewModule from './view';
-import * as avmModule from './view_manager';
+import {AppViewContainer, AppView} from './view';
+/* circular */ import * as avmModule from './view_manager';
 import {ViewContainerRef} from './view_container_ref';
 import {ElementRef} from './element_ref';
 import {TemplateRef} from './template_ref';
@@ -183,8 +183,8 @@ export class DirectiveProvider extends ResolvedProvider_ {
 
 // TODO(rado): benchmark and consider rolling in as ElementInjector fields.
 export class PreBuiltObjects {
-  nestedView: viewModule.AppView = null;
-  constructor(public viewManager: avmModule.AppViewManager, public view: viewModule.AppView,
+  nestedView: AppView = null;
+  constructor(public viewManager: avmModule.AppViewManager, public view: AppView,
               public elementRef: ElementRef, public templateRef: TemplateRef) {}
 }
 
@@ -195,7 +195,7 @@ export class QueryMetadataWithSetter {
 export class EventEmitterAccessor {
   constructor(public eventName: string, public getter: Function) {}
 
-  subscribe(view: viewModule.AppView, boundElementIndex: number, directive: Object): Object {
+  subscribe(view: AppView, boundElementIndex: number, directive: Object): Object {
     var eventEmitter = this.getter(directive);
     return ObservableWrapper.subscribe<Event>(
         eventEmitter,
@@ -235,7 +235,7 @@ function _createProtoQueryRefs(providers: ProviderWithVisibility[]): ProtoQueryR
 }
 
 export class ProtoElementInjector {
-  view: viewModule.AppView;
+  view: AppView;
   attributes: Map<string, string>;
   eventEmitterAccessors: EventEmitterAccessor[][];
   protoQueryRefs: ProtoQueryRef[];
@@ -451,9 +451,9 @@ export class ElementInjector extends TreeNode<ElementInjector> implements Depend
     return new ViewContainerRef_(this._preBuiltObjects.viewManager, this.getElementRef());
   }
 
-  getNestedView(): viewModule.AppView { return this._preBuiltObjects.nestedView; }
+  getNestedView(): AppView { return this._preBuiltObjects.nestedView; }
 
-  getView(): viewModule.AppView { return this._preBuiltObjects.view; }
+  getView(): AppView { return this._preBuiltObjects.view; }
 
   directParent(): ElementInjector { return this._proto.distanceToParent < 2 ? this.parent : null; }
 
@@ -1044,13 +1044,13 @@ export class QueryRef {
     }
   }
 
-  private _visitViewContainer(vc: viewModule.AppViewContainer, aggregator: any[]) {
+  private _visitViewContainer(vc: AppViewContainer, aggregator: any[]) {
     for (var j = 0; j < vc.views.length; j++) {
       this._visitView(vc.views[j], aggregator);
     }
   }
 
-  private _visitView(view: viewModule.AppView, aggregator: any[]) {
+  private _visitView(view: AppView, aggregator: any[]) {
     for (var i = view.elementOffset; i < view.elementOffset + view.ownBindersCount; i++) {
       var inj = view.elementInjectors[i];
       if (isBlank(inj)) continue;


### PR DESCRIPTION
Before: `initial 20s incremental: 5.5s` 
Before with noEmitOnError=false manually patched-in: `initial 18s incremental: 3.15s`
After: `initial 7.7s incremental: 0.5s`

It is faster for the following two reasons: 
- no es6 
- no files from node_modules go into the browser tree.

Now, the time is split more-or-less equally between Funnel, MergeTrees, and TS. 

This PR also fixed the circular dependencies check that was broken.
