### PR TITLE
fix(Dart): make some playground samples run with Dart Dev Compiler

### DIFF
--- a/modules/angular2/src/core/linker/template_ref.ts
+++ b/modules/angular2/src/core/linker/template_ref.ts
@@ -25,7 +25,7 @@ export abstract class TemplateRef {
    *
    */
   // TODO(i): rename to anchor or location
-  elementRef: ElementRef;
+  get elementRef(): ElementRef { return null; }
 }
 
 export class TemplateRef_ extends TemplateRef {

--- a/modules/angular2/src/facade/exceptions.dart
+++ b/modules/angular2/src/facade/exceptions.dart
@@ -4,9 +4,11 @@ import 'exception_handler.dart';
 export 'exception_handler.dart';
 
 class BaseException extends Error {
-  final String message;
+  final String _message;
 
-  BaseException([this.message]);
+  BaseException([this._message]);
+
+  String get message => _message;
 
   String toString() {
     return this.message;
@@ -14,16 +16,16 @@ class BaseException extends Error {
 }
 
 class WrappedException extends Error {
-  final dynamic context;
-  final String wrapperMessage;
+  final dynamic _context;
+  final String _wrapperMessage;
   final originalException;
   final originalStack;
 
   WrappedException(
-      [this.wrapperMessage,
+      [this._wrapperMessage,
       this.originalException,
       this.originalStack,
-      this.context]);
+      this._context]);
 
   get message {
     return ExceptionHandler.exceptionToString(this);
@@ -32,6 +34,10 @@ class WrappedException extends Error {
   String toString() {
     return this.message;
   }
+
+  dynamic get context => _context;
+
+  String get wrapperMessage => _wrapperMessage;
 }
 
 Error makeTypeError([String message = ""]) {

--- a/modules/angular2/src/platform/dom/dom_adapter.ts
+++ b/modules/angular2/src/platform/dom/dom_adapter.ts
@@ -29,7 +29,10 @@ export abstract class DomAdapter {
    * Maps attribute names to their corresponding property names for cases
    * where attribute name doesn't match property name.
    */
-  attrToPropMap: {[key: string]: string};
+  get attrToPropMap(): {[key: string]: string} { return this._attrToPropMap; };
+  set attrToPropMap(value: {[key: string]: string}) { this._attrToPropMap = value; };
+  /** @internal */
+  _attrToPropMap: {[key: string]: string};
 
   abstract parse(templateHtml: string);
   abstract query(selector: string): any;

--- a/modules/angular2/src/platform/dom/events/dom_events.ts
+++ b/modules/angular2/src/platform/dom/events/dom_events.ts
@@ -4,8 +4,6 @@ import {EventManagerPlugin, EventManager} from './event_manager';
 
 @Injectable()
 export class DomEventsPlugin extends EventManagerPlugin {
-  manager: EventManager;
-
   // This plugin should come last in the list of plugins, because it accepts all
   // events.
   supports(eventName: string): boolean { return true; }

--- a/modules/angular2/test/public_api_spec.ts
+++ b/modules/angular2/test/public_api_spec.ts
@@ -1224,7 +1224,6 @@ var NG_CORE = [
   'SimpleChange.isFirstChange()',
   'TemplateRef',
   'TemplateRef.elementRef',
-  'TemplateRef.elementRef=',
   /*
    Abstract method
    'TemplateRef.hasLocal()',

--- a/modules_dart/transform/lib/src/transform/template_compiler/change_detector_codegen.dart
+++ b/modules_dart/transform/lib/src/transform/template_compiler/change_detector_codegen.dart
@@ -225,7 +225,7 @@ class _CodegenState {
     List<String> codes = [];
     _endOfBlockIdxs.clear();
 
-    ListWrapper.forEachWithIndex(eb.records, (r, i) {
+    ListWrapper.forEachWithIndex(eb.records, (_, i) {
       var code;
       var r = eb.records[i];
 


### PR DESCRIPTION
Resolve all invalid field override errors, workaround current
reflection limitations in Dart Dev Compiler. todo, hello_world and
key_events samples now work with Dart Dev Compiler.
