### PR TITLE
feat(dart/transform): DirectiveProcessor: do not process generated files

### DIFF
--- a/modules_dart/transform/lib/src/transform/common/names.dart
+++ b/modules_dart/transform/lib/src/transform/common/names.dart
@@ -39,8 +39,10 @@ const ALL_EXTENSIONS = const [
 bool isGenerated(String uri) {
   return const [
     DEPS_EXTENSION,
+    META_EXTENSION,
     NON_SHIMMED_STYLESHEET_EXTENSION,
     SHIMMED_STYLESHEET_EXTENSION,
+    SUMMARY_META_EXTENSION,
     TEMPLATE_EXTENSION,
   ].any((ext) => uri.endsWith(ext));
 }

--- a/modules_dart/transform/lib/src/transform/directive_processor/transformer.dart
+++ b/modules_dart/transform/lib/src/transform/directive_processor/transformer.dart
@@ -28,7 +28,8 @@ class DirectiveProcessor extends Transformer implements LazyTransformer {
   DirectiveProcessor(this.options);
 
   @override
-  bool isPrimary(AssetId id) => id.extension.endsWith('dart');
+  bool isPrimary(AssetId id) =>
+      id.extension.endsWith('dart') && !isGenerated(id.path);
 
   @override
   declareOutputs(DeclaringTransform transform) {


### PR DESCRIPTION
Prevent `DirectiveProcessor` from processing files which were generated
by the Angular2 Dart transformer.
