### PR TITLE
fix(router): fixed the location wrapper for angular1

### DIFF
--- a/modules/angular1_router/lib/facades.es5
+++ b/modules/angular1_router/lib/facades.es5
@@ -303,8 +303,8 @@ Location.prototype.subscribe = function () {
   //TODO: implement
 };
 Location.prototype.path = function () {
-  return $location.path();
+  return $location.url();
 };
-Location.prototype.go = function (url) {
-  return $location.path(url);
+Location.prototype.go = function (path, query) {
+  return $location.url(path + query);
 };

--- a/modules/angular1_router/src/module_template.js
+++ b/modules/angular1_router/src/module_template.js
@@ -57,7 +57,7 @@ function routerFactory($q, $location, $$directiveIntrospector, $browser, $rootSc
   });
 
   var router = new RootRouter(registry, location, $routerRootComponent);
-  $rootScope.$watch(function () { return $location.path(); }, function (path) {
+  $rootScope.$watch(function () { return $location.url(); }, function (path) {
     if (router.lastNavigationAttempt !== path) {
       router.navigateByUrl(path);
     }


### PR DESCRIPTION
In angular2 `Location.path()` returns the complete path including query string. In angular1 the query parameters are missing. Similar to this `Location.go` does accept two parameters (path _and query_).

Found and fixed by @mischi
