### PR TITLE
Change "feat" to "feature" in commit message format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ If the commit reverts a previous commit, it should begin with `revert: `, follow
 ### Type
 Must be one of the following:
 
-* **feat**: A new feature
+* **feature**: A new feature
 * **fix**: A bug fix
 * **docs**: Documentation only changes
 * **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing


### PR DESCRIPTION
- nicer to read
- still shorter than "refactor"
- backwards-compatible (aka grep feat will still find it)
- not http://www.merriam-webster.com/dictionary/feat
