### PR TITLE
fix(compiler): fix interpolation regexp

### DIFF
--- a/modules/angular2/src/core/change_detection/parser/parser.ts
+++ b/modules/angular2/src/core/change_detection/parser/parser.ts
@@ -49,7 +49,7 @@ import {
 
 var _implicitReceiver = new ImplicitReceiver();
 // TODO(tbosch): Cannot make this const/final right now because of the transpiler...
-var INTERPOLATION_REGEXP = /\{\{(.*?)\}\}/g;
+var INTERPOLATION_REGEXP = /\{\{([\s\S]*?)\}\}/g;
 
 class ParseException extends BaseException {
   constructor(message: string, input: string, errLocation: string, ctxLocation?: any) {

--- a/modules/angular2/test/core/change_detection/parser/parser_spec.ts
+++ b/modules/angular2/test/core/change_detection/parser/parser_spec.ts
@@ -421,6 +421,10 @@ export function main() {
 
       it('should parse conditional expression',
          () => { checkInterpolation('{{ a < b ? a : b }}'); });
+
+      it('should parse expression with newline characters', () => {
+        checkInterpolation(`{{ 'foo' +\n 'bar' +\r 'baz' }}`, `{{ "foo" + "bar" + "baz" }}`);
+      });
     });
 
     describe("parseSimpleBinding", () => {


### PR DESCRIPTION
- Fix the interpolation regexp to match newline characters (i.e. `\n` and `\r`)

This fixes #6044.
