### PR TITLE
fix(forms): correct radio input functionality

### DIFF
--- a/modules/angular2/src/common/forms/directives.ts
+++ b/modules/angular2/src/common/forms/directives.ts
@@ -8,6 +8,7 @@ import {NgForm} from './directives/ng_form';
 import {DefaultValueAccessor} from './directives/default_value_accessor';
 import {CheckboxControlValueAccessor} from './directives/checkbox_value_accessor';
 import {NumberValueAccessor} from './directives/number_value_accessor';
+import {RadioControlValueAccessor} from './directives/radio_control_value_accessor';
 import {NgControlStatus} from './directives/ng_control_status';
 import {
   SelectControlValueAccessor,
@@ -23,6 +24,7 @@ export {NgFormModel} from './directives/ng_form_model';
 export {NgForm} from './directives/ng_form';
 export {DefaultValueAccessor} from './directives/default_value_accessor';
 export {CheckboxControlValueAccessor} from './directives/checkbox_value_accessor';
+export {RadioControlValueAccessor} from './directives/radio_control_value_accessor';
 export {NumberValueAccessor} from './directives/number_value_accessor';
 export {NgControlStatus} from './directives/ng_control_status';
 export {
@@ -63,6 +65,7 @@ export const FORM_DIRECTIVES: Type[] = CONST_EXPR([
   NumberValueAccessor,
   CheckboxControlValueAccessor,
   SelectControlValueAccessor,
+  RadioControlValueAccessor,
   NgControlStatus,
 
   RequiredValidator,

--- a/modules/angular2/src/common/forms/directives/radio_control_value_accessor.ts
+++ b/modules/angular2/src/common/forms/directives/radio_control_value_accessor.ts
@@ -1,0 +1,63 @@
+import {
+  Directive,
+  ElementRef,
+  Renderer,
+  Self,
+  forwardRef,
+  Provider,
+  Attribute,
+  Input
+} from 'angular2/core';
+import {
+  NG_VALUE_ACCESSOR,
+  ControlValueAccessor
+} from 'angular2/src/common/forms/directives/control_value_accessor';
+import {CONST_EXPR} from 'angular2/src/facade/lang';
+
+const RADIO_VALUE_ACCESSOR = CONST_EXPR(new Provider(
+    NG_VALUE_ACCESSOR, {useExisting: forwardRef(() => RadioControlValueAccessor), multi: true}));
+
+/**
+ * The accessor for writing a radio control value and listening to changes that is used by the
+ * {@link NgModel}, {@link NgFormControl}, and {@link NgControlName} directives.
+ *
+ *  ### Example
+ *  ```
+ *  <input type="radio" name="food" [(ng-model)]="food" value="chicken">
+ *  <input type="radio" name="food" [(ng-model)]="food" value="fish">
+ *  ```
+ */
+@Directive({
+  selector:
+      'input[type=radio][ng-control],input[type=radio][ng-form-control],input[type=radio][ng-model]',
+  host: {
+    '(click)': 'onChange($event.target.value)',
+    '(input)': 'onChange($event.target.value)',
+    '(blur)': 'onTouched()'
+  },
+  bindings: [RADIO_VALUE_ACCESSOR]
+})
+export class RadioControlValueAccessor implements ControlValueAccessor {
+  @Input('value') optionValue: any;
+  value: any;
+  onChange = (_) => {};
+  onTouched = () => {};
+
+  constructor(private _renderer: Renderer, private _elementRef: ElementRef) {}
+
+  private _updateCheckedState() {
+    if (this.value == this.optionValue) {
+      this._renderer.setElementProperty(this._elementRef, 'checked', true);
+    }
+  }
+
+  writeValue(value: any): void {
+    this.value = value;
+    this._updateCheckedState();
+  }
+
+  registerOnChange(fn: (_: any) => void): void {
+    this.onChange = (value) => { fn(this.optionValue); };
+  }
+  registerOnTouched(fn: () => void): void { this.onTouched = fn; }
+}

--- a/modules/angular2/test/common/forms/integration_spec.ts
+++ b/modules/angular2/test/common/forms/integration_spec.ts
@@ -304,6 +304,53 @@ export function main() {
              async.done();
            });
          }));
+         
+      it("should support <type=radio>",
+         inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
+           var t = `<div [ng-form-model]="form">
+                  <input type="radio" ng-control="food" name="food" value="chicken">
+                  <input type="radio" ng-control="food" name="food" value="fish">
+                </div>`;
+
+           tcb.overrideTemplate(MyComp, t).createAsync(MyComp).then((fixture) => {
+             fixture.debugElement.componentInstance.form =
+                 new ControlGroup({"food": new Control("fish")});
+             fixture.detectChanges();
+
+             var input = fixture.debugElement.query(By.css("input"));
+             expect(input.nativeElement.checked).toEqual(false);
+
+             dispatchEvent(input.nativeElement, "click");
+             fixture.detectChanges();
+
+             expect(fixture.debugElement.componentInstance.form.value).toEqual({"food": "chicken"});
+             expect(input.nativeElement.checked).toEqual(true);
+             async.done();
+           });
+         }));
+      it("should support <type=radio> with dynamic values",
+         inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
+           var t = `<div [ng-form-model]="form">
+                  <input *ng-for="#c of data" type="radio" ng-control="food" name="food" [value]="c">
+                </div>`;
+
+           tcb.overrideTemplate(MyComp, t).createAsync(MyComp).then((fixture) => {
+             fixture.debugElement.componentInstance.data = ["chicken", "fish"];
+             fixture.debugElement.componentInstance.form =
+                 new ControlGroup({"food": new Control("fish")});
+             fixture.detectChanges();
+
+             var input = fixture.debugElement.query(By.css("input"));
+             expect(input.nativeElement.checked).toEqual(false);
+
+             dispatchEvent(input.nativeElement, "click");
+             fixture.detectChanges();
+
+             expect(fixture.debugElement.componentInstance.form.value).toEqual({"food": "chicken"});
+             expect(input.nativeElement.checked).toEqual(true);
+             async.done();
+           });
+         }));
 
       it("should support <select>",
          inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {


### PR DESCRIPTION
Radio values use the "checked" property to denote state, and use
"value" property to write to model. Add separation between these two
values.

Fixes #5133, Fixes #3104
