### PR TITLE
refactor(Observable): implement toPromise and fromPromise without sid…

### DIFF
--- a/modules/angular2/src/facade/async.ts
+++ b/modules/angular2/src/facade/async.ts
@@ -9,12 +9,10 @@ import {Observable as RxObservable} from 'rxjs/Observable';
 import {Subscription} from 'rxjs/Subscription';
 import {Operator} from 'rxjs/Operator';
 
-import 'rxjs/observable/fromPromise';
-import 'rxjs/operators/toPromise';
+import {PromiseObservable} from 'rxjs/observable/fromPromise';
+import {toPromise} from 'rxjs/operator/toPromise';
 
 export {Subject} from 'rxjs/Subject';
-
-
 
 export namespace NodeJS {
   export interface Timer {}
@@ -62,10 +60,10 @@ export class ObservableWrapper {
   static callComplete(emitter: EventEmitter<any>) { emitter.complete(); }
 
   static fromPromise(promise: Promise<any>): Observable<any> {
-    return RxObservable.fromPromise(promise);
+    return PromiseObservable.create(promise);
   }
 
-  static toPromise(obj: Observable<any>): Promise<any> { return (<any>obj).toPromise(); }
+  static toPromise(obj: Observable<any>): Promise<any> { return toPromise.call(obj); }
 }
 
 /**

--- a/modules/angular2/src/http/backends/mock_backend.ts
+++ b/modules/angular2/src/http/backends/mock_backend.ts
@@ -6,8 +6,8 @@ import {Connection, ConnectionBackend} from '../interfaces';
 import {isPresent} from 'angular2/src/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
 import {Subject} from 'rxjs/Subject';
-import {ReplaySubject} from 'rxjs/subjects/ReplaySubject';
-import 'rxjs/operators/take';
+import {ReplaySubject} from 'rxjs/subject/ReplaySubject';
+import {take} from 'rxjs/operator/take';
 
 /**
  *
@@ -35,7 +35,7 @@ export class MockConnection implements Connection {
   response: any;  // Subject<Response>
 
   constructor(req: Request) {
-    this.response = new ReplaySubject(1).take(1);
+    this.response = take.call(new ReplaySubject(1), 1);
     this.readyState = ReadyState.Open;
     this.request = req;
   }

--- a/modules/angular2/test/public_api_spec.ts
+++ b/modules/angular2/test/public_api_spec.ts
@@ -690,11 +690,8 @@ var NG_ALL = [
   'Observable:js',
   'Observable#create():js',
   'Observable.forEach():js',
-  'Observable#fromPromise():js',
   'Observable.lift():js',
   'Observable.subscribe():js',
-  'Observable.take():js',
-  'Observable.toPromise():js',
 
   'OutputMetadata',
   'OutputMetadata.bindingPropertyName',

--- a/modules/playground/src/http/http_comp.ts
+++ b/modules/playground/src/http/http_comp.ts
@@ -1,6 +1,6 @@
 import {Component, View, NgFor} from 'angular2/angular2';
 import {Http, Response} from 'angular2/http';
-import 'rxjs/operators/map';
+import 'rxjs/add/operator/map';
 
 @Component({selector: 'http-app'})
 @View({

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -13182,7 +13182,7 @@
       }
     },
     "rxjs": {
-      "version": "5.0.0-alpha.11"
+      "version": "5.0.0-alpha.12"
     },
     "selenium-webdriver": {
       "version": "2.48.2",
@@ -14740,5 +14740,5 @@
     }
   },
   "name": "angular-srcs",
-  "version": "2.0.0-alpha.46"
+  "version": "2.0.0-alpha.47"
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "2.0.0-alpha.46",
+  "version": "2.0.0-alpha.47",
   "dependencies": {
     "angular": {
       "version": "1.4.7",
@@ -20207,9 +20207,9 @@
       }
     },
     "rxjs": {
-      "version": "5.0.0-alpha.11",
-      "from": "http://registry.npmjs.org/rxjs/-/rxjs-5.0.0-alpha.11.tgz",
-      "resolved": "http://registry.npmjs.org/rxjs/-/rxjs-5.0.0-alpha.11.tgz"
+      "version": "5.0.0-alpha.12",
+      "from": "rxjs@5.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-alpha.12.tgz"
     },
     "selenium-webdriver": {
       "version": "2.48.2",
@@ -20341,41 +20341,41 @@
     },
     "source-map-loader": {
       "version": "0.1.5",
-      "from": "source-map-loader@>=0.1.5 <0.2.0",
+      "from": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.1.5.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.2 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
         },
         "source-map": {
           "version": "0.1.43",
-          "from": "source-map@>=0.1.33 <0.2.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
         },
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         }
       }


### PR DESCRIPTION
…e effects

BREAKING CHANGE:

toPromise is no longer an instance method of the `Observable` returned
by Angular, and fromPromise is no longer available as a static method.

The easiest way to account for this change in applications is to import
the auto-patching modules from rxjs, which will automatically add these
operators back to the Observable prototype.

```
import 'rxjs/add/operator/toPromise';
import 'rxjs/add/observable/fromPromise';
```

Closes #5542
