### PR TITLE
fix(compiler): use event names for matching directives

### DIFF
--- a/modules/angular2/src/compiler/template_parser.ts
+++ b/modules/angular2/src/compiler/template_parser.ts
@@ -433,8 +433,9 @@ class TemplateParseVisitor implements HtmlAstVisitor {
     var parts = splitAtColon(name, [null, name]);
     var target = parts[0];
     var eventName = parts[1];
-    targetEvents.push(new BoundEventAst(eventName, target,
-                                        this._parseAction(expression, sourceSpan), sourceSpan));
+    var ast = this._parseAction(expression, sourceSpan);
+    targetMatchableAttrs.push([name, ast.source]);
+    targetEvents.push(new BoundEventAst(eventName, target, ast, sourceSpan));
     // Don't detect directives for event names for now,
     // so don't add the event name to the matchableAttrs
   }

--- a/modules/angular2/test/compiler/template_parser_spec.ts
+++ b/modules/angular2/test/compiler/template_parser_spec.ts
@@ -327,6 +327,15 @@ export function main() {
               ]);
         });
 
+        it('should locate directives in event bindings', () => {
+          var dirA = CompileDirectiveMetadata.create(
+              {selector: '[a]', type: new CompileTypeMetadata({name: 'DirB'})});
+
+          expect(humanizeTplAst(parse('<div (a)="b">', [dirA])))
+              .toEqual(
+                  [[ElementAst, 'div'], [BoundEventAst, 'a', null, 'b'], [DirectiveAst, dirA]]);
+        });
+
         it('should parse directive host properties', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: 'div',

--- a/modules/angular2/test/core/linker/integration_spec.ts
+++ b/modules/angular2/test/core/linker/integration_spec.ts
@@ -448,6 +448,21 @@ function declareTests() {
                });
          }));
 
+      it('should support directives where a selector matches event binding',
+         inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
+           tcb.overrideView(
+                  MyComp,
+                  new ViewMetadata(
+                      {template: '<p (customEvent)="doNothing()"></p>', directives: [EventDir]}))
+
+               .createAsync(MyComp)
+               .then((fixture) => {
+                 var tc = fixture.debugElement.children[0];
+                 expect(tc.inject(EventDir)).not.toBe(null);
+                 async.done();
+               });
+         }));
+
       it('should read directives metadata from their binding token',
          inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
            tcb.overrideView(MyComp, new ViewMetadata({
@@ -2131,6 +2146,13 @@ class DirectiveListeningDomEventNoPrevent {
 @Injectable()
 class IdDir {
   id: string;
+}
+
+@Directive({selector: '[customEvent]'})
+@Injectable()
+class EventDir {
+  @Output() customEvent = new EventEmitter();
+  doSomething() {}
 }
 
 @Directive({selector: '[static]'})


### PR DESCRIPTION
Closes #5707
