### PR TITLE
Don't update the location during initial router navigation

### DIFF
--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -459,7 +459,7 @@ export class RootRouter extends Router {
     });
 
     this.registry.configFromComponent(primaryComponent);
-    this.navigateByUrl(location.path());
+    this.navigateByUrl(location.path(), true);
   }
 
   commit(instruction: Instruction, _skipLocationChange: boolean = false): Promise<any> {


### PR DESCRIPTION
Right now a duplicate history entry is created on initial boot, this prevents that by passing `_skipLocationChange = true`.

Cc/ @robwormald 
