### PR TITLE
feat(test): allow tests to specify the platform and application providers used

### DIFF
--- a/modules/angular2/platform/testing/browser.ts
+++ b/modules/angular2/platform/testing/browser.ts
@@ -1,0 +1,21 @@
+import {
+  TEST_BROWSER_STATIC_PLATFORM_PROVIDERS,
+  ADDITIONAL_TEST_BROWSER_PROVIDERS
+} from 'angular2/platform/testing/browser_static';
+
+import {BROWSER_APP_PROVIDERS} from 'angular2/platform/browser';
+
+
+import {CONST_EXPR} from 'angular2/src/facade/lang';
+
+/**
+ * Default patform providers for testing.
+ */
+export const TEST_BROWSER_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
+    CONST_EXPR([TEST_BROWSER_STATIC_PLATFORM_PROVIDERS]);
+
+/**
+ * Default application providers for testing.
+ */
+export const TEST_BROWSER_APPLICATION_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
+    CONST_EXPR([BROWSER_APP_PROVIDERS, ADDITIONAL_TEST_BROWSER_PROVIDERS]);

--- a/modules/angular2/platform/testing/browser_static.ts
+++ b/modules/angular2/platform/testing/browser_static.ts
@@ -1,0 +1,69 @@
+import {
+  APP_ID,
+  DirectiveResolver,
+  NgZone,
+  Provider,
+  ViewResolver,
+  PLATFORM_COMMON_PROVIDERS,
+  PLATFORM_INITIALIZER
+} from 'angular2/core';
+import {BROWSER_APP_COMMON_PROVIDERS} from 'angular2/src/platform/browser_common';
+import {BrowserDomAdapter} from 'angular2/src/platform/browser/browser_adapter';
+
+import {AnimationBuilder} from 'angular2/src/animate/animation_builder';
+import {MockAnimationBuilder} from 'angular2/src/mock/animation_builder_mock';
+import {MockDirectiveResolver} from 'angular2/src/mock/directive_resolver_mock';
+import {MockViewResolver} from 'angular2/src/mock/view_resolver_mock';
+import {MockLocationStrategy} from 'angular2/src/mock/mock_location_strategy';
+import {LocationStrategy} from 'angular2/src/router/location_strategy';
+import {MockNgZone} from 'angular2/src/mock/ng_zone_mock';
+
+import {XHRImpl} from "angular2/src/platform/browser/xhr_impl";
+import {XHR} from 'angular2/compiler';
+
+import {TestComponentBuilder} from 'angular2/src/testing/test_component_builder';
+
+import {BrowserDetection} from 'angular2/src/testing/utils';
+
+import {ELEMENT_PROBE_PROVIDERS} from 'angular2/platform/common_dom';
+
+import {CONST_EXPR} from 'angular2/src/facade/lang';
+
+import {Log} from 'angular2/src/testing/utils';
+
+function initBrowserTests() {
+  BrowserDomAdapter.makeCurrent();
+  BrowserDetection.setup();
+}
+
+/**
+ * Default patform providers for testing without a compiler.
+ */
+export const TEST_BROWSER_STATIC_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
+    CONST_EXPR([
+      PLATFORM_COMMON_PROVIDERS,
+      new Provider(PLATFORM_INITIALIZER, {useValue: initBrowserTests, multi: true})
+    ]);
+
+export const ADDITIONAL_TEST_BROWSER_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
+    CONST_EXPR([
+      new Provider(APP_ID, {useValue: 'a'}),
+      ELEMENT_PROBE_PROVIDERS,
+      new Provider(DirectiveResolver, {useClass: MockDirectiveResolver}),
+      new Provider(ViewResolver, {useClass: MockViewResolver}),
+      Log,
+      TestComponentBuilder,
+      new Provider(NgZone, {useClass: MockNgZone}),
+      new Provider(LocationStrategy, {useClass: MockLocationStrategy}),
+      new Provider(AnimationBuilder, {useClass: MockAnimationBuilder}),
+    ]);
+
+/**
+ * Default application providers for testing without a compiler.
+ */
+export const TEST_BROWSER_STATIC_APPLICATION_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
+    CONST_EXPR([
+      BROWSER_APP_COMMON_PROVIDERS,
+      new Provider(XHR, {useClass: XHRImpl}),
+      ADDITIONAL_TEST_BROWSER_PROVIDERS
+    ]);

--- a/modules/angular2/platform/testing/server.dart
+++ b/modules/angular2/platform/testing/server.dart
@@ -1,0 +1,1 @@
+// Intentionally blank, the Parse5Adapater bindings for JavaScript don't apply.

--- a/modules/angular2/platform/testing/server.ts
+++ b/modules/angular2/platform/testing/server.ts
@@ -1,0 +1,90 @@
+import {
+  APP_ID,
+  DirectiveResolver,
+  NgZone,
+  Provider,
+  ViewResolver,
+  PLATFORM_COMMON_PROVIDERS,
+  PLATFORM_INITIALIZER,
+  APPLICATION_COMMON_PROVIDERS,
+  Renderer
+} from 'angular2/core';
+import {Parse5DomAdapter} from 'angular2/src/platform/server/parse5_adapter';
+
+import {AnimationBuilder} from 'angular2/src/animate/animation_builder';
+import {MockAnimationBuilder} from 'angular2/src/mock/animation_builder_mock';
+import {MockDirectiveResolver} from 'angular2/src/mock/directive_resolver_mock';
+import {MockViewResolver} from 'angular2/src/mock/view_resolver_mock';
+import {MockLocationStrategy} from 'angular2/src/mock/mock_location_strategy';
+import {LocationStrategy} from 'angular2/src/router/location_strategy';
+import {MockNgZone} from 'angular2/src/mock/ng_zone_mock';
+
+import {TestComponentBuilder} from 'angular2/src/testing/test_component_builder';
+import {XHR} from 'angular2/src/compiler/xhr';
+import {BrowserDetection} from 'angular2/src/testing/utils';
+
+import {COMPILER_PROVIDERS} from 'angular2/src/compiler/compiler';
+import {DOCUMENT} from 'angular2/src/platform/dom/dom_tokens';
+import {DOM} from 'angular2/src/platform/dom/dom_adapter';
+import {RootRenderer} from 'angular2/src/core/render/api';
+import {DomRootRenderer, DomRootRenderer_} from 'angular2/src/platform/dom/dom_renderer';
+import {DomSharedStylesHost} from 'angular2/src/platform/dom/shared_styles_host';
+
+import {
+  EventManager,
+  EVENT_MANAGER_PLUGINS,
+  ELEMENT_PROBE_PROVIDERS
+} from 'angular2/platform/common_dom';
+import {DomEventsPlugin} from 'angular2/src/platform/dom/events/dom_events';
+
+import {CONST_EXPR} from 'angular2/src/facade/lang';
+
+import {Log} from 'angular2/src/testing/utils';
+
+function initServerTests() {
+  Parse5DomAdapter.makeCurrent();
+  BrowserDetection.setup();
+}
+
+/**
+ * Default patform providers for testing.
+ */
+export const TEST_SERVER_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[]*/> = CONST_EXPR([
+  PLATFORM_COMMON_PROVIDERS,
+  new Provider(PLATFORM_INITIALIZER, {useValue: initServerTests, multi: true})
+]);
+
+function appDoc() {
+  try {
+    return DOM.defaultDoc();
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Default application providers for testing.
+ */
+export const TEST_SERVER_APPLICATION_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
+    CONST_EXPR([
+      // TODO(julie): when angular2/platform/server is available, use that instead of making our own
+      // list here.
+      APPLICATION_COMMON_PROVIDERS,
+      COMPILER_PROVIDERS,
+      new Provider(DOCUMENT, {useFactory: appDoc}),
+      new Provider(DomRootRenderer, {useClass: DomRootRenderer_}),
+      new Provider(RootRenderer, {useExisting: DomRootRenderer}),
+      EventManager,
+      new Provider(EVENT_MANAGER_PLUGINS, {useClass: DomEventsPlugin, multi: true}),
+      new Provider(XHR, {useClass: XHR}),
+      new Provider(APP_ID, {useValue: 'a'}),
+      DomSharedStylesHost,
+      ELEMENT_PROBE_PROVIDERS,
+      new Provider(DirectiveResolver, {useClass: MockDirectiveResolver}),
+      new Provider(ViewResolver, {useClass: MockViewResolver}),
+      Log,
+      TestComponentBuilder,
+      new Provider(NgZone, {useClass: MockNgZone}),
+      new Provider(LocationStrategy, {useClass: MockLocationStrategy}),
+      new Provider(AnimationBuilder, {useClass: MockAnimationBuilder}),
+    ]);

--- a/modules/angular2/src/platform/dom/dom_adapter.ts
+++ b/modules/angular2/src/platform/dom/dom_adapter.ts
@@ -23,6 +23,7 @@ export abstract class DomAdapter {
   abstract logGroup(error);
   abstract logGroupEnd();
 
+  /** @deprecated */
   abstract getXHR(): Type;
 
   /**

--- a/modules/angular2/src/testing/test_injector.ts
+++ b/modules/angular2/src/testing/test_injector.ts
@@ -1,130 +1,7 @@
-import {
-  APP_ID,
-  APPLICATION_COMMON_PROVIDERS,
-  AppViewManager,
-  DirectiveResolver,
-  DynamicComponentLoader,
-  Injector,
-  NgZone,
-  Renderer,
-  Provider,
-  ViewResolver,
-  provide
-} from 'angular2/core';
-import {AnimationBuilder} from 'angular2/src/animate/animation_builder';
-import {MockAnimationBuilder} from 'angular2/src/mock/animation_builder_mock';
-
-import {ResolvedMetadataCache} from 'angular2/src/core/linker/resolved_metadata_cache';
-import {Reflector, reflector} from 'angular2/src/core/reflection/reflection';
-import {
-  IterableDiffers,
-  defaultIterableDiffers,
-  KeyValueDiffers,
-  defaultKeyValueDiffers,
-  ChangeDetectorGenConfig
-} from 'angular2/src/core/change_detection/change_detection';
+import {Injector, Provider, PLATFORM_INITIALIZER} from 'angular2/core';
 import {BaseException, ExceptionHandler} from 'angular2/src/facade/exceptions';
-import {PipeResolver} from 'angular2/src/core/linker/pipe_resolver';
-import {XHR} from 'angular2/src/compiler/xhr';
-
-import {DOM} from 'angular2/src/platform/dom/dom_adapter';
-
-import {MockDirectiveResolver} from 'angular2/src/mock/directive_resolver_mock';
-import {MockViewResolver} from 'angular2/src/mock/view_resolver_mock';
-import {MockLocationStrategy} from 'angular2/src/mock/mock_location_strategy';
-import {LocationStrategy} from 'angular2/src/router/location_strategy';
-import {MockNgZone} from 'angular2/src/mock/ng_zone_mock';
-
-import {TestComponentBuilder} from './test_component_builder';
-
-import {
-  EventManager,
-  EVENT_MANAGER_PLUGINS,
-  ELEMENT_PROBE_PROVIDERS
-} from 'angular2/platform/common_dom';
-
 import {ListWrapper} from 'angular2/src/facade/collection';
-import {FunctionWrapper, Type} from 'angular2/src/facade/lang';
-
-import {RootRenderer} from 'angular2/src/core/render/api';
-
-import {DOCUMENT} from 'angular2/src/platform/dom/dom_tokens';
-import {DomRootRenderer, DomRootRenderer_} from 'angular2/src/platform/dom/dom_renderer';
-import {DomSharedStylesHost} from 'angular2/src/platform/dom/shared_styles_host';
-import {SharedStylesHost} from 'angular2/src/platform/dom/shared_styles_host';
-import {DomEventsPlugin} from 'angular2/src/platform/dom/events/dom_events';
-
-import {Serializer} from "angular2/src/web_workers/shared/serializer";
-import {Log} from './utils';
-import {COMPILER_PROVIDERS} from 'angular2/src/compiler/compiler';
-import {DynamicComponentLoader_} from "angular2/src/core/linker/dynamic_component_loader";
-import {AppViewManager_} from "angular2/src/core/linker/view_manager";
-
-/**
- * Returns the root injector providers.
- *
- * This must be kept in sync with the _rootBindings in application.js
- *
- * @returns {any[]}
- */
-function _getRootProviders() {
-  return [provide(Reflector, {useValue: reflector})];
-}
-
-/**
- * Returns the application injector providers.
- *
- * This must be kept in sync with _injectorBindings() in application.js
- *
- * @returns {any[]}
- */
-function _getAppBindings() {
-  var appDoc;
-
-  // The document is only available in browser environment
-  try {
-    appDoc = DOM.defaultDoc();
-  } catch (e) {
-    appDoc = null;
-  }
-
-  return [
-    APPLICATION_COMMON_PROVIDERS,
-    provide(ChangeDetectorGenConfig, {useValue: new ChangeDetectorGenConfig(true, false, false)}),
-    provide(DOCUMENT, {useValue: appDoc}),
-    provide(DomRootRenderer, {useClass: DomRootRenderer_}),
-    provide(RootRenderer, {useExisting: DomRootRenderer}),
-    provide(APP_ID, {useValue: 'a'}),
-    DomSharedStylesHost,
-    provide(SharedStylesHost, {useExisting: DomSharedStylesHost}),
-    provide(AppViewManager, {useClass: AppViewManager_}),
-    Serializer,
-    ELEMENT_PROBE_PROVIDERS,
-    ResolvedMetadataCache,
-    provide(DirectiveResolver, {useClass: MockDirectiveResolver}),
-    provide(ViewResolver, {useClass: MockViewResolver}),
-    provide(IterableDiffers, {useValue: defaultIterableDiffers}),
-    provide(KeyValueDiffers, {useValue: defaultKeyValueDiffers}),
-    Log,
-    provide(DynamicComponentLoader, {useClass: DynamicComponentLoader_}),
-    PipeResolver,
-    provide(ExceptionHandler, {useValue: new ExceptionHandler(DOM)}),
-    provide(LocationStrategy, {useClass: MockLocationStrategy}),
-    provide(XHR, {useClass: DOM.getXHR()}),
-    TestComponentBuilder,
-    provide(NgZone, {useClass: MockNgZone}),
-    provide(AnimationBuilder, {useClass: MockAnimationBuilder}),
-    EventManager,
-    new Provider(EVENT_MANAGER_PLUGINS, {useClass: DomEventsPlugin, multi: true})
-  ];
-}
-
-function _runtimeCompilerBindings() {
-  return [
-    provide(XHR, {useClass: DOM.getXHR()}),
-    COMPILER_PROVIDERS,
-  ];
-}
+import {FunctionWrapper, isPresent, Type} from 'angular2/src/facade/lang';
 
 export class TestInjector {
   private _instantiated: boolean = false;
@@ -139,6 +16,10 @@ export class TestInjector {
     this._instantiated = false;
   }
 
+  platformProviders: Array<Type | Provider | any[]> = [];
+
+  applicationProviders: Array<Type | Provider | any[]> = [];
+
   addProviders(providers: Array<Type | Provider | any[]>) {
     if (this._instantiated) {
       throw new BaseException('Cannot add providers after test injector is instantiated');
@@ -147,9 +28,9 @@ export class TestInjector {
   }
 
   createInjector() {
-    var rootInjector = Injector.resolveAndCreate(_getRootProviders());
-    this._injector = rootInjector.resolveAndCreateChild(ListWrapper.concat(
-        ListWrapper.concat(_getAppBindings(), _runtimeCompilerBindings()), this._providers));
+    var rootInjector = Injector.resolveAndCreate(this.platformProviders);
+    this._injector = rootInjector.resolveAndCreateChild(
+        ListWrapper.concat(this.applicationProviders, this._providers));
     this._instantiated = true;
     return this._injector;
   }
@@ -172,19 +53,40 @@ export function getTestInjector() {
 }
 
 /**
- * @deprecated Use TestInjector#createInjector() instead.
+ * Set the providers that the test injector should use. These should be providers
+ * common to every test in the suite.
+ *
+ * This may only be called once, to set up the common providers for the current test
+ * suite on teh current platform. If you absolutely need to change the providers,
+ * first use `resetBaseTestProviders`.
+ *
+ * Test Providers for individual platforms are available from
+ * 'angular2/platform/testing/<platform_name>'.
  */
-export function createTestInjector(providers: Array<Type | Provider | any[]>): Injector {
-  var rootInjector = Injector.resolveAndCreate(_getRootProviders());
-  return rootInjector.resolveAndCreateChild(ListWrapper.concat(_getAppBindings(), providers));
+export function setBaseTestProviders(platformProviders: Array<Type | Provider | any[]>,
+                                     applicationProviders: Array<Type | Provider | any[]>) {
+  var testInjector = getTestInjector();
+  if (testInjector.platformProviders.length > 0 || testInjector.applicationProviders.length > 0) {
+    throw new BaseException('Cannot set base providers because it has already been called');
+  }
+  testInjector.platformProviders = platformProviders;
+  testInjector.applicationProviders = applicationProviders;
+  var injector = testInjector.createInjector();
+  let inits: Function[] = injector.getOptional(PLATFORM_INITIALIZER);
+  if (isPresent(inits)) {
+    inits.forEach(init => init());
+  }
+  testInjector.reset();
 }
 
 /**
- * @deprecated Use TestInjector#createInjector() instead.
+ * Reset the providers for the test injector.
  */
-export function createTestInjectorWithRuntimeCompiler(
-    providers: Array<Type | Provider | any[]>): Injector {
-  return createTestInjector(ListWrapper.concat(_runtimeCompilerBindings(), providers));
+export function resetBaseTestProviders() {
+  var testInjector = getTestInjector();
+  testInjector.platformProviders = [];
+  testInjector.applicationProviders = [];
+  testInjector.reset();
 }
 
 /**

--- a/modules/angular2/src/testing/utils.ts
+++ b/modules/angular2/src/testing/utils.ts
@@ -21,9 +21,12 @@ export class Log {
   result(): string { return this._result.join("; "); }
 }
 
+export var browserDetection: BrowserDetection = null;
 
 export class BrowserDetection {
   private _ua: string;
+
+  static setup() { browserDetection = new BrowserDetection(null); }
 
   constructor(ua: string) {
     if (isPresent(ua)) {
@@ -61,7 +64,6 @@ export class BrowserDetection {
     return this._ua.indexOf('Chrome/4') > -1 && this._ua.indexOf('Edge') == -1;
   }
 }
-export var browserDetection: BrowserDetection = new BrowserDetection(null);
 
 export function dispatchEvent(element, eventType): void {
   DOM.dispatchEvent(element, DOM.createEvent(eventType));

--- a/modules/angular2/test/compiler/runtime_metadata_spec.ts
+++ b/modules/angular2/test/compiler/runtime_metadata_spec.ts
@@ -83,19 +83,19 @@ export function main() {
       it('should return the directive metadatas',
          inject([RuntimeMetadataResolver], (resolver: RuntimeMetadataResolver) => {
            expect(resolver.getViewDirectivesMetadata(ComponentWithEverything))
-               .toEqual([resolver.getDirectiveMetadata(SomeDirective)]);
+               .toContain(resolver.getDirectiveMetadata(SomeDirective));
          }));
 
       describe("platform directives", () => {
-        beforeEachProviders(() => [provide(PLATFORM_DIRECTIVES, {useValue: [ADirective]})]);
+        beforeEachProviders(
+            () => [provide(PLATFORM_DIRECTIVES, {useValue: [ADirective], multi: true})]);
 
         it('should include platform directives when available',
            inject([RuntimeMetadataResolver], (resolver: RuntimeMetadataResolver) => {
              expect(resolver.getViewDirectivesMetadata(ComponentWithEverything))
-                 .toEqual([
-                   resolver.getDirectiveMetadata(ADirective),
-                   resolver.getDirectiveMetadata(SomeDirective)
-                 ]);
+                 .toContain(resolver.getDirectiveMetadata(ADirective));
+             expect(resolver.getViewDirectivesMetadata(ComponentWithEverything))
+                 .toContain(resolver.getDirectiveMetadata(SomeDirective));
            }));
       });
     });

--- a/modules/angular2/test/upgrade/metadata_spec.ts
+++ b/modules/angular2/test/upgrade/metadata_spec.ts
@@ -16,7 +16,6 @@ import {getComponentInfo, parseFields} from 'angular2/src/upgrade/metadata';
 import {DOM} from 'angular2/src/platform/dom/dom_adapter';
 
 export function main() {
-  if (!DOM.supportsDOMEvents()) return;
   describe('upgrade metadata', () => {
     it('should extract component selector', () => {
       expect(getComponentInfo(ElementNameComponent).selector).toEqual('elementNameDashed');

--- a/modules/angular2/test/upgrade/upgrade_spec.ts
+++ b/modules/angular2/test/upgrade/upgrade_spec.ts
@@ -17,7 +17,6 @@ import {UpgradeAdapter} from 'angular2/upgrade';
 import * as angular from 'angular2/src/upgrade/angular_js';
 
 export function main() {
-  if (!DOM.supportsDOMEvents()) return;
   describe('adapter: ng1 to ng2', () => {
     it('should have angular 1 loaded', () => expect(angular.version.major).toBe(1));
 

--- a/modules/angular2/test/web_workers/shared/service_message_broker_spec.ts
+++ b/modules/angular2/test/web_workers/shared/service_message_broker_spec.ts
@@ -28,7 +28,7 @@ export function main() {
   const RESULT = 20;
   const ID = "methodId";
 
-  beforeEachProviders(() => [provide(ON_WEB_WORKER, {useValue: true}), RenderStore]);
+  beforeEachProviders(() => [Serializer, provide(ON_WEB_WORKER, {useValue: true}), RenderStore]);
 
   describe("UIMessageBroker", () => {
     var messageBuses;

--- a/modules/angular2/test/web_workers/worker/renderer_integration_spec.ts
+++ b/modules/angular2/test/web_workers/worker/renderer_integration_spec.ts
@@ -44,7 +44,10 @@ import {
   ServiceMessageBrokerFactory_
 } from 'angular2/src/web_workers/shared/service_message_broker';
 import {ChangeDetectorGenConfig} from 'angular2/src/core/change_detection/change_detection';
-
+import {
+  TEST_BROWSER_PLATFORM_PROVIDERS,
+  TEST_BROWSER_APPLICATION_PROVIDERS
+} from 'angular2/platform/testing/browser';
 
 export function main() {
   function createWebWorkerBrokerFactory(
@@ -83,13 +86,16 @@ export function main() {
 
     beforeEachProviders(() => {
       uiRenderStore = new RenderStore();
-      var testInjector = new TestInjector();
-      testInjector.addProviders([
+      var testUiInjector = new TestInjector();
+      testUiInjector.platformProviders = TEST_BROWSER_PLATFORM_PROVIDERS;
+      testUiInjector.applicationProviders = TEST_BROWSER_APPLICATION_PROVIDERS;
+      testUiInjector.addProviders([
+        Serializer,
         provide(RenderStore, {useValue: uiRenderStore}),
         provide(DomRootRenderer, {useClass: DomRootRenderer_}),
         provide(RootRenderer, {useExisting: DomRootRenderer})
       ]);
-      uiInjector = testInjector.createInjector();
+      uiInjector = testUiInjector.createInjector();
       var uiSerializer = uiInjector.get(Serializer);
       var domRootRenderer = uiInjector.get(DomRootRenderer);
       workerRenderStore = new RenderStore();

--- a/modules_dart/angular2_testing/lib/angular2_testing.dart
+++ b/modules_dart/angular2_testing/lib/angular2_testing.dart
@@ -5,12 +5,12 @@ import 'package:test/test.dart';
 import 'package:angular2/angular2.dart';
 import 'package:angular2/src/core/di/metadata.dart' show InjectMetadata;
 import 'package:angular2/src/core/di/exceptions.dart' show NoAnnotationError;
-import 'package:angular2/platform/browser_static.dart' show BrowserDomAdapter;
 import 'package:angular2/src/core/reflection/reflection.dart';
 import 'package:angular2/src/core/reflection/reflection_capabilities.dart';
 import 'package:angular2/src/testing/test_injector.dart';
 export 'package:angular2/src/testing/test_component_builder.dart';
 export 'package:angular2/src/testing/test_injector.dart' show inject;
+import 'package:angular2/platform/testing/browser.dart';
 
 /// One time initialization that must be done for Angular2 component
 /// tests. Call before any test methods.
@@ -24,8 +24,8 @@ export 'package:angular2/src/testing/test_injector.dart' show inject;
 /// }
 /// ```
 void initAngularTests() {
-  BrowserDomAdapter.makeCurrent();
   reflector.reflectionCapabilities = new ReflectionCapabilities();
+  setBaseTestProviders(TEST_BROWSER_PLATFORM_PROVIDERS, TEST_BROWSER_APPLICATION_PROVIDERS);
 }
 
 void _addTestInjectorTearDown() {

--- a/test-init.dart
+++ b/test-init.dart
@@ -1,5 +1,9 @@
-import 'package:angular2/src/platform/browser/browser_adapter.dart';
+import 'package:angular2/testing.dart';
+import 'package:angular2/platform/testing/browser.dart';
+import 'package:angular2/src/core/reflection/reflection.dart';
+import 'package:angular2/src/core/reflection/reflection_capabilities.dart';
 
 main() {
-  BrowserDomAdapter.makeCurrent();
+  reflector.reflectionCapabilities = new ReflectionCapabilities();
+  setBaseTestProviders(TEST_BROWSER_PLATFORM_PROVIDERS, TEST_BROWSER_APPLICATION_PROVIDERS);
 }

--- a/test-main.js
+++ b/test-main.js
@@ -18,9 +18,13 @@ System.config({
   }
 });
 
-// Import all the specs, execute their `main()` method and kick off Karma (Jasmine).
-System.import('angular2/src/platform/browser/browser_adapter').then(function(browser_adapter) {
-  browser_adapter.BrowserDomAdapter.makeCurrent();
+// Set up the test injector, then import all the specs, execute their `main()`
+// method and kick off Karma (Jasmine).
+System.import('angular2/testing').then(function(testing) {
+  return System.import('angular2/platform/testing/browser').then(function(testing_platform_browser) {
+    testing.setBaseTestProviders(testing_platform_browser.TEST_BROWSER_PLATFORM_PROVIDERS,
+                                 testing_platform_browser.TEST_BROWSER_APPLICATION_PROVIDERS);
+  });
 }).then(function() {
   return Promise.all(
     Object.keys(window.__karma__.files) // All files served by Karma.

--- a/tools/broccoli/trees/node_tree.ts
+++ b/tools/broccoli/trees/node_tree.ts
@@ -36,6 +36,8 @@ module.exports = function makeNodeTree(projects, destinationPath) {
       'angular2/test/symbol_inspector/**/*.ts',
       'angular2/test/public_api_spec.ts',
 
+      'angular2/test/web_workers/worker/renderer_integration_spec.ts',
+
       'angular2/test/upgrade/**/*.ts',
 
       'angular1_router/**',

--- a/tools/build/run_server_dart_tests.js
+++ b/tools/build/run_server_dart_tests.js
@@ -25,8 +25,9 @@ module.exports = function(gulp, plugins, config) {
       // No test files found
       return Q.resolve();
     }
-    var header = ['library _all_tests;', ''];
+    var header = ['library _all_tests;', 'import "package:angular2/testing.dart";', ''];
     var main = ['main() {'];
+    main.push('  setBaseTestProviders([], []);');
     testFiles.forEach(function(fileName, index) {
       header.push('import "' + fileName + '" as test_' + index + ';');
       main.push('  test_' + index + '.main();');

--- a/tools/cjs-jasmine/index.js
+++ b/tools/cjs-jasmine/index.js
@@ -33,4 +33,5 @@ jrunner.onComplete(function(passed) { process.exit(passed ? 0 : 1); });
 jrunner.projectBaseDir = path.resolve(__dirname, '../../');
 jrunner.specDir = '';
 jrunner.addSpecFiles(specFiles);
+require('./test-cjs-main.js');
 jrunner.execute();

--- a/tools/cjs-jasmine/test-cjs-main.js
+++ b/tools/cjs-jasmine/test-cjs-main.js
@@ -1,0 +1,5 @@
+var testingPlatformServer = require('../../dist/js/cjs/angular2/platform/testing/server.js');
+var testing = require('../../dist/js/cjs/angular2/testing.js');
+
+testing.setBaseTestProviders(testingPlatformServer.TEST_SERVER_PLATFORM_PROVIDERS,
+                             testingPlatformServer.TEST_SERVER_APPLICATION_PROVIDERS);


### PR DESCRIPTION
With providers split into bundles, the test injector is now able to
use providers for a given bundle. Suggested provider lists for tests are
available in `angular2/platform/testing/<platform>`.

Change the providers for a test suite using `setBaseTestProviders`. This
should be done once at the start of the test suite, before any test cases
run.

BREAKING CHANGE: Tests are now required to use `setBaseTestProviders`
to set up. Assuming your tests are run on a browser, setup would change
as follows.

Before:

``` js
// Somewhere in test setup
import {BrowserDomAdapter} from 'angular2/src/platform/browser/browser_adapter';
BrowserDomAdapter.makeCurrent
```

After:

``` js
// Somewhere in the test setup
import {setBaseTestProviders} from 'angular2/testing';
import {
  TEST_BROWSER_PLATFORM_PROVIDERS,
  TEST_BROWSER_APPLICATION_PROVIDERS
} from 'angular2/platform/testing/browser';

setBaseTestProviders(TEST_BROWSER_PLATFORM_PROVIDERS,
                     TEST_BROWSER_APPLICATION_PROVIDERS);
```

Closes #5351, Closes #5585
