### PR TITLE
fix(http): error codes / headers / responseURL / request method

### DIFF
--- a/modules/angular2/src/http/backends/jsonp_backend.ts
+++ b/modules/angular2/src/http/backends/jsonp_backend.ts
@@ -57,7 +57,7 @@ export class JSONPConnection_ extends JSONPConnection {
         _dom.cleanup(script);
         if (!this._finished) {
           let responseOptions =
-              new ResponseOptions({body: JSONP_ERR_NO_CALLBACK, type: ResponseTypes.Error});
+              new ResponseOptions({body: JSONP_ERR_NO_CALLBACK, type: ResponseTypes.Error, url});
           if (isPresent(baseResponseOptions)) {
             responseOptions = baseResponseOptions.merge(responseOptions);
           }
@@ -65,7 +65,7 @@ export class JSONPConnection_ extends JSONPConnection {
           return;
         }
 
-        let responseOptions = new ResponseOptions({body: this._responseData});
+        let responseOptions = new ResponseOptions({body: this._responseData, url});
         if (isPresent(this.baseResponseOptions)) {
           responseOptions = this.baseResponseOptions.merge(responseOptions);
         }

--- a/modules/angular2/src/http/backends/xhr_backend.ts
+++ b/modules/angular2/src/http/backends/xhr_backend.ts
@@ -2,6 +2,7 @@ import {ConnectionBackend, Connection} from '../interfaces';
 import {ReadyStates, RequestMethods, ResponseTypes} from '../enums';
 import {Request} from '../static_request';
 import {Response} from '../static_response';
+import {Headers} from '../headers';
 import {ResponseOptions, BaseResponseOptions} from '../base_response_options';
 import {Injectable} from 'angular2/angular2';
 import {BrowserXhr} from './browser_xhr';
@@ -34,8 +35,9 @@ export class XHRConnection implements Connection {
         // responseText is the old-school way of retrieving response (supported by IE8 & 9)
         // response/responseType properties were introduced in XHR Level2 spec (supported by
         // IE10)
-        let xhrResponse = isPresent(_xhr.response) ? _xhr.response : _xhr.responseText;
+        let body = isPresent(_xhr.response) ? _xhr.response : _xhr.responseText;
 
+        let headers = Headers.fromResponseHeaderString(_xhr.getAllResponseHeaders());
 
         // normalize IE9 bug (http://bugs.jquery.com/ticket/1450)
         let status: number = _xhr.status === 1223 ? 204 : _xhr.status;
@@ -44,9 +46,9 @@ export class XHRConnection implements Connection {
         // Occurs when accessing file resources or on Android 4.1 stock browser
         // while retrieving files from application cache.
         if (status === 0) {
-          status = xhrResponse ? 200 : 0;
+          status = body ? 200 : 0;
         }
-        var responseOptions = new ResponseOptions({body: xhrResponse, status: status});
+        var responseOptions = new ResponseOptions({body, status, headers});
         if (isPresent(baseResponseOptions)) {
           responseOptions = baseResponseOptions.merge(responseOptions);
         }

--- a/modules/angular2/src/http/backends/xhr_backend.ts
+++ b/modules/angular2/src/http/backends/xhr_backend.ts
@@ -7,6 +7,7 @@ import {Injectable} from 'angular2/angular2';
 import {BrowserXhr} from './browser_xhr';
 import {isPresent} from 'angular2/src/facade/lang';
 import {Observable} from 'angular2/angular2';
+import {isSuccess} from '../http_utils';
 /**
 * Creates connections using `XMLHttpRequest`. Given a fully-qualified
 * request, an `XHRConnection` will immediately create an `XMLHttpRequest` object and send the
@@ -33,24 +34,30 @@ export class XHRConnection implements Connection {
         // responseText is the old-school way of retrieving response (supported by IE8 & 9)
         // response/responseType properties were introduced in XHR Level2 spec (supported by
         // IE10)
-        let response = isPresent(_xhr.response) ? _xhr.response : _xhr.responseText;
+        let xhrResponse = isPresent(_xhr.response) ? _xhr.response : _xhr.responseText;
+
 
         // normalize IE9 bug (http://bugs.jquery.com/ticket/1450)
-        let status = _xhr.status === 1223 ? 204 : _xhr.status;
+        let status: number = _xhr.status === 1223 ? 204 : _xhr.status;
 
         // fix status code when it is 0 (0 status is undocumented).
         // Occurs when accessing file resources or on Android 4.1 stock browser
         // while retrieving files from application cache.
         if (status === 0) {
-          status = response ? 200 : 0;
+          status = xhrResponse ? 200 : 0;
         }
-        var responseOptions = new ResponseOptions({body: response, status: status});
+        var responseOptions = new ResponseOptions({body: xhrResponse, status: status});
         if (isPresent(baseResponseOptions)) {
           responseOptions = baseResponseOptions.merge(responseOptions);
         }
-        responseObserver.next(new Response(responseOptions));
-        // TODO(gdi2290): defer complete if array buffer until done
-        responseObserver.complete();
+        let response = new Response(responseOptions);
+        if (isSuccess(status)) {
+          responseObserver.next(response);
+          // TODO(gdi2290): defer complete if array buffer until done
+          responseObserver.complete();
+          return;
+        }
+        responseObserver.error(response);
       };
       // error event handler
       let onError = (err) => {

--- a/modules/angular2/src/http/backends/xhr_backend.ts
+++ b/modules/angular2/src/http/backends/xhr_backend.ts
@@ -8,7 +8,7 @@ import {Injectable} from 'angular2/angular2';
 import {BrowserXhr} from './browser_xhr';
 import {isPresent} from 'angular2/src/facade/lang';
 import {Observable} from 'angular2/angular2';
-import {isSuccess} from '../http_utils';
+import {isSuccess, getResponseURL} from '../http_utils';
 /**
 * Creates connections using `XMLHttpRequest`. Given a fully-qualified
 * request, an `XHRConnection` will immediately create an `XMLHttpRequest` object and send the
@@ -39,6 +39,8 @@ export class XHRConnection implements Connection {
 
         let headers = Headers.fromResponseHeaderString(_xhr.getAllResponseHeaders());
 
+        let url = getResponseURL(_xhr);
+
         // normalize IE9 bug (http://bugs.jquery.com/ticket/1450)
         let status: number = _xhr.status === 1223 ? 204 : _xhr.status;
 
@@ -48,7 +50,7 @@ export class XHRConnection implements Connection {
         if (status === 0) {
           status = body ? 200 : 0;
         }
-        var responseOptions = new ResponseOptions({body, status, headers});
+        var responseOptions = new ResponseOptions({body, status, headers, url});
         if (isPresent(baseResponseOptions)) {
           responseOptions = baseResponseOptions.merge(responseOptions);
         }

--- a/modules/angular2/src/http/headers.ts
+++ b/modules/angular2/src/http/headers.ts
@@ -55,6 +55,17 @@ export class Headers {
   }
 
   /**
+   * Returns a new Headers instance from the given DOMString of Response Headers
+   */
+  static fromResponseHeaderString(headersString: string): Headers {
+    return headersString.trim()
+        .split('\n')
+        .map(val => val.split(':'))
+        .map(([key, ...parts]) => ([key.trim(), parts.join(':').trim()]))
+        .reduce((headers, [key, value]) => !headers.set(key, value) && headers, new Headers());
+  }
+
+  /**
    * Appends a header to existing list of header values for a given header name.
    */
   append(name: string, value: string): void {

--- a/modules/angular2/src/http/http.ts
+++ b/modules/angular2/src/http/http.ts
@@ -16,9 +16,9 @@ function mergeOptions(defaultOpts, providedOpts, method, url): RequestOptions {
   var newOptions = defaultOpts;
   if (isPresent(providedOpts)) {
     // Hack so Dart can used named parameters
-    newOptions = newOptions.merge(new RequestOptions({
-      method: providedOpts.method,
-      url: providedOpts.url,
+    return newOptions.merge(new RequestOptions({
+      method: providedOpts.method || method,
+      url: providedOpts.url || url,
       search: providedOpts.search,
       headers: providedOpts.headers,
       body: providedOpts.body

--- a/modules/angular2/src/http/http_utils.ts
+++ b/modules/angular2/src/http/http_utils.ts
@@ -17,4 +17,14 @@ export function normalizeMethodName(method): RequestMethods {
 
 export const isSuccess = (status: number): boolean => (status >= 200 && status < 300);
 
+export function getResponseURL(xhr: any): string {
+  if ('responseURL' in xhr) {
+    return xhr.responseURL;
+  }
+  if (/^X-Request-URL:/m.test(xhr.getAllResponseHeaders())) {
+    return xhr.getResponseHeader('X-Request-URL');
+  }
+  return;
+}
+
 export {isJsObject} from 'angular2/src/facade/lang';

--- a/modules/angular2/src/http/http_utils.ts
+++ b/modules/angular2/src/http/http_utils.ts
@@ -1,6 +1,7 @@
 import {isString} from 'angular2/src/facade/lang';
 import {RequestMethods} from './enums';
 import {makeTypeError} from 'angular2/src/facade/exceptions';
+import {Response} from './static_response';
 
 export function normalizeMethodName(method): RequestMethods {
   if (isString(method)) {
@@ -13,5 +14,7 @@ export function normalizeMethodName(method): RequestMethods {
   }
   return method;
 }
+
+export const isSuccess = (status: number): boolean => (status >= 200 && status < 300);
 
 export {isJsObject} from 'angular2/src/facade/lang';

--- a/modules/angular2/test/http/headers_spec.ts
+++ b/modules/angular2/test/http/headers_spec.ts
@@ -63,4 +63,23 @@ export function main() {
       });
     });
   });
+
+  describe('.fromResponseHeaderString()', () => {
+
+    it('should parse a response header string', () => {
+
+      let responseHeaderString = `Date: Fri, 20 Nov 2015 01:45:26 GMT
+        Content-Type: application/json; charset=utf-8
+        Transfer-Encoding: chunked
+        Connection: keep-alive`;
+
+      let responseHeaders = Headers.fromResponseHeaderString(responseHeaderString);
+
+      expect(responseHeaders.get('Date')).toEqual('Fri, 20 Nov 2015 01:45:26 GMT');
+      expect(responseHeaders.get('Content-Type')).toEqual('application/json; charset=utf-8');
+      expect(responseHeaders.get('Transfer-Encoding')).toEqual('chunked');
+      expect(responseHeaders.get('Connection')).toEqual('keep-alive');
+
+    });
+  });
 }

--- a/modules/angular2/test/http/http_spec.ts
+++ b/modules/angular2/test/http/http_spec.ts
@@ -151,11 +151,52 @@ export function main() {
                  .subscribe((res) => {});
            }));
 
+        it('should accept a fully-qualified request as its only parameter',
+           inject([AsyncTestCompleter], (async) => {
+             backend.connections.subscribe(c => {
+               expect(c.request.url).toBe('https://google.com');
+               expect(c.request.method).toBe(RequestMethods.Post);
+               c.mockRespond(new Response(new ResponseOptions({body: 'Thank you'})));
+               async.done();
+             });
+             http.request(new Request(new RequestOptions(
+                              {url: 'https://google.com', method: RequestMethods.Post})))
+                 .subscribe((res) => {});
+           }));
+
 
         it('should perform a get request for given url if only passed a string',
            inject([AsyncTestCompleter], (async) => {
              backend.connections.subscribe(c => c.mockRespond(baseResponse));
              http.request('http://basic.connection')
+                 .subscribe(res => {
+                   expect(res.text()).toBe('base response');
+                   async.done();
+                 });
+           }));
+
+        it('should perform a post request for given url if options include a method',
+           inject([AsyncTestCompleter], (async) => {
+             backend.connections.subscribe(c => {
+               expect(c.request.method).toEqual(RequestMethods.Post);
+               c.mockRespond(baseResponse);
+             });
+             let requestOptions = new RequestOptions({method: RequestMethods.Post});
+             http.request('http://basic.connection', requestOptions)
+                 .subscribe(res => {
+                   expect(res.text()).toBe('base response');
+                   async.done();
+                 });
+           }));
+
+        it('should perform a post request for given url if options include a method',
+           inject([AsyncTestCompleter], (async) => {
+             backend.connections.subscribe(c => {
+               expect(c.request.method).toEqual(RequestMethods.Post);
+               c.mockRespond(baseResponse);
+             });
+             let requestOptions = {method: RequestMethods.Post};
+             http.request('http://basic.connection', requestOptions)
                  .subscribe(res => {
                    expect(res.text()).toBe('base response');
                    async.done();
@@ -180,18 +221,6 @@ export function main() {
                  .subscribe(res => { expect(res.text()).toBe('base response'); }, null,
                             () => { async.done(); });
            }));
-        // TODO: make dart not complain about "argument type 'Map' cannot be assigned to the
-        // parameter type 'IRequestOptions'"
-        // xit('should perform a get request for given url if passed a dictionary',
-        //     inject([AsyncTestCompleter], async => {
-        //       ObservableWrapper.subscribe(backend.connections, c => c.mockRespond(baseResponse));
-        //       ObservableWrapper.subscribe(http.request(url, {method: RequestMethods.GET}), res =>
-        //       {
-        //         expect(res.text()).toBe('base response');
-        //         async.done();
-        //       });
-        //     }));
-
 
         it('should throw if url is not a string or Request', () => {
           var req = <Request>{};


### PR DESCRIPTION
BREAKING CHANGE:

previously http would only error on network errors to match the fetch
specification. Now status codes less than 200 and greater than 299 will
cause Http's Observable to error. Closes #5130.

Return Response Headers for Requests. Closes #5237 

Return URL in Response. Closes #5165

Allow http.request(url, opts) to pass method. Closes #5309
