### PR TITLE
chore: remove node.d.tsd from manual typings

### DIFF
--- a/modules/angular2/manual_typings/globals-es6.d.ts
+++ b/modules/angular2/manual_typings/globals-es6.d.ts
@@ -9,10 +9,6 @@
 /// <reference path="../typings/jasmine/jasmine.d.ts"/>
 /// <reference path="../typings/angular-protractor/angular-protractor.d.ts"/>
 
-// TODO: ideally the node.d.ts reference should be scoped only for files that need and not to all
-//       the code including client code
-/// <reference path="../typings/node/node.d.ts" />
-
 declare var assert: any;
 
 


### PR DESCRIPTION
- Removes node.d.tsd from manual typing due to problems is causes in any project using any type definition files that have node/node.d.tsd as a dependency

The main driver for this is that it is causing duplicate identifier errors in TypeScript in angular/universal on compilation - see https://github.com/angular/universal/issues/150 .
