### PR TITLE
refactor(http): rename enums to be singular

### DIFF
--- a/modules/angular2/http.ts
+++ b/modules/angular2/http.ts
@@ -32,7 +32,7 @@ export {Http, Jsonp} from './src/http/http';
 
 export {Headers} from './src/http/headers';
 
-export {ResponseTypes, ReadyStates, RequestMethods} from './src/http/enums';
+export {ResponseType, ReadyState, RequestMethod} from './src/http/enums';
 export {URLSearchParams} from './src/http/url_search_params';
 
 /**

--- a/modules/angular2/src/http/backends/mock_backend.ts
+++ b/modules/angular2/src/http/backends/mock_backend.ts
@@ -1,7 +1,7 @@
 import {Injectable} from 'angular2/core';
 import {Request} from '../static_request';
 import {Response} from '../static_response';
-import {ReadyStates} from '../enums';
+import {ReadyState} from '../enums';
 import {Connection, ConnectionBackend} from '../interfaces';
 import {isPresent} from 'angular2/src/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
@@ -21,7 +21,7 @@ export class MockConnection implements Connection {
    * Describes the state of the connection, based on `XMLHttpRequest.readyState`, but with
    * additional states. For example, state 5 indicates an aborted connection.
    */
-  readyState: ReadyStates;
+  readyState: ReadyState;
 
   /**
    * {@link Request} instance used to create the connection.
@@ -36,7 +36,7 @@ export class MockConnection implements Connection {
 
   constructor(req: Request) {
     this.response = new ReplaySubject(1).take(1);
-    this.readyState = ReadyStates.Open;
+    this.readyState = ReadyState.Open;
     this.request = req;
   }
 
@@ -55,10 +55,10 @@ export class MockConnection implements Connection {
    *
    */
   mockRespond(res: Response) {
-    if (this.readyState === ReadyStates.Done || this.readyState === ReadyStates.Cancelled) {
+    if (this.readyState === ReadyState.Done || this.readyState === ReadyState.Cancelled) {
       throw new BaseException('Connection has already been resolved');
     }
-    this.readyState = ReadyStates.Done;
+    this.readyState = ReadyState.Done;
     this.response.next(res);
     this.response.complete();
   }
@@ -84,7 +84,7 @@ export class MockConnection implements Connection {
    */
   mockError(err?: Error) {
     // Matches XHR semantics
-    this.readyState = ReadyStates.Done;
+    this.readyState = ReadyState.Done;
     this.response.error(err);
   }
 }

--- a/modules/angular2/src/http/backends/xhr_backend.ts
+++ b/modules/angular2/src/http/backends/xhr_backend.ts
@@ -1,5 +1,5 @@
 import {ConnectionBackend, Connection} from '../interfaces';
-import {ReadyStates, RequestMethods, ResponseTypes} from '../enums';
+import {ReadyState, RequestMethod, ResponseType} from '../enums';
 import {Request} from '../static_request';
 import {Response} from '../static_response';
 import {Headers} from '../headers';
@@ -24,12 +24,12 @@ export class XHRConnection implements Connection {
    * `XMLHttpRequest`.
    */
   response: Observable<Response>;
-  readyState: ReadyStates;
+  readyState: ReadyState;
   constructor(req: Request, browserXHR: BrowserXhr, baseResponseOptions?: ResponseOptions) {
     this.request = req;
     this.response = new Observable(responseObserver => {
       let _xhr: XMLHttpRequest = browserXHR.build();
-      _xhr.open(RequestMethods[req.method].toUpperCase(), req.url);
+      _xhr.open(RequestMethod[req.method].toUpperCase(), req.url);
       // load event handler
       let onLoad = () => {
         // responseText is the old-school way of retrieving response (supported by IE8 & 9)
@@ -65,7 +65,7 @@ export class XHRConnection implements Connection {
       };
       // error event handler
       let onError = (err) => {
-        var responseOptions = new ResponseOptions({body: err, type: ResponseTypes.Error});
+        var responseOptions = new ResponseOptions({body: err, type: ResponseType.Error});
         if (isPresent(baseResponseOptions)) {
           responseOptions = baseResponseOptions.merge(responseOptions);
         }

--- a/modules/angular2/src/http/base_request_options.ts
+++ b/modules/angular2/src/http/base_request_options.ts
@@ -1,6 +1,6 @@
 import {isPresent, isString} from 'angular2/src/facade/lang';
 import {Headers} from './headers';
-import {RequestMethods} from './enums';
+import {RequestMethod} from './enums';
 import {RequestOptionsArgs} from './interfaces';
 import {Injectable} from 'angular2/core';
 import {URLSearchParams} from './url_search_params';
@@ -19,23 +19,23 @@ import {normalizeMethodName} from './http_utils';
  * ### Example ([live demo](http://plnkr.co/edit/7Wvi3lfLq41aQPKlxB4O?p=preview))
  *
  * ```typescript
- * import {RequestOptions, Request, RequestMethods} from 'angular2/http';
+ * import {RequestOptions, Request, RequestMethod} from 'angular2/http';
  *
  * var options = new RequestOptions({
- *   method: RequestMethods.Post,
+ *   method: RequestMethod.Post,
  *   url: 'https://google.com'
  * });
  * var req = new Request(options);
- * console.log('req.method:', RequestMethods[req.method]); // Post
+ * console.log('req.method:', RequestMethod[req.method]); // Post
  * console.log('options.url:', options.url); // https://google.com
  * ```
  */
 export class RequestOptions {
   /**
    * Http method with which to execute a {@link Request}.
-   * Acceptable methods are defined in the {@link RequestMethods} enum.
+   * Acceptable methods are defined in the {@link RequestMethod} enum.
    */
-  method: RequestMethods | string;
+  method: RequestMethod | string;
   /**
    * {@link Headers} to be attached to a {@link Request}.
    */
@@ -75,15 +75,15 @@ export class RequestOptions {
    * ### Example ([live demo](http://plnkr.co/edit/6w8XA8YTkDRcPYpdB9dk?p=preview))
    *
    * ```typescript
-   * import {RequestOptions, Request, RequestMethods} from 'angular2/http';
+   * import {RequestOptions, Request, RequestMethod} from 'angular2/http';
    *
    * var options = new RequestOptions({
-   *   method: RequestMethods.Post
+   *   method: RequestMethod.Post
    * });
    * var req = new Request(options.merge({
    *   url: 'https://google.com'
    * }));
-   * console.log('req.method:', RequestMethods[req.method]); // Post
+   * console.log('req.method:', RequestMethod[req.method]); // Post
    * console.log('options.url:', options.url); // null
    * console.log('req.url:', req.url); // https://google.com
    * ```
@@ -107,7 +107,7 @@ export class RequestOptions {
  * Subclass of {@link RequestOptions}, with default values.
  *
  * Default values:
- *  * method: {@link RequestMethods RequestMethods.Get}
+ *  * method: {@link RequestMethod RequestMethod.Get}
  *  * headers: empty {@link Headers} object
  *
  * This class could be extended and bound to the {@link RequestOptions} class
@@ -134,19 +134,19 @@ export class RequestOptions {
  * ### Example ([live demo](http://plnkr.co/edit/oyBoEvNtDhOSfi9YxaVb?p=preview))
  *
  * ```
- * import {BaseRequestOptions, Request, RequestMethods} from 'angular2/http';
+ * import {BaseRequestOptions, Request, RequestMethod} from 'angular2/http';
  *
  * var options = new BaseRequestOptions();
  * var req = new Request(options.merge({
- *   method: RequestMethods.Post,
+ *   method: RequestMethod.Post,
  *   url: 'https://google.com'
  * }));
- * console.log('req.method:', RequestMethods[req.method]); // Post
+ * console.log('req.method:', RequestMethod[req.method]); // Post
  * console.log('options.url:', options.url); // null
  * console.log('req.url:', req.url); // https://google.com
  * ```
  */
 @Injectable()
 export class BaseRequestOptions extends RequestOptions {
-  constructor() { super({method: RequestMethods.Get, headers: new Headers()}); }
+  constructor() { super({method: RequestMethod.Get, headers: new Headers()}); }
 }

--- a/modules/angular2/src/http/base_response_options.ts
+++ b/modules/angular2/src/http/base_response_options.ts
@@ -1,7 +1,7 @@
 import {Injectable} from 'angular2/core';
 import {isPresent, isJsObject} from 'angular2/src/facade/lang';
 import {Headers} from './headers';
-import {ResponseTypes} from './enums';
+import {ResponseType} from './enums';
 import {ResponseOptionsArgs} from './interfaces';
 
 /**
@@ -52,7 +52,7 @@ export class ResponseOptions {
   /**
    * @internal
    */
-  type: ResponseTypes;
+  type: ResponseType;
   url: string;
   constructor({body, status, headers, statusText, type, url}: ResponseOptionsArgs = {}) {
     this.body = isPresent(body) ? body : null;
@@ -147,6 +147,6 @@ export class ResponseOptions {
 @Injectable()
 export class BaseResponseOptions extends ResponseOptions {
   constructor() {
-    super({status: 200, statusText: 'Ok', type: ResponseTypes.Default, headers: new Headers()});
+    super({status: 200, statusText: 'Ok', type: ResponseType.Default, headers: new Headers()});
   }
 }

--- a/modules/angular2/src/http/enums.ts
+++ b/modules/angular2/src/http/enums.ts
@@ -3,7 +3,7 @@ import {StringMapWrapper} from 'angular2/src/facade/collection';
 /**
  * Supported http methods.
  */
-export enum RequestMethods {
+export enum RequestMethod {
   Get,
   Post,
   Put,
@@ -18,7 +18,7 @@ export enum RequestMethods {
  * [States](http://www.w3.org/TR/XMLHttpRequest/#states) from the `XMLHttpRequest` spec, but with an
  * additional "CANCELLED" state.
  */
-export enum ReadyStates {
+export enum ReadyState {
   Unsent,
   Open,
   HeadersReceived,
@@ -31,7 +31,7 @@ export enum ReadyStates {
  * Acceptable response types to be associated with a {@link Response}, based on
  * [ResponseType](https://fetch.spec.whatwg.org/#responsetype) from the Fetch spec.
  */
-export enum ResponseTypes {
+export enum ResponseType {
   Basic,
   Cors,
   Default,

--- a/modules/angular2/src/http/http.ts
+++ b/modules/angular2/src/http/http.ts
@@ -5,7 +5,7 @@ import {RequestOptionsArgs, Connection, ConnectionBackend} from './interfaces';
 import {Request} from './static_request';
 import {Response} from './static_response';
 import {BaseRequestOptions, RequestOptions} from './base_request_options';
-import {RequestMethods} from './enums';
+import {RequestMethod} from './enums';
 import {Observable} from 'angular2/core';
 
 function httpRequest(backend: ConnectionBackend, request: Request): Observable<Response> {
@@ -103,7 +103,7 @@ export class Http {
     if (isString(url)) {
       responseObservable = httpRequest(
           this._backend,
-          new Request(mergeOptions(this._defaultOptions, options, RequestMethods.Get, url)));
+          new Request(mergeOptions(this._defaultOptions, options, RequestMethod.Get, url)));
     } else if (url instanceof Request) {
       responseObservable = httpRequest(this._backend, url);
     } else {
@@ -117,7 +117,7 @@ export class Http {
    */
   get(url: string, options?: RequestOptionsArgs): Observable<Response> {
     return httpRequest(this._backend, new Request(mergeOptions(this._defaultOptions, options,
-                                                               RequestMethods.Get, url)));
+                                                               RequestMethod.Get, url)));
   }
 
   /**
@@ -127,7 +127,7 @@ export class Http {
     return httpRequest(
         this._backend,
         new Request(mergeOptions(this._defaultOptions.merge(new RequestOptions({body: body})),
-                                 options, RequestMethods.Post, url)));
+                                 options, RequestMethod.Post, url)));
   }
 
   /**
@@ -137,7 +137,7 @@ export class Http {
     return httpRequest(
         this._backend,
         new Request(mergeOptions(this._defaultOptions.merge(new RequestOptions({body: body})),
-                                 options, RequestMethods.Put, url)));
+                                 options, RequestMethod.Put, url)));
   }
 
   /**
@@ -145,7 +145,7 @@ export class Http {
    */
   delete (url: string, options?: RequestOptionsArgs): Observable<Response> {
     return httpRequest(this._backend, new Request(mergeOptions(this._defaultOptions, options,
-                                                               RequestMethods.Delete, url)));
+                                                               RequestMethod.Delete, url)));
   }
 
   /**
@@ -155,7 +155,7 @@ export class Http {
     return httpRequest(
         this._backend,
         new Request(mergeOptions(this._defaultOptions.merge(new RequestOptions({body: body})),
-                                 options, RequestMethods.Patch, url)));
+                                 options, RequestMethod.Patch, url)));
   }
 
   /**
@@ -163,7 +163,7 @@ export class Http {
    */
   head(url: string, options?: RequestOptionsArgs): Observable<Response> {
     return httpRequest(this._backend, new Request(mergeOptions(this._defaultOptions, options,
-                                                               RequestMethods.Head, url)));
+                                                               RequestMethod.Head, url)));
   }
 }
 
@@ -182,10 +182,10 @@ export class Jsonp extends Http {
   request(url: string | Request, options?: RequestOptionsArgs): Observable<Response> {
     var responseObservable: any;
     if (isString(url)) {
-      url = new Request(mergeOptions(this._defaultOptions, options, RequestMethods.Get, url));
+      url = new Request(mergeOptions(this._defaultOptions, options, RequestMethod.Get, url));
     }
     if (url instanceof Request) {
-      if (url.method !== RequestMethods.Get) {
+      if (url.method !== RequestMethod.Get) {
         makeTypeError('JSONP requests must use GET request method.');
       }
       responseObservable = httpRequest(this._backend, url);

--- a/modules/angular2/src/http/http_utils.ts
+++ b/modules/angular2/src/http/http_utils.ts
@@ -1,13 +1,13 @@
 import {isString} from 'angular2/src/facade/lang';
-import {RequestMethods} from './enums';
+import {RequestMethod} from './enums';
 import {makeTypeError} from 'angular2/src/facade/exceptions';
 import {Response} from './static_response';
 
-export function normalizeMethodName(method): RequestMethods {
+export function normalizeMethodName(method): RequestMethod {
   if (isString(method)) {
     var originalMethod = method;
     method = method.replace(/(\w)(\w*)/g, (g0, g1, g2) => g1.toUpperCase() + g2.toLowerCase());
-    method = RequestMethods[method];
+    method = RequestMethod[method];
     if (typeof method !== 'number')
       throw makeTypeError(
           `Invalid request method. The method "${originalMethod}" is not supported.`);

--- a/modules/angular2/src/http/interfaces.ts
+++ b/modules/angular2/src/http/interfaces.ts
@@ -1,4 +1,4 @@
-import {ReadyStates, RequestMethods, ResponseTypes} from './enums';
+import {ReadyState, RequestMethod, ResponseType} from './enums';
 import {Headers} from './headers';
 import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
 import {EventEmitter} from 'angular2/src/facade/async';
@@ -17,7 +17,7 @@ export abstract class ConnectionBackend { abstract createConnection(request: any
  * Abstract class from which real connections are derived.
  */
 export abstract class Connection {
-  readyState: ReadyStates;
+  readyState: ReadyState;
   request: Request;
   response: any;  // TODO: generic of <Response>;
 }
@@ -28,7 +28,7 @@ export abstract class Connection {
  */
 export interface RequestOptionsArgs {
   url?: string;
-  method?: string | RequestMethods;
+  method?: string | RequestMethod;
   search?: string | URLSearchParams;
   headers?: Headers;
   // TODO: Support Blob, ArrayBuffer, JSON, URLSearchParams, FormData
@@ -50,6 +50,6 @@ export type ResponseOptionsArgs = {
   status?: number;
   statusText?: string;
   headers?: Headers;
-  type?: ResponseTypes;
+  type?: ResponseType;
   url?: string;
 }

--- a/modules/angular2/src/http/static_request.ts
+++ b/modules/angular2/src/http/static_request.ts
@@ -1,4 +1,4 @@
-import {RequestMethods} from './enums';
+import {RequestMethod} from './enums';
 import {RequestArgs} from './interfaces';
 import {Headers} from './headers';
 import {normalizeMethodName} from './http_utils';
@@ -26,14 +26,14 @@ import {
  *
  * ```typescript
  * import {Injectable, Injector} from 'angular2/angular2';
- * import {HTTP_PROVIDERS, Http, Request, RequestMethods} from 'angular2/http';
+ * import {HTTP_PROVIDERS, Http, Request, RequestMethod} from 'angular2/http';
  *
  * @Injectable()
  * class AutoAuthenticator {
  *   constructor(public http:Http) {}
  *   request(url:string) {
  *     return this.http.request(new Request({
- *       method: RequestMethods.Get,
+ *       method: RequestMethod.Get,
  *       url: url,
  *       search: 'password=123'
  *     }));
@@ -52,7 +52,7 @@ export class Request {
   /**
    * Http method with which to perform the request.
    */
-  method: RequestMethods;
+  method: RequestMethod;
   /**
    * {@link Headers} instance
    */

--- a/modules/angular2/src/http/static_response.ts
+++ b/modules/angular2/src/http/static_response.ts
@@ -1,4 +1,4 @@
-import {ResponseTypes} from './enums';
+import {ResponseType} from './enums';
 import {CONST_EXPR, isString, isPresent, Json} from 'angular2/src/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
 import {Headers} from './headers';
@@ -29,7 +29,7 @@ export class Response {
    *
    * Defaults to "default".
    */
-  type: ResponseTypes;
+  type: ResponseType;
   /**
    * True if the response's status is within 200-299
    */

--- a/modules/angular2/test/http/backends/jsonp_backend_spec.ts
+++ b/modules/angular2/test/http/backends/jsonp_backend_spec.ts
@@ -27,7 +27,7 @@ import {Response} from 'angular2/src/http/static_response';
 import {Map} from 'angular2/src/facade/collection';
 import {RequestOptions, BaseRequestOptions} from 'angular2/src/http/base_request_options';
 import {BaseResponseOptions, ResponseOptions} from 'angular2/src/http/base_response_options';
-import {ResponseTypes, ReadyStates, RequestMethods} from 'angular2/src/http/enums';
+import {ResponseType, ReadyState, RequestMethod} from 'angular2/src/http/enums';
 
 var addEventListenerSpy;
 var existingScripts = [];
@@ -94,9 +94,9 @@ export function main() {
       it('should use the injected BaseResponseOptions to create the response',
          inject([AsyncTestCompleter], async => {
            let connection = new JSONPConnection_(sampleRequest, new MockBrowserJsonp(),
-                                                 new ResponseOptions({type: ResponseTypes.Error}));
+                                                 new ResponseOptions({type: ResponseType.Error}));
            connection.response.subscribe(res => {
-             expect(res.type).toBe(ResponseTypes.Error);
+             expect(res.type).toBe(ResponseType.Error);
              async.done();
            });
            connection.finished();
@@ -117,7 +117,7 @@ export function main() {
            existingScripts[0].dispatchEvent('load');
 
            TimerWrapper.setTimeout(() => {
-             expect(connection.readyState).toBe(ReadyStates.Cancelled);
+             expect(connection.readyState).toBe(ReadyState.Cancelled);
              expect(loadSpy).not.toHaveBeenCalled();
              expect(errorSpy).not.toHaveBeenCalled();
              expect(returnSpy).not.toHaveBeenCalled();
@@ -158,8 +158,8 @@ export function main() {
          }));
 
       it('should throw if request method is not GET', () => {
-        [RequestMethods.Post, RequestMethods.Put, RequestMethods.Delete, RequestMethods.Options,
-         RequestMethods.Head, RequestMethods.Patch]
+        [RequestMethod.Post, RequestMethod.Put, RequestMethod.Delete, RequestMethod.Options,
+         RequestMethod.Head, RequestMethod.Patch]
             .forEach(method => {
               let base = new BaseRequestOptions();
               let req = new Request(

--- a/modules/angular2/test/http/backends/mock_backend_spec.ts
+++ b/modules/angular2/test/http/backends/mock_backend_spec.ts
@@ -21,7 +21,7 @@ import {Headers} from 'angular2/src/http/headers';
 import {Map} from 'angular2/src/facade/collection';
 import {RequestOptions, BaseRequestOptions} from 'angular2/src/http/base_request_options';
 import {BaseResponseOptions, ResponseOptions} from 'angular2/src/http/base_response_options';
-import {ResponseTypes} from 'angular2/src/http/enums';
+import {ResponseType} from 'angular2/src/http/enums';
 
 export function main() {
   describe('MockBackend', () => {

--- a/modules/angular2/test/http/backends/xhr_backend_spec.ts
+++ b/modules/angular2/test/http/backends/xhr_backend_spec.ts
@@ -21,7 +21,7 @@ import {Headers} from 'angular2/src/http/headers';
 import {Map} from 'angular2/src/facade/collection';
 import {RequestOptions, BaseRequestOptions} from 'angular2/src/http/base_request_options';
 import {BaseResponseOptions, ResponseOptions} from 'angular2/src/http/base_response_options';
-import {ResponseTypes} from 'angular2/src/http/enums';
+import {ResponseType} from 'angular2/src/http/enums';
 
 var abortSpy;
 var sendSpy;
@@ -104,9 +104,9 @@ export function main() {
       it('should use the injected BaseResponseOptions to create the response',
          inject([AsyncTestCompleter], async => {
            var connection = new XHRConnection(sampleRequest, new MockBrowserXHR(),
-                                              new ResponseOptions({type: ResponseTypes.Error}));
+                                              new ResponseOptions({type: ResponseType.Error}));
            connection.response.subscribe(res => {
-             expect(res.type).toBe(ResponseTypes.Error);
+             expect(res.type).toBe(ResponseType.Error);
              async.done();
            });
            existingXHRs[0].setStatusCode(200);
@@ -115,8 +115,8 @@ export function main() {
 
       it('should complete a request', inject([AsyncTestCompleter], async => {
            var connection = new XHRConnection(sampleRequest, new MockBrowserXHR(),
-                                              new ResponseOptions({type: ResponseTypes.Error}));
-           connection.response.subscribe(res => { expect(res.type).toBe(ResponseTypes.Error); },
+                                              new ResponseOptions({type: ResponseType.Error}));
+           connection.response.subscribe(res => { expect(res.type).toBe(ResponseType.Error); },
                                          null, () => { async.done(); });
            existingXHRs[0].setStatusCode(200);
            existingXHRs[0].dispatchEvent('load');
@@ -131,9 +131,9 @@ export function main() {
 
       it('should create an error Response on error', inject([AsyncTestCompleter], async => {
            var connection = new XHRConnection(sampleRequest, new MockBrowserXHR(),
-                                              new ResponseOptions({type: ResponseTypes.Error}));
+                                              new ResponseOptions({type: ResponseType.Error}));
            connection.response.subscribe(null, res => {
-             expect(res.type).toBe(ResponseTypes.Error);
+             expect(res.type).toBe(ResponseType.Error);
              async.done();
            });
            existingXHRs[0].dispatchEvent('error');

--- a/modules/angular2/test/http/base_request_options_spec.ts
+++ b/modules/angular2/test/http/base_request_options_spec.ts
@@ -10,21 +10,21 @@ import {
   xit
 } from 'angular2/testing_internal';
 import {BaseRequestOptions, RequestOptions} from 'angular2/src/http/base_request_options';
-import {RequestMethods} from 'angular2/src/http/enums';
+import {RequestMethod} from 'angular2/src/http/enums';
 
 export function main() {
   describe('BaseRequestOptions', () => {
     it('should create a new object when calling merge', () => {
       var options1 = new BaseRequestOptions();
-      var options2 = options1.merge(new RequestOptions({method: RequestMethods.Delete}));
+      var options2 = options1.merge(new RequestOptions({method: RequestMethod.Delete}));
       expect(options2).not.toBe(options1);
-      expect(options2.method).toBe(RequestMethods.Delete);
+      expect(options2.method).toBe(RequestMethod.Delete);
     });
 
     it('should retain previously merged values when merging again', () => {
       var options1 = new BaseRequestOptions();
-      var options2 = options1.merge(new RequestOptions({method: RequestMethods.Delete}));
-      expect(options2.method).toBe(RequestMethods.Delete);
+      var options2 = options1.merge(new RequestOptions({method: RequestMethod.Delete}));
+      expect(options2.method).toBe(RequestMethod.Delete);
     });
   });
 }

--- a/modules/angular2/test/http/http_spec.ts
+++ b/modules/angular2/test/http/http_spec.ts
@@ -16,7 +16,7 @@ import {
   BaseRequestOptions,
   ConnectionBackend,
   Request,
-  RequestMethods,
+  RequestMethod,
   RequestOptions,
   Response,
   ResponseOptions,
@@ -143,12 +143,12 @@ export function main() {
            inject([AsyncTestCompleter], (async) => {
              backend.connections.subscribe(c => {
                expect(c.request.url).toBe('https://google.com');
-               expect(c.request.method).toBe(RequestMethods.Post);
+               expect(c.request.method).toBe(RequestMethod.Post);
                c.mockRespond(new Response(new ResponseOptions({body: 'Thank you'})));
                async.done();
              });
              http.request(new Request(new RequestOptions(
-                              {url: 'https://google.com', method: RequestMethods.Post})))
+                              {url: 'https://google.com', method: RequestMethod.Post})))
                  .subscribe((res) => {});
            }));
 
@@ -166,10 +166,10 @@ export function main() {
         it('should perform a post request for given url if options include a method',
            inject([AsyncTestCompleter], (async) => {
              backend.connections.subscribe(c => {
-               expect(c.request.method).toEqual(RequestMethods.Post);
+               expect(c.request.method).toEqual(RequestMethod.Post);
                c.mockRespond(baseResponse);
              });
-             let requestOptions = new RequestOptions({method: RequestMethods.Post});
+             let requestOptions = new RequestOptions({method: RequestMethod.Post});
              http.request('http://basic.connection', requestOptions)
                  .subscribe(res => {
                    expect(res.text()).toBe('base response');
@@ -180,10 +180,10 @@ export function main() {
         it('should perform a post request for given url if options include a method',
            inject([AsyncTestCompleter], (async) => {
              backend.connections.subscribe(c => {
-               expect(c.request.method).toEqual(RequestMethods.Post);
+               expect(c.request.method).toEqual(RequestMethod.Post);
                c.mockRespond(baseResponse);
              });
-             let requestOptions = {method: RequestMethods.Post};
+             let requestOptions = {method: RequestMethod.Post};
              http.request('http://basic.connection', requestOptions)
                  .subscribe(res => {
                    expect(res.text()).toBe('base response');
@@ -221,7 +221,7 @@ export function main() {
       describe('.get()', () => {
         it('should perform a get request for given url', inject([AsyncTestCompleter], async => {
              backend.connections.subscribe(c => {
-               expect(c.request.method).toBe(RequestMethods.Get);
+               expect(c.request.method).toBe(RequestMethod.Get);
                backend.resolveAllConnections();
                async.done();
              });
@@ -233,7 +233,7 @@ export function main() {
       describe('.post()', () => {
         it('should perform a post request for given url', inject([AsyncTestCompleter], async => {
              backend.connections.subscribe(c => {
-               expect(c.request.method).toBe(RequestMethods.Post);
+               expect(c.request.method).toBe(RequestMethod.Post);
                backend.resolveAllConnections();
                async.done();
              });
@@ -256,7 +256,7 @@ export function main() {
       describe('.put()', () => {
         it('should perform a put request for given url', inject([AsyncTestCompleter], async => {
              backend.connections.subscribe(c => {
-               expect(c.request.method).toBe(RequestMethods.Put);
+               expect(c.request.method).toBe(RequestMethod.Put);
                backend.resolveAllConnections();
                async.done();
              });
@@ -278,7 +278,7 @@ export function main() {
       describe('.delete()', () => {
         it('should perform a delete request for given url', inject([AsyncTestCompleter], async => {
              backend.connections.subscribe(c => {
-               expect(c.request.method).toBe(RequestMethods.Delete);
+               expect(c.request.method).toBe(RequestMethod.Delete);
                backend.resolveAllConnections();
                async.done();
              });
@@ -290,7 +290,7 @@ export function main() {
       describe('.patch()', () => {
         it('should perform a patch request for given url', inject([AsyncTestCompleter], async => {
              backend.connections.subscribe(c => {
-               expect(c.request.method).toBe(RequestMethods.Patch);
+               expect(c.request.method).toBe(RequestMethod.Patch);
                backend.resolveAllConnections();
                async.done();
              });
@@ -312,7 +312,7 @@ export function main() {
       describe('.head()', () => {
         it('should perform a head request for given url', inject([AsyncTestCompleter], async => {
              backend.connections.subscribe(c => {
-               expect(c.request.method).toBe(RequestMethods.Head);
+               expect(c.request.method).toBe(RequestMethod.Head);
                backend.resolveAllConnections();
                async.done();
              });
@@ -363,7 +363,7 @@ export function main() {
           inject([AsyncTestCompleter], (async) => {
             backend.connections.subscribe(c => {
               expect(c.request.method)
-                  .toBe(RequestMethods.Post)
+                  .toBe(RequestMethod.Post)
                       c.mockRespond(new Response(new ResponseOptions({body: 'Thank you'})));
               async.done();
             });


### PR DESCRIPTION
As seen with @jeffbcross in #5574

ReadyStates -> ReadyState
RequestMethods -> RequestMethod
ResponseTypes -> ResponseType
