### PR TITLE
refactor(dart/transform): Remove `reflectPropertiesAsAttributes`

### DIFF
--- a/modules_dart/transform/lib/src/transform/common/options.dart
+++ b/modules_dart/transform/lib/src/transform/common/options.dart
@@ -9,8 +9,6 @@ const CUSTOM_ANNOTATIONS_PARAM = 'custom_annotations';
 const ENTRY_POINT_PARAM = 'entry_points';
 const FORMAT_CODE_PARAM = 'format_code';
 const REFLECT_PROPERTIES_AS_ATTRIBUTES = 'reflect_properties_as_attributes';
-// TODO(kegluenq): Remove this after 30 Nov (i/5108).
-const REFLECT_PROPERTIES_AS_ATTRIBUTES_OLD = 'reflectPropertiesAsAttributes';
 const PLATFORM_DIRECTIVES = 'platform_directives';
 const INIT_REFLECTOR_PARAM = 'init_reflector';
 const INLINE_VIEWS_PARAM = 'inline_views';

--- a/modules_dart/transform/lib/src/transform/common/options_reader.dart
+++ b/modules_dart/transform/lib/src/transform/common/options_reader.dart
@@ -7,17 +7,11 @@ import 'options.dart';
 
 TransformerOptions parseBarbackSettings(BarbackSettings settings) {
   var config = settings.configuration;
-  _warnDeprecated(config);
   var entryPoints = _readStringList(config, ENTRY_POINT_PARAM);
   var initReflector =
       _readBool(config, INIT_REFLECTOR_PARAM, defaultValue: true);
   var reflectPropertiesAsAttributes =
       _readBool(config, REFLECT_PROPERTIES_AS_ATTRIBUTES, defaultValue: false);
-  if (!config.containsKey(REFLECT_PROPERTIES_AS_ATTRIBUTES)) {
-    reflectPropertiesAsAttributes = _readBool(
-        config, REFLECT_PROPERTIES_AS_ATTRIBUTES_OLD,
-        defaultValue: false);
-  }
   var platformDirectives = _readStringList(config, PLATFORM_DIRECTIVES);
   var formatCode = _readBool(config, FORMAT_CODE_PARAM, defaultValue: false);
   String mirrorModeVal =
@@ -120,11 +114,3 @@ const CUSTOM_ANNOTATIONS_ERROR = '''
         - name: ...
           import: ...
           superClass: ...''';
-
-void _warnDeprecated(Map config) {
-  if (config.containsKey(REFLECT_PROPERTIES_AS_ATTRIBUTES_OLD)) {
-    print('${REFLECT_PROPERTIES_AS_ATTRIBUTES_OLD} has been renamed to '
-        '${REFLECT_PROPERTIES_AS_ATTRIBUTES}. Please update it in your '
-        'pubspec.');
-  }
-}


### PR DESCRIPTION
Remove deprecated `reflectPropertiesAsAttributes` as an option. It has
been renamed `reflect_properties_as_attributes`.

Closes #5108
