### PR TITLE
fix(dom_renderer): moveNodeAfterSiblings doesn't detach nodes. Fixes #5077

### DIFF
--- a/modules/angular2/src/platform/dom/dom_renderer.ts
+++ b/modules/angular2/src/platform/dom/dom_renderer.ts
@@ -346,11 +346,12 @@ function resolveInternalDomFragment(fragmentRef: RenderFragmentRef): Node[] {
 }
 
 function moveNodesAfterSibling(sibling, nodes) {
+  let sib = sibling;
   if (nodes.length > 0 && isPresent(DOM.parentElement(sibling))) {
     for (var i = 0; i < nodes.length; i++) {
-      DOM.insertBefore(sibling, nodes[i]);
+      sib.parentNode.insertBefore(nodes[i], sib.nextSibling);
+      sib = nodes[i];
     }
-    DOM.insertBefore(nodes[0], sibling);
   }
 }
 

--- a/modules/angular2/src/platform/dom/dom_renderer.ts
+++ b/modules/angular2/src/platform/dom/dom_renderer.ts
@@ -347,9 +347,10 @@ function resolveInternalDomFragment(fragmentRef: RenderFragmentRef): Node[] {
 
 function moveNodesAfterSibling(sibling, nodes) {
   let sib = sibling;
-  if (nodes.length > 0 && isPresent(DOM.parentElement(sibling))) {
+  let parent = DOM.parentElement(sib);
+  if (nodes.length > 0 && isPresent(parent)) {
     for (var i = 0; i < nodes.length; i++) {
-      sib.parentNode.insertBefore(nodes[i], sib.nextSibling);
+      parent.insertBefore(nodes[i], sib.nextSibling);
       sib = nodes[i];
     }
   }


### PR DESCRIPTION
This fixes the issue described in #5077, where `moveNodesAfterSibling` would incorrectly cause the browser to detach and reattach existing nodes, which caused such undesirable effects as scrollTop being reset to zero.

Now, nodes will be appended sequentially and never move the target sibling node.
