### PR TITLE
chore(parser): add tests for conditional expressions

### DIFF
--- a/modules/angular2/test/core/change_detection/parser/parser_spec.ts
+++ b/modules/angular2/test/core/change_detection/parser/parser_spec.ts
@@ -31,6 +31,12 @@ export function main() {
 
   function unparse(ast: AST): string { return new Unparser().unparse(ast); }
 
+  function checkInterpolation(exp: string, expected?: string) {
+    var ast = parseInterpolation(exp);
+    if (isBlank(expected)) expected = exp;
+    expect(unparse(ast)).toEqual(expected);
+  }
+
   function checkBinding(exp: string, expected?: string) {
     var ast = parseBinding(exp);
     if (isBlank(expected)) expected = exp;
@@ -262,6 +268,8 @@ export function main() {
         expectBindingError("{{a.b}}")
             .toThrowErrorWith('Got interpolation ({{}}) where expression was expected');
       });
+
+      it('should parse conditional expression', () => { checkBinding('a < b ? a : b'); });
     });
 
     describe('parseTemplateBindings', () => {
@@ -410,6 +418,9 @@ export function main() {
             .toThrowErrorWith(
                 "Parser Error: Blank expressions are not allowed in interpolated strings");
       });
+
+      it('should parse conditional expression',
+         () => { checkInterpolation('{{ a < b ? a : b }}'); });
     });
 
     describe("parseSimpleBinding", () => {


### PR DESCRIPTION
Bindings and text interpolations were not testing conditional expressions
