### PR TITLE
upgrade rxjs dependency and implement pure operators

### DIFF
--- a/modules/angular2/src/facade/async.ts
+++ b/modules/angular2/src/facade/async.ts
@@ -9,12 +9,10 @@ import {Observable as RxObservable} from 'rxjs/Observable';
 import {Subscription} from 'rxjs/Subscription';
 import {Operator} from 'rxjs/Operator';
 
-import 'rxjs/observable/fromPromise';
-import 'rxjs/operators/toPromise';
+import {PromiseObservable} from 'rxjs/observable/fromPromise';
+import {toPromise} from 'rxjs/operator/toPromise';
 
 export {Subject} from 'rxjs/Subject';
-
-
 
 export namespace NodeJS {
   export interface Timer {}
@@ -62,10 +60,10 @@ export class ObservableWrapper {
   static callComplete(emitter: EventEmitter<any>) { emitter.complete(); }
 
   static fromPromise(promise: Promise<any>): Observable<any> {
-    return RxObservable.fromPromise(promise);
+    return PromiseObservable.create(promise);
   }
 
-  static toPromise(obj: Observable<any>): Promise<any> { return (<any>obj).toPromise(); }
+  static toPromise(obj: Observable<any>): Promise<any> { return toPromise.call(obj); }
 }
 
 /**

--- a/modules/angular2/src/http/backends/mock_backend.ts
+++ b/modules/angular2/src/http/backends/mock_backend.ts
@@ -6,8 +6,8 @@ import {Connection, ConnectionBackend} from '../interfaces';
 import {isPresent} from 'angular2/src/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
 import {Subject} from 'rxjs/Subject';
-import {ReplaySubject} from 'rxjs/subjects/ReplaySubject';
-import 'rxjs/operators/take';
+import {ReplaySubject} from 'rxjs/subject/ReplaySubject';
+import {take} from 'rxjs/operator/take';
 
 /**
  *
@@ -35,7 +35,7 @@ export class MockConnection implements Connection {
   response: any;  // Subject<Response>
 
   constructor(req: Request) {
-    this.response = new ReplaySubject(1).take(1);
+    this.response = take.call(new ReplaySubject(1), 1);
     this.readyState = ReadyState.Open;
     this.request = req;
   }

--- a/modules/angular2/test/public_api_spec.ts
+++ b/modules/angular2/test/public_api_spec.ts
@@ -690,11 +690,8 @@ var NG_ALL = [
   'Observable:js',
   'Observable#create():js',
   'Observable.forEach():js',
-  'Observable#fromPromise():js',
   'Observable.lift():js',
   'Observable.subscribe():js',
-  'Observable.take():js',
-  'Observable.toPromise():js',
 
   'OutputMetadata',
   'OutputMetadata.bindingPropertyName',

--- a/modules/playground/src/http/http_comp.ts
+++ b/modules/playground/src/http/http_comp.ts
@@ -1,6 +1,6 @@
 import {Component, View, NgFor} from 'angular2/angular2';
 import {Http, Response} from 'angular2/http';
-import 'rxjs/operators/map';
+import 'rxjs/add/operator/map';
 
 @Component({selector: 'http-app'})
 @View({

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -13182,7 +13182,7 @@
       }
     },
     "rxjs": {
-      "version": "5.0.0-alpha.11"
+      "version": "5.0.0-alpha.13"
     },
     "selenium-webdriver": {
       "version": "2.48.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20207,9 +20207,9 @@
       }
     },
     "rxjs": {
-      "version": "5.0.0-alpha.11",
-      "from": "rxjs@5.0.0-alpha.11",
-      "resolved": "http://registry.npmjs.org/rxjs/-/rxjs-5.0.0-alpha.11.tgz"
+      "version": "5.0.0-alpha.13",
+      "from": "rxjs@5.0.0-alpha.13",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-alpha.13.tgz"
     },
     "selenium-webdriver": {
       "version": "2.48.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "reflect-metadata": "0.1.2",
-    "rxjs": "5.0.0-alpha.11",
+    "rxjs": "5.0.0-alpha.13",
     "zone.js": "0.5.8"
   },
   "devDependencies": {


### PR DESCRIPTION
…e effects

BREAKING CHANGE:

toPromise is no longer an instance method of the `Observable` returned
by Angular, and fromPromise is no longer available as a static method.

The easiest way to account for this change in applications is to import
the auto-patching modules from rxjs, which will automatically add these
operators back to the Observable prototype.

```
import 'rxjs/add/operator/toPromise';
import 'rxjs/add/observable/fromPromise';
```

Closes #5542
