### PR TITLE
feat(platform): add toggleClass functionality

### DIFF
--- a/modules/angular2/src/platform/browser/browser_adapter.dart
+++ b/modules/angular2/src/platform/browser/browser_adapter.dart
@@ -329,6 +329,14 @@ class BrowserDomAdapter extends GenericBrowserDomAdapter {
     element.classes.remove(className);
   }
 
+  void toggleClass(Element element, String className, [bool force = null]) {
+    if (isPresent(force)) {
+      element.classes.toggle(className, force);
+    } else {
+      element.classes.toggle(className);
+    }
+  }
+
   bool hasClass(Element element, String className) =>
       element.classes.contains(className);
 

--- a/modules/angular2/src/platform/browser/browser_adapter.ts
+++ b/modules/angular2/src/platform/browser/browser_adapter.ts
@@ -204,6 +204,13 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   classList(element): any[] { return <any[]>Array.prototype.slice.call(element.classList, 0); }
   addClass(element, className: string) { element.classList.add(className); }
   removeClass(element, className: string) { element.classList.remove(className); }
+  toggleClass(element: Element, className: string, force?: boolean) {
+    if (isPresent(force)) {
+      element.classList.toggle(className, force);
+    } else {
+      element.classList.toggle(className);
+    }
+  }
   hasClass(element, className: string): boolean { return element.classList.contains(className); }
   setStyle(element, styleName: string, styleValue: string) {
     element.style[styleName] = styleValue;

--- a/modules/angular2/src/platform/dom/dom_adapter.ts
+++ b/modules/angular2/src/platform/dom/dom_adapter.ts
@@ -85,6 +85,7 @@ export abstract class DomAdapter {
   abstract classList(element): any[];
   abstract addClass(element, className: string);
   abstract removeClass(element, className: string);
+  abstract toggleClass(element, className: string, force?: boolean);
   abstract hasClass(element, className: string): boolean;
   abstract setStyle(element, styleName: string, styleValue: string);
   abstract removeStyle(element, styleName: string);

--- a/modules/angular2/src/platform/server/abstract_html_adapter.dart
+++ b/modules/angular2/src/platform/server/abstract_html_adapter.dart
@@ -261,6 +261,10 @@ abstract class AbstractHtml5LibAdapter implements DomAdapter {
     throw 'not implemented';
   }
 
+  toggleClass(element, String className, [bool force = null]) {
+    throw 'not implemented';
+  }
+
   hasClass(element, String className) => element.classes.contains(className);
 
   setStyle(element, String styleName, String styleValue) {

--- a/modules/angular2/src/platform/server/parse5_adapter.ts
+++ b/modules/angular2/src/platform/server/parse5_adapter.ts
@@ -372,6 +372,15 @@ export class Parse5DomAdapter extends DomAdapter {
       element.attribs["class"] = element.className = classList.join(" ");
     }
   }
+  toggleClass(element: Element, className: string, force?: boolean) {
+    if (force){
+      this.addClass(element, className);
+    } else if (force === false || this.hasClass(element, className)) {
+      this.removeClass(element, className);
+    } else {
+      this.addClass(element, className);
+    }
+  }
   hasClass(element, className: string): boolean {
     return ListWrapper.contains(this.classList(element), className);
   }

--- a/modules/angular2/test/core/dom/dom_adapter_spec.ts
+++ b/modules/angular2/test/core/dom/dom_adapter_spec.ts
@@ -69,6 +69,50 @@ export function main() {
       expect(() => DOM.remove(d)).not.toThrow();
     });
 
+    describe('toggleClass', () => {
+      it('should be able to remove existing class', () => {
+        var d = DOM.createElement('div');
+        DOM.setAttribute(d, 'class', 'class1');
+        DOM.toggleClass(d, 'class1');
+        expect(d.className).toEqual('');
+      });
+
+      it('should be able to force remove existing class', () => {
+        var d = DOM.createElement('div');
+        DOM.setAttribute(d, 'class', 'class1');
+        DOM.toggleClass(d, 'class1', false);
+        expect(d.className).toEqual('');
+      });
+
+      it('should not add a class when using force remove', () => {
+        var d = DOM.createElement('div');
+        DOM.setAttribute(d, 'class', 'class2');
+        DOM.toggleClass(d, 'class1', false);
+        expect(d.className).toEqual('class2');
+      });
+
+      it('should be able to add class via toggle', () => {
+        var d = DOM.createElement('div');
+        DOM.setAttribute(d, 'class', 'class2');
+        DOM.toggleClass(d, 'class1');
+        expect(d.className).toEqual('class2 class1');
+      });
+
+      it('should be able to add class using force true', () => {
+        var d = DOM.createElement('div');
+        DOM.setAttribute(d, 'class', 'class2');
+        DOM.toggleClass(d, 'class1', true);
+        expect(d.className).toEqual('class2 class1');
+      });
+
+      it('should keep class using force true', () => {
+        var d = DOM.createElement('div');
+        DOM.setAttribute(d, 'class', 'class1');
+        DOM.toggleClass(d, 'class1', true);
+        expect(d.className).toEqual('class1');
+      });
+    });
+
     if (DOM.supportsDOMEvents()) {
       describe('getBaseHref', () => {
         beforeEach(() => DOM.resetBaseElement());


### PR DESCRIPTION
I started using the DOM Adapter for a directive and noticed I had to write a lot of if/else boiler-code for CSS-Class-handling, since it does not provide any toggle functionality in the moment.
Since this is a pretty common use-case I thought I could try to contribute this `toggleClass` functionality.

For the `browser_adapter` it's just a thin wrapper around the native `element.classList.toggle(className, force)`. This implementation will currently [not fully work in IE](http://caniuse.com/#feat=classlist), due to the lacking support for the `force` parameter, but will work in Edge. but it is not too complicated to get it working, I just couldn't see any feature detection patterns etc in the existing code base to use as reference.

For the tests to succeed it'll need to be added to the `/test/public_api_spec.ts` but I'll wait for clearance and feedback first.
