### PR TITLE
#6729 add unit test 

### DIFF
--- a/modules/angular1_router/test/integration/navigation_spec.js
+++ b/modules/angular1_router/test/integration/navigation_spec.js
@@ -112,6 +112,26 @@ describe('navigation', function () {
     expect(elt.text()).toBe('outer { inner { one } }');
   });
 
+  it('should work when parent route has empty path', inject(function ($location) {
+    registerComponent('childCmp', {
+      template: '<div>inner { <div ng-outlet></div> }</div>',
+      $routeConfig: [
+        { path: '/b', component: 'oneCmp' }
+      ]
+    });
+
+    $router.config([
+      { path: '/...', component: 'childCmp' }
+    ]);
+    compile('<div>outer { <div ng-outlet></div> }</div>');
+
+    $router.navigateByUrl('/b');
+    $rootScope.$digest();
+
+    expect(elt.text()).toBe('outer { inner { one } }');
+    expect($location.path()).toBe('/b');
+  }));
+
 
   it('should work with recursive nested outlets', function () {
     registerComponent('recurCmp', {

--- a/modules/angular2/test/router/integration/navigation_spec.ts
+++ b/modules/angular2/test/router/integration/navigation_spec.ts
@@ -105,6 +105,20 @@ export function main() {
              });
        }));
 
+    it('should navigate to child routes when the root component has an empty path',
+      inject([AsyncTestCompleter, Location], (async, location) => {
+        compile(tcb, 'outer { <router-outlet></router-outlet> }')
+            .then((rtc) => {fixture = rtc})
+            .then((_) => rtr.config([new Route({path: '/...', component: ParentCmp})]))
+            .then((_) => rtr.navigateByUrl('/b'))
+            .then((_) => {
+              fixture.detectChanges();
+              expect(fixture.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+              expect(location.urlChanges).toEqual(['/b']);
+              async.done();
+            });
+      }));
+
     it('should navigate to child routes of async routes', inject([AsyncTestCompleter], (async) => {
          compile(tcb, 'outer { <router-outlet></router-outlet> }')
              .then((rtc) => {fixture = rtc})


### PR DESCRIPTION
#6729 This unit test verifies that the router emits the right location paths when the parent components has an empty path (/...)

Testcase for Issue #5502 
