### PR TITLE
docs(cheatsheet): add Dart-specific content

### DIFF
--- a/modules/angular2/docs/cheatsheet/built-in-directives.md
+++ b/modules/angular2/docs/cheatsheet/built-in-directives.md
@@ -2,7 +2,8 @@
 Built-in directives
 @cheatsheetIndex 2
 @description
-`import {NgIf, ...} from 'angular2/angular2';`
+{@target js ts}`import {NgIf, ...} from 'angular2/angular2';`{@endtarget}
+{@target dart}`import 'package:angular2/angular2.dart';`{@endtarget}
 
 @cheatsheetItem
 syntax:

--- a/modules/angular2/docs/cheatsheet/class-decorators.md
+++ b/modules/angular2/docs/cheatsheet/class-decorators.md
@@ -2,24 +2,34 @@
 Class decorators
 @cheatsheetIndex 4
 @description
-`import {Directive, ...} from 'angular2/angular2';`
+{@target js ts}`import {Directive, ...} from 'angular2/angular2';`{@endtarget}
+{@target dart}`import 'package:angular2/angular2.dart';`{@endtarget}
 
 @cheatsheetItem
-syntax:
+syntax(js ts):
 `@Component({...})
 class MyComponent() {}`|`@Component({...})`
+syntax(dart):
+`@Component(...)
+class MyComponent() {}`|`@Component(...)`
 description:
 Declares that a class is a component and provides metadata about the component.
 
 @cheatsheetItem
-syntax:
+syntax(js ts):
 `@Pipe({...})
 class MyPipe() {}`|`@Pipe({...})`
+syntax(dart):
+`@Pipe(...)
+class MyPipe() {}`|`@Pipe(...)`
 description:
 Declares that a class is a pipe and provides metadata about the pipe.
 
 @cheatsheetItem
-syntax:
+syntax(js ts):
+`@Injectable()
+class MyService() {}`|`@Injectable()`
+syntax(dart):
 `@Injectable()
 class MyService() {}`|`@Injectable()`
 description:

--- a/modules/angular2/docs/cheatsheet/dependency-injection.md
+++ b/modules/angular2/docs/cheatsheet/dependency-injection.md
@@ -2,7 +2,8 @@
 Dependency injection configuration
 @cheatsheetIndex 9
 @description
-`import {provide} from 'angular2/angular2';`
+{@target js ts}`import {provide} from 'angular2/angular2';`{@endtarget}
+{@target dart}`import 'package:angular2/angular2.dart';`{@endtarget}
 
 @cheatsheetItem
 syntax:

--- a/modules/angular2/docs/cheatsheet/directive-and-component-decorators.md
+++ b/modules/angular2/docs/cheatsheet/directive-and-component-decorators.md
@@ -2,7 +2,8 @@
 Class field decorators for directives and components
 @cheatsheetIndex 7
 @description
-`import {Input, ...} from 'angular2/angular2';`
+{@target js ts}`import {Input, ...} from 'angular2/angular2';`{@endtarget}
+{@target dart}`import 'package:angular2/angular2.dart';`{@endtarget}
 
 @cheatsheetItem
 syntax:

--- a/modules/angular2/docs/cheatsheet/directive-configuration.md
+++ b/modules/angular2/docs/cheatsheet/directive-configuration.md
@@ -2,7 +2,8 @@
 Directive configuration
 @cheatsheetIndex 5
 @description
-`@Directive({ property1: value1, ... }) )`
+{@target js ts}`@Directive({ property1: value1, ... })`{@endtarget}
+{@target dart}`@Directive(property1: value1, ...)`{@endtarget}
 
 @cheatsheetItem
 syntax:

--- a/modules/angular2/docs/cheatsheet/forms.md
+++ b/modules/angular2/docs/cheatsheet/forms.md
@@ -2,7 +2,8 @@
 Forms
 @cheatsheetIndex 3
 @description
-`import {FORM_DIRECTIVES} from 'angular2/angular2';`
+{@target js ts}`import {FORM_DIRECTIVES} from 'angular2/angular2';`{@endtarget}
+{@target dart}`import 'package:angular2/angular2.dart';`{@endtarget}
 
 @cheatsheetItem
 syntax:

--- a/modules/angular2/docs/cheatsheet/lifecycle hooks.md
+++ b/modules/angular2/docs/cheatsheet/lifecycle hooks.md
@@ -5,8 +5,10 @@ Directive and component change detection and lifecycle hooks
 (implemented as class methods)
 
 @cheatsheetItem
-syntax:
+syntax(js ts):
 `constructor(myService: MyService, ...) { ... }`|`constructor(myService: MyService, ...)`
+syntax(dart):
+`MyAppComponent(MyService myService, ...) { ... }`|`MyAppComponent(MyService myService, ...)`
 description:
 The class constructor is called before any other lifecycle hook. Use it to inject dependencies, but avoid any serious work here.
 

--- a/modules/angular2/docs/cheatsheet/routing.md
+++ b/modules/angular2/docs/cheatsheet/routing.md
@@ -2,17 +2,22 @@
 Routing and navigation
 @cheatsheetIndex 10
 @description
-`import {RouteConfig, ROUTER_DIRECTIVES, ROUTER_PROVIDERS, ...} from 'angular2/router';`
+{@target js ts}`import {RouteConfig, ROUTER_DIRECTIVES, ROUTER_PROVIDERS, ...} from 'angular2/router';`{@endtarget}
+{@target dart}`import 'package:angular2/angular2.dart';`{@endtarget}
 
 
 @cheatsheetItem
-syntax:
+syntax(js ts):
 `@RouteConfig([
   { path: '/:myParam', component: MyComponent, as: 'MyCmp' },
   { path: '/staticPath', component: ..., as: ...},
   { path: '/*wildCardParam', component: ..., as: ...}
 ])
 class MyComponent() {}`|`@RouteConfig`
+syntax(dart):
+`@RouteConfig(const [
+  const Route(path: '/:myParam', component: MyComponent, name: 'MyCmp' ),
+])`
 description:
 Configures routes for the decorated component. Supports static, parameterized and wildcard routes.
 
@@ -32,8 +37,10 @@ Creates a link to a different view based on a route instruction consisting of a 
 
 
 @cheatsheetItem
-syntax:
+syntax(js ts):
 `@CanActivate(() => { ... })class MyComponent() {}`|`@CanActivate`
+syntax(dart):
+`@CanActivate(() => ...)class MyComponent() {}`|`@CanActivate`
 description:
 A component decorator defining a function that the router should call first to determine if it should activate this component. Should return a boolean or a promise.
 


### PR DESCRIPTION
@naomiblack or @petebacondarwin could you please make sure this builds for you? @tomplusplus, could you review the content?

The cheat sheet content is currently hidden from https://angular.io/docs/dart/latest/guide/cheatsheet.html, but that's a temporary hack (via naomi's local changes, not checked into master).
