### PR TITLE
Provide support for SVG foreignObject by adding xhtml namespace

### DIFF
--- a/modules/angular2/src/compiler/schema/dom_element_schema_registry.ts
+++ b/modules/angular2/src/compiler/schema/dom_element_schema_registry.ts
@@ -6,8 +6,11 @@ import {splitNsName} from 'angular2/src/compiler/html_tags';
 
 import {ElementSchemaRegistry} from './element_schema_registry';
 
-const NAMESPACE_URIS =
-    CONST_EXPR({'xlink': 'http://www.w3.org/1999/xlink', 'svg': 'http://www.w3.org/2000/svg'});
+const NAMESPACE_URIS = CONST_EXPR({
+  'xlink': 'http://www.w3.org/1999/xlink',
+  'svg': 'http://www.w3.org/2000/svg',
+  'xhtml': 'http://www.w3.org/1999/xhtml'
+});
 
 @Injectable()
 export class DomElementSchemaRegistry extends ElementSchemaRegistry {

--- a/modules/angular2/src/platform/dom/dom_renderer.ts
+++ b/modules/angular2/src/platform/dom/dom_renderer.ts
@@ -43,8 +43,11 @@ import {ViewEncapsulation} from 'angular2/src/core/metadata';
 import {DOM} from 'angular2/src/platform/dom/dom_adapter';
 import {camelCaseToDashCase} from './util';
 
-const NAMESPACE_URIS =
-    CONST_EXPR({'xlink': 'http://www.w3.org/1999/xlink', 'svg': 'http://www.w3.org/2000/svg'});
+const NAMESPACE_URIS = CONST_EXPR({
+  'xlink': 'http://www.w3.org/1999/xlink',
+  'svg': 'http://www.w3.org/2000/svg',
+  'xhtml': 'http://www.w3.org/1999/xhtml'
+});
 const TEMPLATE_COMMENT_TEXT = 'template bindings={}';
 var TEMPLATE_BINDINGS_EXP = /^template bindings=(.*)$/g;
 

--- a/modules/angular2/test/core/linker/integration_spec.ts
+++ b/modules/angular2/test/core/linker/integration_spec.ts
@@ -1833,6 +1833,30 @@ export function main() {
                  });
            }));
 
+        it('should support foreignObjects',
+           inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder,
+                                                               async) => {
+             tcb.overrideView(
+                    MyComp, new ViewMetadata({
+                      template:
+                          '<svg><foreignObject><xhtml:div><p>Test</p></xhtml:div></foreignObject></svg>'
+                    }))
+                 .createAsync(MyComp)
+                 .then((fixture) => {
+                   var el = fixture.debugElement.nativeElement;
+                   var svg = DOM.childNodes(el)[0];
+                   var foreignObject = DOM.childNodes(svg)[0];
+                   var p = DOM.childNodes(foreignObject)[0];
+                   expect(DOM.getProperty(<Element>svg, 'namespaceURI'))
+                       .toEqual('http://www.w3.org/2000/svg');
+                   expect(DOM.getProperty(<Element>foreignObject, 'namespaceURI'))
+                       .toEqual('http://www.w3.org/2000/svg');
+                   expect(DOM.getProperty(<Element>p, 'namespaceURI'))
+                       .toEqual('http://www.w3.org/1999/xhtml');
+
+                   async.done();
+                 });
+           }));
       });
     }
   });


### PR DESCRIPTION
This PR enables the use of elements with HTML namespace within SVG foreignObjects.
