### PR TITLE
fix(bundles): clean-up and re-organize UMD bundles

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1115,24 +1115,8 @@ gulp.task('!bundles.js.umd', ['build.js.dev'], function() {
   }
 
   return q.all([
-    webpack(webPackConf(['angular2/angular2.js'], 'angular2', 'dev')),
-    webpack(webPackConf(['angular2/angular2.js'], 'angular2', 'prod')),
-    webpack(webPackConf(
-        [
-          'angular2/angular2.js',
-          'angular2/http.js',
-          'angular2/router/router_link_dsl.js',
-          'angular2/router.js'
-        ],
-        'angular2_all', 'dev')),
-    webpack(webPackConf(
-        [
-          'angular2/angular2.js',
-          'angular2/http.js',
-          'angular2/router/router_link_dsl.js',
-          'angular2/router.js'
-        ],
-        'angular2_all', 'prod'))
+    webpack(webPackConf([__dirname + '/tools/build/webpack/angular2.umd.js'], 'angular2', 'dev')),
+    webpack(webPackConf([__dirname + '/tools/build/webpack/angular2.umd.js'], 'angular2', 'prod'))
   ]);
 });
 

--- a/tools/build/webpack/angular2.umd.js
+++ b/tools/build/webpack/angular2.umd.js
@@ -1,0 +1,11 @@
+exports.core = require('angular2/core');
+exports.common = require('angular2/common');
+exports.platform = {
+  browser: require('angular2/platform/browser'),
+  common_dom: require('angular2/platform/common_dom')
+};
+exports.http = require('angular2/http');
+exports.router = require('angular2/router');
+exports.router_link_dsl = require('angular2/router/router_link_dsl.js');
+exports.instrumentation = require('angular2/instrumentation');
+exports.upgrade = require('angular2/upgrade');


### PR DESCRIPTION
Fixes #5593
Part of #5665

BREAKING CHANGE:

Number and content of UMD bundles have changed:
- we only publish one bundle that contains: core, common, platform/browser, http, router, instrumentation and upgrade
- exported names have changed and now:
  - core is exported as `ng.core`
  - common is exported as `ng.common`
  - platform/browser is exported as `ng.platform.browser`
  - http is exported as `ng.http`
  - router is exported as `ng.router`
  - instrumentation is exported as `ng.instrumentation`
  - upgrade is exported as `ng.upgrade`
