### PR TITLE
feat(core): remove typings from package.json to disallow 'import * as…

### DIFF
--- a/modules/angular2/package.json
+++ b/modules/angular2/package.json
@@ -12,6 +12,5 @@
     "@reactivex/rxjs": "<%= packageJson.dependencies['@reactivex/rxjs'] %>",
     "zone.js": "<%= packageJson.dependencies['zone.js'] %>"
   },
-  "devDependencies": <%= JSON.stringify(packageJson.defaultDevDependencies) %>,
-  "typings": "./angular2.d.ts"
+  "devDependencies": <%= JSON.stringify(packageJson.defaultDevDependencies) %>
 }


### PR DESCRIPTION
… n from 'angular2'''

The typings property is being removed because angular2.ts is deprecated, and the developers should import from angular2/core and angular2/platform/*.  So aliasing angular2 to angular2/angular2 does not make sense.

BREAKING CHANGE

Before

import \* as ng from 'angular2';

After

import \* as core from 'angular2/core';

Closes #5539
