### PR TITLE
fix(angular2): don't export compiler bits as public API

### DIFF
--- a/modules/angular2/angular2.ts
+++ b/modules/angular2/angular2.ts
@@ -5,4 +5,3 @@ export * from './platform/browser';
 export * from './src/platform/dom/dom_adapter';
 export * from './src/platform/dom/events/event_manager';
 export * from './upgrade';
-export {UrlResolver, AppRootUrl, getUrlScheme, DEFAULT_PACKAGE_URL_PROVIDER} from './compiler';


### PR DESCRIPTION
Closes #5815

BREAKING CHANGE:

The following symbols are not exported from angular2/angular2 any more:
`UrlResolver`, `AppRootUrl`, `getUrlScheme`, `DEFAULT_PACKAGE_URL_PROVIDER`.
