### PR TITLE
chore(build): remove use of q.denodeify

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -690,12 +690,11 @@ gulp.task('build.payload.js', ['build.js'], function(done) {
 });
 
 gulp.task('!build.payload.js.webpack', function() {
-  var q = require('q');
-  var webpack = q.denodeify(require('webpack'));
+  var webpack = require('./tools/build/webpack/promiseify');
 
   var ES5_PROD_ROOT = __dirname + '/' + CONFIG.dest.js.prod.es5;
 
-  return q.all(PAYLOAD_TESTS_CONFIG.ts.cases.map(function(caseName) {
+  return Promise.all(PAYLOAD_TESTS_CONFIG.ts.cases.map(function(caseName) {
     var CASE_PATH = PAYLOAD_TESTS_CONFIG.ts.dist(caseName, 'webpack');
 
     return webpack({
@@ -1253,8 +1252,7 @@ gulp.task('!bundles.js.docs', ['clean'], function() {
 });
 
 gulp.task('!bundles.js.umd', ['build.js.dev'], function() {
-  var q = require('q');
-  var webpack = q.denodeify(require('webpack'));
+  var webpack = require('./tools/build/webpack/promiseify');
 
   function resolveOptions(devOrProd) {
     return {
@@ -1310,7 +1308,7 @@ gulp.task('!bundles.js.umd', ['build.js.dev'], function() {
     };
   }
 
-  return q.all([
+  return Promise.all([
     webpack(webPackConf([__dirname + '/tools/build/webpack/angular2-all.umd.js'], 'angular2-all',
                         'dev')),
     webpack(webPackConf([__dirname + '/tools/build/webpack/angular2-all.umd.js'], 'angular2-all',

--- a/tools/build/webpack/promiseify.js
+++ b/tools/build/webpack/promiseify.js
@@ -1,0 +1,32 @@
+var webpack = require('webpack');
+
+/**
+ * Wraps the original `webpack` function to convert execution
+ * result to a promise and properly report errors.
+ *
+ * @param options
+ * @returns {Function}
+ */
+function webPackPromiseify(options) {
+
+  return new Promise(function (resolve, reject) {
+
+    webpack(options, function(err, stats) {
+      var jsonStats = stats.toJson() || {};
+      var statsErrors = jsonStats.errors || [];
+
+      if (err) {
+        return reject(err);
+      }
+
+      if (statsErrors.length) {
+        return reject(statsErrors);
+      }
+
+      return resolve(stats);
+    });
+
+  });
+}
+
+module.exports  = webPackPromiseify;


### PR DESCRIPTION
This change also makes webpack properly reject
promise on build errors
