### PR TITLE
Perftest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,8 @@ pubspec.lock
 # Don't check in secret files
 *secret.js
 
+# Don't check in downloaded jar files or log files
+*.jar
+*.log
+
 /docs/bower_components/

--- a/README.md
+++ b/README.md
@@ -74,6 +74,32 @@ Angular specific command line options when running protractor:
 Angular specific command line options when running protractor (e.g. force gc, ...):
 `protractor protractor-{js|dart2js}-conf.js --ng-help`
 
+### Test on mobile devices
+
+## iOS:
+
+1. Download [latest iphone-driver](http://ios-driver-ci.ebaystratus.com/userContent/ios-server-standalone-0.6.6-SNAPSHOT.jar),
+   see `scripts/ci/install_io_driver.sh`.
+2. create a wifi network on which the iOS device can see the server
+3. Run `java -jar ios-server-standalone-0.6.6-SNAPSHOT.jar -real`
+4. `protractor protractor-js.conf.js --browsers=SafariIos --seleniumAddress=http://localhost:5555/wd/hub --serverAddress=yourServerName`
+
+Notes:
+* ios-driver does not yet support iOS 8.x native devices, so only use iOS 7.x for them
+* ios-driver does support iOS 8.x for the iOS simulator
+
+## Android:
+
+1. get root access so that you can control the CPU speed of the device
+  * e.g. flash a so called user-debug build of Android
+2. connect your Android device via usb
+3. run `./scripts/ci/init_android.sh`. This will:
+  * set up a reverse proxy so that the browser on Android can use `localhost`
+  * set the cpu speed to a fixed value
+  * prevent the device from sleeping
+4. `protractor protractor-js.conf.js --browsers=ChromeAndroid`
+
+
 ### Examples
 
 To see the examples, first build the project as described above.

--- a/modules/benchpress/src/runner.js
+++ b/modules/benchpress/src/runner.js
@@ -72,9 +72,6 @@ var _DEFAULT_BINDINGS = [
   WebDriverExtension.bindTo([ChromeDriverExtension, IOsDriverExtension]),
   Metric.bindTo(MultiMetric),
 
-  bind(Options.CAPABILITIES).toAsyncFactory(
-    (adapter) => adapter.capabilities(), [WebDriverAdapter]
-  ),
   bind(Options.USER_AGENT).toAsyncFactory(
     (adapter) => adapter.executeScript('return window.navigator.userAgent;'), [WebDriverAdapter]
   )

--- a/modules/benchpress/src/sample_options.js
+++ b/modules/benchpress/src/sample_options.js
@@ -14,8 +14,6 @@ export class Options {
   // TODO(tbosch): use static initializer when our transpiler supports it
   static get EXECUTE() { return _EXECUTE; }
   // TODO(tbosch): use static initializer when our transpiler supports it
-  static get CAPABILITIES() { return _CAPABILITIES; }
-  // TODO(tbosch): use static initializer when our transpiler supports it
   static get USER_AGENT() { return _USER_AGENT; }
   // TODO(tbosch): use static initializer when our transpiler supports it
   /**
@@ -31,6 +29,5 @@ var _SAMPLE_DESCRIPTION = new OpaqueToken('Options.sampleDescription');
 var _FORCE_GC = new OpaqueToken('Options.forceGc');
 var _PREPARE = new OpaqueToken('Options.prepare');
 var _EXECUTE = new OpaqueToken('Options.execute');
-var _CAPABILITIES = new OpaqueToken('Options.capabilities');
 var _USER_AGENT = new OpaqueToken('Options.userAgent');
 var _MICRO_ITERATIONS = new OpaqueToken('Options.microIterations');

--- a/modules/benchpress/src/web_driver_extension.js
+++ b/modules/benchpress/src/web_driver_extension.js
@@ -20,19 +20,19 @@ export class WebDriverExtension {
         [Injector]
       ),
       bind(WebDriverExtension).toFactory(
-        (children, capabilities) => {
+        (children, userAgent) => {
           var delegate;
           ListWrapper.forEach(children, (extension) => {
-            if (extension.supports(capabilities)) {
+            if (extension.supports(userAgent)) {
               delegate = extension;
             }
           });
           if (isBlank(delegate)) {
-            throw new BaseException('Could not find a delegate for given capabilities!');
+            throw new BaseException(`Could not find a delegate for userAgent ${userAgent}!`);
           }
           return delegate;
         },
-        [_CHILDREN, Options.CAPABILITIES]
+        [_CHILDREN, Options.USER_AGENT]
       )
     ];
   }
@@ -64,7 +64,7 @@ export class WebDriverExtension {
     throw new BaseException('NYI');
   }
 
-  supports(capabilities:StringMap):boolean {
+  supports(userAgent:string):boolean {
     return true;
   }
 }

--- a/modules/benchpress/src/webdriver/chrome_driver_extension.js
+++ b/modules/benchpress/src/webdriver/chrome_driver_extension.js
@@ -111,8 +111,8 @@ export class ChromeDriverExtension extends WebDriverExtension {
     return normalizedEvents;
   }
 
-  supports(capabilities:StringMap):boolean {
-    return StringWrapper.equals(capabilities['browserName'].toLowerCase(), 'chrome');
+  supports(userAgent:string):boolean {
+    return isPresent(RegExpWrapper.firstMatch(_USER_AGENT_REGEX, userAgent));
   }
 }
 
@@ -141,6 +141,8 @@ function normalizeEvent(chromeEvent, data) {
   });
   return result;
 }
+
+var _USER_AGENT_REGEX = RegExpWrapper.create('\\bChrome\\b');
 
 var _BINDINGS = [
   bind(ChromeDriverExtension).toFactory(

--- a/modules/benchpress/test/web_driver_extension_spec.js
+++ b/modules/benchpress/test/web_driver_extension_spec.js
@@ -7,18 +7,18 @@ import { PromiseWrapper } from 'angular2/src/facade/async';
 import { WebDriverExtension, bind, Injector, Options } from 'benchpress/common';
 
 export function main() {
-  function createExtension(ids, caps) {
+  function createExtension(ids, userAgent) {
     return new Injector([
       ListWrapper.map(ids, (id) => bind(id).toValue(new MockExtension(id)) ),
-      bind(Options.CAPABILITIES).toValue(caps),
+      bind(Options.USER_AGENT).toValue(userAgent),
       WebDriverExtension.bindTo(ids)
     ]).asyncGet(WebDriverExtension);
   }
 
   describe('WebDriverExtension.bindTo', () => {
 
-    it('should bind the extension that matches the capabilities', (done) => {
-      createExtension(['m1', 'm2', 'm3'], {'browser': 'm2'}).then( (m) => {
+    it('should bind the extension that matches the userAgent', (done) => {
+      createExtension(['m1', 'm2', 'm3'], 'm2').then( (m) => {
         expect(m.id).toEqual('m2');
         done();
       });
@@ -26,7 +26,7 @@ export function main() {
 
     it('should throw if there is no match', (done) => {
       PromiseWrapper.catchError(
-        createExtension(['m1'], {'browser': 'm2'}),
+        createExtension(['m1'], 'm2'),
         (err) => {
           expect(isPresent(err)).toBe(true);
           done();
@@ -45,7 +45,7 @@ class MockExtension extends WebDriverExtension {
     this.id = id;
   }
 
-  supports(capabilities:StringMap):boolean {
-    return StringWrapper.equals(capabilities['browser'], this.id);
+  supports(userAgent:string):boolean {
+    return StringWrapper.equals(userAgent, this.id);
   }
 }

--- a/modules/benchpress/test/webdriver/chrome_driver_extension_spec.js
+++ b/modules/benchpress/test/webdriver/chrome_driver_extension_spec.js
@@ -208,13 +208,8 @@ export function main() {
       });
 
       it('should match chrome browsers', () => {
-        expect(createExtension().supports({
-          'browserName': 'chrome'
-        })).toBe(true);
-
-        expect(createExtension().supports({
-          'browserName': 'Chrome'
-        })).toBe(true);
+        expect(createExtension().supports('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) '
+          +'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.74 Safari/537.36')).toBe(true);
       });
 
     });

--- a/modules/benchpress/test/webdriver/ios_driver_extension_spec.js
+++ b/modules/benchpress/test/webdriver/ios_driver_extension_spec.js
@@ -156,13 +156,8 @@ export function main() {
       });
 
       it('should match safari browsers', () => {
-        expect(createExtension().supports({
-          'browserName': 'safari'
-        })).toBe(true);
-
-        expect(createExtension().supports({
-          'browserName': 'Safari'
-        })).toBe(true);
+        expect(createExtension().supports('Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) '+
+          'AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53')).toBe(true);
       });
 
     });

--- a/modules/examples/e2e_test/benchpress/smoke_test_perf.es6
+++ b/modules/examples/e2e_test/benchpress/smoke_test_perf.es6
@@ -1,0 +1,31 @@
+// Note: This does not use the common utilities for perf tests
+// in Angular2 to show how to write a simple standalone perf test
+// with benchpress.
+var benchpress = require('benchpress/benchpress');
+var runner = createRunner();
+
+describe('benchpress', () => {
+
+  fit('should work', (done) => {
+    browser.get('examples/src/benchpress/index.html');
+
+    runner.sample({
+      id: 'benchpress smoke test',
+      execute: () => {
+        $('button').click();
+        expect($('#log').getText()).toBe('hi');
+      }
+    }).then(done, done.fail);
+
+  });
+
+});
+
+function createRunner() {
+  return new benchpress.Runner([
+    benchpress.SeleniumWebDriverAdapter.PROTRACTOR_BINDINGS,
+    benchpress.bind(benchpress.Options.FORCE_GC).toValue(false),
+    benchpress.Validator.bindTo(benchpress.RegressionSlopeValidator),
+    benchpress.bind(benchpress.RegressionSlopeValidator.SAMPLE_SIZE).toValue(3)
+  ]);
+}

--- a/protractor-dart2js.conf.js
+++ b/protractor-dart2js.conf.js
@@ -1,7 +1,7 @@
 var data = module.exports = require('./protractor-shared.js');
 var config = data.config;
 
-config.baseUrl = 'http://localhost:8002/';
+config.baseUrl = 'http://'+config.serverAddress+':8002/';
 
 config.exclude.push(
   'dist/js/cjs/examples/e2e_test/sourcemap/sourcemap_spec.js',

--- a/protractor-js.conf.js
+++ b/protractor-js.conf.js
@@ -1,7 +1,7 @@
 var data = module.exports = require('./protractor-shared.js');
 var config = data.config;
 
-config.baseUrl = 'http://localhost:8001/';
+config.baseUrl = 'http://'+config.serverAddress+':8001/';
 // TODO: remove exclusion when JS verison of scrolling benchmark is available
 config.exclude.push('dist/js/cjs/benchmarks_external/e2e_test/naive_infinite_scroll_spec.js');
 config.exclude.push('dist/js/cjs/benchmarks_external/e2e_test/naive_infinite_scroll_perf.js');

--- a/protractor-shared.js
+++ b/protractor-shared.js
@@ -143,8 +143,10 @@ function patchProtractorWait(browser) {
   var _get = browser.get;
   var sleepInterval = process.env.TRAVIS || process.env.JENKINS_URL ? 10000 : 10000;
   browser.get = function() {
+    console.log('------> waiting before get');
     browser.sleep(4000);
     var result = _get.apply(this, arguments);
+    console.log('------> waiting after get');
     browser.sleep(sleepInterval);
     return result;
   }

--- a/protractor-shared.js
+++ b/protractor-shared.js
@@ -141,7 +141,7 @@ var config = exports.config = {
 function patchProtractorWait(browser) {
   browser.ignoreSynchronization = true;
   var _get = browser.get;
-  var sleepInterval = process.env.TRAVIS || process.env.JENKINS_URL ? 7000 : 3000;
+  var sleepInterval = process.env.TRAVIS || process.env.JENKINS_URL ? 10000 : 10000;
   browser.get = function() {
     var result = _get.apply(this, arguments);
     browser.sleep(sleepInterval);

--- a/protractor-shared.js
+++ b/protractor-shared.js
@@ -143,6 +143,7 @@ function patchProtractorWait(browser) {
   var _get = browser.get;
   var sleepInterval = process.env.TRAVIS || process.env.JENKINS_URL ? 10000 : 10000;
   browser.get = function() {
+    browser.sleep(4000);
     var result = _get.apply(this, arguments);
     browser.sleep(sleepInterval);
     return result;

--- a/scripts/ci/install_ios_driver.sh
+++ b/scripts/ci/install_ios_driver.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+set -e -x
+
+curl -O -L http://ios-driver-ci.ebaystratus.com/userContent/ios-server-standalone-0.6.6-SNAPSHOT.jar

--- a/scripts/ci/test_perf.sh
+++ b/scripts/ci/test_perf.sh
@@ -7,7 +7,9 @@ SCRIPT_DIR=$(dirname $0)
 cd $SCRIPT_DIR/../..
 
 IOS_SERVER_BINARY="ios-server-standalone-0.6.6-SNAPSHOT.jar"
-HOSTNAME=$(hostname)
+# This is fixed as Jenkins is running on the host
+# that also hosts the wifi
+HOSTNAME="192.168.2.1"
 PROTRACTOR="./node_modules/.bin/protractor"
 # TODO(tbosch): only running a smoke test on iOS as our transpiled sources don't run in Safari yet.
 IOS_ARGS="--seleniumAddress=http://localhost:5555/wd/hub --hostname=$HOSTNAME \
@@ -51,7 +53,7 @@ if [[ $IOS_BROWSER ]]; then
 fi
 
 # wait for server to come up!
-sleep 10
+sleep 20
 
 if [[ $IOS_BROWSER ]]; then
   echo Running ios tests

--- a/scripts/ci/test_perf.sh
+++ b/scripts/ci/test_perf.sh
@@ -7,12 +7,9 @@ SCRIPT_DIR=$(dirname $0)
 cd $SCRIPT_DIR/../..
 
 IOS_SERVER_BINARY="ios-server-standalone-0.6.6-SNAPSHOT.jar"
-# This is fixed as Jenkins is running on the host
-# that also hosts the wifi
-HOSTNAME="192.168.2.1"
 PROTRACTOR="./node_modules/.bin/protractor"
 # TODO(tbosch): only running a smoke test on iOS as our transpiled sources don't run in Safari yet.
-IOS_ARGS="--seleniumAddress=http://localhost:5555/wd/hub --hostname=$HOSTNAME \
+IOS_ARGS="--seleniumAddress=http://localhost:5555/wd/hub --hostname=$CIHOSTADDRESS \
   --specs=dist/js/cjs/examples/e2e_test/benchpress/smoke_test_perf.js"
 IOS_BROWSER_NAME="SafariIos"
 
@@ -48,12 +45,12 @@ serverPid=$!
 
 if [[ $IOS_BROWSER ]]; then
   echo Starting ios selenium server
-  java -jar $IOS_SERVER_BINARY -real &>/dev/null&
+  java -jar $IOS_SERVER_BINARY -real&
   iosServerPid=$!
 fi
 
 # wait for server to come up!
-sleep 20
+sleep 40
 
 if [[ $IOS_BROWSER ]]; then
   echo Running ios tests

--- a/scripts/ci/test_perf.sh
+++ b/scripts/ci/test_perf.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 echo =============================================================================
 # go to project dir
@@ -29,7 +29,6 @@ function killServer () {
   if [[ $serverPid ]]; then
     kill $serverPid
   fi
-  kill $serverPid
   if [[ $iosServerPid ]]; then
     kill $iosServerPid
   fi
@@ -50,7 +49,7 @@ if [[ $IOS_BROWSER ]]; then
 fi
 
 # wait for server to come up!
-sleep 40
+sleep 120
 
 if [[ $IOS_BROWSER ]]; then
   echo Running ios tests

--- a/scripts/ci/test_perf.sh
+++ b/scripts/ci/test_perf.sh
@@ -45,6 +45,7 @@ function waitForUrl {
     echo waiting $((COUNT++)) seconds
   done
   if [[ $COUNT == $MAX_COUNT ]]; then
+    echo timeout after waiting $COUNT seconds!
     return 1
   else
     return 0

--- a/scripts/ci/test_perf.sh
+++ b/scripts/ci/test_perf.sh
@@ -4,22 +4,62 @@ set -e
 echo =============================================================================
 # go to project dir
 SCRIPT_DIR=$(dirname $0)
-source $SCRIPT_DIR/env_dart.sh
 cd $SCRIPT_DIR/../..
+
+IOS_SERVER_BINARY="ios-server-standalone-0.6.6-SNAPSHOT.jar"
+HOSTNAME=$(hostname)
+PROTRACTOR="./node_modules/.bin/protractor"
+# TODO(tbosch): only running a smoke test on iOS as our transpiled sources don't run in Safari yet.
+IOS_ARGS="--seleniumAddress=http://localhost:5555/wd/hub --hostname=$HOSTNAME \
+  --specs=dist/js/cjs/examples/e2e_test/benchpress/smoke_test_perf.js"
+IOS_BROWSER_NAME="SafariIos"
+
+# Split $PERF_BROWSERS into $NON_IOS_BROWSERS and $IOS_BROWSER
+# This is needed as we need a special selenium server for ios
+if [[ $PERF_BROWSERS == *$IOS_BROWSER_NAME* ]]; then
+  IOS_BROWSER=$IOS_BROWSER_NAME
+fi
+NON_IOS_BROWSERS=${PERF_BROWSERS/$IOS_BROWSER_NAME/}
+# remove extra command at front/end
+NON_IOS_BROWSERS=${NON_IOS_BROWSERS#,}
+NON_IOS_BROWSERS=${NON_IOS_BROWSERS%,}
+
+source $SCRIPT_DIR/env_dart.sh
+
+function killServer () {
+  if [[ $serverPid ]]; then
+    kill $serverPid
+  fi
+  kill $serverPid
+  if [[ $iosServerPid ]]; then
+    kill $iosServerPid
+  fi
+}
+
+trap killServer EXIT
 
 ./node_modules/.bin/webdriver-manager update
 
-function killServer () {
-  kill $serverPid
-}
-
+echo Starting webserver
 ./node_modules/.bin/gulp serve.js.prod serve.js.dart2js&
 serverPid=$!
 
-trap killServer EXIT
+if [[ $IOS_BROWSER ]]; then
+  echo Starting ios selenium server
+  java -jar $IOS_SERVER_BINARY -real &>/dev/null&
+  iosServerPid=$!
+fi
 
 # wait for server to come up!
 sleep 10
 
-./node_modules/.bin/protractor protractor-js.conf.js --browsers=$PERF_BROWSERS --benchmark
-./node_modules/.bin/protractor protractor-dart2js.conf.js --browsers=$PERF_BROWSERS --benchmark
+if [[ $IOS_BROWSER ]]; then
+  echo Running ios tests
+  $PROTRACTOR protractor-js.conf.js --benchmark --browsers=$IOS_BROWSER $IOS_ARGS
+  # TODO $PROTRACTOR protractor-dart2js.conf.js --benchmark --browsers=$IOS_BROWSER $IOS_ARGS
+fi
+if [[ $NON_IOS_BROWSERS ]]; then
+  echo Running non ios tests
+  $PROTRACTOR protractor-js.conf.js --benchmark --browsers=$NON_IOS_BROWSERS
+  # TODO $PROTRACTOR protractor-dart2js.conf.js --benchmark --browsers=$NON_IOS_BROWSERS
+fi

--- a/scripts/ci/test_perf.sh
+++ b/scripts/ci/test_perf.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 echo =============================================================================
 # go to project dir
@@ -61,7 +61,7 @@ echo Started webserver
 
 if [[ $IOS_BROWSER ]]; then
   echo Starting ios selenium server
-  java -jar $IOS_SERVER_BINARY -real&
+  java -jar $IOS_SERVER_BINARY -real &> /dev/null&
   iosServerPid=$!
   waitForUrl http://localhost:5555/wd/hub
   echo Started ios selenium server

--- a/scripts/jenkins/jenkins_perf.sh
+++ b/scripts/jenkins/jenkins_perf.sh
@@ -13,6 +13,10 @@ export PERF_BROWSERS=SafariIos
 export CLOUD_SECRET_PATH="/Users/Shared/jenkins/keys/perf-cloud-secret"
 export GIT_SHA=$(git rev-parse HEAD)
 
+# This is fixed as Jenkins is running on the host
+# that also hosts the wifi
+export CIHOSTADDRESS=192.168.2.1
+
 nvm use 0.10
 
 # TODO ./scripts/ci/init_android.sh

--- a/scripts/jenkins/jenkins_perf.sh
+++ b/scripts/jenkins/jenkins_perf.sh
@@ -8,19 +8,20 @@ export PATH+=":/usr/local/git/bin"
 
 export DART_CHANNEL=dev
 export ARCH=macos-ia32
-export PERF_BROWSERS=ChromeAndroid
+# TODO export PERF_BROWSERS=ChromeAndroid,SafariIos
+export PERF_BROWSERS=SafariIos
 export CLOUD_SECRET_PATH="/Users/Shared/jenkins/keys/perf-cloud-secret"
 export GIT_SHA=$(git rev-parse HEAD)
 
 nvm use 0.10
 
-./scripts/ci/init_android.sh
+# TODO ./scripts/ci/init_android.sh
 ./scripts/ci/install_dart.sh ${DART_CHANNEL} ${ARCH}
-npm cache clean
+./scripts/ci/install_ios_driver.sh
 # use newest npm because of errors during npm install like
 # npm ERR! EEXIST, open '/Users/Shared/Jenkins/.npm/e4d0eb16-adable-stream-1-1-13-package-tgz.lock'
 npm install -g npm@2.6
 npm install
 ./scripts/ci/build_js.sh
-./scripts/ci/build_dart.sh
+# TODO ./scripts/ci/build_dart.sh
 ./scripts/ci/test_perf.sh


### PR DESCRIPTION
## Certificate Expiry

_According to Thawte, you can buy a code-signing certificate from them, valid for one or two years. You can sign code for one or two years_, then the certificate stops working. However the code you sign stays valid up to ten years. You get to choose how long you want it to remain valid when you do the signing. However, since jarsigner.exe has no -expiry option, I don’t know just how you would specify that.

More and more websites are refusing to update their expired SSL certificates. If you want to see the content, you have to override the expiry. This is defeating the whole point of expiry dates. However, the bright side of this is it should force down the cost of renewed certificates which should be cheaper for the certificate authority to research. It is a blinking nuisance though for link checking.

```
// insert a dash between chars
String cute = "AA54BG4G3G".\u006C( "(\\w{2})(?!$)", "$1:" );
// cute is "AA-54-BG-4G-3G"
```
