### PR TITLE
feat(http): support withCredentials option for BaseRequestOptions

### DIFF
--- a/modules/angular2/src/http/backends/xhr_backend.ts
+++ b/modules/angular2/src/http/backends/xhr_backend.ts
@@ -29,6 +29,7 @@ export class XHRConnection implements Connection {
     this.request = req;
     this.response = new Observable(responseObserver => {
       let _xhr: XMLHttpRequest = browserXHR.build();
+      _xhr.withCredentials = req.withCredentials;
       _xhr.open(RequestMethod[req.method].toUpperCase(), req.url);
       // load event handler
       let onLoad = () => {

--- a/modules/angular2/src/http/base_request_options.ts
+++ b/modules/angular2/src/http/base_request_options.ts
@@ -53,7 +53,11 @@ export class RequestOptions {
    * Search parameters to be included in a {@link Request}.
    */
   search: URLSearchParams;
-  constructor({method, headers, body, url, search}: RequestOptionsArgs = {}) {
+  /**
+   * withCredentials with which to perform a {@link Request} on CORS.
+   */
+  withCredentials: boolean;
+  constructor({method, headers, body, url, search, withCredentials}: RequestOptionsArgs = {}) {
     this.method = isPresent(method) ? normalizeMethodName(method) : null;
     this.headers = isPresent(headers) ? headers : null;
     this.body = isPresent(body) ? body : null;
@@ -61,6 +65,7 @@ export class RequestOptions {
     this.search = isPresent(search) ? (isString(search) ? new URLSearchParams(<string>(search)) :
                                                           <URLSearchParams>(search)) :
                                       null;
+    this.withCredentials = isPresent(withCredentials) ? withCredentials : null;
   }
 
   /**
@@ -95,9 +100,10 @@ export class RequestOptions {
       body: isPresent(options) && isPresent(options.body) ? options.body : this.body,
       url: isPresent(options) && isPresent(options.url) ? options.url : this.url,
       search: isPresent(options) && isPresent(options.search) ?
-                  (isString(options.search) ? new URLSearchParams(<string>(options.search)) :
+                                              (isString(options.search) ? new URLSearchParams(<string>(options.search)) :
                                               (<URLSearchParams>(options.search)).clone()) :
-                  this.search
+                  this.search,
+      withCredentials: isPresent(options) && isPresent(options.withCredentials) ? options.withCredentials : this.withCredentials
     });
   }
 }

--- a/modules/angular2/src/http/base_request_options.ts
+++ b/modules/angular2/src/http/base_request_options.ts
@@ -100,10 +100,12 @@ export class RequestOptions {
       body: isPresent(options) && isPresent(options.body) ? options.body : this.body,
       url: isPresent(options) && isPresent(options.url) ? options.url : this.url,
       search: isPresent(options) && isPresent(options.search) ?
-                                              (isString(options.search) ? new URLSearchParams(<string>(options.search)) :
+                  (isString(options.search) ? new URLSearchParams(<string>(options.search)) :
                                               (<URLSearchParams>(options.search)).clone()) :
                   this.search,
-      withCredentials: isPresent(options) && isPresent(options.withCredentials) ? options.withCredentials : this.withCredentials
+      withCredentials: isPresent(options) && isPresent(options.withCredentials) ?
+                           options.withCredentials :
+                           this.withCredentials
     });
   }
 }

--- a/modules/angular2/src/http/http.ts
+++ b/modules/angular2/src/http/http.ts
@@ -21,7 +21,8 @@ function mergeOptions(defaultOpts, providedOpts, method, url): RequestOptions {
       url: providedOpts.url || url,
       search: providedOpts.search,
       headers: providedOpts.headers,
-      body: providedOpts.body
+      body: providedOpts.body,
+      withCredentials: providedOpts.withCredentials
     }));
   }
   if (isPresent(method)) {

--- a/modules/angular2/src/http/interfaces.ts
+++ b/modules/angular2/src/http/interfaces.ts
@@ -33,6 +33,7 @@ export interface RequestOptionsArgs {
   headers?: Headers;
   // TODO: Support Blob, ArrayBuffer, JSON, URLSearchParams, FormData
   body?: string;
+  withCredentials?: boolean;
 }
 
 /**

--- a/modules/angular2/src/http/static_request.ts
+++ b/modules/angular2/src/http/static_request.ts
@@ -61,6 +61,8 @@ export class Request {
   url: string;
   // TODO: support URLSearchParams | FormData | Blob | ArrayBuffer
   private _body: string;
+  /** withCredentials options */
+  withCredentials: boolean;
   constructor(requestOptions: RequestArgs) {
     // TODO: assert that url is present
     let url = requestOptions.url;
@@ -82,6 +84,7 @@ export class Request {
     // Defaults to 'omit', consistent with browser
     // TODO(jeffbcross): implement behavior
     this.headers = new Headers(requestOptions.headers);
+    this.withCredentials = !!requestOptions.withCredentials;
   }
 
 


### PR DESCRIPTION
add `withCredentials: boolean` option to BaseRequestOptions to handle CORS requests
