### PR TITLE
Presubmit alxhub pr 5892

### DIFF
--- a/modules/angular2/src/core/change_detection/codegen_logic_util.ts
+++ b/modules/angular2/src/core/change_detection/codegen_logic_util.ts
@@ -103,7 +103,7 @@ export class CodegenLogicUtil {
         break;
 
       case RecordType.Chain:
-        rhs = 'null';
+        rhs = `${getLocalName(protoRec.args[protoRec.args.length - 1])}`;
         break;
 
       default:

--- a/modules/angular2/test/core/change_detection/change_detector_config.ts
+++ b/modules/angular2/test/core/change_detection/change_detector_config.ts
@@ -433,6 +433,7 @@ var _availableEventDefinitions = [
   '(event)="a[0]=\$event"',
   // '(event)="\$event=1"',
   '(event)="a=a+1; a=a+1;"',
+  '(event)="true; false"',
   '(event)="false"',
   '(event)="true"',
   '(event)="true ? a = a + 1 : a = a + 1"',

--- a/modules/angular2/test/core/change_detection/change_detector_spec.ts
+++ b/modules/angular2/test/core/change_detection/change_detector_spec.ts
@@ -1341,12 +1341,16 @@ export function main() {
 
         it('should return the prevent default value', () => {
           var val = _createChangeDetector('(event)="false"', d, null);
-          var res = val.changeDetector.handleEvent("event", 0, locals);
-          expect(res).toBe(true);
+          var preventDefault = val.changeDetector.handleEvent("event", 0, locals);
+          expect(preventDefault).toBe(true);
 
           val = _createChangeDetector('(event)="true"', d, null);
-          res = val.changeDetector.handleEvent("event", 0, locals);
-          expect(res).toBe(false);
+          preventDefault = val.changeDetector.handleEvent("event", 0, locals);
+          expect(preventDefault).toBe(false);
+
+          val = _createChangeDetector('(event)="true; false"', d, null);
+          preventDefault = val.changeDetector.handleEvent("event", 0, locals);
+          expect(preventDefault).toEqual(true);
         });
 
         it('should support short-circuiting', () => {


### PR DESCRIPTION
Latest commit 89f32f8  9 days ago @kegluneq kegluneq committed with tbosch perf(dart/transform): Avoid unnecessary reads for files with no view …
In the `TemplateCompiler` phase, avoid reading in the `.ng_meta.json` files of
imported libraries when we can determine that the file we are processing
does not define any `View`s.

Closes #6183  @vicb fix(ChangeDetection): chain expressions evaluate to the last expressi… …     d22e103
 @vicb  Merge d22e103 into b44d36c

 14027.1
linux
 Node.js: 4.2.1
 MODE=dart DART_CHANNEL=stable DART_VERSION=$DART_STABLE_VERSION
 17 min 28 sec
 14027.6
linux
 Node.js: 4.2.1
 MODE=js DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
 12 min 6 sec
 14027.7
linux
 Node.js: 4.2.1
 MODE=router DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
 1 min 11 sec
 14027.8
linux
 Node.js: 4.2.1
 MODE=build_only DART_CHANNEL=stable DART_VERSION=$DART_STABLE_VERSION
 10 min 24 sec
 14027.9
linux
 Node.js: 4.2.1
 MODE=lint DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
 1 min 41 sec
 14027.10
linux
 Node.js: 4.2.1
 MODE=payload DART_CHANNEL=stable DART_VERSION=$DART_STABLE_VERSION
 2 min 53 sec
Allowed Failures 

 14027.2
linux
 Node.js: 4.2.1
 MODE=dart DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
 3 min 42 sec
 14027.3
linux
 Node.js: 4.2.1
 MODE=saucelabs DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
 15 min 4 sec
 14027.4
linux
 Node.js: 4.2.1
 MODE=browserstack DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
 5 min 58 sec
 14027.5
linux
 Node.js: 4.2.1
 MODE=dart_experimental DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION
 3 min 34 sec
