### PR TITLE
feat(change_detection): allow all legal programs in the dev mode

### DIFF
--- a/modules/angular2/src/core/change_detection/change_detection_util.ts
+++ b/modules/angular2/src/core/change_detection/change_detection_util.ts
@@ -4,10 +4,17 @@ import {
   isBlank,
   Type,
   StringWrapper,
-  looseIdentical
+  looseIdentical,
+  isPrimitive
 } from 'angular2/src/facade/lang';
 import {BaseException} from 'angular2/src/facade/exceptions';
-import {ListWrapper, MapWrapper, StringMapWrapper} from 'angular2/src/facade/collection';
+import {
+  ListWrapper,
+  MapWrapper,
+  StringMapWrapper,
+  isListLikeIterable,
+  areIterablesEqual
+} from 'angular2/src/facade/collection';
 import {ProtoRecord} from './proto_record';
 import {ChangeDetectionStrategy, isDefaultChangeDetectionStrategy} from './constants';
 import {implementsOnDestroy} from './pipe_lifecycle_reflector';
@@ -214,4 +221,17 @@ export class ChangeDetectionUtil {
   }
 
   static looseNotIdentical(a: any, b: any): boolean { return !looseIdentical(a, b); }
+
+  static devModeEqual(a: any, b: any): boolean {
+    if (isListLikeIterable(a) && isListLikeIterable(b)) {
+      return areIterablesEqual(a, b, ChangeDetectionUtil.devModeEqual);
+
+    } else if (!isListLikeIterable(a) && !isPrimitive(a) && !isListLikeIterable(b) &&
+               !isPrimitive(b)) {
+      return true;
+
+    } else {
+      return looseIdentical(a, b);
+    }
+  }
 }

--- a/modules/angular2/src/core/change_detection/dynamic_change_detector.ts
+++ b/modules/angular2/src/core/change_detection/dynamic_change_detector.ts
@@ -302,7 +302,10 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
 
     if (proto.shouldBeChecked()) {
       var prevValue = this._readSelf(proto, values);
-      if (ChangeDetectionUtil.looseNotIdentical(prevValue, currValue)) {
+      var detectedChange = throwOnChange ?
+                               !ChangeDetectionUtil.devModeEqual(prevValue, currValue) :
+                               ChangeDetectionUtil.looseNotIdentical(prevValue, currValue);
+      if (detectedChange) {
         if (proto.lastInBinding) {
           var change = ChangeDetectionUtil.simpleChange(prevValue, currValue);
           if (throwOnChange) this.throwOnChangeError(prevValue, currValue);
@@ -403,7 +406,10 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
 
       if (proto.shouldBeChecked()) {
         var prevValue = this._readSelf(proto, values);
-        if (ChangeDetectionUtil.looseNotIdentical(prevValue, currValue)) {
+        var detectedChange = throwOnChange ?
+                                 !ChangeDetectionUtil.devModeEqual(prevValue, currValue) :
+                                 ChangeDetectionUtil.looseNotIdentical(prevValue, currValue);
+        if (detectedChange) {
           currValue = ChangeDetectionUtil.unwrapValue(currValue);
 
           if (proto.lastInBinding) {

--- a/modules/angular2/src/facade/collection.dart
+++ b/modules/angular2/src/facade/collection.dart
@@ -225,6 +225,19 @@ class ListWrapper {
 
 bool isListLikeIterable(obj) => obj is Iterable;
 
+bool areIterablesEqual(Iterable a, Iterable b, Function comparator) {
+  var iterator1 = a.iterator;
+  var iterator2 = b.iterator;
+
+  while (true) {
+    var done1 = !iterator1.moveNext();
+    var done2 = !iterator2.moveNext();
+    if (done1 && done2) return true;
+    if (done1 || done2) return false;
+    if (!comparator(iterator2.current, iterator2.current)) return false;
+  }
+}
+
 void iterateListLike(iter, fn(item)) {
   assert(iter is Iterable);
   for (var item in iter) {

--- a/modules/angular2/src/facade/collection.ts
+++ b/modules/angular2/src/facade/collection.ts
@@ -274,6 +274,19 @@ export function isListLikeIterable(obj: any): boolean {
           getSymbolIterator() in obj);  // JS Iterable have a Symbol.iterator prop
 }
 
+export function areIterablesEqual(a: any, b: any, comparator: Function): boolean {
+  var iterator1 = a[getSymbolIterator()]();
+  var iterator2 = b[getSymbolIterator()]();
+
+  while (true) {
+    let item1 = iterator1.next();
+    let item2 = iterator2.next();
+    if (item1.done && item2.done) return true;
+    if (item1.done || item2.done) return false;
+    if (!comparator(item1.value, item2.value)) return false;
+  }
+}
+
 export function iterateListLike(obj: any, fn: Function) {
   if (isArray(obj)) {
     for (var i = 0; i < obj.length; i++) {

--- a/modules/angular2/src/facade/lang.dart
+++ b/modules/angular2/src/facade/lang.dart
@@ -329,6 +329,8 @@ class DateWrapper {
   }
 }
 
+bool isPrimitive(Object obj) => obj is num || obj is bool || obj == null || obj is String;
+
 // needed to match the exports from lang.js
 var global = null;
 

--- a/modules/angular2/src/facade/lang.ts
+++ b/modules/angular2/src/facade/lang.ts
@@ -427,3 +427,7 @@ export function evalExpression(sourceUrl: string, expr: string, declarations: st
   }
   return new Function(...fnArgNames.concat(fnBody))(...fnArgValues);
 }
+
+export function isPrimitive(obj: any): boolean {
+  return !isJsObject(obj);
+}

--- a/modules/angular2/test/core/change_detection/change_detector_spec.ts
+++ b/modules/angular2/test/core/change_detection/change_detector_spec.ts
@@ -887,6 +887,13 @@ export function main() {
                   'Expression [\'"]a in location[\'"] has changed after it was checked'));
         });
 
+        it('should not throw when two arrays are structurally the same', () => {
+          var val = _createChangeDetector('a', new TestDataWithGetter(() => ['value']));
+          val.changeDetector.detectChanges();
+
+          expect(() => { val.changeDetector.checkNoChanges(); }).not.toThrow();
+        });
+
         it('should not break the next run', () => {
           var val = _createChangeDetector('a', new TestData('value'));
           expect(() => val.changeDetector.checkNoChanges())
@@ -1591,6 +1598,12 @@ class Uninitialized {
 
 class TestData {
   constructor(public a: any) {}
+}
+
+class TestDataWithGetter {
+  constructor(private fn: Function) {}
+
+  get a() { return this.fn(); }
 }
 
 class TestDispatcher implements ChangeDispatcher {

--- a/modules/angular2/test/core/change_detection/change_detector_util_spec.ts
+++ b/modules/angular2/test/core/change_detection/change_detector_util_spec.ts
@@ -1,0 +1,60 @@
+import {
+  ddescribe,
+  describe,
+  it,
+  iit,
+  xit,
+  expect,
+  beforeEach,
+  afterEach
+} from 'angular2/testing_internal';
+
+import {ChangeDetectionUtil} from 'angular2/src/core/change_detection/change_detection_util';
+
+export function main() {
+  describe("ChangeDetectionUtil", () => {
+    describe("devModeEqual", () => {
+      it("should do the deep comparison of iterables", () => {
+        expect(ChangeDetectionUtil.devModeEqual([['one']], [['one']])).toBe(true);
+        expect(ChangeDetectionUtil.devModeEqual(['one'], ['one', 'two'])).toBe(false);
+        expect(ChangeDetectionUtil.devModeEqual(['one', 'two'], ['one'])).toBe(false);
+        expect(ChangeDetectionUtil.devModeEqual(['one'], 'one')).toBe(false);
+        expect(ChangeDetectionUtil.devModeEqual(['one'], new Object())).toBe(false);
+        expect(ChangeDetectionUtil.devModeEqual('one', ['one'])).toBe(false);
+        expect(ChangeDetectionUtil.devModeEqual(new Object(), ['one'])).toBe(false);
+      });
+
+      it("should compare primitive numbers", () => {
+        expect(ChangeDetectionUtil.devModeEqual(1, 1)).toBe(true);
+        expect(ChangeDetectionUtil.devModeEqual(1, 2)).toBe(false);
+        expect(ChangeDetectionUtil.devModeEqual(new Object(), 2)).toBe(false);
+        expect(ChangeDetectionUtil.devModeEqual(1, new Object())).toBe(false);
+      });
+
+      it("should compare primitive strings", () => {
+        expect(ChangeDetectionUtil.devModeEqual('one', 'one')).toBe(true);
+        expect(ChangeDetectionUtil.devModeEqual('one', 'two')).toBe(false);
+        expect(ChangeDetectionUtil.devModeEqual(new Object(), 'one')).toBe(false);
+        expect(ChangeDetectionUtil.devModeEqual('one', new Object())).toBe(false);
+      });
+
+      it("should compare primitive booleans", () => {
+        expect(ChangeDetectionUtil.devModeEqual(true, true)).toBe(true);
+        expect(ChangeDetectionUtil.devModeEqual(true, false)).toBe(false);
+        expect(ChangeDetectionUtil.devModeEqual(new Object(), true)).toBe(false);
+        expect(ChangeDetectionUtil.devModeEqual(true, new Object())).toBe(false);
+      });
+
+      it("should compare null", () => {
+        expect(ChangeDetectionUtil.devModeEqual(null, null)).toBe(true);
+        expect(ChangeDetectionUtil.devModeEqual(null, 1)).toBe(false);
+        expect(ChangeDetectionUtil.devModeEqual(new Object(), null)).toBe(false);
+        expect(ChangeDetectionUtil.devModeEqual(null, new Object())).toBe(false);
+      });
+
+      it("should return true for other objects", () => {
+        expect(ChangeDetectionUtil.devModeEqual(new Object(), new Object())).toBe(true);
+      });
+    });
+  });
+}

--- a/modules_dart/transform/lib/src/transform/template_compiler/change_detector_codegen.dart
+++ b/modules_dart/transform/lib/src/transform/template_compiler/change_detector_codegen.dart
@@ -433,6 +433,7 @@ class _CodegenState {
     var condition = '''!${pipe}.pure || (${contexOrArgCheck.join(" || ")})''';
 
     var check = '''
+      ${_genThrowOnChangeCheck(oldValue, newValue)}
       if (${_genPrefix}$_UTIL.looseNotIdentical($oldValue, $newValue)) {
         $newValue = ${_genPrefix}$_UTIL.unwrapValue($newValue);
         ${_genChangeMarker(r)}
@@ -459,6 +460,7 @@ class _CodegenState {
     ''';
 
     var check = '''
+      ${_genThrowOnChangeCheck(oldValue, newValue)}
       if (${_genPrefix}$_UTIL.looseNotIdentical($newValue, $oldValue)) {
         ${_genChangeMarker(r)}
         ${_genUpdateDirectiveOrElement(r)}
@@ -492,7 +494,6 @@ class _CodegenState {
     if (!r.lastInBinding) return '';
 
     var newValue = _names.getLocalName(r.selfIndex);
-    var oldValue = _names.getFieldName(r.selfIndex);
     var notifyDebug = _genConfig.logBindingUpdate
         ? "this.logBindingUpdate(${newValue});"
         : "";
@@ -502,14 +503,12 @@ class _CodegenState {
       var directiveProperty =
           '${_names.getDirectiveName(br.directiveRecord.directiveIndex)}.${br.target.name}';
       return '''
-      ${_genThrowOnChangeCheck(oldValue, newValue)}
       $directiveProperty = $newValue;
       ${notifyDebug}
       $_IS_CHANGED_LOCAL = true;
     ''';
     } else {
       return '''
-      ${_genThrowOnChangeCheck(oldValue, newValue)}
       this.notifyDispatcher(${newValue});
       ${notifyDebug}
     ''';
@@ -518,7 +517,7 @@ class _CodegenState {
 
   String _genThrowOnChangeCheck(String oldValue, String newValue) {
     return '''
-      if(${_genPrefix}assertionsEnabled() && throwOnChange) {
+      if(${_genPrefix}assertionsEnabled() && throwOnChange && !${_genPrefix}${_UTIL}.devModeEqual(${oldValue}, ${newValue})) {
         this.throwOnChangeError(${oldValue}, ${newValue});
       }
     ''';


### PR DESCRIPTION
BEFORE:

The following would throw in the dev mode because `f` would return a new array on the second run.

```
@Component({
  template: `
    {{f()}}
  `
})
class A {
  f() { return [1]; }
}
```

AFTER:

The checkNoChanges function compares only primitives types for equality, and deeply compares iterables. Other objects cannot cause checkNoChanges to throw. This means that the dev mode would never fail given a legal program, but may allow some illegal programs.
