### PR TITLE
[HtmlLexer] Add support for expressions in text nodes

### DIFF
--- a/modules/angular2/src/compiler/html_lexer.ts
+++ b/modules/angular2/src/compiler/html_lexer.ts
@@ -102,24 +102,24 @@ class ControlFlowError {
 
 // See http://www.w3.org/TR/html51/syntax.html#writing
 class _HtmlTokenizer {
-  private input: string;
-  private inputLowercase: string;
-  private length: number;
+  private _input: string;
+  private _inputLowercase: string;
+  private _length: number;
   // Note: this is always lowercase!
-  private peek: number = -1;
-  private index: number = -1;
-  private line: number = 0;
-  private column: number = -1;
-  private currentTokenStart: ParseLocation;
-  private currentTokenType: HtmlTokenType;
+  private _peek: number = -1;
+  private _index: number = -1;
+  private _line: number = 0;
+  private _column: number = -1;
+  private _currentTokenStart: ParseLocation;
+  private _currentTokenType: HtmlTokenType;
 
   tokens: HtmlToken[] = [];
   errors: HtmlTokenError[] = [];
 
-  constructor(private file: ParseSourceFile) {
-    this.input = file.content;
-    this.inputLowercase = file.content.toLowerCase();
-    this.length = file.content.length;
+  constructor(private _file: ParseSourceFile) {
+    this._input = _file.content;
+    this._inputLowercase = _file.content.toLowerCase();
+    this._length = _file.content.length;
     this._advance();
   }
 
@@ -132,7 +132,7 @@ class _HtmlTokenizer {
   }
 
   tokenize(): HtmlTokenizeResult {
-    while (this.peek !== $EOF) {
+    while (this._peek !== $EOF) {
       var start = this._getLocation();
       try {
         if (this._attemptChar($LT)) {
@@ -166,53 +166,53 @@ class _HtmlTokenizer {
   }
 
   private _getLocation(): ParseLocation {
-    return new ParseLocation(this.file, this.index, this.line, this.column);
+    return new ParseLocation(this._file, this._index, this._line, this._column);
   }
 
   private _beginToken(type: HtmlTokenType, start: ParseLocation = null) {
     if (isBlank(start)) {
       start = this._getLocation();
     }
-    this.currentTokenStart = start;
-    this.currentTokenType = type;
+    this._currentTokenStart = start;
+    this._currentTokenType = type;
   }
 
   private _endToken(parts: string[], end: ParseLocation = null): HtmlToken {
     if (isBlank(end)) {
       end = this._getLocation();
     }
-    var token = new HtmlToken(this.currentTokenType, parts,
-                              new ParseSourceSpan(this.currentTokenStart, end));
+    var token = new HtmlToken(this._currentTokenType, parts,
+                              new ParseSourceSpan(this._currentTokenStart, end));
     this.tokens.push(token);
-    this.currentTokenStart = null;
-    this.currentTokenType = null;
+    this._currentTokenStart = null;
+    this._currentTokenType = null;
     return token;
   }
 
   private _createError(msg: string, position: ParseLocation): ControlFlowError {
-    var error = new HtmlTokenError(msg, this.currentTokenType, position);
-    this.currentTokenStart = null;
-    this.currentTokenType = null;
+    var error = new HtmlTokenError(msg, this._currentTokenType, position);
+    this._currentTokenStart = null;
+    this._currentTokenType = null;
     return new ControlFlowError(error);
   }
 
   private _advance() {
-    if (this.index >= this.length) {
+    if (this._index >= this._length) {
       throw this._createError(unexpectedCharacterErrorMsg($EOF), this._getLocation());
     }
-    if (this.peek === $LF) {
-      this.line++;
-      this.column = 0;
-    } else if (this.peek !== $LF && this.peek !== $CR) {
-      this.column++;
+    if (this._peek === $LF) {
+      this._line++;
+      this._column = 0;
+    } else if (this._peek !== $LF && this._peek !== $CR) {
+      this._column++;
     }
-    this.index++;
-    this.peek = this.index >= this.length ? $EOF : StringWrapper.charCodeAt(this.inputLowercase,
-                                                                            this.index);
+    this._index++;
+    this._peek = this._index >= this._length ? $EOF : StringWrapper.charCodeAt(this._inputLowercase,
+                                                                               this._index);
   }
 
   private _attemptChar(charCode: number): boolean {
-    if (this.peek === charCode) {
+    if (this._peek === charCode) {
       this._advance();
       return true;
     }
@@ -222,7 +222,7 @@ class _HtmlTokenizer {
   private _requireChar(charCode: number) {
     var location = this._getLocation();
     if (!this._attemptChar(charCode)) {
-      throw this._createError(unexpectedCharacterErrorMsg(this.peek), location);
+      throw this._createError(unexpectedCharacterErrorMsg(this._peek), location);
     }
   }
 
@@ -238,12 +238,12 @@ class _HtmlTokenizer {
   private _requireChars(chars: string) {
     var location = this._getLocation();
     if (!this._attemptChars(chars)) {
-      throw this._createError(unexpectedCharacterErrorMsg(this.peek), location);
+      throw this._createError(unexpectedCharacterErrorMsg(this._peek), location);
     }
   }
 
   private _attemptUntilFn(predicate: Function) {
-    while (!predicate(this.peek)) {
+    while (!predicate(this._peek)) {
       this._advance();
     }
   }
@@ -251,24 +251,24 @@ class _HtmlTokenizer {
   private _requireUntilFn(predicate: Function, len: number) {
     var start = this._getLocation();
     this._attemptUntilFn(predicate);
-    if (this.index - start.offset < len) {
-      throw this._createError(unexpectedCharacterErrorMsg(this.peek), start);
+    if (this._index - start.offset < len) {
+      throw this._createError(unexpectedCharacterErrorMsg(this._peek), start);
     }
   }
 
   private _attemptUntilChar(char: number) {
-    while (this.peek !== char) {
+    while (this._peek !== char) {
       this._advance();
     }
   }
 
   private _readChar(decodeEntities: boolean): string {
-    if (decodeEntities && this.peek === $AMPERSAND) {
+    if (decodeEntities && this._peek === $AMPERSAND) {
       return this._decodeEntity();
     } else {
-      var index = this.index;
+      var index = this._index;
       this._advance();
-      return this.input[index];
+      return this._input[index];
     }
   }
 
@@ -279,27 +279,27 @@ class _HtmlTokenizer {
       let isHex = this._attemptChar($x);
       let numberStart = this._getLocation().offset;
       this._attemptUntilFn(isDigitEntityEnd);
-      if (this.peek != $SEMICOLON) {
-        throw this._createError(unexpectedCharacterErrorMsg(this.peek), this._getLocation());
+      if (this._peek != $SEMICOLON) {
+        throw this._createError(unexpectedCharacterErrorMsg(this._peek), this._getLocation());
       }
       this._advance();
-      let strNum = this.input.substring(numberStart, this.index - 1);
+      let strNum = this._input.substring(numberStart, this._index - 1);
       try {
         let charCode = NumberWrapper.parseInt(strNum, isHex ? 16 : 10);
         return StringWrapper.fromCharCode(charCode);
       } catch (e) {
-        let entity = this.input.substring(start.offset + 1, this.index - 1);
+        let entity = this._input.substring(start.offset + 1, this._index - 1);
         throw this._createError(unknownEntityErrorMsg(entity), start);
       }
     } else {
       let startPosition = this._savePosition();
       this._attemptUntilFn(isNamedEntityEnd);
-      if (this.peek != $SEMICOLON) {
+      if (this._peek != $SEMICOLON) {
         this._restorePosition(startPosition);
         return '&';
       }
       this._advance();
-      let name = this.input.substring(start.offset + 1, this.index - 1);
+      let name = this._input.substring(start.offset + 1, this._index - 1);
       let char = NAMED_ENTITIES[name];
       if (isBlank(char)) {
         throw this._createError(unknownEntityErrorMsg(name), start);
@@ -320,10 +320,10 @@ class _HtmlTokenizer {
       if (this._attemptChar(firstCharOfEnd) && attemptEndRest()) {
         break;
       }
-      if (this.index > tagCloseStart.offset) {
-        parts.push(this.input.substring(tagCloseStart.offset, this.index));
+      if (this._index > tagCloseStart.offset) {
+        parts.push(this._input.substring(tagCloseStart.offset, this._index));
       }
-      while (this.peek !== firstCharOfEnd) {
+      while (this._peek !== firstCharOfEnd) {
         parts.push(this._readChar(decodeEntities));
       }
     }
@@ -352,25 +352,25 @@ class _HtmlTokenizer {
     this._beginToken(HtmlTokenType.DOC_TYPE, start);
     this._attemptUntilChar($GT);
     this._advance();
-    this._endToken([this.input.substring(start.offset + 2, this.index - 1)]);
+    this._endToken([this._input.substring(start.offset + 2, this._index - 1)]);
   }
 
   private _consumePrefixAndName(): string[] {
-    var nameOrPrefixStart = this.index;
+    var nameOrPrefixStart = this._index;
     var prefix = null;
-    while (this.peek !== $COLON && !isPrefixEnd(this.peek)) {
+    while (this._peek !== $COLON && !isPrefixEnd(this._peek)) {
       this._advance();
     }
     var nameStart;
-    if (this.peek === $COLON) {
+    if (this._peek === $COLON) {
       this._advance();
-      prefix = this.input.substring(nameOrPrefixStart, this.index - 1);
-      nameStart = this.index;
+      prefix = this._input.substring(nameOrPrefixStart, this._index - 1);
+      nameStart = this._index;
     } else {
       nameStart = nameOrPrefixStart;
     }
-    this._requireUntilFn(isNameEnd, this.index === nameStart ? 1 : 0);
-    var name = this.input.substring(nameStart, this.index);
+    this._requireUntilFn(isNameEnd, this._index === nameStart ? 1 : 0);
+    var name = this._input.substring(nameStart, this._index);
     return [prefix, name];
   }
 
@@ -378,14 +378,14 @@ class _HtmlTokenizer {
     let savedPos = this._savePosition();
     let lowercaseTagName;
     try {
-      if (!isAsciiLetter(this.peek)) {
-        throw this._createError(unexpectedCharacterErrorMsg(this.peek), this._getLocation());
+      if (!isAsciiLetter(this._peek)) {
+        throw this._createError(unexpectedCharacterErrorMsg(this._peek), this._getLocation());
       }
-      var nameStart = this.index;
+      var nameStart = this._index;
       this._consumeTagOpenStart(start);
-      lowercaseTagName = this.inputLowercase.substring(nameStart, this.index);
+      lowercaseTagName = this._inputLowercase.substring(nameStart, this._index);
       this._attemptUntilFn(isNotWhitespace);
-      while (this.peek !== $SLASH && this.peek !== $GT) {
+      while (this._peek !== $SLASH && this._peek !== $GT) {
         this._consumeAttributeName();
         this._attemptUntilFn(isNotWhitespace);
         if (this._attemptChar($EQ)) {
@@ -444,19 +444,19 @@ class _HtmlTokenizer {
   private _consumeAttributeValue() {
     this._beginToken(HtmlTokenType.ATTR_VALUE);
     var value;
-    if (this.peek === $SQ || this.peek === $DQ) {
-      var quoteChar = this.peek;
+    if (this._peek === $SQ || this._peek === $DQ) {
+      var quoteChar = this._peek;
       this._advance();
       var parts = [];
-      while (this.peek !== quoteChar) {
+      while (this._peek !== quoteChar) {
         parts.push(this._readChar(true));
       }
       value = parts.join('');
       this._advance();
     } else {
-      var valueStart = this.index;
+      var valueStart = this._index;
       this._requireUntilFn(isNameEnd, 1);
-      value = this.input.substring(valueStart, this.index);
+      value = this._input.substring(valueStart, this._index);
     }
     this._endToken([this._processCarriageReturns(value)]);
   }
@@ -483,21 +483,21 @@ class _HtmlTokenizer {
     var start = this._getLocation();
     this._beginToken(HtmlTokenType.TEXT, start);
     var parts = [this._readChar(true)];
-    while (!isTextEnd(this.peek)) {
+    while (!isTextEnd(this._peek)) {
       parts.push(this._readChar(true));
     }
     this._endToken([this._processCarriageReturns(parts.join(''))]);
   }
 
   private _savePosition(): number[] {
-    return [this.peek, this.index, this.column, this.line, this.tokens.length];
+    return [this._peek, this._index, this._column, this._line, this.tokens.length];
   }
 
   private _restorePosition(position: number[]): void {
-    this.peek = position[0];
-    this.index = position[1];
-    this.column = position[2];
-    this.line = position[3];
+    this._peek = position[0];
+    this._index = position[1];
+    this._column = position[2];
+    this._line = position[3];
     let nbTokens = position[4];
     if (nbTokens < this.tokens.length) {
       // remove any extra tokens

--- a/modules/angular2/src/compiler/legacy_template.ts
+++ b/modules/angular2/src/compiler/legacy_template.ts
@@ -35,7 +35,7 @@ export class LegacyHtmlAstTransformer implements HtmlAstVisitor {
   rewrittenAst: HtmlAst[] = [];
   visitingTemplateEl: boolean = false;
 
-  constructor(private dashCaseSelectors?: string[]) {}
+  constructor(private _dashCaseSelectors?: string[]) {}
 
   visitElement(ast: HtmlElementAst, context: any): HtmlElementAst {
     this.visitingTemplateEl = ast.name.toLowerCase() == 'template';
@@ -191,7 +191,7 @@ export class LegacyHtmlAstTransformer implements HtmlAstVisitor {
       return new HtmlAttrAst(dashCaseToCamelCase(attrName), ast.value, ast.sourceSpan);
     }
 
-    if (isPresent(this.dashCaseSelectors) && this.dashCaseSelectors.indexOf(attrName) > -1) {
+    if (isPresent(this._dashCaseSelectors) && this._dashCaseSelectors.indexOf(attrName) > -1) {
       return new HtmlAttrAst(dashCaseToCamelCase(attrName), ast.value, ast.sourceSpan);
     }
 


### PR DESCRIPTION
Before this PR any mal-formed start tag would be interpreted as a text node. This behavior was introduced in the lexer so that we can use "<" in angular expressions:

`<p>{{ a < b ...}}</p>`

Note that "<" are not allowed in text nodes per html spec (browsers tolerate them)

This PR makes the `HtmlLexer` aware of expressions, they could contain any text and a _text token_ is emitted.

We can now report more detailed error when the start tag is malformed (see the added unit tests).

@tbosch let's discuss about this change next week.

Note: as of today expression delimiters (`{{` / `}}`) are hard-coded in the lexer - making them configurable should be part of a follow up PR.
