### PR TITLE
fix(dart/reflection): Fix `NoReflectionCapabilities` interface

### DIFF
--- a/modules/angular2/src/core/reflection/reflection.dart
+++ b/modules/angular2/src/core/reflection/reflection.dart
@@ -7,45 +7,53 @@ import 'platform_reflection_capabilities.dart';
 import 'package:angular2/src/facade/lang.dart';
 
 class NoReflectionCapabilities implements PlatformReflectionCapabilities {
+  @override
   bool isReflectionEnabled() {
     return false;
   }
 
+  @override
   Function factory(Type type) {
     throw "Cannot find reflection information on ${stringify(type)}";
   }
 
+  @override
   List interfaces(Type type) {
     throw "Cannot find reflection information on ${stringify(type)}";
   }
 
-  List parameters(Type type) {
+  @override
+  List parameters(dynamic type) {
     throw "Cannot find reflection information on ${stringify(type)}";
   }
 
-  List annotations(Type type) {
+  @override
+  List annotations(dynamic type) {
     throw "Cannot find reflection information on ${stringify(type)}";
   }
 
-  Map propMetadata(Type type) {
+  @override
+  Map propMetadata(dynamic type) {
     throw "Cannot find reflection information on ${stringify(type)}";
   }
 
+  @override
   GetterFn getter(String name) {
     throw "Cannot find getter ${name}";
   }
 
+  @override
   SetterFn setter(String name) {
     throw "Cannot find setter ${name}";
   }
 
+  @override
   MethodFn method(String name) {
     throw "Cannot find method ${name}";
   }
 
+  @override
   String importUri(Type type) => './';
-
-  String moduleId(Type type) => './';
 }
 
 final Reflector reflector = new Reflector(new NoReflectionCapabilities());

--- a/modules/angular2/test/public_api_spec.ts
+++ b/modules/angular2/test/public_api_spec.ts
@@ -1449,7 +1449,6 @@ var NG_ALL = [
   "NoReflectionCapabilities.interfaces():dart",
   "NoReflectionCapabilities.isReflectionEnabled():dart",
   "NoReflectionCapabilities.method():dart",
-  "NoReflectionCapabilities.moduleId():dart",
   "NoReflectionCapabilities.parameters():dart",
   "NoReflectionCapabilities.propMetadata():dart",
   "NoReflectionCapabilities.setter():dart",


### PR DESCRIPTION
Make `NoReflectionCapabilities` conform to the `PlatformReflectionCapbilities`
api, which prevents some confusing error messages.

Closes #5559
