### PR TITLE
Angular2 testing tweaks

### DIFF
--- a/modules_dart/angular2_testing/lib/angular2_testing.dart
+++ b/modules_dart/angular2_testing/lib/angular2_testing.dart
@@ -54,7 +54,6 @@ void setUpProviders(Iterable<Provider> providerFactory()) {
   });
 }
 
-
 dynamic _runInjectableFunction(Function fn) {
   var params = reflector.parameters(fn);
   List<dynamic> tokens = <dynamic>[];
@@ -111,8 +110,10 @@ void ngTest(String description, Function fn,
   }, testOn: testOn, timeout: timeout, skip: skip, onPlatform: onPlatform);
 }
 
-final _providersExpando = new Expando<List<Provider>>('Providers for the current test');
-final _injectorExpando = new Expando<Injector>('Angular Injector for the current test');
+final _providersExpando =
+    new Expando<List<Provider>>('Providers for the current test');
+final _injectorExpando =
+    new Expando<Injector>('Angular Injector for the current test');
 
 List get _currentTestProviders {
   if (_providersExpando[_currentTest] == null) {
@@ -120,6 +121,7 @@ List get _currentTestProviders {
   }
   return _providersExpando[_currentTest];
 }
+
 Injector get _currentInjector => _injectorExpando[_currentTest];
 void set _currentInjector(Injector newInjector) {
   _injectorExpando[_currentTest] = newInjector;

--- a/modules_dart/angular2_testing/pubspec.yaml
+++ b/modules_dart/angular2_testing/pubspec.yaml
@@ -6,3 +6,8 @@ dependencies:
     path: ../../dist/dart/angular2
 dev_dependencies:
   test: '^0.12.6'
+transformers:
+# Allows testing with `pub serve`
+# See https://github.com/dart-lang/test#testing-with-barback
+- test/pub_serve:
+    $include: test/**_test.dart

--- a/modules_dart/angular2_testing/test/angular2_testing_test.dart
+++ b/modules_dart/angular2_testing/test/angular2_testing_test.dart
@@ -41,7 +41,8 @@ void main() {
     expect(string.split(','), equals(['foo', 'bar', 'baz']));
   });
 
-  ngTest('can grab injected values', (@Inject(MyToken) token, TestService testService) {
+  ngTest('can grab injected values',
+      (@Inject(MyToken) token, TestService testService) {
     expect(token, equals('my string'));
     expect(testService.status, equals('not ready'));
   });
@@ -56,7 +57,8 @@ void main() {
     });
   });
 
-  ngTest('create a component using the TestComponentBuilder', (TestComponentBuilder tcb) async {
+  ngTest('create a component using the TestComponentBuilder',
+      (TestComponentBuilder tcb) async {
     var rootTC = await tcb
         .overrideTemplate(TestComponent, TEMPLATE)
         .createAsync(TestComponent);


### PR DESCRIPTION
Aside from the format, the tweaks to the pubspec allow one to test with `barback` – see https://github.com/dart-lang/test#testing-with-barback.

Very nice.
