### PR TITLE
chore(dart): Use pub for presubmit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
 env:
   global:
   - KARMA_BROWSERS=DartiumWithWebPlatform
-  - E2E_BROWSERS=Dartium
+  - E2E_BROWSERS=DartiumWithWebPlatform
   - LOGS_DIR=/tmp/angular-build/logs
   - SAUCE_USERNAME=angular-ci
   - SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987

--- a/scripts/ci/test_e2e_dart.sh
+++ b/scripts/ci/test_e2e_dart.sh
@@ -15,14 +15,14 @@ function killServer () {
 # Serving pre-compiled dart JS takes an extra 15m.
 # So we do this only for post-commit testing.
 # Pull requests test with Dartium and pub serve
-if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+#if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
   # WARNING: the build/pubbuild.dart task is assumed to have been run before, in test_server_dart.sh
-  ./node_modules/.bin/gulp serve.js.dart2js&
-  serverPid=$!
-else
+#  ./node_modules/.bin/gulp serve.js.dart2js&
+#  serverPid=$!
+#else
   ./node_modules/.bin/gulp serve.dart&
   serverPid=$!
-fi
+#fi
 
 ./node_modules/.bin/gulp build.css.material&
 

--- a/scripts/ci/test_e2e_dart.sh
+++ b/scripts/ci/test_e2e_dart.sh
@@ -15,15 +15,14 @@ function killServer () {
 # Serving pre-compiled dart JS takes an extra 15m.
 # So we do this only for post-commit testing.
 # Pull requests test with Dartium and pub serve
-# TODO(jeffbcross): restore conditional dart2js/pubserve #4316
-#if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
   # WARNING: the build/pubbuild.dart task is assumed to have been run before, in test_server_dart.sh
   ./node_modules/.bin/gulp serve.js.dart2js&
   serverPid=$!
-#else
-#  ./node_modules/.bin/gulp serve.dart&
-#  serverPid=$!
-#fi
+else
+  ./node_modules/.bin/gulp serve.dart&
+  serverPid=$!
+fi
 
 ./node_modules/.bin/gulp build.css.material&
 

--- a/scripts/ci/test_perf.sh
+++ b/scripts/ci/test_perf.sh
@@ -16,15 +16,14 @@ function killServer () {
 # Serving pre-compiled dart JS takes an extra 15m.
 # So we do this only for post-commit testing.
 # Pull requests test with Dartium and pub serve
-# TODO(jeffbcross): restore conditional dart2js/pubserve #4316
-#if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
   ./node_modules/.bin/gulp build/pubbuild.dart
   ./node_modules/.bin/gulp serve.js.prod serve.js.dart2js&
   serverPid=$!
-#else
-#  ./node_modules/.bin/gulp serve.js.prod serve.dart&
-#  serverPid=$!
-#fi
+else
+  ./node_modules/.bin/gulp serve.js.prod serve.dart&
+  serverPid=$!
+fi
 
 trap killServer EXIT
 

--- a/scripts/ci/test_server_dart.sh
+++ b/scripts/ci/test_server_dart.sh
@@ -14,15 +14,14 @@ ps -ef | grep webdriver-manager
 # Serving pre-compiled dart JS takes an extra 15m.
 # So we do this only for post-commit testing.
 # Pull requests test with Dartium and pub serve
-# TODO(jeffbcross): restore conditional dart2js/pubserve #4316
-#if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
   ./node_modules/.bin/gulp build/pubbuild.dart
   ./node_modules/.bin/gulp serve.js.dart2js&
   serverPid=$!
-#else
-#  ./node_modules/.bin/gulp serve.dart&
-#  serverPid=$!
-#fi
+else
+  ./node_modules/.bin/gulp serve.dart&
+  serverPid=$!
+fi
 
 function killAllServers () {
   kill $serverPid


### PR DESCRIPTION
Upload pub logs to allow easier debugging.
Change travis to use pub for presubmit again.

Closes #4316
