### PR TITLE
build(sauce/bs): make some browsers required in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,10 @@ env:
     # Order: a slower build first, so that we don't occupy an idle travis worker waiting for others to complete.
     - MODE=dart DART_CHANNEL=stable DART_VERSION=$DART_STABLE_VERSION
     - MODE=dart DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
-    - MODE=saucelabs DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
-    - MODE=browserstack DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
+    - MODE=saucelabs_required DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
+    - MODE=browserstack_required DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
+    - MODE=saucelabs_optional DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
+    - MODE=browserstack_optional DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
     - MODE=dart_experimental DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
     - MODE=js DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
     - MODE=router DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
@@ -48,8 +50,8 @@ env:
 
 matrix:
   allow_failures:
-  - env: "MODE=saucelabs DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION"
-  - env: "MODE=browserstack DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION"
+  - env: "MODE=saucelabs_optional DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION"
+  - env: "MODE=browserstack_optional DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION"
   - env: "MODE=dart_experimental DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION"
   # TODO(alxhub): remove when dartdoc #1039 is in dev channel
   - env: "MODE=dart DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION"

--- a/browser-providers.conf.js
+++ b/browser-providers.conf.js
@@ -1,3 +1,32 @@
+// Unique place to configure the browsers which are used in the different CI jobs in Sauce Labs (SL) and BrowserStack (BS).
+// If the target is set to null, then the browser is not run anywhere during CI.
+// If a category becomes empty (e.g. BS and required), then the corresponding job must be commented out in Travis configuration.
+var CIconfiguration = {
+  'Chrome':       { unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
+  'Firefox':      { unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
+  'ChromeBeta':   { unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
+  'FirefoxBeta':  { unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
+  'ChromeDev':    { unitTest: {target: null, required: true}, e2e: {target: null, required: true}},
+  'FirefoxDev':   { unitTest: {target: null, required: true}, e2e: {target: null, required: true}},
+  'IE9':          { unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
+  'IE10':         { unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
+  'IE11':         { unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
+  'Edge':         { unitTest: {target: 'SL', required: true}, e2e: {target: null, required: true}},
+  'Android4.1':   { unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
+  'Android4.2':   { unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
+  'Android4.3':   { unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
+  'Android4.4':   { unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
+  'Android5':     { unitTest: {target: 'SL', required: false}, e2e: {target: null, required: true}},
+  'Safari7':      { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
+  'Safari8':      { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
+  'Safari9':      { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
+  'iOS7':         { unitTest: {target: 'BS', required: true}, e2e: {target: null, required: true}},
+  'iOS8':         { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}},
+  // TODO(mlaval): iOS9 deactivated as not reliable, reactivate after https://github.com/angular/angular/issues/5408
+  'iOS9':         { unitTest: {target: null, required: false}, e2e: {target: null, required: true}},
+  'WindowsPhone': { unitTest: {target: 'BS', required: false}, e2e: {target: null, required: true}}
+};
+
 var customLaunchers = {
   'DartiumWithWebPlatform': {
     base: 'Dartium',
@@ -47,7 +76,7 @@ var customLaunchers = {
     platform: 'OS X 10.10',
     version: '8'
   },
-  'SL_SAFARI9.0': {
+  'SL_SAFARI9': {
     base: 'SauceLabs',
     browserName: 'safari',
     platform: 'OS X 10.11',
@@ -119,7 +148,7 @@ var customLaunchers = {
     platform: 'Linux',
     version: '4.4'
   },
-  'SL_ANDROID5.1': {
+  'SL_ANDROID5': {
     base: 'SauceLabs',
     browserName: 'android',
     platform: 'Linux',
@@ -239,21 +268,18 @@ var customLaunchers = {
   }
 };
 
-// iOS9 deactivated as not reliable in both providers
-// TODO(mlaval): reactivate after https://github.com/angular/angular/issues/5408
-
 var sauceAliases = {
   'ALL': Object.keys(customLaunchers).filter(function(item) {return customLaunchers[item].base == 'SauceLabs';}),
-  'DESKTOP': ['SL_CHROME', 'SL_FIREFOX', 'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_EDGE', 'SL_SAFARI7', 'SL_SAFARI8', 'SL_SAFARI9.0'],
-  'MOBILE': ['SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4', 'SL_ANDROID5.1', 'SL_IOS7', 'SL_IOS8', 'SL_IOS9'],
-  'ANDROID': ['SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4', 'SL_ANDROID5.1'],
+  'DESKTOP': ['SL_CHROME', 'SL_FIREFOX', 'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_EDGE', 'SL_SAFARI7', 'SL_SAFARI8', 'SL_SAFARI9'],
+  'MOBILE': ['SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4', 'SL_ANDROID5', 'SL_IOS7', 'SL_IOS8', 'SL_IOS9'],
+  'ANDROID': ['SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4', 'SL_ANDROID5'],
   'IE': ['SL_IE9', 'SL_IE10', 'SL_IE11'],
   'IOS': ['SL_IOS7', 'SL_IOS8', 'SL_IOS9'],
-  'SAFARI': ['SL_SAFARI7', 'SL_SAFARI8', 'SL_SAFARI9.0'],
+  'SAFARI': ['SL_SAFARI7', 'SL_SAFARI8', 'SL_SAFARI9'],
   'BETA': ['SL_CHROMEBETA', 'SL_FIREFOXBETA'],
   'DEV': ['SL_CHROMEDEV', 'SL_FIREFOXDEV'],
-  'CI': ['SL_CHROME',' SL_FIREFOX', 'SL_CHROMEDEV', 'SL_FIREFOXBETA', 'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_EDGE',
-    'SL_ANDROID4.1', 'SL_ANDROID4.2', 'SL_ANDROID4.3', 'SL_ANDROID4.4', 'SL_ANDROID5.1']
+  'CI_REQUIRED': buildConfiguration('unitTest', 'SL', true),
+  'CI_OPTIONAL': buildConfiguration('unitTest', 'SL', false)
 };
 
 var browserstackAliases = {
@@ -264,7 +290,8 @@ var browserstackAliases = {
   'IE': ['BS_IE9', 'BS_IE10', 'BS_IE11'],
   'IOS': ['BS_IOS7', 'BS_IOS8', 'BS_IOS9'],
   'SAFARI': ['BS_SAFARI7', 'BS_SAFARI8', 'BS_SAFARI9'],
-  'CI': ['BS_SAFARI7', 'BS_SAFARI8', 'BS_SAFARI9', 'BS_IOS7', 'BS_IOS8', 'BS_WINDOWSPHONE']
+  'CI_REQUIRED': buildConfiguration('unitTest', 'BS', true),
+  'CI_OPTIONAL': buildConfiguration('unitTest', 'BS', false)
 };
 
 module.exports = {
@@ -276,4 +303,15 @@ module.exports = {
 if (process.env.TRAVIS) {
   process.env.SAUCE_ACCESS_KEY = process.env.SAUCE_ACCESS_KEY.split('').reverse().join('');
   process.env.BROWSER_STACK_ACCESS_KEY = process.env.BROWSER_STACK_ACCESS_KEY.split('').reverse().join('');
+}
+
+function buildConfiguration(type, target, required) {
+  return Object.keys(CIconfiguration)
+    .filter((item) => {
+      var conf = CIconfiguration[item][type];
+      return conf.required === required && conf.target === target;
+    })
+    .map((item) => {
+      return target + '_' + item.toUpperCase();
+    });
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -720,12 +720,19 @@ gulp.task('test.unit.js/ci', function(done) {
 });
 
 gulp.task('test.unit.js.sauce/ci', function(done) {
-  launchKarmaWithExternalBrowsers(['dots', 'saucelabs'], browserProvidersConf.sauceAliases.CI,
-                                  done);
+  var browsers = browserProvidersConf.sauceAliases.CI_REQUIRED;
+  if (cliArgs.mode && cliArgs.mode == 'saucelabs_optional') {
+    browsers = browserProvidersConf.sauceAliases.CI_OPTIONAL;
+  }
+  launchKarmaWithExternalBrowsers(['dots', 'saucelabs'], browsers, done);
 });
 
 gulp.task('test.unit.js.browserstack/ci', function(done) {
-  launchKarmaWithExternalBrowsers(['dots'], browserProvidersConf.browserstackAliases.CI, done);
+  var browsers = browserProvidersConf.browserstackAliases.CI_REQUIRED;
+  if (cliArgs.mode && cliArgs.mode == 'browserstack_optional') {
+    browsers = browserProvidersConf.browserstackAliases.CI_OPTIONAL;
+  }
+  launchKarmaWithExternalBrowsers(['dots'], browsers, done);
 });
 
 gulp.task('test.unit.dart/ci', function(done) {

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -79,7 +79,7 @@ module.exports = function(config) {
 
   if (process.env.TRAVIS) {
     var buildId = 'TRAVIS #' + process.env.TRAVIS_BUILD_NUMBER + ' (' + process.env.TRAVIS_BUILD_ID + ')';
-    if (process.env.MODE === 'saucelabs') {
+    if (process.env.MODE.startsWith('saucelabs')) {
       config.sauceLabs.build = buildId;
       config.sauceLabs.tunnelIdentifier = process.env.TRAVIS_JOB_NUMBER;
 
@@ -89,7 +89,7 @@ module.exports = function(config) {
       config.transports = ['polling'];
     }
 
-    if (process.env.MODE === 'browserstack') {
+    if (process.env.MODE.startsWith('browserstack')) {
       config.browserStack.build = buildId;
       config.browserStack.tunnelIdentifier = process.env.TRAVIS_JOB_NUMBER;
     }

--- a/scripts/ci/build_and_test.sh
+++ b/scripts/ci/build_and_test.sh
@@ -10,8 +10,10 @@ cd $SCRIPT_DIR/../..
 
 if [ "$MODE" = "dart_experimental" ]; then
   ${SCRIPT_DIR}/build_$MODE.sh
-elif [ "$MODE" = "saucelabs" ] || [ "$MODE" = "browserstack" ] ; then
-  ${SCRIPT_DIR}/test_$MODE.sh
+elif [[ $MODE = saucelabs* ]] ; then
+  ${SCRIPT_DIR}/test_saucelabs.sh $MODE
+elif [[ $MODE = browserstack* ]] ; then
+  ${SCRIPT_DIR}/test_browserstack.sh $MODE
 elif [ "$MODE" = "lint" ]; then
   ./node_modules/.bin/gulp static-checks
 elif [ "$MODE" = "build_only" ]; then

--- a/scripts/ci/test_browserstack.sh
+++ b/scripts/ci/test_browserstack.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+MODE=$1
+
 echo =============================================================================
 # go to project dir
 SCRIPT_DIR=$(dirname $0)
@@ -9,4 +11,4 @@ cd $SCRIPT_DIR/../..
 ./scripts/browserstack/start_tunnel.sh
 ./scripts/browserstack/waitfor_tunnel.sh
 ./node_modules/.bin/gulp build.js.dev
-./node_modules/.bin/gulp test.unit.js.browserstack/ci
+./node_modules/.bin/gulp test.unit.js.browserstack/ci --mode=$MODE

--- a/scripts/ci/test_saucelabs.sh
+++ b/scripts/ci/test_saucelabs.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+MODE=$1
+
 echo =============================================================================
 # go to project dir
 SCRIPT_DIR=$(dirname $0)
@@ -9,4 +11,4 @@ cd $SCRIPT_DIR/../..
 ./scripts/sauce/sauce_connect_setup.sh
 ./scripts/sauce/sauce_connect_block.sh
 ./node_modules/.bin/gulp build.js.dev
-./node_modules/.bin/gulp test.unit.js.sauce/ci
+./node_modules/.bin/gulp test.unit.js.sauce/ci --mode=$MODE


### PR DESCRIPTION
As discussed with @IgorMinar and @juliemr , let's add the very stable browsers as required jobs in CI.

For other ones, they are kept in optional jobs. Analytics will be added later in order to have more details about them.
