### PR TITLE
refactor(test_injector): Provide separate methods for creating test i…

### DIFF
--- a/modules/angular2/src/testing/test_injector.ts
+++ b/modules/angular2/src/testing/test_injector.ts
@@ -57,6 +57,7 @@ import {COMPILER_PROVIDERS} from 'angular2/src/compiler/compiler';
 import {DomRenderer_} from "angular2/src/platform/dom/dom_renderer";
 import {DynamicComponentLoader_} from "angular2/src/core/linker/dynamic_component_loader";
 import {AppViewManager_} from "angular2/src/core/linker/view_manager";
+import {APPLICATION_COMMON_PROVIDERS} from 'angular2/src/core/application_common_providers';
 
 /**
  * Returns the root injector providers.
@@ -87,7 +88,7 @@ function _getAppBindings() {
   }
 
   return [
-    COMPILER_PROVIDERS,
+    APPLICATION_COMMON_PROVIDERS,
     provide(ChangeDetectorGenConfig, {useValue: new ChangeDetectorGenConfig(true, false, true)}),
     provide(DOCUMENT, {useValue: appDoc}),
     provide(DomRenderer, {useClass: DomRenderer_}),
@@ -120,9 +121,21 @@ function _getAppBindings() {
   ];
 }
 
+function _runtimeCompilerBindings() {
+  return [
+    provide(XHR, {useClass: DOM.getXHR()}),
+    COMPILER_PROVIDERS,
+  ];
+}
+
 export function createTestInjector(providers: Array<Type | Provider | any[]>): Injector {
   var rootInjector = Injector.resolveAndCreate(_getRootProviders());
   return rootInjector.resolveAndCreateChild(ListWrapper.concat(_getAppBindings(), providers));
+}
+
+export function createTestInjectorWithRuntimeCompiler(
+    providers: Array<Type | Provider | any[]>): Injector {
+  return createTestInjector(ListWrapper.concat(_runtimeCompilerBindings(), providers));
 }
 
 /**

--- a/modules/angular2/src/testing/testing.ts
+++ b/modules/angular2/src/testing/testing.ts
@@ -6,7 +6,12 @@ import {global} from 'angular2/src/facade/lang';
 import {ListWrapper} from 'angular2/src/facade/collection';
 import {bind} from 'angular2/src/core/di';
 
-import {createTestInjector, FunctionWithParamTokens, inject, injectAsync} from './test_injector';
+import {
+  createTestInjectorWithRuntimeCompiler,
+  FunctionWithParamTokens,
+  inject,
+  injectAsync
+} from './test_injector';
 
 export {inject, injectAsync} from './test_injector';
 
@@ -150,7 +155,7 @@ function _it(jsmFn: Function, name: string, testFn: FunctionWithParamTokens | An
   if (testFn instanceof FunctionWithParamTokens) {
     jsmFn(name, (done) => {
       if (!injector) {
-        injector = createTestInjector(testProviders);
+        injector = createTestInjectorWithRuntimeCompiler(testProviders);
       }
 
       var returnedTestValue = runInTestZone(() => testFn.execute(injector), done, done.fail);
@@ -179,7 +184,7 @@ export function beforeEach(fn: FunctionWithParamTokens | AnyTestFn): void {
 
     jsmBeforeEach((done) => {
       if (!injector) {
-        injector = createTestInjector(testProviders);
+        injector = createTestInjectorWithRuntimeCompiler(testProviders);
       }
 
       runInTestZone(() => fn.execute(injector), done, done.fail);

--- a/modules/angular2/src/testing/testing_internal.dart
+++ b/modules/angular2/src/testing/testing_internal.dart
@@ -63,7 +63,7 @@ void testSetup() {
   gns.beforeEach(() {
     _isCurrentTestAsync = false;
     _testBindings.add(completerBinding);
-    _injector = createTestInjector(_testBindings);
+    _injector = createTestInjectorWithRuntimeCompiler(_testBindings);
   }, priority: 1);
 }
 

--- a/modules/angular2/src/testing/testing_internal.ts
+++ b/modules/angular2/src/testing/testing_internal.ts
@@ -5,7 +5,11 @@ import {NgZoneZone} from 'angular2/src/core/zone/ng_zone';
 
 import {provide} from 'angular2/src/core/di';
 
-import {createTestInjector, FunctionWithParamTokens, inject} from './test_injector';
+import {
+  createTestInjectorWithRuntimeCompiler,
+  FunctionWithParamTokens,
+  inject
+} from './test_injector';
 import {browserDetection} from './utils';
 
 export {inject} from './test_injector';
@@ -143,7 +147,7 @@ function _it(jsmFn: Function, name: string, testFn: FunctionWithParamTokens | An
           }
         });
 
-        var injector = createTestInjector([...testProviders, completerProvider]);
+        var injector = createTestInjectorWithRuntimeCompiler([...testProviders, completerProvider]);
         runner.run(injector);
 
         inIt = true;
@@ -152,7 +156,7 @@ function _it(jsmFn: Function, name: string, testFn: FunctionWithParamTokens | An
       }, timeOut);
     } else {
       jsmFn(name, () => {
-        var injector = createTestInjector(testProviders);
+        var injector = createTestInjectorWithRuntimeCompiler(testProviders);
         runner.run(injector);
         testFn.execute(injector);
       }, timeOut);
@@ -163,13 +167,13 @@ function _it(jsmFn: Function, name: string, testFn: FunctionWithParamTokens | An
 
     if ((<any>testFn).length === 0) {
       jsmFn(name, () => {
-        var injector = createTestInjector(testProviders);
+        var injector = createTestInjectorWithRuntimeCompiler(testProviders);
         runner.run(injector);
         (<SyncTestFn>testFn)();
       }, timeOut);
     } else {
       jsmFn(name, (done) => {
-        var injector = createTestInjector(testProviders);
+        var injector = createTestInjectorWithRuntimeCompiler(testProviders);
         runner.run(injector);
         (<AsyncTestFn>testFn)(done);
       }, timeOut);

--- a/modules/angular2/test/web_workers/shared/message_bus_spec.ts
+++ b/modules/angular2/test/web_workers/shared/message_bus_spec.ts
@@ -5,7 +5,7 @@ import {
   it,
   expect,
   beforeEach,
-  createTestInjector,
+  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders,
   SpyObject,
   proxy

--- a/modules/angular2/test/web_workers/shared/service_message_broker_spec.ts
+++ b/modules/angular2/test/web_workers/shared/service_message_broker_spec.ts
@@ -5,7 +5,7 @@ import {
   it,
   expect,
   beforeEach,
-  createTestInjector,
+  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders,
   SpyObject,
   proxy

--- a/modules/angular2/test/web_workers/worker/event_dispatcher_spec.ts
+++ b/modules/angular2/test/web_workers/worker/event_dispatcher_spec.ts
@@ -5,7 +5,7 @@ import {
   it,
   expect,
   beforeEach,
-  createTestInjector,
+  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders,
   SpyObject,
   proxy

--- a/modules/angular2/test/web_workers/worker/renderer_integration_spec.ts
+++ b/modules/angular2/test/web_workers/worker/renderer_integration_spec.ts
@@ -7,7 +7,7 @@ import {
   iit,
   expect,
   beforeEach,
-  createTestInjector,
+  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders,
   TestComponentBuilder
 } from "angular2/testing_internal";
@@ -101,7 +101,7 @@ export function main() {
     beforeEachProviders(() => {
       var uiRenderProtoViewStore = new RenderProtoViewRefStore(false);
       uiRenderViewStore = new RenderViewWithFragmentsStore(false);
-      uiInjector = createTestInjector([
+      uiInjector = createTestInjectorWithRuntimeCompiler([
         provide(RenderProtoViewRefStore, {useValue: uiRenderProtoViewStore}),
         provide(RenderViewWithFragmentsStore, {useValue: uiRenderViewStore}),
         provide(DomRenderer, {useClass: DomRenderer_}),

--- a/modules/angular2/test/web_workers/worker/xhr_impl_spec.ts
+++ b/modules/angular2/test/web_workers/worker/xhr_impl_spec.ts
@@ -5,7 +5,7 @@ import {
   it,
   expect,
   beforeEach,
-  createTestInjector,
+  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders
 } from 'angular2/testing_internal';
 import {SpyMessageBroker} from './spies';

--- a/modules_dart/angular2_testing/lib/angular2_testing.dart
+++ b/modules_dart/angular2_testing/lib/angular2_testing.dart
@@ -74,7 +74,7 @@ dynamic _runInjectableFunction(Function fn) {
   }
 
   if (_currentInjector == null) {
-    _currentInjector = createTestInjector(_currentTestProviders);
+    _currentInjector = createTestInjectorWithRuntimeCompiler(_currentTestProviders);
   }
   var injectFn = new FunctionWithParamTokens(tokens, fn, false);
   return injectFn.execute(_currentInjector);


### PR DESCRIPTION
…njector with and without runtime compiler.

BREAKING CHANGE:
`createTestInjector()` does not more include the runtime compiler. Use `createTestInjectorWithRuntimeCompiler()` instead.
