### PR TITLE
feat(bootstrap): add platform and app initializers

### DIFF
--- a/modules/angular2/core.dart
+++ b/modules/angular2/core.dart
@@ -9,6 +9,7 @@ export 'package:angular2/src/common/pipes.dart';
 export 'package:angular2/src/facade/facade.dart';
 export 'package:angular2/src/core/application_ref.dart'
     hide ApplicationRef_, PlatformRef_;
+export 'package:angular2/src/core/application_tokens.dart' show APP_ID, APP_COMPONENT, APP_INITIALIZER, PLATFORM_INITIALIZER;
 export 'package:angular2/src/core/linker.dart';
 export 'package:angular2/src/core/zone.dart';
 export 'package:angular2/src/core/render.dart';

--- a/modules/angular2/core.ts
+++ b/modules/angular2/core.ts
@@ -10,7 +10,12 @@ export * from './src/common/pipes';
 export * from './src/facade/facade';
 export * from './src/core/linker';
 export {platform, createNgZone, PlatformRef, ApplicationRef} from './src/core/application_ref';
-export {APP_ID, APP_COMPONENT} from './src/core/application_tokens';
+export {
+  APP_ID,
+  APP_COMPONENT,
+  APP_INITIALIZER,
+  PLATFORM_INITIALIZER
+} from './src/core/application_tokens';
 export * from './src/core/zone';
 export * from './src/core/render';
 export * from './src/common/directives';

--- a/modules/angular2/platform/browser.ts
+++ b/modules/angular2/platform/browser.ts
@@ -13,8 +13,7 @@ import {Type, isPresent, CONST_EXPR} from 'angular2/src/facade/lang';
 import {Promise} from 'angular2/src/facade/promise';
 import {
   BROWSER_PROVIDERS,
-  BROWSER_APP_COMMON_PROVIDERS,
-  initDomAdapter
+  BROWSER_APP_COMMON_PROVIDERS
 } from 'angular2/src/platform/browser_common';
 import {COMPILER_PROVIDERS} from 'angular2/compiler';
 import {ComponentRef, platform, reflector} from 'angular2/core';
@@ -120,8 +119,6 @@ export function bootstrap(
     appComponentType: Type,
     customProviders?: Array<any /*Type | Provider | any[]*/>): Promise<ComponentRef> {
   reflector.reflectionCapabilities = new ReflectionCapabilities();
-  initDomAdapter();
-
   let appProviders =
       isPresent(customProviders) ? [BROWSER_APP_PROVIDERS, customProviders] : BROWSER_APP_PROVIDERS;
   return platform(BROWSER_PROVIDERS).application(appProviders).bootstrap(appComponentType);

--- a/modules/angular2/platform/browser_static.ts
+++ b/modules/angular2/platform/browser_static.ts
@@ -12,8 +12,7 @@ import {Type, isPresent, CONST_EXPR} from 'angular2/src/facade/lang';
 import {Promise} from 'angular2/src/facade/promise';
 import {
   BROWSER_PROVIDERS,
-  BROWSER_APP_COMMON_PROVIDERS,
-  initDomAdapter
+  BROWSER_APP_COMMON_PROVIDERS
 } from 'angular2/src/platform/browser_common';
 import {ComponentRef, platform, reflector} from 'angular2/core';
 
@@ -31,7 +30,6 @@ export const BROWSER_APP_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
 export function bootstrapStatic(appComponentType: Type,
                                 customProviders?: Array<any /*Type | Provider | any[]*/>,
                                 initReflector?: Function): Promise<ComponentRef> {
-  initDomAdapter();
   if (isPresent(initReflector)) {
     initReflector();
   }

--- a/modules/angular2/src/core/application_tokens.ts
+++ b/modules/angular2/src/core/application_tokens.ts
@@ -48,3 +48,14 @@ export const APP_ID_RANDOM_PROVIDER: Provider =
 function _randomChar(): string {
   return StringWrapper.fromCharCode(97 + Math.floor(Math.random() * 25));
 }
+
+/**
+ * A function that will be executed when a platform is initialized.
+ */
+export const PLATFORM_INITIALIZER: OpaqueToken =
+    CONST_EXPR(new OpaqueToken("Platform Initializer"));
+
+/**
+ * A function that will be executed when an application is initialized.
+ */
+export const APP_INITIALIZER: OpaqueToken = CONST_EXPR(new OpaqueToken("Application Initializer"));

--- a/modules/angular2/src/platform/browser_common.ts
+++ b/modules/angular2/src/platform/browser_common.ts
@@ -11,13 +11,13 @@ import {
   reflector,
   APPLICATION_COMMON_PROVIDERS,
   PLATFORM_COMMON_PROVIDERS,
-  EVENT_MANAGER_PLUGINS
+  EVENT_MANAGER_PLUGINS,
+  PLATFORM_INITIALIZER
 } from "angular2/core";
 import {COMMON_DIRECTIVES, COMMON_PIPES, FORM_PROVIDERS} from "angular2/common";
 import {Renderer} from 'angular2/render';
 import {Testability} from 'angular2/src/core/testability/testability';
 
-// TODO change these imports once dom_adapter is moved out of core
 import {DOM} from 'angular2/src/core/dom/dom_adapter';
 import {DomEventsPlugin} from 'angular2/src/platform/dom/events/dom_events';
 import {KeyEventsPlugin} from 'angular2/src/platform/dom/events/key_events';
@@ -42,8 +42,10 @@ export {
 export {By} from 'angular2/src/platform/browser/debug/by';
 export {BrowserDomAdapter} from './browser/browser_adapter';
 
-export const BROWSER_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
-    CONST_EXPR([PLATFORM_COMMON_PROVIDERS]);
+export const BROWSER_PROVIDERS: Array<any /*Type | Provider | any[]*/> = CONST_EXPR([
+  PLATFORM_COMMON_PROVIDERS,
+  new Provider(PLATFORM_INITIALIZER, {useValue: initDomAdapter, multi: true}),
+]);
 
 function _exceptionHandler(): ExceptionHandler {
   return new ExceptionHandler(DOM, false);
@@ -73,7 +75,6 @@ export const BROWSER_APP_COMMON_PROVIDERS: Array<any /*Type | Provider | any[]*/
 ]);
 
 export function initDomAdapter() {
-  // TODO: refactor into a generic init function
   BrowserDomAdapter.makeCurrent();
   wtfInit();
   BrowserGetTestability.init();

--- a/modules/angular2/test/public_api_spec.ts
+++ b/modules/angular2/test/public_api_spec.ts
@@ -27,6 +27,7 @@ import {SymbolsDiff} from './symbol_inspector/symbol_differ';
 
 var NG_ALL = [
   'APP_COMPONENT',
+  'APP_INITIALIZER',
   'APP_ID',
   'AbstractProviderError',
   'AbstractProviderError.addKey()',
@@ -1395,6 +1396,7 @@ var NG_ALL = [
   'resolveForwardRef():js',
   'wtfCreateScope():js',
   'PLATFORM_COMMON_PROVIDERS',
+  'PLATFORM_INITIALIZER',
   'wtfCreateScope:dart',
   'wtfEndTimeRange():js',
   'wtfEndTimeRange:dart',


### PR DESCRIPTION
Often some init logic needs to run when a platform or an application is boostrapped.
For example, boostraping a platform requires initializing the dom adapter.
Now, it can be done as follows:

new Provider(PLATFORM_INITIALIZER, {useValue: initDomAdapter, multi: true}),

All platform initializers will be run after the platform injector has been created.

Similarly, all application initializers will be run after the app injector has been
created.
