### PR TITLE
chore(test): remove deprecated injectAsync

### DIFF
--- a/modules/angular2/src/testing/test_injector.ts
+++ b/modules/angular2/src/testing/test_injector.ts
@@ -167,18 +167,11 @@ export function createTestInjectorWithRuntimeCompiler(
  * @return {FunctionWithParamTokens}
  */
 export function inject(tokens: any[], fn: Function): FunctionWithParamTokens {
-  return new FunctionWithParamTokens(tokens, fn, false);
-}
-
-/**
- * @deprecated Use inject instead, which now supports both synchronous and asynchronous tests.
- */
-export function injectAsync(tokens: any[], fn: Function): FunctionWithParamTokens {
-  return new FunctionWithParamTokens(tokens, fn, true);
+  return new FunctionWithParamTokens(tokens, fn);
 }
 
 export class FunctionWithParamTokens {
-  constructor(private _tokens: any[], private _fn: Function, public isAsync: boolean) {}
+  constructor(private _tokens: any[], private _fn: Function) {}
 
   /**
    * Returns the value of the executed function.

--- a/modules/angular2/src/testing/testing.ts
+++ b/modules/angular2/src/testing/testing.ts
@@ -9,11 +9,10 @@ import {bind} from 'angular2/src/core/di';
 import {
   createTestInjectorWithRuntimeCompiler,
   FunctionWithParamTokens,
-  inject,
-  injectAsync
+  inject
 } from './test_injector';
 
-export {inject, injectAsync} from './test_injector';
+export {inject} from './test_injector';
 
 export {expect, NgMatchers} from './matchers';
 

--- a/modules/angular2/src/testing/testing_internal.dart
+++ b/modules/angular2/src/testing/testing_internal.dart
@@ -93,7 +93,7 @@ void beforeEachBindings(Function fn) {
 
 void beforeEach(fn) {
   if (fn is! FunctionWithParamTokens) fn =
-      new FunctionWithParamTokens([], fn, false);
+      new FunctionWithParamTokens([], fn);
   gns.beforeEach(() {
     fn.execute(_injector);
   });
@@ -101,7 +101,7 @@ void beforeEach(fn) {
 
 void _it(gnsFn, name, fn) {
   if (fn is! FunctionWithParamTokens) fn =
-      new FunctionWithParamTokens([], fn, false);
+      new FunctionWithParamTokens([], fn);
   gnsFn(name, () {
     _inIt = true;
     fn.execute(_injector);

--- a/modules_dart/angular2_testing/lib/angular2_testing.dart
+++ b/modules_dart/angular2_testing/lib/angular2_testing.dart
@@ -75,7 +75,7 @@ dynamic _runInjectableFunction(Function fn) {
   if (_currentInjector == null) {
     _currentInjector = createTestInjectorWithRuntimeCompiler(_currentTestProviders);
   }
-  var injectFn = new FunctionWithParamTokens(tokens, fn, false);
+  var injectFn = new FunctionWithParamTokens(tokens, fn);
   return injectFn.execute(_currentInjector);
 }
 


### PR DESCRIPTION
injectAsync was deprecated in 0c9596ae2b31135711fba1d132f8e5d349a1e095.
Finish removing it.
