### PR TITLE
chore(test): remove deprecated angular2/test and angular2/test_lib

### DIFF
--- a/modules/angular2/test.ts
+++ b/modules/angular2/test.ts
@@ -1,5 +1,0 @@
-/**
- * @deprecated Please use testing instead
- */
-
-export * from './testing';

--- a/modules/angular2/test/core/zone/ng_zone_DEPRECATED_spec.ts
+++ b/modules/angular2/test/core/zone/ng_zone_DEPRECATED_spec.ts
@@ -14,7 +14,7 @@ import {
   Log,
   isInInnerZone,
   browserDetection
-} from 'angular2/test_lib';
+} from 'angular2/testing_internal';
 
 import {PromiseCompleter, PromiseWrapper, TimerWrapper} from 'angular2/src/facade/async';
 import {BaseException} from 'angular2/src/facade/exceptions';

--- a/modules/angular2/test_lib.ts
+++ b/modules/angular2/test_lib.ts
@@ -1,5 +1,0 @@
-/*
- * @deprecated Please use testing_internal instead
- */
-
-export * from './testing_internal';


### PR DESCRIPTION
These have been deprecated for a while. Instead of angular2/test, use
angular2/testing. Instead of angular2/test_lib, use angular2_testing_internal.
