### PR TITLE
#5502 Bug: Don't prepend unnecessary '/' to path

### DIFF
--- a/modules/angular1_router/test/integration/navigation_spec.js
+++ b/modules/angular1_router/test/integration/navigation_spec.js
@@ -112,6 +112,26 @@ describe('navigation', function () {
     expect(elt.text()).toBe('outer { inner { one } }');
   });
 
+  it('should work when parent route has empty path', inject(function ($location) {
+    registerComponent('childCmp', {
+      template: '<div>inner { <div ng-outlet></div> }</div>',
+      $routeConfig: [
+        { path: '/b', component: 'oneCmp' }
+      ]
+    });
+
+    $router.config([
+      { path: '/...', component: 'childCmp' }
+    ]);
+    compile('<div>outer { <div ng-outlet></div> }</div>');
+
+    $router.navigateByUrl('/b');
+    $rootScope.$digest();
+
+    expect(elt.text()).toBe('outer { inner { one } }');
+    expect($location.path()).toBe('/b');
+  }));
+
 
   it('should work with recursive nested outlets', function () {
     registerComponent('recurCmp', {

--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -438,7 +438,7 @@ export class RootRouter extends Router {
                   }
                   var emitPath = instruction.toUrlPath();
                   var emitQuery = instruction.toUrlQuery();
-                  if (emitPath.length > 0) {
+                  if (emitPath.length > 0 && emitPath[0] !== '/') {
                     emitPath = '/' + emitPath;
                   }
 
@@ -465,7 +465,7 @@ export class RootRouter extends Router {
   commit(instruction: Instruction, _skipLocationChange: boolean = false): Promise<any> {
     var emitPath = instruction.toUrlPath();
     var emitQuery = instruction.toUrlQuery();
-    if (emitPath.length > 0) {
+    if (emitPath.length > 0 && emitPath[0] !== '/') {
       emitPath = '/' + emitPath;
     }
     var promise = super.commit(instruction);

--- a/modules/angular2/test/router/integration/navigation_spec.ts
+++ b/modules/angular2/test/router/integration/navigation_spec.ts
@@ -105,6 +105,20 @@ export function main() {
              });
        }));
 
+    it('should navigate to child routes when the root component has an empty path',
+      inject([AsyncTestCompleter, Location], (async, location) => {
+        compile(tcb, 'outer { <router-outlet></router-outlet> }')
+            .then((rtc) => {fixture = rtc})
+            .then((_) => rtr.config([new Route({path: '/...', component: ParentCmp})]))
+            .then((_) => rtr.navigateByUrl('/b'))
+            .then((_) => {
+              fixture.detectChanges();
+              expect(fixture.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+              expect(location.urlChanges).toEqual(['/b']);
+              async.done();
+            });
+      }));
+
     it('should navigate to child routes of async routes', inject([AsyncTestCompleter], (async) => {
          compile(tcb, 'outer { <router-outlet></router-outlet> }')
              .then((rtc) => {fixture = rtc})


### PR DESCRIPTION
This is a fix to the Child Router Issue as described in #5502.

I reproduced this bug in this Plunkr
http://plnkr.co/edit/OjXZK9

You will not get errors thrown displayed in the console while running in Plunkr so here is the exact same code on our servers
http://test.loop-one.de/
