### PR TITLE
fix(build): lock down version of package:code_transformers

### DIFF
--- a/modules/angular2/pubspec.yaml
+++ b/modules/angular2/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   analyzer: '>=0.24.4 <0.27.0'
   barback: '^0.15.2+2'
-  code_transformers: '^0.2.8'
+  code_transformers: '0.2.9+4'
   dart_style: '>=0.1.8 <0.3.0'
   glob: '^1.0.0'
   html: '^0.12.0'


### PR DESCRIPTION
A new verion is causing build issues, perhaps due to an undeclared
dependency on package:test. For now, lock down the version to the
last known working one.
