### PR TITLE
fix(di): throw if a token uses more than 20 dependencies.

### DIFF
--- a/modules/angular2/src/core/di/injector.ts
+++ b/modules/angular2/src/core/di/injector.ts
@@ -17,6 +17,7 @@ import {
   OutOfBoundsError
 } from './exceptions';
 import {FunctionWrapper, Type, isPresent, isBlank, CONST_EXPR} from 'angular2/src/facade/lang';
+import {BaseException} from 'angular2/src/facade/exceptions';
 import {Key} from './key';
 import {SelfMetadata, HostMetadata, SkipSelfMetadata} from './metadata';
 
@@ -874,6 +875,9 @@ export class Injector {
           obj = factory(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16,
                         d17, d18, d19);
           break;
+        default:
+          throw new BaseException(
+              `Cannot instantiate '${provider.key.displayName}' because it has more than 20 dependencies`);
       }
     } catch (e) {
       throw new InstantiationError(this, e, e.stack, provider.key);

--- a/modules/angular2/test/core/di/injector_spec.ts
+++ b/modules/angular2/test/core/di/injector_spec.ts
@@ -189,6 +189,49 @@ export function main() {
         expect(car.engine).toBeAnInstanceOf(Engine);
       });
 
+      it('should throw when using a factory with more than 20 dependencies', () => {
+        function factoryWithTooManyArgs() { return new Car(null); }
+
+        var injector = createInjector([
+          Engine,
+          provide(Car,
+                  {
+                    useFactory: factoryWithTooManyArgs,
+                    deps: [
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine,
+                      Engine
+                    ]
+                  })
+        ]);
+
+        try {
+          injector.get(Car);
+          throw "Must throw";
+        } catch (e) {
+          expect(e.message)
+              .toContain(`Cannot instantiate 'Car' because it has more than 20 dependencies`);
+        }
+      });
+
       it('should supporting provider to null', () => {
         var injector = createInjector([provide(Engine, {useValue: null})]);
         var engine = injector.get(Engine);


### PR DESCRIPTION
Fixes #6690
