### PR TITLE
fix(benchpress): fix flake

### DIFF
--- a/modules/benchpress/src/firefox_extension/lib/main.ts
+++ b/modules/benchpress/src/firefox_extension/lib/main.ts
@@ -54,7 +54,7 @@ mod.PageMod({
   contentScriptFile: data.url('installed_script.js'),
   onAttach: worker => {
     worker.port.on('startProfiler',
-                   (timeStarted) => profiler.start(/* = profiler memory */ 1000000, 0.1,
+                   (timeStarted) => profiler.start(/* = profiler memory */ 3000000, 0.1,
                                                    ['leaf', 'js', 'stackwalk', 'gc'], timeStarted));
     worker.port.on('stopProfiler', () => profiler.stop());
     worker.port.on('getProfile',

--- a/modules/benchpress/test/firefox_extension/spec.ts
+++ b/modules/benchpress/test/firefox_extension/spec.ts
@@ -24,6 +24,7 @@ describe('firefox extension', function() {
     browser.executeScript('window.startProfiler()')
         .then(function() { console.log('started measuring perf'); });
 
+    browser.executeAsyncScript('setTimeout(arguments[0], 1000);');
     browser.executeScript('window.forceGC()');
 
     browser.executeAsyncScript('var cb = arguments[0]; window.getProfile(cb);')

--- a/scripts/ci/test_e2e_js.sh
+++ b/scripts/ci/test_e2e_js.sh
@@ -30,8 +30,5 @@ fi
 
 ./node_modules/.bin/protractor protractor-js.conf.js $OPTIONS
 ./node_modules/.bin/protractor protractor-js.conf.js $OPTIONS --benchmark --dryrun
-# TODO(tbosch): tests for benchpress on firefox are disabled
-# as they are very flake. Enable once https://github.com/angular/angular/issues/5611
-# is resolved.
-# ./node_modules/.bin/protractor dist/js/cjs/benchpress/test/firefox_extension/conf.js
+./node_modules/.bin/protractor dist/js/cjs/benchpress/test/firefox_extension/conf.js
 


### PR DESCRIPTION
memory was not allocated to be high enough, resulting in partial results to be
clipped, and therefore failing the assertions. Also created a longer script call so it's harder to miss the script via firefox's polling mechanism.
