### PR TITLE
docs(router): typo fix for registerPrimaryOutlet description

### DIFF
--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -68,7 +68,7 @@ export class Router {
   auxRouter(hostComponent: any): Router { return new ChildRouter(this, hostComponent); }
 
   /**
-   * Register an outlet to notified of primary route changes.
+   * Register an outlet to be notified of primary route changes.
    *
    * You probably don't need to use this unless you're writing a reusable component.
    */


### PR DESCRIPTION
"Register an outlet to notified of auxiliary route changes." missed the "be".
