### PR TITLE
Bugfix for running karma via gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -826,7 +826,7 @@ gulp.task('test.unit.js/ci', function(done) {
                  reporters: ['dots'],
                  browsers: browserConf.browsersToRun
                },
-               done)
+               function(err) { done(); })
       .start();
 });
 


### PR DESCRIPTION
As described below, the karma server shutdown process can crash, if the done() function, provided
by gulp is referenced directly instead of wrapped in a closure function
http://stackoverflow.com/questions/26614738/issue-running-karma-task-from-gulp
