### PR TITLE
fix(code size): revert previous devMode change to restore size targets

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -638,7 +638,7 @@ gulp.task('test.unit.dart', function(done) {
 // This test will fail if the size of our hello_world app goes beyond one of
 // these values when compressed at the specified level.
 // Measure in bytes.
-var _DART_PAYLOAD_SIZE_LIMITS = {'uncompressed': 375 * 1024, 'gzip level=6': 105 * 1024};
+var _DART_PAYLOAD_SIZE_LIMITS = {'uncompressed': 320 * 1024, 'gzip level=6': 90 * 1024};
 gulp.task('test.payload.dart/ci', function(done) {
   runSequence('build/packages.dart', '!pubget.payload.dart', '!pubbuild.payload.dart',
               '!checkAndReport.payload.dart', done);

--- a/modules/angular2/src/facade/lang.dart
+++ b/modules/angular2/src/facade/lang.dart
@@ -249,38 +249,34 @@ bool isJsObject(o) {
   return false;
 }
 
-bool _forceDevMode = true;
-bool _modeLocked = false;
+// Functions below are noop in Dart. Imperatively controlling dev mode kills
+// tree shaking. We should only rely on `assertionsEnabled`.
+@Deprecated('Do not use this function. It is for JS only. There is no alternative.')
+void lockMode() {}
+@Deprecated('Do not use this function. It is for JS only. There is no alternative.')
+void enableDevMode() {}
+@Deprecated('Do not use this function. It is for JS only. There is no alternative.')
+void enableProdMode() {}
 
-void lockMode() {
-  _modeLocked = true;
-}
-
-@deprecated
-void enableDevMode() {
-  if (_forceDevMode) {
-    return;
-  }
-  if (_modeLocked) {
-    throw new Exception("Cannot enable dev mode after platform setup.");
-  }
-  _forceDevMode = true;
-}
-
-void enableProdMode() {
-  if (_forceDevMode) {
-    return;
-  }
-  if (_modeLocked) {
-    throw new Exception("Cannot enable prod mode after platform setup.");
-  }
-  _forceDevMode = false;
-}
-
+/// Use this function to guard debugging code. When Dart is compiled in
+/// production mode, the code guarded using this function will be tree
+/// shaken away, reducing code size.
+///
+/// WARNING: DO NOT CHANGE THIS METHOD! This method is designed to have no
+/// more AST nodes than the maximum allowed by dart2js to inline it. In
+/// addition, the use of `assert` allows the compiler to statically compute
+/// the value returned by this function and tree shake conditions guarded by
+/// it.
+///
+/// Example:
+///
+/// if (assertionsEnabled()) {
+///   ...code here is tree shaken away in prod mode...
+/// }
 bool assertionsEnabled() {
   var k = false;
   assert((k = true));
-  return _forceDevMode || k;
+  return k;
 }
 
 // Can't be all uppercase as our transpiler would think it is a special directive...


### PR DESCRIPTION
This commit reverts https://github.com/angular/angular/commit/a8d9dbf110496075617b956654894cf3e7f0d190 that introduced a code size regression (16kb gzipped, 63kb minified) in Dart.

Effect on the hello world app:

gzipped: 105kb -> 89kb
minified: 370kb -> 317kb

BREAKING CHANGE:
- This is very unlikely to be breaking, but I'm still marking just in case. The only change to the user should be that dev mode is driven by Dart's checked mode, like it was in the past.

Closes #5883
Closes #5888
