### PR TITLE
chore(ci): deflake test and turn on saucelabs_required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,6 @@ matrix:
   - env: "MODE=browserstack_optional DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION"
   # TODO(alxhub): remove when dartdoc #1039 is in dev channel
   - env: "MODE=dart DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION"
-  # TODO: move back once issue #6725 is resolved.
-  - env: "MODE=saucelabs_required DART_CHANNEL=dev DART_VERSION=$DART_DEV_VERSION"
 
 addons:
   firefox: "38.0"

--- a/modules/angular2/test/testing/testing_public_spec.ts
+++ b/modules/angular2/test/testing/testing_public_spec.ts
@@ -325,7 +325,7 @@ export function main() {
         done();
       });
       restoreJasmineIt();
-    });
+    }, 10000);
 
     describe('using beforeEachProviders', () => {
       beforeEachProviders(() => [bind(FancyService).toValue(new FancyService())]);


### PR DESCRIPTION
Fixes #6725 

On all browsers, an obvious culprit is the `errors should fail when an XHR fails` test which involves an actual XHR from SL to Travis.
Let's see if increasing the timeout can help, the same was empirically done for https://github.com/angular/angular/blob/master/modules/angular2/test/platform/browser/xhr_impl_spec.ts
