### PR TITLE
fix(router): set correct redirect/default URL from hashchange

### DIFF
--- a/modules/angular2/src/mock/location_mock.ts
+++ b/modules/angular2/src/mock/location_mock.ts
@@ -21,7 +21,16 @@ export class SpyLocation implements Location {
 
   path(): string { return this._path; }
 
-  simulateUrlPop(pathname: string) { ObservableWrapper.callEmit(this._subject, {'url': pathname}); }
+  simulateUrlPop(pathname: string) {
+    ObservableWrapper.callEmit(this._subject, {'url': pathname, 'pop': true});
+  }
+
+  simulateHashChange(pathname: string) {
+    // Because we don't prevent the native event, the browser will independently update the path
+    this.setInitialPath(pathname);
+    this.urlChanges.push('hash: ' + pathname);
+    ObservableWrapper.callEmit(this._subject, {'url': pathname, 'pop': true, 'type': 'hashchange'});
+  }
 
   prepareExternalUrl(url: string): string {
     if (url.length > 0 && !url.startsWith('/')) {
@@ -40,6 +49,15 @@ export class SpyLocation implements Location {
 
     var url = path + (query.length > 0 ? ('?' + query) : '');
     this.urlChanges.push(url);
+  }
+
+  replaceState(path: string, query: string = '') {
+    path = this.prepareExternalUrl(path);
+    this._path = path;
+    this._query = query;
+
+    var url = path + (query.length > 0 ? ('?' + query) : '');
+    this.urlChanges.push('replace: ' + url);
   }
 
   forward() {

--- a/modules/angular2/src/mock/mock_location_strategy.ts
+++ b/modules/angular2/src/mock/mock_location_strategy.ts
@@ -15,7 +15,7 @@ export class MockLocationStrategy extends LocationStrategy {
 
   simulatePopState(url: string): void {
     this.internalPath = url;
-    ObservableWrapper.callEmit(this._subject, null);
+    ObservableWrapper.callEmit(this._subject, new MockPopStateEvent(this.path()));
   }
 
   path(): string { return this.internalPath; }
@@ -27,10 +27,6 @@ export class MockLocationStrategy extends LocationStrategy {
     return this.internalBaseHref + internal;
   }
 
-  simulateUrlPop(pathname: string): void {
-    ObservableWrapper.callEmit(this._subject, {'url': pathname});
-  }
-
   pushState(ctx: any, title: string, path: string, query: string): void {
     this.internalTitle = title;
 
@@ -39,6 +35,16 @@ export class MockLocationStrategy extends LocationStrategy {
 
     var externalUrl = this.prepareExternalUrl(url);
     this.urlChanges.push(externalUrl);
+  }
+
+  replaceState(ctx: any, title: string, path: string, query: string): void {
+    this.internalTitle = title;
+
+    var url = path + (query.length > 0 ? ('?' + query) : '');
+    this.internalPath = url;
+
+    var externalUrl = this.prepareExternalUrl(url);
+    this.urlChanges.push('replace: ' + externalUrl);
   }
 
   onPopState(fn: (value: any) => void): void { ObservableWrapper.subscribe(this._subject, fn); }
@@ -54,4 +60,10 @@ export class MockLocationStrategy extends LocationStrategy {
   }
 
   forward(): void { throw 'not implemented'; }
+}
+
+class MockPopStateEvent {
+  pop: boolean = true;
+  type: string = 'popstate';
+  constructor(public newUrl: string) {}
 }

--- a/modules/angular2/src/router/hash_location_strategy.ts
+++ b/modules/angular2/src/router/hash_location_strategy.ts
@@ -58,7 +58,10 @@ export class HashLocationStrategy extends LocationStrategy {
     }
   }
 
-  onPopState(fn: EventListener): void { this._platformLocation.onPopState(fn); }
+  onPopState(fn: EventListener): void {
+    this._platformLocation.onPopState(fn);
+    this._platformLocation.onHashChange(fn);
+  }
 
   getBaseHref(): string { return this._baseHref; }
 
@@ -85,6 +88,14 @@ export class HashLocationStrategy extends LocationStrategy {
       url = this._platformLocation.pathname;
     }
     this._platformLocation.pushState(state, title, url);
+  }
+
+  replaceState(state: any, title: string, path: string, queryParams: string) {
+    var url = this.prepareExternalUrl(path + normalizeQueryParams(queryParams));
+    if (url.length == 0) {
+      url = this._platformLocation.pathname;
+    }
+    this._platformLocation.replaceState(state, title, url);
   }
 
   forward(): void { this._platformLocation.forward(); }

--- a/modules/angular2/src/router/location.ts
+++ b/modules/angular2/src/router/location.ts
@@ -52,8 +52,9 @@ export class Location {
   constructor(public platformStrategy: LocationStrategy) {
     var browserBaseHref = this.platformStrategy.getBaseHref();
     this._baseHref = stripTrailingSlash(stripIndexHtml(browserBaseHref));
-    this.platformStrategy.onPopState(
-        (_) => { ObservableWrapper.callEmit(this._subject, {'url': this.path(), 'pop': true}); });
+    this.platformStrategy.onPopState((ev) => {
+      ObservableWrapper.callEmit(this._subject, {'url': this.path(), 'pop': true, 'type': ev.type});
+    });
   }
 
   /**
@@ -82,12 +83,21 @@ export class Location {
     return this.platformStrategy.prepareExternalUrl(url);
   }
 
+  // TODO: rename this method to pushState
   /**
    * Changes the browsers URL to the normalized version of the given URL, and pushes a
    * new item onto the platform's history.
    */
   go(path: string, query: string = ''): void {
     this.platformStrategy.pushState(null, '', path, query);
+  }
+
+  /**
+   * Changes the browsers URL to the normalized version of the given URL, and replaces
+   * the top item on the platform's history stack.
+   */
+  replaceState(path: string, query: string = ''): void {
+    this.platformStrategy.replaceState(null, '', path, query);
   }
 
   /**

--- a/modules/angular2/src/router/location_strategy.ts
+++ b/modules/angular2/src/router/location_strategy.ts
@@ -21,6 +21,7 @@ export abstract class LocationStrategy {
   abstract path(): string;
   abstract prepareExternalUrl(internal: string): string;
   abstract pushState(state: any, title: string, url: string, queryParams: string): void;
+  abstract replaceState(state: any, title: string, url: string, queryParams: string): void;
   abstract forward(): void;
   abstract back(): void;
   abstract onPopState(fn: (_: any) => any): void;

--- a/modules/angular2/src/router/path_location_strategy.ts
+++ b/modules/angular2/src/router/path_location_strategy.ts
@@ -93,6 +93,11 @@ export class PathLocationStrategy extends LocationStrategy {
     this._platformLocation.pushState(state, title, externalUrl);
   }
 
+  replaceState(state: any, title: string, url: string, queryParams: string) {
+    var externalUrl = this.prepareExternalUrl(url + normalizeQueryParams(queryParams));
+    this._platformLocation.replaceState(state, title, externalUrl);
+  }
+
   forward(): void { this._platformLocation.forward(); }
 
   back(): void { this._platformLocation.back(); }

--- a/modules/angular2/src/router/platform_location.ts
+++ b/modules/angular2/src/router/platform_location.ts
@@ -40,6 +40,10 @@ export class PlatformLocation {
     this._history.pushState(state, title, url);
   }
 
+  replaceState(state: any, title: string, url: string): void {
+    this._history.replaceState(state, title, url);
+  }
+
   forward(): void { this._history.forward(); }
 
   back(): void { this._history.back(); }


### PR DESCRIPTION
Currently, hashchange events outside of Angular that cause navigation do not take into account cases where the initial route URL changes due to a redirect or a default route.

Tracks internal bug b/26013076

Closes #5590
