### PR TITLE
chore(tests): increase timeout for change detector compiler

### DIFF
--- a/modules/angular2/test/compiler/change_detector_compiler_spec.ts
+++ b/modules/angular2/test/compiler/change_detector_compiler_spec.ts
@@ -88,7 +88,7 @@ export function main() {
       it('should watch element properties', () => {
         expect(detectChanges(compiler, '<div [elProp]="someProp">'))
             .toEqual(['elementProperty(elProp)=someValue']);
-      });
+      }, 3000); // This is slow and sometimes times out after 2 seconds on CI.
     });
 
     describe('compileComponentCodeGen', () => {


### PR DESCRIPTION
Dart unit tests are frequently timing out on Travis due to this
test.
