### PR TITLE
fix(css): combinator shimming in the presence of host(-context)

### DIFF
--- a/modules/angular2/src/compiler/shadow_css.ts
+++ b/modules/angular2/src/compiler/shadow_css.ts
@@ -1,4 +1,3 @@
-import {ListWrapper} from 'angular2/src/facade/collection';
 import {
   StringWrapper,
   RegExp,
@@ -346,9 +345,8 @@ export class ShadowCss {
       var p = parts[i];
       p = p.trim();
       if (this._selectorNeedsScoping(p, scopeSelector)) {
-        p = strict && !StringWrapper.contains(p, _polyfillHostNoCombinator) ?
-                this._applyStrictSelectorScope(p, scopeSelector) :
-                this._applySelectorScope(p, scopeSelector, hostSelector);
+        p = strict ? this._applyStrictSelectorScope(p, scopeSelector, hostSelector) :
+                     this._applySelectorScope(p, scopeSelector, hostSelector);
       }
       r.push(p);
     }
@@ -388,28 +386,51 @@ export class ShadowCss {
 
   // return a selector with [name] suffix on each simple selector
   // e.g. .foo.bar > .zot becomes .foo[name].bar[name] > .zot[name]  /** @internal */
-  private _applyStrictSelectorScope(selector: string, scopeSelector: string): string {
+  private _applyStrictSelectorScope(selector: string, scopeSelector: string,
+                                    hostSelector: string): string {
     var isRe = /\[is=([^\]]*)\]/g;
     scopeSelector = StringWrapper.replaceAllMapped(scopeSelector, isRe, (m) => m[1]);
-    var splits = [' ', '>', '+', '~'], scoped = selector, attrName = '[' + scopeSelector + ']';
-    for (var i = 0; i < splits.length; i++) {
-      var sep = splits[i];
-      var parts = scoped.split(sep);
-      scoped = parts.map(p => {
-                      // remove :host since it should be unnecessary
-                      var t = StringWrapper.replaceAll(p.trim(), _polyfillHostRe, '');
-                      if (t.length > 0 && !ListWrapper.contains(splits, t) &&
-                          !StringWrapper.contains(t, attrName)) {
-                        var re = /([^:]*)(:*)(.*)/g;
-                        var m = RegExpWrapper.firstMatch(re, t);
-                        if (isPresent(m)) {
-                          p = m[1] + attrName + m[2] + m[3];
-                        }
-                      }
-                      return p;
-                    })
-                   .join(sep);
+    var attrName = '[' + scopeSelector + ']';
+
+    var _scopeSelectorPart = (p: string) => {
+      var scopedP = p.trim();
+      if (scopedP.length == 0) {
+        return '';
+      }
+
+      if (StringWrapper.contains(p, _polyfillHostNoCombinator)) {
+        scopedP = this._applySimpleSelectorScope(p, scopeSelector, hostSelector);
+      } else {
+        // remove :host since it should be unnecessary
+        var t = StringWrapper.replaceAll(p, _polyfillHostRe, '');
+        if (t.length > 0) {
+          var re = /([^:]*)(:*)(.*)/g;
+          var m1 = RegExpWrapper.firstMatch(re, t);
+          if (isPresent(m1)) {
+            scopedP = m1[1] + attrName + m1[2] + m1[3];
+          }
+        }
+      }
+
+      return scopedP;
+    };
+
+    var sep = / |>|\+|\~/g;
+    var prev = 0;
+    var next = 0;
+    var scoped = '';
+    var indexOfShadowHost = selector.indexOf(_polyfillHostNoCombinator);
+    while ((next = RegExpWrapper.indexOf(sep, prev, selector)) > -1) {
+      var separator = selector[next];
+      var part = selector.substring(prev, next).trim();
+      // if a selector appears before :host-context it should not be shimmed as it
+      // matches on ancestor elements and not on elements in the host's shadow
+      var scopedPart =
+          (indexOfShadowHost == -1 || prev >= indexOfShadowHost) ? _scopeSelectorPart(part) : part;
+      scoped += `${scopedPart} ${separator} `;
+      prev = next + 1;
     }
+    scoped += _scopeSelectorPart(selector.substring(prev));
     return scoped;
   }
 

--- a/modules/angular2/src/facade/lang.dart
+++ b/modules/angular2/src/facade/lang.dart
@@ -199,6 +199,10 @@ class RegExpWrapper {
     return regExp.firstMatch(input);
   }
 
+  static int indexOf(RegExp regExp, num startFrom, String input) {
+    return input.indexOf(regExp, startFrom);
+  }
+
   static bool test(RegExp regExp, String input) {
     return regExp.hasMatch(input);
   }

--- a/modules/angular2/src/facade/lang.ts
+++ b/modules/angular2/src/facade/lang.ts
@@ -299,6 +299,18 @@ export class RegExpWrapper {
     regExp.lastIndex = 0;
     return regExp.exec(input);
   }
+
+  /**
+   * Returns the position of the first match of regex in the input,
+   * starting at `startFrom`, inclusive.
+   *
+   * Returns -1 if no match is found.
+   */
+  static indexOf(regExp: RegExp, startFrom: number, input: string): number {
+    regExp.lastIndex = startFrom;
+    return regExp.exec(input) ? regExp.lastIndex - 1 : -1;
+  }
+
   static test(regExp: RegExp, input: string): boolean {
     regExp.lastIndex = 0;
     return regExp.test(input);

--- a/modules/angular2/test/compiler/shadow_css_spec.ts
+++ b/modules/angular2/test/compiler/shadow_css_spec.ts
@@ -96,13 +96,14 @@ export function main() {
       expect(s(':host {}', 'a', 'a-host')).toEqual('[a-host] {}');
       expect(s(':host(.x,.y) {}', 'a', 'a-host')).toEqual('[a-host].x, [a-host].y {}');
       expect(s(':host(.x,.y) > .z {}', 'a', 'a-host'))
-          .toEqual('[a-host].x > .z, [a-host].y > .z {}');
+          .toEqual('[a-host].x > .z[a], [a-host].y > .z[a] {}');
+      expect(s(':host .x {}', 'a', 'a-host')).toEqual('[a-host] .x[a] {}');
     });
 
     it('should handle :host-context', () => {
       expect(s(':host-context(.x) {}', 'a', 'a-host')).toEqual('[a-host].x, .x [a-host] {}');
       expect(s(':host-context(.x) > .y {}', 'a', 'a-host'))
-          .toEqual('[a-host].x > .y, .x [a-host] > .y {}');
+          .toEqual('[a-host].x > .y[a], .x [a-host] > .y[a] {}');
     });
 
     it('should support polyfill-next-selector', () => {
@@ -131,10 +132,10 @@ export function main() {
 
     it('should support polyfill-rule', () => {
       var css = s("polyfill-rule {content: ':host.foo .bar';color: blue;}", 'a', 'a-host');
-      expect(css).toEqual('[a-host].foo .bar {;color:blue;}');
+      expect(css).toEqual('[a-host].foo .bar[a] {;color:blue;}');
 
       css = s('polyfill-rule {content: ":host.foo .bar";color:blue;}', 'a', 'a-host');
-      expect(css).toEqual('[a-host].foo .bar {;color:blue;}');
+      expect(css).toEqual('[a-host].foo .bar[a] {;color:blue;}');
     });
 
     it('should handle ::shadow', () => {


### PR DESCRIPTION
Fixes #5390

BREAKING CHANGE:
- CSS code that relied on broken host shimming function may stop working
