### PR TITLE
Fixed rxjs paths after rxjs alpha-12 changed folder names

### DIFF
--- a/modules/angular2/src/facade/async.ts
+++ b/modules/angular2/src/facade/async.ts
@@ -10,7 +10,7 @@ import {Subscription} from 'rxjs/Subscription';
 import {Operator} from 'rxjs/Operator';
 
 import 'rxjs/observable/fromPromise';
-import 'rxjs/operators/toPromise';
+import 'rxjs/operator/toPromise';
 
 export {Subject} from 'rxjs/Subject';
 

--- a/modules/angular2/src/http/backends/mock_backend.ts
+++ b/modules/angular2/src/http/backends/mock_backend.ts
@@ -6,8 +6,8 @@ import {Connection, ConnectionBackend} from '../interfaces';
 import {isPresent} from 'angular2/src/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
 import {Subject} from 'rxjs/Subject';
-import {ReplaySubject} from 'rxjs/subjects/ReplaySubject';
-import 'rxjs/operators/take';
+import {ReplaySubject} from 'rxjs/subject/ReplaySubject';
+import 'rxjs/operator/take';
 
 /**
  *

--- a/modules/playground/src/http/http_comp.ts
+++ b/modules/playground/src/http/http_comp.ts
@@ -1,6 +1,6 @@
 import {Component, View, NgFor} from 'angular2/angular2';
 import {Http, Response} from 'angular2/http';
-import 'rxjs/operators/map';
+import 'rxjs/operator/map';
 
 @Component({selector: 'http-app'})
 @View({


### PR DESCRIPTION
Commit 5514dc19d9779fb6b0d7bbae8268dc21dd1dde39 introduced direct dependency on
rxjs, and changed most of the paths. However, Rxjs introduced some changes since alpha.10

Alpha.11 was apparently removed and alpha.12 (current) changes some folder names
for dependencies from plural to singular.

I noticed the following changes:

```
/operators/map       => /operator/map
/operators/take      => /operator/take
/operators/toPromise => /operator/toPromise
```

Now, I had not the possibility to test this on my own angular2 repos. But I found this error in an attempt to update mgechev/angular2-seed project.

Can you please give me some feedback on the pullrequest?? Does it work for you without this change?

If it does, please explain how alpha-48 can work without this fix of the rxjs paths
