### PR TITLE
chore(zone.js) : update to 0.5.10

### DIFF
--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -14761,7 +14761,7 @@
       }
     },
     "zone.js": {
-      "version": "0.5.8"
+      "version": "0.5.10"
     }
   },
   "name": "angular-srcs",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20730,29 +20730,29 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.2 <0.5.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
         },
         "source-map-support": {
           "version": "0.3.3",
-          "from": "source-map-support@>=0.3.1 <0.4.0",
+          "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
-              "from": "source-map@0.1.32",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
@@ -22644,9 +22644,9 @@
       }
     },
     "zone.js": {
-      "version": "0.5.8",
-      "from": "https://registry.npmjs.org/zone.js/-/zone.js-0.5.8.tgz",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.5.8.tgz"
+      "version": "0.5.10",
+      "from": "zone.js@0.5.10",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.5.10.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "es6-shim": "^0.33.3",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-alpha.14",
-    "zone.js": "0.5.8"
+    "zone.js": "0.5.10"
   },
   "devDependencies": {
     "angular": "^1.4.7",


### PR DESCRIPTION
Skipping 0.5.9 because of a bug ([details](https://github.com/angular/zone.js/pull/215)) -> this PR supersedes #5754
