### PR TITLE
refactor(testing): move common testing logic into test_injector

### DIFF
--- a/modules/angular2/src/testing/test_injector.ts
+++ b/modules/angular2/src/testing/test_injector.ts
@@ -23,7 +23,7 @@ import {
   defaultKeyValueDiffers,
   ChangeDetectorGenConfig
 } from 'angular2/src/core/change_detection/change_detection';
-import {ExceptionHandler} from 'angular2/src/facade/exceptions';
+import {BaseException, ExceptionHandler} from 'angular2/src/facade/exceptions';
 import {PipeResolver} from 'angular2/src/core/linker/pipe_resolver';
 import {XHR} from 'angular2/src/compiler/xhr';
 
@@ -131,11 +131,62 @@ function _runtimeCompilerBindings() {
   ];
 }
 
+export class TestInjector {
+  private _instantiated: boolean = false;
+
+  private _injector: Injector = null;
+
+  private _providers: Array<Type | Provider | any[]> = [];
+
+  reset() {
+    this._injector = null;
+    this._providers = [];
+    this._instantiated = false;
+  }
+
+  addProviders(providers: Array<Type | Provider | any[]>) {
+    if (this._instantiated) {
+      throw new BaseException('Cannot add providers after test injector is instantiated');
+    }
+    this._providers = ListWrapper.concat(this._providers, providers);
+  }
+
+  createInjector() {
+    var rootInjector = Injector.resolveAndCreate(_getRootProviders());
+    this._injector = rootInjector.resolveAndCreateChild(ListWrapper.concat(
+        ListWrapper.concat(_getAppBindings(), _runtimeCompilerBindings()), this._providers));
+    this._instantiated = true;
+    return this._injector;
+  }
+
+  execute(fn: FunctionWithParamTokens): any {
+    if (!this._instantiated) {
+      this.createInjector();
+    }
+    return fn.execute(this._injector);
+  }
+}
+
+var _testInjector: TestInjector = null;
+
+export function getTestInjector() {
+  if (_testInjector == null) {
+    _testInjector = new TestInjector();
+  }
+  return _testInjector;
+}
+
+/**
+ * @deprecated Use TestInjector#createInjector() instead.
+ */
 export function createTestInjector(providers: Array<Type | Provider | any[]>): Injector {
   var rootInjector = Injector.resolveAndCreate(_getRootProviders());
   return rootInjector.resolveAndCreateChild(ListWrapper.concat(_getAppBindings(), providers));
 }
 
+/**
+ * @deprecated Use TestInjector#createInjector() instead.
+ */
 export function createTestInjectorWithRuntimeCompiler(
     providers: Array<Type | Provider | any[]>): Injector {
   return createTestInjector(ListWrapper.concat(_runtimeCompilerBindings(), providers));
@@ -159,7 +210,8 @@ export function createTestInjectorWithRuntimeCompiler(
  * ```
  *
  * Notes:
- * - inject is currently a function because of some Traceur limitation the syntax should eventually
+ * - inject is currently a function because of some Traceur limitation the syntax should
+ * eventually
  *   becomes `it('...', @Inject (object: AClass, async: AsyncTestCompleter) => { ... });`
  *
  * @param {Array} tokens

--- a/modules/angular2/test/web_workers/debug_tools/multi_client_server_message_bus.server.spec.dart
+++ b/modules/angular2/test/web_workers/debug_tools/multi_client_server_message_bus.server.spec.dart
@@ -11,7 +11,6 @@ import "package:angular2/testing_internal.dart"
         iit,
         expect,
         beforeEach,
-        createTestInjector,
         beforeEachProviders,
         SpyObject,
         proxy;

--- a/modules/angular2/test/web_workers/debug_tools/single_client_server_message_bus.server.spec.dart
+++ b/modules/angular2/test/web_workers/debug_tools/single_client_server_message_bus.server.spec.dart
@@ -10,7 +10,6 @@ import "package:angular2/testing_internal.dart"
         it,
         expect,
         beforeEach,
-        createTestInjector,
         beforeEachProviders,
         SpyObject,
         proxy;

--- a/modules/angular2/test/web_workers/debug_tools/web_socket_message_bus_spec.dart
+++ b/modules/angular2/test/web_workers/debug_tools/web_socket_message_bus_spec.dart
@@ -8,7 +8,6 @@ import "package:angular2/testing_internal.dart"
         it,
         expect,
         beforeEach,
-        createTestInjector,
         beforeEachProviders,
         SpyObject,
         proxy;

--- a/modules/angular2/test/web_workers/shared/message_bus_spec.ts
+++ b/modules/angular2/test/web_workers/shared/message_bus_spec.ts
@@ -5,7 +5,6 @@ import {
   it,
   expect,
   beforeEach,
-  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders,
   SpyObject,
   proxy

--- a/modules/angular2/test/web_workers/shared/service_message_broker_spec.ts
+++ b/modules/angular2/test/web_workers/shared/service_message_broker_spec.ts
@@ -5,7 +5,6 @@ import {
   it,
   expect,
   beforeEach,
-  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders,
   SpyObject,
   proxy

--- a/modules/angular2/test/web_workers/worker/event_dispatcher_spec.ts
+++ b/modules/angular2/test/web_workers/worker/event_dispatcher_spec.ts
@@ -5,7 +5,6 @@ import {
   it,
   expect,
   beforeEach,
-  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders,
   SpyObject,
   proxy

--- a/modules/angular2/test/web_workers/worker/renderer_integration_spec.ts
+++ b/modules/angular2/test/web_workers/worker/renderer_integration_spec.ts
@@ -7,8 +7,8 @@ import {
   iit,
   expect,
   beforeEach,
-  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders,
+  TestInjector,
   TestComponentBuilder
 } from "angular2/testing_internal";
 import {DOM} from 'angular2/src/platform/dom/dom_adapter';
@@ -102,12 +102,14 @@ export function main() {
     beforeEachProviders(() => {
       var uiRenderProtoViewStore = new RenderProtoViewRefStore(false);
       uiRenderViewStore = new RenderViewWithFragmentsStore(false);
-      uiInjector = createTestInjectorWithRuntimeCompiler([
+      var testInjector = new TestInjector();
+      testInjector.addProviders([
         provide(RenderProtoViewRefStore, {useValue: uiRenderProtoViewStore}),
         provide(RenderViewWithFragmentsStore, {useValue: uiRenderViewStore}),
         provide(DomRenderer, {useClass: DomRenderer_}),
         provide(Renderer, {useExisting: DomRenderer})
       ]);
+      uiInjector = testInjector.createInjector();
       var uiSerializer = uiInjector.get(Serializer);
       var domRenderer = uiInjector.get(DomRenderer);
       var workerRenderProtoViewStore = new RenderProtoViewRefStore(true);

--- a/modules/angular2/test/web_workers/worker/xhr_impl_spec.ts
+++ b/modules/angular2/test/web_workers/worker/xhr_impl_spec.ts
@@ -5,7 +5,6 @@ import {
   it,
   expect,
   beforeEach,
-  createTestInjectorWithRuntimeCompiler,
   beforeEachProviders
 } from 'angular2/testing_internal';
 import {SpyMessageBroker} from './spies';


### PR DESCRIPTION
Before, all test framework wrappers (internal for dart and js/ts,
angular2_test for dart and testing for js/ts) had similar logic to
keep track of current global test injector and test provider list.
This change wraps that logic into one class managed by the test
injector.
