### PR TITLE
style(ReflectionCapabilities) _zipTypesAndAnnotations, not _zipTypesAndAnnotaions

### DIFF
--- a/modules/angular2/src/core/reflection/reflection_capabilities.ts
+++ b/modules/angular2/src/core/reflection/reflection_capabilities.ts
@@ -83,7 +83,7 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
   }
 
   /** @internal */
-  _zipTypesAndAnnotaions(paramTypes, paramAnnotations): any[][] {
+  _zipTypesAndAnnotations(paramTypes, paramAnnotations): any[][] {
     var result;
 
     if (typeof paramTypes === 'undefined') {
@@ -119,7 +119,7 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
       var paramAnnotations = this._reflect.getMetadata('parameters', typeOrFunc);
       var paramTypes = this._reflect.getMetadata('design:paramtypes', typeOrFunc);
       if (isPresent(paramTypes) || isPresent(paramAnnotations)) {
-        return this._zipTypesAndAnnotaions(paramTypes, paramAnnotations);
+        return this._zipTypesAndAnnotations(paramTypes, paramAnnotations);
       }
     }
     // The array has to be filled with `undefined` because holes would be skipped by `some`


### PR DESCRIPTION
I was stepping through the Reflector and came across this little guy.
