### PR TITLE
feat(typings): import global-es6.d.ts in core

### DIFF
--- a/tools/broccoli/trees/node_tree.ts
+++ b/tools/broccoli/trees/node_tree.ts
@@ -125,7 +125,7 @@ module.exports = function makeNodeTree(projects, destinationPath) {
   // because of the duplicate definitions.
   // TODO(alexeagle): remove this when typescript releases a fix
   nodeTree = replace(nodeTree, {
-    files: ['angular2/angular2.d.ts'],
+    files: ['angular2/core.d.ts', 'angular2/angular2.d.ts'],
     patterns: [{match: /$/, replacement: 'import "./manual_typings/globals-es6.d.ts";\r\n'}]
   });
 


### PR DESCRIPTION
Currently, importing from 'angular2/angular2', in addition to providing Angular tokens, brings in global-es6.d.ts. Since we are deprecating 'angular2/angular2', we need to do the same in 'angular2/core'.

Closes #5596
