### PR TITLE
refactor(EventEmitter): rename .next() to .emit()

### DIFF
--- a/modules/angular1_router/lib/facades.es5
+++ b/modules/angular1_router/lib/facades.es5
@@ -276,6 +276,9 @@ var ObservableWrapper = {
   callNext: function(ob, val) {
     ob.fn(val);
   },
+  callEmit: function(ob, val) {
+    ob.fn(val);
+  },
 
   subscribe: function(ob, fn) {
     ob.fn = fn;

--- a/modules/angular2/docs/web_workers/web_workers.md
+++ b/modules/angular2/docs/web_workers/web_workers.md
@@ -230,7 +230,7 @@ import {bootstrap} from 'angular2/web_worker/ui';
 var instance = bootstrap("loader.js");
 var bus = instance.bus;
 bus.initChannel("My Custom Channel");
-bus.to("My Custom Channel").next("hello from the UI");
+bus.to("My Custom Channel").emit("hello from the UI");
 ```
 ```TypeScript
 // background_index.ts, which is running on the WebWorker

--- a/modules/angular2/src/common/forms/directives/ng_control_name.ts
+++ b/modules/angular2/src/common/forms/directives/ng_control_name.ts
@@ -117,7 +117,7 @@ export class NgControlName extends NgControl implements OnChanges,
 
   viewToModelUpdate(newValue: any): void {
     this.viewModel = newValue;
-    ObservableWrapper.callNext(this.update, newValue);
+    ObservableWrapper.callEmit(this.update, newValue);
   }
 
   get path(): string[] { return controlPath(this.name, this._parent); }

--- a/modules/angular2/src/common/forms/directives/ng_form.ts
+++ b/modules/angular2/src/common/forms/directives/ng_form.ts
@@ -160,7 +160,7 @@ export class NgForm extends ControlContainer implements Form {
   }
 
   onSubmit(): boolean {
-    ObservableWrapper.callNext(this.ngSubmit, null);
+    ObservableWrapper.callEmit(this.ngSubmit, null);
     return false;
   }
 

--- a/modules/angular2/src/common/forms/directives/ng_form_control.ts
+++ b/modules/angular2/src/common/forms/directives/ng_form_control.ts
@@ -110,7 +110,7 @@ export class NgFormControl extends NgControl implements OnChanges {
 
   viewToModelUpdate(newValue: any): void {
     this.viewModel = newValue;
-    ObservableWrapper.callNext(this.update, newValue);
+    ObservableWrapper.callEmit(this.update, newValue);
   }
 
   private _isControlChanged(changes: {[key: string]: any}): boolean {

--- a/modules/angular2/src/common/forms/directives/ng_form_model.ts
+++ b/modules/angular2/src/common/forms/directives/ng_form_model.ts
@@ -157,7 +157,7 @@ export class NgFormModel extends ControlContainer implements Form,
   }
 
   onSubmit(): boolean {
-    ObservableWrapper.callNext(this.ngSubmit, null);
+    ObservableWrapper.callEmit(this.ngSubmit, null);
     return false;
   }
 

--- a/modules/angular2/src/common/forms/directives/ng_model.ts
+++ b/modules/angular2/src/common/forms/directives/ng_model.ts
@@ -86,6 +86,6 @@ export class NgModel extends NgControl implements OnChanges {
 
   viewToModelUpdate(newValue: any): void {
     this.viewModel = newValue;
-    ObservableWrapper.callNext(this.update, newValue);
+    ObservableWrapper.callEmit(this.update, newValue);
   }
 }

--- a/modules/angular2/src/common/forms/model.ts
+++ b/modules/angular2/src/common/forms/model.ts
@@ -128,8 +128,8 @@ export abstract class AbstractControl {
     }
 
     if (emitEvent) {
-      ObservableWrapper.callNext(this._valueChanges, this._value);
-      ObservableWrapper.callNext(this._statusChanges, this._status);
+      ObservableWrapper.callEmit(this._valueChanges, this._value);
+      ObservableWrapper.callEmit(this._statusChanges, this._status);
     }
 
     if (isPresent(this._parent) && !onlySelf) {
@@ -185,7 +185,7 @@ export abstract class AbstractControl {
     this._status = this._calculateStatus();
 
     if (emitEvent) {
-      ObservableWrapper.callNext(this._statusChanges, this._status);
+      ObservableWrapper.callEmit(this._statusChanges, this._status);
     }
 
     if (isPresent(this._parent)) {

--- a/modules/angular2/src/core/linker/query_list.ts
+++ b/modules/angular2/src/core/linker/query_list.ts
@@ -66,5 +66,5 @@ export class QueryList<T> {
   reset(res: T[]): void { this._results = res; }
 
   /** @internal */
-  notifyOnChanges(): void { this._emitter.next(this); }
+  notifyOnChanges(): void { this._emitter.emit(this); }
 }

--- a/modules/angular2/src/core/metadata.ts
+++ b/modules/angular2/src/core/metadata.ts
@@ -1321,8 +1321,8 @@ export var Input: InputFactory = makePropDecorator(InputMetadata);
  *   @Output('everyFiveSeconds') five5Secs = new EventEmitter();
  *
  *   constructor() {
- *     setInterval(() => this.everySecond.next("event"), 1000);
- *     setInterval(() => this.five5Secs.next("event"), 5000);
+ *     setInterval(() => this.everySecond.emit("event"), 1000);
+ *     setInterval(() => this.five5Secs.emit("event"), 5000);
  *   }
  * }
  *

--- a/modules/angular2/src/core/metadata/directives.ts
+++ b/modules/angular2/src/core/metadata/directives.ts
@@ -496,8 +496,8 @@ export class DirectiveMetadata extends InjectableMetadata {
    *   five5Secs = new EventEmitter();
    *
    *   constructor() {
-   *     setInterval(() => this.everySecond.next("event"), 1000);
-   *     setInterval(() => this.five5Secs.next("event"), 5000);
+   *     setInterval(() => this.everySecond.emit("event"), 1000);
+   *     setInterval(() => this.five5Secs.emit("event"), 5000);
    *   }
    * }
    *
@@ -1047,8 +1047,8 @@ export class InputMetadata {
  *   @Output('everyFiveSeconds') five5Secs = new EventEmitter();
  *
  *   constructor() {
- *     setInterval(() => this.everySecond.next("event"), 1000);
- *     setInterval(() => this.five5Secs.next("event"), 5000);
+ *     setInterval(() => this.everySecond.emit("event"), 1000);
+ *     setInterval(() => this.five5Secs.emit("event"), 5000);
  *   }
  * }
  *

--- a/modules/angular2/src/core/zone/ng_zone.ts
+++ b/modules/angular2/src/core/zone/ng_zone.ts
@@ -187,7 +187,7 @@ export class NgZone {
 
   /** @internal */
   _notifyOnTurnStart(parentRun): void {
-    parentRun.call(this._innerZone, () => { this._onTurnStartEvents.next(null); });
+    parentRun.call(this._innerZone, () => { this._onTurnStartEvents.emit(null); });
   }
 
   /**
@@ -216,7 +216,7 @@ export class NgZone {
 
   /** @internal */
   _notifyOnTurnDone(parentRun): void {
-    parentRun.call(this._innerZone, () => { this._onTurnDoneEvents.next(null); });
+    parentRun.call(this._innerZone, () => { this._onTurnDoneEvents.emit(null); });
   }
 
   /**
@@ -255,7 +255,7 @@ export class NgZone {
 
   /** @internal */
   _notifyOnEventDone(): void {
-    this.runOutsideAngular(() => { this._onEventDoneEvents.next(null); });
+    this.runOutsideAngular(() => { this._onEventDoneEvents.emit(null); });
   }
 
   /**
@@ -440,7 +440,7 @@ export class NgZone {
         zone = zone.parent;
       }
       if (ObservableWrapper.hasSubscribers(this._onErrorEvents)) {
-        ObservableWrapper.callNext(this._onErrorEvents, new NgZoneError(e, trace));
+        ObservableWrapper.callEmit(this._onErrorEvents, new NgZoneError(e, trace));
       }
       if (isPresent(this._onErrorHandler)) {
         this._onErrorHandler(e, trace);

--- a/modules/angular2/src/facade/async.dart
+++ b/modules/angular2/src/facade/async.dart
@@ -46,7 +46,12 @@ class ObservableWrapper {
     s.cancel();
   }
 
+  @Deprecated('Use callEmit() instead')
   static void callNext(EventEmitter emitter, value) {
+    emitter.add(value);
+  }
+  
+  static void callEmit(EventEmitter emitter, value) {
     emitter.add(value);
   }
 
@@ -83,6 +88,10 @@ class EventEmitter<T> extends Stream<T> {
   }
 
   void add(value) {
+    _controller.add(value);
+  }
+  
+  void emit(value) {
     _controller.add(value);
   }
 

--- a/modules/angular2/src/facade/async.ts
+++ b/modules/angular2/src/facade/async.ts
@@ -39,7 +39,12 @@ export class ObservableWrapper {
 
   static dispose(subscription: any) { subscription.unsubscribe(); }
 
+  /**
+   * @deprecated - use callEmit() instead
+   */
   static callNext(emitter: EventEmitter<any>, value: any) { emitter.next(value); }
+
+  static callEmit(emitter: EventEmitter<any>, value: any) { emitter.emit(value); }
 
   static callError(emitter: EventEmitter<any>, error: any) { emitter.error(error); }
 
@@ -78,9 +83,9 @@ export class ObservableWrapper {
  *   toggle() {
  *     this.visible = !this.visible;
  *     if (this.visible) {
- *       this.open.next(null);
+ *       this.open.emit(null);
  *     } else {
- *       this.close.next(null);
+ *       this.close.emit(null);
  *     }
  *   }
  * }
@@ -103,6 +108,13 @@ export class EventEmitter<T> extends Subject<T> {
     super();
     this._isAsync = isAsync;
   }
+
+  emit(value: T) { super.next(value); }
+
+  /**
+   * @deprecated - use .emit(value) instead
+   */
+  next(value: any) { super.next(value); }
 
   subscribe(generatorOrNext?: any, error?: any, complete?: any): any {
     if (generatorOrNext && typeof generatorOrNext === 'object') {

--- a/modules/angular2/src/mock/location_mock.ts
+++ b/modules/angular2/src/mock/location_mock.ts
@@ -19,7 +19,7 @@ export class SpyLocation implements Location {
 
   path(): string { return this._path; }
 
-  simulateUrlPop(pathname: string) { ObservableWrapper.callNext(this._subject, {'url': pathname}); }
+  simulateUrlPop(pathname: string) { ObservableWrapper.callEmit(this._subject, {'url': pathname}); }
 
   prepareExternalUrl(url: string): string {
     if (url.length > 0 && !url.startsWith('/')) {

--- a/modules/angular2/src/mock/mock_location_strategy.ts
+++ b/modules/angular2/src/mock/mock_location_strategy.ts
@@ -13,7 +13,7 @@ export class MockLocationStrategy extends LocationStrategy {
 
   simulatePopState(url: string): void {
     this.internalPath = url;
-    ObservableWrapper.callNext(this._subject, null);
+    ObservableWrapper.callEmit(this._subject, null);
   }
 
   path(): string { return this.internalPath; }
@@ -21,7 +21,7 @@ export class MockLocationStrategy extends LocationStrategy {
   prepareExternalUrl(internal: string): string { return internal; }
 
   simulateUrlPop(pathname: string): void {
-    ObservableWrapper.callNext(this._subject, {'url': pathname});
+    ObservableWrapper.callEmit(this._subject, {'url': pathname});
   }
 
   pushState(ctx: any, title: string, path: string, query: string): void {

--- a/modules/angular2/src/router/location.ts
+++ b/modules/angular2/src/router/location.ts
@@ -94,7 +94,7 @@ export class Location {
 
     this._baseHref = stripTrailingSlash(stripIndexHtml(browserBaseHref));
     this.platformStrategy.onPopState(
-        (_) => { ObservableWrapper.callNext(this._subject, {'url': this.path(), 'pop': true}); });
+        (_) => { ObservableWrapper.callEmit(this._subject, {'url': this.path(), 'pop': true}); });
   }
 
   /**

--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -241,7 +241,7 @@ export class Router {
     return PromiseWrapper.all(unsettledInstructions);
   }
 
-  private _emitNavigationFinish(url): void { ObservableWrapper.callNext(this._subject, url); }
+  private _emitNavigationFinish(url): void { ObservableWrapper.callEmit(this._subject, url); }
 
   private _afterPromiseFinishNavigating(promise: Promise<any>): Promise<any> {
     return PromiseWrapper.catchError(promise.then((_) => this._finishNavigating()), (err) => {

--- a/modules/angular2/src/upgrade/upgrade_ng1_adapter.ts
+++ b/modules/angular2/src/upgrade/upgrade_ng1_adapter.ts
@@ -216,7 +216,7 @@ class UpgradeNg1ComponentAdapter implements OnChanges, DoCheck {
     }
     for (var j = 0; j < outputs.length; j++) {
       var emitter = this[outputs[j]] = new EventEmitter();
-      this.setComponentProperty(outputs[j], ((emitter) => (value) => emitter.next(value))(emitter));
+      this.setComponentProperty(outputs[j], ((emitter) => (value) => emitter.emit(value))(emitter));
     }
     for (var k = 0; k < propOuts.length; k++) {
       this[propOuts[k]] = new EventEmitter();
@@ -246,7 +246,7 @@ class UpgradeNg1ComponentAdapter implements OnChanges, DoCheck {
           // ignore because NaN != NaN
         } else {
           var eventEmitter: EventEmitter<any> = this[this.propOuts[i]];
-          eventEmitter.next(lastValues[i] = value);
+          eventEmitter.emit(lastValues[i] = value);
         }
       }
     }

--- a/modules/angular2/src/web_workers/shared/client_message_broker.ts
+++ b/modules/angular2/src/web_workers/shared/client_message_broker.ts
@@ -107,7 +107,7 @@ export class ClientMessageBroker_ extends ClientMessageBroker {
     if (id != null) {
       message['id'] = id;
     }
-    ObservableWrapper.callNext(this._sink, message);
+    ObservableWrapper.callEmit(this._sink, message);
 
     return promise;
   }

--- a/modules/angular2/src/web_workers/shared/post_message_bus.ts
+++ b/modules/angular2/src/web_workers/shared/post_message_bus.ts
@@ -125,9 +125,9 @@ export class PostMessageBusSource implements MessageBusSource {
     if (StringMapWrapper.contains(this._channels, channel)) {
       var channelInfo = this._channels[channel];
       if (channelInfo.runInZone) {
-        this._zone.run(() => { channelInfo.emitter.next(data.message); });
+        this._zone.run(() => { channelInfo.emitter.emit(data.message); });
       } else {
-        channelInfo.emitter.next(data.message);
+        channelInfo.emitter.emit(data.message);
       }
     }
   }

--- a/modules/angular2/src/web_workers/shared/service_message_broker.ts
+++ b/modules/angular2/src/web_workers/shared/service_message_broker.ts
@@ -75,7 +75,7 @@ export class ServiceMessageBroker_ extends ServiceMessageBroker {
 
   private _wrapWebWorkerPromise(id: string, promise: Promise<any>, type: Type): void {
     PromiseWrapper.then(promise, (result: any) => {
-      ObservableWrapper.callNext(
+      ObservableWrapper.callEmit(
           this._sink,
           {'type': 'result', 'value': this._serializer.serialize(result, type), 'id': id});
     });

--- a/modules/angular2/src/web_workers/ui/event_dispatcher.ts
+++ b/modules/angular2/src/web_workers/ui/event_dispatcher.ts
@@ -101,7 +101,7 @@ export class EventDispatcher implements RenderEventDispatcher {
     var serializedLocals = StringMapWrapper.create();
     StringMapWrapper.set(serializedLocals, '$event', serializedEvent);
 
-    ObservableWrapper.callNext(this._sink, {
+    ObservableWrapper.callEmit(this._sink, {
       "viewRef": this._serializer.serialize(this._viewRef, RenderViewRef),
       "elementIndex": elementIndex,
       "eventName": eventName,

--- a/modules/angular2/src/web_workers/ui/setup.ts
+++ b/modules/angular2/src/web_workers/ui/setup.ts
@@ -20,7 +20,7 @@ export class WebWorkerSetup {
 
     ObservableWrapper.subscribe(source, (message: string) => {
       if (StringWrapper.equals(message, "ready")) {
-        ObservableWrapper.callNext(sink, {"rootUrl": this.rootUrl});
+        ObservableWrapper.callEmit(sink, {"rootUrl": this.rootUrl});
       }
     });
   }

--- a/modules/angular2/src/web_workers/worker/application_common.ts
+++ b/modules/angular2/src/web_workers/worker/application_common.ts
@@ -140,7 +140,7 @@ export function bootstrapWebWorkerCommon(
       ObservableWrapper.dispose(subscription);
     });
 
-    ObservableWrapper.callNext(bus.to(SETUP_CHANNEL), "ready");
+    ObservableWrapper.callEmit(bus.to(SETUP_CHANNEL), "ready");
     return bootstrapProcess.promise;
   });
   return PromiseWrapper.then(appPromise, (app) => app.bootstrap(appComponentType));

--- a/modules/angular2/test/common/forms/integration_spec.ts
+++ b/modules/angular2/test/common/forms/integration_spec.ts
@@ -990,7 +990,7 @@ class MyInput implements ControlValueAccessor {
   registerOnTouched(fn) {}
 
   dispatchChangeEvent() {
-    ObservableWrapper.callNext(this.onChange, this.value.substring(1, this.value.length - 1));
+    ObservableWrapper.callEmit(this.onChange, this.value.substring(1, this.value.length - 1));
   }
 }
 

--- a/modules/angular2/test/common/forms/model_spec.ts
+++ b/modules/angular2/test/common/forms/model_spec.ts
@@ -37,7 +37,7 @@ export function main() {
 
   function asyncValidatorReturningObservable(c) {
     var e = new EventEmitter();
-    PromiseWrapper.scheduleMicrotask(() => ObservableWrapper.callNext(e, {"async": true}));
+    PromiseWrapper.scheduleMicrotask(() => ObservableWrapper.callEmit(e, {"async": true}));
     return e;
   }
 

--- a/modules/angular2/test/common/forms/validators_spec.ts
+++ b/modules/angular2/test/common/forms/validators_spec.ts
@@ -101,9 +101,9 @@ export function main() {
           var res = c.value != expected ? response : null;
 
           PromiseWrapper.scheduleMicrotask(() => {
-            ObservableWrapper.callNext(emitter, res);
+            ObservableWrapper.callEmit(emitter, res);
             // this is required because of a bug in ObservableWrapper
-            // where callComplete can fire before callNext
+            // where callComplete can fire before callEmit
             // remove this one the bug is fixed
             TimerWrapper.setTimeout(() => { ObservableWrapper.callComplete(emitter); }, 0);
           });

--- a/modules/angular2/test/common/pipes/async_pipe_spec.ts
+++ b/modules/angular2/test/common/pipes/async_pipe_spec.ts
@@ -46,7 +46,7 @@ export function main() {
            inject([AsyncTestCompleter], (async) => {
              pipe.transform(emitter);
 
-             ObservableWrapper.callNext(emitter, message);
+             ObservableWrapper.callEmit(emitter, message);
 
              TimerWrapper.setTimeout(() => {
                expect(pipe.transform(emitter)).toEqual(new WrappedValue(message));
@@ -58,7 +58,7 @@ export function main() {
         it("should return same value when nothing has changed since the last call",
            inject([AsyncTestCompleter], (async) => {
              pipe.transform(emitter);
-             ObservableWrapper.callNext(emitter, message);
+             ObservableWrapper.callEmit(emitter, message);
 
              TimerWrapper.setTimeout(() => {
                pipe.transform(emitter);
@@ -75,7 +75,7 @@ export function main() {
              expect(pipe.transform(newEmitter)).toBe(null);
 
              // this should not affect the pipe
-             ObservableWrapper.callNext(emitter, message);
+             ObservableWrapper.callEmit(emitter, message);
 
              TimerWrapper.setTimeout(() => {
                expect(pipe.transform(newEmitter)).toBe(null);
@@ -86,7 +86,7 @@ export function main() {
         it("should request a change detection check upon receiving a new value",
            inject([AsyncTestCompleter], (async) => {
              pipe.transform(emitter);
-             ObservableWrapper.callNext(emitter, message);
+             ObservableWrapper.callEmit(emitter, message);
 
              TimerWrapper.setTimeout(() => {
                expect(ref.spy('markForCheck')).toHaveBeenCalled();
@@ -103,7 +103,7 @@ export function main() {
              pipe.transform(emitter);
              pipe.onDestroy();
 
-             ObservableWrapper.callNext(emitter, message);
+             ObservableWrapper.callEmit(emitter, message);
 
              TimerWrapper.setTimeout(() => {
                expect(pipe.transform(emitter)).toBe(null);

--- a/modules/angular2/test/core/facade/async_spec.ts
+++ b/modules/angular2/test/core/facade/async_spec.ts
@@ -32,7 +32,7 @@ export function main() {
            async.done();
          });
 
-         ObservableWrapper.callNext(emitter, 99);
+         ObservableWrapper.callEmit(emitter, 99);
        }));
 
     it("should call the throw callback", inject([AsyncTestCompleter], (async) => {
@@ -58,7 +58,7 @@ export function main() {
       var called = false;
       ObservableWrapper.subscribe(emitter, (value) => { called = true; });
 
-      ObservableWrapper.callNext(emitter, 99);
+      ObservableWrapper.callEmit(emitter, 99);
       expect(called).toBe(false);
     });
 
@@ -71,7 +71,7 @@ export function main() {
            async.done();
          });
          log.push(1);
-         ObservableWrapper.callNext(e, 2);
+         ObservableWrapper.callEmit(e, 2);
          log.push(3);
        }));
 
@@ -80,7 +80,7 @@ export function main() {
       var log = [];
       ObservableWrapper.subscribe(e, (x) => { log.push(x); });
       log.push(1);
-      ObservableWrapper.callNext(e, 2);
+      ObservableWrapper.callEmit(e, 2);
       log.push(3);
       expect(log).toEqual([1, 2, 3]);
     });

--- a/modules/angular2/test/core/linker/integration_spec.ts
+++ b/modules/angular2/test/core/linker/integration_spec.ts
@@ -2029,7 +2029,7 @@ class DirectiveEmitingEvent {
     this.event = new EventEmitter();
   }
 
-  fireEvent(msg: string) { ObservableWrapper.callNext(this.event, msg); }
+  fireEvent(msg: string) { ObservableWrapper.callEmit(this.event, msg); }
 }
 
 @Directive({selector: '[update-host-attributes]', host: {'role': 'button'}})
@@ -2052,7 +2052,7 @@ class DirectiveUpdatingHostActions {
 
   constructor() { this.setAttr = new EventEmitter(); }
 
-  triggerSetAttr(attrValue) { ObservableWrapper.callNext(this.setAttr, ["key", attrValue]); }
+  triggerSetAttr(attrValue) { ObservableWrapper.callEmit(this.setAttr, ["key", attrValue]); }
 }
 
 @Directive({selector: '[listener]', host: {'(event)': 'onEvent($event)'}})
@@ -2187,7 +2187,7 @@ class DirectiveWithTwoWayBinding {
   controlChange = new EventEmitter();
   control = null;
 
-  triggerChange(value) { ObservableWrapper.callNext(this.controlChange, value); }
+  triggerChange(value) { ObservableWrapper.callEmit(this.controlChange, value); }
 }
 
 @Injectable()
@@ -2395,5 +2395,5 @@ class DirectiveWithPropDecorators {
     this.target = target;
   }
 
-  fireEvent(msg) { ObservableWrapper.callNext(this.event, msg); }
+  fireEvent(msg) { ObservableWrapper.callEmit(this.event, msg); }
 }

--- a/modules/angular2/test/core/testability/testability_spec.ts
+++ b/modules/angular2/test/core/testability/testability_spec.ts
@@ -34,9 +34,9 @@ class MockNgZone extends NgZone {
     this._onEventDoneStream = new EventEmitter(false);
   }
 
-  start(): void { ObservableWrapper.callNext(this._onTurnStartStream, null); }
+  start(): void { ObservableWrapper.callEmit(this._onTurnStartStream, null); }
 
-  finish(): void { ObservableWrapper.callNext(this._onEventDoneStream, null); }
+  finish(): void { ObservableWrapper.callEmit(this._onEventDoneStream, null); }
 }
 
 export function main() {

--- a/modules/angular2/test/public_api_spec.ts
+++ b/modules/angular2/test/public_api_spec.ts
@@ -552,6 +552,7 @@ var NG_ALL = [
   */
   'EventEmitter.mapTo():js',
   'EventEmitter.next():js',
+  'EventEmitter.emit():js',
   'EventEmitter.materialize():js',
   'EventEmitter.merge():js',
   'EventEmitter.mergeAll():js',

--- a/modules/angular2/test/router/integration/lifecycle_hook_spec.ts
+++ b/modules/angular2/test/router/integration/lifecycle_hook_spec.ts
@@ -404,7 +404,7 @@ function logHook(name: string, next: ComponentInstruction, prev: ComponentInstru
   var message = name + ': ' + (isPresent(prev) ? ('/' + prev.urlPath) : 'null') + ' -> ' +
                 (isPresent(next) ? ('/' + next.urlPath) : 'null');
   log.push(message);
-  ObservableWrapper.callNext(eventBus, message);
+  ObservableWrapper.callEmit(eventBus, message);
 }
 
 @Component({selector: 'activate-cmp'})

--- a/modules/angular2/test/upgrade/upgrade_spec.ts
+++ b/modules/angular2/test/upgrade/upgrade_spec.ts
@@ -178,10 +178,10 @@ export function main() {
                            assertChange('twoWayA', 'initModelA');
                            assertChange('twoWayB', 'initModelB');
 
-                           this.twoWayAEmitter.next('newA');
-                           this.twoWayBEmitter.next('newB');
-                           this.eventA.next('aFired');
-                           this.eventB.next('bFired');
+                           this.twoWayAEmitter.emit('newA');
+                           this.twoWayBEmitter.emit('newB');
+                           this.eventA.emit('aFired');
+                           this.eventB.emit('bFired');
                            break;
                          case 1:
                            assertChange('twoWayA', 'newA');

--- a/modules/angular2/test/web_workers/shared/message_bus_spec.ts
+++ b/modules/angular2/test/web_workers/shared/message_bus_spec.ts
@@ -37,7 +37,7 @@ export function main() {
            async.done();
          });
          var toEmitter = bus.to(CHANNEL);
-         ObservableWrapper.callNext(toEmitter, MESSAGE);
+         ObservableWrapper.callEmit(toEmitter, MESSAGE);
        }));
 
     it("should broadcast", inject([AsyncTestCompleter], (async) => {
@@ -61,7 +61,7 @@ export function main() {
          }
 
          var toEmitter = bus.to(CHANNEL);
-         ObservableWrapper.callNext(toEmitter, MESSAGE);
+         ObservableWrapper.callEmit(toEmitter, MESSAGE);
        }));
 
     it("should keep channels independent", inject([AsyncTestCompleter], (async) => {
@@ -91,10 +91,10 @@ export function main() {
          });
 
          var firstToEmitter = bus.to(CHANNEL_ONE);
-         ObservableWrapper.callNext(firstToEmitter, MESSAGE_ONE);
+         ObservableWrapper.callEmit(firstToEmitter, MESSAGE_ONE);
 
          var secondToEmitter = bus.to(CHANNEL_TWO);
-         ObservableWrapper.callNext(secondToEmitter, MESSAGE_TWO);
+         ObservableWrapper.callEmit(secondToEmitter, MESSAGE_TWO);
        }));
   });
 
@@ -121,7 +121,7 @@ export function main() {
 
          var wasCalled = false;
          ObservableWrapper.subscribe(bus.from(CHANNEL), (message) => { wasCalled = true; });
-         ObservableWrapper.callNext(bus.to(CHANNEL), "hi");
+         ObservableWrapper.callEmit(bus.to(CHANNEL), "hi");
 
 
          flushMessages(() => {
@@ -141,7 +141,7 @@ export function main() {
 
          var wasCalled = false;
          ObservableWrapper.subscribe(bus.from(CHANNEL), (message) => { wasCalled = true; });
-         ObservableWrapper.callNext(bus.to(CHANNEL), "hi");
+         ObservableWrapper.callEmit(bus.to(CHANNEL), "hi");
 
          flushMessages(() => {
            expect(wasCalled).toBeTruthy();

--- a/modules/angular2/test/web_workers/shared/mock_event_emitter.ts
+++ b/modules/angular2/test/web_workers/shared/mock_event_emitter.ts
@@ -10,7 +10,7 @@ export class MockEventEmitter<T> extends EventEmitter<T> {
     return new MockDisposable();
   }
 
-  next(value: any) { this._nextFns.forEach(fn => fn(value)); }
+  emit(value: any) { this._nextFns.forEach(fn => fn(value)); }
 }
 
 class MockDisposable {

--- a/modules/angular2/test/web_workers/shared/service_message_broker_spec.ts
+++ b/modules/angular2/test/web_workers/shared/service_message_broker_spec.ts
@@ -53,7 +53,7 @@ export function main() {
            expect(arg1).toEqual(PASSED_ARG_1);
            expect(arg2).toEqual(PASSED_ARG_2);
          });
-         ObservableWrapper.callNext(messageBuses.worker.to(CHANNEL),
+         ObservableWrapper.callEmit(messageBuses.worker.to(CHANNEL),
                                     {'method': TEST_METHOD, 'args': [PASSED_ARG_1, PASSED_ARG_2]});
        }));
 
@@ -63,7 +63,7 @@ export function main() {
            expect(arg1).toEqual(PASSED_ARG_1);
            return PromiseWrapper.wrap(() => { return RESULT; });
          });
-         ObservableWrapper.callNext(messageBuses.worker.to(CHANNEL),
+         ObservableWrapper.callEmit(messageBuses.worker.to(CHANNEL),
                                     {'method': TEST_METHOD, 'id': ID, 'args': [PASSED_ARG_1]});
          ObservableWrapper.subscribe(messageBuses.worker.from(CHANNEL), (data: any) => {
            expect(data.type).toEqual("result");

--- a/modules/angular2/test/web_workers/worker/event_dispatcher_spec.ts
+++ b/modules/angular2/test/web_workers/worker/event_dispatcher_spec.ts
@@ -52,7 +52,7 @@ export function main() {
              serializer.deserialize(serializer.serialize(viewRef, RenderViewRef), RenderViewRef);
          webWorkerEventDispatcher.registerEventDispatcher(viewRef, eventDispatcher);
 
-         ObservableWrapper.callNext(messageBuses.ui.to(EVENT_CHANNEL), {
+         ObservableWrapper.callEmit(messageBuses.ui.to(EVENT_CHANNEL), {
            'viewRef': viewRef.serialize(),
            'elementIndex': elementIndex,
            'eventName': eventName,

--- a/modules/angular2_material/src/components/input/input.ts
+++ b/modules/angular2_material/src/components/input/input.ts
@@ -85,10 +85,10 @@ export class MdInput {
 
   updateValue(event) {
     this.value = event.target.value;
-    ObservableWrapper.callNext(this.mdChange, this.value);
+    ObservableWrapper.callEmit(this.mdChange, this.value);
   }
 
   setHasFocus(hasFocus: boolean) {
-    ObservableWrapper.callNext(this.mdFocusChange, hasFocus);
+    ObservableWrapper.callEmit(this.mdFocusChange, hasFocus);
   }
 }

--- a/modules/angular2_material/src/components/radio/radio_button.ts
+++ b/modules/angular2_material/src/components/radio/radio_button.ts
@@ -125,7 +125,7 @@ export class MdRadioGroup implements OnChanges {
     this.value = value;
     this.selectedRadioId = id;
     this.activedescendant = id;
-    ObservableWrapper.callNext(this.change, null);
+    ObservableWrapper.callEmit(this.change, null);
   }
 
   /** Registers a child radio button with this group. */
@@ -179,7 +179,7 @@ export class MdRadioGroup implements OnChanges {
 
     this.radioDispatcher.notify(this.name_);
     radio.checked = true;
-    ObservableWrapper.callNext(this.change, null);
+    ObservableWrapper.callEmit(this.change, null);
 
     this.value = radio.value;
     this.selectedRadioId = radio.id;

--- a/modules/playground/src/order_management/index.ts
+++ b/modules/playground/src/order_management/index.ts
@@ -147,7 +147,7 @@ class OrderItemComponent {
   @Input() item: OrderItem;
   @Output() delete = new EventEmitter();
 
-  onDelete(): void { this.delete.next(this.item); }
+  onDelete(): void { this.delete.emit(this.item); }
 }
 
 @Component({

--- a/modules/playground/src/upgrade/index.ts
+++ b/modules/playground/src/upgrade/index.ts
@@ -54,7 +54,7 @@ class Pane {
         <table cellpadding="3">
           <tr>
             <td><ng-content></ng-content></td>
-            <td><user [handle]="user" (reset)="reset.next()"></user></td>
+            <td><user [handle]="user" (reset)="reset.emit()"></user></td>
           </tr>
         </table>
       </pane>

--- a/modules/playground/src/zippy_component/zippy.ts
+++ b/modules/playground/src/zippy_component/zippy.ts
@@ -11,9 +11,9 @@ export class Zippy {
   toggle() {
     this.visible = !this.visible;
     if (this.visible) {
-      ObservableWrapper.callNext(this.open, null);
+      ObservableWrapper.callEmit(this.open, null);
     } else {
-      ObservableWrapper.callNext(this.close, null);
+      ObservableWrapper.callEmit(this.close, null);
     }
   }
 }


### PR DESCRIPTION
BREAKING CHANGE

EventEmitter#next(value) is deprecated, use EventEmitter#emit(value)
instead.

Closes #4287 
