### PR TITLE
fix(Animation): Problem decimals using commas as decimal separation

### DIFF
--- a/modules/angular2/src/animate/animation.ts
+++ b/modules/angular2/src/animate/animation.ts
@@ -182,6 +182,7 @@ export class Animation {
       let value = NumberWrapper.parseInt(this.stripLetters(duration), 10);
       if (value > maxValue) maxValue = value;
     } else if (duration.substring(duration.length - 1) == 's') {
+      duration = StringWrapper.replace(duration, ',', '.');
       let ms = NumberWrapper.parseFloat(this.stripLetters(duration)) * 1000;
       let value = Math.floor(ms);
       if (value > maxValue) maxValue = value;

--- a/modules/angular2/test/animate/animation_builder_spec.ts
+++ b/modules/angular2/test/animate/animation_builder_spec.ts
@@ -91,6 +91,15 @@ export function main() {
          }
        }));
 
+    it('should support parsing when commas are used as decimal separator due to regional settings',
+       inject([AnimationBuilder], (animate) => {
+         var animateCss = animate.css();
+         var element = el(`<div></div>`);
+         var runner = animateCss.start(element);
+         expect(runner.parseDurationString('0,5s')).toBe(500);
+         expect(runner.parseDurationString('0.5s')).toBe(500);
+       }));
+
     it('should add classes', inject([AnimationBuilder], (animate) => {
          var animateCss = animate.css().addClass('one').addClass('two');
          var element = el('<div></div>');


### PR DESCRIPTION
Tests (and probably regular applications also) where failing due to `.` character being used as decimal separator in some regional settings (like spanish for example) when using `CSSStyleDeclaration.getPropertyValue`. This solves it by unconditionally replacing `,` per `.` before parsing the number in Animation.ts.

Closes #6335
