### PR TITLE
fix(compiler): support properties on SVG elements

### DIFF
--- a/modules/angular2/src/compiler/html_tags.ts
+++ b/modules/angular2/src/compiler/html_tags.ts
@@ -1,4 +1,10 @@
-import {isPresent, isBlank, normalizeBool, CONST_EXPR} from 'angular2/src/facade/lang';
+import {
+  isPresent,
+  isBlank,
+  normalizeBool,
+  RegExpWrapper,
+  CONST_EXPR
+} from 'angular2/src/facade/lang';
 
 // see http://www.w3.org/TR/html51/syntax.html#named-character-references
 // see https://html.spec.whatwg.org/multipage/entities.json
@@ -380,4 +386,18 @@ var DEFAULT_TAG_DEFINITION = new HtmlTagDefinition();
 export function getHtmlTagDefinition(tagName: string): HtmlTagDefinition {
   var result = TAG_DEFINITIONS[tagName.toLowerCase()];
   return isPresent(result) ? result : DEFAULT_TAG_DEFINITION;
+}
+
+var NS_PREFIX_RE = /^@([^:]+):(.+)/g;
+
+export function splitHtmlTagNamespace(elementName: string): string[] {
+  if (elementName[0] != '@') {
+    return [null, elementName];
+  }
+  let match = RegExpWrapper.firstMatch(NS_PREFIX_RE, elementName);
+  return [match[1], match[2]];
+}
+
+export function getHtmlTagNamespacePrefix(elementName: string): string {
+  return splitHtmlTagNamespace(elementName)[0];
 }

--- a/modules/angular2/src/compiler/schema/dom_element_schema_registry.ts
+++ b/modules/angular2/src/compiler/schema/dom_element_schema_registry.ts
@@ -1,9 +1,13 @@
 import {Injectable} from 'angular2/src/core/di';
-import {isPresent, isBlank} from 'angular2/src/facade/lang';
+import {isPresent, isBlank, CONST_EXPR} from 'angular2/src/facade/lang';
 import {StringMapWrapper} from 'angular2/src/facade/collection';
 import {DOM} from 'angular2/src/platform/dom/dom_adapter';
+import {splitHtmlTagNamespace} from 'angular2/src/compiler/html_tags';
 
 import {ElementSchemaRegistry} from './element_schema_registry';
+
+const NAMESPACE_URIS =
+    CONST_EXPR({'xlink': 'http://www.w3.org/1999/xlink', 'svg': 'http://www.w3.org/2000/svg'});
 
 @Injectable()
 export class DomElementSchemaRegistry extends ElementSchemaRegistry {
@@ -12,7 +16,10 @@ export class DomElementSchemaRegistry extends ElementSchemaRegistry {
   private _getProtoElement(tagName: string): Element {
     var element = this._protoElements.get(tagName);
     if (isBlank(element)) {
-      element = DOM.createElement(tagName);
+      var nsAndName = splitHtmlTagNamespace(tagName);
+      element = isPresent(nsAndName[0]) ?
+                    DOM.createElementNS(NAMESPACE_URIS[nsAndName[0]], nsAndName[1]) :
+                    DOM.createElement(nsAndName[1]);
       this._protoElements.set(tagName, element);
     }
     return element;

--- a/modules/angular2/src/platform/server/parse5_adapter.ts
+++ b/modules/angular2/src/platform/server/parse5_adapter.ts
@@ -274,7 +274,7 @@ export class Parse5DomAdapter extends DomAdapter {
   createElement(tagName): HTMLElement {
     return treeAdapter.createElement(tagName, 'http://www.w3.org/1999/xhtml', []);
   }
-  createElementNS(ns, tagName): HTMLElement { throw 'not implemented'; }
+  createElementNS(ns, tagName): HTMLElement { return treeAdapter.createElement(tagName, ns, []); }
   createTextNode(text: string): Text {
     var t = <any>this.createComment(text);
     t.type = 'text';

--- a/modules/angular2/test/compiler/schema/dom_element_schema_registry_spec.ts
+++ b/modules/angular2/test/compiler/schema/dom_element_schema_registry_spec.ts
@@ -40,5 +40,8 @@ export function main() {
       expect(registry.getMappedPropName('title')).toEqual('title');
       expect(registry.getMappedPropName('exotic-unknown')).toEqual('exotic-unknown');
     });
+
+    it('should detect properties on namespaced elements',
+       () => { expect(registry.hasProperty('@svg:g', 'id')).toBeTruthy(); });
   });
 }

--- a/modules/playground/e2e_test/svg/svg_spec.dart
+++ b/modules/playground/e2e_test/svg/svg_spec.dart
@@ -1,0 +1,3 @@
+library playground.e2e_test.svg.svg_spec;
+
+main() {}

--- a/modules/playground/e2e_test/svg/svg_spec.ts
+++ b/modules/playground/e2e_test/svg/svg_spec.ts
@@ -1,0 +1,15 @@
+import {verifyNoBrowserErrors} from 'angular2/src/testing/e2e_util';
+
+describe('SVG', function() {
+
+  var URL = 'playground/src/svg/index.html';
+
+  afterEach(verifyNoBrowserErrors);
+  beforeEach(() => { browser.get(URL); });
+
+  it('should display SVG component contents', function() {
+    var svgText = element.all(by.css('g text')).get(0);
+    expect(svgText.getText()).toEqual('Hello');
+  });
+
+});

--- a/modules/playground/pubspec.yaml
+++ b/modules/playground/pubspec.yaml
@@ -31,6 +31,7 @@ transformers:
         - web/src/routing/index.dart
         - web/src/template_driven_forms/index.dart
         - web/src/zippy_component/index.dart
+        - web/src/svg/index.dart
         - web/src/material/button/index.dart
         - web/src/material/checkbox/index.dart
         - web/src/material/dialog/index.dart

--- a/modules/playground/src/svg/index.html
+++ b/modules/playground/src/svg/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <title>SVG</title>
+<body>
+  <svg-app>
+    Loading...
+  </svg-app>
+  $SCRIPTS$
+</body>
+</html>

--- a/modules/playground/src/svg/index.ts
+++ b/modules/playground/src/svg/index.ts
@@ -1,0 +1,22 @@
+import {bootstrap} from 'angular2/bootstrap';
+import {Component} from 'angular2/core';
+
+@Component({selector: '[svg-group]', template: `<svg:text x="20" y="20">Hello</svg:text>`})
+class SvgGroup {
+}
+
+
+@Component({
+  selector: 'svg-app',
+  template: `<svg>
+    <g svg-group></g>
+  </svg>`,
+  directives: [SvgGroup]
+})
+class SvgApp {
+}
+
+
+export function main() {
+  bootstrap(SvgApp);
+}

--- a/tools/broccoli/trees/browser_tree.ts
+++ b/tools/broccoli/trees/browser_tree.ts
@@ -51,6 +51,7 @@ const kServedPaths = [
   'playground/src/key_events',
   'playground/src/routing',
   'playground/src/sourcemap',
+  'playground/src/svg',
   'playground/src/todo',
   'playground/src/upgrade',
   'playground/src/zippy_component',


### PR DESCRIPTION
Have `DomElementSchemaRegistry` support namespaced elements,
so that it does not fail when directives are applied in SVG (or xlink).
Without this fix, directives or property bindings cannot be
used in SVG.

Partially closes #5547
