### PR TITLE
fix(router): fix incorrect url param value coercion of 1 to true

### DIFF
--- a/modules/angular2/src/router/url_parser.ts
+++ b/modules/angular2/src/router/url_parser.ts
@@ -206,7 +206,7 @@ export function serializeParams(paramMap: {[key: string]: any}): string[] {
   var params = [];
   if (isPresent(paramMap)) {
     StringMapWrapper.forEach(paramMap, (value, key) => {
-      if (value == true) {
+      if (value === true) {
         params.push(key);
       } else {
         params.push(key + '=' + value);

--- a/modules/angular2/test/router/router_spec.ts
+++ b/modules/angular2/test/router/router_spec.ts
@@ -220,6 +220,15 @@ export function main() {
         expect(path).toEqual('hi/how/are/you?name=brad');
       });
 
+      it('should preserve the number 1 as a query string value', () => {
+        router.config(
+            [new Route({path: '/hi/how/are/you', component: DummyComponent, name: 'GreetingUrl'})]);
+
+        var instruction = router.generate(['/GreetingUrl', {'name': 1}]);
+        var path = stringifyInstruction(instruction);
+        expect(path).toEqual('hi/how/are/you?name=1');
+      });
+
       it('should serialize parameters that are not part of the route definition as query string params',
          () => {
            router.config([


### PR DESCRIPTION
seriliazeParams is coercing a value of 1 to true, which causes the value to be completey dropped.
Change the test from double equals to triple equals to prevent this from happening.

Closes #5346
