### PR TITLE
fix(dart/transform): Ensure template codegen is completed sync

### DIFF
--- a/modules_dart/transform/lib/src/transform/common/logging.dart
+++ b/modules_dart/transform/lib/src/transform/common/logging.dart
@@ -22,13 +22,31 @@ Future logElapsedAsync(Future asyncOperation(),
   final timer = new Stopwatch()..start();
   final result = await asyncOperation();
   timer.stop();
+  _logElapsed(timer, operationName, assetId);
+  return result;
+}
+
+/// Writes a log entry at `LogLevel.FINE` granularity with the time taken by
+/// `operation`.
+///
+/// Returns the result of executing `operation`.
+dynamic logElapsedSync(dynamic operation(),
+    {String operationName: 'unknown', AssetId assetId}) {
+  final timer = new Stopwatch()..start();
+  final result = operation();
+  timer.stop();
+  _logElapsed(timer, operationName, assetId);
+  return result;
+}
+
+/// Logs the time since `timer` was started.
+void _logElapsed(Stopwatch timer, String operationName, AssetId assetId) {
   final buf =
       new StringBuffer('[$operationName] took ${timer.elapsedMilliseconds} ms');
   if (assetId != null) {
     buf.write(' on $assetId');
   }
   log.fine(buf.toString(), asset: assetId);
-  return result;
 }
 
 /// Prints logged messages to the console.

--- a/modules_dart/transform/lib/src/transform/template_compiler/generator.dart
+++ b/modules_dart/transform/lib/src/transform/template_compiler/generator.dart
@@ -69,7 +69,9 @@ Future<Outputs> processTemplates(AssetReader reader, AssetId assetId,
 
   var savedReflectionCapabilities = reflector.reflectionCapabilities;
   reflector.reflectionCapabilities = const NullReflectionCapabilities();
-  final compiledTemplates = await logElapsedAsync(() async {
+  // Since we need global state to remain consistent here, make sure not to do
+  // any asynchronous operations here.
+  final compiledTemplates = logElapsedSync(() {
     return templateCompiler.compileTemplatesCodeGen(compileData);
   }, operationName: 'compileTemplatesCodegen', assetId: assetId);
   reflector.reflectionCapabilities = savedReflectionCapabilities;


### PR DESCRIPTION
Previously, template codegen was done asynchronously, which could result
in reflector state being overwritten and leading to compile errors.

Update the codegen to run synchronously to ensure this does not happen.
