### PR TITLE
chore(bundles): don't distribute sfx bundles for http

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -980,12 +980,7 @@ gulp.task('!bundle.js.sfx.dev', ['build.js.dev'], function() {
   devBundleConfig.paths = merge(true, devBundleConfig.paths, {'*': 'dist/js/dev/es5/*.js'});
   return bundler.bundle(devBundleConfig, 'angular2/angular2_sfx',
                         './dist/build/angular2.sfx.dev.js', {sourceMaps: true},
-                        /* self-executing */ true)
-      .then(function() {
-        return bundler.bundle(devBundleConfig, 'angular2/http', './dist/build/http.sfx.dev.js',
-                              {sourceMaps: true},
-                              /* self-executing */ true);
-      });
+                        /* self-executing */ true);
 });
 
 gulp.task('!bundle.js.prod.deps', ['!bundle.js.prod'], function() {
@@ -1036,11 +1031,9 @@ gulp.task('!bundle.js.dev.deps', ['!bundle.js.dev'], function() {
 });
 
 gulp.task('!bundle.js.sfx.dev.deps', ['!bundle.js.sfx.dev'], function() {
-  return merge2(
-      bundler.modify(JS_DEV_DEPS.concat(['dist/build/angular2.sfx.dev.js']), 'angular2.sfx.dev.js')
-          .pipe(gulp.dest('dist/js/bundle')),
-      bundler.modify(['dist/build/http.sfx.dev.js'], 'http.sfx.dev.js')
-          .pipe(gulp.dest('dist/js/bundle')));
+  return bundler.modify(JS_DEV_DEPS.concat(['dist/build/angular2.sfx.dev.js']),
+                        'angular2.sfx.dev.js')
+      .pipe(gulp.dest('dist/js/bundle'));
 });
 
 gulp.task('!bundle.web_worker.js.dev.deps', ['!bundle.web_worker.js.dev'], function() {

--- a/modules/angular2/src/http/http_sfx.ts
+++ b/modules/angular2/src/http/http_sfx.ts
@@ -1,3 +1,0 @@
-import * as ngHttp from './http';
-
-(<any>window).ngHttp = ngHttp;


### PR DESCRIPTION
Currently the main sfx bundle already contains http and router
and the http sfx bundles duplicates all core.

Additionally https://github.com/angular/angular/issues/5223
modifies our strategy for individual bundles
