### PR TITLE
fix(testing): remove test zone for now and rely on returned promises

### DIFF
--- a/modules/angular2/test/testing/static_assets/test.html
+++ b/modules/angular2/test/testing/static_assets/test.html
@@ -1,0 +1,1 @@
+<span>from external template</span>

--- a/modules_dart/angular2_testing/test/angular2_testing_test.dart
+++ b/modules_dart/angular2_testing/test/angular2_testing_test.dart
@@ -26,6 +26,13 @@ class TestService {
   }
 }
 
+@Component(selector: 'external-template-cmp')
+@View(templateUrl: 'test_template.html')
+class ExternalTemplateComponent {
+  ExternalTemplateComponent() {
+  }
+}
+
 class MyToken {}
 
 const TEMPLATE =
@@ -77,6 +84,15 @@ void main() {
     rootTC.detectChanges();
 
     expect(rootTC.debugElement.nativeElement.text, equals('1;2;3;'));
+  });
+
+  ngTest('should allow a component using a templateUrl', (TestComponentBuilder tcb) async {
+    var rootTC = await tcb
+        .createAsync(ExternalTemplateComponent);
+
+    rootTC.detectChanges();
+
+    expect(rootTC.debugElement.nativeElement.text, equals('from external template\n'));
   });
 
   group('expected failures', () {

--- a/modules_dart/angular2_testing/test/test_template.html
+++ b/modules_dart/angular2_testing/test/test_template.html
@@ -1,0 +1,1 @@
+<span>from external template</span>


### PR DESCRIPTION
Adds tests for public Dart and TS frameworks to make sure that
components with templateUrl can be created by the TestComponentBuilder.

Closes #6359
