### PR TITLE
feat(Injector): add a method to retrieve providers from injector

### DIFF
--- a/modules/angular2/src/core/di/injector.ts
+++ b/modules/angular2/src/core/di/injector.ts
@@ -748,6 +748,18 @@ export class Injector {
     return this._instantiateProvider(provider, Visibility.PublicAndPrivate);
   }
 
+  /**
+   * Returns an array of providers
+   *
+   */
+  getResolvedProviders(): ResolvedProvider[] {
+    var res = [];
+    for (var i = 0; i < this._proto.numberOfProviders; ++i) {
+      res.push(this._proto.getProviderAtIndex(i));
+    }
+    return res;
+  }
+
   /** @internal */
   _new(provider: ResolvedProvider, visibility: Visibility): any {
     if (this._constructionCounter++ > this._strategy.getMaxNumberOfObjects()) {

--- a/modules/angular2/src/core/linker/dynamic_component_loader.ts
+++ b/modules/angular2/src/core/linker/dynamic_component_loader.ts
@@ -192,7 +192,7 @@ export abstract class DynamicComponentLoader {
    * ```
    */
   abstract loadIntoLocation(type: Type, hostLocation: ElementRef, anchorName: string,
-                            providers?: ResolvedProvider[],
+                            providers?: ResolvedProvider[] | Injector,
                             projectableNodes?: any[][]): Promise<ComponentRef>;
 
   /**
@@ -235,7 +235,8 @@ export abstract class DynamicComponentLoader {
    * <child-component>Child</child-component>
    * ```
    */
-  abstract loadNextToLocation(type: Type, location: ElementRef, providers?: ResolvedProvider[],
+  abstract loadNextToLocation(type: Type, location: ElementRef,
+                              providers?: ResolvedProvider[] | Injector,
                               projectableNodes?: any[][]): Promise<ComponentRef>;
 }
 
@@ -262,19 +263,29 @@ export class DynamicComponentLoader_ extends DynamicComponentLoader {
   }
 
   loadIntoLocation(type: Type, hostLocation: ElementRef, anchorName: string,
-                   providers: ResolvedProvider[] = null,
+                   providers: ResolvedProvider[] | Injector = null,
                    projectableNodes: any[][] = null): Promise<ComponentRef> {
+    if (providers instanceof Injector) {
+      let resolvedProviders = (<Injector>providers).getResolvedProviders();
+      providers = resolvedProviders.length == 0 ? null : resolvedProviders;
+    }
     return this.loadNextToLocation(
         type, this._viewManager.getNamedElementInComponentView(hostLocation, anchorName), providers,
         projectableNodes);
   }
 
-  loadNextToLocation(type: Type, location: ElementRef, providers: ResolvedProvider[] = null,
+  loadNextToLocation(type: Type, location: ElementRef,
+                     providers: ResolvedProvider[] | Injector = null,
                      projectableNodes: any[][] = null): Promise<ComponentRef> {
+    if (providers instanceof Injector) {
+      let resolvedProviders = (<Injector>providers).getResolvedProviders();
+      providers = resolvedProviders.length == 0 ? null : resolvedProviders;
+    }
     return this._compiler.compileInHost(type).then(hostProtoViewRef => {
       var viewContainer = this._viewManager.getViewContainer(location);
-      var hostViewRef = viewContainer.createHostView(hostProtoViewRef, viewContainer.length,
-                                                     providers, projectableNodes);
+      var hostViewRef =
+          viewContainer.createHostView(hostProtoViewRef, viewContainer.length,
+                                       (<ResolvedProvider[]>providers), projectableNodes);
       var newLocation = this._viewManager.getHostElement(hostViewRef);
       var component = this._viewManager.getComponent(newLocation);
 

--- a/modules/angular2/test/core/di/injector_spec.ts
+++ b/modules/angular2/test/core/di/injector_spec.ts
@@ -388,6 +388,15 @@ export function main() {
             .toHaveBeenCalledWith(injector, providers[0],
                                   providers[0].resolvedFactories[0].dependencies[0]);
       });
+
+      it('should return an array of resolved providers', () => {
+        var injector = Injector.resolveAndCreate(
+            [provide('foo', {useValue: 'bar'}), provide('baz', {useValue: 'xyz'})]);
+        var resolvedProviders = injector.getResolvedProviders();
+        expect(resolvedProviders.length).toBeGreaterThan(0);
+        expect(resolvedProviders[0].key.displayName).toEqual('foo');
+        expect(resolvedProviders[1].key.displayName).toEqual('baz');
+      });
     });
 
 

--- a/modules/angular2/test/public_api_spec.ts
+++ b/modules/angular2/test/public_api_spec.ts
@@ -1046,6 +1046,7 @@ var NG_CORE = [
   'Injector.getOptional()',
   'Injector.hostBoundary',
   'Injector.instantiateResolved()',
+  'Injector.getResolvedProviders()',
   'Injector.internalStrategy',
   'Injector.parent',
   'Injector.resolveAndCreateChild()',


### PR DESCRIPTION
closes https://github.com/angular/angular/issues/5990

I'm giving it a shot with this PR. It contains two things
- Injector : adds a method to retrieve the resolved providers from the injector

```
constructor(injector: Injector) {
   injector.getResolvedProviders();
}
```
- DynamicComponentLoader : both loadNextToLocation and loadIntoLocation accept both providers or an Injector as param.

```
constructor(injector: Injector) {
   providers = injector.getResolvedProviders();

   // Using the array of providers
   loadIntoLocation(Component, elementRef, 'anchor', providers)
   loadNextToLocation(Component, elementRef, providers)

   // Or pass directly the injector
   loadIntoLocation(Component, elementRef, 'anchor', injector);
   loadNextToLocation(Component, elementRef, injector)
}
```

I sent it as one PR because the changes to DCL depend on the changes to Injector

Weirdly enough Injector already have a helper function to print the providers

```
function _mapProviders(injector: Injector, fn: Function): any[] {
  var res = [];
  for (var i = 0; i < injector._proto.numberOfProviders; ++i) {
    res.push(fn(injector._proto.getProviderAtIndex(i)));
  }
  return res;
}
```

But it wasn't exposed as part of Injector.

This required to modify the public api, so I need it to be reviewed
/cc @mhevery 
