### PR TITLE
docs(cheatsheet): fix some Dart terminology, plus copyedit a bit

### DIFF
--- a/modules/angular2/docs/cheatsheet/bootstrapping.md
+++ b/modules/angular2/docs/cheatsheet/bootstrapping.md
@@ -9,4 +9,5 @@ Bootstrapping
 syntax:
 `bootstrap​(MyAppComponent, [MyService, provide(...)]);`|`provide`
 description:
-Bootstraps an application with MyAppComponent as the root component and configures the DI providers.
+Bootstraps an application with MyAppComponent as the root component, and
+configures the app's dependency injection providers.

--- a/modules/angular2/docs/cheatsheet/built-in-directives.md
+++ b/modules/angular2/docs/cheatsheet/built-in-directives.md
@@ -31,5 +31,4 @@ Conditionally swaps the contents of the div by selecting one of the embedded tem
 syntax:
 `<div [ngClass]="{active: isActive, disabled: isDisabled}">`|`[ngClass]`
 description:
-Binds the presence of css classes on the element to the truthiness of the associated map values. The right-hand side expression should return {class-name: true/false} map.
-
+Binds the presence of CSS classes on the element to the truthiness of the associated map values. The right-hand side expression should return {class-name: true/false} map.

--- a/modules/angular2/docs/cheatsheet/component-configuration.md
+++ b/modules/angular2/docs/cheatsheet/component-configuration.md
@@ -17,7 +17,7 @@ syntax:
 `template: 'Hello {{name}}'
 templateUrl: 'my-component.html'`|`template:`|`templateUrl:`
 description:
-Inline template / external template url of the component's view.
+Inline template / external template URL of the component's view.
 
 
 @cheatsheetItem
@@ -25,7 +25,7 @@ syntax:
 `styles: ['.primary {color: red}']
 styleUrls: ['my-component.css']`|`styles:`|`styleUrls:`
 description:
-List of inline css styles / external stylesheet urls for styling component’s view.
+List of inline CSS styles / external stylesheet URLs for styling component’s view.
 
 
 @cheatsheetItem

--- a/modules/angular2/docs/cheatsheet/directive-and-component-decorators.md
+++ b/modules/angular2/docs/cheatsheet/directive-and-component-decorators.md
@@ -9,22 +9,22 @@ Class field decorators for directives and components
 syntax:
 `@Input() myProperty;`|`@Input()`
 description:
-Declares an input property that we can update via property binding, e.g.
-`<my-cmp [my-property]="someExpression">`
+Declares an input property that we can update via property binding (e.g.
+`<my-cmp [my-property]="someExpression">`).
 
 
 @cheatsheetItem
 syntax:
 `@Output() myEvent = new EventEmitter();`|`@Output()`
 description:
-Declares an output property that fires events to which we can subscribe with an event binding, e.g. `<my-cmp (my-event)="doSomething()">`
+Declares an output property that fires events to which we can subscribe with an event binding (e.g. `<my-cmp (my-event)="doSomething()">`).
 
 
 @cheatsheetItem
 syntax:
 `@HostBinding('[class.valid]') isValid;`|`@HostBinding('[class.valid]')`
 description:
-Binds a host element property (e.g. css class valid) to directive/component property (e.g. isValid)
+Binds a host element property (e.g. CSS class valid) to directive/component property (e.g. isValid).
 
 
 
@@ -32,7 +32,7 @@ Binds a host element property (e.g. css class valid) to directive/component prop
 syntax:
 `@HostListener('click', ['$event']) onClick(e) {...}`|`@HostListener('click', ['$event'])`
 description:
-Subscribes to a host element event (e.g. click) with a directive/component method (e.g., onClick), optionally passing an argument ($event)
+Subscribes to a host element event (e.g. click) with a directive/component method (e.g. onClick), optionally passing an argument ($event).
 
 
 @cheatsheetItem

--- a/modules/angular2/docs/cheatsheet/directive-configuration.md
+++ b/modules/angular2/docs/cheatsheet/directive-configuration.md
@@ -9,7 +9,7 @@ Directive configuration
 syntax:
 `selector: '.cool-button:not(a)'`|`selector:`
 description:
-Specifies a css selector that identifies this directive within a template. Supported selectors include: `element`,
+Specifies a CSS selector that identifies this directive within a template. Supported selectors include `element`,
 `[attribute]`, `.class`, and `:not()`.
 
 Does not support parent-child relationship selectors.

--- a/modules/angular2/docs/cheatsheet/routing.md
+++ b/modules/angular2/docs/cheatsheet/routing.md
@@ -17,9 +17,9 @@ class MyComponent() {}`|`@RouteConfig`
 syntax(dart):
 `@RouteConfig(const [
   const Route(path: '/:myParam', component: MyComponent, name: 'MyCmp' ),
-])`
+])`|`@RouteConfig`
 description:
-Configures routes for the decorated component. Supports static, parameterized and wildcard routes.
+Configures routes for the decorated component. Supports static, parameterized, and wildcard routes.
 
 
 @cheatsheetItem
@@ -30,6 +30,7 @@ Marks the location to load the component of the active route.
 
 
 @cheatsheetItem
+syntax:
 `<a [routerLink]="[ '/MyCmp', {myParam: 'value' } ]">`|`[routerLink]`
 description:
 Creates a link to a different view based on a route instruction consisting of a route name and optional parameters. The route name matches the as property of a configured route. Add the '/' prefix to navigate to a root route; add the './' prefix for a child route.
@@ -41,21 +42,21 @@ syntax(js ts):
 syntax(dart):
 `@CanActivate(() => ...)class MyComponent() {}`|`@CanActivate`
 description:
-A component decorator defining a function that the router should call first to determine if it should activate this component. Should return a boolean or a promise.
+A component decorator defining a function that the router should call first to determine if it should activate this component. Should return a boolean or a {@target js ts}promise{@endtarget}{@target dart}future{@endtarget}.
 
 
 @cheatsheetItem
 syntax:
 `routerOnActivate(nextInstruction, prevInstruction) { ... }`|`routerOnActivate`
 description:
-After navigating to a component, the router calls component's routerOnActivate method (if defined).
+After navigating to a component, the router calls the component's routerOnActivate method (if defined).
 
 
 @cheatsheetItem
 syntax:
 `routerCanReuse(nextInstruction, prevInstruction) { ... }`|`routerCanReuse`
 description:
-The router calls a component's routerCanReuse method (if defined) to determine whether to reuse the instance or destroy it and create a new instance. Should return a boolean or a promise.
+The router calls a component's routerCanReuse method (if defined) to determine whether to reuse the instance or destroy it and create a new instance. Should return a boolean or a {@target js ts}promise{@endtarget}{@target dart}future{@endtarget}.
 
 
 @cheatsheetItem
@@ -69,11 +70,11 @@ The router calls the component's routerOnReuse method (if defined) when it re-us
 syntax:
 `routerCanDeactivate(nextInstruction, prevInstruction) { ... }`|`routerCanDeactivate`
 description:
-The router calls the routerCanDeactivate methods (if defined) of every component that would be removed after a navigation. The navigation proceeds if and only if all such methods return true or a promise that is resolved.
+The router calls the routerCanDeactivate methods (if defined) of every component that would be removed after a navigation. The navigation proceeds if and only if all such methods return true or a {@target js ts}promise that is resolved{@endtarget}{@target dart}future that completes successfully{@endtarget}.
 
 
 @cheatsheetItem
 syntax:
 `routerOnDeactivate(nextInstruction, prevInstruction) { ... }`|`routerOnDeactivate`
 description:
-Called before the directive is removed as the result of a route change. May return a promise that pauses removing the directive until the promise resolves.
+Called before the directive is removed as the result of a route change. May return a {@target js ts}promise{@endtarget}{@target dart}future{@endtarget} that pauses removing the directive until the {@target js ts}promise resolves{@endtarget}{@target dart}future completes{@endtarget}.

--- a/modules/angular2/docs/cheatsheet/template-syntax.md
+++ b/modules/angular2/docs/cheatsheet/template-syntax.md
@@ -19,7 +19,7 @@ Binds attribute `role` to the result of expression `myAriaRole`.
 syntax:
 `<div [class.extra-sparkle]="isDelightful">`|`[class.extra-sparkle]`
 description:
-Binds the presence of the css class `extra-sparkle` on the element to the truthiness of the expression `isDelightful`.
+Binds the presence of the CSS class `extra-sparkle` on the element to the truthiness of the expression `isDelightful`.
 
 @cheatsheetItem
 syntax:


### PR DESCRIPTION
Fixed a few little things. I'll probably have more changes to make later, once I understand everything better.

Also added a missing syntax line.
