### PR TITLE
fix(dart/transform): Omit bootstrap.dart in ng_deps

### DIFF
--- a/modules_dart/transform/lib/src/transform/common/names.dart
+++ b/modules_dart/transform/lib/src/transform/common/names.dart
@@ -1,6 +1,7 @@
 library angular2.transform.common.names;
 
 const BOOTSTRAP_NAME = 'bootstrap';
+const BOOTSTRAP_STATIC_NAME = 'bootstrapStatic';
 const SETUP_METHOD_NAME = 'initReflector';
 const REFLECTOR_VAR_NAME = 'reflector';
 const TRANSFORM_DYNAMIC_MODE = 'transform_dynamic';

--- a/modules_dart/transform/lib/src/transform/reflection_remover/rewriter.dart
+++ b/modules_dart/transform/lib/src/transform/reflection_remover/rewriter.dart
@@ -140,7 +140,7 @@ class _RewriterVisitor extends Object with RecursiveAstVisitor<Object> {
           _setupAdded ? '' : ', () { ${_getStaticReflectorInitBlock()} }';
 
       // rewrite `bootstrap(...)` to `bootstrapStatic(...)`
-      buf.write('bootstrapStatic(${args[0]}');
+      buf.write('$BOOTSTRAP_STATIC_NAME(${args[0]}');
       if (numArgs == 1) {
         // bootstrap args are positional, so before we pass reflectorInit code
         // we need to pass `null` for DI bindings.

--- a/modules_dart/transform/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
+++ b/modules_dart/transform/test/transform/integration/simple_annotation_files/expected/index.ng_deps.dart
@@ -2,7 +2,7 @@ library web_foo.ng_deps.dart;
 
 import 'index.dart';
 import 'package:angular2/src/core/reflection/reflection.dart' as _ngRef;
-import 'package:angular2/bootstrap_static.dart';
+import 'package:angular2/bootstrap_static.dart' show bootstrapStatic;
 import 'package:angular2/src/core/reflection/reflection.dart';
 import 'bar.dart';
 import 'bar.ng_deps.dart' as i0;

--- a/modules_dart/transform/test/transform/integration/simple_annotation_files/index.dart
+++ b/modules_dart/transform/test/transform/integration/simple_annotation_files/index.dart
@@ -1,6 +1,6 @@
 library web_foo;
 
-import 'package:angular2/bootstrap.dart';
+import 'package:angular2/bootstrap.dart' show bootstrap;
 import 'package:angular2/src/core/reflection/reflection.dart';
 import 'package:angular2/src/core/reflection/reflection_capabilities.dart';
 import 'bar.dart';


### PR DESCRIPTION
Special-case to avoid copying the bootstrap{,_static}.dart import when creating
`.ng_deps.dart` files.

Closes #5315
