### PR TITLE
fix(ng-zone) Use instance instead of type

### DIFF
--- a/modules/angular2/src/core/zone/ng_zone.ts
+++ b/modules/angular2/src/core/zone/ng_zone.ts
@@ -349,7 +349,7 @@ export class NgZone {
 
     if (enableLongStackTrace) {
       errorHandling = StringMapWrapper.merge(
-          Zone.longStackTraceZone, {onError: function(e) { ngZone._notifyOnError(this, e); }});
+          zone.longStackTraceZone, {onError: function(e) { ngZone._notifyOnError(this, e); }});
     } else {
       errorHandling = {onError: function(e) { ngZone._notifyOnError(this, e); }};
     }


### PR DESCRIPTION
I'm getting an undefined error on this line, it looks like we were meant to use the instance instead of the type identifier.
