### PR TITLE
docs(async): adding type to EventEmitter now that it is generic

### DIFF
--- a/modules/angular2/src/facade/async.ts
+++ b/modules/angular2/src/facade/async.ts
@@ -77,8 +77,8 @@ export class ObservableWrapper {
  *  </div>`})
  * export class Zippy {
  *   visible: boolean = true;
- *   @Output() open: EventEmitter = new EventEmitter();
- *   @Output() close: EventEmitter = new EventEmitter();
+ *   @Output() open: EventEmitter<any> = new EventEmitter();
+ *   @Output() close: EventEmitter<any> = new EventEmitter();
  *
  *   toggle() {
  *     this.visible = !this.visible;


### PR DESCRIPTION
Small fix in the documentation for EventEmitter (/poke @robwormald)
