### PR TITLE
docs(http): fix example usage of MockBackend

### DIFF
--- a/modules/angular2/src/http/backends/mock_backend.ts
+++ b/modules/angular2/src/http/backends/mock_backend.ts
@@ -131,7 +131,8 @@ export class MockBackend implements ConnectionBackend {
    * ### Example
    *
    * ```
-   * import {MockBackend, Http, BaseRequestOptions} from 'angular2/http';
+   * import {Http, BaseRequestOptions} from 'angular2/http';
+   * import {MockBackend} from 'angular2/http/testing';
    * import {Injector} from 'angular2/core';
    *
    * it('should get a response', () => {
@@ -139,7 +140,7 @@ export class MockBackend implements ConnectionBackend {
    *   var text; //this will be set from mock response
    *   var injector = Injector.resolveAndCreate([
    *     MockBackend,
-   *     provide(Http, {useFactory: (backend, options) {
+   *     provide(Http, {useFactory: (backend, options) => {
    *       return new Http(backend, options);
    *     }, deps: [MockBackend, BaseRequestOptions]}]);
    *   var backend = injector.get(MockBackend);


### PR DESCRIPTION
This pull request is just fixing two minor mistakes in the documentation of the MockBackend. With the changes I made the example can be copied and pasted again without modifications.
