### PR TITLE
docs(cheatsheet): fix Dart cheatsheet

### DIFF
--- a/modules/angular2/docs/cheatsheet/bootstrapping.md
+++ b/modules/angular2/docs/cheatsheet/bootstrapping.md
@@ -3,7 +3,7 @@ Bootstrapping
 @cheatsheetIndex 0
 @description
 {@target ts}`import {bootstrap} from 'angular2/platform/browser';`{@endtarget}
-{@target js}Available from the `ng.platform.browser` namespace.{@endtarget}
+{@target js}Available from the `ng.platform.browser` namespace{@endtarget}
 {@target dart}`import 'package:angular2/bootstrap.dart';`{@endtarget}
 
 @cheatsheetItem

--- a/modules/angular2/docs/cheatsheet/built-in-directives.md
+++ b/modules/angular2/docs/cheatsheet/built-in-directives.md
@@ -4,7 +4,7 @@ Built-in directives
 @description
 {@target ts}`import {NgIf, ...} from 'angular2/common';`{@endtarget}
 {@target js}Available from the `ng.common` namespace{@endtarget}
-{@target dart}`import 'package:angular2/common.dart';`{@endtarget}
+{@target dart}Available using `platform_directives` in pubspec{@endtarget}
 
 @cheatsheetItem
 syntax:

--- a/modules/angular2/docs/cheatsheet/class-decorators.md
+++ b/modules/angular2/docs/cheatsheet/class-decorators.md
@@ -4,7 +4,7 @@ Class decorators
 @description
 {@target ts}`import {Directive, ...} from 'angular2/core';`{@endtarget}
 {@target js}Available from the `ng.core` namespace{@endtarget}
-{@target dart}`import 'package:angular2/core.dart';`{@endtarget}
+{@target dart}`import 'package:angular2/angular2.dart';`{@endtarget}
 
 @cheatsheetItem
 syntax(ts):

--- a/modules/angular2/docs/cheatsheet/dependency-injection.md
+++ b/modules/angular2/docs/cheatsheet/dependency-injection.md
@@ -4,7 +4,7 @@ Dependency injection configuration
 @description
 {@target ts}`import {provide} from 'angular2/core';`{@endtarget}
 {@target js}Available from the `ng.core` namespace{@endtarget}
-{@target dart}`import 'package:angular2/core.dart';`{@endtarget}
+{@target dart}`import 'package:angular2/angular2.dart';`{@endtarget}
 
 @cheatsheetItem
 syntax(ts dart):

--- a/modules/angular2/docs/cheatsheet/directive-and-component-decorators.md
+++ b/modules/angular2/docs/cheatsheet/directive-and-component-decorators.md
@@ -4,7 +4,7 @@ Class field decorators for directives and components
 @description
 {@target ts}`import {Input, ...} from 'angular2/core';`{@endtarget}
 {@target js}Available from the `ng.core` namespace{@endtarget}
-{@target dart}`import 'package:angular2/core.dart';`{@endtarget}
+{@target dart}`import 'package:angular2/angular2.dart';`{@endtarget}
 
 @cheatsheetItem
 syntax(ts dart):

--- a/modules/angular2/docs/cheatsheet/forms.md
+++ b/modules/angular2/docs/cheatsheet/forms.md
@@ -4,7 +4,7 @@ Forms
 @description
 {@target ts}`import {FORM_DIRECTIVES} from 'angular2/common';`{@endtarget}
 {@target js}Available from `ng.common.FORM_DIRECTIVES`{@endtarget}
-{@target dart}`import 'package:angular2/common.dart';`{@endtarget}
+{@target dart}Available using `platform_directives` in pubspec{@endtarget}
 
 @cheatsheetItem
 syntax:

--- a/modules/angular2/docs/cheatsheet/routing.md
+++ b/modules/angular2/docs/cheatsheet/routing.md
@@ -4,7 +4,7 @@ Routing and navigation
 @description
 {@target ts}`import {RouteConfig, ROUTER_DIRECTIVES, ROUTER_PROVIDERS, ...} from 'angular2/router';`{@endtarget}
 {@target js}Available from the `ng.router` namespace{@endtarget}
-{@target dart}`import 'package:angular2/router.dart';`{@endtarget}
+{@target dart}`import 'package:angular2/angular2.dart';`{@endtarget}
 
 
 @cheatsheetItem


### PR DESCRIPTION
Also deletes an extraneous period from the JS cheatsheet.
