### PR TITLE
fix(dart/transform): Relative uris in part files

### DIFF
--- a/modules/angular2/src/core/reflection/reflection_capabilities.dart
+++ b/modules/angular2/src/core/reflection/reflection_capabilities.dart
@@ -321,6 +321,6 @@ class ReflectionCapabilities implements PlatformReflectionCapabilities {
   }
 
   String importUri(Type type) {
-    return '${(reflectClass(type).owner as LibraryMirror).uri}';
+    return '${reflectClass(type).location.sourceUri}';
   }
 }

--- a/modules_dart/transform/lib/src/transform/directive_processor/inliner.dart
+++ b/modules_dart/transform/lib/src/transform/directive_processor/inliner.dart
@@ -4,13 +4,15 @@ import 'dart:async';
 
 import 'package:analyzer/analyzer.dart';
 import 'package:analyzer/src/generated/ast.dart';
-import 'package:angular2/src/transform/common/async_string_writer.dart';
-import 'package:angular2/src/transform/common/logging.dart';
-import 'package:code_transformers/assets.dart';
-import 'package:angular2/src/transform/common/asset_reader.dart';
 import 'package:barback/barback.dart' show AssetId;
 import 'package:source_span/source_span.dart';
 import 'package:path/path.dart' as path;
+
+import 'package:angular2/src/transform/common/asset_reader.dart';
+import 'package:angular2/src/transform/common/async_string_writer.dart';
+import 'package:angular2/src/transform/common/logging.dart';
+import 'package:angular2/src/transform/common/naive_eval.dart';
+import 'package:angular2/src/transform/common/url_resolver.dart';
 
 /// Reads the code at `assetId`, inlining any `part` directives in that code.
 ///
@@ -42,11 +44,16 @@ Future<String> inlineParts(AssetReader reader, AssetId assetId) async {
   }, operationName: 'inlineParts', assetId: assetId);
 }
 
+const _resolver = const TransformerUrlResolver();
+
 /// Processes `visitor.parts`, reading and appending their contents to the
 /// original `code`.
 Future<String> _getAllDeclarations(AssetReader reader, AssetId assetId,
     String code, _NgDepsDirectivesVisitor visitor) {
   if (visitor.parts.isEmpty) return new Future<String>.value(code);
+
+  final assetUri = toAssetUri(assetId);
+  final tracker = new _UriTrackerImpl(assetId);
 
   var partsStart = visitor.parts.first.offset,
       partsEnd = visitor.parts.last.end;
@@ -54,8 +61,8 @@ Future<String> _getAllDeclarations(AssetReader reader, AssetId assetId,
   var asyncWriter = new AsyncStringWriter(code.substring(0, partsStart));
   visitor.parts.forEach((partDirective) {
     var uri = stringLiteralToString(partDirective.uri);
-    var partAssetId = uriToAssetId(assetId, uri, log, null /* span */,
-        errorOnAbsolute: false);
+    var partAssetId = fromUri(_resolver.resolve(assetUri, uri));
+    asyncWriter.println(tracker.getInlinerCurrentUriAssignment(partAssetId));
     asyncWriter.asyncPrint(reader.readAsString(partAssetId).then((partCode) {
       if (partCode == null || partCode.isEmpty) {
         log.warning('Empty part at "${partDirective.uri}. Ignoring.',
@@ -75,9 +82,75 @@ Future<String> _getAllDeclarations(AssetReader reader, AssetId assetId,
               .span(partDirective.offset, partDirective.end));
     }));
   });
+  asyncWriter.println(tracker.getInlinerCurrentUriAssignment(assetId));
   asyncWriter.print(code.substring(partsEnd));
 
   return asyncWriter.asyncToString();
+}
+
+const _uriVarTemplate = '_\$\$inlinerCurrentUri';
+
+/// Stores the [AssetId] of the [CompilationUnit] containing following code.
+///
+/// This allows us to accurately resolve relative uris from parts, which may not
+/// exist as siblings to the files they are parts of.
+///
+/// For example:
+/// ```dart
+/// library main;
+///
+/// import 'a.dart';
+///
+/// const __inlinerCurrentUri0 = 'asset:angular2/lib/maindir/subdir/foo.dart';
+///
+/// @Component(..., templateUrl: 'template.html')
+/// class MyComponent {}
+///
+/// const __inlinerCurrentUri1 = 'asset:angular2/lib/maindir/main.dart';
+///
+/// // Contents of main.dart
+abstract class UriTracker {
+  factory UriTracker(AssetId initialAssetId) =>
+      new _UriTrackerImpl(initialAssetId);
+
+  AssetId get current;
+
+  /// Updates `current` if necessary.
+  ///
+  /// Checks if `node` is one of our specially formatted
+  /// [TopLevelVariableDeclaration] statements and, if so, updates the value
+  /// of `current` with its value.
+  void update(TopLevelVariableDeclaration node);
+}
+
+class _UriTrackerImpl implements UriTracker {
+  final AssetId initialAssetId;
+  AssetId _current;
+  // Used to ensure unique names in variable declarations.
+  int _counter = 0;
+
+  _UriTrackerImpl(this.initialAssetId);
+
+  AssetId get current => _current != null ? _current : initialAssetId;
+
+  String getInlinerCurrentUriAssignment(AssetId id) =>
+      '''const $_uriVarTemplate${_counter++} = '${toAssetUri(id)}';''';
+
+  void update(TopLevelVariableDeclaration node) {
+    if (node == null ||
+        node.variables == null ||
+        !node.variables.isConst ||
+        node.variables.variables.length != 1) {
+      return;
+    }
+    final variable = node.variables.variables.single;
+    if (variable.name.name.startsWith(_uriVarTemplate)) {
+      final val = naiveEval(variable.initializer);
+      if (val is String) {
+        _current = fromUri(val);
+      }
+    }
+  }
 }
 
 /// Visitor responsible for reading the `part` files of the visited AST and

--- a/modules_dart/transform/test/transform/directive_processor/all_tests.dart
+++ b/modules_dart/transform/test/transform/directive_processor/all_tests.dart
@@ -91,6 +91,16 @@ void allTests() {
     it('should not generate anything for `part` files.', () async {
       expect(await _testCreateModel('part_files/part.dart')).toBeNull();
     });
+
+    it('should resolve urls in `part`s relative to the `part` file.', () async {
+      var logger = new RecordingLogger();
+      var ngMeta = await _testCreateModel('part_relative_files/main.dart',
+          logger: logger);
+      expect(logger.hasErrors).toBeFalse();
+      expect(ngMeta.types['PartComponent']).toBeNotNull();
+      expect(ngMeta.types['PartComponent'].template.template)
+          .toContain('{{greeting}}');
+    });
   });
 
   describe('custom annotations', () {

--- a/modules_dart/transform/test/transform/directive_processor/part_relative_files/main.dart
+++ b/modules_dart/transform/test/transform/directive_processor/part_relative_files/main.dart
@@ -1,0 +1,11 @@
+library main;
+
+import 'package:angular2/src/core/metadata.dart';
+
+part 'subdir/part.dart';
+
+@Component(selector: '[main]')
+@View(template: '')
+class MainComponent {
+  MainComponent();
+}

--- a/modules_dart/transform/test/transform/directive_processor/part_relative_files/subdir/part.dart
+++ b/modules_dart/transform/test/transform/directive_processor/part_relative_files/subdir/part.dart
@@ -1,0 +1,7 @@
+part of main;
+
+@Component(selector: '[part]')
+@View(templateUrl: 'template.html')
+class PartComponent {
+  PartComponent();
+}

--- a/modules_dart/transform/test/transform/directive_processor/part_relative_files/subdir/template.html
+++ b/modules_dart/transform/test/transform/directive_processor/part_relative_files/subdir/template.html
@@ -1,0 +1,1 @@
+{{greeting}}


### PR DESCRIPTION
Resolve relative uris in `part` files relative to the `part` (that is,
the `CompilationUnit`) rather than the `library`.

Closes #5587
