### PR TITLE
chore(core): deactivate the tests that use Dart isolates

### DIFF
--- a/modules/angular2/test/compiler/change_detector_compiler_spec.ts
+++ b/modules/angular2/test/compiler/change_detector_compiler_spec.ts
@@ -14,7 +14,7 @@ import {
 } from 'angular2/testing_internal';
 import {provide} from 'angular2/src/core/di';
 
-import {CONST_EXPR, stringify} from 'angular2/src/facade/lang';
+import {CONST_EXPR, stringify, IS_DART} from 'angular2/src/facade/lang';
 import {MapWrapper} from 'angular2/src/facade/collection';
 import {Promise} from 'angular2/src/facade/async';
 
@@ -55,6 +55,11 @@ var THIS_MODULE_URL = `package:${THIS_MODULE_ID}${MODULE_SUFFIX}`;
 var THIS_MODULE_REF = moduleRef(THIS_MODULE_URL);
 
 export function main() {
+  // Dart's isolate support is broken, and these tests will be obsolote soon with
+  // https://github.com/angular/angular/issues/6270
+  if (IS_DART) {
+    return;
+  }
   describe('ChangeDetectorCompiler', () => {
     beforeEachProviders(() => [
       TEST_PROVIDERS,

--- a/modules/angular2/test/compiler/eval_module_spec.ts
+++ b/modules/angular2/test/compiler/eval_module_spec.ts
@@ -22,6 +22,11 @@ export var TEST_VALUE = 23;
 const THIS_MODULE_URL = `package:angular2/test/compiler/eval_module_spec${IS_DART?'.dart':'.js'}`;
 
 export function main() {
+  // Dart's isolate support is broken, and these tests will be obsolote soon with
+  // https://github.com/angular/angular/issues/6270
+  if (IS_DART) {
+    return;
+  }
   describe('evalModule', () => {
     it('should call the "run" function and allow to use imports',
        inject([AsyncTestCompleter], (async) => {

--- a/modules/angular2/test/compiler/style_compiler_spec.ts
+++ b/modules/angular2/test/compiler/style_compiler_spec.ts
@@ -17,7 +17,14 @@ import {SpyXHR} from './spies';
 import {XHR} from 'angular2/src/compiler/xhr';
 import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
 
-import {CONST_EXPR, isPresent, isBlank, StringWrapper, isArray} from 'angular2/src/facade/lang';
+import {
+  CONST_EXPR,
+  isPresent,
+  isBlank,
+  StringWrapper,
+  isArray,
+  IS_DART
+} from 'angular2/src/facade/lang';
 import {PromiseWrapper, Promise} from 'angular2/src/facade/async';
 import {evalModule} from './eval_module';
 import {StyleCompiler} from 'angular2/src/compiler/style_compiler';
@@ -40,6 +47,11 @@ var IMPORT_ABS_STYLESHEET_URL_WITH_IMPORT =
     `package:angular2/test/compiler/style_compiler_transitive_import.css`;
 
 export function main() {
+  // Dart's isolate support is broken, and these tests will be obsolote soon with
+  // https://github.com/angular/angular/issues/6270
+  if (IS_DART) {
+    return;
+  }
   describe('StyleCompiler', () => {
     var xhr: SpyXHR;
 

--- a/modules/angular2/test/compiler/template_compiler_spec.ts
+++ b/modules/angular2/test/compiler/template_compiler_spec.ts
@@ -14,7 +14,7 @@ import {
 } from 'angular2/testing_internal';
 
 import {Promise, PromiseWrapper} from 'angular2/src/facade/async';
-import {Type, isPresent, isBlank, stringify, isString} from 'angular2/src/facade/lang';
+import {Type, isPresent, isBlank, stringify, isString, IS_DART} from 'angular2/src/facade/lang';
 import {
   MapWrapper,
   SetWrapper,
@@ -58,6 +58,11 @@ var REFLECTION_CAPS_MODULE_REF =
     moduleRef(`package:angular2/src/core/reflection/reflection_capabilities${MODULE_SUFFIX}`);
 
 export function main() {
+  // Dart's isolate support is broken, and these tests will be obsolote soon with
+  // https://github.com/angular/angular/issues/6270
+  if (IS_DART) {
+    return;
+  }
   describe('TemplateCompiler', () => {
     var compiler: TemplateCompiler;
     var runtimeMetadataResolver: RuntimeMetadataResolver;


### PR DESCRIPTION
These are broken with Dart 1.13.2 stable, and will soon be obsolete (see #6270).
