### PR TITLE
refactor(WebWorker): Rename WORKER_RENDER_APP to WORKER_RENDER_APPLICATION

### DIFF
--- a/modules/angular2/docs/web_workers/web_workers.md
+++ b/modules/angular2/docs/web_workers/web_workers.md
@@ -371,14 +371,14 @@ In TypeScript:
 import {platform, Provider, APP_INITIALIZER, Injector} from 'angular2/core';
 import {
     WORKER_RENDER_PLATFORM,
-    WORKER_RENDER_APP_COMMON,
+    WORKER_RENDER_APPLICATION_COMMON,
     initializeGenericWorkerRenderer,
     MessageBus
 } from 'angular2/platform/worker_render';
 
 var bus = new MyAwesomeMessageBus();
 platform([WORKER_RENDER_PLATFORM])
-.application([WORKER_RENDER_APP_COMMON, new Provider(MessageBus, {useValue: bus}),
+.application([WORKER_RENDER_APPLICATION_COMMON, new Provider(MessageBus, {useValue: bus}),
   new Provider(APP_INITIALIZER, {
     useFactory: (injector) => () => initializeGenericWorkerRenderer(injector),
     deps: [Injector],
@@ -419,7 +419,7 @@ import 'package:angular2/platform/worker_render.dart';
 main() {
   var bus = new MyAwesomeMessageBus();
   platform([WORKER_RENDER_PLATFORM])
-  .application([WORKER_RENDER_APP_COMMON, new Provider(MessageBus, useValue: bus),
+  .application([WORKER_RENDER_APPLICATION_COMMON, new Provider(MessageBus, useValue: bus),
     new Provider(APP_INITIALIZER, 
       useFactory: (injector) => () => initializeGenericWorkerRenderer(injector),
       deps: [Injector],
@@ -456,9 +456,9 @@ void initAppThread(NgZone zone) {
   */
 }
 ```
-Notice how we use the `WORKER_RENDER_APP_COMMON` providers instead of the `WORKER_RENDER_APP` providers on the render thread.
-This is because the `WORKER_RENDER_APP` providers include an application initializer that starts a new WebWorker/Isolate.
-The `WORKER_RENDER_APP_COMMON` providers make no assumption about where your application code lives.
+Notice how we use the `WORKER_RENDER_APPLICTION_COMMON` providers instead of the `WORKER_RENDER_APPLICATION` providers on the render thread.
+This is because the `WORKER_RENDER_APPLICATION` providers include an application initializer that starts a new WebWorker/Isolate.
+The `WORKER_RENDER_APPLICATION_COMMON` providers make no assumption about where your application code lives.
 However, we now need to provide our own app initializer. At the very least this initializer needs to call `initializeGenericWorkerRenderer`.
 
 ## MessageBroker

--- a/modules/angular2/platform/worker_render.dart
+++ b/modules/angular2/platform/worker_render.dart
@@ -4,11 +4,11 @@ export 'package:angular2/src/platform/worker_render_common.dart'
     show
         WORKER_SCRIPT,
         WORKER_RENDER_PLATFORM,
-        WORKER_RENDER_APP_COMMON,
+        WORKER_RENDER_APPLICATION_COMMON,
         initializeGenericWorkerRenderer;
 
 export 'package:angular2/src/platform/worker_render.dart'
-    show WORKER_RENDER_APP, initIsolate, WebWorkerInstance;
+    show WORKER_RENDER_APPLICATION, initIsolate, WebWorkerInstance;
 
 export '../src/web_workers/shared/client_message_broker.dart'
     show ClientMessageBroker, ClientMessageBrokerFactory, FnArg, UiArguments;
@@ -18,3 +18,7 @@ export '../src/web_workers/shared/service_message_broker.dart'
 
 export '../src/web_workers/shared/serializer.dart' show PRIMITIVE;
 export '../src/web_workers/shared/message_bus.dart';
+
+import 'package:angular2/src/platform/worker_render_common.dart';
+
+const WORKER_RENDER_APP = WORKER_RENDER_APPLICATION_COMMON;

--- a/modules/angular2/platform/worker_render.ts
+++ b/modules/angular2/platform/worker_render.ts
@@ -2,9 +2,9 @@ export {
   WORKER_SCRIPT,
   WORKER_RENDER_PLATFORM,
   initializeGenericWorkerRenderer,
-  WORKER_RENDER_APP_COMMON
+  WORKER_RENDER_APPLICATION_COMMON
 } from 'angular2/src/platform/worker_render_common';
-export * from 'angular2/src/platform/worker_render';
+export {WORKER_RENDER_APPLICATION, WebWorkerInstance} from 'angular2/src/platform/worker_render';
 export {
   ClientMessageBroker,
   ClientMessageBrokerFactory,
@@ -18,3 +18,9 @@ export {
 } from '../src/web_workers/shared/service_message_broker';
 export {PRIMITIVE} from '../src/web_workers/shared/serializer';
 export * from '../src/web_workers/shared/message_bus';
+import {WORKER_RENDER_APPLICATION} from 'angular2/src/platform/worker_render';
+
+/**
+ * @deprecated Use WORKER_RENDER_APPLICATION
+ */
+export const WORKER_RENDER_APP = WORKER_RENDER_APPLICATION;

--- a/modules/angular2/src/platform/worker_render.dart
+++ b/modules/angular2/src/platform/worker_render.dart
@@ -2,7 +2,7 @@ library angular2.src.platform.worker_render;
 
 import 'package:angular2/src/platform/worker_render_common.dart'
     show
-        WORKER_RENDER_APP_COMMON,
+        WORKER_RENDER_APPLICATION_COMMON,
         WORKER_RENDER_MESSAGING_PROVIDERS,
         WORKER_SCRIPT,
         initializeGenericWorkerRenderer;
@@ -14,14 +14,14 @@ import 'package:angular2/src/core/zone/ng_zone.dart';
 import 'dart:isolate';
 import 'dart:async';
 
-const WORKER_RENDER_APP = WORKER_RENDER_APP_COMMON;
+const WORKER_RENDER_APP = WORKER_RENDER_APPLICATION_COMMON;
 
 initIsolate(String scriptUri) {
   return (NgZone zone) async {
     var instance = await spawnIsolate(Uri.parse(scriptUri));
 
     return [
-      WORKER_RENDER_APP_COMMON,
+      WORKER_RENDER_APPLICATION_COMMON,
       new Provider(WebWorkerInstance, useValue: instance),
       new Provider(APP_INITIALIZER,
           useFactory: (injector) => () => initializeGenericWorkerRenderer(injector),

--- a/modules/angular2/src/platform/worker_render.ts
+++ b/modules/angular2/src/platform/worker_render.ts
@@ -9,7 +9,7 @@ import {Injector, Injectable, Provider} from 'angular2/src/core/di';
 import {MessageBasedRenderer} from 'angular2/src/web_workers/ui/renderer';
 import {MessageBasedXHRImpl} from 'angular2/src/web_workers/ui/xhr_impl';
 import {
-  WORKER_RENDER_APP_COMMON,
+  WORKER_RENDER_APPLICATION_COMMON,
   WORKER_RENDER_MESSAGING_PROVIDERS,
   WORKER_SCRIPT,
   initializeGenericWorkerRenderer
@@ -36,8 +36,8 @@ export class WebWorkerInstance {
 /**
  * An array of providers that should be passed into `application()` when initializing a new Worker.
  */
-export const WORKER_RENDER_APP: Array<any /*Type | Provider | any[]*/> = CONST_EXPR([
-  WORKER_RENDER_APP_COMMON,
+export const WORKER_RENDER_APPLICATION: Array<any /*Type | Provider | any[]*/> = CONST_EXPR([
+  WORKER_RENDER_APPLICATION_COMMON,
   WebWorkerInstance,
   new Provider(APP_INITIALIZER,
                {

--- a/modules/angular2/src/platform/worker_render_common.ts
+++ b/modules/angular2/src/platform/worker_render_common.ts
@@ -59,7 +59,7 @@ export const WORKER_RENDER_PLATFORM: Array<any /*Type | Provider | any[]*/> = CO
   new Provider(PLATFORM_INITIALIZER, {useValue: initWebWorkerRenderPlatform, multi: true})
 ]);
 
-export const WORKER_RENDER_APP_COMMON: Array<any /*Type | Provider | any[]*/> = CONST_EXPR([
+export const WORKER_RENDER_APPLICATION_COMMON: Array<any /*Type | Provider | any[]*/> = CONST_EXPR([
   APPLICATION_COMMON_PROVIDERS,
   WORKER_RENDER_MESSAGING_PROVIDERS,
   new Provider(ExceptionHandler, {useFactory: _exceptionHandler, deps: []}),

--- a/modules/playground/src/web_workers/images/index.ts
+++ b/modules/playground/src/web_workers/images/index.ts
@@ -1,9 +1,9 @@
 import {platform, Provider} from 'angular2/core';
 import {
-  WORKER_RENDER_APP,
+  WORKER_RENDER_APPLICATION,
   WORKER_RENDER_PLATFORM,
   WORKER_SCRIPT
 } from 'angular2/platform/worker_render';
 
 platform([WORKER_RENDER_PLATFORM])
-    .application([WORKER_RENDER_APP, new Provider(WORKER_SCRIPT, {useValue: "loader.js"})]);
+    .application([WORKER_RENDER_APPLICATION, new Provider(WORKER_SCRIPT, {useValue: "loader.js"})]);

--- a/modules/playground/src/web_workers/kitchen_sink/index.ts
+++ b/modules/playground/src/web_workers/kitchen_sink/index.ts
@@ -1,9 +1,9 @@
 import {platform, Provider} from 'angular2/core';
 import {
-  WORKER_RENDER_APP,
+  WORKER_RENDER_APPLICATION,
   WORKER_RENDER_PLATFORM,
   WORKER_SCRIPT
 } from 'angular2/platform/worker_render';
 
 platform([WORKER_RENDER_PLATFORM])
-    .application([WORKER_RENDER_APP, new Provider(WORKER_SCRIPT, {useValue: "loader.js"})]);
+    .application([WORKER_RENDER_APPLICATION, new Provider(WORKER_SCRIPT, {useValue: "loader.js"})]);

--- a/modules/playground/src/web_workers/message_broker/index.ts
+++ b/modules/playground/src/web_workers/message_broker/index.ts
@@ -1,6 +1,6 @@
 import {platform, Provider} from 'angular2/core';
 import {
-  WORKER_RENDER_APP,
+  WORKER_RENDER_APPLICATION,
   WORKER_RENDER_PLATFORM,
   WORKER_SCRIPT,
   UiArguments,
@@ -13,7 +13,8 @@ const ECHO_CHANNEL = "ECHO";
 
 let ref =
     platform([WORKER_RENDER_PLATFORM])
-        .application([WORKER_RENDER_APP, new Provider(WORKER_SCRIPT, {useValue: "loader.js"})]);
+        .application(
+            [WORKER_RENDER_APPLICATION, new Provider(WORKER_SCRIPT, {useValue: "loader.js"})]);
 let brokerFactory: ClientMessageBrokerFactory = ref.injector.get(ClientMessageBrokerFactory);
 var broker = brokerFactory.createMessageBroker(ECHO_CHANNEL, false);
 

--- a/modules/playground/src/web_workers/todo/index.ts
+++ b/modules/playground/src/web_workers/todo/index.ts
@@ -1,9 +1,9 @@
 import {platform, Provider} from 'angular2/core';
 import {
-  WORKER_RENDER_APP,
+  WORKER_RENDER_APPLICATION,
   WORKER_RENDER_PLATFORM,
   WORKER_SCRIPT
 } from 'angular2/platform/worker_render';
 
 platform([WORKER_RENDER_PLATFORM])
-    .application([WORKER_RENDER_APP, new Provider(WORKER_SCRIPT, {useValue: "loader.js"})]);
+    .application([WORKER_RENDER_APPLICATION, new Provider(WORKER_SCRIPT, {useValue: "loader.js"})]);

--- a/modules/playground/src/web_workers/todo/index_web_socket.dart
+++ b/modules/playground/src/web_workers/todo/index_web_socket.dart
@@ -14,7 +14,7 @@ main() {
     var bus = new WebSocketMessageBus.fromWebSocket(webSocket);
 
     platform([WORKER_RENDER_PLATFORM])
-    .application([WORKER_RENDER_APP_COMMON, new Provider(MessageBus, useValue: bus),
+    .application([WORKER_RENDER_APPLICATION_COMMON, new Provider(MessageBus, useValue: bus),
       new Provider(APP_INITIALIZER, 
         useFactory: (injector) => () => initializeGenericWorkerRenderer(injector),
         deps: [Injector],


### PR DESCRIPTION
BREAKING CHANGE

WORKER_RENDER_APP is now deprecated. Use WORKER_RENDER_APPLICATION instead

closes #6184
