### PR TITLE
fix(bundles): adjust exports from angular2/angular2

### DIFF
--- a/modules/angular2/angular2.ts
+++ b/modules/angular2/angular2.ts
@@ -2,7 +2,5 @@ export * from './common';
 export * from './core';
 export * from './instrumentation';
 export * from './platform/browser';
-export * from './src/platform/dom/dom_adapter';
-export * from './src/platform/dom/events/event_manager';
+export * from './platform/common_dom';
 export * from './upgrade';
-export {UrlResolver, AppRootUrl, getUrlScheme, DEFAULT_PACKAGE_URL_PROVIDER} from './compiler';


### PR DESCRIPTION
Fixes #5700

BREAKING CHANGE:

`UrlResolver` and `AppRootUrl` symbols are no longer exported
from the `angular2/angular2` namespace.
