### PR TITLE
test(schema): fix test names

### DIFF
--- a/modules/angular2/test/compiler/schema/dom_element_schema_registry_spec.ts
+++ b/modules/angular2/test/compiler/schema/dom_element_schema_registry_spec.ts
@@ -33,7 +33,7 @@ export function main() {
     it('should return true for custom-like elements',
        () => { expect(registry.hasProperty('custom-like', 'unknown')).toBeTruthy(); });
 
-    it('should not re-map property names that are not specified in DOM facade',
+    it('should re-map property names that are specified in DOM facade',
        () => { expect(registry.getMappedPropName('readonly')).toEqual('readOnly'); });
 
     it('should not re-map property names that are not specified in DOM facade', () => {


### PR DESCRIPTION
2 tests had the same name and were shadowing each other.
