### PR TITLE
fix(core): always remove DOM listeners and stream subscriptions

### DIFF
--- a/modules/angular2/src/core/change_detection/codegen_logic_util.ts
+++ b/modules/angular2/src/core/change_detection/codegen_logic_util.ts
@@ -153,6 +153,7 @@ export class CodegenLogicUtil {
 
   genHydrateDirectives(directiveRecords: DirectiveRecord[]): string {
     var res = [];
+    var outputCount = 0;
     for (var i = 0; i < directiveRecords.length; ++i) {
       var r = directiveRecords[i];
       var dirVarName = this._names.getDirectiveName(r.directiveIndex);
@@ -160,12 +161,22 @@ export class CodegenLogicUtil {
       if (isPresent(r.outputs)) {
         r.outputs.forEach(output => {
           var eventHandlerExpr = this._genEventHandler(r.directiveIndex.elementIndex, output[1]);
+          var statementStart =
+              `this.outputSubscriptions[${outputCount++}] = ${dirVarName}.${output[0]}`;
           if (IS_DART) {
-            res.push(`${dirVarName}.${output[0]}.listen(${eventHandlerExpr});`);
+            res.push(`${statementStart}.listen(${eventHandlerExpr});`);
           } else {
-            res.push(`${dirVarName}.${output[0]}.subscribe({next: ${eventHandlerExpr}});`);
+            res.push(`${statementStart}.subscribe({next: ${eventHandlerExpr}});`);
           }
         });
+      }
+    }
+    if (outputCount > 0) {
+      var statementStart = 'this.outputSubscriptions';
+      if (IS_DART) {
+        res.unshift(`${statementStart} = new List(${outputCount});`);
+      } else {
+        res.unshift(`${statementStart} = new Array(${outputCount});`);
       }
     }
     return res.join("\n");

--- a/modules/angular2/src/core/change_detection/dynamic_change_detector.ts
+++ b/modules/angular2/src/core/change_detection/dynamic_change_detector.ts
@@ -114,6 +114,7 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
         super.observeDirective(this._getDirectiveFor(index), i);
       }
     }
+    this.outputSubscriptions = [];
     for (var i = 0; i < this._directiveRecords.length; ++i) {
       var r = this._directiveRecords[i];
       if (isPresent(r.outputs)) {
@@ -122,7 +123,8 @@ export class DynamicChangeDetector extends AbstractChangeDetector<any> {
               <any>this._createEventHandler(r.directiveIndex.elementIndex, output[1]);
           var directive = this._getDirectiveFor(r.directiveIndex);
           var getter = reflector.getter(output[0]);
-          ObservableWrapper.subscribe(getter(directive), eventHandler);
+          this.outputSubscriptions.push(
+              ObservableWrapper.subscribe(getter(directive), eventHandler));
         });
       }
     }

--- a/modules/angular2/src/core/change_detection/exceptions.ts
+++ b/modules/angular2/src/core/change_detection/exceptions.ts
@@ -91,7 +91,7 @@ export class ChangeDetectionError extends WrappedException {
  * This is an internal Angular error.
  */
 export class DehydratedException extends BaseException {
-  constructor() { super('Attempt to detect changes on a dehydrated detector.'); }
+  constructor() { super('Attempt to use a dehydrated detector.'); }
 }
 
 /**

--- a/modules/angular2/src/core/render/api.ts
+++ b/modules/angular2/src/core/render/api.ts
@@ -28,7 +28,7 @@ export abstract class Renderer implements ParentRenderer {
 
   abstract destroyView(hostElement: any, viewAllNodes: any[]);
 
-  abstract listen(renderElement: any, name: string, callback: Function);
+  abstract listen(renderElement: any, name: string, callback: Function): Function;
 
   abstract listenGlobal(target: string, name: string, callback: Function): Function;
 

--- a/modules/angular2/src/platform/dom/dom_renderer.ts
+++ b/modules/angular2/src/platform/dom/dom_renderer.ts
@@ -155,9 +155,9 @@ export class DomRenderer implements Renderer {
     }
   }
 
-  listen(renderElement: any, name: string, callback: Function) {
-    this._rootRenderer.eventManager.addEventListener(renderElement, name,
-                                                     decoratePreventDefault(callback));
+  listen(renderElement: any, name: string, callback: Function): Function {
+    return this._rootRenderer.eventManager.addEventListener(renderElement, name,
+                                                            decoratePreventDefault(callback));
   }
 
   listenGlobal(target: string, name: string, callback: Function): Function {

--- a/modules/angular2/src/platform/dom/events/dom_events.ts
+++ b/modules/angular2/src/platform/dom/events/dom_events.ts
@@ -8,10 +8,11 @@ export class DomEventsPlugin extends EventManagerPlugin {
   // events.
   supports(eventName: string): boolean { return true; }
 
-  addEventListener(element: HTMLElement, eventName: string, handler: Function) {
+  addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
     var zone = this.manager.getZone();
     var outsideHandler = (event) => zone.run(() => handler(event));
-    this.manager.getZone().runOutsideAngular(() => { DOM.on(element, eventName, outsideHandler); });
+    return this.manager.getZone().runOutsideAngular(
+        () => DOM.onAndCancel(element, eventName, outsideHandler));
   }
 
   addGlobalEventListener(target: string, eventName: string, handler: Function): Function {
@@ -19,6 +20,6 @@ export class DomEventsPlugin extends EventManagerPlugin {
     var zone = this.manager.getZone();
     var outsideHandler = (event) => zone.run(() => handler(event));
     return this.manager.getZone().runOutsideAngular(
-        () => { return DOM.onAndCancel(element, eventName, outsideHandler); });
+        () => DOM.onAndCancel(element, eventName, outsideHandler));
   }
 }

--- a/modules/angular2/src/platform/dom/events/event_manager.ts
+++ b/modules/angular2/src/platform/dom/events/event_manager.ts
@@ -16,9 +16,9 @@ export class EventManager {
     this._plugins = ListWrapper.reversed(plugins);
   }
 
-  addEventListener(element: HTMLElement, eventName: string, handler: Function) {
+  addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
     var plugin = this._findPluginFor(eventName);
-    plugin.addEventListener(element, eventName, handler);
+    return plugin.addEventListener(element, eventName, handler);
   }
 
   addGlobalEventListener(target: string, eventName: string, handler: Function): Function {
@@ -47,7 +47,7 @@ export class EventManagerPlugin {
   // That is equivalent to having supporting $event.target
   supports(eventName: string): boolean { return false; }
 
-  addEventListener(element: HTMLElement, eventName: string, handler: Function) {
+  addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
     throw "not implemented";
   }
 

--- a/modules/angular2/src/platform/dom/events/hammer_gestures.ts
+++ b/modules/angular2/src/platform/dom/events/hammer_gestures.ts
@@ -15,17 +15,18 @@ export class HammerGesturesPlugin extends HammerGesturesPluginCommon {
     return true;
   }
 
-  addEventListener(element: HTMLElement, eventName: string, handler: Function) {
+  addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
     var zone = this.manager.getZone();
     eventName = eventName.toLowerCase();
 
-    zone.runOutsideAngular(function() {
+    return zone.runOutsideAngular(function() {
       // Creating the manager bind events, must be done outside of angular
       var mc = new Hammer(element);
       mc.get('pinch').set({enable: true});
       mc.get('rotate').set({enable: true});
-
-      mc.on(eventName, function(eventObj) { zone.run(function() { handler(eventObj); }); });
+      var handler = function(eventObj) { zone.run(function() { handler(eventObj); }); };
+      mc.on(eventName, handler);
+      return () => { mc.off(eventName, handler); };
     });
   }
 }

--- a/modules/angular2/src/platform/dom/events/key_events.ts
+++ b/modules/angular2/src/platform/dom/events/key_events.ts
@@ -27,14 +27,15 @@ export class KeyEventsPlugin extends EventManagerPlugin {
     return isPresent(KeyEventsPlugin.parseEventName(eventName));
   }
 
-  addEventListener(element: HTMLElement, eventName: string, handler: Function) {
+  addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
     var parsedEvent = KeyEventsPlugin.parseEventName(eventName);
 
     var outsideHandler = KeyEventsPlugin.eventCallback(
         element, StringMapWrapper.get(parsedEvent, 'fullKey'), handler, this.manager.getZone());
 
-    this.manager.getZone().runOutsideAngular(() => {
-      DOM.on(element, StringMapWrapper.get(parsedEvent, 'domEventName'), outsideHandler);
+    return this.manager.getZone().runOutsideAngular(() => {
+      return DOM.onAndCancel(element, StringMapWrapper.get(parsedEvent, 'domEventName'),
+                             outsideHandler);
     });
   }
 

--- a/modules/angular2/src/web_workers/ui/renderer.ts
+++ b/modules/angular2/src/web_workers/ui/renderer.ts
@@ -66,12 +66,12 @@ export class MessageBasedRenderer {
                           bind(this._invokeElementMethod, this));
     broker.registerMethod("setText", [RenderStoreObject, RenderStoreObject, PRIMITIVE],
                           bind(this._setText, this));
-    broker.registerMethod("listen", [RenderStoreObject, RenderStoreObject, PRIMITIVE],
+    broker.registerMethod("listen", [RenderStoreObject, RenderStoreObject, PRIMITIVE, PRIMITIVE],
                           bind(this._listen, this));
     broker.registerMethod("listenGlobal", [RenderStoreObject, PRIMITIVE, PRIMITIVE, PRIMITIVE],
                           bind(this._listenGlobal, this));
-    broker.registerMethod("listenGlobalDone", [RenderStoreObject, RenderStoreObject],
-                          bind(this._listenGlobalDone, this));
+    broker.registerMethod("listenDone", [RenderStoreObject, RenderStoreObject],
+                          bind(this._listenDone, this));
   }
 
   private _renderComponent(renderComponentType: RenderComponentType, rendererId: number) {
@@ -155,9 +155,11 @@ export class MessageBasedRenderer {
     renderer.setText(renderNode, text);
   }
 
-  private _listen(renderer: Renderer, renderElement: any, eventName: string) {
-    renderer.listen(renderElement, eventName, (event) => this._eventDispatcher.dispatchRenderEvent(
-                                                  renderElement, null, eventName, event));
+  private _listen(renderer: Renderer, renderElement: any, eventName: string, unlistenId: number) {
+    var unregisterCallback = renderer.listen(renderElement, eventName,
+                                             (event) => this._eventDispatcher.dispatchRenderEvent(
+                                                 renderElement, null, eventName, event));
+    this._renderStore.store(unregisterCallback, unlistenId);
   }
 
   private _listenGlobal(renderer: Renderer, eventTarget: string, eventName: string,
@@ -168,5 +170,5 @@ export class MessageBasedRenderer {
     this._renderStore.store(unregisterCallback, unlistenId);
   }
 
-  private _listenGlobalDone(renderer: Renderer, unlistenCallback: Function) { unlistenCallback(); }
+  private _listenDone(renderer: Renderer, unlistenCallback: Function) { unlistenCallback(); }
 }

--- a/modules/angular2/test/core/change_detection/change_detector_spec.ts
+++ b/modules/angular2/test/core/change_detection/change_detector_spec.ts
@@ -1267,7 +1267,7 @@ export function main() {
 
           val.changeDetector.dehydrate();
           expect(() => {val.changeDetector.detectChanges()})
-              .toThrowErrorWith("Attempt to detect changes on a dehydrated detector");
+              .toThrowErrorWith("Attempt to use a dehydrated detector");
           expect(val.dispatcher.log).toEqual(['propName=Bob']);
         });
       });

--- a/modules/angular2/test/core/linker/integration_spec.ts
+++ b/modules/angular2/test/core/linker/integration_spec.ts
@@ -877,13 +877,22 @@ function declareTests() {
                  var listener = tc.inject(DirectiveListeningEvent);
 
                  expect(listener.msg).toEqual('');
+                 var eventCount = 0;
 
                  ObservableWrapper.subscribe(emitter.event, (_) => {
-                   expect(listener.msg).toEqual('fired !');
-                   async.done();
+                   eventCount++;
+                   if (eventCount === 1) {
+                     expect(listener.msg).toEqual('fired !');
+                     fixture.destroy();
+                     emitter.fireEvent('fired again !');
+                   } else {
+                     expect(listener.msg).toEqual('fired !');
+                     async.done();
+                   }
                  });
 
                  emitter.fireEvent('fired !');
+
                });
          }));
 
@@ -960,6 +969,11 @@ function declareTests() {
                  expect(listener.eventTypes)
                      .toEqual(
                          ['domEvent', 'body_domEvent', 'document_domEvent', 'window_domEvent']);
+
+                 fixture.destroy();
+                 listener.eventTypes = [];
+                 dispatchEvent(tc.nativeElement, 'domEvent');
+                 expect(listener.eventTypes).toEqual([]);
 
                  async.done();
                });


### PR DESCRIPTION
This is needed to prevent memory leaks. The DOM
listeners don’t need to be removed for simple examples,
but a big internal app shows memory leaks because of them.
