### PR TITLE
refactor(WebWorker): Make WebWorker bootstrap synchronous

### DIFF
--- a/modules/angular2/platform/worker_app.dart
+++ b/modules/angular2/platform/worker_app.dart
@@ -1,0 +1,14 @@
+library angular2.platform.worker_app;
+
+export "package:angular2/src/platform/worker_app_common.dart"
+    show WORKER_APP_PLATFORM, WORKER_APP_APPLICATION_COMMON;
+export "package:angular2/src/core/angular_entrypoint.dart"
+    show AngularEntrypoint;
+export "package:angular2/src/platform/worker_app.dart"
+    show WORKER_APP_APPLICATION, RENDER_SEND_PORT;
+export 'package:angular2/src/web_workers/shared/client_message_broker.dart'
+    show ClientMessageBroker, ClientMessageBrokerFactory, FnArg, UiArguments;
+export 'package:angular2/src/web_workers/shared/service_message_broker.dart'
+    show ReceivedMessage, ServiceMessageBroker, ServiceMessageBrokerFactory;
+export 'package:angular2/src/web_workers/shared/serializer.dart' show PRIMITIVE;
+export 'package:angular2/src/web_workers/shared/message_bus.dart';

--- a/modules/angular2/platform/worker_app.ts
+++ b/modules/angular2/platform/worker_app.ts
@@ -1,8 +1,8 @@
 export {
   WORKER_APP_PLATFORM,
-  genericWorkerAppProviders
+  WORKER_APP_APPLICATION_COMMON
 } from 'angular2/src/platform/worker_app_common';
-export * from 'angular2/src/platform/worker_app';
+export {WORKER_APP_APPLICATION} from 'angular2/src/platform/worker_app';
 export {
   ClientMessageBroker,
   ClientMessageBrokerFactory,

--- a/modules/angular2/src/platform/worker_app.dart
+++ b/modules/angular2/src/platform/worker_app.dart
@@ -3,19 +3,31 @@ library angular2.src.platform.worker_app;
 import 'package:angular2/src/core/zone/ng_zone.dart';
 import 'package:angular2/src/platform/server/webworker_adapter.dart';
 import 'package:angular2/src/platform/worker_app_common.dart';
+import 'package:angular2/core.dart';
 import 'package:angular2/src/web_workers/shared/isolate_message_bus.dart';
+import 'package:angular2/src/web_workers/shared/message_bus.dart';
 import 'dart:isolate';
 
-setupIsolate(SendPort replyTo) {
-  return (NgZone zone) {
-    WebWorkerDomAdapter.makeCurrent();
+const OpaqueToken RENDER_SEND_PORT = const OpaqueToken("RenderSendPort");
 
-    ReceivePort rPort = new ReceivePort();
-    var sink = new WebWorkerMessageBusSink(replyTo, rPort);
-    var source = new IsolateMessageBusSource(rPort);
-    IsolateMessageBus bus = new IsolateMessageBus(sink, source);
-    return genericWorkerAppProviders(bus, zone);
-  };
+const List<dynamic> WORKER_APP_APPLICATION = const [
+  WORKER_APP_APPLICATION_COMMON,
+  const Provider(MessageBus,
+      useFactory: createMessageBus, deps: const [NgZone, RENDER_SEND_PORT]),
+  const Provider(APP_INITIALIZER, useValue: setupIsolate, multi: true)
+];
+
+MessageBus createMessageBus(NgZone zone, SendPort replyTo) {
+  ReceivePort rPort = new ReceivePort();
+  var sink = new WebWorkerMessageBusSink(replyTo, rPort);
+  var source = new IsolateMessageBusSource(rPort);
+  var bus = new IsolateMessageBus(sink, source);
+  bus.attachToZone(zone);
+  return bus;
+}
+
+setupIsolate() {
+  WebWorkerDomAdapter.makeCurrent();
 }
 
 class WebWorkerMessageBusSink extends IsolateMessageBusSink {

--- a/modules/angular2/src/platform/worker_app_common.ts
+++ b/modules/angular2/src/platform/worker_app_common.ts
@@ -1,9 +1,7 @@
 import {XHR} from 'angular2/src/compiler/xhr';
 import {WebWorkerXHRImpl} from 'angular2/src/web_workers/worker/xhr_impl';
-import {ListWrapper} from 'angular2/src/facade/collection';
 import {WebWorkerRenderer} from 'angular2/src/web_workers/worker/renderer';
 import {print, Type, CONST_EXPR, isPresent} from 'angular2/src/facade/lang';
-import {MessageBus} from 'angular2/src/web_workers/shared/message_bus';
 import {Renderer} from 'angular2/src/core/render/api';
 import {
   PLATFORM_DIRECTIVES,
@@ -30,8 +28,6 @@ import {
   RenderViewWithFragmentsStore
 } from 'angular2/src/web_workers/shared/render_view_with_fragments_store';
 import {WebWorkerEventDispatcher} from 'angular2/src/web_workers/worker/event_dispatcher';
-import {NgZone} from 'angular2/src/core/zone/ng_zone';
-import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
 
 class PrintLogger {
   log = print;
@@ -43,7 +39,7 @@ class PrintLogger {
 export const WORKER_APP_PLATFORM: Array<any /*Type | Provider | any[]*/> =
     CONST_EXPR([PLATFORM_COMMON_PROVIDERS]);
 
-export const WORKER_APP_COMMON_PROVIDERS: Array<any /*Type | Provider | any[]*/> = CONST_EXPR([
+export const WORKER_APP_APPLICATION_COMMON: Array<any /*Type | Provider | any[]*/> = CONST_EXPR([
   APPLICATION_COMMON_PROVIDERS,
   COMPILER_PROVIDERS,
   FORM_PROVIDERS,
@@ -65,18 +61,4 @@ export const WORKER_APP_COMMON_PROVIDERS: Array<any /*Type | Provider | any[]*/>
 
 function _exceptionHandler(): ExceptionHandler {
   return new ExceptionHandler(new PrintLogger());
-}
-
-/**
- * Asynchronously returns a list of providers that can be used to initialize the
- * Application injector.
- * Also takes care of attaching the {@link MessageBus} to the given {@link NgZone}.
- */
-export function genericWorkerAppProviders(bus: MessageBus,
-                                          zone: NgZone): Promise<Array<Type | Provider | any[]>> {
-  bus.attachToZone(zone);
-  var bindings = ListWrapper.concat(WORKER_APP_COMMON_PROVIDERS, [
-    new Provider(MessageBus, {useValue: bus}),
-  ]);
-  return PromiseWrapper.resolve(bindings);
 }

--- a/modules/angular2/src/web_workers/debug_tools/multi_client_server_message_bus.dart
+++ b/modules/angular2/src/web_workers/debug_tools/multi_client_server_message_bus.dart
@@ -84,7 +84,7 @@ class WebSocketWrapper {
     _socket.addStream(_sendStream.stream);
   }
 
-  void send (String data) {
+  void send(String data) {
     _sendStream.add(data);
   }
 

--- a/modules/angular2/src/web_workers/shared/generic_message_bus.dart
+++ b/modules/angular2/src/web_workers/shared/generic_message_bus.dart
@@ -9,15 +9,12 @@ import 'package:angular2/src/facade/lang.dart';
 import 'package:angular2/src/facade/exceptions.dart';
 
 class GenericMessageBus implements MessageBus {
-  final MessageBusSink _sink;
-  final MessageBusSource _source;
-
-  MessageBusSink get sink => _sink;
-  MessageBusSource get source => _source;
+  MessageBusSink sink;
+  MessageBusSource source;
 
   GenericMessageBus(MessageBusSink sink, MessageBusSource source)
-      : _sink = sink,
-        _source = source;
+      : sink = sink,
+        source = source;
 
   void attachToZone(NgZone zone) {
     sink.attachToZone(zone);

--- a/modules/angular2/test/web_workers/debug_tools/bootstrap.server.spec.dart
+++ b/modules/angular2/test/web_workers/debug_tools/bootstrap.server.spec.dart
@@ -4,7 +4,7 @@ import 'package:angular2/src/platform/server/html_adapter.dart';
 import "package:angular2/testing_internal.dart";
 import "package:angular2/src/core/reflection/reflection_capabilities.dart";
 import "package:angular2/src/core/reflection/reflection.dart";
-import "package:angular2/src/platform/worker_app_common.dart" show WORKER_APP_COMMON_PROVIDERS;
+import "package:angular2/src/platform/worker_app_common.dart" show WORKER_APP_APPLICATION_COMMON;
 import "package:angular2/platform/worker_app.dart" show WORKER_APP_PLATFORM;
 import "package:angular2/core.dart";
 import "../shared/web_worker_test_util.dart";
@@ -19,7 +19,7 @@ main() {
       reflector.reflectionCapabilities = new ReflectionCapabilities();
       var buses = createPairedMessageBuses();
       platform([WORKER_APP_PLATFORM])
-      .application([WORKER_APP_COMMON_PROVIDERS]);
+      .application([WORKER_APP_APPLICATION_COMMON]);
     });
   });
 }

--- a/modules/playground/src/web_workers/images/background_index.dart
+++ b/modules/playground/src/web_workers/images/background_index.dart
@@ -9,7 +9,7 @@ import "package:angular2/src/core/reflection/reflection.dart";
 
 main(List<String> args, SendPort replyTo) {
   reflector.reflectionCapabilities = new ReflectionCapabilities();
-  platform([WORKER_APP_PLATFORM])
-      .asyncApplication(setupIsolate(replyTo))
-      .then((ref) => ref.bootstrap(ImageDemo));
+  platform([WORKER_APP_PLATFORM, new Provider(RENDER_SEND_PORT, useValue: replyTo)])
+      .application([WORKER_APP_APPLICATION])
+      .bootstrap(ImageDemo);
 }

--- a/modules/playground/src/web_workers/images/background_index.ts
+++ b/modules/playground/src/web_workers/images/background_index.ts
@@ -1,9 +1,7 @@
 import {ImageDemo} from "./index_common";
 import {platform} from "angular2/core";
-import {WORKER_APP_PLATFORM, setupWebWorker} from "angular2/platform/worker_app";
+import {WORKER_APP_PLATFORM, WORKER_APP_APPLICATION} from "angular2/platform/worker_app";
 
 export function main() {
-  platform([WORKER_APP_PLATFORM])
-      .asyncApplication(setupWebWorker)
-      .then((ref) => ref.bootstrap(ImageDemo));
+  platform([WORKER_APP_PLATFORM]).application([WORKER_APP_APPLICATION]).bootstrap(ImageDemo)
 }

--- a/modules/playground/src/web_workers/kitchen_sink/background_index.dart
+++ b/modules/playground/src/web_workers/kitchen_sink/background_index.dart
@@ -9,7 +9,7 @@ import "package:angular2/src/core/reflection/reflection.dart";
 
 main(List<String> args, SendPort replyTo) {
   reflector.reflectionCapabilities = new ReflectionCapabilities();
-  platform([WORKER_APP_PLATFORM])
-      .asyncApplication(setupIsolate(replyTo))
-      .then((ref) => ref.bootstrap(HelloCmp));
+  platform([WORKER_APP_PLATFORM, new Provider(RENDER_SEND_PORT, useValue: replyTo)])
+      .application([WORKER_APP_APPLICATION])
+      .bootstrap(HelloCmp);
 }

--- a/modules/playground/src/web_workers/kitchen_sink/background_index.ts
+++ b/modules/playground/src/web_workers/kitchen_sink/background_index.ts
@@ -1,9 +1,7 @@
 import {HelloCmp} from "./index_common";
 import {platform} from "angular2/core";
-import {WORKER_APP_PLATFORM, setupWebWorker} from "angular2/platform/worker_app";
+import {WORKER_APP_PLATFORM, WORKER_APP_APPLICATION} from "angular2/platform/worker_app";
 
 export function main() {
-  platform([WORKER_APP_PLATFORM])
-      .asyncApplication(setupWebWorker)
-      .then((ref) => ref.bootstrap(HelloCmp));
+  platform([WORKER_APP_PLATFORM]).application([WORKER_APP_APPLICATION]).bootstrap(HelloCmp);
 }

--- a/modules/playground/src/web_workers/message_broker/background_index.dart
+++ b/modules/playground/src/web_workers/message_broker/background_index.dart
@@ -9,7 +9,7 @@ import "dart:isolate";
 
 main(List<String> args, SendPort replyTo) {
   reflector.reflectionCapabilities = new ReflectionCapabilities();
-  platform([WORKER_APP_PLATFORM])
-    .asyncApplication(setupIsolate(replyTo))
-    .then((ref) => ref.bootstrap(App));
+  platform([WORKER_APP_PLATFORM, new Provider(RENDER_SEND_PORT, useValue: replyTo)])
+    .application([WORKER_APP_APPLICATION])
+    .bootstrap(App);
 }

--- a/modules/playground/src/web_workers/message_broker/background_index.ts
+++ b/modules/playground/src/web_workers/message_broker/background_index.ts
@@ -1,9 +1,7 @@
 import {platform} from "angular2/core";
-import {WORKER_APP_PLATFORM, setupWebWorker} from "angular2/platform/worker_app";
+import {WORKER_APP_PLATFORM, WORKER_APP_APPLICATION} from "angular2/platform/worker_app";
 import {App} from "./index_common";
 
 export function main() {
-  platform([WORKER_APP_PLATFORM])
-      .asyncApplication(setupWebWorker)
-      .then((ref) => ref.bootstrap(App));
+  platform([WORKER_APP_PLATFORM]).application([WORKER_APP_APPLICATION]).bootstrap(App)
 }

--- a/modules/playground/src/web_workers/todo/background_index.dart
+++ b/modules/playground/src/web_workers/todo/background_index.dart
@@ -9,7 +9,7 @@ import "package:angular2/src/core/reflection/reflection.dart";
 
 main(List<String> args, SendPort replyTo) {
   reflector.reflectionCapabilities = new ReflectionCapabilities();
-  platform([WORKER_APP_PLATFORM])
-      .asyncApplication(setupIsolate(replyTo))
-      .then((ref) => ref.bootstrap(TodoApp));
+  platform([WORKER_APP_PLATFORM, new Provider(RENDER_SEND_PORT, useValue: replyTo)])
+      .application([WORKER_APP_APPLICATION])
+      .bootstrap(TodoApp);
 }

--- a/modules/playground/src/web_workers/todo/background_index.ts
+++ b/modules/playground/src/web_workers/todo/background_index.ts
@@ -1,9 +1,7 @@
 import {TodoApp} from "./index_common";
 import {platform} from "angular2/core";
-import {WORKER_APP_PLATFORM, setupWebWorker} from "angular2/platform/worker_app";
+import {WORKER_APP_PLATFORM, WORKER_APP_APPLICATION} from "angular2/platform/worker_app";
 
 export function main() {
-  platform([WORKER_APP_PLATFORM])
-      .asyncApplication(setupWebWorker)
-      .then((ref) => ref.bootstrap(TodoApp));
+  platform([WORKER_APP_PLATFORM]).application([WORKER_APP_APPLICATION]).bootstrap(TodoApp)
 }

--- a/modules/playground/src/web_workers/todo/server_index.dart
+++ b/modules/playground/src/web_workers/todo/server_index.dart
@@ -5,24 +5,28 @@ import "package:angular2/src/web_workers/debug_tools/multi_client_server_message
 import "package:angular2/platform/worker_app.dart";
 import "package:angular2/core.dart";
 import 'dart:io';
-import 'dart:async';
 import "package:angular2/src/core/reflection/reflection_capabilities.dart";
 import "package:angular2/src/core/reflection/reflection.dart";
 import "package:angular2/src/platform/server/html_adapter.dart";
 
 void main() {
-  reflector.reflectionCapabilities = new ReflectionCapabilities(); 
-  platform([WORKER_APP_PLATFORM])
-  .asyncApplication(initAppThread)
-  .then((ref) => ref.bootstrap(TodoApp));
-}
-
-Future<dynamic> initAppThread(NgZone zone) {
-  Html5LibDomAdapter.makeCurrent();
-  return HttpServer.bind('127.0.0.1', 1337).then((HttpServer server) {
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  HttpServer.bind('127.0.0.1', 1337).then((HttpServer server) {
     print("Server Listening for requests on 127.0.0.1:1337");
     var bus = new MultiClientServerMessageBus.fromHttpServer(server);
-    return genericWorkerAppProviders(bus, zone);
+
+    platform([WORKER_APP_PLATFORM]).application([
+      WORKER_APP_APPLICATION_COMMON,
+      new Provider(MessageBus, useValue: bus),
+      new Provider(APP_INITIALIZER,
+          useFactory: initAppThread, multi: true, deps: [NgZone, MessageBus])
+    ]).bootstrap(TodoApp);
   });
 }
 
+initAppThread(NgZone zone, MessageBus bus) {
+  return () {
+    Html5LibDomAdapter.makeCurrent();
+    bus.attachToZone(zone);
+  };
+}


### PR DESCRIPTION
Previously bootstrap needed to be async because of AppRootUrl's setup. Now that we've removed that we can make bootstrap synchronous.

BREAKING CHANGE

From the app thread, in both TypeScript and Dart, you bootstrap the app
using `application` instead of `asyncApplication`.
Before:

``` TypeScript
platform([WORKER_APP_PLATFORM])
.asyncApplication(setupWebWorker, optionalProviders?)
.then((ref) => ref.bootstrap(RootComponent));
```

Now:

``` TypeScript
platform([WORKER_APP_PLATFORM])
.application([WORKER_APP_APPLICATION])
.bootstrap(RootComponent);
```

closes #5857
