### PR TITLE
refactor(dart/transform): Error in name convert funcs on unexpected input

### DIFF
--- a/modules_dart/transform/lib/src/transform/common/names.dart
+++ b/modules_dart/transform/lib/src/transform/common/names.dart
@@ -83,5 +83,9 @@ String _toExtension(
           '$toExtension';
     }
   }
-  return uri;
+  throw new ArgumentError.value(
+      uri,
+      'uri',
+      'Provided value ends with an unexpected extension. '
+      'Expected extension(s): [${fromExtensions.join(', ')}].');
 }


### PR DESCRIPTION
Issue raised in PR #6745.
Previously, the transformer name conversion functions could return the
input string on unexpected input, which is almost certainly an error.

`throw` in this case instead, so we know early that something has likely
gone wrong.
