### PR TITLE
test(dart/transform): Update e2e tests to run in a separate file

### DIFF
--- a/modules/angular2/pubspec.yaml
+++ b/modules/angular2/pubspec.yaml
@@ -9,7 +9,7 @@ homepage: <%= packageJson.homepage %>
 environment:
   sdk: '>=1.10.0 <2.0.0'
 dependencies:
-  analyzer: '>=0.24.4 <0.27.0'
+  analyzer: '>=0.24.4 <0.28.0'
   barback: '^0.15.2+2'
   dart_style: '>=0.1.8 <0.3.0'
   glob: '^1.0.0'
@@ -22,8 +22,9 @@ dependencies:
   source_span: '^1.0.0'
   stack_trace: '^1.1.1'
 dev_dependencies:
-  code_transformers: '0.2.9+4'
+  code_transformers: '>=0.2.9+4 <0.4.0'
   guinness: '^0.1.18'
+  test: '^0.12.6'
 transformers:
 - angular2
 - $dart2js:

--- a/modules/angular2/test/web_workers/debug_tools/multi_client_server_message_bus.server.spec.dart
+++ b/modules/angular2/test/web_workers/debug_tools/multi_client_server_message_bus.server.spec.dart
@@ -5,15 +5,17 @@ import "dart:async";
 import "package:angular2/testing_internal.dart"
     show
         AsyncTestCompleter,
-        inject,
-        describe,
-        it,
-        iit,
-        expect,
+        SpyObject,
         beforeEach,
         beforeEachProviders,
-        SpyObject,
-        proxy;
+        describe,
+        expect,
+        iit,
+        inject,
+        it,
+        proxy,
+        testSetup;
+import 'package:angular2/src/platform/server/html_adapter.dart';
 import "package:angular2/src/web_workers/debug_tools/multi_client_server_message_bus.dart";
 import "package:angular2/src/web_workers/shared/messaging_api.dart";
 import "./message_bus_common.dart";
@@ -22,6 +24,9 @@ import "dart:convert" show JSON;
 import 'dart:math';
 
 main() {
+  Html5LibDomAdapter.makeCurrent();
+  testSetup();
+
   List<String> messageHistory = new List<String>();
   List<int> resultMarkers = new List<int>();
   describe("MultiClientServerMessageBusSink", () {

--- a/modules/angular2/test/web_workers/debug_tools/single_client_server_message_bus.server.spec.dart
+++ b/modules/angular2/test/web_workers/debug_tools/single_client_server_message_bus.server.spec.dart
@@ -5,20 +5,25 @@ import "dart:async";
 import "package:angular2/testing_internal.dart"
     show
         AsyncTestCompleter,
-        inject,
-        describe,
-        it,
-        expect,
+        SpyObject,
         beforeEach,
         beforeEachProviders,
-        SpyObject,
-        proxy;
+        describe,
+        expect,
+        inject,
+        it,
+        proxy,
+        testSetup;
+import 'package:angular2/src/platform/server/html_adapter.dart';
 import "package:angular2/src/web_workers/debug_tools/single_client_server_message_bus.dart";
 import "./message_bus_common.dart";
 import "./spy_web_socket.dart";
 import "dart:convert" show JSON;
 
 main() {
+  Html5LibDomAdapter.makeCurrent();
+  testSetup();
+
   var MESSAGE = const {'test': 10};
   const CHANNEL = "TEST_CHANNEL";
   describe("SingleClientServerMessageBusSink", () {

--- a/modules_dart/transform/test/transform/transform.e2e.server.spec.dart
+++ b/modules_dart/transform/test/transform/transform.e2e.server.spec.dart
@@ -1,0 +1,11 @@
+library angular2.test.transform.transform.e2e.spec;
+
+import 'package:test/test.dart';
+
+import 'inliner_for_test/all_tests.dart' as inliner;
+import 'integration/all_tests.dart' as integration;
+
+main() {
+  group('Inliner For Test e2e', inliner.endToEndTests);
+  group('Transformer Pipeline', integration.allTests);
+}

--- a/modules_dart/transform/test/transform/transform.server.spec.dart
+++ b/modules_dart/transform/test/transform/transform.server.spec.dart
@@ -1,4 +1,4 @@
-library angular2.test.transform;
+library angular2.test.transform.transform.server.spec;
 
 import 'package:guinness/guinness.dart';
 import 'package:unittest/unittest.dart' hide expect;
@@ -12,7 +12,6 @@ import 'deferred_rewriter/all_tests.dart' as deferredRewriter;
 import 'directive_metadata_linker/all_tests.dart' as directiveMeta;
 import 'directive_processor/all_tests.dart' as directiveProcessor;
 import 'inliner_for_test/all_tests.dart' as inliner;
-import 'integration/all_tests.dart' as integration;
 import 'reflection_remover/all_tests.dart' as reflectionRemover;
 import 'template_compiler/all_tests.dart' as templateCompiler;
 import 'stylesheet_compiler/all_tests.dart' as stylesheetCompiler;
@@ -30,8 +29,4 @@ main() {
   describe('Deferred Rewriter', deferredRewriter.allTests);
   describe('Stylesheet Compiler', stylesheetCompiler.allTests);
   describe('Url Resolver', urlResolver.allTests);
-  // NOTE(kegluneq): These use `code_transformers#testPhases`, which is not
-  // designed to work with `guinness`.
-  group('Inliner For Test e2e', inliner.endToEndTests);
-  group('Transformer Pipeline', integration.allTests);
 }


### PR DESCRIPTION
A conflict between `package:guinness` and `package:test` is causing our
end-to-end Dart transformer tests to be skipped.

Run these end-to-end tests in a separate file to fix this.

Closes #5934

/cc @kevmoo 
