### PR TITLE
fix(angular1-router): add support for using the component helper

### DIFF
--- a/modules/angular1_router/src/ng_outlet.ts
+++ b/modules/angular1_router/src/ng_outlet.ts
@@ -155,7 +155,8 @@ function ngOutletDirective($animate, $q: ng.IQService, $router) {
         }
 
         this.controller.$$routeParams = instruction.params;
-        this.controller.$$template = '<div ' + dashCase(componentName) + '></div>';
+        this.controller.$$template =
+            '<' + dashCase(componentName) + '></' + dashCase(componentName) + '>';
         this.controller.$$router = this.router.childRouter(instruction.componentType);
 
         let newScope = scope.$new();

--- a/modules/angular1_router/test/integration/navigation_spec.js
+++ b/modules/angular1_router/test/integration/navigation_spec.js
@@ -21,16 +21,20 @@ describe('navigation', function () {
       $router = _$router_;
     });
 
-    registerComponent('userCmp', {
+    registerDirective('userCmp', {
       template: '<div>hello {{userCmp.$routeParams.name}}</div>'
     });
-    registerComponent('oneCmp', {
+    registerDirective('oneCmp', {
       template: '<div>{{oneCmp.number}}</div>',
       controller: function () {this.number = 'one'}
     });
-    registerComponent('twoCmp', {
+    registerDirective('twoCmp', {
       template: '<div>{{twoCmp.number}}</div>',
       controller: function () {this.number = 'two'}
+    });
+    registerComponent('threeCmp', {
+      template: '<div>{{$ctrl.number}}</div>',
+      controller: function () {this.number = 'three'}
     });
   });
 
@@ -46,6 +50,21 @@ describe('navigation', function () {
 
     expect(elt.text()).toBe('one');
   });
+
+
+  it('should work with components created by the `mod.component()` helper', function () {
+    compile('<ng-outlet></ng-outlet>');
+
+    $router.config([
+      { path: '/', component: 'threeCmp' }
+    ]);
+
+    $router.navigateByUrl('/');
+    $rootScope.$digest();
+
+    expect(elt.text()).toBe('three');
+  });
+
 
   it('should navigate between components with different parameters', function () {
     $router.config([
@@ -68,7 +87,7 @@ describe('navigation', function () {
     function ParentController() {
       instanceCount += 1;
     }
-    registerComponent('parentCmp', {
+    registerDirective('parentCmp', {
       template: 'parent { <ng-outlet></ng-outlet> }',
       $routeConfig: [
         { path: '/user/:name', component: 'userCmp' }
@@ -94,7 +113,7 @@ describe('navigation', function () {
 
 
   it('should work with nested outlets', function () {
-    registerComponent('childCmp', {
+    registerDirective('childCmp', {
       template: '<div>inner { <div ng-outlet></div> }</div>',
       $routeConfig: [
         { path: '/b', component: 'oneCmp' }
@@ -114,7 +133,7 @@ describe('navigation', function () {
 
 
   it('should work with recursive nested outlets', function () {
-    registerComponent('recurCmp', {
+    registerDirective('recurCmp', {
       template: '<div>recur { <div ng-outlet></div> }</div>',
       $routeConfig: [
         { path: '/recur', component: 'recurCmp' },
@@ -163,7 +182,7 @@ describe('navigation', function () {
 
 
   it('should change location to the canonical route with nested components', inject(function ($location) {
-    registerComponent('childRouter', {
+    registerDirective('childRouter', {
       template: '<div>inner { <div ng-outlet></div> }</div>',
       $routeConfig: [
         { path: '/new-child', component: 'oneCmp', name: 'NewChild'},
@@ -208,7 +227,7 @@ describe('navigation', function () {
 
   it('should expose a "navigating" property on $router', inject(function ($q) {
     var defer;
-    registerComponent('pendingActivate', {
+    registerDirective('pendingActivate', {
       $canActivate: function () {
         defer = $q.defer();
         return defer.promise;
@@ -227,31 +246,26 @@ describe('navigation', function () {
     expect($router.navigating).toBe(false);
   }));
 
-  function registerComponent(name, options) {
-    var controller = options.controller || function () {};
-
-    ['$routerOnActivate', '$routerOnDeactivate', '$routerOnReuse', '$routerCanReuse', '$routerCanDeactivate'].forEach(function (hookName) {
-      if (options[hookName]) {
-        controller.prototype[hookName] = options[hookName];
-      }
-    });
-
+  function registerDirective(name, options) {
     function factory() {
       return {
         template: options.template || '',
         controllerAs: name,
-        controller: controller
+        controller: getController(options)
       };
     }
-
-    if (options.$canActivate) {
-      factory.$canActivate = options.$canActivate;
-    }
-    if (options.$routeConfig) {
-      factory.$routeConfig = options.$routeConfig;
-    }
-
+    applyStaticProperties(factory, options);
     $compileProvider.directive(name, factory);
+  }
+
+  function registerComponent(name, options) {
+
+    var definition = {
+      template: options.template || '',
+      controller: getController(options),
+    }
+    applyStaticProperties(definition, options);
+    $compileProvider.component(name, definition);
   }
 
   function compile(template) {
@@ -259,4 +273,27 @@ describe('navigation', function () {
     $rootScope.$digest();
     return elt;
   }
+
+  function getController(options) {
+    var controller = options.controller || function () {};
+    [
+      '$routerOnActivate', '$routerOnDeactivate',
+      '$routerOnReuse', '$routerCanReuse',
+      '$routerCanDeactivate'
+    ].forEach(function (hookName) {
+      if (options[hookName]) {
+        controller.prototype[hookName] = options[hookName];
+      }
+    });
+    return controller;
+  }
+
+  function applyStaticProperties(target, options) {
+    ['$canActivate', '$routeConfig'].forEach(function(property) {
+      if (options[property]) {
+        target[property] = options[property];
+      }
+    });
+  }
 });
+

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -46,13 +46,13 @@
       "version": "1.0.0"
     },
     "angular": {
-      "version": "1.4.8"
+      "version": "1.5.0-rc.2"
     },
     "angular-animate": {
-      "version": "1.4.8"
+      "version": "1.5.0-rc.2"
     },
     "angular-mocks": {
-      "version": "1.4.8"
+      "version": "1.5.0-rc.2"
     },
     "ansi": {
       "version": "0.3.0"
@@ -5337,7 +5337,12 @@
       "version": "1.0.0"
     },
     "ts-api-guardian": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "dependencies": {
+        "typescript": {
+          "version": "1.7.3"
+        }
+      }
     },
     "ts2dart": {
       "version": "0.7.19",
@@ -5823,5 +5828,5 @@
     }
   },
   "name": "angular-srcs",
-  "version": "2.0.0-beta.1"
+  "version": "2.0.0-beta.2"
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "dependencies": {
     "abbrev": {
       "version": "1.0.7",
@@ -74,19 +74,19 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
     },
     "angular": {
-      "version": "1.4.8",
-      "from": "angular@>=1.4.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/angular/-/angular-1.4.8.tgz"
+      "version": "1.5.0-rc.2",
+      "from": "angular@1.5.0-rc.2",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.5.0-rc.2.tgz"
     },
     "angular-animate": {
-      "version": "1.4.8",
-      "from": "angular-animate@>=1.4.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/angular-animate/-/angular-animate-1.4.8.tgz"
+      "version": "1.5.0-rc.2",
+      "from": "angular-animate@1.5.0-rc.2",
+      "resolved": "https://registry.npmjs.org/angular-animate/-/angular-animate-1.5.0-rc.2.tgz"
     },
     "angular-mocks": {
-      "version": "1.4.8",
-      "from": "angular-mocks@>=1.4.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.4.8.tgz"
+      "version": "1.5.0-rc.2",
+      "from": "angular-mocks@1.5.0-rc.2",
+      "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.5.0-rc.2.tgz"
     },
     "ansi": {
       "version": "0.3.0",
@@ -2659,7 +2659,8 @@
       "dependencies": {
         "mime-db": {
           "version": "1.20.0",
-          "from": "mime-db@>=1.19.0 <2.0.0"
+          "from": "mime-db@1.20.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
         }
       }
     },
@@ -7809,7 +7810,8 @@
         },
         "mime-types": {
           "version": "2.1.8",
-          "from": "mime-types@>=2.1.4 <2.2.0"
+          "from": "mime-types@2.1.8",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz"
         }
       }
     },
@@ -8505,7 +8507,15 @@
     },
     "ts-api-guardian": {
       "version": "0.0.2",
-      "from": "ts-api-guardian@0.0.2"
+      "from": "ts-api-guardian@0.0.2",
+      "resolved": "https://registry.npmjs.org/ts-api-guardian/-/ts-api-guardian-0.0.2.tgz",
+      "dependencies": {
+        "typescript": {
+          "version": "1.7.3",
+          "from": "typescript@1.7.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.7.3.tgz"
+        }
+      }
     },
     "ts2dart": {
       "version": "0.7.19",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "zone.js": "0.5.10"
   },
   "devDependencies": {
-    "angular": "^1.4.7",
-    "angular-animate": "^1.4.7",
-    "angular-mocks": "^1.4.7",
+    "angular": "^1.5.0-rc.2",
+    "angular-animate": "^1.5.0-rc.2",
+    "angular-mocks": "^1.5.0-rc.2",
     "base64-js": "^0.0.8",
     "bower": "^1.3.12",
     "broccoli": "^0.16.9",


### PR DESCRIPTION
In Angular 1.5 there is a new helper method for creating component directives.
See https://docs.angularjs.org/guide/component for more information about components.

These kind of directives only match the `E` element form and the previously component
router only created HTML that matched directives that matched the `A` attribute form.

This commit changes the `<ng-outlet>` directive so that it generates custom HTML
elements rather divs with custom attributes to trigger the relevant component to
appear in the DOM.

Going forward, Angular 1.5 users are encouraged to create their router components
using the following style:

```
myModule.componnet('component-name', {
  // component definition object
});
```

Closes angular/angular.js#13860
Closes #5278

BREAKING CHANGE:

The component router now creates custom element HTML rather than custom attribute
HTML, in order to create a new component. So rather than

``` html
<div custom-component></div>
```

it now creates

``` html
<custom-component></custom-component>
```

If you defined you router components using the `directive()` helper and
specified the `restrict` properties such that element matching was not allowed,
e.g. `restrict: 'A'` then these components will no longer be instantiated
by the component router and the outlet will be empty.

The fix is to include `E` in the `restrict` property.

`restrict: 'EA'`

Note that this does not affect directives that did not specify the `restrict`
property as the default for this property is already `EA`.
