### PR TITLE
fix(async): handle synchronous initial value in async pipe

### DIFF
--- a/modules/angular2/src/common/pipes/async_pipe.ts
+++ b/modules/angular2/src/common/pipes/async_pipe.ts
@@ -81,6 +81,7 @@ export class AsyncPipe implements PipeTransform, OnDestroy {
       if (isPresent(obj)) {
         this._subscribe(obj);
       }
+      this._latestReturnedValue = this._latestValue;
       return this._latestValue;
     }
 


### PR DESCRIPTION
closes #5992 - values delivered sync via the async pipe would cause change detection errors in dev mode.
