### PR TITLE
ddc: fix(ddc): use dynamic types in reflection typedefs

### DIFF
--- a/modules/angular2/src/core/reflection/types.dart
+++ b/modules/angular2/src/core/reflection/types.dart
@@ -1,5 +1,5 @@
 library reflection.types;
 
-typedef SetterFn(Object obj, value);
-typedef GetterFn(Object obj);
-typedef MethodFn(Object obj, List args);
+typedef SetterFn(obj, value);
+typedef GetterFn(obj);
+typedef MethodFn(obj, List args);


### PR DESCRIPTION
We should use `dynamic` whenever we need to perform dynamic property access on objects. `Object` results in errors from DDC.
