### PR TITLE
chore(test): remove deprecated RootTestComponent

### DIFF
--- a/modules/angular2/src/testing/test_component_builder.ts
+++ b/modules/angular2/src/testing/test_component_builder.ts
@@ -24,17 +24,14 @@ import {DebugElement, DebugElement_} from 'angular2/src/core/debug/debug_element
 
 
 /**
- * @deprecated Use ComponentFixture
+ * Fixture for debugging and testing a component.
  */
-export abstract class RootTestComponent {
+export abstract class ComponentFixture {
   debugElement: DebugElement;
 
   abstract detectChanges(): void;
   abstract destroy(): void;
 }
-
-
-export abstract class ComponentFixture extends RootTestComponent {}
 
 
 export class ComponentFixture_ extends ComponentFixture {

--- a/modules/angular2/test/router/integration/auxiliary_route_spec.ts
+++ b/modules/angular2/test/router/integration/auxiliary_route_spec.ts
@@ -1,5 +1,5 @@
 import {
-  RootTestComponent,
+  ComponentFixture,
   AsyncTestCompleter,
   TestComponentBuilder,
   beforeEach,
@@ -22,7 +22,7 @@ import {RouteConfig, Route, AuxRoute, Redirect} from 'angular2/src/router/route_
 
 import {TEST_ROUTER_PROVIDERS, RootCmp, compile, clickOnElement, getHref} from './util';
 
-function getLinkElement(rtc: RootTestComponent) {
+function getLinkElement(rtc: ComponentFixture) {
   return rtc.debugElement.componentViewChildren[0].nativeElement;
 }
 
@@ -33,7 +33,7 @@ export function main() {
   describe('auxiliary routes', () => {
 
     var tcb: TestComponentBuilder;
-    var fixture: RootTestComponent;
+    var fixture: ComponentFixture;
     var rtr;
 
     beforeEachProviders(() => TEST_ROUTER_PROVIDERS);

--- a/modules/angular2/test/router/integration/impl/async_route_spec_impl.ts
+++ b/modules/angular2/test/router/integration/impl/async_route_spec_impl.ts
@@ -8,7 +8,7 @@ import {
   inject,
   it,
   TestComponentBuilder,
-  RootTestComponent,
+  ComponentFixture,
   xit,
 } from 'angular2/testing_internal';
 
@@ -32,7 +32,7 @@ import {
   asyncRouteDataCmp
 } from './fixture_components';
 
-function getLinkElement(rtc: RootTestComponent) {
+function getLinkElement(rtc: ComponentFixture) {
   return rtc.debugElement.componentViewChildren[0].nativeElement;
 }
 

--- a/modules/angular2/test/router/integration/impl/sync_route_spec_impl.ts
+++ b/modules/angular2/test/router/integration/impl/sync_route_spec_impl.ts
@@ -8,7 +8,7 @@ import {
   inject,
   it,
   TestComponentBuilder,
-  RootTestComponent,
+  ComponentFixture,
   xit,
 } from 'angular2/testing_internal';
 
@@ -19,7 +19,7 @@ import {Router, Route, Location} from 'angular2/router';
 import {HelloCmp, UserCmp, TeamCmp, ParentCmp, ParentWithDefaultCmp} from './fixture_components';
 
 
-function getLinkElement(rtc: RootTestComponent) {
+function getLinkElement(rtc: ComponentFixture) {
   return rtc.debugElement.componentViewChildren[0].nativeElement;
 }
 

--- a/modules/angular2/test/router/integration/redirect_route_spec.ts
+++ b/modules/angular2/test/router/integration/redirect_route_spec.ts
@@ -1,5 +1,5 @@
 import {
-  RootTestComponent,
+  ComponentFixture,
   AsyncTestCompleter,
   TestComponentBuilder,
   beforeEach,
@@ -34,7 +34,7 @@ export function main() {
   describe('redirects', () => {
 
     var tcb: TestComponentBuilder;
-    var rootTC: RootTestComponent;
+    var rootTC: ComponentFixture;
     var rtr;
 
     beforeEachProviders(() => TEST_ROUTER_PROVIDERS);

--- a/modules/angular2/test/router/integration/util.ts
+++ b/modules/angular2/test/router/integration/util.ts
@@ -3,7 +3,7 @@ import {Type, isBlank} from 'angular2/src/facade/lang';
 import {BaseException} from 'angular2/src/facade/exceptions';
 
 import {
-  RootTestComponent,
+  ComponentFixture,
   AsyncTestCompleter,
   TestComponentBuilder,
   beforeEach,

--- a/modules/angular2/testing.ts
+++ b/modules/angular2/testing.ts
@@ -7,11 +7,7 @@
  *
  */
 export * from './src/testing/testing';
-export {
-  ComponentFixture,
-  RootTestComponent,
-  TestComponentBuilder
-} from './src/testing/test_component_builder';
+export {ComponentFixture, TestComponentBuilder} from './src/testing/test_component_builder';
 export * from './src/testing/test_injector';
 export * from './src/testing/fake_async';
 


### PR DESCRIPTION
Uses of `RootTestComponent` should be migrated to `ComponentFixture`.
