### PR TITLE
feat(TemplateParser): allow template elements regardless the namespace

### DIFF
--- a/modules/angular2/src/compiler/template_parser.ts
+++ b/modules/angular2/src/compiler/template_parser.ts
@@ -7,6 +7,7 @@ import {Parser, AST, ASTWithSource} from 'angular2/src/core/change_detection/cha
 import {TemplateBinding} from 'angular2/src/core/change_detection/parser/ast';
 import {CompileDirectiveMetadata} from './directive_metadata';
 import {HtmlParser} from './html_parser';
+import {splitHtmlTagNamespace} from './html_tags';
 import {ParseSourceSpan, ParseError, ParseLocation} from './parse_util';
 
 
@@ -215,7 +216,8 @@ class TemplateParseVisitor implements HtmlAstVisitor {
       }
     });
 
-    var isTemplateElement = nodeName.toLowerCase() == TEMPLATE_ELEMENT;
+    var lcElName = splitHtmlTagNamespace(nodeName.toLowerCase())[1];
+    var isTemplateElement = lcElName == TEMPLATE_ELEMENT;
     var elementCssSelector = createElementCssSelector(nodeName, matchableAttrs);
     var directives = this._createDirectiveAsts(
         element.name, this._parseDirectives(this.selectorMatcher, elementCssSelector),

--- a/modules/angular2/test/compiler/template_parser_spec.ts
+++ b/modules/angular2/test/compiler/template_parser_spec.ts
@@ -500,6 +500,15 @@ There is no directive with "exportAs" set to "dirA" ("<div [ERROR ->]#a="dirA"><
           expect(humanizeTplAst(parse('<TEMPLATE></TEMPLATE>', [])))
               .toEqual([[EmbeddedTemplateAst]]);
         });
+
+        it('should create embedded templates for <template> elements regardless the namespace',
+           () => {
+             expect(humanizeTplAst(parse('<svg><template></template></svg>', [])))
+                 .toEqual([
+                   [ElementAst, '@svg:svg'],
+                   [EmbeddedTemplateAst],
+                 ]);
+           });
       });
 
       describe('inline templates', () => {


### PR DESCRIPTION
note: svg and mathml do not have template elements
