### PR TITLE
docs: Remove text about Dart Editor bundle; clean up text

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -32,16 +32,14 @@ following products on your development machine:
   (version `>=3.5.3 <4.0`), which comes with Node. Depending on your system, you can install Node either from
   source or as a pre-packaged bundle.
 
-* *Optional*: [Dart](https://www.dartlang.org) (version ` >=1.13.2 <2.0.0`), specifically the Dart-SDK and
+* *Optional*: [Dart](https://www.dartlang.org) (version `>=1.13.2 <2.0.0`), specifically the Dart SDK and
   Dartium (a version of [Chromium](http://www.chromium.org) with native support for Dart through
-  the Dart VM). One of the **simplest** ways to get both is to install the **Dart Editor bundle**,
-  which includes the editor, SDK and Dartium. See the [Dart tools](https://www.dartlang.org/tools)
-  download [page for instructions](https://www.dartlang.org/tools/download.html).  
-  You can also download both **stable** and **dev** channel versions from the [download
-  archive](https://www.dartlang.org/tools/download-archive). In that case, on Windows, Dart must be added
-  to the `Path` (e.g. `path-to-dart-sdk-folder\bin`) and a new `DARTIUM_BIN` environment variable must be
-  created, pointing to the executable (e.g. `path-to-dartium-folder\chrome.exe).`
-
+  the Dart VM). Visit Dart's [Downloads page](https://www.dartlang.org/downloads) page for
+  instructions. You can also download both **stable** and **dev** channel versions from the
+  [download archive](https://www.dartlang.org/downloads/archive/). In that case, on Windows, Dart
+  must be added to the `PATH` (e.g. `path-to-dart-sdk-folder\bin`) and a new `DARTIUM_BIN`
+  environment variable must be created, pointing to the executable (e.g.
+  `path-to-dartium-folder\chrome.exe`).
 
 
 ## Getting the Sources


### PR DESCRIPTION
- Remove text about Dart Editor bundle.
- Fix links.
- Fix some grammar and Markdown formatting.
