### PR TITLE
chore(package.json): ensure zone.js allows patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "es6-shim": "^0.33.3",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.0",
-    "zone.js": "0.5.11"
+    "zone.js": "~0.5.11"
   },
   "devDependencies": {
     "angular": "^1.4.7",


### PR DESCRIPTION
rather than publishing all the time why don't we just allow all patches? There shouldn't be any breaking changes in the api for patches

related problem: https://github.com/angular/zone.js/issues/240
