### PR TITLE
refactor(testing): move common testing logic into test_injector

### DIFF
--- a/modules/angular2/src/testing/test_injector.ts
+++ b/modules/angular2/src/testing/test_injector.ts
@@ -23,7 +23,7 @@ import {
   defaultKeyValueDiffers,
   ChangeDetectorGenConfig
 } from 'angular2/src/core/change_detection/change_detection';
-import {ExceptionHandler} from 'angular2/src/facade/exceptions';
+import {BaseException, ExceptionHandler} from 'angular2/src/facade/exceptions';
 import {PipeResolver} from 'angular2/src/core/linker/pipe_resolver';
 import {XHR} from 'angular2/src/compiler/xhr';
 
@@ -131,14 +131,49 @@ function _runtimeCompilerBindings() {
   ];
 }
 
-export function createTestInjector(providers: Array<Type | Provider | any[]>): Injector {
-  var rootInjector = Injector.resolveAndCreate(_getRootProviders());
-  return rootInjector.resolveAndCreateChild(ListWrapper.concat(_getAppBindings(), providers));
+export class TestInjector {
+  private _instantiated: boolean = false;
+
+  private _injector: Injector = null;
+
+  private _providers: Array<Type | Provider | any[]> = [];
+
+  reset() {
+    this._injector = null;
+    this._providers = [];
+    this._instantiated = false;
+  }
+
+  addProviders(providers: Array<Type | Provider | any[]>) {
+    if (this._instantiated) {
+      throw new BaseException('Cannot add providers after test injector is instantiated');
+    }
+    this._providers = ListWrapper.concat(this._providers, providers);
+  }
+
+  createInjector() {
+    var rootInjector = Injector.resolveAndCreate(_getRootProviders());
+    this._injector = rootInjector.resolveAndCreateChild(ListWrapper.concat(
+        ListWrapper.concat(_getAppBindings(), _runtimeCompilerBindings()), this._providers));
+    this._instantiated = true;
+    return this._injector;
+  }
+
+  execute(fn: FunctionWithParamTokens): any {
+    if (!this._instantiated) {
+      this.createInjector();
+    }
+    return fn.execute(this._injector);
+  }
 }
 
-export function createTestInjectorWithRuntimeCompiler(
-    providers: Array<Type | Provider | any[]>): Injector {
-  return createTestInjector(ListWrapper.concat(_runtimeCompilerBindings(), providers));
+var _testInjector: TestInjector = null;
+
+export function getTestInjector() {
+  if (_testInjector == null) {
+    _testInjector = new TestInjector();
+  }
+  return _testInjector;
 }
 
 /**

--- a/modules/angular2/src/testing/testing_internal.ts
+++ b/modules/angular2/src/testing/testing_internal.ts
@@ -5,11 +5,7 @@ import {NgZoneZone} from 'angular2/src/core/zone/ng_zone';
 
 import {provide} from 'angular2/core';
 
-import {
-  createTestInjectorWithRuntimeCompiler,
-  FunctionWithParamTokens,
-  inject
-} from './test_injector';
+import {TestInjector, getTestInjector, FunctionWithParamTokens, inject} from './test_injector';
 import {browserDetection} from './utils';
 
 export {inject} from './test_injector';
@@ -45,7 +41,7 @@ var inIt = false;
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 500;
 var globalTimeOut = browserDetection.isSlow ? 3000 : jasmine.DEFAULT_TIMEOUT_INTERVAL;
 
-var testProviders;
+var testInjector = getTestInjector();
 
 /**
  * Mechanism to run `beforeEach()` functions of Angular tests.
@@ -59,16 +55,17 @@ class BeforeEachRunner {
 
   beforeEach(fn: FunctionWithParamTokens | SyncTestFn): void { this._fns.push(fn); }
 
-  run(injector): void {
-    if (this._parent) this._parent.run(injector);
+  run(): void {
+    if (this._parent) this._parent.run();
     this._fns.forEach((fn) => {
-      return isFunction(fn) ? (<SyncTestFn>fn)() : (<FunctionWithParamTokens>fn).execute(injector);
+      return isFunction(fn) ? (<SyncTestFn>fn)() :
+                              (testInjector.execute(<FunctionWithParamTokens>fn));
     });
   }
 }
 
 // Reset the test providers before each test
-jsmBeforeEach(() => { testProviders = []; });
+jsmBeforeEach(() => { testInjector.reset(); });
 
 function _describe(jsmFn, ...args) {
   var parentRunner = runnerStack.length === 0 ? null : runnerStack[runnerStack.length - 1];
@@ -117,7 +114,7 @@ export function beforeEachProviders(fn): void {
   jsmBeforeEach(() => {
     var providers = fn();
     if (!providers) return;
-    testProviders = [...testProviders, ...providers];
+    testInjector.addProviders(providers);
   });
 }
 
@@ -147,18 +144,17 @@ function _it(jsmFn: Function, name: string, testFn: FunctionWithParamTokens | An
           }
         });
 
-        var injector = createTestInjectorWithRuntimeCompiler([...testProviders, completerProvider]);
-        runner.run(injector);
+        testInjector.addProviders([completerProvider]);
+        runner.run();
 
         inIt = true;
-        testFn.execute(injector);
+        testInjector.execute(testFn);
         inIt = false;
       }, timeOut);
     } else {
       jsmFn(name, () => {
-        var injector = createTestInjectorWithRuntimeCompiler(testProviders);
-        runner.run(injector);
-        testFn.execute(injector);
+        runner.run();
+        testInjector.execute(testFn);
       }, timeOut);
     }
 
@@ -167,14 +163,12 @@ function _it(jsmFn: Function, name: string, testFn: FunctionWithParamTokens | An
 
     if ((<any>testFn).length === 0) {
       jsmFn(name, () => {
-        var injector = createTestInjectorWithRuntimeCompiler(testProviders);
-        runner.run(injector);
+        runner.run();
         (<SyncTestFn>testFn)();
       }, timeOut);
     } else {
       jsmFn(name, (done) => {
-        var injector = createTestInjectorWithRuntimeCompiler(testProviders);
-        runner.run(injector);
+        runner.run();
         (<AsyncTestFn>testFn)(done);
       }, timeOut);
     }

--- a/modules/angular2/test/web_workers/debug_tools/multi_client_server_message_bus.server.spec.dart
+++ b/modules/angular2/test/web_workers/debug_tools/multi_client_server_message_bus.server.spec.dart
@@ -11,7 +11,6 @@ import "package:angular2/testing_internal.dart"
         iit,
         expect,
         beforeEach,
-        createTestInjector,
         beforeEachProviders,
         SpyObject,
         proxy;

--- a/modules/angular2/test/web_workers/debug_tools/single_client_server_message_bus.server.spec.dart
+++ b/modules/angular2/test/web_workers/debug_tools/single_client_server_message_bus.server.spec.dart
@@ -10,7 +10,6 @@ import "package:angular2/testing_internal.dart"
         it,
         expect,
         beforeEach,
-        createTestInjector,
         beforeEachProviders,
         SpyObject,
         proxy;

--- a/modules/angular2/test/web_workers/debug_tools/web_socket_message_bus_spec.dart
+++ b/modules/angular2/test/web_workers/debug_tools/web_socket_message_bus_spec.dart
@@ -8,7 +8,6 @@ import "package:angular2/testing_internal.dart"
         it,
         expect,
         beforeEach,
-        createTestInjector,
         beforeEachProviders,
         SpyObject,
         proxy;

--- a/modules/angular2/test/web_workers/shared/message_bus_spec.ts
+++ b/modules/angular2/test/web_workers/shared/message_bus_spec.ts
@@ -5,7 +5,6 @@ import {
   it,
   expect,
   beforeEach,
-  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders,
   SpyObject,
   proxy

--- a/modules/angular2/test/web_workers/shared/service_message_broker_spec.ts
+++ b/modules/angular2/test/web_workers/shared/service_message_broker_spec.ts
@@ -5,7 +5,6 @@ import {
   it,
   expect,
   beforeEach,
-  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders,
   SpyObject,
   proxy

--- a/modules/angular2/test/web_workers/worker/event_dispatcher_spec.ts
+++ b/modules/angular2/test/web_workers/worker/event_dispatcher_spec.ts
@@ -5,7 +5,6 @@ import {
   it,
   expect,
   beforeEach,
-  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders,
   SpyObject,
   proxy

--- a/modules/angular2/test/web_workers/worker/renderer_integration_spec.ts
+++ b/modules/angular2/test/web_workers/worker/renderer_integration_spec.ts
@@ -7,8 +7,8 @@ import {
   iit,
   expect,
   beforeEach,
-  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders,
+  TestInjector,
   TestComponentBuilder
 } from "angular2/testing_internal";
 import {DOM} from 'angular2/src/platform/dom/dom_adapter';
@@ -102,12 +102,14 @@ export function main() {
     beforeEachProviders(() => {
       var uiRenderProtoViewStore = new RenderProtoViewRefStore(false);
       uiRenderViewStore = new RenderViewWithFragmentsStore(false);
-      uiInjector = createTestInjectorWithRuntimeCompiler([
+      var testInjector = new TestInjector();
+      testInjector.addProviders([
         provide(RenderProtoViewRefStore, {useValue: uiRenderProtoViewStore}),
         provide(RenderViewWithFragmentsStore, {useValue: uiRenderViewStore}),
         provide(DomRenderer, {useClass: DomRenderer_}),
         provide(Renderer, {useExisting: DomRenderer})
       ]);
+      uiInjector = testInjector.createInjector();
       var uiSerializer = uiInjector.get(Serializer);
       var domRenderer = uiInjector.get(DomRenderer);
       var workerRenderProtoViewStore = new RenderProtoViewRefStore(true);

--- a/modules/angular2/test/web_workers/worker/xhr_impl_spec.ts
+++ b/modules/angular2/test/web_workers/worker/xhr_impl_spec.ts
@@ -5,7 +5,6 @@ import {
   it,
   expect,
   beforeEach,
-  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders
 } from 'angular2/testing_internal';
 import {SpyMessageBroker} from './spies';


### PR DESCRIPTION
Before, all test framework wrappers (internal for dart and js/ts,
angular2_test for dart and testing for js/ts) had similar logic to
keep track of current global test injector and test provider list.
This change wraps that logic into one class managed by the test
injector.
