### PR TITLE
chore(build): fix race condition for the !bundles.js.docs task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1127,8 +1127,8 @@ gulp.task('!bundle.testing', ['build.js.dev'], function() {
                         {sourceMaps: true});
 });
 
-gulp.task('!bundles.js.docs', function() {
-  gulp.src('modules/angular2/docs/bundles/*').pipe(gulp.dest('dist/js/bundle'));
+gulp.task('!bundles.js.docs', ['clean'], function() {
+  return gulp.src('modules/angular2/docs/bundles/*').pipe(gulp.dest('dist/js/bundle'));
 });
 
 gulp.task('!bundles.js.umd', ['build.js.dev'], function() {


### PR DESCRIPTION
Previously it could happen that the `!bundles.js.docs` task finishes before the `clean` task and this would result in either stat errors or docs not being copied to npm.
