### PR TITLE
build(npm): upgrade to npm v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ addons:
   firefox: "38.0"
 
 before_install:
+- npm install -g npm@3.5.2
 - node tools/analytics/build-analytics start ci job
 - node tools/analytics/build-analytics start ci before_install
 - echo ${TSDRC} > .tsdrc
@@ -75,7 +76,9 @@ install:
   # Check the size of caches
   - du -sh ./node_modules || true
   # Install npm dependecies
-  - npm install
+  # check-node-modules will exit(1) if we don't need to install
+  # we need to manually kick off the postinstall script if check-node-modules exit(0)s
+  - node tools/npm/check-node-modules --purge && npm install || npm run postinstall
   - node tools/analytics/build-analytics success ci install
 
 before_script:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@
 // THIS CHECK SHOULD BE THE FIRST THING IN THIS FILE
 // This is to ensure that we catch env issues before we error while requiring other dependencies.
 require('./tools/check-environment')(
-    {requiredNpmVersion: '>=2.14.7 <3.0.0', requiredNodeVersion: '>=4.2.1 <5.0.0'});
+    {requiredNpmVersion: '>=3.5.2 <4.0.0', requiredNodeVersion: '>=4.2.1 <5.0.0'});
 
 
 var del = require('del');
@@ -313,7 +313,9 @@ gulp.task('lint', ['build.tools'], function() {
       "requireParameterType": true,
       "requireReturnType": true,
       "semicolon": true,
-      "variable-name": [true, "ban-keywords"]
+
+      // TODO: find a way to just screen for reserved names
+      "variable-name": false
     }
   };
   return gulp.src(['modules/angular2/src/**/*.ts', '!modules/angular2/src/testing/**'])

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
+    "abbrev": {
+      "version": "1.0.7"
+    },
     "angular": {
       "version": "1.4.7"
     },
@@ -11,6 +14,9 @@
     },
     "base64-js": {
       "version": "0.0.8"
+    },
+    "bindings": {
+      "version": "1.2.1"
     },
     "bower": {
       "version": "1.6.5",
@@ -30,11 +36,11 @@
             "optimist": {
               "version": "0.6.1",
               "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3"
-                },
                 "minimist": {
                   "version": "0.0.10"
+                },
+                "wordwrap": {
+                  "version": "0.0.3"
                 }
               }
             },
@@ -80,17 +86,20 @@
             "graceful-fs": {
               "version": "4.1.2"
             },
-            "request-replay": {
-              "version": "0.2.0"
-            },
             "mkdirp": {
               "version": "0.3.5"
+            },
+            "request-replay": {
+              "version": "0.2.0"
             }
           }
         },
         "cardinal": {
           "version": "0.4.4",
           "dependencies": {
+            "ansicolors": {
+              "version": "0.2.1"
+            },
             "redeyed": {
               "version": "0.4.4",
               "dependencies": {
@@ -98,9 +107,6 @@
                   "version": "1.0.4"
                 }
               }
-            },
-            "ansicolors": {
-              "version": "0.2.1"
             }
           }
         },
@@ -187,6 +193,9 @@
             "binary": {
               "version": "0.3.0",
               "dependencies": {
+                "buffers": {
+                  "version": "0.1.1"
+                },
                 "chainsaw": {
                   "version": "0.1.0",
                   "dependencies": {
@@ -194,9 +203,6 @@
                       "version": "0.3.9"
                     }
                   }
-                },
-                "buffers": {
-                  "version": "0.1.1"
                 }
               }
             },
@@ -209,14 +215,14 @@
                 "core-util-is": {
                   "version": "1.0.1"
                 },
+                "inherits": {
+                  "version": "2.0.1"
+                },
                 "isarray": {
                   "version": "0.0.1"
                 },
                 "string_decoder": {
                   "version": "0.10.31"
-                },
-                "inherits": {
-                  "version": "2.0.1"
                 }
               }
             },
@@ -586,6 +592,9 @@
         "request": {
           "version": "2.53.0",
           "dependencies": {
+            "aws-sign2": {
+              "version": "0.5.0"
+            },
             "bl": {
               "version": "0.9.4",
               "dependencies": {
@@ -595,14 +604,14 @@
                     "core-util-is": {
                       "version": "1.0.1"
                     },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
                     "isarray": {
                       "version": "0.0.1"
                     },
                     "string_decoder": {
                       "version": "0.10.31"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
                     }
                   }
                 }
@@ -610,6 +619,14 @@
             },
             "caseless": {
               "version": "0.9.0"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5"
+                }
+              }
             },
             "forever-agent": {
               "version": "0.5.2"
@@ -621,6 +638,40 @@
                   "version": "0.9.2"
                 }
               }
+            },
+            "hawk": {
+              "version": "2.3.1",
+              "dependencies": {
+                "boom": {
+                  "version": "2.9.0"
+                },
+                "cryptiles": {
+                  "version": "2.0.5"
+                },
+                "hoek": {
+                  "version": "2.16.3"
+                },
+                "sntp": {
+                  "version": "1.0.9"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.1.11"
+                },
+                "assert-plus": {
+                  "version": "0.1.5"
+                },
+                "ctype": {
+                  "version": "0.5.3"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2"
             },
             "json-stringify-safe": {
               "version": "5.0.1"
@@ -636,65 +687,20 @@
             "node-uuid": {
               "version": "1.4.3"
             },
-            "qs": {
-              "version": "2.3.3"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1"
-            },
-            "tough-cookie": {
-              "version": "2.2.0"
-            },
-            "http-signature": {
-              "version": "0.10.1",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5"
-                },
-                "asn1": {
-                  "version": "0.1.11"
-                },
-                "ctype": {
-                  "version": "0.5.3"
-                }
-              }
-            },
             "oauth-sign": {
               "version": "0.6.0"
             },
-            "hawk": {
-              "version": "2.3.1",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3"
-                },
-                "boom": {
-                  "version": "2.9.0"
-                },
-                "cryptiles": {
-                  "version": "2.0.5"
-                },
-                "sntp": {
-                  "version": "1.0.9"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.5.0"
+            "qs": {
+              "version": "2.3.3"
             },
             "stringstream": {
               "version": "0.0.4"
             },
-            "combined-stream": {
-              "version": "0.0.7",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "0.0.5"
-                }
-              }
+            "tough-cookie": {
+              "version": "2.2.0"
             },
-            "isstream": {
-              "version": "0.1.2"
+            "tunnel-agent": {
+              "version": "0.4.1"
             }
           }
         },
@@ -763,16 +769,16 @@
         "shell-quote": {
           "version": "1.4.3",
           "dependencies": {
-            "jsonify": {
-              "version": "0.0.0"
-            },
             "array-filter": {
               "version": "0.0.1"
+            },
+            "array-map": {
+              "version": "0.0.0"
             },
             "array-reduce": {
               "version": "0.0.0"
             },
-            "array-map": {
+            "jsonify": {
               "version": "0.0.0"
             }
           }
@@ -980,17 +986,17 @@
                         "rc": {
                           "version": "1.1.2",
                           "dependencies": {
-                            "minimist": {
-                              "version": "1.2.0"
-                            },
                             "deep-extend": {
                               "version": "0.2.11"
                             },
-                            "strip-json-comments": {
-                              "version": "0.1.3"
-                            },
                             "ini": {
                               "version": "1.3.4"
+                            },
+                            "minimist": {
+                              "version": "1.2.0"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3"
                             }
                           }
                         }
@@ -1047,14 +1053,6 @@
         "broccoli-kitchen-sink-helpers": {
           "version": "0.2.9",
           "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8"
-                }
-              }
-            },
             "glob": {
               "version": "5.0.15",
               "dependencies": {
@@ -1079,6 +1077,14 @@
                 },
                 "path-is-absolute": {
                   "version": "1.0.0"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8"
                 }
               }
             }
@@ -1168,11 +1174,11 @@
             "optimist": {
               "version": "0.6.1",
               "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3"
-                },
                 "minimist": {
                   "version": "0.0.10"
+                },
+                "wordwrap": {
+                  "version": "0.0.3"
                 }
               }
             },
@@ -1211,11 +1217,11 @@
         "quick-temp": {
           "version": "0.1.3",
           "dependencies": {
-            "rimraf": {
-              "version": "2.2.8"
-            },
             "mktemp": {
               "version": "0.3.5"
+            },
+            "rimraf": {
+              "version": "2.2.8"
             },
             "underscore.string": {
               "version": "2.3.3"
@@ -1351,11 +1357,11 @@
             "quick-temp": {
               "version": "0.1.3",
               "dependencies": {
-                "rimraf": {
-                  "version": "2.2.8"
-                },
                 "mktemp": {
                   "version": "0.3.5"
+                },
+                "rimraf": {
+                  "version": "2.2.8"
                 },
                 "underscore.string": {
                   "version": "2.3.3"
@@ -1432,14 +1438,6 @@
             "broccoli-kitchen-sink-helpers": {
               "version": "0.2.9",
               "dependencies": {
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8"
-                    }
-                  }
-                },
                 "glob": {
                   "version": "5.0.15",
                   "dependencies": {
@@ -1466,6 +1464,14 @@
                       "version": "1.0.0"
                     }
                   }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8"
+                    }
+                  }
                 }
               }
             },
@@ -1478,11 +1484,11 @@
             "quick-temp": {
               "version": "0.1.3",
               "dependencies": {
-                "rimraf": {
-                  "version": "2.2.8"
-                },
                 "mktemp": {
                   "version": "0.3.5"
+                },
+                "rimraf": {
+                  "version": "2.2.8"
                 },
                 "underscore.string": {
                   "version": "2.3.3"
@@ -1551,11 +1557,11 @@
                 "quick-temp": {
                   "version": "0.1.3",
                   "dependencies": {
-                    "rimraf": {
-                      "version": "2.2.8"
-                    },
                     "mktemp": {
                       "version": "0.3.5"
+                    },
+                    "rimraf": {
+                      "version": "2.2.8"
                     },
                     "underscore.string": {
                       "version": "2.3.3"
@@ -1639,11 +1645,11 @@
         "fs-extra": {
           "version": "0.13.0",
           "dependencies": {
-            "ncp": {
-              "version": "1.0.1"
-            },
             "jsonfile": {
               "version": "2.2.3"
+            },
+            "ncp": {
+              "version": "1.0.1"
             },
             "rimraf": {
               "version": "2.4.3",
@@ -1696,11 +1702,11 @@
         "quick-temp": {
           "version": "0.1.3",
           "dependencies": {
-            "rimraf": {
-              "version": "2.2.8"
-            },
             "mktemp": {
               "version": "0.3.5"
+            },
+            "rimraf": {
+              "version": "2.2.8"
             },
             "underscore.string": {
               "version": "2.3.3"
@@ -1715,17 +1721,6 @@
     "browserify": {
       "version": "10.2.6",
       "dependencies": {
-        "JSONStream": {
-          "version": "1.0.6",
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.2.0"
-            },
-            "through": {
-              "version": "2.3.8"
-            }
-          }
-        },
         "assert": {
           "version": "1.3.0"
         },
@@ -2077,17 +2072,28 @@
         "isarray": {
           "version": "0.0.1"
         },
+        "JSONStream": {
+          "version": "1.0.6",
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.2.0"
+            },
+            "through": {
+              "version": "2.3.8"
+            }
+          }
+        },
         "labeled-stream-splicer": {
           "version": "1.0.2",
           "dependencies": {
             "stream-splicer": {
               "version": "1.3.2",
               "dependencies": {
-                "readable-wrap": {
-                  "version": "1.0.0"
-                },
                 "indexof": {
                   "version": "0.0.1"
+                },
+                "readable-wrap": {
+                  "version": "1.0.0"
                 }
               }
             }
@@ -2244,6 +2250,22 @@
         "unzip": {
           "version": "0.1.11",
           "dependencies": {
+            "binary": {
+              "version": "0.3.0",
+              "dependencies": {
+                "buffers": {
+                  "version": "0.1.1"
+                },
+                "chainsaw": {
+                  "version": "0.1.0",
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.3.9"
+                    }
+                  }
+                }
+              }
+            },
             "fstream": {
               "version": "0.1.31",
               "dependencies": {
@@ -2292,6 +2314,14 @@
                 }
               }
             },
+            "match-stream": {
+              "version": "0.0.2",
+              "dependencies": {
+                "buffers": {
+                  "version": "0.1.1"
+                }
+              }
+            },
             "pullstream": {
               "version": "0.4.1",
               "dependencies": {
@@ -2303,53 +2333,32 @@
                 }
               }
             },
-            "binary": {
-              "version": "0.3.0",
-              "dependencies": {
-                "chainsaw": {
-                  "version": "0.1.0",
-                  "dependencies": {
-                    "traverse": {
-                      "version": "0.3.9"
-                    }
-                  }
-                },
-                "buffers": {
-                  "version": "0.1.1"
-                }
-              }
-            },
             "readable-stream": {
               "version": "1.0.33",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1"
                 },
+                "inherits": {
+                  "version": "2.0.1"
+                },
                 "isarray": {
                   "version": "0.0.1"
                 },
                 "string_decoder": {
                   "version": "0.10.31"
-                },
-                "inherits": {
-                  "version": "2.0.1"
                 }
               }
             },
             "setimmediate": {
               "version": "1.0.4"
-            },
-            "match-stream": {
-              "version": "0.0.2",
-              "dependencies": {
-                "buffers": {
-                  "version": "0.1.1"
-                }
-              }
             }
           }
         }
       }
+    },
+    "bufferutil": {
+      "version": "1.2.1"
     },
     "canonical-path": {
       "version": "0.0.2"
@@ -2498,6 +2507,481 @@
         "async-each": {
           "version": "0.1.6"
         },
+        "fsevents": {
+          "version": "1.0.2",
+          "dependencies": {
+            "nan": {
+              "version": "2.1.0"
+            },
+            "node-pre-gyp": {
+              "version": "0.6.12",
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.4",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7"
+                    }
+                  }
+                },
+                "npmlog": {
+                  "version": "1.2.1",
+                  "dependencies": {
+                    "ansi": {
+                      "version": "0.3.0"
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.0.4",
+                      "dependencies": {
+                        "delegates": {
+                          "version": "0.1.0"
+                        },
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1"
+                            },
+                            "inherits": {
+                              "version": "2.0.1"
+                            },
+                            "isarray": {
+                              "version": "0.0.1"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "gauge": {
+                      "version": "1.2.2",
+                      "dependencies": {
+                        "has-unicode": {
+                          "version": "1.0.0"
+                        },
+                        "lodash.pad": {
+                          "version": "3.1.1",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.padleft": {
+                          "version": "3.1.1",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.padright": {
+                          "version": "3.1.1",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "rc": {
+                  "version": "1.1.2",
+                  "dependencies": {
+                    "deep-extend": {
+                      "version": "0.2.11"
+                    },
+                    "ini": {
+                      "version": "1.3.4"
+                    },
+                    "minimist": {
+                      "version": "1.2.0"
+                    },
+                    "strip-json-comments": {
+                      "version": "0.1.3"
+                    }
+                  }
+                },
+                "request": {
+                  "version": "2.64.0",
+                  "dependencies": {
+                    "aws-sign2": {
+                      "version": "0.5.0"
+                    },
+                    "bl": {
+                      "version": "1.0.0",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "2.0.2",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1"
+                            },
+                            "inherits": {
+                              "version": "2.0.1"
+                            },
+                            "isarray": {
+                              "version": "0.0.1"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.3"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "caseless": {
+                      "version": "0.11.0"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "1.0.0"
+                        }
+                      }
+                    },
+                    "extend": {
+                      "version": "3.0.0"
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc3",
+                      "dependencies": {
+                        "async": {
+                          "version": "1.4.2"
+                        }
+                      }
+                    },
+                    "har-validator": {
+                      "version": "1.8.0",
+                      "dependencies": {
+                        "bluebird": {
+                          "version": "2.10.2"
+                        },
+                        "chalk": {
+                          "version": "1.1.1",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.3"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0"
+                            }
+                          }
+                        },
+                        "commander": {
+                          "version": "2.8.1",
+                          "dependencies": {
+                            "graceful-readlink": {
+                              "version": "1.0.1"
+                            }
+                          }
+                        },
+                        "is-my-json-valid": {
+                          "version": "2.12.2",
+                          "dependencies": {
+                            "generate-function": {
+                              "version": "2.0.0"
+                            },
+                            "generate-object-property": {
+                              "version": "1.2.0",
+                              "dependencies": {
+                                "is-property": {
+                                  "version": "1.0.2"
+                                }
+                              }
+                            },
+                            "jsonpointer": {
+                              "version": "2.0.0"
+                            },
+                            "xtend": {
+                              "version": "4.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hawk": {
+                      "version": "3.1.0",
+                      "dependencies": {
+                        "boom": {
+                          "version": "2.9.0"
+                        },
+                        "cryptiles": {
+                          "version": "2.0.5"
+                        },
+                        "hoek": {
+                          "version": "2.16.3"
+                        },
+                        "sntp": {
+                          "version": "1.0.9"
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "0.11.0",
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.1.11"
+                        },
+                        "assert-plus": {
+                          "version": "0.1.5"
+                        },
+                        "ctype": {
+                          "version": "0.5.3"
+                        }
+                      }
+                    },
+                    "isstream": {
+                      "version": "0.1.2"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1"
+                    },
+                    "mime-types": {
+                      "version": "2.1.7",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.19.0"
+                        }
+                      }
+                    },
+                    "node-uuid": {
+                      "version": "1.4.3"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.0"
+                    },
+                    "qs": {
+                      "version": "5.1.0"
+                    },
+                    "stringstream": {
+                      "version": "0.0.4"
+                    },
+                    "tough-cookie": {
+                      "version": "2.1.0"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.1"
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.4.3",
+                  "dependencies": {
+                    "glob": {
+                      "version": "5.0.15",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.1",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.0"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.2",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "5.0.3"
+                },
+                "tar": {
+                  "version": "2.2.1",
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.8"
+                    },
+                    "fstream": {
+                      "version": "1.0.8",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.2"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1"
+                    }
+                  }
+                },
+                "tar-pack": {
+                  "version": "2.0.0",
+                  "dependencies": {
+                    "debug": {
+                      "version": "0.7.4"
+                    },
+                    "fstream": {
+                      "version": "0.1.31",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "3.0.8"
+                        },
+                        "inherits": {
+                          "version": "2.0.1"
+                        }
+                      }
+                    },
+                    "fstream-ignore": {
+                      "version": "0.0.7",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.0"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "1.2.3"
+                    },
+                    "once": {
+                      "version": "1.1.1"
+                    },
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1"
+                        },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
+                        "isarray": {
+                          "version": "0.0.1"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31"
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.2.8"
+                    },
+                    "tar": {
+                      "version": "0.1.20",
+                      "dependencies": {
+                        "block-stream": {
+                          "version": "0.0.8"
+                        },
+                        "inherits": {
+                          "version": "2.0.1"
+                        }
+                      }
+                    },
+                    "uid-number": {
+                      "version": "0.0.3"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "glob-parent": {
           "version": "2.0.0"
         },
@@ -2569,481 +3053,6 @@
               }
             }
           }
-        },
-        "fsevents": {
-          "version": "1.0.2",
-          "dependencies": {
-            "nan": {
-              "version": "2.1.0"
-            },
-            "node-pre-gyp": {
-              "version": "0.6.12",
-              "dependencies": {
-                "nopt": {
-                  "version": "3.0.4",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7"
-                    }
-                  }
-                },
-                "npmlog": {
-                  "version": "1.2.1",
-                  "dependencies": {
-                    "ansi": {
-                      "version": "0.3.0"
-                    },
-                    "are-we-there-yet": {
-                      "version": "1.0.4",
-                      "dependencies": {
-                        "delegates": {
-                          "version": "0.1.0"
-                        },
-                        "readable-stream": {
-                          "version": "1.1.13",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1"
-                            },
-                            "isarray": {
-                              "version": "0.0.1"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31"
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "gauge": {
-                      "version": "1.2.2",
-                      "dependencies": {
-                        "has-unicode": {
-                          "version": "1.0.0"
-                        },
-                        "lodash.pad": {
-                          "version": "3.1.1",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash.padleft": {
-                          "version": "3.1.1",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash.padright": {
-                          "version": "3.1.1",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "request": {
-                  "version": "2.64.0",
-                  "dependencies": {
-                    "bl": {
-                      "version": "1.0.0",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "2.0.2",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1"
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
-                            },
-                            "isarray": {
-                              "version": "0.0.1"
-                            },
-                            "process-nextick-args": {
-                              "version": "1.0.3"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31"
-                            },
-                            "util-deprecate": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "caseless": {
-                      "version": "0.11.0"
-                    },
-                    "extend": {
-                      "version": "3.0.0"
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1"
-                    },
-                    "form-data": {
-                      "version": "1.0.0-rc3",
-                      "dependencies": {
-                        "async": {
-                          "version": "1.4.2"
-                        }
-                      }
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1"
-                    },
-                    "mime-types": {
-                      "version": "2.1.7",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.19.0"
-                        }
-                      }
-                    },
-                    "node-uuid": {
-                      "version": "1.4.3"
-                    },
-                    "qs": {
-                      "version": "5.1.0"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.1"
-                    },
-                    "tough-cookie": {
-                      "version": "2.1.0"
-                    },
-                    "http-signature": {
-                      "version": "0.11.0",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.1.5"
-                        },
-                        "asn1": {
-                          "version": "0.1.11"
-                        },
-                        "ctype": {
-                          "version": "0.5.3"
-                        }
-                      }
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.0"
-                    },
-                    "hawk": {
-                      "version": "3.1.0",
-                      "dependencies": {
-                        "hoek": {
-                          "version": "2.16.3"
-                        },
-                        "boom": {
-                          "version": "2.9.0"
-                        },
-                        "cryptiles": {
-                          "version": "2.0.5"
-                        },
-                        "sntp": {
-                          "version": "1.0.9"
-                        }
-                      }
-                    },
-                    "aws-sign2": {
-                      "version": "0.5.0"
-                    },
-                    "stringstream": {
-                      "version": "0.0.4"
-                    },
-                    "combined-stream": {
-                      "version": "1.0.5",
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "isstream": {
-                      "version": "0.1.2"
-                    },
-                    "har-validator": {
-                      "version": "1.8.0",
-                      "dependencies": {
-                        "bluebird": {
-                          "version": "2.10.2"
-                        },
-                        "chalk": {
-                          "version": "1.1.1",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.1.0"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.3"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.0",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        },
-                        "commander": {
-                          "version": "2.8.1",
-                          "dependencies": {
-                            "graceful-readlink": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "is-my-json-valid": {
-                          "version": "2.12.2",
-                          "dependencies": {
-                            "generate-function": {
-                              "version": "2.0.0"
-                            },
-                            "generate-object-property": {
-                              "version": "1.2.0",
-                              "dependencies": {
-                                "is-property": {
-                                  "version": "1.0.2"
-                                }
-                              }
-                            },
-                            "jsonpointer": {
-                              "version": "2.0.0"
-                            },
-                            "xtend": {
-                              "version": "4.0.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "5.0.3"
-                },
-                "tar": {
-                  "version": "2.2.1",
-                  "dependencies": {
-                    "block-stream": {
-                      "version": "0.0.8"
-                    },
-                    "fstream": {
-                      "version": "1.0.8",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.2"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    }
-                  }
-                },
-                "tar-pack": {
-                  "version": "2.0.0",
-                  "dependencies": {
-                    "uid-number": {
-                      "version": "0.0.3"
-                    },
-                    "once": {
-                      "version": "1.1.1"
-                    },
-                    "debug": {
-                      "version": "0.7.4"
-                    },
-                    "rimraf": {
-                      "version": "2.2.8"
-                    },
-                    "fstream": {
-                      "version": "0.1.31",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "3.0.8"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
-                        }
-                      }
-                    },
-                    "tar": {
-                      "version": "0.1.20",
-                      "dependencies": {
-                        "block-stream": {
-                          "version": "0.0.8"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
-                        }
-                      }
-                    },
-                    "fstream-ignore": {
-                      "version": "0.0.7",
-                      "dependencies": {
-                        "minimatch": {
-                          "version": "0.2.14",
-                          "dependencies": {
-                            "lru-cache": {
-                              "version": "2.7.0"
-                            },
-                            "sigmund": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
-                        }
-                      }
-                    },
-                    "readable-stream": {
-                      "version": "1.0.33",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1"
-                        },
-                        "isarray": {
-                          "version": "0.0.1"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "1.2.3"
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8"
-                    }
-                  }
-                },
-                "rc": {
-                  "version": "1.1.2",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "1.2.0"
-                    },
-                    "deep-extend": {
-                      "version": "0.2.11"
-                    },
-                    "strip-json-comments": {
-                      "version": "0.1.3"
-                    },
-                    "ini": {
-                      "version": "1.3.4"
-                    }
-                  }
-                },
-                "rimraf": {
-                  "version": "2.4.3",
-                  "dependencies": {
-                    "glob": {
-                      "version": "5.0.15",
-                      "dependencies": {
-                        "inflight": {
-                          "version": "1.0.4",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
-                        },
-                        "minimatch": {
-                          "version": "3.0.0",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.1",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.2.0"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "once": {
-                          "version": "1.3.2",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "path-is-absolute": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
         }
       }
     },
@@ -3092,11 +3101,11 @@
                 "optimist": {
                   "version": "0.6.1",
                   "dependencies": {
-                    "wordwrap": {
-                      "version": "0.0.3"
-                    },
                     "minimist": {
                       "version": "0.0.10"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3"
                     }
                   }
                 },
@@ -3139,6 +3148,14 @@
         "conventional-commits-parser": {
           "version": "0.0.19",
           "dependencies": {
+            "is-text-path": {
+              "version": "1.0.1",
+              "dependencies": {
+                "text-extensions": {
+                  "version": "1.3.3"
+                }
+              }
+            },
             "JSONStream": {
               "version": "1.0.6",
               "dependencies": {
@@ -3147,14 +3164,6 @@
                 },
                 "through": {
                   "version": "2.3.8"
-                }
-              }
-            },
-            "is-text-path": {
-              "version": "1.0.1",
-              "dependencies": {
-                "text-extensions": {
-                  "version": "1.3.3"
                 }
               }
             },
@@ -3625,6 +3634,14 @@
     "es6-shim": {
       "version": "0.33.10"
     },
+    "findup-sync": {
+      "version": "0.2.1",
+      "dependencies": {
+        "glob": {
+          "version": "4.3.5"
+        }
+      }
+    },
     "firefox-profile": {
       "version": "0.3.11",
       "dependencies": {
@@ -3670,14 +3687,14 @@
                 "core-util-is": {
                   "version": "1.0.1"
                 },
+                "inherits": {
+                  "version": "2.0.1"
+                },
                 "isarray": {
                   "version": "0.0.1"
                 },
                 "string_decoder": {
                   "version": "0.10.31"
-                },
-                "inherits": {
-                  "version": "2.0.1"
                 }
               }
             },
@@ -3784,14 +3801,14 @@
                 "core-util-is": {
                   "version": "1.0.1"
                 },
+                "inherits": {
+                  "version": "2.0.1"
+                },
                 "isarray": {
                   "version": "0.0.1"
                 },
                 "string_decoder": {
                   "version": "0.10.31"
-                },
-                "inherits": {
-                  "version": "2.0.1"
                 }
               }
             }
@@ -3895,39 +3912,6 @@
             "jws": {
               "version": "3.0.0",
               "dependencies": {
-                "jwa": {
-                  "version": "1.0.2",
-                  "dependencies": {
-                    "base64url": {
-                      "version": "0.0.6"
-                    },
-                    "buffer-equal-constant-time": {
-                      "version": "1.0.1"
-                    },
-                    "ecdsa-sig-formatter": {
-                      "version": "1.0.2",
-                      "dependencies": {
-                        "asn1.js": {
-                          "version": "2.2.1",
-                          "dependencies": {
-                            "bn.js": {
-                              "version": "2.2.0"
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
-                            },
-                            "minimalistic-assert": {
-                              "version": "1.0.0"
-                            }
-                          }
-                        },
-                        "base64-url": {
-                          "version": "1.2.1"
-                        }
-                      }
-                    }
-                  }
-                },
                 "base64url": {
                   "version": "1.0.4",
                   "dependencies": {
@@ -3936,9 +3920,6 @@
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1"
-                        },
-                        "typedarray": {
-                          "version": "0.0.6"
                         },
                         "readable-stream": {
                           "version": "1.1.13",
@@ -3953,6 +3934,9 @@
                               "version": "0.10.31"
                             }
                           }
+                        },
+                        "typedarray": {
+                          "version": "0.0.6"
                         }
                       }
                     },
@@ -3997,12 +3981,48 @@
                       }
                     }
                   }
+                },
+                "jwa": {
+                  "version": "1.0.2",
+                  "dependencies": {
+                    "base64url": {
+                      "version": "0.0.6"
+                    },
+                    "buffer-equal-constant-time": {
+                      "version": "1.0.1"
+                    },
+                    "ecdsa-sig-formatter": {
+                      "version": "1.0.2",
+                      "dependencies": {
+                        "asn1.js": {
+                          "version": "2.2.1",
+                          "dependencies": {
+                            "bn.js": {
+                              "version": "2.2.0"
+                            },
+                            "inherits": {
+                              "version": "2.0.1"
+                            },
+                            "minimalistic-assert": {
+                              "version": "1.0.0"
+                            }
+                          }
+                        },
+                        "base64-url": {
+                          "version": "1.2.1"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
             "request": {
               "version": "2.65.0",
               "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0"
+                },
                 "bl": {
                   "version": "1.0.0",
                   "dependencies": {
@@ -4034,6 +4054,14 @@
                 "caseless": {
                   "version": "0.11.0"
                 },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
                 "extend": {
                   "version": "3.0.0"
                 },
@@ -4047,77 +4075,6 @@
                       "version": "1.5.0"
                     }
                   }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1"
-                },
-                "mime-types": {
-                  "version": "2.1.7",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.19.0"
-                    }
-                  }
-                },
-                "qs": {
-                  "version": "5.2.0"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.1"
-                },
-                "tough-cookie": {
-                  "version": "2.2.0"
-                },
-                "http-signature": {
-                  "version": "0.11.0",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5"
-                    },
-                    "asn1": {
-                      "version": "0.1.11"
-                    },
-                    "ctype": {
-                      "version": "0.5.3"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.0"
-                },
-                "hawk": {
-                  "version": "3.1.0",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3"
-                    },
-                    "boom": {
-                      "version": "2.10.1"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5"
-                    },
-                    "sntp": {
-                      "version": "1.0.9"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.6.0"
-                },
-                "stringstream": {
-                  "version": "0.0.5"
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "isstream": {
-                  "version": "0.1.2"
                 },
                 "har-validator": {
                   "version": "2.0.2",
@@ -4191,6 +4148,66 @@
                       }
                     }
                   }
+                },
+                "hawk": {
+                  "version": "3.1.0",
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5"
+                    },
+                    "hoek": {
+                      "version": "2.16.3"
+                    },
+                    "sntp": {
+                      "version": "1.0.9"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.11.0",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.1.11"
+                    },
+                    "assert-plus": {
+                      "version": "0.1.5"
+                    },
+                    "ctype": {
+                      "version": "0.5.3"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1"
+                },
+                "mime-types": {
+                  "version": "2.1.7",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.19.0"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.0"
+                },
+                "qs": {
+                  "version": "5.2.0"
+                },
+                "stringstream": {
+                  "version": "0.0.5"
+                },
+                "tough-cookie": {
+                  "version": "2.2.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.1"
                 }
               }
             }
@@ -4199,6 +4216,9 @@
         "request": {
           "version": "2.51.0",
           "dependencies": {
+            "aws-sign2": {
+              "version": "0.5.0"
+            },
             "bl": {
               "version": "0.9.4",
               "dependencies": {
@@ -4208,14 +4228,14 @@
                     "core-util-is": {
                       "version": "1.0.1"
                     },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
                     "isarray": {
                       "version": "0.0.1"
                     },
                     "string_decoder": {
                       "version": "0.10.31"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
                     }
                   }
                 }
@@ -4223,6 +4243,14 @@
             },
             "caseless": {
               "version": "0.8.0"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5"
+                }
+              }
             },
             "forever-agent": {
               "version": "0.5.2"
@@ -4240,68 +4268,57 @@
                 }
               }
             },
-            "json-stringify-safe": {
-              "version": "5.0.1"
-            },
-            "mime-types": {
-              "version": "1.0.2"
-            },
-            "qs": {
-              "version": "2.3.3"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1"
-            },
-            "tough-cookie": {
-              "version": "2.2.0"
-            },
-            "http-signature": {
-              "version": "0.10.1",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5"
-                },
-                "asn1": {
-                  "version": "0.1.11"
-                },
-                "ctype": {
-                  "version": "0.5.3"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.5.0"
-            },
             "hawk": {
               "version": "1.1.1",
               "dependencies": {
-                "hoek": {
-                  "version": "0.9.1"
-                },
                 "boom": {
                   "version": "0.4.2"
                 },
                 "cryptiles": {
                   "version": "0.2.2"
                 },
+                "hoek": {
+                  "version": "0.9.1"
+                },
                 "sntp": {
                   "version": "0.2.4"
                 }
               }
             },
-            "aws-sign2": {
+            "http-signature": {
+              "version": "0.10.1",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.1.11"
+                },
+                "assert-plus": {
+                  "version": "0.1.5"
+                },
+                "ctype": {
+                  "version": "0.5.3"
+                }
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1"
+            },
+            "mime-types": {
+              "version": "1.0.2"
+            },
+            "oauth-sign": {
               "version": "0.5.0"
+            },
+            "qs": {
+              "version": "2.3.3"
             },
             "stringstream": {
               "version": "0.0.5"
             },
-            "combined-stream": {
-              "version": "0.0.7",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "0.0.5"
-                }
-              }
+            "tough-cookie": {
+              "version": "2.2.0"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1"
             }
           }
         },
@@ -4630,14 +4647,14 @@
                         "core-util-is": {
                           "version": "1.0.1"
                         },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
                         "isarray": {
                           "version": "0.0.1"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
                         }
                       }
                     }
@@ -4804,9 +4821,6 @@
             "glob-stream": {
               "version": "3.1.18",
               "dependencies": {
-                "ordered-read-streams": {
-                  "version": "0.1.0"
-                },
                 "glob2base": {
                   "version": "0.0.12",
                   "dependencies": {
@@ -4814,6 +4828,9 @@
                       "version": "0.1.1"
                     }
                   }
+                },
+                "ordered-read-streams": {
+                  "version": "0.1.0"
                 },
                 "unique-stream": {
                   "version": "1.0.0"
@@ -4829,9 +4846,6 @@
                     "globule": {
                       "version": "0.1.0",
                       "dependencies": {
-                        "lodash": {
-                          "version": "1.0.2"
-                        },
                         "glob": {
                           "version": "3.1.21",
                           "dependencies": {
@@ -4842,6 +4856,9 @@
                               "version": "1.0.2"
                             }
                           }
+                        },
+                        "lodash": {
+                          "version": "1.0.2"
                         },
                         "minimatch": {
                           "version": "0.2.14",
@@ -4903,14 +4920,14 @@
         "autoprefixer": {
           "version": "6.0.3",
           "dependencies": {
-            "num2fraction": {
-              "version": "1.2.2"
-            },
             "browserslist": {
               "version": "1.0.1"
             },
             "caniuse-db": {
               "version": "1.0.30000356"
+            },
+            "num2fraction": {
+              "version": "1.2.2"
             }
           }
         },
@@ -5225,14 +5242,14 @@
                         "core-util-is": {
                           "version": "1.0.1"
                         },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
                         "isarray": {
                           "version": "0.0.1"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
                         }
                       }
                     }
@@ -5262,6 +5279,12 @@
         "postcss": {
           "version": "5.0.10",
           "dependencies": {
+            "js-base64": {
+              "version": "2.1.9"
+            },
+            "source-map": {
+              "version": "0.5.3"
+            },
             "supports-color": {
               "version": "3.1.2",
               "dependencies": {
@@ -5269,12 +5292,6 @@
                   "version": "1.0.0"
                 }
               }
-            },
-            "source-map": {
-              "version": "0.5.3"
-            },
-            "js-base64": {
-              "version": "2.1.9"
             }
           }
         },
@@ -5325,40 +5342,6 @@
         "gulp-diff": {
           "version": "1.0.0",
           "dependencies": {
-            "diff": {
-              "version": "2.2.0"
-            },
-            "through2": {
-              "version": "2.0.0",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.4",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.3"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1"
-                }
-              }
-            },
             "cli-color": {
               "version": "1.1.0",
               "dependencies": {
@@ -5419,12 +5402,12 @@
                 }
               }
             },
+            "diff": {
+              "version": "2.2.0"
+            },
             "event-stream": {
               "version": "3.3.2",
               "dependencies": {
-                "through": {
-                  "version": "2.3.8"
-                },
                 "duplexer": {
                   "version": "0.1.1"
                 },
@@ -5442,6 +5425,40 @@
                 },
                 "stream-combiner": {
                   "version": "0.0.4"
+                },
+                "through": {
+                  "version": "2.3.8"
+                }
+              }
+            },
+            "through2": {
+              "version": "2.0.0",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.4",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1"
+                    },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
+                    "isarray": {
+                      "version": "0.0.1"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.3"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1"
                 }
               }
             }
@@ -5763,14 +5780,14 @@
                         "core-util-is": {
                           "version": "1.0.1"
                         },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
                         "isarray": {
                           "version": "0.0.1"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
                         }
                       }
                     }
@@ -6189,14 +6206,14 @@
                         "core-util-is": {
                           "version": "1.0.1"
                         },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
                         "isarray": {
                           "version": "0.0.1"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
                         }
                       }
                     }
@@ -6259,6 +6276,212 @@
     "gulp-connect": {
       "version": "1.1.1",
       "dependencies": {
+        "connect": {
+          "version": "2.14.5",
+          "dependencies": {
+            "basic-auth-connect": {
+              "version": "1.0.0"
+            },
+            "bytes": {
+              "version": "0.3.0"
+            },
+            "compression": {
+              "version": "1.0.0",
+              "dependencies": {
+                "bytes": {
+                  "version": "0.2.1"
+                },
+                "compressible": {
+                  "version": "1.0.0"
+                },
+                "negotiator": {
+                  "version": "0.3.0"
+                }
+              }
+            },
+            "connect-timeout": {
+              "version": "1.0.0"
+            },
+            "cookie-parser": {
+              "version": "1.0.1",
+              "dependencies": {
+                "cookie": {
+                  "version": "0.1.0"
+                }
+              }
+            },
+            "cookie-signature": {
+              "version": "1.0.3"
+            },
+            "csurf": {
+              "version": "1.1.0",
+              "dependencies": {
+                "scmp": {
+                  "version": "0.0.3"
+                },
+                "uid2": {
+                  "version": "0.0.3"
+                }
+              }
+            },
+            "debug": {
+              "version": "0.8.1"
+            },
+            "errorhandler": {
+              "version": "1.0.0"
+            },
+            "express-session": {
+              "version": "1.0.2",
+              "dependencies": {
+                "buffer-crc32": {
+                  "version": "0.2.1"
+                },
+                "cookie": {
+                  "version": "0.1.0"
+                },
+                "debug": {
+                  "version": "0.7.4"
+                },
+                "uid2": {
+                  "version": "0.0.3"
+                },
+                "utils-merge": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "fresh": {
+              "version": "0.2.2"
+            },
+            "method-override": {
+              "version": "1.0.0",
+              "dependencies": {
+                "methods": {
+                  "version": "1.1.1"
+                }
+              }
+            },
+            "morgan": {
+              "version": "1.0.0",
+              "dependencies": {
+                "bytes": {
+                  "version": "0.2.1"
+                }
+              }
+            },
+            "multiparty": {
+              "version": "2.2.0",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1"
+                    },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
+                    "isarray": {
+                      "version": "0.0.1"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31"
+                    }
+                  }
+                },
+                "stream-counter": {
+                  "version": "0.2.0"
+                }
+              }
+            },
+            "pause": {
+              "version": "0.0.1"
+            },
+            "qs": {
+              "version": "0.6.6"
+            },
+            "raw-body": {
+              "version": "1.1.4"
+            },
+            "response-time": {
+              "version": "1.0.0"
+            },
+            "serve-index": {
+              "version": "1.0.1",
+              "dependencies": {
+                "batch": {
+                  "version": "0.5.0"
+                },
+                "negotiator": {
+                  "version": "0.4.2"
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.1.0",
+              "dependencies": {
+                "parseurl": {
+                  "version": "1.0.1"
+                },
+                "send": {
+                  "version": "0.3.0",
+                  "dependencies": {
+                    "buffer-crc32": {
+                      "version": "0.2.1"
+                    },
+                    "debug": {
+                      "version": "0.8.0"
+                    },
+                    "mime": {
+                      "version": "1.2.11"
+                    },
+                    "range-parser": {
+                      "version": "1.0.3"
+                    }
+                  }
+                }
+              }
+            },
+            "setimmediate": {
+              "version": "1.0.1"
+            },
+            "static-favicon": {
+              "version": "1.0.2"
+            },
+            "vhost": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "connect-livereload": {
+          "version": "0.3.2"
+        },
+        "event-stream": {
+          "version": "3.1.7",
+          "dependencies": {
+            "duplexer": {
+              "version": "0.1.1"
+            },
+            "from": {
+              "version": "0.1.3"
+            },
+            "map-stream": {
+              "version": "0.1.0"
+            },
+            "pause-stream": {
+              "version": "0.0.11"
+            },
+            "split": {
+              "version": "0.2.10"
+            },
+            "stream-combiner": {
+              "version": "0.0.4"
+            },
+            "through": {
+              "version": "2.3.8"
+            }
+          }
+        },
         "gulp-util": {
           "version": "2.2.20",
           "dependencies": {
@@ -6485,6 +6708,9 @@
             "lodash.template": {
               "version": "2.4.1",
               "dependencies": {
+                "lodash._escapestringchar": {
+                  "version": "2.4.1"
+                },
                 "lodash.defaults": {
                   "version": "2.4.1",
                   "dependencies": {
@@ -6514,16 +6740,13 @@
                     }
                   }
                 },
-                "lodash._escapestringchar": {
-                  "version": "2.4.1"
-                },
                 "lodash.keys": {
                   "version": "2.4.1",
                   "dependencies": {
                     "lodash._isnative": {
                       "version": "2.4.1"
                     },
-                    "lodash.isobject": {
+                    "lodash._shimkeys": {
                       "version": "2.4.1",
                       "dependencies": {
                         "lodash._objecttypes": {
@@ -6531,7 +6754,7 @@
                         }
                       }
                     },
-                    "lodash._shimkeys": {
+                    "lodash.isobject": {
                       "version": "2.4.1",
                       "dependencies": {
                         "lodash._objecttypes": {
@@ -6564,14 +6787,14 @@
                         "core-util-is": {
                           "version": "1.0.1"
                         },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
                         "isarray": {
                           "version": "0.0.1"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
                         }
                       }
                     }
@@ -6588,14 +6811,14 @@
                     "core-util-is": {
                       "version": "1.0.1"
                     },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
                     "isarray": {
                       "version": "0.0.1"
                     },
                     "string_decoder": {
                       "version": "0.10.31"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
                     }
                   }
                 },
@@ -6614,34 +6837,8 @@
             }
           }
         },
-        "event-stream": {
-          "version": "3.1.7",
-          "dependencies": {
-            "through": {
-              "version": "2.3.8"
-            },
-            "duplexer": {
-              "version": "0.1.1"
-            },
-            "from": {
-              "version": "0.1.3"
-            },
-            "map-stream": {
-              "version": "0.1.0"
-            },
-            "pause-stream": {
-              "version": "0.0.11"
-            },
-            "split": {
-              "version": "0.2.10"
-            },
-            "stream-combiner": {
-              "version": "0.0.4"
-            }
-          }
-        },
-        "connect-livereload": {
-          "version": "0.3.2"
+        "noptify": {
+          "version": "0.0.3"
         },
         "open": {
           "version": "0.0.4"
@@ -6649,204 +6846,14 @@
         "tiny-lr": {
           "version": "0.0.5",
           "dependencies": {
-            "qs": {
-              "version": "0.5.6"
+            "debug": {
+              "version": "0.7.4"
             },
             "faye-websocket": {
               "version": "0.4.4"
             },
-            "noptify": {
-              "version": "0.0.3",
-              "dependencies": {
-                "nopt": {
-                  "version": "2.0.0",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7"
-                    }
-                  }
-                }
-              }
-            },
-            "debug": {
-              "version": "0.7.4"
-            }
-          }
-        },
-        "connect": {
-          "version": "2.14.5",
-          "dependencies": {
-            "basic-auth-connect": {
-              "version": "1.0.0"
-            },
-            "cookie-parser": {
-              "version": "1.0.1",
-              "dependencies": {
-                "cookie": {
-                  "version": "0.1.0"
-                }
-              }
-            },
-            "cookie-signature": {
-              "version": "1.0.3"
-            },
-            "compression": {
-              "version": "1.0.0",
-              "dependencies": {
-                "bytes": {
-                  "version": "0.2.1"
-                },
-                "negotiator": {
-                  "version": "0.3.0"
-                },
-                "compressible": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "connect-timeout": {
-              "version": "1.0.0"
-            },
-            "csurf": {
-              "version": "1.1.0",
-              "dependencies": {
-                "uid2": {
-                  "version": "0.0.3"
-                },
-                "scmp": {
-                  "version": "0.0.3"
-                }
-              }
-            },
-            "errorhandler": {
-              "version": "1.0.0"
-            },
-            "express-session": {
-              "version": "1.0.2",
-              "dependencies": {
-                "utils-merge": {
-                  "version": "1.0.0"
-                },
-                "cookie": {
-                  "version": "0.1.0"
-                },
-                "uid2": {
-                  "version": "0.0.3"
-                },
-                "buffer-crc32": {
-                  "version": "0.2.1"
-                },
-                "debug": {
-                  "version": "0.7.4"
-                }
-              }
-            },
-            "fresh": {
-              "version": "0.2.2"
-            },
-            "method-override": {
-              "version": "1.0.0",
-              "dependencies": {
-                "methods": {
-                  "version": "1.1.1"
-                }
-              }
-            },
-            "morgan": {
-              "version": "1.0.0",
-              "dependencies": {
-                "bytes": {
-                  "version": "0.2.1"
-                }
-              }
-            },
             "qs": {
-              "version": "0.6.6"
-            },
-            "raw-body": {
-              "version": "1.1.4"
-            },
-            "response-time": {
-              "version": "1.0.0"
-            },
-            "setimmediate": {
-              "version": "1.0.1"
-            },
-            "serve-index": {
-              "version": "1.0.1",
-              "dependencies": {
-                "batch": {
-                  "version": "0.5.0"
-                },
-                "negotiator": {
-                  "version": "0.4.2"
-                }
-              }
-            },
-            "serve-static": {
-              "version": "1.1.0",
-              "dependencies": {
-                "parseurl": {
-                  "version": "1.0.1"
-                },
-                "send": {
-                  "version": "0.3.0",
-                  "dependencies": {
-                    "buffer-crc32": {
-                      "version": "0.2.1"
-                    },
-                    "debug": {
-                      "version": "0.8.0"
-                    },
-                    "mime": {
-                      "version": "1.2.11"
-                    },
-                    "range-parser": {
-                      "version": "1.0.3"
-                    }
-                  }
-                }
-              }
-            },
-            "static-favicon": {
-              "version": "1.0.2"
-            },
-            "vhost": {
-              "version": "1.0.0"
-            },
-            "bytes": {
-              "version": "0.3.0"
-            },
-            "pause": {
-              "version": "0.0.1"
-            },
-            "debug": {
-              "version": "0.8.1"
-            },
-            "multiparty": {
-              "version": "2.2.0",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    }
-                  }
-                },
-                "stream-counter": {
-                  "version": "0.2.0"
-                }
-              }
+              "version": "0.5.6"
             }
           }
         }
@@ -7094,6 +7101,9 @@
             "lodash.template": {
               "version": "2.4.1",
               "dependencies": {
+                "lodash._escapestringchar": {
+                  "version": "2.4.1"
+                },
                 "lodash.defaults": {
                   "version": "2.4.1",
                   "dependencies": {
@@ -7123,16 +7133,13 @@
                     }
                   }
                 },
-                "lodash._escapestringchar": {
-                  "version": "2.4.1"
-                },
                 "lodash.keys": {
                   "version": "2.4.1",
                   "dependencies": {
                     "lodash._isnative": {
                       "version": "2.4.1"
                     },
-                    "lodash.isobject": {
+                    "lodash._shimkeys": {
                       "version": "2.4.1",
                       "dependencies": {
                         "lodash._objecttypes": {
@@ -7140,7 +7147,7 @@
                         }
                       }
                     },
-                    "lodash._shimkeys": {
+                    "lodash.isobject": {
                       "version": "2.4.1",
                       "dependencies": {
                         "lodash._objecttypes": {
@@ -7173,14 +7180,14 @@
                         "core-util-is": {
                           "version": "1.0.1"
                         },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
                         "isarray": {
                           "version": "0.0.1"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
                         }
                       }
                     }
@@ -7197,14 +7204,14 @@
                     "core-util-is": {
                       "version": "1.0.1"
                     },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
                     "isarray": {
                       "version": "0.0.1"
                     },
                     "string_decoder": {
                       "version": "0.10.31"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
                     }
                   }
                 },
@@ -7235,14 +7242,14 @@
                 "core-util-is": {
                   "version": "1.0.1"
                 },
+                "inherits": {
+                  "version": "2.0.1"
+                },
                 "isarray": {
                   "version": "0.0.1"
                 },
                 "string_decoder": {
                   "version": "0.10.31"
-                },
-                "inherits": {
-                  "version": "2.0.1"
                 }
               }
             },
@@ -7267,14 +7274,14 @@
             "core-util-is": {
               "version": "1.0.1"
             },
+            "inherits": {
+              "version": "2.0.1"
+            },
             "isarray": {
               "version": "0.0.1"
             },
             "string_decoder": {
               "version": "0.10.31"
-            },
-            "inherits": {
-              "version": "2.0.1"
             }
           }
         },
@@ -7345,11 +7352,11 @@
         "istextorbinary": {
           "version": "1.0.2",
           "dependencies": {
-            "textextensions": {
-              "version": "1.0.1"
-            },
             "binaryextensions": {
               "version": "1.0.0"
+            },
+            "textextensions": {
+              "version": "1.0.1"
             }
           }
         },
@@ -7703,14 +7710,14 @@
                         "core-util-is": {
                           "version": "1.0.1"
                         },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
                         "isarray": {
                           "version": "0.0.1"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
                         }
                       }
                     }
@@ -7793,9 +7800,6 @@
                         "inherits": {
                           "version": "2.0.1"
                         },
-                        "typedarray": {
-                          "version": "0.0.6"
-                        },
                         "readable-stream": {
                           "version": "2.0.4",
                           "dependencies": {
@@ -7815,6 +7819,9 @@
                               "version": "1.0.2"
                             }
                           }
+                        },
+                        "typedarray": {
+                          "version": "0.0.6"
                         }
                       }
                     },
@@ -7831,9 +7838,6 @@
                 "globule": {
                   "version": "0.1.0",
                   "dependencies": {
-                    "lodash": {
-                      "version": "1.0.2"
-                    },
                     "glob": {
                       "version": "3.1.21",
                       "dependencies": {
@@ -7844,6 +7848,9 @@
                           "version": "1.0.2"
                         }
                       }
+                    },
+                    "lodash": {
+                      "version": "1.0.2"
                     },
                     "minimatch": {
                       "version": "0.2.14",
@@ -8069,55 +8076,6 @@
             "nan": {
               "version": "2.1.0"
             },
-            "npmconf": {
-              "version": "2.1.2",
-              "dependencies": {
-                "config-chain": {
-                  "version": "1.1.9",
-                  "dependencies": {
-                    "proto-list": {
-                      "version": "1.2.4"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                },
-                "ini": {
-                  "version": "1.3.4"
-                },
-                "nopt": {
-                  "version": "3.0.4",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7"
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.2",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1"
-                    },
-                    "os-tmpdir": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "uid-number": {
-                  "version": "0.0.5"
-                }
-              }
-            },
             "node-gyp": {
               "version": "3.0.3",
               "dependencies": {
@@ -8209,14 +8167,14 @@
                             "core-util-is": {
                               "version": "1.0.1"
                             },
+                            "inherits": {
+                              "version": "2.0.1"
+                            },
                             "isarray": {
                               "version": "0.0.1"
                             },
                             "string_decoder": {
                               "version": "0.10.31"
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
                             }
                           }
                         }
@@ -8370,9 +8328,61 @@
                 }
               }
             },
+            "npmconf": {
+              "version": "2.1.2",
+              "dependencies": {
+                "config-chain": {
+                  "version": "1.1.9",
+                  "dependencies": {
+                    "proto-list": {
+                      "version": "1.2.4"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1"
+                },
+                "ini": {
+                  "version": "1.3.4"
+                },
+                "nopt": {
+                  "version": "3.0.4",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.3",
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.1"
+                    },
+                    "os-tmpdir": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
+                "uid-number": {
+                  "version": "0.0.5"
+                }
+              }
+            },
             "request": {
               "version": "2.65.0",
               "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0"
+                },
                 "bl": {
                   "version": "1.0.0",
                   "dependencies": {
@@ -8404,6 +8414,14 @@
                 "caseless": {
                   "version": "0.11.0"
                 },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
                 "extend": {
                   "version": "3.0.0"
                 },
@@ -8417,77 +8435,6 @@
                       "version": "1.5.0"
                     }
                   }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1"
-                },
-                "mime-types": {
-                  "version": "2.1.7",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.19.0"
-                    }
-                  }
-                },
-                "qs": {
-                  "version": "5.2.0"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.1"
-                },
-                "tough-cookie": {
-                  "version": "2.2.0"
-                },
-                "http-signature": {
-                  "version": "0.11.0",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5"
-                    },
-                    "asn1": {
-                      "version": "0.1.11"
-                    },
-                    "ctype": {
-                      "version": "0.5.3"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.0"
-                },
-                "hawk": {
-                  "version": "3.1.0",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3"
-                    },
-                    "boom": {
-                      "version": "2.10.1"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5"
-                    },
-                    "sntp": {
-                      "version": "1.0.9"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.6.0"
-                },
-                "stringstream": {
-                  "version": "0.0.5"
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "isstream": {
-                  "version": "0.1.2"
                 },
                 "har-validator": {
                   "version": "2.0.2",
@@ -8531,6 +8478,66 @@
                       }
                     }
                   }
+                },
+                "hawk": {
+                  "version": "3.1.0",
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5"
+                    },
+                    "hoek": {
+                      "version": "2.16.3"
+                    },
+                    "sntp": {
+                      "version": "1.0.9"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.11.0",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.1.11"
+                    },
+                    "assert-plus": {
+                      "version": "0.1.5"
+                    },
+                    "ctype": {
+                      "version": "0.5.3"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1"
+                },
+                "mime-types": {
+                  "version": "2.1.7",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.19.0"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.0"
+                },
+                "qs": {
+                  "version": "5.2.0"
+                },
+                "stringstream": {
+                  "version": "0.0.5"
+                },
+                "tough-cookie": {
+                  "version": "2.2.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.1"
                 }
               }
             },
@@ -8972,14 +8979,14 @@
                         "core-util-is": {
                           "version": "1.0.1"
                         },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
                         "isarray": {
                           "version": "0.0.1"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
                         }
                       }
                     }
@@ -9420,14 +9427,14 @@
                         "core-util-is": {
                           "version": "1.0.1"
                         },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
                         "isarray": {
                           "version": "0.0.1"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
                         }
                       }
                     }
@@ -9542,11 +9549,11 @@
             "optimist": {
               "version": "0.6.1",
               "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3"
-                },
                 "minimist": {
                   "version": "0.0.10"
+                },
+                "wordwrap": {
+                  "version": "0.0.3"
                 }
               }
             },
@@ -9876,14 +9883,14 @@
                         "core-util-is": {
                           "version": "1.0.2"
                         },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
                         "isarray": {
                           "version": "0.0.1"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
                         }
                       }
                     }
@@ -9943,6 +9950,9 @@
               "version": "4.0.1"
             }
           }
+        },
+        "typescript": {
+          "version": "1.7.3"
         },
         "vinyl-fs": {
           "version": "2.2.1",
@@ -10069,14 +10079,14 @@
                         "core-util-is": {
                           "version": "1.0.2"
                         },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
                         "isarray": {
                           "version": "0.0.1"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
                         }
                       }
                     },
@@ -10723,14 +10733,14 @@
                         "core-util-is": {
                           "version": "1.0.1"
                         },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
                         "isarray": {
                           "version": "0.0.1"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
                         }
                       }
                     }
@@ -10843,6 +10853,9 @@
     "hash-files": {
       "version": "1.0.0",
       "dependencies": {
+        "async": {
+          "version": "0.9.2"
+        },
         "glob": {
           "version": "3.2.11",
           "dependencies": {
@@ -10867,11 +10880,14 @@
         },
         "underscore": {
           "version": "1.8.3"
-        },
-        "async": {
-          "version": "0.9.2"
         }
       }
+    },
+    "inflight": {
+      "version": "1.0.4"
+    },
+    "inherits": {
+      "version": "2.0.1"
     },
     "jasmine": {
       "version": "2.3.1",
@@ -10908,88 +10924,6 @@
       "dependencies": {
         "commander": {
           "version": "2.6.0"
-        },
-        "fs-promise": {
-          "version": "0.3.1",
-          "dependencies": {
-            "any-promise": {
-              "version": "0.1.0"
-            }
-          }
-        },
-        "fs-extra": {
-          "version": "0.16.4",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "3.0.8"
-            },
-            "jsonfile": {
-              "version": "2.2.3"
-            },
-            "rimraf": {
-              "version": "2.4.3",
-              "dependencies": {
-                "glob": {
-                  "version": "5.0.15",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    },
-                    "once": {
-                      "version": "1.3.2",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "fx-runner": {
-          "version": "0.0.7",
-          "dependencies": {
-            "lodash": {
-              "version": "2.4.1"
-            },
-            "when": {
-              "version": "3.6.4"
-            },
-            "winreg": {
-              "version": "0.0.12"
-            }
-          }
-        },
-        "jpm-core": {
-          "version": "0.0.9"
-        },
-        "jetpack-id": {
-          "version": "0.0.4"
-        },
-        "jetpack-validation": {
-          "version": "0.0.4",
-          "dependencies": {
-            "resolve": {
-              "version": "0.7.4"
-            },
-            "semver": {
-              "version": "2.3.2"
-            }
-          }
         },
         "firefox-profile": {
           "version": "0.3.9",
@@ -11036,14 +10970,14 @@
                     "core-util-is": {
                       "version": "1.0.1"
                     },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
                     "isarray": {
                       "version": "0.0.1"
                     },
                     "string_decoder": {
                       "version": "0.10.31"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
                     }
                   }
                 },
@@ -11092,6 +11026,9 @@
             "async": {
               "version": "0.9.2"
             },
+            "ini": {
+              "version": "1.3.4"
+            },
             "lazystream": {
               "version": "0.1.0",
               "dependencies": {
@@ -11101,14 +11038,14 @@
                     "core-util-is": {
                       "version": "1.0.1"
                     },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
                     "isarray": {
                       "version": "0.0.1"
                     },
                     "string_decoder": {
                       "version": "0.10.31"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
                     }
                   }
                 }
@@ -11130,11 +11067,90 @@
                   "version": "4.0.0"
                 }
               }
-            },
-            "ini": {
-              "version": "1.3.4"
             }
           }
+        },
+        "fs-extra": {
+          "version": "0.16.4",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.8"
+            },
+            "jsonfile": {
+              "version": "2.2.3"
+            },
+            "rimraf": {
+              "version": "2.4.3",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "fs-promise": {
+          "version": "0.3.1",
+          "dependencies": {
+            "any-promise": {
+              "version": "0.1.0"
+            }
+          }
+        },
+        "fx-runner": {
+          "version": "0.0.7",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.1"
+            },
+            "when": {
+              "version": "3.6.4"
+            },
+            "winreg": {
+              "version": "0.0.12"
+            }
+          }
+        },
+        "jetpack-id": {
+          "version": "0.0.4"
+        },
+        "jetpack-validation": {
+          "version": "0.0.4",
+          "dependencies": {
+            "resolve": {
+              "version": "0.7.4"
+            },
+            "semver": {
+              "version": "2.3.2"
+            }
+          }
+        },
+        "jpm-core": {
+          "version": "0.0.9"
         },
         "jsontoxml": {
           "version": "0.0.11"
@@ -11158,11 +11174,14 @@
             }
           }
         },
+        "mozilla-toolkit-versioning": {
+          "version": "0.0.2"
+        },
+        "mozilla-version-comparator": {
+          "version": "1.0.2"
+        },
         "node-watch": {
           "version": "0.3.4"
-        },
-        "tmp": {
-          "version": "0.0.25"
         },
         "open": {
           "version": "0.0.5"
@@ -11181,11 +11200,8 @@
         "semver": {
           "version": "4.3.3"
         },
-        "mozilla-version-comparator": {
-          "version": "1.0.2"
-        },
-        "mozilla-toolkit-versioning": {
-          "version": "0.0.2"
+        "tmp": {
+          "version": "0.0.25"
         },
         "when": {
           "version": "3.7.2"
@@ -11451,14 +11467,14 @@
                 "core-util-is": {
                   "version": "1.0.1"
                 },
+                "inherits": {
+                  "version": "2.0.1"
+                },
                 "isarray": {
                   "version": "0.0.1"
                 },
                 "string_decoder": {
                   "version": "0.10.31"
-                },
-                "inherits": {
-                  "version": "2.0.1"
                 }
               }
             },
@@ -11489,11 +11505,11 @@
         "optimist": {
           "version": "0.6.1",
           "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3"
-            },
             "minimist": {
               "version": "0.0.10"
+            },
+            "wordwrap": {
+              "version": "0.0.3"
             }
           }
         },
@@ -11503,6 +11519,14 @@
         "socket.io": {
           "version": "1.3.7",
           "dependencies": {
+            "debug": {
+              "version": "2.1.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2"
+                }
+              }
+            },
             "engine.io": {
               "version": "1.5.4",
               "dependencies": {
@@ -11558,29 +11582,62 @@
                 }
               }
             },
-            "socket.io-parser": {
-              "version": "2.2.4",
+            "has-binary-data": {
+              "version": "0.1.3",
               "dependencies": {
-                "debug": {
-                  "version": "0.7.4"
-                },
-                "json3": {
-                  "version": "3.2.6"
-                },
-                "component-emitter": {
-                  "version": "1.1.2"
-                },
                 "isarray": {
                   "version": "0.0.1"
+                }
+              }
+            },
+            "socket.io-adapter": {
+              "version": "0.3.1",
+              "dependencies": {
+                "debug": {
+                  "version": "1.0.2",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2"
+                    }
+                  }
                 },
-                "benchmark": {
-                  "version": "1.0.0"
+                "object-keys": {
+                  "version": "1.0.1"
+                },
+                "socket.io-parser": {
+                  "version": "2.2.2",
+                  "dependencies": {
+                    "benchmark": {
+                      "version": "1.0.0"
+                    },
+                    "component-emitter": {
+                      "version": "1.1.2"
+                    },
+                    "debug": {
+                      "version": "0.7.4"
+                    },
+                    "isarray": {
+                      "version": "0.0.1"
+                    },
+                    "json3": {
+                      "version": "3.2.6"
+                    }
+                  }
                 }
               }
             },
             "socket.io-client": {
               "version": "1.3.7",
               "dependencies": {
+                "backo2": {
+                  "version": "1.0.2"
+                },
+                "component-bind": {
+                  "version": "1.0.0"
+                },
+                "component-emitter": {
+                  "version": "1.1.2"
+                },
                 "debug": {
                   "version": "0.7.4"
                 },
@@ -11681,15 +11738,6 @@
                     }
                   }
                 },
-                "component-bind": {
-                  "version": "1.0.0"
-                },
-                "component-emitter": {
-                  "version": "1.1.2"
-                },
-                "object-component": {
-                  "version": "0.0.3"
-                },
                 "has-binary": {
                   "version": "0.1.6",
                   "dependencies": {
@@ -11700,6 +11748,9 @@
                 },
                 "indexof": {
                   "version": "0.0.1"
+                },
+                "object-component": {
+                  "version": "0.0.3"
                 },
                 "parseuri": {
                   "version": "0.0.2",
@@ -11716,61 +11767,26 @@
                 },
                 "to-array": {
                   "version": "0.1.3"
-                },
-                "backo2": {
-                  "version": "1.0.2"
                 }
               }
             },
-            "socket.io-adapter": {
-              "version": "0.3.1",
+            "socket.io-parser": {
+              "version": "2.2.4",
               "dependencies": {
+                "benchmark": {
+                  "version": "1.0.0"
+                },
+                "component-emitter": {
+                  "version": "1.1.2"
+                },
                 "debug": {
-                  "version": "1.0.2",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2"
-                    }
-                  }
+                  "version": "0.7.4"
                 },
-                "socket.io-parser": {
-                  "version": "2.2.2",
-                  "dependencies": {
-                    "debug": {
-                      "version": "0.7.4"
-                    },
-                    "json3": {
-                      "version": "3.2.6"
-                    },
-                    "component-emitter": {
-                      "version": "1.1.2"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "benchmark": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "object-keys": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "has-binary-data": {
-              "version": "0.1.3",
-              "dependencies": {
                 "isarray": {
                   "version": "0.0.1"
-                }
-              }
-            },
-            "debug": {
-              "version": "2.1.0",
-              "dependencies": {
-                "ms": {
-                  "version": "0.6.2"
+                },
+                "json3": {
+                  "version": "3.2.6"
                 }
               }
             }
@@ -11825,18 +11841,6 @@
             "q-io": {
               "version": "1.10.9",
               "dependencies": {
-                "qs": {
-                  "version": "0.1.0"
-                },
-                "url2": {
-                  "version": "0.0.0"
-                },
-                "mime": {
-                  "version": "1.2.11"
-                },
-                "mimeparse": {
-                  "version": "0.1.4"
-                },
                 "collections": {
                   "version": "0.2.2",
                   "dependencies": {
@@ -11844,6 +11848,18 @@
                       "version": "1.0.0"
                     }
                   }
+                },
+                "mime": {
+                  "version": "1.2.11"
+                },
+                "mimeparse": {
+                  "version": "0.1.4"
+                },
+                "qs": {
+                  "version": "0.1.0"
+                },
+                "url2": {
+                  "version": "0.0.0"
                 }
               }
             }
@@ -11857,6 +11873,29 @@
     "karma-sauce-launcher": {
       "version": "0.2.14",
       "dependencies": {
+        "q": {
+          "version": "0.9.7"
+        },
+        "sauce-connect-launcher": {
+          "version": "0.11.1",
+          "dependencies": {
+            "adm-zip": {
+              "version": "0.4.7"
+            },
+            "async": {
+              "version": "0.9.0"
+            },
+            "lodash": {
+              "version": "3.5.0"
+            },
+            "rimraf": {
+              "version": "2.2.6"
+            }
+          }
+        },
+        "saucelabs": {
+          "version": "0.1.1"
+        },
         "wd": {
           "version": "0.3.12",
           "dependencies": {
@@ -11905,14 +11944,14 @@
                     "core-util-is": {
                       "version": "1.0.1"
                     },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
                     "isarray": {
                       "version": "0.0.1"
                     },
                     "string_decoder": {
                       "version": "0.10.31"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
                     }
                   }
                 },
@@ -11970,6 +12009,9 @@
             "request": {
               "version": "2.55.0",
               "dependencies": {
+                "aws-sign2": {
+                  "version": "0.5.0"
+                },
                 "bl": {
                   "version": "0.9.4",
                   "dependencies": {
@@ -11979,14 +12021,14 @@
                         "core-util-is": {
                           "version": "1.0.1"
                         },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
                         "isarray": {
                           "version": "0.0.1"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
                         }
                       }
                     }
@@ -11994,6 +12036,14 @@
                 },
                 "caseless": {
                   "version": "0.9.0"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5"
+                    }
+                  }
                 },
                 "forever-agent": {
                   "version": "0.6.1"
@@ -12005,77 +12055,6 @@
                       "version": "0.9.2"
                     }
                   }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1"
-                },
-                "mime-types": {
-                  "version": "2.0.14",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.12.0"
-                    }
-                  }
-                },
-                "qs": {
-                  "version": "2.4.2"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.1"
-                },
-                "tough-cookie": {
-                  "version": "2.2.0"
-                },
-                "http-signature": {
-                  "version": "0.10.1",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5"
-                    },
-                    "asn1": {
-                      "version": "0.1.11"
-                    },
-                    "ctype": {
-                      "version": "0.5.3"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.6.0"
-                },
-                "hawk": {
-                  "version": "2.3.1",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3"
-                    },
-                    "boom": {
-                      "version": "2.10.1"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5"
-                    },
-                    "sntp": {
-                      "version": "1.0.9"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.5.0"
-                },
-                "stringstream": {
-                  "version": "0.0.5"
-                },
-                "combined-stream": {
-                  "version": "0.0.7",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "0.0.5"
-                    }
-                  }
-                },
-                "isstream": {
-                  "version": "0.1.2"
                 },
                 "har-validator": {
                   "version": "1.8.0",
@@ -12144,6 +12123,66 @@
                       }
                     }
                   }
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5"
+                    },
+                    "hoek": {
+                      "version": "2.16.3"
+                    },
+                    "sntp": {
+                      "version": "1.0.9"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.1.11"
+                    },
+                    "assert-plus": {
+                      "version": "0.1.5"
+                    },
+                    "ctype": {
+                      "version": "0.5.3"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1"
+                },
+                "mime-types": {
+                  "version": "2.0.14",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.12.0"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.6.0"
+                },
+                "qs": {
+                  "version": "2.4.2"
+                },
+                "stringstream": {
+                  "version": "0.0.5"
+                },
+                "tough-cookie": {
+                  "version": "2.2.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.1"
                 }
               }
             },
@@ -12154,29 +12193,6 @@
               "version": "0.1.0"
             }
           }
-        },
-        "sauce-connect-launcher": {
-          "version": "0.11.1",
-          "dependencies": {
-            "lodash": {
-              "version": "3.5.0"
-            },
-            "async": {
-              "version": "0.9.0"
-            },
-            "adm-zip": {
-              "version": "0.4.7"
-            },
-            "rimraf": {
-              "version": "2.2.6"
-            }
-          }
-        },
-        "q": {
-          "version": "0.9.7"
-        },
-        "saucelabs": {
-          "version": "0.1.1"
         }
       }
     },
@@ -12239,33 +12255,8 @@
             "commoner": {
               "version": "0.10.1",
               "dependencies": {
-                "q": {
-                  "version": "1.1.2"
-                },
-                "recast": {
-                  "version": "0.9.11",
-                  "dependencies": {
-                    "esprima-fb": {
-                      "version": "8001.1001.0-dev-harmony-fb"
-                    },
-                    "source-map": {
-                      "version": "0.1.41",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "0.1.0"
-                        }
-                      }
-                    },
-                    "ast-types": {
-                      "version": "0.6.7"
-                    }
-                  }
-                },
                 "commander": {
                   "version": "2.5.1"
-                },
-                "graceful-fs": {
-                  "version": "3.0.5"
                 },
                 "glob": {
                   "version": "4.2.2",
@@ -12302,6 +12293,15 @@
                     }
                   }
                 },
+                "graceful-fs": {
+                  "version": "3.0.5"
+                },
+                "iconv-lite": {
+                  "version": "0.4.5"
+                },
+                "install": {
+                  "version": "0.1.8"
+                },
                 "mkdirp": {
                   "version": "0.5.0",
                   "dependencies": {
@@ -12313,11 +12313,27 @@
                 "private": {
                   "version": "0.1.6"
                 },
-                "install": {
-                  "version": "0.1.8"
+                "q": {
+                  "version": "1.1.2"
                 },
-                "iconv-lite": {
-                  "version": "0.4.5"
+                "recast": {
+                  "version": "0.9.11",
+                  "dependencies": {
+                    "ast-types": {
+                      "version": "0.6.7"
+                    },
+                    "esprima-fb": {
+                      "version": "8001.1001.0-dev-harmony-fb"
+                    },
+                    "source-map": {
+                      "version": "0.1.41",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
@@ -12386,21 +12402,103 @@
         }
       }
     },
+    "nan": {
+      "version": "2.1.0"
+    },
     "node-uuid": {
       "version": "1.4.3"
+    },
+    "nopt": {
+      "version": "2.0.0"
     },
     "on-headers": {
       "version": "1.0.1"
     },
+    "once": {
+      "version": "1.3.3"
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10"
+        }
+      }
+    },
     "parse5": {
       "version": "1.3.2"
+    },
+    "path-is-absolute": {
+      "version": "1.0.0"
     },
     "protractor": {
       "version": "2.5.1",
       "dependencies": {
+        "accessibility-developer-tools": {
+          "version": "2.6.0"
+        },
+        "adm-zip": {
+          "version": "0.4.4"
+        },
+        "glob": {
+          "version": "3.2.11",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1"
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.7.0"
+                },
+                "sigmund": {
+                  "version": "1.0.1"
+                }
+              }
+            }
+          }
+        },
+        "html-entities": {
+          "version": "1.1.3"
+        },
+        "jasmine": {
+          "version": "2.3.2",
+          "dependencies": {
+            "exit": {
+              "version": "0.1.2"
+            }
+          }
+        },
+        "jasminewd": {
+          "version": "1.1.0"
+        },
+        "jasminewd2": {
+          "version": "0.0.6"
+        },
+        "minijasminenode": {
+          "version": "1.1.1"
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10"
+            },
+            "wordwrap": {
+              "version": "0.0.3"
+            }
+          }
+        },
+        "q": {
+          "version": "1.0.0"
+        },
         "request": {
           "version": "2.57.0",
           "dependencies": {
+            "aws-sign2": {
+              "version": "0.5.0"
+            },
             "bl": {
               "version": "0.9.4",
               "dependencies": {
@@ -12410,14 +12508,14 @@
                     "core-util-is": {
                       "version": "1.0.1"
                     },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
                     "isarray": {
                       "version": "0.0.1"
                     },
                     "string_decoder": {
                       "version": "0.10.31"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
                     }
                   }
                 }
@@ -12425,6 +12523,14 @@
             },
             "caseless": {
               "version": "0.10.0"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0"
+                }
+              }
             },
             "forever-agent": {
               "version": "0.6.1"
@@ -12444,77 +12550,6 @@
                   }
                 }
               }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1"
-            },
-            "mime-types": {
-              "version": "2.0.14",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.12.0"
-                }
-              }
-            },
-            "qs": {
-              "version": "3.1.0"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1"
-            },
-            "tough-cookie": {
-              "version": "2.2.0"
-            },
-            "http-signature": {
-              "version": "0.11.0",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5"
-                },
-                "asn1": {
-                  "version": "0.1.11"
-                },
-                "ctype": {
-                  "version": "0.5.3"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.0"
-            },
-            "hawk": {
-              "version": "2.3.1",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3"
-                },
-                "boom": {
-                  "version": "2.10.1"
-                },
-                "cryptiles": {
-                  "version": "2.0.5"
-                },
-                "sntp": {
-                  "version": "1.0.9"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.5.0"
-            },
-            "stringstream": {
-              "version": "0.0.5"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "isstream": {
-              "version": "0.1.2"
             },
             "har-validator": {
               "version": "1.8.0",
@@ -12581,6 +12616,95 @@
                       "version": "4.0.1"
                     }
                   }
+                }
+              }
+            },
+            "hawk": {
+              "version": "2.3.1",
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1"
+                },
+                "cryptiles": {
+                  "version": "2.0.5"
+                },
+                "hoek": {
+                  "version": "2.16.3"
+                },
+                "sntp": {
+                  "version": "1.0.9"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.11.0",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.1.11"
+                },
+                "assert-plus": {
+                  "version": "0.1.5"
+                },
+                "ctype": {
+                  "version": "0.5.3"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1"
+            },
+            "mime-types": {
+              "version": "2.0.14",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.12.0"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.0"
+            },
+            "qs": {
+              "version": "3.1.0"
+            },
+            "stringstream": {
+              "version": "0.0.5"
+            },
+            "tough-cookie": {
+              "version": "2.2.0"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1"
+            }
+          }
+        },
+        "saucelabs": {
+          "version": "1.0.1",
+          "dependencies": {
+            "https-proxy-agent": {
+              "version": "1.0.0",
+              "dependencies": {
+                "agent-base": {
+                  "version": "2.0.1",
+                  "dependencies": {
+                    "semver": {
+                      "version": "5.0.3"
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1"
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.0"
                 }
               }
             }
@@ -12653,88 +12777,6 @@
             }
           }
         },
-        "minijasminenode": {
-          "version": "1.1.1"
-        },
-        "jasminewd": {
-          "version": "1.1.0"
-        },
-        "jasminewd2": {
-          "version": "0.0.6"
-        },
-        "jasmine": {
-          "version": "2.3.2",
-          "dependencies": {
-            "exit": {
-              "version": "0.1.2"
-            }
-          }
-        },
-        "saucelabs": {
-          "version": "1.0.1",
-          "dependencies": {
-            "https-proxy-agent": {
-              "version": "1.0.0",
-              "dependencies": {
-                "agent-base": {
-                  "version": "2.0.1",
-                  "dependencies": {
-                    "semver": {
-                      "version": "5.0.3"
-                    }
-                  }
-                },
-                "debug": {
-                  "version": "2.2.0",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1"
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.0"
-                }
-              }
-            }
-          }
-        },
-        "glob": {
-          "version": "3.2.11",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1"
-            },
-            "minimatch": {
-              "version": "0.3.0",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.0"
-                },
-                "sigmund": {
-                  "version": "1.0.1"
-                }
-              }
-            }
-          }
-        },
-        "adm-zip": {
-          "version": "0.4.4"
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3"
-            },
-            "minimist": {
-              "version": "0.0.10"
-            }
-          }
-        },
-        "q": {
-          "version": "1.0.0"
-        },
         "source-map-support": {
           "version": "0.2.10",
           "dependencies": {
@@ -12747,12 +12789,6 @@
               }
             }
           }
-        },
-        "html-entities": {
-          "version": "1.1.3"
-        },
-        "accessibility-developer-tools": {
-          "version": "2.6.0"
         }
       }
     },
@@ -12768,9 +12804,6 @@
         "envify": {
           "version": "3.4.0",
           "dependencies": {
-            "through": {
-              "version": "2.3.8"
-            },
             "jstransform": {
               "version": "10.1.0",
               "dependencies": {
@@ -12789,6 +12822,9 @@
                   }
                 }
               }
+            },
+            "through": {
+              "version": "2.3.8"
             }
           }
         },
@@ -13144,14 +13180,14 @@
                         "core-util-is": {
                           "version": "1.0.1"
                         },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
                         "isarray": {
                           "version": "0.0.1"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
                         }
                       }
                     }
@@ -13301,6 +13337,9 @@
     "source-map-loader": {
       "version": "0.1.5",
       "dependencies": {
+        "async": {
+          "version": "0.9.2"
+        },
         "loader-utils": {
           "version": "0.2.12",
           "dependencies": {
@@ -13319,9 +13358,6 @@
               "version": "1.0.0"
             }
           }
-        },
-        "async": {
-          "version": "0.9.2"
         }
       }
     },
@@ -13504,14 +13540,14 @@
             "core-util-is": {
               "version": "1.0.1"
             },
+            "inherits": {
+              "version": "2.0.1"
+            },
             "isarray": {
               "version": "0.0.1"
             },
             "string_decoder": {
               "version": "0.10.31"
-            },
-            "inherits": {
-              "version": "2.0.1"
             }
           }
         },
@@ -13543,6 +13579,9 @@
               }
             }
           }
+        },
+        "typescript": {
+          "version": "1.7.3"
         }
       }
     },
@@ -13561,14 +13600,14 @@
                 "core-util-is": {
                   "version": "1.0.1"
                 },
+                "inherits": {
+                  "version": "2.0.1"
+                },
                 "isarray": {
                   "version": "0.0.1"
                 },
                 "string_decoder": {
                   "version": "0.10.31"
-                },
-                "inherits": {
-                  "version": "2.0.1"
                 }
               }
             }
@@ -13646,9 +13685,6 @@
         "event-stream": {
           "version": "3.1.7",
           "dependencies": {
-            "through": {
-              "version": "2.3.8"
-            },
             "duplexer": {
               "version": "0.1.1"
             },
@@ -13666,6 +13702,9 @@
             },
             "stream-combiner": {
               "version": "0.0.4"
+            },
+            "through": {
+              "version": "2.3.8"
             }
           }
         },
@@ -13678,14 +13717,14 @@
             "hoek": {
               "version": "2.16.3"
             },
-            "topo": {
-              "version": "1.1.0"
-            },
             "isemail": {
               "version": "1.2.0"
             },
             "moment": {
               "version": "2.10.6"
+            },
+            "topo": {
+              "version": "1.1.0"
             }
           }
         },
@@ -13750,6 +13789,9 @@
         "request": {
           "version": "2.65.0",
           "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0"
+            },
             "bl": {
               "version": "1.0.0",
               "dependencies": {
@@ -13781,6 +13823,14 @@
             "caseless": {
               "version": "0.11.0"
             },
+            "combined-stream": {
+              "version": "1.0.5",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0"
+                }
+              }
+            },
             "extend": {
               "version": "3.0.0"
             },
@@ -13794,77 +13844,6 @@
                   "version": "1.5.0"
                 }
               }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1"
-            },
-            "mime-types": {
-              "version": "2.1.7",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.19.0"
-                }
-              }
-            },
-            "qs": {
-              "version": "5.2.0"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1"
-            },
-            "tough-cookie": {
-              "version": "2.2.0"
-            },
-            "http-signature": {
-              "version": "0.11.0",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5"
-                },
-                "asn1": {
-                  "version": "0.1.11"
-                },
-                "ctype": {
-                  "version": "0.5.3"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.0"
-            },
-            "hawk": {
-              "version": "3.1.0",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3"
-                },
-                "boom": {
-                  "version": "2.10.1"
-                },
-                "cryptiles": {
-                  "version": "2.0.5"
-                },
-                "sntp": {
-                  "version": "1.0.9"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.6.0"
-            },
-            "stringstream": {
-              "version": "0.0.5"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "isstream": {
-              "version": "0.1.2"
             },
             "har-validator": {
               "version": "2.0.2",
@@ -13908,6 +13887,66 @@
                   }
                 }
               }
+            },
+            "hawk": {
+              "version": "3.1.0",
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1"
+                },
+                "cryptiles": {
+                  "version": "2.0.5"
+                },
+                "hoek": {
+                  "version": "2.16.3"
+                },
+                "sntp": {
+                  "version": "1.0.9"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.11.0",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.1.11"
+                },
+                "assert-plus": {
+                  "version": "0.1.5"
+                },
+                "ctype": {
+                  "version": "0.5.3"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1"
+            },
+            "mime-types": {
+              "version": "2.1.7",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.19.0"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.0"
+            },
+            "qs": {
+              "version": "5.2.0"
+            },
+            "stringstream": {
+              "version": "0.0.5"
+            },
+            "tough-cookie": {
+              "version": "2.2.0"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1"
             }
           }
         },
@@ -14107,11 +14146,11 @@
                             "deep-extend": {
                               "version": "0.2.11"
                             },
-                            "strip-json-comments": {
-                              "version": "0.1.3"
-                            },
                             "ini": {
                               "version": "1.3.4"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3"
                             }
                           }
                         }
@@ -14156,65 +14195,31 @@
       }
     },
     "tslint": {
-      "version": "3.0.0-dev.1",
+      "version": "3.2.1",
       "dependencies": {
-        "findup-sync": {
-          "version": "0.2.1",
-          "dependencies": {
-            "glob": {
-              "version": "4.3.5",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                },
-                "once": {
-                  "version": "1.3.2",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3"
-            },
-            "minimist": {
-              "version": "0.0.10"
-            }
-          }
-        },
-        "underscore.string": {
-          "version": "3.1.1"
-        },
-        "typescript": {
-          "version": "1.8.0-dev.20151103"
+        "glob": {
+          "version": "6.0.1"
         }
       }
     },
     "typescript": {
-      "version": "1.7.3"
+      "version": "1.7.5"
+    },
+    "underscore.string": {
+      "version": "3.1.1"
     },
     "universal-analytics": {
       "version": "0.3.9",
       "dependencies": {
+        "async": {
+          "version": "0.2.10"
+        },
         "request": {
           "version": "2.65.0",
           "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0"
+            },
             "bl": {
               "version": "1.0.0",
               "dependencies": {
@@ -14246,6 +14251,14 @@
             "caseless": {
               "version": "0.11.0"
             },
+            "combined-stream": {
+              "version": "1.0.5",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0"
+                }
+              }
+            },
             "extend": {
               "version": "3.0.0"
             },
@@ -14259,77 +14272,6 @@
                   "version": "1.5.0"
                 }
               }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1"
-            },
-            "mime-types": {
-              "version": "2.1.7",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.19.0"
-                }
-              }
-            },
-            "qs": {
-              "version": "5.2.0"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1"
-            },
-            "tough-cookie": {
-              "version": "2.2.0"
-            },
-            "http-signature": {
-              "version": "0.11.0",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5"
-                },
-                "asn1": {
-                  "version": "0.1.11"
-                },
-                "ctype": {
-                  "version": "0.5.3"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.0"
-            },
-            "hawk": {
-              "version": "3.1.0",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3"
-                },
-                "boom": {
-                  "version": "2.10.1"
-                },
-                "cryptiles": {
-                  "version": "2.0.5"
-                },
-                "sntp": {
-                  "version": "1.0.9"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.6.0"
-            },
-            "stringstream": {
-              "version": "0.0.5"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "isstream": {
-              "version": "0.1.2"
             },
             "har-validator": {
               "version": "2.0.2",
@@ -14403,16 +14345,76 @@
                   }
                 }
               }
+            },
+            "hawk": {
+              "version": "3.1.0",
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1"
+                },
+                "cryptiles": {
+                  "version": "2.0.5"
+                },
+                "hoek": {
+                  "version": "2.16.3"
+                },
+                "sntp": {
+                  "version": "1.0.9"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.11.0",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.1.11"
+                },
+                "assert-plus": {
+                  "version": "0.1.5"
+                },
+                "ctype": {
+                  "version": "0.5.3"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1"
+            },
+            "mime-types": {
+              "version": "2.1.7",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.19.0"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.0"
+            },
+            "qs": {
+              "version": "5.2.0"
+            },
+            "stringstream": {
+              "version": "0.0.5"
+            },
+            "tough-cookie": {
+              "version": "2.2.0"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1"
             }
           }
         },
         "underscore": {
           "version": "1.8.3"
-        },
-        "async": {
-          "version": "0.2.10"
         }
       }
+    },
+    "utf-8-validate": {
+      "version": "1.2.1"
     },
     "webpack": {
       "version": "1.12.6",
@@ -14550,11 +14552,11 @@
                 "core-util-is": {
                   "version": "1.0.1"
                 },
-                "isarray": {
-                  "version": "0.0.1"
-                },
                 "inherits": {
                   "version": "2.0.1"
+                },
+                "isarray": {
+                  "version": "0.0.1"
                 }
               }
             },
@@ -14604,11 +14606,11 @@
         "optimist": {
           "version": "0.6.1",
           "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3"
-            },
             "minimist": {
               "version": "0.0.10"
+            },
+            "wordwrap": {
+              "version": "0.0.3"
             }
           }
         },
@@ -14724,6 +14726,9 @@
         "webpack-core": {
           "version": "0.6.8",
           "dependencies": {
+            "source-list-map": {
+              "version": "0.1.5"
+            },
             "source-map": {
               "version": "0.4.4",
               "dependencies": {
@@ -14731,9 +14736,6 @@
                   "version": "1.0.0"
                 }
               }
-            },
-            "source-list-map": {
-              "version": "0.1.5"
             }
           }
         }
@@ -14752,6 +14754,12 @@
         }
       }
     },
+    "wordwrap": {
+      "version": "0.0.3"
+    },
+    "wrappy": {
+      "version": "1.0.1"
+    },
     "yargs": {
       "version": "2.3.0",
       "dependencies": {
@@ -14765,5 +14773,5 @@
     }
   },
   "name": "angular-srcs",
-  "version": "2.0.0-alpha.53"
+  "version": "2.0.0-beta.0"
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,7 +1,12 @@
 {
   "name": "angular-srcs",
-  "version": "2.0.0-alpha.53",
+  "version": "2.0.0-beta.0",
   "dependencies": {
+    "abbrev": {
+      "version": "1.0.7",
+      "from": "abbrev@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+    },
     "angular": {
       "version": "1.4.7",
       "from": "https://registry.npmjs.org/angular/-/angular-1.4.7.tgz",
@@ -21,6 +26,11 @@
       "version": "0.0.8",
       "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+    },
+    "bindings": {
+      "version": "1.2.1",
+      "from": "bindings@>=1.2.0 <1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
     },
     "bower": {
       "version": "1.6.5",
@@ -52,15 +62,15 @@
               "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                },
                 "minimist": {
                   "version": "0.0.10",
                   "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 }
               }
             },
@@ -130,15 +140,15 @@
               "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
             },
-            "request-replay": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
-            },
             "mkdirp": {
               "version": "0.3.5",
               "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "request-replay": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
             }
           }
         },
@@ -147,6 +157,11 @@
           "from": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
           "dependencies": {
+            "ansicolors": {
+              "version": "0.2.1",
+              "from": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
+            },
             "redeyed": {
               "version": "0.4.4",
               "from": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
@@ -158,11 +173,6 @@
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 }
               }
-            },
-            "ansicolors": {
-              "version": "0.2.1",
-              "from": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
             }
           }
         },
@@ -295,6 +305,11 @@
               "from": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
               "dependencies": {
+                "buffers": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                },
                 "chainsaw": {
                   "version": "0.1.0",
                   "from": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -306,11 +321,6 @@
                       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                     }
                   }
-                },
-                "buffers": {
-                  "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                 }
               }
             },
@@ -329,6 +339,11 @@
                   "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -338,11 +353,6 @@
                   "version": "0.10.31",
                   "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
@@ -904,6 +914,11 @@
           "from": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
           "dependencies": {
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
             "bl": {
               "version": "0.9.4",
               "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
@@ -919,6 +934,11 @@
                       "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -928,11 +948,6 @@
                       "version": "0.10.31",
                       "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -942,6 +957,18 @@
               "version": "0.9.0",
               "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
             },
             "forever-agent": {
               "version": "0.5.2",
@@ -959,6 +986,60 @@
                   "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 }
               }
+            },
+            "hawk": {
+              "version": "2.3.1",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "dependencies": {
+                "boom": {
+                  "version": "2.9.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
@@ -982,101 +1063,30 @@
               "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
             },
-            "qs": {
-              "version": "2.3.3",
-              "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.0",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
-            },
-            "http-signature": {
-              "version": "0.10.1",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "asn1": {
-                  "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                }
-              }
-            },
             "oauth-sign": {
               "version": "0.6.0",
               "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
             },
-            "hawk": {
-              "version": "2.3.1",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "boom": {
-                  "version": "2.9.0",
-                  "from": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.5.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            "qs": {
+              "version": "2.3.3",
+              "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
             },
             "stringstream": {
               "version": "0.0.4",
               "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
-            "combined-stream": {
-              "version": "0.0.7",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                }
-              }
+            "tough-cookie": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
             },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            "tunnel-agent": {
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             }
           }
         },
@@ -1179,25 +1189,25 @@
           "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
           "dependencies": {
-            "jsonify": {
-              "version": "0.0.0",
-              "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-            },
             "array-filter": {
               "version": "0.0.1",
               "from": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
+            },
+            "array-map": {
+              "version": "0.0.0",
+              "from": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
             },
             "array-reduce": {
               "version": "0.0.0",
               "from": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
             },
-            "array-map": {
+            "jsonify": {
               "version": "0.0.0",
-              "from": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+              "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
             }
           }
         },
@@ -1518,25 +1528,25 @@
                           "from": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
                           "dependencies": {
-                            "minimist": {
-                              "version": "1.2.0",
-                              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                            },
                             "deep-extend": {
                               "version": "0.2.11",
                               "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
                               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
                             },
-                            "strip-json-comments": {
-                              "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-                            },
                             "ini": {
                               "version": "1.3.4",
                               "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
                               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3",
+                              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                             }
                           }
                         }
@@ -1615,18 +1625,6 @@
           "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
           "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
           "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
             "glob": {
               "version": "5.0.15",
               "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -1665,6 +1663,18 @@
                   "version": "1.0.0",
                   "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             }
@@ -1798,15 +1808,15 @@
               "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                },
                 "minimist": {
                   "version": "0.0.10",
                   "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 }
               }
             },
@@ -1863,15 +1873,15 @@
           "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.3.tgz",
           "dependencies": {
-            "rimraf": {
-              "version": "2.2.8",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-            },
             "mktemp": {
               "version": "0.3.5",
               "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
               "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
@@ -2076,15 +2086,15 @@
               "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.3.tgz",
               "dependencies": {
-                "rimraf": {
-                  "version": "2.2.8",
-                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-                },
                 "mktemp": {
                   "version": "0.3.5",
                   "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                },
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 },
                 "underscore.string": {
                   "version": "2.3.3",
@@ -2199,18 +2209,6 @@
               "from": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
               "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
               "dependencies": {
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    }
-                  }
-                },
                 "glob": {
                   "version": "5.0.15",
                   "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -2251,6 +2249,18 @@
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                     }
                   }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
                 }
               }
             },
@@ -2269,15 +2279,15 @@
               "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.3.tgz",
               "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.3.tgz",
               "dependencies": {
-                "rimraf": {
-                  "version": "2.2.8",
-                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-                },
                 "mktemp": {
                   "version": "0.3.5",
                   "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                },
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                 },
                 "underscore.string": {
                   "version": "2.3.3",
@@ -2380,15 +2390,15 @@
                   "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.3.tgz",
                   "dependencies": {
-                    "rimraf": {
-                      "version": "2.2.8",
-                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-                    },
                     "mktemp": {
                       "version": "0.3.5",
                       "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
                       "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                    },
+                    "rimraf": {
+                      "version": "2.2.8",
+                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
                     },
                     "underscore.string": {
                       "version": "2.3.3",
@@ -2512,15 +2522,15 @@
           "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.13.0.tgz",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.13.0.tgz",
           "dependencies": {
-            "ncp": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz"
-            },
             "jsonfile": {
               "version": "2.2.3",
               "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz",
               "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
+            },
+            "ncp": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz"
             },
             "rimraf": {
               "version": "2.4.3",
@@ -2599,15 +2609,15 @@
           "from": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.3.tgz",
           "dependencies": {
-            "rimraf": {
-              "version": "2.2.8",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-            },
             "mktemp": {
               "version": "0.3.5",
               "from": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz",
               "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
@@ -2628,23 +2638,6 @@
       "from": "https://registry.npmjs.org/browserify/-/browserify-10.2.6.tgz",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-10.2.6.tgz",
       "dependencies": {
-        "JSONStream": {
-          "version": "1.0.6",
-          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.6.tgz",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.6.tgz",
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.2.0",
-              "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
-            },
-            "through": {
-              "version": "2.3.8",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            }
-          }
-        },
         "assert": {
           "version": "1.3.0",
           "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
@@ -3186,6 +3179,23 @@
           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
+        "JSONStream": {
+          "version": "1.0.6",
+          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.6.tgz",
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
+            },
+            "through": {
+              "version": "2.3.8",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+          }
+        },
         "labeled-stream-splicer": {
           "version": "1.0.2",
           "from": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
@@ -3196,15 +3206,15 @@
               "from": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
               "dependencies": {
-                "readable-wrap": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
-                },
                 "indexof": {
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                },
+                "readable-wrap": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
                 }
               }
             }
@@ -3443,6 +3453,30 @@
           "from": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
           "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
           "dependencies": {
+            "binary": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+              "dependencies": {
+                "buffers": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                },
+                "chainsaw": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.3.9",
+                      "from": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+                    }
+                  }
+                }
+              }
+            },
             "fstream": {
               "version": "0.1.31",
               "from": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
@@ -3515,6 +3549,18 @@
                 }
               }
             },
+            "match-stream": {
+              "version": "0.0.2",
+              "from": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
+              "dependencies": {
+                "buffers": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                }
+              }
+            },
             "pullstream": {
               "version": "0.4.1",
               "from": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
@@ -3532,30 +3578,6 @@
                 }
               }
             },
-            "binary": {
-              "version": "0.3.0",
-              "from": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-              "dependencies": {
-                "chainsaw": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-                  "dependencies": {
-                    "traverse": {
-                      "version": "0.3.9",
-                      "from": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
-                    }
-                  }
-                },
-                "buffers": {
-                  "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
-                }
-              }
-            },
             "readable-stream": {
               "version": "1.0.33",
               "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
@@ -3566,6 +3588,11 @@
                   "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3575,11 +3602,6 @@
                   "version": "0.10.31",
                   "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
@@ -3587,22 +3609,15 @@
               "version": "1.0.4",
               "from": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz"
-            },
-            "match-stream": {
-              "version": "0.0.2",
-              "from": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
-              "dependencies": {
-                "buffers": {
-                  "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
-                }
-              }
             }
           }
         }
       }
+    },
+    "bufferutil": {
+      "version": "1.2.1",
+      "from": "bufferutil@>=1.2.0 <1.3.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.2.1.tgz"
     },
     "canonical-path": {
       "version": "0.0.2",
@@ -3833,6 +3848,739 @@
           "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
           "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
         },
+        "fsevents": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.2.tgz",
+          "dependencies": {
+            "nan": {
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+            },
+            "node-pre-gyp": {
+              "version": "0.6.12",
+              "from": "node-pre-gyp@0.6.12",
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.12.tgz",
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@~0.5.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.4",
+                  "from": "nopt@~3.0.1",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "abbrev@1",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                    }
+                  }
+                },
+                "npmlog": {
+                  "version": "1.2.1",
+                  "from": "npmlog@~1.2.0",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+                  "dependencies": {
+                    "ansi": {
+                      "version": "0.3.0",
+                      "from": "ansi@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.0.4",
+                      "from": "are-we-there-yet@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                      "dependencies": {
+                        "delegates": {
+                          "version": "0.1.0",
+                          "from": "delegates@^0.1.0",
+                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "readable-stream@^1.1.13",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@2",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@~0.10.x",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "gauge": {
+                      "version": "1.2.2",
+                      "from": "gauge@~1.2.0",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
+                      "dependencies": {
+                        "has-unicode": {
+                          "version": "1.0.0",
+                          "from": "has-unicode@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
+                        },
+                        "lodash.pad": {
+                          "version": "3.1.1",
+                          "from": "lodash.pad@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "lodash._basetostring@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "lodash._createpadding@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "lodash.repeat@^3.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.padleft": {
+                          "version": "3.1.1",
+                          "from": "lodash.padleft@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "lodash._basetostring@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "lodash._createpadding@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "lodash.repeat@^3.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.padright": {
+                          "version": "3.1.1",
+                          "from": "lodash.padright@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+                          "dependencies": {
+                            "lodash._basetostring": {
+                              "version": "3.0.1",
+                              "from": "lodash._basetostring@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                            },
+                            "lodash._createpadding": {
+                              "version": "3.6.1",
+                              "from": "lodash._createpadding@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "3.0.1",
+                                  "from": "lodash.repeat@^3.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "rc": {
+                  "version": "1.1.2",
+                  "from": "rc@~1.1.0",
+                  "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
+                  "dependencies": {
+                    "deep-extend": {
+                      "version": "0.2.11",
+                      "from": "deep-extend@~0.2.5",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@~1.3.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "minimist@^1.1.2",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "0.1.3",
+                      "from": "strip-json-comments@0.1.x",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                    }
+                  }
+                },
+                "request": {
+                  "version": "2.64.0",
+                  "from": "request@2.x",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.64.0.tgz",
+                  "dependencies": {
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "from": "aws-sign2@~0.5.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                    },
+                    "bl": {
+                      "version": "1.0.0",
+                      "from": "bl@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "2.0.2",
+                          "from": "readable-stream@~2.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@~2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.3",
+                              "from": "process-nextick-args@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@~0.10.x",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.1",
+                              "from": "util-deprecate@~1.0.1",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "caseless": {
+                      "version": "0.11.0",
+                      "from": "caseless@~0.11.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "from": "combined-stream@~1.0.1",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "1.0.0",
+                          "from": "delayed-stream@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "extend": {
+                      "version": "3.0.0",
+                      "from": "extend@~3.0.0",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "from": "forever-agent@~0.6.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc3",
+                      "from": "form-data@~1.0.0-rc1",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                      "dependencies": {
+                        "async": {
+                          "version": "1.4.2",
+                          "from": "async@^1.4.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
+                        }
+                      }
+                    },
+                    "har-validator": {
+                      "version": "1.8.0",
+                      "from": "har-validator@^1.6.1",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+                      "dependencies": {
+                        "bluebird": {
+                          "version": "2.10.2",
+                          "from": "bluebird@^2.9.30",
+                          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+                        },
+                        "chalk": {
+                          "version": "1.1.1",
+                          "from": "chalk@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0",
+                              "from": "ansi-styles@^2.1.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.3",
+                              "from": "escape-string-regexp@^1.0.2",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "from": "strip-ansi@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "commander": {
+                          "version": "2.8.1",
+                          "from": "commander@^2.8.1",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                          "dependencies": {
+                            "graceful-readlink": {
+                              "version": "1.0.1",
+                              "from": "graceful-readlink@>= 1.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "is-my-json-valid": {
+                          "version": "2.12.2",
+                          "from": "is-my-json-valid@^2.12.0",
+                          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
+                          "dependencies": {
+                            "generate-function": {
+                              "version": "2.0.0",
+                              "from": "generate-function@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                            },
+                            "generate-object-property": {
+                              "version": "1.2.0",
+                              "from": "generate-object-property@^1.1.0",
+                              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                              "dependencies": {
+                                "is-property": {
+                                  "version": "1.0.2",
+                                  "from": "is-property@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "jsonpointer": {
+                              "version": "2.0.0",
+                              "from": "jsonpointer@2.0.0",
+                              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                            },
+                            "xtend": {
+                              "version": "4.0.0",
+                              "from": "xtend@^4.0.0",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hawk": {
+                      "version": "3.1.0",
+                      "from": "hawk@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                      "dependencies": {
+                        "boom": {
+                          "version": "2.9.0",
+                          "from": "boom@^2.8.x",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "2.0.5",
+                          "from": "cryptiles@2.x.x",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                        },
+                        "hoek": {
+                          "version": "2.16.3",
+                          "from": "hoek@2.x.x",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                        },
+                        "sntp": {
+                          "version": "1.0.9",
+                          "from": "sntp@1.x.x",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "0.11.0",
+                      "from": "http-signature@~0.11.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "from": "assert-plus@^0.1.5",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.3",
+                          "from": "ctype@0.5.3",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                        }
+                      }
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "from": "isstream@~0.1.1",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@~5.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.7",
+                      "from": "mime-types@~2.1.2",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.19.0",
+                          "from": "mime-db@~1.19.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                        }
+                      }
+                    },
+                    "node-uuid": {
+                      "version": "1.4.3",
+                      "from": "node-uuid@~1.4.0",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.0",
+                      "from": "oauth-sign@~0.8.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                    },
+                    "qs": {
+                      "version": "5.1.0",
+                      "from": "qs@~5.1.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.4",
+                      "from": "stringstream@~0.0.4",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.1.0",
+                      "from": "tough-cookie@>=0.12.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.1.0.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.1",
+                      "from": "tunnel-agent@~0.4.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.4.3",
+                  "from": "rimraf@~2.4.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "5.0.15",
+                      "from": "glob@^5.0.14",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@^1.0.4",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@1",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "minimatch@2 || 3",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.1",
+                              "from": "brace-expansion@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.0",
+                                  "from": "balanced-match@^0.2.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.2",
+                          "from": "once@^1.3.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@1",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "path-is-absolute@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "5.0.3",
+                  "from": "semver@~5.0.1",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+                },
+                "tar": {
+                  "version": "2.2.1",
+                  "from": "tar@~2.2.0",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.8",
+                      "from": "block-stream@*",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                    },
+                    "fstream": {
+                      "version": "1.0.8",
+                      "from": "fstream@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.2",
+                          "from": "graceful-fs@^4.1.2",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "tar-pack": {
+                  "version": "2.0.0",
+                  "from": "tar-pack@~2.0.0",
+                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@~0.7.2",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "fstream": {
+                      "version": "0.1.31",
+                      "from": "fstream@~0.1.22",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "3.0.8",
+                          "from": "graceful-fs@~3.0.2",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "fstream-ignore": {
+                      "version": "0.0.7",
+                      "from": "fstream-ignore@0.0.7",
+                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "minimatch@~0.2.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.0",
+                              "from": "lru-cache@2",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "from": "sigmund@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "from": "graceful-fs@1.2",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                    },
+                    "once": {
+                      "version": "1.1.1",
+                      "from": "once@~1.1.1",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@~1.0.2",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.2.8",
+                      "from": "rimraf@~2.2.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                    },
+                    "tar": {
+                      "version": "0.1.20",
+                      "from": "tar@~0.1.17",
+                      "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                      "dependencies": {
+                        "block-stream": {
+                          "version": "0.0.8",
+                          "from": "block-stream@*",
+                          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@2",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "uid-number": {
+                      "version": "0.0.3",
+                      "from": "uid-number@0.0.3",
+                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "glob-parent": {
           "version": "2.0.0",
           "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
@@ -3944,739 +4692,6 @@
               }
             }
           }
-        },
-        "fsevents": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.2.tgz",
-          "dependencies": {
-            "nan": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
-            },
-            "node-pre-gyp": {
-              "version": "0.6.12",
-              "from": "node-pre-gyp@0.6.12",
-              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.12.tgz",
-              "dependencies": {
-                "nopt": {
-                  "version": "3.0.4",
-                  "from": "nopt@~3.0.1",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "abbrev@1",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                    }
-                  }
-                },
-                "npmlog": {
-                  "version": "1.2.1",
-                  "from": "npmlog@~1.2.0",
-                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-                  "dependencies": {
-                    "ansi": {
-                      "version": "0.3.0",
-                      "from": "ansi@~0.3.0",
-                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
-                    },
-                    "are-we-there-yet": {
-                      "version": "1.0.4",
-                      "from": "are-we-there-yet@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
-                      "dependencies": {
-                        "delegates": {
-                          "version": "0.1.0",
-                          "from": "delegates@^0.1.0",
-                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
-                        },
-                        "readable-stream": {
-                          "version": "1.1.13",
-                          "from": "readable-stream@^1.1.13",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@~1.0.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@~0.10.x",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@2",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "gauge": {
-                      "version": "1.2.2",
-                      "from": "gauge@~1.2.0",
-                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz",
-                      "dependencies": {
-                        "has-unicode": {
-                          "version": "1.0.0",
-                          "from": "has-unicode@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
-                        },
-                        "lodash.pad": {
-                          "version": "3.1.1",
-                          "from": "lodash.pad@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1",
-                              "from": "lodash._basetostring@^3.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "from": "lodash._createpadding@^3.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1",
-                                  "from": "lodash.repeat@^3.0.0",
-                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash.padleft": {
-                          "version": "3.1.1",
-                          "from": "lodash.padleft@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1",
-                              "from": "lodash._basetostring@^3.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "from": "lodash._createpadding@^3.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1",
-                                  "from": "lodash.repeat@^3.0.0",
-                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash.padright": {
-                          "version": "3.1.1",
-                          "from": "lodash.padright@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
-                          "dependencies": {
-                            "lodash._basetostring": {
-                              "version": "3.0.1",
-                              "from": "lodash._basetostring@^3.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-                            },
-                            "lodash._createpadding": {
-                              "version": "3.6.1",
-                              "from": "lodash._createpadding@^3.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "3.0.1",
-                                  "from": "lodash.repeat@^3.0.0",
-                                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "request": {
-                  "version": "2.64.0",
-                  "from": "request@2.x",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.64.0.tgz",
-                  "dependencies": {
-                    "bl": {
-                      "version": "1.0.0",
-                      "from": "bl@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "2.0.2",
-                          "from": "readable-stream@~2.0.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.1",
-                              "from": "core-util-is@~1.0.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@~2.0.1",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            },
-                            "process-nextick-args": {
-                              "version": "1.0.3",
-                              "from": "process-nextick-args@~1.0.0",
-                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@~0.10.x",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            },
-                            "util-deprecate": {
-                              "version": "1.0.1",
-                              "from": "util-deprecate@~1.0.1",
-                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "caseless": {
-                      "version": "0.11.0",
-                      "from": "caseless@~0.11.0",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-                    },
-                    "extend": {
-                      "version": "3.0.0",
-                      "from": "extend@~3.0.0",
-                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1",
-                      "from": "forever-agent@~0.6.0",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-                    },
-                    "form-data": {
-                      "version": "1.0.0-rc3",
-                      "from": "form-data@~1.0.0-rc1",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-                      "dependencies": {
-                        "async": {
-                          "version": "1.4.2",
-                          "from": "async@^1.4.0",
-                          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
-                        }
-                      }
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "from": "json-stringify-safe@~5.0.0",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.1.7",
-                      "from": "mime-types@~2.1.2",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.19.0",
-                          "from": "mime-db@~1.19.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
-                        }
-                      }
-                    },
-                    "node-uuid": {
-                      "version": "1.4.3",
-                      "from": "node-uuid@~1.4.0",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-                    },
-                    "qs": {
-                      "version": "5.1.0",
-                      "from": "qs@~5.1.0",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.1",
-                      "from": "tunnel-agent@~0.4.0",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-                    },
-                    "tough-cookie": {
-                      "version": "2.1.0",
-                      "from": "tough-cookie@>=0.12.0",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.1.0.tgz"
-                    },
-                    "http-signature": {
-                      "version": "0.11.0",
-                      "from": "http-signature@~0.11.0",
-                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.1.5",
-                          "from": "assert-plus@^0.1.5",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                        },
-                        "asn1": {
-                          "version": "0.1.11",
-                          "from": "asn1@0.1.11",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                        },
-                        "ctype": {
-                          "version": "0.5.3",
-                          "from": "ctype@0.5.3",
-                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                        }
-                      }
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.0",
-                      "from": "oauth-sign@~0.8.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-                    },
-                    "hawk": {
-                      "version": "3.1.0",
-                      "from": "hawk@~3.1.0",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-                      "dependencies": {
-                        "hoek": {
-                          "version": "2.16.3",
-                          "from": "hoek@2.x.x",
-                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                        },
-                        "boom": {
-                          "version": "2.9.0",
-                          "from": "boom@^2.8.x",
-                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
-                        },
-                        "cryptiles": {
-                          "version": "2.0.5",
-                          "from": "cryptiles@2.x.x",
-                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                        },
-                        "sntp": {
-                          "version": "1.0.9",
-                          "from": "sntp@1.x.x",
-                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                        }
-                      }
-                    },
-                    "aws-sign2": {
-                      "version": "0.5.0",
-                      "from": "aws-sign2@~0.5.0",
-                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-                    },
-                    "stringstream": {
-                      "version": "0.0.4",
-                      "from": "stringstream@~0.0.4",
-                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-                    },
-                    "combined-stream": {
-                      "version": "1.0.5",
-                      "from": "combined-stream@~1.0.1",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "1.0.0",
-                          "from": "delayed-stream@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "isstream": {
-                      "version": "0.1.2",
-                      "from": "isstream@~0.1.1",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                    },
-                    "har-validator": {
-                      "version": "1.8.0",
-                      "from": "har-validator@^1.6.1",
-                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-                      "dependencies": {
-                        "bluebird": {
-                          "version": "2.10.2",
-                          "from": "bluebird@^2.9.30",
-                          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
-                        },
-                        "chalk": {
-                          "version": "1.1.1",
-                          "from": "chalk@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.1.0",
-                              "from": "ansi-styles@^2.1.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.3",
-                              "from": "escape-string-regexp@^1.0.2",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "has-ansi@^2.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "ansi-regex@^2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.0",
-                              "from": "strip-ansi@^3.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "ansi-regex@^2.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "supports-color@^2.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "commander": {
-                          "version": "2.8.1",
-                          "from": "commander@^2.8.1",
-                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                          "dependencies": {
-                            "graceful-readlink": {
-                              "version": "1.0.1",
-                              "from": "graceful-readlink@>= 1.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "is-my-json-valid": {
-                          "version": "2.12.2",
-                          "from": "is-my-json-valid@^2.12.0",
-                          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz",
-                          "dependencies": {
-                            "generate-function": {
-                              "version": "2.0.0",
-                              "from": "generate-function@^2.0.0",
-                              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                            },
-                            "generate-object-property": {
-                              "version": "1.2.0",
-                              "from": "generate-object-property@^1.1.0",
-                              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                              "dependencies": {
-                                "is-property": {
-                                  "version": "1.0.2",
-                                  "from": "is-property@^1.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                                }
-                              }
-                            },
-                            "jsonpointer": {
-                              "version": "2.0.0",
-                              "from": "jsonpointer@2.0.0",
-                              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                            },
-                            "xtend": {
-                              "version": "4.0.0",
-                              "from": "xtend@^4.0.0",
-                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "5.0.3",
-                  "from": "semver@~5.0.1",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
-                },
-                "tar": {
-                  "version": "2.2.1",
-                  "from": "tar@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-                  "dependencies": {
-                    "block-stream": {
-                      "version": "0.0.8",
-                      "from": "block-stream@*",
-                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-                    },
-                    "fstream": {
-                      "version": "1.0.8",
-                      "from": "fstream@^1.0.2",
-                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.2",
-                          "from": "graceful-fs@^4.1.2",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "tar-pack": {
-                  "version": "2.0.0",
-                  "from": "tar-pack@~2.0.0",
-                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
-                  "dependencies": {
-                    "uid-number": {
-                      "version": "0.0.3",
-                      "from": "uid-number@0.0.3",
-                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
-                    },
-                    "once": {
-                      "version": "1.1.1",
-                      "from": "once@~1.1.1",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
-                    },
-                    "debug": {
-                      "version": "0.7.4",
-                      "from": "debug@~0.7.2",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                    },
-                    "rimraf": {
-                      "version": "2.2.8",
-                      "from": "rimraf@~2.2.0",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-                    },
-                    "fstream": {
-                      "version": "0.1.31",
-                      "from": "fstream@~0.1.22",
-                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "3.0.8",
-                          "from": "graceful-fs@~3.0.2",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@~2.0.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
-                    },
-                    "tar": {
-                      "version": "0.1.20",
-                      "from": "tar@~0.1.17",
-                      "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
-                      "dependencies": {
-                        "block-stream": {
-                          "version": "0.0.8",
-                          "from": "block-stream@*",
-                          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@2",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
-                    },
-                    "fstream-ignore": {
-                      "version": "0.0.7",
-                      "from": "fstream-ignore@0.0.7",
-                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
-                      "dependencies": {
-                        "minimatch": {
-                          "version": "0.2.14",
-                          "from": "minimatch@~0.2.0",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                          "dependencies": {
-                            "lru-cache": {
-                              "version": "2.7.0",
-                              "from": "lru-cache@2",
-                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
-                            },
-                            "sigmund": {
-                              "version": "1.0.1",
-                              "from": "sigmund@~1.0.0",
-                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
-                    },
-                    "readable-stream": {
-                      "version": "1.0.33",
-                      "from": "readable-stream@~1.0.2",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "1.2.3",
-                      "from": "graceful-fs@1.2",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "from": "mkdirp@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    }
-                  }
-                },
-                "rc": {
-                  "version": "1.1.2",
-                  "from": "rc@~1.1.0",
-                  "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "1.2.0",
-                      "from": "minimist@^1.1.2",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                    },
-                    "deep-extend": {
-                      "version": "0.2.11",
-                      "from": "deep-extend@~0.2.5",
-                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
-                    },
-                    "strip-json-comments": {
-                      "version": "0.1.3",
-                      "from": "strip-json-comments@0.1.x",
-                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-                    },
-                    "ini": {
-                      "version": "1.3.4",
-                      "from": "ini@~1.3.0",
-                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                    }
-                  }
-                },
-                "rimraf": {
-                  "version": "2.4.3",
-                  "from": "rimraf@~2.4.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
-                  "dependencies": {
-                    "glob": {
-                      "version": "5.0.15",
-                      "from": "glob@^5.0.14",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                      "dependencies": {
-                        "inflight": {
-                          "version": "1.0.4",
-                          "from": "inflight@^1.0.4",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@1",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "minimatch": {
-                          "version": "3.0.0",
-                          "from": "minimatch@2 || 3",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.1",
-                              "from": "brace-expansion@^1.0.0",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.2.0",
-                                  "from": "balanced-match@^0.2.0",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "once": {
-                          "version": "1.3.2",
-                          "from": "once@^1.3.0",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@1",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "path-is-absolute": {
-                          "version": "1.0.0",
-                          "from": "path-is-absolute@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
         }
       }
     },
@@ -4751,15 +4766,15 @@
                   "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                   "dependencies": {
-                    "wordwrap": {
-                      "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                    },
                     "minimist": {
                       "version": "0.0.10",
                       "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                     }
                   }
                 },
@@ -4820,6 +4835,18 @@
           "from": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-0.0.19.tgz",
           "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-0.0.19.tgz",
           "dependencies": {
+            "is-text-path": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+              "dependencies": {
+                "text-extensions": {
+                  "version": "1.3.3",
+                  "from": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.3.3.tgz"
+                }
+              }
+            },
             "JSONStream": {
               "version": "1.0.6",
               "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.6.tgz",
@@ -4834,18 +4861,6 @@
                   "version": "2.3.8",
                   "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                }
-              }
-            },
-            "is-text-path": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-              "dependencies": {
-                "text-extensions": {
-                  "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.3.3.tgz"
                 }
               }
             },
@@ -5558,6 +5573,18 @@
       "from": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.33.10.tgz",
       "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.33.10.tgz"
     },
+    "findup-sync": {
+      "version": "0.2.1",
+      "from": "findup-sync@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "4.3.5",
+          "from": "glob@>=4.3.0 <4.4.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz"
+        }
+      }
+    },
     "firefox-profile": {
       "version": "0.3.11",
       "from": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-0.3.11.tgz",
@@ -5629,6 +5656,11 @@
                   "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -5638,11 +5670,6 @@
                   "version": "0.10.31",
                   "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
@@ -5803,6 +5830,11 @@
                   "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -5812,11 +5844,6 @@
                   "version": "0.10.31",
                   "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             }
@@ -5972,57 +5999,6 @@
               "from": "https://registry.npmjs.org/jws/-/jws-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/jws/-/jws-3.0.0.tgz",
               "dependencies": {
-                "jwa": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
-                  "dependencies": {
-                    "base64url": {
-                      "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
-                      "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz"
-                    },
-                    "buffer-equal-constant-time": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
-                    },
-                    "ecdsa-sig-formatter": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.2.tgz",
-                      "dependencies": {
-                        "asn1.js": {
-                          "version": "2.2.1",
-                          "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz",
-                          "dependencies": {
-                            "bn.js": {
-                              "version": "2.2.0",
-                              "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            },
-                            "minimalistic-assert": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "base64-url": {
-                          "version": "1.2.1",
-                          "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
                 "base64url": {
                   "version": "1.0.4",
                   "from": "https://registry.npmjs.org/base64url/-/base64url-1.0.4.tgz",
@@ -6037,11 +6013,6 @@
                           "version": "2.0.1",
                           "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "typedarray": {
-                          "version": "0.0.6",
-                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
                           "version": "1.1.13",
@@ -6064,6 +6035,11 @@
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             }
                           }
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         }
                       }
                     },
@@ -6128,6 +6104,57 @@
                       }
                     }
                   }
+                },
+                "jwa": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.0.2.tgz",
+                  "dependencies": {
+                    "base64url": {
+                      "version": "0.0.6",
+                      "from": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/base64url/-/base64url-0.0.6.tgz"
+                    },
+                    "buffer-equal-constant-time": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
+                    },
+                    "ecdsa-sig-formatter": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.2.tgz",
+                      "dependencies": {
+                        "asn1.js": {
+                          "version": "2.2.1",
+                          "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz",
+                          "dependencies": {
+                            "bn.js": {
+                              "version": "2.2.0",
+                              "from": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimalistic-assert": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "base64-url": {
+                          "version": "1.2.1",
+                          "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
@@ -6136,6 +6163,11 @@
               "from": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
               "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                },
                 "bl": {
                   "version": "1.0.0",
                   "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
@@ -6185,6 +6217,18 @@
                   "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    }
+                  }
+                },
                 "extend": {
                   "version": "3.0.0",
                   "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
@@ -6206,119 +6250,6 @@
                       "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
                     }
                   }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                },
-                "mime-types": {
-                  "version": "2.1.7",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.19.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
-                    }
-                  }
-                },
-                "qs": {
-                  "version": "5.2.0",
-                  "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-                },
-                "tough-cookie": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
-                },
-                "http-signature": {
-                  "version": "0.11.0",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                    },
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                    },
-                    "ctype": {
-                      "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-                },
-                "hawk": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                    },
-                    "boom": {
-                      "version": "2.10.1",
-                      "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                    }
-                  }
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "har-validator": {
                   "version": "2.0.2",
@@ -6430,6 +6361,102 @@
                       }
                     }
                   }
+                },
+                "hawk": {
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1",
+                      "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.11.0",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.7",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.19.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                },
+                "qs": {
+                  "version": "5.2.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.1",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 }
               }
             }
@@ -6440,6 +6467,11 @@
           "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
           "dependencies": {
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
             "bl": {
               "version": "0.9.4",
               "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
@@ -6455,6 +6487,11 @@
                       "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -6464,11 +6501,6 @@
                       "version": "0.10.31",
                       "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -6478,6 +6510,18 @@
               "version": "0.8.0",
               "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
             },
             "forever-agent": {
               "version": "0.5.2",
@@ -6503,68 +6547,11 @@
                 }
               }
             },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-            },
-            "qs": {
-              "version": "2.3.3",
-              "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.0",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
-            },
-            "http-signature": {
-              "version": "0.10.1",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "asn1": {
-                  "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.5.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
-            },
             "hawk": {
               "version": "1.1.1",
               "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
               "dependencies": {
-                "hoek": {
-                  "version": "0.9.1",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                },
                 "boom": {
                   "version": "0.4.2",
                   "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
@@ -6575,6 +6562,11 @@
                   "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                 },
+                "hoek": {
+                  "version": "0.9.1",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                },
                 "sntp": {
                   "version": "0.2.4",
                   "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
@@ -6582,27 +6574,62 @@
                 }
               }
             },
-            "aws-sign2": {
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+            },
+            "oauth-sign": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+            },
+            "qs": {
+              "version": "2.3.3",
+              "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
               "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
-            "combined-stream": {
-              "version": "0.0.7",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                }
-              }
+            "tough-cookie": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             }
           }
         },
@@ -7105,6 +7132,11 @@
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -7114,11 +7146,6 @@
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -7371,11 +7398,6 @@
               "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
               "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
               "dependencies": {
-                "ordered-read-streams": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
-                },
                 "glob2base": {
                   "version": "0.0.12",
                   "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
@@ -7387,6 +7409,11 @@
                       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
                     }
                   }
+                },
+                "ordered-read-streams": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
                 },
                 "unique-stream": {
                   "version": "1.0.0",
@@ -7410,11 +7437,6 @@
                       "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                       "dependencies": {
-                        "lodash": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                        },
                         "glob": {
                           "version": "3.1.21",
                           "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
@@ -7431,6 +7453,11 @@
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
                             }
                           }
+                        },
+                        "lodash": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                         },
                         "minimatch": {
                           "version": "0.2.14",
@@ -7520,11 +7547,6 @@
           "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.0.3.tgz",
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.0.3.tgz",
           "dependencies": {
-            "num2fraction": {
-              "version": "1.2.2",
-              "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
-            },
             "browserslist": {
               "version": "1.0.1",
               "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
@@ -7534,6 +7556,11 @@
               "version": "1.0.30000356",
               "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000356.tgz",
               "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000356.tgz"
+            },
+            "num2fraction": {
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
             }
           }
         },
@@ -8014,6 +8041,11 @@
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -8023,11 +8055,6 @@
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -8069,6 +8096,16 @@
           "from": "https://registry.npmjs.org/postcss/-/postcss-5.0.10.tgz",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.10.tgz",
           "dependencies": {
+            "js-base64": {
+              "version": "2.1.9",
+              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            },
+            "source-map": {
+              "version": "0.5.3",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+            },
             "supports-color": {
               "version": "3.1.2",
               "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
@@ -8080,16 +8117,6 @@
                   "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
                 }
               }
-            },
-            "source-map": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
             }
           }
         },
@@ -8166,60 +8193,6 @@
           "from": "https://registry.npmjs.org/gulp-diff/-/gulp-diff-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/gulp-diff/-/gulp-diff-1.0.0.tgz",
           "dependencies": {
-            "diff": {
-              "version": "2.2.0",
-              "from": "https://registry.npmjs.org/diff/-/diff-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.0.tgz"
-            },
-            "through2": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.4",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                }
-              }
-            },
             "cli-color": {
               "version": "1.1.0",
               "from": "https://registry.npmjs.org/cli-color/-/cli-color-1.1.0.tgz",
@@ -8312,16 +8285,16 @@
                 }
               }
             },
+            "diff": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/diff/-/diff-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.0.tgz"
+            },
             "event-stream": {
               "version": "3.3.2",
               "from": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
               "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
               "dependencies": {
-                "through": {
-                  "version": "2.3.8",
-                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                },
                 "duplexer": {
                   "version": "0.1.1",
                   "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -8351,6 +8324,60 @@
                   "version": "0.0.4",
                   "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.4",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             }
@@ -8840,6 +8867,11 @@
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -8849,11 +8881,6 @@
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -9494,6 +9521,11 @@
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -9503,11 +9535,6 @@
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -9600,6 +9627,332 @@
       "from": "https://registry.npmjs.org/gulp-connect/-/gulp-connect-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/gulp-connect/-/gulp-connect-1.1.1.tgz",
       "dependencies": {
+        "connect": {
+          "version": "2.14.5",
+          "from": "https://registry.npmjs.org/connect/-/connect-2.14.5.tgz",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-2.14.5.tgz",
+          "dependencies": {
+            "basic-auth-connect": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
+            },
+            "bytes": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.3.0.tgz"
+            },
+            "compression": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/compression/-/compression-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/compression/-/compression-1.0.0.tgz",
+              "dependencies": {
+                "bytes": {
+                  "version": "0.2.1",
+                  "from": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz"
+                },
+                "compressible": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/compressible/-/compressible-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-1.0.0.tgz"
+                },
+                "negotiator": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz"
+                }
+              }
+            },
+            "connect-timeout": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.0.0.tgz"
+            },
+            "cookie-parser": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.0.1.tgz",
+              "dependencies": {
+                "cookie": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
+                }
+              }
+            },
+            "cookie-signature": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz"
+            },
+            "csurf": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/csurf/-/csurf-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.1.0.tgz",
+              "dependencies": {
+                "scmp": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/scmp/-/scmp-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/scmp/-/scmp-0.0.3.tgz"
+                },
+                "uid2": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz"
+                }
+              }
+            },
+            "debug": {
+              "version": "0.8.1",
+              "from": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz"
+            },
+            "errorhandler": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.0.0.tgz"
+            },
+            "express-session": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/express-session/-/express-session-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.0.2.tgz",
+              "dependencies": {
+                "buffer-crc32": {
+                  "version": "0.2.1",
+                  "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
+                },
+                "cookie": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
+                },
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                },
+                "uid2": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz"
+                },
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                }
+              }
+            },
+            "fresh": {
+              "version": "0.2.2",
+              "from": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
+            },
+            "method-override": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/method-override/-/method-override-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/method-override/-/method-override-1.0.0.tgz",
+              "dependencies": {
+                "methods": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
+                }
+              }
+            },
+            "morgan": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/morgan/-/morgan-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.0.0.tgz",
+              "dependencies": {
+                "bytes": {
+                  "version": "0.2.1",
+                  "from": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz"
+                }
+              }
+            },
+            "multiparty": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
+                },
+                "stream-counter": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
+                }
+              }
+            },
+            "pause": {
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
+            },
+            "qs": {
+              "version": "0.6.6",
+              "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+            },
+            "raw-body": {
+              "version": "1.1.4",
+              "from": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.4.tgz"
+            },
+            "response-time": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/response-time/-/response-time-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/response-time/-/response-time-1.0.0.tgz"
+            },
+            "serve-index": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.1.tgz",
+              "dependencies": {
+                "batch": {
+                  "version": "0.5.0",
+                  "from": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz"
+                },
+                "negotiator": {
+                  "version": "0.4.2",
+                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.2.tgz"
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.1.0.tgz",
+              "dependencies": {
+                "parseurl": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz"
+                },
+                "send": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/send/-/send-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/send/-/send-0.3.0.tgz",
+                  "dependencies": {
+                    "buffer-crc32": {
+                      "version": "0.2.1",
+                      "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
+                    },
+                    "debug": {
+                      "version": "0.8.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-0.8.0.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.0.tgz"
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                    },
+                    "range-parser": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "setimmediate": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.1.tgz"
+            },
+            "static-favicon": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/static-favicon/-/static-favicon-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/static-favicon/-/static-favicon-1.0.2.tgz"
+            },
+            "vhost": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/vhost/-/vhost-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/vhost/-/vhost-1.0.0.tgz"
+            }
+          }
+        },
+        "connect-livereload": {
+          "version": "0.3.2",
+          "from": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.3.2.tgz"
+        },
+        "event-stream": {
+          "version": "3.1.7",
+          "from": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
+          "dependencies": {
+            "duplexer": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+            },
+            "from": {
+              "version": "0.1.3",
+              "from": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
+            },
+            "map-stream": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+            },
+            "pause-stream": {
+              "version": "0.0.11",
+              "from": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+              "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
+            },
+            "split": {
+              "version": "0.2.10",
+              "from": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+              "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
+            },
+            "stream-combiner": {
+              "version": "0.0.4",
+              "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+            },
+            "through": {
+              "version": "2.3.8",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+          }
+        },
         "gulp-util": {
           "version": "2.2.20",
           "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
@@ -9942,6 +10295,11 @@
               "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
               "dependencies": {
+                "lodash._escapestringchar": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+                },
                 "lodash.defaults": {
                   "version": "2.4.1",
                   "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
@@ -9985,11 +10343,6 @@
                     }
                   }
                 },
-                "lodash._escapestringchar": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
-                },
                 "lodash.keys": {
                   "version": "2.4.1",
                   "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
@@ -10000,10 +10353,10 @@
                       "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                     },
-                    "lodash.isobject": {
+                    "lodash._shimkeys": {
                       "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
                       "dependencies": {
                         "lodash._objecttypes": {
                           "version": "2.4.1",
@@ -10012,10 +10365,10 @@
                         }
                       }
                     },
-                    "lodash._shimkeys": {
+                    "lodash.isobject": {
                       "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
                       "dependencies": {
                         "lodash._objecttypes": {
                           "version": "2.4.1",
@@ -10063,6 +10416,11 @@
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -10072,11 +10430,6 @@
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -10099,6 +10452,11 @@
                       "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -10108,11 +10466,6 @@
                       "version": "0.10.31",
                       "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
@@ -10137,52 +10490,10 @@
             }
           }
         },
-        "event-stream": {
-          "version": "3.1.7",
-          "from": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
-          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
-          "dependencies": {
-            "through": {
-              "version": "2.3.8",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            },
-            "duplexer": {
-              "version": "0.1.1",
-              "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
-            },
-            "from": {
-              "version": "0.1.3",
-              "from": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
-            },
-            "map-stream": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
-            },
-            "pause-stream": {
-              "version": "0.0.11",
-              "from": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-              "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
-            },
-            "split": {
-              "version": "0.2.10",
-              "from": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
-              "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
-            },
-            "stream-combiner": {
-              "version": "0.0.4",
-              "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
-            }
-          }
-        },
-        "connect-livereload": {
-          "version": "0.3.2",
-          "from": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.3.2.tgz"
+        "noptify": {
+          "version": "0.0.3",
+          "from": "noptify@latest",
+          "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz"
         },
         "open": {
           "version": "0.0.4",
@@ -10194,318 +10505,20 @@
           "from": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.0.5.tgz",
           "dependencies": {
-            "qs": {
-              "version": "0.5.6",
-              "from": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
+            "debug": {
+              "version": "0.7.4",
+              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             },
             "faye-websocket": {
               "version": "0.4.4",
               "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
               "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
             },
-            "noptify": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
-              "dependencies": {
-                "nopt": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "debug": {
-              "version": "0.7.4",
-              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-            }
-          }
-        },
-        "connect": {
-          "version": "2.14.5",
-          "from": "https://registry.npmjs.org/connect/-/connect-2.14.5.tgz",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-2.14.5.tgz",
-          "dependencies": {
-            "basic-auth-connect": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
-            },
-            "cookie-parser": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.0.1.tgz",
-              "dependencies": {
-                "cookie": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
-                }
-              }
-            },
-            "cookie-signature": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz"
-            },
-            "compression": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/compression/-/compression-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/compression/-/compression-1.0.0.tgz",
-              "dependencies": {
-                "bytes": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz"
-                },
-                "negotiator": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz"
-                },
-                "compressible": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/compressible/-/compressible-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-1.0.0.tgz"
-                }
-              }
-            },
-            "connect-timeout": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.0.0.tgz"
-            },
-            "csurf": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/csurf/-/csurf-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.1.0.tgz",
-              "dependencies": {
-                "uid2": {
-                  "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz"
-                },
-                "scmp": {
-                  "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/scmp/-/scmp-0.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/scmp/-/scmp-0.0.3.tgz"
-                }
-              }
-            },
-            "errorhandler": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.0.0.tgz"
-            },
-            "express-session": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/express-session/-/express-session-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.0.2.tgz",
-              "dependencies": {
-                "utils-merge": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
-                },
-                "cookie": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
-                },
-                "uid2": {
-                  "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz"
-                },
-                "buffer-crc32": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
-                },
-                "debug": {
-                  "version": "0.7.4",
-                  "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                }
-              }
-            },
-            "fresh": {
-              "version": "0.2.2",
-              "from": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
-            },
-            "method-override": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/method-override/-/method-override-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/method-override/-/method-override-1.0.0.tgz",
-              "dependencies": {
-                "methods": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
-                }
-              }
-            },
-            "morgan": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/morgan/-/morgan-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.0.0.tgz",
-              "dependencies": {
-                "bytes": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz"
-                }
-              }
-            },
             "qs": {
-              "version": "0.6.6",
-              "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
-            },
-            "raw-body": {
-              "version": "1.1.4",
-              "from": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.4.tgz",
-              "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.4.tgz"
-            },
-            "response-time": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/response-time/-/response-time-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/response-time/-/response-time-1.0.0.tgz"
-            },
-            "setimmediate": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.1.tgz"
-            },
-            "serve-index": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.1.tgz",
-              "dependencies": {
-                "batch": {
-                  "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz"
-                },
-                "negotiator": {
-                  "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.2.tgz"
-                }
-              }
-            },
-            "serve-static": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.1.0.tgz",
-              "dependencies": {
-                "parseurl": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz"
-                },
-                "send": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/send/-/send-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/send/-/send-0.3.0.tgz",
-                  "dependencies": {
-                    "buffer-crc32": {
-                      "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
-                    },
-                    "debug": {
-                      "version": "0.8.0",
-                      "from": "https://registry.npmjs.org/debug/-/debug-0.8.0.tgz",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.0.tgz"
-                    },
-                    "mime": {
-                      "version": "1.2.11",
-                      "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                    },
-                    "range-parser": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "static-favicon": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/static-favicon/-/static-favicon-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/static-favicon/-/static-favicon-1.0.2.tgz"
-            },
-            "vhost": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/vhost/-/vhost-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/vhost/-/vhost-1.0.0.tgz"
-            },
-            "bytes": {
-              "version": "0.3.0",
-              "from": "https://registry.npmjs.org/bytes/-/bytes-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.3.0.tgz"
-            },
-            "pause": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
-            },
-            "debug": {
-              "version": "0.8.1",
-              "from": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz"
-            },
-            "multiparty": {
-              "version": "2.2.0",
-              "from": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "stream-counter": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
-                }
-              }
+              "version": "0.5.6",
+              "from": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
             }
           }
         }
@@ -10877,6 +10890,11 @@
               "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
               "dependencies": {
+                "lodash._escapestringchar": {
+                  "version": "2.4.1",
+                  "from": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+                },
                 "lodash.defaults": {
                   "version": "2.4.1",
                   "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
@@ -10920,11 +10938,6 @@
                     }
                   }
                 },
-                "lodash._escapestringchar": {
-                  "version": "2.4.1",
-                  "from": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
-                },
                 "lodash.keys": {
                   "version": "2.4.1",
                   "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
@@ -10935,10 +10948,10 @@
                       "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                     },
-                    "lodash.isobject": {
+                    "lodash._shimkeys": {
                       "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
                       "dependencies": {
                         "lodash._objecttypes": {
                           "version": "2.4.1",
@@ -10947,10 +10960,10 @@
                         }
                       }
                     },
-                    "lodash._shimkeys": {
+                    "lodash.isobject": {
                       "version": "2.4.1",
-                      "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
                       "dependencies": {
                         "lodash._objecttypes": {
                           "version": "2.4.1",
@@ -10998,6 +11011,11 @@
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -11007,11 +11025,6 @@
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -11034,6 +11047,11 @@
                       "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -11043,11 +11061,6 @@
                       "version": "0.10.31",
                       "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
@@ -11092,6 +11105,11 @@
                   "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -11101,11 +11119,6 @@
                   "version": "0.10.31",
                   "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
@@ -11140,6 +11153,11 @@
               "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
             "isarray": {
               "version": "0.0.1",
               "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -11149,11 +11167,6 @@
               "version": "0.10.31",
               "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
@@ -11258,15 +11271,15 @@
           "from": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
           "dependencies": {
-            "textextensions": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.1.tgz"
-            },
             "binaryextensions": {
               "version": "1.0.0",
               "from": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.0.tgz"
+            },
+            "textextensions": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.1.tgz"
             }
           }
         },
@@ -11808,6 +11821,11 @@
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -11817,11 +11835,6 @@
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -11946,11 +11959,6 @@
                           "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
-                        "typedarray": {
-                          "version": "0.0.6",
-                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                        },
                         "readable-stream": {
                           "version": "2.0.4",
                           "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
@@ -11982,6 +11990,11 @@
                               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                             }
                           }
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         }
                       }
                     },
@@ -12004,11 +12017,6 @@
                   "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                   "dependencies": {
-                    "lodash": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                    },
                     "glob": {
                       "version": "3.1.21",
                       "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
@@ -12025,6 +12033,11 @@
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
                         }
                       }
+                    },
+                    "lodash": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                     },
                     "minimatch": {
                       "version": "0.2.14",
@@ -12362,81 +12375,6 @@
               "from": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
             },
-            "npmconf": {
-              "version": "2.1.2",
-              "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
-              "dependencies": {
-                "config-chain": {
-                  "version": "1.1.9",
-                  "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
-                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
-                  "dependencies": {
-                    "proto-list": {
-                      "version": "1.2.4",
-                      "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "ini": {
-                  "version": "1.3.4",
-                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                },
-                "nopt": {
-                  "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    },
-                    "os-tmpdir": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                    }
-                  }
-                },
-                "uid-number": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
-                }
-              }
-            },
             "node-gyp": {
               "version": "3.0.3",
               "from": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.0.3.tgz",
@@ -12578,6 +12516,11 @@
                               "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                             },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
                             "isarray": {
                               "version": "0.0.1",
                               "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -12587,11 +12530,6 @@
                               "version": "0.10.31",
                               "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
                         }
@@ -12817,11 +12755,91 @@
                 }
               }
             },
+            "npmconf": {
+              "version": "2.1.2",
+              "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+              "dependencies": {
+                "config-chain": {
+                  "version": "1.1.9",
+                  "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+                  "dependencies": {
+                    "proto-list": {
+                      "version": "1.2.4",
+                      "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                },
+                "nopt": {
+                  "version": "3.0.4",
+                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.3",
+                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                    },
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    }
+                  }
+                },
+                "uid-number": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+                }
+              }
+            },
             "request": {
               "version": "2.65.0",
               "from": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
               "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                },
                 "bl": {
                   "version": "1.0.0",
                   "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
@@ -12871,6 +12889,18 @@
                   "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    }
+                  }
+                },
                 "extend": {
                   "version": "3.0.0",
                   "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
@@ -12892,119 +12922,6 @@
                       "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
                     }
                   }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                },
-                "mime-types": {
-                  "version": "2.1.7",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.19.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
-                    }
-                  }
-                },
-                "qs": {
-                  "version": "5.2.0",
-                  "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-                },
-                "tough-cookie": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
-                },
-                "http-signature": {
-                  "version": "0.11.0",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                    },
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                    },
-                    "ctype": {
-                      "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-                },
-                "hawk": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                    },
-                    "boom": {
-                      "version": "2.10.1",
-                      "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                    }
-                  }
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "har-validator": {
                   "version": "2.0.2",
@@ -13070,6 +12987,102 @@
                       }
                     }
                   }
+                },
+                "hawk": {
+                  "version": "3.1.0",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1",
+                      "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.11.0",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.7",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.19.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                },
+                "qs": {
+                  "version": "5.2.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.1",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 }
               }
             },
@@ -13743,6 +13756,11 @@
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -13752,11 +13770,6 @@
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -14431,6 +14444,11 @@
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -14440,11 +14458,6 @@
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -14617,15 +14630,15 @@
               "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                },
                 "minimist": {
                   "version": "0.0.10",
                   "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 }
               }
             },
@@ -15127,6 +15140,11 @@
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -15136,11 +15154,6 @@
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -15230,6 +15243,11 @@
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
+        },
+        "typescript": {
+          "version": "1.7.3",
+          "from": "typescript@1.7.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.7.3.tgz"
         },
         "vinyl-fs": {
           "version": "2.2.1",
@@ -15426,6 +15444,11 @@
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -15435,11 +15458,6 @@
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     },
@@ -16420,6 +16438,11 @@
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -16429,11 +16452,6 @@
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -16604,6 +16622,11 @@
       "from": "https://registry.npmjs.org/hash-files/-/hash-files-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/hash-files/-/hash-files-1.0.0.tgz",
       "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
         "glob": {
           "version": "3.2.11",
           "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
@@ -16642,13 +16665,18 @@
           "version": "1.8.3",
           "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
-        },
-        "async": {
-          "version": "0.9.2",
-          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         }
       }
+    },
+    "inflight": {
+      "version": "1.0.4",
+      "from": "inflight@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "from": "inherits@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "jasmine": {
       "version": "2.3.1",
@@ -16705,132 +16733,6 @@
           "version": "2.6.0",
           "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
-        },
-        "fs-promise": {
-          "version": "0.3.1",
-          "from": "https://registry.npmjs.org/fs-promise/-/fs-promise-0.3.1.tgz",
-          "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-0.3.1.tgz",
-          "dependencies": {
-            "any-promise": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz"
-            }
-          }
-        },
-        "fs-extra": {
-          "version": "0.16.4",
-          "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.4.tgz",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.4.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "3.0.8",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-            },
-            "jsonfile": {
-              "version": "2.2.3",
-              "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
-            },
-            "rimraf": {
-              "version": "2.4.3",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "5.0.15",
-                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "once": {
-                      "version": "1.3.2",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "fx-runner": {
-          "version": "0.0.7",
-          "from": "https://registry.npmjs.org/fx-runner/-/fx-runner-0.0.7.tgz",
-          "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-0.0.7.tgz",
-          "dependencies": {
-            "lodash": {
-              "version": "2.4.1",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
-            },
-            "when": {
-              "version": "3.6.4",
-              "from": "https://registry.npmjs.org/when/-/when-3.6.4.tgz",
-              "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz"
-            },
-            "winreg": {
-              "version": "0.0.12",
-              "from": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz",
-              "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz"
-            }
-          }
-        },
-        "jpm-core": {
-          "version": "0.0.9",
-          "from": "https://registry.npmjs.org/jpm-core/-/jpm-core-0.0.9.tgz",
-          "resolved": "https://registry.npmjs.org/jpm-core/-/jpm-core-0.0.9.tgz"
-        },
-        "jetpack-id": {
-          "version": "0.0.4",
-          "from": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-0.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-0.0.4.tgz"
-        },
-        "jetpack-validation": {
-          "version": "0.0.4",
-          "from": "https://registry.npmjs.org/jetpack-validation/-/jetpack-validation-0.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/jetpack-validation/-/jetpack-validation-0.0.4.tgz",
-          "dependencies": {
-            "resolve": {
-              "version": "0.7.4",
-              "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
-            },
-            "semver": {
-              "version": "2.3.2",
-              "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
-            }
-          }
         },
         "firefox-profile": {
           "version": "0.3.9",
@@ -16903,6 +16805,11 @@
                       "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -16912,11 +16819,6 @@
                       "version": "0.10.31",
                       "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
@@ -16987,6 +16889,11 @@
               "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
             },
+            "ini": {
+              "version": "1.3.4",
+              "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+            },
             "lazystream": {
               "version": "0.1.0",
               "from": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
@@ -17002,6 +16909,11 @@
                       "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -17011,11 +16923,6 @@
                       "version": "0.10.31",
                       "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -17047,13 +16954,134 @@
                   "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz"
                 }
               }
-            },
-            "ini": {
-              "version": "1.3.4",
-              "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
             }
           }
+        },
+        "fs-extra": {
+          "version": "0.16.4",
+          "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.4.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.4.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.8",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+            },
+            "jsonfile": {
+              "version": "2.2.3",
+              "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
+            },
+            "rimraf": {
+              "version": "2.4.3",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "fs-promise": {
+          "version": "0.3.1",
+          "from": "https://registry.npmjs.org/fs-promise/-/fs-promise-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-0.3.1.tgz",
+          "dependencies": {
+            "any-promise": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz"
+            }
+          }
+        },
+        "fx-runner": {
+          "version": "0.0.7",
+          "from": "https://registry.npmjs.org/fx-runner/-/fx-runner-0.0.7.tgz",
+          "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-0.0.7.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            },
+            "when": {
+              "version": "3.6.4",
+              "from": "https://registry.npmjs.org/when/-/when-3.6.4.tgz",
+              "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz"
+            },
+            "winreg": {
+              "version": "0.0.12",
+              "from": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz",
+              "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz"
+            }
+          }
+        },
+        "jetpack-id": {
+          "version": "0.0.4",
+          "from": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-0.0.4.tgz"
+        },
+        "jetpack-validation": {
+          "version": "0.0.4",
+          "from": "https://registry.npmjs.org/jetpack-validation/-/jetpack-validation-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/jetpack-validation/-/jetpack-validation-0.0.4.tgz",
+          "dependencies": {
+            "resolve": {
+              "version": "0.7.4",
+              "from": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+            },
+            "semver": {
+              "version": "2.3.2",
+              "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+            }
+          }
+        },
+        "jpm-core": {
+          "version": "0.0.9",
+          "from": "https://registry.npmjs.org/jpm-core/-/jpm-core-0.0.9.tgz",
+          "resolved": "https://registry.npmjs.org/jpm-core/-/jpm-core-0.0.9.tgz"
         },
         "jsontoxml": {
           "version": "0.0.11",
@@ -17089,15 +17117,20 @@
             }
           }
         },
+        "mozilla-toolkit-versioning": {
+          "version": "0.0.2",
+          "from": "https://registry.npmjs.org/mozilla-toolkit-versioning/-/mozilla-toolkit-versioning-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/mozilla-toolkit-versioning/-/mozilla-toolkit-versioning-0.0.2.tgz"
+        },
+        "mozilla-version-comparator": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/mozilla-version-comparator/-/mozilla-version-comparator-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/mozilla-version-comparator/-/mozilla-version-comparator-1.0.2.tgz"
+        },
         "node-watch": {
           "version": "0.3.4",
           "from": "https://registry.npmjs.org/node-watch/-/node-watch-0.3.4.tgz",
           "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.3.4.tgz"
-        },
-        "tmp": {
-          "version": "0.0.25",
-          "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz"
         },
         "open": {
           "version": "0.0.5",
@@ -17126,15 +17159,10 @@
           "from": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
         },
-        "mozilla-version-comparator": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/mozilla-version-comparator/-/mozilla-version-comparator-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/mozilla-version-comparator/-/mozilla-version-comparator-1.0.2.tgz"
-        },
-        "mozilla-toolkit-versioning": {
-          "version": "0.0.2",
-          "from": "https://registry.npmjs.org/mozilla-toolkit-versioning/-/mozilla-toolkit-versioning-0.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/mozilla-toolkit-versioning/-/mozilla-toolkit-versioning-0.0.2.tgz"
+        "tmp": {
+          "version": "0.0.25",
+          "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz"
         },
         "when": {
           "version": "3.7.2",
@@ -17544,6 +17572,11 @@
                   "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -17553,11 +17586,6 @@
                   "version": "0.10.31",
                   "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
@@ -17602,15 +17630,15 @@
           "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-            },
             "minimist": {
               "version": "0.0.10",
               "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             }
           }
         },
@@ -17624,6 +17652,18 @@
           "from": "https://registry.npmjs.org/socket.io/-/socket.io-1.3.7.tgz",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.3.7.tgz",
           "dependencies": {
+            "debug": {
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
             "engine.io": {
               "version": "1.5.4",
               "from": "https://registry.npmjs.org/engine.io/-/engine.io-1.5.4.tgz",
@@ -17709,35 +17749,71 @@
                 }
               }
             },
-            "socket.io-parser": {
-              "version": "2.2.4",
-              "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.4.tgz",
-              "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.4.tgz",
+            "has-binary-data": {
+              "version": "0.1.3",
+              "from": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.3.tgz",
               "dependencies": {
-                "debug": {
-                  "version": "0.7.4",
-                  "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                },
-                "json3": {
-                  "version": "3.2.6",
-                  "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
-                  "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
-                },
-                "component-emitter": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
-                },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                }
+              }
+            },
+            "socket.io-adapter": {
+              "version": "0.3.1",
+              "from": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.3.1.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    }
+                  }
                 },
-                "benchmark": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                "object-keys": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.1.tgz"
+                },
+                "socket.io-parser": {
+                  "version": "2.2.2",
+                  "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
+                  "dependencies": {
+                    "benchmark": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                    },
+                    "component-emitter": {
+                      "version": "1.1.2",
+                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                    },
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "json3": {
+                      "version": "3.2.6",
+                      "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
+                      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                    }
+                  }
                 }
               }
             },
@@ -17746,6 +17822,21 @@
               "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.3.7.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.3.7.tgz",
               "dependencies": {
+                "backo2": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
+                },
+                "component-bind": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
+                },
+                "component-emitter": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                },
                 "debug": {
                   "version": "0.7.4",
                   "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
@@ -17898,21 +17989,6 @@
                     }
                   }
                 },
-                "component-bind": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
-                },
-                "component-emitter": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
-                },
-                "object-component": {
-                  "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
-                },
                 "has-binary": {
                   "version": "0.1.6",
                   "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
@@ -17929,6 +18005,11 @@
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                },
+                "object-component": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
                 },
                 "parseuri": {
                   "version": "0.0.2",
@@ -17953,91 +18034,38 @@
                   "version": "0.1.3",
                   "from": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz"
-                },
-                "backo2": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
                 }
               }
             },
-            "socket.io-adapter": {
-              "version": "0.3.1",
-              "from": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.3.1.tgz",
+            "socket.io-parser": {
+              "version": "2.2.4",
+              "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.4.tgz",
+              "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.4.tgz",
               "dependencies": {
+                "benchmark": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                },
+                "component-emitter": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                },
                 "debug": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-                    }
-                  }
+                  "version": "0.7.4",
+                  "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                 },
-                "socket.io-parser": {
-                  "version": "2.2.2",
-                  "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
-                  "dependencies": {
-                    "debug": {
-                      "version": "0.7.4",
-                      "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                    },
-                    "json3": {
-                      "version": "3.2.6",
-                      "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
-                      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
-                    },
-                    "component-emitter": {
-                      "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "benchmark": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
-                    }
-                  }
-                },
-                "object-keys": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.1.tgz"
-                }
-              }
-            },
-            "has-binary-data": {
-              "version": "0.1.3",
-              "from": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.3.tgz",
-              "dependencies": {
                 "isarray": {
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                }
-              }
-            },
-            "debug": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "0.6.2",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                },
+                "json3": {
+                  "version": "3.2.6",
+                  "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
+                  "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
                 }
               }
             }
@@ -18118,26 +18146,6 @@
               "from": "https://registry.npmjs.org/q-io/-/q-io-1.10.9.tgz",
               "resolved": "https://registry.npmjs.org/q-io/-/q-io-1.10.9.tgz",
               "dependencies": {
-                "qs": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/qs/-/qs-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.1.0.tgz"
-                },
-                "url2": {
-                  "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz"
-                },
-                "mime": {
-                  "version": "1.2.11",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                },
-                "mimeparse": {
-                  "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz"
-                },
                 "collections": {
                   "version": "0.2.2",
                   "from": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
@@ -18149,6 +18157,26 @@
                       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz"
                     }
                   }
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "mimeparse": {
+                  "version": "0.1.4",
+                  "from": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz"
+                },
+                "qs": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.1.0.tgz"
+                },
+                "url2": {
+                  "version": "0.0.0",
+                  "from": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz"
                 }
               }
             }
@@ -18166,6 +18194,43 @@
       "from": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.2.14.tgz",
       "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.2.14.tgz",
       "dependencies": {
+        "q": {
+          "version": "0.9.7",
+          "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+        },
+        "sauce-connect-launcher": {
+          "version": "0.11.1",
+          "from": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.11.1.tgz",
+          "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.11.1.tgz",
+          "dependencies": {
+            "adm-zip": {
+              "version": "0.4.7",
+              "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
+              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
+            },
+            "async": {
+              "version": "0.9.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            },
+            "lodash": {
+              "version": "3.5.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
+            },
+            "rimraf": {
+              "version": "2.2.6",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz"
+            }
+          }
+        },
+        "saucelabs": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz"
+        },
         "wd": {
           "version": "0.3.12",
           "from": "https://registry.npmjs.org/wd/-/wd-0.3.12.tgz",
@@ -18242,6 +18307,11 @@
                       "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -18251,11 +18321,6 @@
                       "version": "0.10.31",
                       "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
@@ -18341,6 +18406,11 @@
               "from": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
               "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
               "dependencies": {
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
                 "bl": {
                   "version": "0.9.4",
                   "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
@@ -18356,6 +18426,11 @@
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -18365,11 +18440,6 @@
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -18379,6 +18449,18 @@
                   "version": "0.9.0",
                   "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
                 },
                 "forever-agent": {
                   "version": "0.6.1",
@@ -18396,119 +18478,6 @@
                       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                     }
                   }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                },
-                "mime-types": {
-                  "version": "2.0.14",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.12.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-                    }
-                  }
-                },
-                "qs": {
-                  "version": "2.4.2",
-                  "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-                },
-                "tough-cookie": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
-                },
-                "http-signature": {
-                  "version": "0.10.1",
-                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                    },
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                    },
-                    "ctype": {
-                      "version": "0.5.3",
-                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
-                },
-                "hawk": {
-                  "version": "2.3.1",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                    },
-                    "boom": {
-                      "version": "2.10.1",
-                      "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-                },
-                "combined-stream": {
-                  "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                    }
-                  }
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "har-validator": {
                   "version": "1.8.0",
@@ -18613,6 +18582,102 @@
                       }
                     }
                   }
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1",
+                      "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.0.14",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.12.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.6.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+                },
+                "qs": {
+                  "version": "2.4.2",
+                  "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.1",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 }
               }
             },
@@ -18627,43 +18692,6 @@
               "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz"
             }
           }
-        },
-        "sauce-connect-launcher": {
-          "version": "0.11.1",
-          "from": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.11.1.tgz",
-          "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.11.1.tgz",
-          "dependencies": {
-            "lodash": {
-              "version": "3.5.0",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
-            },
-            "async": {
-              "version": "0.9.0",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-            },
-            "adm-zip": {
-              "version": "0.4.7",
-              "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
-              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
-            },
-            "rimraf": {
-              "version": "2.2.6",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz"
-            }
-          }
-        },
-        "q": {
-          "version": "0.9.7",
-          "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
-          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
-        },
-        "saucelabs": {
-          "version": "0.1.1",
-          "from": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz"
         }
       }
     },
@@ -18760,49 +18788,10 @@
               "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.1.tgz",
               "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.1.tgz",
               "dependencies": {
-                "q": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
-                },
-                "recast": {
-                  "version": "0.9.11",
-                  "from": "https://registry.npmjs.org/recast/-/recast-0.9.11.tgz",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.11.tgz",
-                  "dependencies": {
-                    "esprima-fb": {
-                      "version": "8001.1001.0-dev-harmony-fb",
-                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
-                    },
-                    "source-map": {
-                      "version": "0.1.41",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
-                        }
-                      }
-                    },
-                    "ast-types": {
-                      "version": "0.6.7",
-                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.7.tgz",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.7.tgz"
-                    }
-                  }
-                },
                 "commander": {
                   "version": "2.5.1",
                   "from": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
-                },
-                "graceful-fs": {
-                  "version": "3.0.5",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
                 },
                 "glob": {
                   "version": "4.2.2",
@@ -18857,6 +18846,21 @@
                     }
                   }
                 },
+                "graceful-fs": {
+                  "version": "3.0.5",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+                },
+                "iconv-lite": {
+                  "version": "0.4.5",
+                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz"
+                },
+                "install": {
+                  "version": "0.1.8",
+                  "from": "https://registry.npmjs.org/install/-/install-0.1.8.tgz",
+                  "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
+                },
                 "mkdirp": {
                   "version": "0.5.0",
                   "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
@@ -18874,15 +18878,39 @@
                   "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
                 },
-                "install": {
-                  "version": "0.1.8",
-                  "from": "https://registry.npmjs.org/install/-/install-0.1.8.tgz",
-                  "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
+                "q": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
                 },
-                "iconv-lite": {
-                  "version": "0.4.5",
-                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz"
+                "recast": {
+                  "version": "0.9.11",
+                  "from": "https://registry.npmjs.org/recast/-/recast-0.9.11.tgz",
+                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.11.tgz",
+                  "dependencies": {
+                    "ast-types": {
+                      "version": "0.6.7",
+                      "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.7.tgz",
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.7.tgz"
+                    },
+                    "esprima-fb": {
+                      "version": "8001.1001.0-dev-harmony-fb",
+                      "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.41",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
@@ -18985,31 +19013,161 @@
         }
       }
     },
+    "nan": {
+      "version": "2.1.0",
+      "from": "nan@>=2.0.5 <3.0.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+    },
     "node-uuid": {
       "version": "1.4.3",
       "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+    },
+    "nopt": {
+      "version": "2.0.0",
+      "from": "nopt@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz"
     },
     "on-headers": {
       "version": "1.0.1",
       "from": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
     },
+    "once": {
+      "version": "1.3.3",
+      "from": "once@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "from": "optimist@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "from": "minimist@>=0.0.1 <0.1.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+        }
+      }
+    },
     "parse5": {
       "version": "1.3.2",
       "from": "https://registry.npmjs.org/parse5/-/parse5-1.3.2.tgz",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.3.2.tgz"
+    },
+    "path-is-absolute": {
+      "version": "1.0.0",
+      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
     },
     "protractor": {
       "version": "2.5.1",
       "from": "https://registry.npmjs.org/protractor/-/protractor-2.5.1.tgz",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-2.5.1.tgz",
       "dependencies": {
+        "accessibility-developer-tools": {
+          "version": "2.6.0",
+          "from": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.6.0.tgz"
+        },
+        "adm-zip": {
+          "version": "0.4.4",
+          "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+        },
+        "glob": {
+          "version": "3.2.11",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.7.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "html-entities": {
+          "version": "1.1.3",
+          "from": "https://registry.npmjs.org/html-entities/-/html-entities-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.1.3.tgz"
+        },
+        "jasmine": {
+          "version": "2.3.2",
+          "from": "https://registry.npmjs.org/jasmine/-/jasmine-2.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.3.2.tgz",
+          "dependencies": {
+            "exit": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+            }
+          }
+        },
+        "jasminewd": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/jasminewd/-/jasminewd-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/jasminewd/-/jasminewd-1.1.0.tgz"
+        },
+        "jasminewd2": {
+          "version": "0.0.6",
+          "from": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.6.tgz"
+        },
+        "minijasminenode": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-1.1.1.tgz"
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            }
+          }
+        },
+        "q": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/q/-/q-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.0.0.tgz"
+        },
         "request": {
           "version": "2.57.0",
           "from": "https://registry.npmjs.org/request/-/request-2.57.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.57.0.tgz",
           "dependencies": {
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
             "bl": {
               "version": "0.9.4",
               "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
@@ -19025,6 +19183,11 @@
                       "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -19034,11 +19197,6 @@
                       "version": "0.10.31",
                       "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -19048,6 +19206,18 @@
               "version": "0.10.0",
               "from": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                }
+              }
             },
             "forever-agent": {
               "version": "0.6.1",
@@ -19077,119 +19247,6 @@
                   }
                 }
               }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.0.14",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.12.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-                }
-              }
-            },
-            "qs": {
-              "version": "3.1.0",
-              "from": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.0",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
-            },
-            "http-signature": {
-              "version": "0.11.0",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "asn1": {
-                  "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-            },
-            "hawk": {
-              "version": "2.3.1",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.5.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
               "version": "1.8.0",
@@ -19292,6 +19349,145 @@
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
+                }
+              }
+            },
+            "hawk": {
+              "version": "2.3.1",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.11.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.0.14",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.12.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+            },
+            "qs": {
+              "version": "3.1.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+            }
+          }
+        },
+        "saucelabs": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.0.1.tgz",
+          "dependencies": {
+            "https-proxy-agent": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+              "dependencies": {
+                "agent-base": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
+                  "dependencies": {
+                    "semver": {
+                      "version": "5.0.3",
+                      "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 }
               }
             }
@@ -19398,132 +19594,6 @@
             }
           }
         },
-        "minijasminenode": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-1.1.1.tgz"
-        },
-        "jasminewd": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/jasminewd/-/jasminewd-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/jasminewd/-/jasminewd-1.1.0.tgz"
-        },
-        "jasminewd2": {
-          "version": "0.0.6",
-          "from": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.6.tgz",
-          "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.6.tgz"
-        },
-        "jasmine": {
-          "version": "2.3.2",
-          "from": "https://registry.npmjs.org/jasmine/-/jasmine-2.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.3.2.tgz",
-          "dependencies": {
-            "exit": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-            }
-          }
-        },
-        "saucelabs": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.0.1.tgz",
-          "dependencies": {
-            "https-proxy-agent": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-              "dependencies": {
-                "agent-base": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
-                  "dependencies": {
-                    "semver": {
-                      "version": "5.0.3",
-                      "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
-                    }
-                  }
-                },
-                "debug": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "glob": {
-          "version": "3.2.11",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "0.3.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.0",
-                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "adm-zip": {
-          "version": "0.4.4",
-          "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
-          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-            },
-            "minimist": {
-              "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-            }
-          }
-        },
-        "q": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/q/-/q-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.0.0.tgz"
-        },
         "source-map-support": {
           "version": "0.2.10",
           "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
@@ -19542,16 +19612,6 @@
               }
             }
           }
-        },
-        "html-entities": {
-          "version": "1.1.3",
-          "from": "https://registry.npmjs.org/html-entities/-/html-entities-1.1.3.tgz",
-          "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.1.3.tgz"
-        },
-        "accessibility-developer-tools": {
-          "version": "2.6.0",
-          "from": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.6.0.tgz"
         }
       }
     },
@@ -19575,11 +19635,6 @@
           "from": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz",
           "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz",
           "dependencies": {
-            "through": {
-              "version": "2.3.8",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            },
             "jstransform": {
               "version": "10.1.0",
               "from": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
@@ -19608,6 +19663,11 @@
                   }
                 }
               }
+            },
+            "through": {
+              "version": "2.3.8",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
@@ -20151,6 +20211,11 @@
                           "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -20160,11 +20225,6 @@
                           "version": "0.10.31",
                           "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -20390,6 +20450,11 @@
       "from": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.1.5.tgz",
       "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
         "loader-utils": {
           "version": "0.2.12",
           "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
@@ -20418,11 +20483,6 @@
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
-        },
-        "async": {
-          "version": "0.9.2",
-          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         }
       }
     },
@@ -20699,6 +20759,11 @@
               "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
             },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
             "isarray": {
               "version": "0.0.1",
               "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -20708,11 +20773,6 @@
               "version": "0.10.31",
               "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
@@ -20758,6 +20818,11 @@
               }
             }
           }
+        },
+        "typescript": {
+          "version": "1.7.3",
+          "from": "typescript@1.7.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.7.3.tgz"
         }
       }
     },
@@ -20786,6 +20851,11 @@
                   "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -20795,11 +20865,6 @@
                   "version": "0.10.31",
                   "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             }
@@ -20917,11 +20982,6 @@
           "from": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
           "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz",
           "dependencies": {
-            "through": {
-              "version": "2.3.8",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            },
             "duplexer": {
               "version": "0.1.1",
               "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -20951,6 +21011,11 @@
               "version": "0.0.4",
               "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+            },
+            "through": {
+              "version": "2.3.8",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
@@ -20969,11 +21034,6 @@
               "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
-            "topo": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
-            },
             "isemail": {
               "version": "1.2.0",
               "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
@@ -20983,6 +21043,11 @@
               "version": "2.10.6",
               "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+            },
+            "topo": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
             }
           }
         },
@@ -21081,6 +21146,11 @@
           "from": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
           "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+            },
             "bl": {
               "version": "1.0.0",
               "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
@@ -21130,6 +21200,18 @@
               "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                }
+              }
+            },
             "extend": {
               "version": "3.0.0",
               "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
@@ -21151,119 +21233,6 @@
                   "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
                 }
               }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.7",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.19.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
-                }
-              }
-            },
-            "qs": {
-              "version": "5.2.0",
-              "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.0",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
-            },
-            "http-signature": {
-              "version": "0.11.0",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "asn1": {
-                  "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-            },
-            "hawk": {
-              "version": "3.1.0",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
               "version": "2.0.2",
@@ -21329,6 +21298,102 @@
                   }
                 }
               }
+            },
+            "hawk": {
+              "version": "3.1.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.11.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.7",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.19.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+            },
+            "qs": {
+              "version": "5.2.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             }
           }
         },
@@ -21640,15 +21705,15 @@
                               "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
                               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
                             },
-                            "strip-json-comments": {
-                              "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-                            },
                             "ini": {
                               "version": "1.3.4",
                               "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
                               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3",
+                              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                             }
                           }
                         }
@@ -21709,97 +21774,47 @@
       }
     },
     "tslint": {
-      "version": "3.0.0-dev.1",
-      "from": "https://registry.npmjs.org/tslint/-/tslint-3.0.0-dev.1.tgz",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-3.0.0-dev.1.tgz",
+      "version": "3.2.1",
+      "from": "tslint@3.2.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-3.2.1.tgz",
       "dependencies": {
-        "findup-sync": {
-          "version": "0.2.1",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "4.3.5",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "once": {
-                  "version": "1.3.2",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-            },
-            "minimist": {
-              "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-            }
-          }
-        },
-        "underscore.string": {
-          "version": "3.1.1",
-          "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.1.1.tgz"
-        },
-        "typescript": {
-          "version": "1.8.0-dev.20151103",
-          "from": "https://registry.npmjs.org/typescript/-/typescript-1.8.0-dev.20151103.tgz",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.8.0-dev.20151103.tgz"
+        "glob": {
+          "version": "6.0.1",
+          "from": "glob@>=6.0.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.1.tgz"
         }
       }
     },
     "typescript": {
-      "version": "1.7.3",
-      "from": "https://registry.npmjs.org/typescript/-/typescript-1.7.3.tgz",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.7.3.tgz"
+      "version": "1.7.5",
+      "from": "typescript@>=1.7.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.7.5.tgz"
+    },
+    "underscore.string": {
+      "version": "3.1.1",
+      "from": "underscore.string@>=3.1.1 <3.2.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.1.1.tgz"
     },
     "universal-analytics": {
       "version": "0.3.9",
       "from": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.3.9.tgz",
       "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.3.9.tgz",
       "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
         "request": {
           "version": "2.65.0",
           "from": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
           "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+            },
             "bl": {
               "version": "1.0.0",
               "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
@@ -21849,6 +21864,18 @@
               "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                }
+              }
+            },
             "extend": {
               "version": "3.0.0",
               "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
@@ -21870,119 +21897,6 @@
                   "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
                 }
               }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.7",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.19.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
-                }
-              }
-            },
-            "qs": {
-              "version": "5.2.0",
-              "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.0",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
-            },
-            "http-signature": {
-              "version": "0.11.0",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "asn1": {
-                  "version": "0.1.11",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-            },
-            "hawk": {
-              "version": "3.1.0",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "har-validator": {
               "version": "2.0.2",
@@ -22094,6 +22008,102 @@
                   }
                 }
               }
+            },
+            "hawk": {
+              "version": "3.1.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.11.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.7",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.19.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+            },
+            "qs": {
+              "version": "5.2.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.1",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
             }
           }
         },
@@ -22101,13 +22111,13 @@
           "version": "1.8.3",
           "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
-        },
-        "async": {
-          "version": "0.2.10",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         }
       }
+    },
+    "utf-8-validate": {
+      "version": "1.2.1",
+      "from": "utf-8-validate@>=1.2.0 <1.3.0",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.2.1.tgz"
     },
     "webpack": {
       "version": "1.12.6",
@@ -22325,15 +22335,15 @@
                   "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
                 "inherits": {
                   "version": "2.0.1",
                   "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 }
               }
             },
@@ -22407,15 +22417,15 @@
           "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-            },
             "minimist": {
               "version": "0.0.10",
               "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             }
           }
         },
@@ -22591,6 +22601,11 @@
           "from": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
           "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
           "dependencies": {
+            "source-list-map": {
+              "version": "0.1.5",
+              "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
+            },
             "source-map": {
               "version": "0.4.4",
               "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
@@ -22602,11 +22617,6 @@
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
-            },
-            "source-list-map": {
-              "version": "0.1.5",
-              "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz",
-              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
             }
           }
         }
@@ -22630,6 +22640,16 @@
           }
         }
       }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "from": "wordwrap@>=0.0.2 <0.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+    },
+    "wrappy": {
+      "version": "1.0.1",
+      "from": "wrappy@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
     },
     "yargs": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "url": "https://github.com/angular/angular.git"
   },
   "scripts": {
-    "preinstall": "node tools/analytics/build-analytics start install npm-install && node tools/analytics/build-analytics start install npm-preinstall && node tools/npm/check-node-modules --purge && node tools/analytics/build-analytics success install npm-preinstall && node tools/analytics/build-analytics start install npm-install-net",
-    "postinstall": "node tools/analytics/build-analytics success install npm-install-net && node tools/analytics/build-analytics start install npm-postinstall && node tools/npm/copy-npm-shrinkwrap && node tools/chromedriverpatch.js && webdriver-manager update && bower install && gulp pubget.dart && tsd reinstall --overwrite --clean --config modules/angular2/tsd.json && tsd reinstall --overwrite --clean --config tools/tsd.json && tsd reinstall --overwrite --config modules/angular1_router/tsd.json && node tools/analytics/build-analytics success install npm-postinstall && node tools/analytics/build-analytics success install npm-install",
+    "preinstall": "node tools/analytics/build-analytics start install npm3-install && node tools/analytics/build-analytics start install npm-preinstall && node tools/npm/check-node-modules && node tools/analytics/build-analytics success install npm-preinstall && node tools/analytics/build-analytics start install npm-install-net",
+    "postinstall": "node tools/analytics/build-analytics success install npm-install-net && node tools/analytics/build-analytics start install npm-postinstall && node tools/npm/copy-npm-shrinkwrap && node tools/chromedriverpatch.js && webdriver-manager update && bower install && gulp pubget.dart && tsd reinstall --overwrite --clean --config modules/angular2/tsd.json && tsd reinstall --overwrite --clean --config tools/tsd.json && tsd reinstall --overwrite --config modules/angular1_router/tsd.json && node tools/analytics/build-analytics success install npm-postinstall && node tools/analytics/build-analytics success install npm3-install",
     "test": "gulp test.all.js && gulp test.all.dart"
   },
   "dependencies": {
@@ -114,7 +114,7 @@
     "through2": "^0.6.5",
     "ts2dart": "^0.7.18",
     "tsd": "^0.6.5-beta",
-    "tslint": "^3.0.0-dev.1",
+    "tslint": "^3.2.1",
     "typescript": "^1.7.3",
     "universal-analytics": "^0.3.9",
     "webpack": "^1.12.6",

--- a/tools/analytics/build-analytics
+++ b/tools/analytics/build-analytics
@@ -40,9 +40,13 @@ switch (eventType) {
     fs.writeFileSync(startTimestampFilePath, Date.now(), 'utf-8');
     break;
   case 'success':
-    var startTime = fs.readFileSync(startTimestampFilePath, 'utf-8');
-    analytics[actionCategory + 'Success'](actionName, Date.now() - startTime);
-    fs.unlinkSync(startTimestampFilePath);
+    try {
+      var startTime = fs.readFileSync(startTimestampFilePath, 'utf-8');
+      analytics[actionCategory + 'Success'](actionName, Date.now() - startTime);
+      fs.unlinkSync(startTimestampFilePath);
+    } catch(e) {
+      console.log('No start timestamp file "' + startTimestampFilePath + '" found, skipping analytics.');
+    }
     break;
   case 'error':
     var startTime = fs.readFileSync(startTimestampFilePath, 'utf-8');

--- a/tools/npm/check-node-modules
+++ b/tools/npm/check-node-modules
@@ -2,6 +2,9 @@
 
 var checkNpm = require('./check-node-modules.js');
 
-var purgeIfStale = (process.argv.indexOf('--purge') !== -1)
+var purgeIfStale = (process.argv.indexOf('--purge') !== -1);
 
-checkNpm(true, purgeIfStale);
+// check-node-modules will exit(1) if we don't need to install to short-circuit `npm install`
+// see .travis.yml's `install` block to see the reason for this
+process.exit(checkNpm(true, purgeIfStale) ? 1 : 0);
+

--- a/tools/npm/check-node-modules.js
+++ b/tools/npm/check-node-modules.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var path = require('path');
 
 var NPM_SHRINKWRAP_FILE = 'npm-shrinkwrap.json';
-var NPM_SHRINKWRAP_CACHED_FILE = 'node_modules/npm-shrinkwrap.cached.json';
+var NPM_SHRINKWRAP_CACHED_FILE = 'node_modules/.npm-shrinkwrap.cached.json';
 var FS_OPTS = {encoding: 'utf-8'};
 var PROJECT_ROOT = path.join(__dirname, '../../');
 

--- a/tools/npm/copy-npm-shrinkwrap
+++ b/tools/npm/copy-npm-shrinkwrap
@@ -4,7 +4,7 @@ var fse = require('fs-extra');
 var path = require('path');
 
 var NPM_SHRINKWRAP_FILE = 'npm-shrinkwrap.json';
-var NPM_SHRINKWRAP_CACHED_FILE = 'node_modules/npm-shrinkwrap.cached.json';
+var NPM_SHRINKWRAP_CACHED_FILE = 'node_modules/.npm-shrinkwrap.cached.json';
 var PROJECT_ROOT = path.join(__dirname, '../../');
 
 process.chdir(PROJECT_ROOT);

--- a/tools/tslint/requireInternalWithUnderscoreRule.ts
+++ b/tools/tslint/requireInternalWithUnderscoreRule.ts
@@ -1,7 +1,7 @@
 import {RuleFailure} from 'tslint/lib/lint';
 import {AbstractRule} from 'tslint/lib/rules';
 import {RuleWalker} from 'tslint/lib/language/walker';
-import * as ts from 'tslint/node_modules/typescript';
+import * as ts from 'typescript';
 
 export class Rule extends AbstractRule {
   public apply(sourceFile: ts.SourceFile): RuleFailure[] {

--- a/tools/tslint/requireParameterTypeRule.ts
+++ b/tools/tslint/requireParameterTypeRule.ts
@@ -1,7 +1,7 @@
 import {RuleFailure} from 'tslint/lib/lint';
 import {AbstractRule} from 'tslint/lib/rules';
 import {RuleWalker} from 'tslint/lib/language/walker';
-import * as ts from 'tslint/node_modules/typescript';
+import * as ts from 'typescript';
 
 export class Rule extends AbstractRule {
   public static FAILURE_STRING = "missing type declaration";

--- a/tools/tslint/requireReturnTypeRule.ts
+++ b/tools/tslint/requireReturnTypeRule.ts
@@ -1,7 +1,7 @@
 import {RuleFailure} from 'tslint/lib/lint';
 import {AbstractRule} from 'tslint/lib/rules';
 import {RuleWalker} from 'tslint/lib/language/walker';
-import * as ts from 'tslint/node_modules/typescript';
+import * as ts from 'typescript';
 
 export class Rule extends AbstractRule {
   public static FAILURE_STRING = "missing type declaration";


### PR DESCRIPTION
This is a WIP PR to upgrade to npm v3.

Here are all the tasks @IgorMinar noted in the original issue:
- [x] ~~~the way we verify state of node_modules by copying over shrinkwrap.json as a fingerprint is not compatible with v3 and in fact it should be unnecessary - we should remove it from npm postinstall~~~ jk we still need this
- [x] new dedupe algorithm changes paths to d.ts files for our tslint - the paths will neeed to be updated
- [x] update travis.yaml
- [x] update `requiredNpmVersion` in gulpfile.js
- [x] update all dependencies and reshrinkwrap the dependency tree
- [x] resolve issues with peerDependencies that now work differently in v3 (must be explicitly required by the parent component)
- [x] benchmark difference in install time (using Travis)

Closes #3193 
