### PR TITLE
fix(web worker): remove usages of deprecated zone API

### DIFF
--- a/modules/angular2/src/mock/ng_zone_mock.ts
+++ b/modules/angular2/src/mock/ng_zone_mock.ts
@@ -1,18 +1,20 @@
 import {NgZone} from 'angular2/src/core/zone/ng_zone';
+import {EventEmitter, ObservableWrapper} from 'angular2/src/facade/async';
 
 export class MockNgZone extends NgZone {
   /** @internal */
-  _onEventDone: () => void;
+  _mockOnEventDone: EventEmitter<any>;
 
-  constructor() { super({enableLongStackTrace: false}); }
+  constructor() {
+    super({enableLongStackTrace: false});
+    this._mockOnEventDone = new EventEmitter<any>(false);
+  }
+
+  get onEventDone() { return this._mockOnEventDone; }
 
   run(fn: Function): any { return fn(); }
 
   runOutsideAngular(fn: Function): any { return fn(); }
 
-  overrideOnEventDone(fn: () => void, opt_waitForAsync: boolean = false): void {
-    this._onEventDone = fn;
-  }
-
-  simulateZoneExit(): void { this._onEventDone(); }
+  simulateZoneExit(): void { ObservableWrapper.callNext(this.onEventDone, null); }
 }

--- a/modules/angular2/src/web_workers/shared/generic_message_bus.dart
+++ b/modules/angular2/src/web_workers/shared/generic_message_bus.dart
@@ -45,12 +45,14 @@ abstract class GenericMessageBusSink implements MessageBusSink {
 
   void attachToZone(NgZone zone) {
     _zone = zone;
-    _zone.overrideOnEventDone(() {
-      if (_messageBuffer.length > 0) {
-        sendMessages(_messageBuffer);
-        _messageBuffer.clear();
-      }
-    }, false);
+    _zone.runOutsideAngular(() {
+      _zone.onEventDone.listen((_) {
+        if (_messageBuffer.length > 0) {
+          sendMessages(_messageBuffer);
+          _messageBuffer.clear();
+        }
+      });
+    });
   }
 
   void initChannel(String channelName, [bool runInZone = true]) {

--- a/modules/angular2/src/web_workers/shared/post_message_bus.ts
+++ b/modules/angular2/src/web_workers/shared/post_message_bus.ts
@@ -4,7 +4,7 @@ import {
   MessageBusSink
 } from "angular2/src/web_workers/shared/message_bus";
 import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
-import {EventEmitter} from 'angular2/src/facade/async';
+import {EventEmitter, ObservableWrapper} from 'angular2/src/facade/async';
 import {StringMapWrapper} from 'angular2/src/facade/collection';
 import {Injectable} from "angular2/src/core/di";
 import {NgZone} from 'angular2/src/core/zone/ng_zone';
@@ -41,7 +41,9 @@ export class PostMessageBusSink implements MessageBusSink {
 
   attachToZone(zone: NgZone): void {
     this._zone = zone;
-    this._zone.overrideOnEventDone(() => this._handleOnEventDone(), false);
+    this._zone.runOutsideAngular(() => {
+      ObservableWrapper.subscribe(this._zone.onEventDone, (_) => { this._handleOnEventDone(); });
+    });
   }
 
   initChannel(channel: string, runInZone: boolean = true): void {


### PR DESCRIPTION
This replaces usages of `overrideOnEventDone` with `onEventDone` stream-based API
