### PR TITLE
fix(RootRouter): Path prefixed with a slash when not needed

### DIFF
--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -464,7 +464,7 @@ export class RootRouter extends Router {
   commit(instruction: Instruction, _skipLocationChange: boolean = false): Promise<any> {
     var emitPath = instruction.toUrlPath();
     var emitQuery = instruction.toUrlQuery();
-    if (emitPath.length > 0) {
+    if (emitPath.length > 0 && emitPath.substring(0, 1) != '/') {
       emitPath = '/' + emitPath;
     }
     var promise = super.commit(instruction);


### PR DESCRIPTION
Add a condition to avoid prefixing a second slash at the beginning of the path there is already one.

Closes #5627
