### PR TITLE
ddc: chore(build): make experimental Dart build useful

### DIFF
--- a/scripts/ci/build_dart_experimental.sh
+++ b/scripts/ci/build_dart_experimental.sh
@@ -10,6 +10,53 @@ SCRIPT_DIR=$(dirname $0)
 source $SCRIPT_DIR/env_dart.sh
 cd $SCRIPT_DIR/../..
 
+# Variables
+DDC_WARNING_CAP="260"
+DDC_DIR=`pwd`/tmp/dev_compiler
+DDC_VERSION="0.1.14"
+
+# Get DDC
+mkdir -p tmp
+rm -rf tmp/dev_compiler
+git clone https://github.com/dart-lang/dev_compiler.git tmp/dev_compiler
+(cd $DDC_DIR && \
+  git checkout tags/$DDC_VERSION && \
+  $PUB get)
+
+# Convert TypeScript to Dart
 ./node_modules/.bin/gulp build/packages.dart
 ./node_modules/.bin/gulp build/pubspec.dart
-./node_modules/.bin/gulp build/analyze.ddc.dart
+node ./scripts/ci/dart_experimental/pubspec_for_ddc.js \
+    --pubspec-file=dist/dart/playground/pubspec.yaml
+
+# Compile playground
+cd dist/dart/playground
+$PUB build --mode=debug
+cd build/web
+LOG_FILE="analyzer.log"
+set +e
+$DART_SDK/bin/dart $DDC_DIR/bin/dartdevc.dart \
+  --dart-sdk=$DART_SDK_LIB_SEARCH_PATH -o out src/hello_world/index.dart \
+  >$LOG_FILE
+EXIT_CODE=`echo $?`
+set -e
+
+# Analyzer exits with 1 when there are warnings and something crazy
+# like 255 when it crashes. We don't want to fail the build if its
+# only warnings (until our code is warning-free).
+if [[ "$EXIT_CODE" -ne "0" && "$EXIT_CODE" -ne "1" ]]
+then
+  echo "DDC compiler crashed with exit code $EXIT_CODE"
+  exit 1
+fi
+
+cat $LOG_FILE
+WARNING_COUNT=`cat $LOG_FILE | wc -l | sed -e 's/^[[:space:]]*//'`
+
+if [[ "$WARNING_COUNT" -gt "$DDC_WARNING_CAP" ]]
+then
+  echo "Too many warnings: $WARNING_COUNT"
+  exit 1
+else
+  echo "Warning count ok"
+fi

--- a/scripts/ci/dart_experimental/pubspec_for_ddc.js
+++ b/scripts/ci/dart_experimental/pubspec_for_ddc.js
@@ -1,0 +1,25 @@
+// Removes dart2js from pubspec.yaml for faster building
+// Usage: node pubspec_for_ddc.js --pubspec-file=PATH_TO_PUBSPEC_YAML
+
+var fs = require('fs');
+var yaml = require('js-yaml');
+var yargs = require('yargs');
+
+var pubspecFileOpt = 'pubspec-file';
+var pubspecFile = yargs
+    .demand([pubspecFileOpt])
+    .argv[pubspecFileOpt];
+
+var doc = yaml.safeLoad(fs.readFileSync(pubspecFile, 'utf8'));
+
+var transformers = doc['transformers'];
+if (transformers) {
+  transformers.forEach(function (transformer) {
+    var dart2js = transformer['\$dart2js'];
+    if (dart2js) {
+      dart2js['$exclude'] = [ 'web/**/*' ];
+    }
+  });
+}
+
+fs.writeFileSync(pubspecFile, yaml.safeDump(doc));

--- a/scripts/ci/env_dart.sh
+++ b/scripts/ci/env_dart.sh
@@ -66,6 +66,12 @@ if [[ -z $ENV_SET ]]; then
     fi
   fi
 
+  case "$PLATFORM" in
+    (Linux) export DART_SDK_LIB_SEARCH_PATH="$DART_SDK" ;;
+    (Darwin) export DART_SDK_LIB_SEARCH_PATH="$DART_SDK/libexec" ;;
+    (*) echo Unsupported platform $PLATFORM.  Exiting ... >&2 ; exit 3 ;;
+  esac
+
   export DART_SDK
   export DARTSDK
   export DART
@@ -85,6 +91,7 @@ if [[ -z $ENV_SET ]]; then
   echo '** ENV **'
   echo '*********'
   echo DART_SDK=$DART_SDK
+  echo DART_SDK_LIB_SEARCH_PATH=$DART_SDK_LIB_SEARCH_PATH
   echo DART=$DART
   echo PUB=$PUB
   echo DARTANALYZER=$DARTANALYZER


### PR DESCRIPTION
Previously we grepped all hand-written Dart code and ran analyzer in strong mode against it.

Now we run it against transformed playground apps, which:
1. does not analyze unnecessary code (we primarily care about stuff that runs in the browser)
2. analyzes generated code, which does run in the browser and which we failed to analyze in the previous version of the build
