### PR TITLE
fix(router): fix a typing issue {next}

### DIFF
--- a/modules/angular2/src/router/route_registry.ts
+++ b/modules/angular2/src/router/route_registry.ts
@@ -434,7 +434,7 @@ export class RouteRegistry {
 
     return new UnresolvedInstruction(() => {
       return componentRecognizer.defaultRoute.handler.resolveComponentType().then(
-          () => this.generateDefault(componentCursor));
+          (_) => this.generateDefault(componentCursor));
     });
   }
 }


### PR DESCRIPTION
Latest commit 200dc00  on Dec 12, 2015 @tbosch tbosch fix(angular2): remove `angular2.ts` module …
Closes #5815
Closes #5844

BREAKING CHANGE:

`angular2/angular2` was removed. Use the correct import from one of the barrels. E.g. `angular2/core`, `angular2/platform/browser`,  `angular2/common`, …

Note: This only applies to JavaScript, Dart is not changed.
          1 parent 909031e commit bc72ac6d00aa150a1e09ccfb1f038440ff51635d @btford btford committed on Dec 1, 1922
