### PR TITLE
feat(ViewContainer) support for ES6 iterable so views can be iterated

### DIFF
--- a/modules/angular2/src/core/linker/view_container_ref.ts
+++ b/modules/angular2/src/core/linker/view_container_ref.ts
@@ -63,6 +63,23 @@ export abstract class ViewContainerRef {
   get length(): number { return unimplemented(); };
 
   /**
+   * Adds iterator function so ViewContainerRef can be used with spread operators, Array.from, for..of and other constructs supporing ES6 iterables.
+   */
+  [Symbol.iterator]() {
+    let index = 0;
+    const length = this.length;
+    return {
+      next() {
+        if (index < length) {
+          return {value: this.get(index++), done: false};
+        } else {
+          return {value: this.get(index++), done: true};
+        }
+      }
+    };
+  }
+
+  /**
    * Instantiates an Embedded View based on the {@link TemplateRef `templateRef`} and inserts it
    * into this container at the specified `index`.
    *


### PR DESCRIPTION
This change would allow to treat `ViewContainer` as an ES6 iterable and therefore support for..of, spread operator, Array.from and other constructs that support better integration. Some of these methods might affect performance slightly but since it's up to the developer how to use it I'd personally not be concerned too much.

Maybe this can be included in other areas too?
