### PR TITLE
fix(dart/transform): Handle edge cases in ReflectionRemover

### DIFF
--- a/modules_dart/transform/test/transform/reflection_remover/all_tests.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/all_tests.dart
@@ -12,7 +12,10 @@ import 'package:angular2/src/transform/reflection_remover/rewriter.dart';
 
 import '../common/read_file.dart';
 import 'bootstrap_files/expected/index.dart' as bootstrap_expected;
+import 'combinator_files/expected/index.dart' as combinator_expected;
 import 'debug_mirrors_files/expected/index.dart' as debug_mirrors;
+import 'deferred_bootstrap_files/expected/index.dart'
+    as deferred_bootstrap_expected;
 import 'function_annotation_files/expected/index.dart'
     as func_annotation_expected;
 import 'log_mirrors_files/expected/index.dart' as log_mirrors;
@@ -64,13 +67,31 @@ void allTests() {
     expect(output).toEqual(log_mirrors.code);
   });
 
-  it('should rewrite bootstrap.', () {
-    final bootstrapCode =
-        readFile('reflection_remover/bootstrap_files/index.dart')
-            .replaceAll('\r\n', '\n');
-    var output = new Rewriter(bootstrapCode, codegen, entrypointMatcher,
-        writeStaticInit: true).rewrite(parseCompilationUnit(bootstrapCode));
-    expect(output).toEqual(bootstrap_expected.code);
+  describe('`bootstrap` import and call', () {
+    it('should be rewritten to `bootstrapStatic`.', () {
+      final bootstrapCode =
+          readFile('reflection_remover/bootstrap_files/index.dart')
+              .replaceAll('\r\n', '\n');
+      var output = new Rewriter(bootstrapCode, codegen, entrypointMatcher,
+          writeStaticInit: true).rewrite(parseCompilationUnit(bootstrapCode));
+      expect(output).toEqual(bootstrap_expected.code);
+    });
+
+    it('should be rewritten correctly when deferred.', () {
+      final bootstrapCode =
+          readFile('reflection_remover/deferred_bootstrap_files/index.dart');
+      var output = new Rewriter(bootstrapCode, codegen, entrypointMatcher,
+          writeStaticInit: true).rewrite(parseCompilationUnit(bootstrapCode));
+      expect(output).toEqual(deferred_bootstrap_expected.code);
+    });
+
+    it('should maintain any combinators.', () {
+      final bootstrapCode =
+          readFile('reflection_remover/combinator_files/index.dart');
+      var output = new Rewriter(bootstrapCode, codegen, entrypointMatcher,
+          writeStaticInit: true).rewrite(parseCompilationUnit(bootstrapCode));
+      expect(output).toEqual(combinator_expected.code);
+    });
   });
 
   describe('AngularEntrypoint annotation', () {

--- a/modules_dart/transform/test/transform/reflection_remover/combinator_files/expected/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/combinator_files/expected/index.dart
@@ -1,0 +1,17 @@
+library angular2.test.transform.reflection_remover.combinator_files;
+
+// This file is intentionally formatted as a string to avoid having the
+// automatic transformer prettify it.
+//
+// This file represents transformed user code. Because this code will be
+// linked to output by a source map, we cannot change line numbers from the
+// original code and we therefore add our generated code on the same line as
+// those we are removing.
+
+var code = """
+import 'package:angular2/bootstrap_static.dart' show bootstrapStatic, initReflector;import 'index.ng_deps.dart' as ngStaticInit;
+
+void main() {
+  bootstrapStatic(MyComponent, null, () { ngStaticInit.initReflector(); });
+}
+""";

--- a/modules_dart/transform/test/transform/reflection_remover/combinator_files/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/combinator_files/index.dart
@@ -1,0 +1,5 @@
+import 'package:angular2/bootstrap.dart' show bootstrap;
+
+void main() {
+  bootstrap(MyComponent);
+}

--- a/modules_dart/transform/test/transform/reflection_remover/deferred_bootstrap_files/expected/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/deferred_bootstrap_files/expected/index.dart
@@ -1,0 +1,19 @@
+library angular2.test.transform.reflection_remover.deferred_bootstrap_files;
+
+// This file is intentionally formatted as a string to avoid having the
+// automatic transformer prettify it.
+//
+// This file represents transformed user code. Because this code will be
+// linked to output by a source map, we cannot change line numbers from the
+// original code and we therefore add our generated code on the same line as
+// those we are removing.
+
+var code = """
+import 'package:angular2/bootstrap_static.dart' deferred as ng;import 'index.ng_deps.dart' as ngStaticInit;
+
+void main() {
+  ng.loadLibrary().then((_) {
+    ng.bootstrapStatic(MyComponent, null, () { ngStaticInit.initReflector(); });
+  });
+}
+""";

--- a/modules_dart/transform/test/transform/reflection_remover/deferred_bootstrap_files/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/deferred_bootstrap_files/index.dart
@@ -1,0 +1,7 @@
+import 'package:angular2/bootstrap.dart' deferred as ng;
+
+void main() {
+  ng.loadLibrary().then((_) {
+    ng.bootstrap(MyComponent);
+  });
+}


### PR DESCRIPTION
Handle some cases which would previously result in broken code.
- Importing bootstrap.dart deferred
- Using combinators when importing bootstrap.dart
- Importing bootstrap.dart with a prefix

Closes #6749
