### PR TITLE
fix(compiler): add ability to parse : in * directives

### DIFF
--- a/modules/angular2/src/compiler/template_parser.ts
+++ b/modules/angular2/src/compiler/template_parser.ts
@@ -281,7 +281,9 @@ class TemplateParseVisitor implements HtmlAstVisitor {
       templateBindingsSource = attr.value;
     } else if (attr.name.startsWith(TEMPLATE_ATTR_PREFIX)) {
       var key = attr.name.substring(TEMPLATE_ATTR_PREFIX.length);  // remove the star
-      templateBindingsSource = (attr.value.length == 0) ? key : key + ' ' + attr.value;
+      templateBindingsSource = (attr.value.length == 0) ?
+                                   key :
+                                   key + ' ' + StringWrapper.replaceAll(attr.value, /:/g, ' ');
     }
     if (isPresent(templateBindingsSource)) {
       var bindings = this._parseTemplateBindings(templateBindingsSource, attr.sourceSpan);

--- a/modules/angular2/test/compiler/template_parser_spec.ts
+++ b/modules/angular2/test/compiler/template_parser_spec.ts
@@ -395,7 +395,7 @@ export function main() {
 
         it('should support optional directive properties', () => {
           var dirA = CompileDirectiveMetadata.create(
-              {selector: 'div', type: new CompileTypeMetadata({name: 'DirA'}), inputs: ['a']});
+              {selector: 'div', type: new CompileTypeMetadata({name: 'Dir'}), inputs: ['a']});
           expect(humanizeTplAst(parse('<div></div>', [dirA])))
               .toEqual([[ElementAst, 'div'], [DirectiveAst, dirA]]);
         });
@@ -567,6 +567,18 @@ There is no directive with "exportAs" set to "dirA" ("<div [ERROR ->]#a="dirA"><
                 [EmbeddedTemplateAst],
                 [DirectiveAst, ngIf],
                 [BoundDirectivePropertyAst, 'ngIf', 'null'],
+                [ElementAst, 'div']
+              ]);
+        });
+
+        it('should work with *... and :', () => {
+          var dirA = CompileDirectiveMetadata.create(
+              {selector: '[a]', type: new CompileTypeMetadata({name: 'DirA'}), inputs: ['a', 'b']});
+          expect(humanizeTplAst(parse('<div *a="b: foo">', [dirA])))
+              .toEqual([
+                [EmbeddedTemplateAst],
+                [DirectiveAst, dirA],
+                [BoundDirectivePropertyAst, 'a', 'b'],
                 [ElementAst, 'div']
               ]);
         });


### PR DESCRIPTION
- Add ability to parse bindings properly when `:` is present when using a directive with the `*` prefix

This is an attempt at fixing #5894.
