### PR TITLE
refactor(DomRootRenderer): allow registeredComponents access

### DIFF
--- a/modules/angular2/src/platform/dom/dom_renderer.ts
+++ b/modules/angular2/src/platform/dom/dom_renderer.ts
@@ -34,16 +34,16 @@ const TEMPLATE_COMMENT_TEXT = 'template bindings={}';
 var TEMPLATE_BINDINGS_EXP = /^template bindings=(.*)$/g;
 
 export abstract class DomRootRenderer implements RootRenderer {
-  private _registeredComponents: Map<string, DomRenderer> = new Map<string, DomRenderer>();
+  protected registeredComponents: Map<string, DomRenderer> = new Map<string, DomRenderer>();
 
   constructor(public document: any, public eventManager: EventManager,
               public sharedStylesHost: DomSharedStylesHost, public animate: AnimationBuilder) {}
 
   renderComponent(componentProto: RenderComponentType): Renderer {
-    var renderer = this._registeredComponents.get(componentProto.id);
+    var renderer = this.registeredComponents.get(componentProto.id);
     if (isBlank(renderer)) {
       renderer = new DomRenderer(this, componentProto);
-      this._registeredComponents.set(componentProto.id, renderer);
+      this.registeredComponents.set(componentProto.id, renderer);
     }
     return renderer;
   }


### PR DESCRIPTION
allow for `ServerDomRootRenderer_`  to use `_renderComponent` with `ServerDomRenderer` as default
https://github.com/angular/universal/blob/54ef5564f7973d21c902b4641e1987519fe7c224/modules/universal/server/src/platform/dom/server_dom_renderer.ts#L26...L40
