### PR TITLE
The old code does not work. The new one works.

### DIFF
--- a/modules/angular2/src/core/metadata.ts
+++ b/modules/angular2/src/core/metadata.ts
@@ -1217,7 +1217,7 @@ export var Pipe: PipeFactory = <PipeFactory>makeDecorator(PipeMetadata);
  *   `
  * })
  * class BankAccount {
- *   @Input() bankName: string;
+ *   @Input('bankName') bankName: string;
  *   @Input('account-id') id: string;
  *
  *   // this property is not bound, and won't be automatically updated by Angular
@@ -1227,7 +1227,7 @@ export var Pipe: PipeFactory = <PipeFactory>makeDecorator(PipeMetadata);
  * @Component({
  *   selector: 'app',
  *   template: `
- *     <bank-account bank-name="RBC" account-id="4747"></bank-account>
+ *     <bank-account bankName="RBC" account-id="4747"></bank-account>
  *   `,
  *   directives: [BankAccount]
  * })


### PR DESCRIPTION
docs: In the [Input example](https://angular.io/docs/ts/latest/api/core/Input-var.html), if omit the `'bankName'` in `@Input('bankName')`, the browser does show the value of the bankName.
However, it should be a way to omit the `'bankName'` like in the [Output example](https://angular.io/docs/ts/latest/api/core/Output-var.html).
But I tried both kebab-case and camelCase, neither works. So I add `'bankName'` in `@Input()`.
