### PR TITLE
Make Angular2 transformers lazy in debug mode when`lazy_transformers: true`

### DIFF
--- a/modules_dart/transform/lib/src/transform/common/eager_transformer_wrapper.dart
+++ b/modules_dart/transform/lib/src/transform/common/eager_transformer_wrapper.dart
@@ -1,0 +1,45 @@
+library angular2.src.transform.common.eager_transformer_wrapper;
+
+import 'package:barback/barback.dart';
+
+abstract class EagerTransformerWrapper {
+  EagerTransformerWrapper._();
+  factory EagerTransformerWrapper(wrapped) {
+    return wrapped is AggregateTransformer
+        ? new _EagerAggregateTransformerWrapper(wrapped)
+        : new _EagerTransformerWrapper(wrapped);
+  }
+}
+
+class _EagerTransformerWrapper extends EagerTransformerWrapper
+    implements Transformer {
+  final Transformer _wrapped;
+  _EagerTransformerWrapper(this._wrapped) : super._();
+
+  @override
+  String get allowedExtensions => _wrapped.allowedExtensions;
+
+  @override
+  apply(Transform transform) => _wrapped.apply(transform);
+
+  @override
+  isPrimary(AssetId id) => _wrapped.isPrimary(id);
+
+  @override
+  toString() => _wrapped.toString();
+}
+
+class _EagerAggregateTransformerWrapper extends EagerTransformerWrapper
+    implements AggregateTransformer {
+  final AggregateTransformer _wrapped;
+  _EagerAggregateTransformerWrapper(this._wrapped) : super._();
+
+  @override
+  apply(AggregateTransform transform) => _wrapped.apply(transform);
+
+  @override
+  classifyPrimary(AssetId id) => _wrapped.classifyPrimary(id);
+
+  @override
+  toString() => _wrapped.toString();
+}

--- a/modules_dart/transform/lib/src/transform/common/options.dart
+++ b/modules_dart/transform/lib/src/transform/common/options.dart
@@ -15,6 +15,7 @@ const PLATFORM_DIRECTIVES = 'platform_directives';
 const INIT_REFLECTOR_PARAM = 'init_reflector';
 const INLINE_VIEWS_PARAM = 'inline_views';
 const MIRROR_MODE_PARAM = 'mirror_mode';
+const LAZY_TRANSFORMERS = 'lazy_transformers';
 
 /// Provides information necessary to transform an Angular2 app.
 class TransformerOptions {
@@ -56,6 +57,13 @@ class TransformerOptions {
   /// at any time.
   final bool inlineViews;
 
+  /// Whether to make transformers lazy.
+  /// If this is `true`, and in `debug` mode only, the transformers will be
+  /// lazy (will only build assets that are requested).
+  /// This is undocumented, for testing purposes only, and may change or break
+  /// at any time.
+  final bool lazyTransformers;
+
   TransformerOptions._internal(
       this.entryPoints,
       this.entryPointGlobs,
@@ -66,6 +74,7 @@ class TransformerOptions {
       {this.reflectPropertiesAsAttributes,
       this.platformDirectives,
       this.inlineViews,
+      this.lazyTransformers,
       this.formatCode});
 
   factory TransformerOptions(List<String> entryPoints,
@@ -76,6 +85,7 @@ class TransformerOptions {
       bool inlineViews: false,
       bool reflectPropertiesAsAttributes: true,
       List<String> platformDirectives,
+      bool lazyTransformers: false,
       bool formatCode: false}) {
     var annotationMatcher = new AnnotationMatcher()
       ..addAll(customAnnotationDescriptors);
@@ -87,6 +97,7 @@ class TransformerOptions {
         reflectPropertiesAsAttributes: reflectPropertiesAsAttributes,
         platformDirectives: platformDirectives,
         inlineViews: inlineViews,
+        lazyTransformers: lazyTransformers,
         formatCode: formatCode);
   }
 }

--- a/modules_dart/transform/lib/src/transform/common/options_reader.dart
+++ b/modules_dart/transform/lib/src/transform/common/options_reader.dart
@@ -42,6 +42,8 @@ TransformerOptions parseBarbackSettings(BarbackSettings settings) {
       reflectPropertiesAsAttributes: reflectPropertiesAsAttributes,
       platformDirectives: platformDirectives,
       inlineViews: _readBool(config, INLINE_VIEWS_PARAM, defaultValue: false),
+      lazyTransformers:
+          _readBool(config, LAZY_TRANSFORMERS, defaultValue: false),
       formatCode: formatCode);
 }
 

--- a/modules_dart/transform/lib/src/transform/deferred_rewriter/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/deferred_rewriter/transformer.dart
@@ -14,10 +14,15 @@ import 'rewriter.dart';
 /// Transformer responsible for rewriting deferred library loads to enable
 /// initializing the reflector in a deferred way to keep the code with the
 /// deferred library.
-class DeferredRewriter extends Transformer {
+class DeferredRewriter extends Transformer implements LazyTransformer {
   final TransformerOptions options;
 
   DeferredRewriter(this.options);
+
+  @override
+  declareOutputs(DeclaringTransform transform) {
+    transform.declareOutput(transform.primaryId);
+  }
 
   @override
   bool isPrimary(AssetId id) =>

--- a/modules_dart/transform/lib/src/transform/directive_processor/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/directive_processor/transformer.dart
@@ -21,7 +21,7 @@ import 'rewriter.dart';
 ///
 /// This transformer is part of a multi-phase transform.
 /// See `angular2/src/transform/transformer.dart` for transformer ordering.
-class DirectiveProcessor extends Transformer {
+class DirectiveProcessor extends Transformer implements LazyTransformer {
   final TransformerOptions options;
   final _encoder = const JsonEncoder.withIndent('  ');
 
@@ -29,6 +29,11 @@ class DirectiveProcessor extends Transformer {
 
   @override
   bool isPrimary(AssetId id) => id.extension.endsWith('dart');
+
+  @override
+  declareOutputs(DeclaringTransform transform) {
+    transform.declareOutput(_ngSummaryAssetId(transform.primaryId));
+  }
 
   @override
   Future apply(Transform transform) async {

--- a/modules_dart/transform/lib/src/transform/reflection_remover/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/reflection_remover/transformer.dart
@@ -21,7 +21,7 @@ import 'remove_reflection_capabilities.dart';
 /// have already been run and that a .ng_deps.dart file has been generated for
 /// {@link options.entryPoint}. The instantiation of {@link ReflectionCapabilities} is
 /// replaced by calling `setupReflection` in that .ng_deps.dart file.
-class ReflectionRemover extends Transformer {
+class ReflectionRemover extends Transformer implements LazyTransformer {
   final TransformerOptions options;
 
   ReflectionRemover(this.options);
@@ -29,6 +29,11 @@ class ReflectionRemover extends Transformer {
   @override
   bool isPrimary(AssetId id) => options.entryPointGlobs != null &&
       options.entryPointGlobs.any((g) => g.matches(id.path));
+
+  @override
+  declareOutputs(DeclaringTransform transform) {
+    transform.declareOutput(transform.primaryId);
+  }
 
   @override
   Future apply(Transform transform) async {

--- a/modules_dart/transform/lib/src/transform/template_compiler/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/template_compiler/transformer.dart
@@ -23,13 +23,19 @@ import 'generator.dart';
 ///
 /// This transformer is part of a multi-phase transform.
 /// See `angular2/src/transform/transformer.dart` for transformer ordering.
-class TemplateCompiler extends Transformer {
+class TemplateCompiler extends Transformer implements LazyTransformer {
   final TransformerOptions options;
 
   TemplateCompiler(this.options);
 
   @override
   bool isPrimary(AssetId id) => id.path.endsWith(META_EXTENSION);
+
+  @override
+  declareOutputs(DeclaringTransform transform) {
+    transform.declareOutput(ngDepsAssetId(transform.primaryId));
+    transform.declareOutput(templatesAssetId(transform.primaryId));
+  }
 
   @override
   Future apply(Transform transform) async {

--- a/modules_dart/transform/lib/src/transform/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/transformer.dart
@@ -3,6 +3,7 @@ library angular2.src.transform.transformer;
 import 'package:barback/barback.dart';
 import 'package:dart_style/dart_style.dart';
 
+import 'common/eager_transformer_wrapper.dart';
 import 'common/formatter.dart' as formatter;
 import 'common/options.dart';
 import 'common/options_reader.dart';
@@ -41,6 +42,10 @@ class AngularTransformerGroup extends TransformerGroup {
           new TemplateCompiler(options)
         ],
       ];
+    }
+    if (options.modeName == BarbackMode.RELEASE || !options.lazyTransformers) {
+      phases = phases
+          .map((phase) => phase.map((t) => new EagerTransformerWrapper(t)));
     }
     return new AngularTransformerGroup._(phases,
         formatCode: options.formatCode);


### PR DESCRIPTION
This make apps to load quicker with pub serve (only builds what is needed).

Note that lazy transformers seem to make pub build slower, so we wrap
transformers to force them to be eager in release mode.
