### PR TITLE
docs(cleanup): fix bad h3 markup and normalize headings

### DIFF
--- a/modules/angular2/src/common/directives/ng_if.ts
+++ b/modules/angular2/src/common/directives/ng_if.ts
@@ -18,7 +18,7 @@ import {isBlank} from 'angular2/src/facade/lang';
  * </div>
  * ```
  *
- *##Syntax
+ * ### Syntax
  *
  * - `<div *ng-if="condition">...</div>`
  * - `<div template="ng-if condition">...</div>`

--- a/modules/angular2/src/common/directives/ng_style.ts
+++ b/modules/angular2/src/common/directives/ng_style.ts
@@ -15,7 +15,7 @@ import {isPresent, isBlank, print} from 'angular2/src/facade/lang';
  * corresponding element styles are updated based on changes to this object. Style names to update
  * are taken from the object's keys, and values - from the corresponding object's values.
  *
- *##Syntax
+ * ### Syntax
  *
  * - `<div [ng-style]="{'font-style': style}"></div>`
  * - `<div [ng-style]="styleExp"></div>` - here the `styleExp` must evaluate to an object

--- a/modules/angular2/src/common/forms/directives/ng_control_group.ts
+++ b/modules/angular2/src/common/forms/directives/ng_control_group.ts
@@ -18,7 +18,7 @@ const controlGroupProvider =
  *
  * This directive can only be used as a child of {@link NgForm} or {@link NgFormModel}.
  *
- * # Example ([live demo](http://plnkr.co/edit/7EJ11uGeaggViYM6T5nq?p=preview))
+ * ### Example ([live demo](http://plnkr.co/edit/7EJ11uGeaggViYM6T5nq?p=preview))
  *
  * ```typescript
  * @Component({

--- a/modules/angular2/src/common/forms/directives/ng_form.ts
+++ b/modules/angular2/src/common/forms/directives/ng_form.ts
@@ -23,19 +23,19 @@ const formDirectiveProvider =
  * If `NgForm` is bound in a component, `<form>` elements in that component will be
  * upgraded to use the Angular form system.
  *
- *##Typical Use
+ * ### Typical Use
  *
  * Include `FORM_DIRECTIVES` in the `directives` section of a {@link View} annotation
  * to use `NgForm` and its associated controls.
  *
- *##Structure
+ * ### Structure
  *
  * An Angular form is a collection of `Control`s in some hierarchy.
  * `Control`s can be at the top level or can be organized in `ControlGroup`s
  * or `ControlArray`s. This hierarchy is reflected in the form's `value`, a
  * JSON object that mirrors the form structure.
  *
- *##Submission
+ * ### Submission
  *
  * The `ng-submit` event signals when the user triggers a form submission.
  *

--- a/modules/angular2/src/common/forms/directives/ng_form_control.ts
+++ b/modules/angular2/src/common/forms/directives/ng_form_control.ts
@@ -49,7 +49,7 @@ const formControlBinding =
  * }
  *  ```
  *
- *##ng-model
+ * ###ng-model
  *
  * We can also use `ng-model` to bind a domain model to the form.
  *

--- a/modules/angular2/src/common/forms/directives/ng_model.ts
+++ b/modules/angular2/src/common/forms/directives/ng_model.ts
@@ -22,7 +22,7 @@ const formControlBinding =
 /**
  * Binds a domain model to a form control.
  *
- *##Usage
+ * ### Usage
  *
  * `ng-model` binds an existing domain model to a form control. For a
  * two-way binding, use `[(ng-model)]` to ensure the model updates in

--- a/modules/angular2/src/common/forms/directives/validators.ts
+++ b/modules/angular2/src/common/forms/directives/validators.ts
@@ -33,7 +33,7 @@ const REQUIRED_VALIDATOR =
  * A Directive that adds the `required` validator to any controls marked with the
  * `required` attribute, via the {@link NG_VALIDATORS} binding.
  *
- * # Example
+ * ### Example
  *
  * ```
  * <input ng-control="fullName" required>

--- a/modules/angular2/src/common/forms/model.ts
+++ b/modules/angular2/src/common/forms/model.ts
@@ -245,7 +245,7 @@ export abstract class AbstractControl {
  * `Control` is one of the three fundamental building blocks used to define forms in Angular, along
  * with {@link ControlGroup} and {@link ControlArray}.
  *
- * ##Usage
+ * ## Usage
  *
  * By default, a `Control` is created for every `<input>` or other form component.
  * With {@link NgFormControl} or {@link NgFormModel} an existing {@link Control} can be
@@ -421,7 +421,7 @@ export class ControlGroup extends AbstractControl {
  * along with {@link Control} and {@link ControlGroup}. {@link ControlGroup} can also contain
  * other controls, but is of fixed length.
  *
- * ##Adding or removing controls
+ * ## Adding or removing controls
  *
  * To change the controls in the array, use the `push`, `insert`, or `removeAt` methods
  * in `ControlArray` itself. These methods ensure the controls are properly tracked in the

--- a/modules/angular2/src/common/forms/validators.ts
+++ b/modules/angular2/src/common/forms/validators.ts
@@ -29,7 +29,7 @@ export const NG_ASYNC_VALIDATORS: OpaqueToken = CONST_EXPR(new OpaqueToken("NgAs
  * controls and returns a {@link StringMap} of errors. A null map means that
  * validation has passed.
  *
- * # Example
+ * ### Example
  *
  * ```typescript
  * var loginControl = new Control("", Validators.required)

--- a/modules/angular2/src/common/pipes/number_pipe.ts
+++ b/modules/angular2/src/common/pipes/number_pipe.ts
@@ -66,7 +66,7 @@ export class NumberPipe {
  * Formats a number as local text. i.e. group sizing and separator and other locale-specific
  * configurations are based on the active locale.
  *
- *##Usage
+ * ### Usage
  *
  *     expression | number[:digitInfo]
  *
@@ -101,7 +101,7 @@ export class DecimalPipe extends NumberPipe implements PipeTransform {
  *
  * Formats a number as local percent.
  *
- *##Usage
+ * ### Usage
  *
  *     expression | percent[:digitInfo]
  *
@@ -127,7 +127,7 @@ export class PercentPipe extends NumberPipe implements PipeTransform {
  *
  * Formats a number as local currency.
  *
- *##Usage
+ * ### Usage
  *
  *     expression | currency[:currencyCode[:symbolDisplay[:digitInfo]]]
  *

--- a/modules/angular2/src/common/pipes/slice_pipe.ts
+++ b/modules/angular2/src/common/pipes/slice_pipe.ts
@@ -16,7 +16,7 @@ import {Pipe} from 'angular2/src/core/metadata';
  *
  * The ending index of the subset to return is specified by the optional `end` parameter.
  *
- *##Usage
+ * ### Usage
  *
  *     expression | slice:start[:end]
  *

--- a/modules/angular2/src/core/application_ref.ts
+++ b/modules/angular2/src/core/application_ref.ts
@@ -135,13 +135,13 @@ export abstract class PlatformRef {
   /**
    * Instantiate a new Angular application on the page.
    *
-   *##What is an application?
+   * ### What is an application?
    *
    * Each Angular application has its own zone, change detection, compiler,
    * renderer, and other framework components. An application hosts one or more
    * root components, which can be initialized via `ApplicationRef.bootstrap()`.
    *
-   *##Application Providers
+   * ### Application Providers
    *
    * Angular applications require numerous providers to be properly instantiated.
    * When using `application()` to create a new app on the page, these providers
@@ -156,7 +156,7 @@ export abstract class PlatformRef {
    *   .application([myAppProviders])
    *   .bootstrap(MyTopLevelComponent);
    * ```
-   *##See Also
+   * ### See Also
    *
    * See the {@link bootstrap} documentation for more details.
    */
@@ -167,7 +167,7 @@ export abstract class PlatformRef {
    * are only available asynchronously. One such use case is to initialize an
    * application running in a web worker.
    *
-   *##Usage
+   * ### Usage
    *
    * `bindingFn` is a function that will be called in the new application's zone.
    * It should return a `Promise` to a list of providers to be used for the
@@ -269,13 +269,13 @@ export abstract class ApplicationRef {
   /**
    * Bootstrap a new component at the root level of the application.
    *
-   *##Bootstrap process
+   * ### Bootstrap process
    *
    * When bootstrapping a new root component into an application, Angular mounts the
    * specified application component onto DOM elements identified by the [componentType]'s
    * selector and kicks off automatic change detection to finish initializing the component.
    *
-   *##Optional Providers
+   * ### Optional Providers
    *
    * Providers for the given component can optionally be overridden via the `providers`
    * parameter. These providers will only apply for the root component being added and any

--- a/modules/angular2/src/router/instruction.ts
+++ b/modules/angular2/src/router/instruction.ts
@@ -46,7 +46,7 @@ export class RouteParams {
  *
  * You can inject `RouteData` into the constructor of a component to use it.
  *
- * ## Example
+ * ### Example
  *
  * ```
  * import {bootstrap, Component, View} from 'angular2/angular2';

--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -129,7 +129,7 @@ export class Router {
   /**
    * Dynamically update the routing configuration and trigger a navigation.
    *
-   *##Usage
+   * ### Usage
    *
    * ```
    * router.config([
@@ -148,7 +148,7 @@ export class Router {
    * Navigate based on the provided Route Link DSL. It's preferred to navigate with this method
    * over `navigateByUrl`.
    *
-   *##Usage
+   * ### Usage
    *
    * This method takes an array representing the Route Link DSL:
    * ```

--- a/modules/angular2/src/web_workers/worker/application_common.ts
+++ b/modules/angular2/src/web_workers/worker/application_common.ts
@@ -52,7 +52,7 @@ import {COMPILER_PROVIDERS} from 'angular2/src/compiler/compiler';
  *
  * See {@link PlatformRef} for details on the Angular platform.
  *
- *##Without specified providers
+ * ### Without specified providers
  *
  * If no providers are specified, `platform`'s behavior depends on whether an existing
  * platform exists:
@@ -63,7 +63,7 @@ import {COMPILER_PROVIDERS} from 'angular2/src/compiler/compiler';
  * was created with). This is a convenience feature, allowing for multiple applications
  * to be loaded into the same platform without awareness of each other.
  *
- *##With specified providers
+ * ### With specified providers
  *
  * It is also possible to specify providers to be made in the new platform. These providers
  * will be shared between all applications on the page. For example, an abstraction for
@@ -74,7 +74,7 @@ import {COMPILER_PROVIDERS} from 'angular2/src/compiler/compiler';
  * them if a platform did not exist already. If it did exist, however, an error will be
  * thrown.
  *
- *##For Web Worker Applications
+ * ### For Web Worker Applications
  *
  * This version of `platform` initializes Angular for use with applications
  * that do not directly touch the DOM, such as applications which run in a


### PR DESCRIPTION
Fixing bad H3s and making Example headings consistent
