### PR TITLE
build(npm): Move rxjs to `dependencies` of angular2

### DIFF
--- a/modules/angular2/package.json
+++ b/modules/angular2/package.json
@@ -7,12 +7,14 @@
   "contributors": <%= JSON.stringify(packageJson.contributors) %>,
   "license": "<%= packageJson.license %>",
   "repository": <%= JSON.stringify(packageJson.repository) %>,
+  "dependencies": {
+    "rxjs": "<%= packageJson.dependencies['rxjs'] %>"
+  },
   "devDependencies": <%= JSON.stringify(packageJson.defaultDevDependencies) %>,
   "peerDependencies": {
     "es6-promise": "<%= packageJson.dependencies['es6-promise'] %>",
     "es6-shim": "<%= packageJson.dependencies['es6-shim'] %>",
     "reflect-metadata": "<%= packageJson.dependencies['reflect-metadata'] %>",
-    "rxjs": "<%= packageJson.dependencies['rxjs'] %>",
     "zone.js": "<%= packageJson.dependencies['zone.js'] %>"
   }
 }

--- a/modules/angular2/src/http/package.json
+++ b/modules/angular2/src/http/package.json
@@ -9,7 +9,6 @@
   "repository": <%= JSON.stringify(packageJson.repository) %>,
   "devDependencies": <%= JSON.stringify(packageJson.defaultDevDependencies) %>,
   "peerDependencies": {
-    "angular2": "<%= packageJson.version %>",
-    "rxjs": "<%= packageJson.dependencies['rxjs'] %>"
+    "angular2": "<%= packageJson.version %>"
   }
 }


### PR DESCRIPTION
Close #6659 

In npm v3, peerDependencies are no longer installed implicitly.

Contributors can install those as dependencies from package.json on root, but library users cannot. I must install rxjs explicitly; `npm install --save angular2@2.0.0-beta.2 rxjs@5.0.0-beta.0`. 

RxJS is needed always. I think it should be in `dependencies`.
