### PR TITLE
fix(router): preserve specificity for redirects

### DIFF
--- a/modules/angular2/src/router/instruction.ts
+++ b/modules/angular2/src/router/instruction.ts
@@ -281,9 +281,11 @@ export class UnresolvedInstruction extends Instruction {
 
 export class RedirectInstruction extends ResolvedInstruction {
   constructor(component: ComponentInstruction, child: Instruction,
-              auxInstruction: {[key: string]: Instruction}) {
+              auxInstruction: {[key: string]: Instruction}, private _specificity: string) {
     super(component, child, auxInstruction);
   }
+
+  get specificity(): string { return this._specificity; }
 }
 
 

--- a/modules/angular2/src/router/route_registry.ts
+++ b/modules/angular2/src/router/route_registry.ts
@@ -205,7 +205,7 @@ export class RouteRegistry {
             var instruction =
                 this.generate(candidate.redirectTo, ancestorInstructions.concat([null]));
             return new RedirectInstruction(instruction.component, instruction.child,
-                                           instruction.auxInstruction);
+                                           instruction.auxInstruction, candidate.specificity);
           }
         }));
 

--- a/modules/angular2/test/router/integration/impl/fixture_components.ts
+++ b/modules/angular2/test/router/integration/impl/fixture_components.ts
@@ -10,6 +10,12 @@ import {
 } from 'angular2/router';
 import {PromiseWrapper} from 'angular2/src/facade/async';
 
+@Component({selector: 'goodbye-cmp', template: `{{farewell}}`})
+export class GoodbyeCmp {
+  farewell: string;
+  constructor() { this.farewell = 'goodbye'; }
+}
+
 @Component({selector: 'hello-cmp', template: `{{greeting}}`})
 export class HelloCmp {
   greeting: string;

--- a/modules/angular2/test/router/integration/redirect_route_spec.ts
+++ b/modules/angular2/test/router/integration/redirect_route_spec.ts
@@ -25,7 +25,7 @@ import {
 } from 'angular2/src/router/route_config_decorator';
 
 import {TEST_ROUTER_PROVIDERS, RootCmp, compile} from './util';
-import {HelloCmp, RedirectToParentCmp} from './impl/fixture_components';
+import {HelloCmp, GoodbyeCmp, RedirectToParentCmp} from './impl/fixture_components';
 
 var cmpInstanceCount;
 var childCmpInstanceCount;
@@ -114,6 +114,25 @@ export function main() {
                rootTC.detectChanges();
                expect(rootTC.debugElement.nativeElement).toHaveText('hello');
                expect(location.urlChanges).toEqual(['/redirected']);
+               async.done();
+             });
+       }));
+
+
+    it('should not redirect when redirect is less specific than other matching routes',
+       inject([AsyncTestCompleter, Location], (async, location) => {
+         compile(tcb)
+             .then((rtc) => {rootTC = rtc})
+             .then((_) => rtr.config([
+               new Route({path: '/foo', component: HelloCmp, name: 'Hello'}),
+               new Route({path: '/:param', component: GoodbyeCmp, name: 'Goodbye'}),
+               new Redirect({path: '/*rest', redirectTo: ['/Hello']})
+             ]))
+             .then((_) => rtr.navigateByUrl('/bye'))
+             .then((_) => {
+               rootTC.detectChanges();
+               expect(rootTC.debugElement.nativeElement).toHaveText('goodbye');
+               expect(location.urlChanges).toEqual(['/bye']);
                async.done();
              });
        }));


### PR DESCRIPTION
Previously when comparing which of multiple possible routes to choose in an ambiguous case, we looked at the specificity of the target of redirect matches rather than the original match. This meant that if a redirect used a wildcard, but redirected to a target that was a static path, we'd count the static path's specificity instead of the wildcard.

This change stores the specificity of the redirect on the `RedirectInstruction`.
