### PR TITLE
fix(web_workers): support @AngularEntrypoint in web workers

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -906,24 +906,20 @@ gulp.task('build/pure-packages.dart/standalone', function() {
       .pipe(gulp.dest(CONFIG.dest.dart));
 });
 
-gulp.task('build/pure-packages.dart/license',
-          function() {
-            return gulp.src(['LICENSE'])
-                .pipe(gulp.dest(path.join(CONFIG.dest.dart, 'angular2_testing')));
-          })
+gulp.task('build/pure-packages.dart/license', function() {
+  return gulp.src(['LICENSE']).pipe(gulp.dest(path.join(CONFIG.dest.dart, 'angular2_testing')));
+});
 
 
-    gulp.task('build/pure-packages.dart/angular2', function() {
-      var yaml = require('js-yaml');
-
-      return gulp.src([
-                   'modules_dart/transform/**/*',
-                   '!modules_dart/transform/**/*.proto',
-                   '!modules_dart/transform/pubspec.yaml',
-                   '!modules_dart/transform/**/packages{,/**}',
-                 ])
-          .pipe(gulp.dest(path.join(CONFIG.dest.dart, 'angular2')));
-    });
+gulp.task('build/pure-packages.dart/angular2', function() {
+  return gulp.src([
+               'modules_dart/transform/**/*',
+               '!modules_dart/transform/**/*.proto',
+               '!modules_dart/transform/pubspec.yaml',
+               '!modules_dart/transform/**/packages{,/**}',
+             ])
+      .pipe(gulp.dest(path.join(CONFIG.dest.dart, 'angular2')));
+});
 
 // Builds all Dart packages, but does not compile them
 gulp.task('build/packages.dart', function(done) {

--- a/modules/angular2/angular2.dart
+++ b/modules/angular2/angular2.dart
@@ -5,8 +5,7 @@ library angular2;
  *
  * This library does not include `bootstrap`. Import `bootstrap.dart` instead.
  */
-export 'package:angular2/core.dart'
-    hide forwardRef, resolveForwardRef, ForwardRefFn;
+export 'package:angular2/core.dart';
 export 'package:angular2/common.dart';
 export 'package:angular2/instrumentation.dart';
 export 'package:angular2/src/core/angular_entrypoint.dart' show AngularEntrypoint;

--- a/modules/angular2/core.dart
+++ b/modules/angular2/core.dart
@@ -1,5 +1,6 @@
 library angular2.core;
 
+export './src/core/angular_entrypoint.dart' show AngularEntrypoint;
 export './src/core/metadata.dart';
 export './src/core/util.dart';
 export 'package:angular2/src/facade/lang.dart' show enableProdMode;

--- a/modules/angular2/src/platform/worker_app.ts
+++ b/modules/angular2/src/platform/worker_app.ts
@@ -10,6 +10,7 @@ import {
 import {WORKER_APP_APPLICATION_COMMON} from './worker_app_common';
 import {APP_INITIALIZER} from 'angular2/core';
 import {MessageBus} from 'angular2/src/web_workers/shared/message_bus';
+import {COMPILER_PROVIDERS} from 'angular2/src/compiler/compiler';
 
 // TODO(jteplitz602) remove this and compile with lib.webworker.d.ts (#3492)
 let _postMessage = {
@@ -20,6 +21,7 @@ let _postMessage = {
 
 export const WORKER_APP_APPLICATION: Array<any /*Type | Provider | any[]*/> = [
   WORKER_APP_APPLICATION_COMMON,
+  COMPILER_PROVIDERS,
   new Provider(MessageBus, {useFactory: createMessageBus, deps: [NgZone]}),
   new Provider(APP_INITIALIZER, {useValue: setupWebWorker, multi: true})
 ];

--- a/modules/angular2/src/platform/worker_app_common.ts
+++ b/modules/angular2/src/platform/worker_app_common.ts
@@ -19,7 +19,6 @@ import {
   ServiceMessageBrokerFactory,
   ServiceMessageBrokerFactory_
 } from 'angular2/src/web_workers/shared/service_message_broker';
-import {COMPILER_PROVIDERS} from 'angular2/src/compiler/compiler';
 import {Serializer} from "angular2/src/web_workers/shared/serializer";
 import {ON_WEB_WORKER} from "angular2/src/web_workers/shared/api";
 import {Provider} from 'angular2/src/core/di';
@@ -37,7 +36,6 @@ export const WORKER_APP_PLATFORM: Array<any /*Type | Provider | any[]*/> =
 
 export const WORKER_APP_APPLICATION_COMMON: Array<any /*Type | Provider | any[]*/> = CONST_EXPR([
   APPLICATION_COMMON_PROVIDERS,
-  COMPILER_PROVIDERS,
   FORM_PROVIDERS,
   Serializer,
   new Provider(PLATFORM_PIPES, {useValue: COMMON_PIPES, multi: true}),

--- a/modules/benchmarks/pubspec.yaml
+++ b/modules/benchmarks/pubspec.yaml
@@ -26,9 +26,11 @@ transformers:
         - web/src/static_tree/tree_benchmark.dart
         - web/src/tree/tree_benchmark.dart
 - $dart2js:
+    $include: web/src/**
     minify: false
     commandLineOptions:
     - --dump-info
     - --trust-type-annotations
     - --trust-primitives
     - --show-package-warnings
+    - --fatal-warnings

--- a/modules/benchmarks_external/pubspec.yaml
+++ b/modules/benchmarks_external/pubspec.yaml
@@ -11,10 +11,11 @@ dependency_overrides:
   intl: '^0.12.4' # angular depends on an older version of intl.
 transformers:
 - angular:
-    $exclude: "web/e2e_test"
+    $include: "web/src"
     html_files:
       - web/src/naive_infinite_scroll/scroll_area.html
       - web/src/naive_infinite_scroll/scroll_item.html
 - $dart2js:
+    $include: "web/src"
     commandLineOptions:
     - --show-package-warnings

--- a/modules/playground/pubspec.yaml
+++ b/modules/playground/pubspec.yaml
@@ -19,20 +19,12 @@ transformers:
 - angular2:
     platform_directives: 'package:angular2/src/common/directives.dart#CORE_DIRECTIVES'
     entry_points:
+        - web/src/animate/index.dart
+        - web/src/async/index.dart
         - web/src/gestures/index.dart
+        - web/src/hash_routing/index.dart
         - web/src/hello_world/index.dart
         - web/src/key_events/index.dart
-        - web/src/sourcemap/index.dart
-        - web/src/todo/index.dart
-        - web/src/order_management/index.dart
-        - web/src/model_driven_forms/index.dart
-        - web/src/observable_models/index.dart
-        - web/src/person_management/index.dart
-        - web/src/routing/index.dart
-        - web/src/template_driven_forms/index.dart
-        - web/src/zippy_component/index.dart
-        - web/src/relative_assets/index.dart
-        - web/src/svg/index.dart
         - web/src/material/button/index.dart
         - web/src/material/checkbox/index.dart
         - web/src/material/dialog/index.dart
@@ -41,25 +33,50 @@ transformers:
         - web/src/material/progress-linear/index.dart
         - web/src/material/radio/index.dart
         - web/src/material/switcher/index.dart
-
-        # These entrypoints are disabled untl the transformer supports UI bootstrap (issue #3971)
-        # - web/src/web_workers/message_broker/index.dart
-        # - web/src/web_workers/kitchen_sink/index.dart
-        # - web/src/web_workers/todo/index.dart
-        # - web/src/web_workers/todo/server_index.dart
-        # - web/src/web_workers/todo/background_index.dart
-        # - web/src/web_workers/message_broker/background_index.dart
-        # - web/src/web_workers/kitchen_sink/background_index.dart
-        #
-        # This entrypoint is not needed:
-        # - web/src/material/demo_common.dart
+        - web/src/model_driven_forms/index.dart
+        - web/src/observable_models/index.dart
+        - web/src/order_management/index.dart
+        - web/src/person_management/index.dart
+        - web/src/relative_assets/index.dart
+        - web/src/routing/index.dart
+        - web/src/sourcemap/index.dart
+        - web/src/svg/index.dart
+        - web/src/template_driven_forms/index.dart
+        - web/src/todo/index.dart
+        - web/src/web_workers/kitchen_sink/background_index.dart
+        - web/src/web_workers/kitchen_sink/index.dart
+        - web/src/web_workers/message_broker/background_index.dart
+        - web/src/web_workers/message_broker/index.dart
+        - web/src/web_workers/todo/background_index.dart
+        - web/src/web_workers/todo/index.dart
+        - web/src/web_workers/todo/server_index.dart
+        - web/src/zippy_component/index.dart
 
 - $dart2js:
+    $include:
+        - web/src/**
+    $exclude:
+        # web worker code compiled separately; see below
+        - web/src/web_workers/**
     minify: false
     commandLineOptions:
-    - --show-package-warnings
-    - --trust-type-annotations
-    - --trust-primitives
-    - --enable-experimental-mirrors
-    # Uncomment to generate summaries from dart2js
-    # - --dump-info
+        - --show-package-warnings
+        - --trust-type-annotations
+        - --trust-primitives
+        - --enable-experimental-mirrors
+        - --fatal-warnings
+
+# TODO(yjbanov): cannot use --fatal-warnings on web-worker code due to
+#                dart2js bug https://github.com/dart-lang/sdk/issues/23875
+- $dart2js:
+    $include:
+        - web/src/web_workers/**
+    $exclude:
+        - web/src/web_workers/images/**
+        - web/src/web_workers/todo/server_index.dart
+    minify: false
+    commandLineOptions:
+        - --show-package-warnings
+        - --trust-type-annotations
+        - --trust-primitives
+        - --enable-experimental-mirrors

--- a/modules/playground/src/web_workers/kitchen_sink/background_index.dart
+++ b/modules/playground/src/web_workers/kitchen_sink/background_index.dart
@@ -4,11 +4,9 @@ import "index_common.dart" show HelloCmp;
 import "dart:isolate";
 import "package:angular2/platform/worker_app.dart";
 import "package:angular2/core.dart";
-import "package:angular2/src/core/reflection/reflection_capabilities.dart";
-import "package:angular2/src/core/reflection/reflection.dart";
 
+@AngularEntrypoint()
 main(List<String> args, SendPort replyTo) {
-  reflector.reflectionCapabilities = new ReflectionCapabilities();
   platform([WORKER_APP_PLATFORM, new Provider(RENDER_SEND_PORT, useValue: replyTo)])
       .application([WORKER_APP_APPLICATION])
       .bootstrap(HelloCmp);

--- a/modules/playground/src/web_workers/kitchen_sink/index.dart
+++ b/modules/playground/src/web_workers/kitchen_sink/index.dart
@@ -2,11 +2,9 @@ library angular2.examples.web_workers.kitchen_sink.index;
 
 import "package:angular2/platform/worker_render.dart";
 import "package:angular2/core.dart";
-import "package:angular2/src/core/reflection/reflection_capabilities.dart";
-import "package:angular2/src/core/reflection/reflection.dart";
 
+@AngularEntrypoint()
 main() {
-  reflector.reflectionCapabilities = new ReflectionCapabilities();
   platform([WORKER_RENDER_PLATFORM])
       .asyncApplication(initIsolate("background_index.dart"));
 }

--- a/modules/playground/src/web_workers/message_broker/background_index.dart
+++ b/modules/playground/src/web_workers/message_broker/background_index.dart
@@ -2,13 +2,11 @@ library angular2.examples.message_broker.background_index;
 
 import "package:angular2/platform/worker_app.dart";
 import "package:angular2/core.dart";
-import "package:angular2/src/core/reflection/reflection_capabilities.dart";
-import "package:angular2/src/core/reflection/reflection.dart";
 import "index_common.dart" show App;
 import "dart:isolate";
 
+@AngularEntrypoint()
 main(List<String> args, SendPort replyTo) {
-  reflector.reflectionCapabilities = new ReflectionCapabilities();
   platform([WORKER_APP_PLATFORM, new Provider(RENDER_SEND_PORT, useValue: replyTo)])
     .application([WORKER_APP_APPLICATION])
     .bootstrap(App);

--- a/modules/playground/src/web_workers/message_broker/index.dart
+++ b/modules/playground/src/web_workers/message_broker/index.dart
@@ -2,12 +2,10 @@ library angular2.examples.message_broker.index;
 
 import "package:angular2/platform/worker_render.dart";
 import "package:angular2/core.dart";
-import "package:angular2/src/core/reflection/reflection_capabilities.dart";
-import "package:angular2/src/core/reflection/reflection.dart";
 import "dart:html";
 
+@AngularEntrypoint()
 main() {
-  reflector.reflectionCapabilities = new ReflectionCapabilities();
   const ECHO_CHANNEL = "ECHO";
   platform([WORKER_RENDER_PLATFORM])
       .asyncApplication(initIsolate("background_index.dart"))

--- a/modules/playground/src/web_workers/todo/background_index.dart
+++ b/modules/playground/src/web_workers/todo/background_index.dart
@@ -4,11 +4,9 @@ import "index_common.dart" show TodoApp;
 import "dart:isolate";
 import "package:angular2/platform/worker_app.dart";
 import "package:angular2/core.dart";
-import "package:angular2/src/core/reflection/reflection_capabilities.dart";
-import "package:angular2/src/core/reflection/reflection.dart";
 
+@AngularEntrypoint()
 main(List<String> args, SendPort replyTo) {
-  reflector.reflectionCapabilities = new ReflectionCapabilities();
   platform([WORKER_APP_PLATFORM, new Provider(RENDER_SEND_PORT, useValue: replyTo)])
       .application([WORKER_APP_APPLICATION])
       .bootstrap(TodoApp);

--- a/modules/playground/src/web_workers/todo/index.dart
+++ b/modules/playground/src/web_workers/todo/index.dart
@@ -2,11 +2,9 @@ library angular2.examples.web_workers.todo.index;
 
 import "package:angular2/platform/worker_render.dart";
 import "package:angular2/core.dart";
-import "package:angular2/src/core/reflection/reflection_capabilities.dart";
-import "package:angular2/src/core/reflection/reflection.dart";
 
+@AngularEntrypoint()
 main() {
-  reflector.reflectionCapabilities = new ReflectionCapabilities();
   platform([WORKER_RENDER_PLATFORM])
       .asyncApplication(initIsolate("background_index.dart"));
 }

--- a/modules/playground/src/web_workers/todo/index_web_socket.dart
+++ b/modules/playground/src/web_workers/todo/index_web_socket.dart
@@ -1,14 +1,12 @@
 library angular2.examples.web_workers.todo.index_web_socket;
 
-import "package:angular2/src/core/reflection/reflection_capabilities.dart";
-import "package:angular2/src/core/reflection/reflection.dart";
 import "package:angular2/core.dart";
 import "package:angular2/platform/worker_render.dart";
 import "package:angular2/src/web_workers/debug_tools/web_socket_message_bus.dart";
 import 'dart:html' show WebSocket;
 
+@AngularEntrypoint()
 main() {
-  reflector.reflectionCapabilities = new ReflectionCapabilities();
   var webSocket = new WebSocket("ws://127.0.0.1:1337/ws");
   webSocket.onOpen.listen((e) {
     var bus = new WebSocketMessageBus.fromWebSocket(webSocket);

--- a/modules_dart/transform/lib/src/transform/common/annotation_matcher.dart
+++ b/modules_dart/transform/lib/src/transform/common/annotation_matcher.dart
@@ -73,11 +73,14 @@ const _VIEWS = const [
 
 const _ENTRYPOINTS = const [
   const ClassDescriptor('AngularEntrypoint', 'package:angular2/angular2.dart'),
+  const ClassDescriptor('AngularEntrypoint', 'package:angular2/core.dart'),
   const ClassDescriptor('AngularEntrypoint', 'package:angular2/bootstrap.dart'),
   const ClassDescriptor(
       'AngularEntrypoint', 'package:angular2/bootstrap_static.dart'),
   const ClassDescriptor(
       'AngularEntrypoint', 'package:angular2/platform/browser.dart'),
+  const ClassDescriptor(
+      'AngularEntrypoint', 'package:angular2/platform/worker_app.dart'),
   const ClassDescriptor(
       'AngularEntrypoint', 'package:angular2/platform/browser_static.dart'),
   const ClassDescriptor(

--- a/modules_dart/transform/test/transform/reflection_remover/function_annotation_files/expected/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/function_annotation_files/expected/index.dart
@@ -17,7 +17,7 @@ import 'package:angular2/src/core/reflection/reflection.dart';
 
 @AngularEntrypoint()
 void main() {ngStaticInit.initReflector();
-  ngStaticInit.initReflector();/*reflector.reflectionCapabilities = new ReflectionCapabilities();*/
+  /*reflector.reflectionCapabilities = new ReflectionCapabilities();*/
   bootstrapStatic(MyComponent);
 }
 """;


### PR DESCRIPTION
- add support for `@AngularEntrypoint` in web workers
- convert all playground apps to use transformers
- make `dart2js` warnings fatal from now on
- drop 7 minutes from Dart Travis build (transformed apps build much faster)

Closes #3971
