### PR TITLE
fix(router): fix url path for star segment in path recognizer

### DIFF
--- a/modules/angular2/src/router/path_recognizer.ts
+++ b/modules/angular2/src/router/path_recognizer.ts
@@ -215,7 +215,7 @@ export class PathRecognizer {
           nextSegment = null;
           break;
         }
-        
+
         captured.push(currentSegment.path);
 
         if (segment instanceof DynamicSegment) {

--- a/modules/angular2/src/router/path_recognizer.ts
+++ b/modules/angular2/src/router/path_recognizer.ts
@@ -208,14 +208,15 @@ export class PathRecognizer {
       }
 
       if (isPresent(currentSegment)) {
-        captured.push(currentSegment.path);
-
         // the star segment consumes all of the remaining URL, including matrix params
         if (segment instanceof StarSegment) {
           positionalParams[segment.name] = currentSegment.toString();
+          captured.push(currentSegment.toString());
           nextSegment = null;
           break;
         }
+        
+        captured.push(currentSegment.path);
 
         if (segment instanceof DynamicSegment) {
           positionalParams[segment.name] = currentSegment.path;

--- a/modules/angular2/test/router/path_recognizer_spec.ts
+++ b/modules/angular2/test/router/path_recognizer_spec.ts
@@ -90,5 +90,14 @@ export function main() {
         expect(match['allParams']).toEqual({'c': '3'});
       });
     });
+    
+    describe('wildcard segment', () => {
+      it('should be ignored on a wildcard segment', () => {
+        var rec = new PathRecognizer('/wild/*everything');
+        var url = parser.parse('/wild/super;variable=value/anotherPartAfterSlash');
+        var match = rec.recognize(url);
+        expect(match['urlPath']).toEqual('wild/super;variable=value/anotherPartAfterSlash');
+      });
+    });
   });
 }

--- a/modules/angular2/test/router/path_recognizer_spec.ts
+++ b/modules/angular2/test/router/path_recognizer_spec.ts
@@ -92,7 +92,7 @@ export function main() {
     });
     
     describe('wildcard segment', () => {
-      it('should be ignored on a wildcard segment', () => {
+      it('should return a url path which matches the original url path', () => {
         var rec = new PathRecognizer('/wild/*everything');
         var url = parser.parse('/wild/super;variable=value/anotherPartAfterSlash');
         var match = rec.recognize(url);

--- a/modules/angular2/test/router/path_recognizer_spec.ts
+++ b/modules/angular2/test/router/path_recognizer_spec.ts
@@ -90,7 +90,7 @@ export function main() {
         expect(match['allParams']).toEqual({'c': '3'});
       });
     });
-    
+
     describe('wildcard segment', () => {
       it('should return a url path which matches the original url path', () => {
         var rec = new PathRecognizer('/wild/*everything');


### PR DESCRIPTION
If you register the route `/app/*location` and invoke a url like `/app/foo/bar` the PathRecognizer should return a url path equal to the invoked url.

Before this patch, everything after `foo` was ignored, which resulted in a redirect to `/app/foo` which was probably not intended (at least in the angular 1.5 component router).

This is a bugfix for #6305.
