### PR TITLE
chore(ci): cleanup artifact upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,24 +109,3 @@ notifications:
   slack:
     secure: EP4MzZ8JMyNQJ4S3cd5LEPWSMjC7ZRdzt3veelDiOeorJ6GwZfCDHncR+4BahDzQAuqyE/yNpZqaLbwRWloDi15qIUsm09vgl/1IyNky1Sqc6lEknhzIXpWSalo4/T9ZP8w870EoDvM/UO+LCV99R3wS8Nm9o99eLoWVb2HIUu0=
 
-deploy:
-  - provider: gcs
-    # This is for project angular-github-babysitter
-    access_key_id: GOOGIOQTDBEOPBUAWFZQ
-    secret_access_key:
-      secure: "MEDggllZ5fw4wI9CEUi8WR6jKsKXqdRF/DLxSNC2JpzM5RlVeBm0uqjntYT1Cf1dASvQ2/+vZCUikL/3A48NcoEYRHXGmxu8D6t/SvleQD8Xv434xFOdsa2QqP/HiCtqCLOI5jJz1JVoB5nNyKKZ33ogTUL1LV1TfcrAioyizW8="
-    # this bucket has a lifecycle to delete after 90 days:
-    # $ echo '{"rule": [{"action": {"type": "Delete"}, "condition": {"age": 90}}]}' > lifecycle.json
-    # $ gsutil lifecycle set lifecycle.json gs://angular2-snapshots
-    bucket: angular2-snapshots
-    # don't delete generated files
-    skip_cleanup: true
-    # serve to public at https://storage.googleapis.com/angular2-snapshots/SHA/dist.tgz
-    acl: public-read
-    # upload the .tgz archive created in scripts/ci/build_and_test.sh
-    local-dir: deploy
-    # create a "subdirectory" for each commit
-    upload-dir: $TRAVIS_COMMIT
-    on:
-      repo: angular/angular
-      condition: "$MODE = build_only"

--- a/scripts/ci/build_and_test.sh
+++ b/scripts/ci/build_and_test.sh
@@ -17,7 +17,6 @@ elif [ "$MODE" = "lint" ]; then
 elif [ "$MODE" = "build_only" ]; then
   ${SCRIPT_DIR}/build_js.sh
   ${SCRIPT_DIR}/build_dart.sh
-  mkdir deploy; tar -czpf deploy/dist.tgz -C dist .
 elif [ "$MODE" = "payload" ]; then
   source ${SCRIPT_DIR}/env_dart.sh
   ./node_modules/.bin/gulp test.payload.dart/ci


### PR DESCRIPTION
This is no longer needed for g3sync. Also, it frees up a travis worker.
