### PR TITLE
docs(OutputMetadata): change documentation to correct event names

### DIFF
--- a/modules/angular2/src/core/metadata/directives.ts
+++ b/modules/angular2/src/core/metadata/directives.ts
@@ -1035,7 +1035,7 @@ export class InputMetadata {
  * @Component({
  *   selector: 'app',
  *   template: `
- *     <interval-dir (every-second)="everySecond()" (every-five-seconds)="everyFiveSeconds()">
+ *     <interval-dir (everySecond)="everySecond()" (everyFiveSeconds)="everyFiveSeconds()">
  *     </interval-dir>
  *   `,
  *   directives: [IntervalDir]


### PR DESCRIPTION
The documentation is slightly confusing because the event names used to
bind to in the example template are `every-second` and
`every-five-seconds`, but the actual event names available are
`everySecond` and `everyFiveSeconds`.
