### PR TITLE
build(publish.sh): do not error when tmp/code.angularjs.org already e…

### DIFF
--- a/tools/code.angularjs.org/publish.sh
+++ b/tools/code.angularjs.org/publish.sh
@@ -26,8 +26,23 @@ function init {
 
 function prepare {
 
-  echo "-- Cloning code.angularjs.org"
-  git clone git@github.com:angular/code.angularjs.org.git $REPO_DIR --depth=1
+
+
+  if [ -d "$REPO_DIR" ]; then
+    # TODO(i): it's not clear how to safely fetch and update a shallow clone
+    #          I'll need to test this during the next release
+    echo "-- TODO: Update code.angularjs.org repo at $REPO_DIR"
+    echo "-- TODO: if pushing the 'publish' action fails, rebase the repo manually and push"
+    echo "-- TODO: or delete $REPO_DIR and rerun the prepare and publish steps"
+    #cd $REPO_DIR
+    #git fetch --update-shallow origin
+    #git checkout master
+    #git merge --ff-only origin/master
+    #cd -
+  else
+    echo "-- Cloning code.angularjs.org into $REPO_DIR"
+    git clone git@github.com:angular/code.angularjs.org.git $REPO_DIR --depth=1
+  fi
 
   echo "-- Updating code.angularjs.org"
 


### PR DESCRIPTION
…xists

I'm not sure what's the best way to update the shallow repo and I'm in a state where there is nothing to be
updated so I'll revisit the proper fix the next time I'm doing a release unless someone beats me to it.
