### PR TITLE
build(broccoli-typescript): check for map files before deleting them

### DIFF
--- a/tools/broccoli/broccoli-typescript.ts
+++ b/tools/broccoli/broccoli-typescript.ts
@@ -212,7 +212,10 @@ class DiffingTSCompiler implements DiffingBroccoliPlugin {
 
     if (fs.existsSync(absoluteJsFilePath)) {
       fs.unlinkSync(absoluteJsFilePath);
-      fs.unlinkSync(absoluteMapFilePath);
+      if (fs.existsSync(absoluteMapFilePath)) {
+        // source map could be inline or not generated
+        fs.unlinkSync(absoluteMapFilePath);
+      }
       fs.unlinkSync(absoluteDtsFilePath);
     }
   }


### PR DESCRIPTION
fixes #5610 

/cc @vsavkin 
