### PR TITLE
build(travis): Make Dart.dev build required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,6 @@ matrix:
   allow_failures:
   - env: "MODE=saucelabs_optional DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION"
   - env: "MODE=browserstack_optional DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION"
-  # TODO(alxhub): remove when dartdoc #1039 is in dev channel
-  - env: "MODE=dart DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION"
 
 addons:
   firefox: "38.0"


### PR DESCRIPTION
The newest version of the analyzer emits hints when it encounters TODOs
in code, which is breaking the Dart dev version of our build.

Ignore TODOs for the purpose of build health.

See #6410
