### PR TITLE
refactor(dart/transform): Migrates tests to use package:test

### DIFF
--- a/modules_dart/transform/test/transform/common/async_string_writer_tests.dart
+++ b/modules_dart/transform/test/transform/common/async_string_writer_tests.dart
@@ -1,76 +1,78 @@
 library angular2.test.transform.common.async_string_writer;
 
 import 'dart:async';
+
+import 'package:test/test.dart';
+
 import 'package:angular2/src/transform/common/async_string_writer.dart';
-import 'package:guinness/guinness.dart';
 
 void allTests() {
-  it('should function as a basic Writer without async calls.', () {
+  test('should function as a basic Writer without async calls.', () {
     var writer = new AsyncStringWriter();
     writer.print('hello');
-    expect('$writer').toEqual('hello');
+    expect('$writer', equals('hello'));
     writer.println(', world');
-    expect('$writer').toEqual('hello, world\n');
+    expect('$writer', equals('hello, world\n'));
   });
 
-  it('should concatenate futures added with `asyncPrint`.', () async {
+  test('should concatenate futures added with `asyncPrint`.', () async {
     var writer = new AsyncStringWriter();
     writer.print('hello');
-    expect('$writer').toEqual('hello');
+    expect('$writer', equals('hello'));
     writer.asyncPrint(new Future.value(', world.'));
     writer.print(' It is a beautiful day.');
-    expect(await writer.asyncToString())
-        .toEqual('hello, world. It is a beautiful day.');
+    expect(await writer.asyncToString(),
+        equals('hello, world. It is a beautiful day.'));
   });
 
-  it('should concatenate multiple futures regardless of order.', () async {
+  test('should concatenate multiple futures regardless of order.', () async {
     var completer1 = new Completer<String>();
     var completer2 = new Completer<String>();
 
     var writer = new AsyncStringWriter();
     writer.print('hello');
-    expect('$writer').toEqual('hello');
+    expect('$writer', equals('hello'));
     writer.asyncPrint(completer1.future);
     writer.asyncPrint(completer2.future);
 
     completer2.complete(' It is a beautiful day.');
     completer1.complete(', world.');
 
-    expect(await writer.asyncToString())
-        .toEqual('hello, world. It is a beautiful day.');
+    expect(await writer.asyncToString(),
+        equals('hello, world. It is a beautiful day.'));
   });
 
-  it('should allow multiple "rounds" of `asyncPrint`.', () async {
+  test('should allow multiple "rounds" of `asyncPrint`.', () async {
     var writer = new AsyncStringWriter();
     writer.print('hello');
-    expect('$writer').toEqual('hello');
+    expect('$writer', equals('hello'));
     writer.asyncPrint(new Future.value(', world.'));
-    expect(await writer.asyncToString()).toEqual('hello, world.');
+    expect(await writer.asyncToString(), equals('hello, world.'));
 
     writer.asyncPrint(new Future.value(' It is '));
     writer.asyncPrint(new Future.value('a beautiful '));
     writer.asyncPrint(new Future.value('day.'));
 
-    expect(await writer.asyncToString())
-        .toEqual('hello, world. It is a beautiful day.');
+    expect(await writer.asyncToString(),
+        equals('hello, world. It is a beautiful day.'));
   });
 
-  it('should handle calls to async methods while waiting.', () {
+  test('should handle calls to async methods while waiting.', () {
     var completer1 = new Completer<String>();
     var completer2 = new Completer<String>();
 
     var writer = new AsyncStringWriter();
     writer.print('hello');
-    expect('$writer').toEqual('hello');
+    expect('$writer', equals('hello'));
 
     writer.asyncPrint(completer1.future);
     var f1 = writer.asyncToString().then((result) {
-      expect(result).toEqual('hello, world.');
+      expect(result, equals('hello, world.'));
     });
 
     writer.asyncPrint(completer2.future);
     var f2 = writer.asyncToString().then((result) {
-      expect(result).toEqual('hello, world. It is a beautiful day.');
+      expect(result, equals('hello, world. It is a beautiful day.'));
     });
 
     completer1.complete(', world.');
@@ -79,7 +81,7 @@ void allTests() {
     return Future.wait([f1, f2]);
   });
 
-  it(
+  test(
       'should handle calls to async methods that complete in reverse '
       'order while waiting.', () {
     var completer1 = new Completer<String>();
@@ -87,16 +89,16 @@ void allTests() {
 
     var writer = new AsyncStringWriter();
     writer.print('hello');
-    expect('$writer').toEqual('hello');
+    expect('$writer', equals('hello'));
 
     writer.asyncPrint(completer1.future);
     var f1 = writer.asyncToString().then((result) {
-      expect(result).toEqual('hello, world.');
+      expect(result, equals('hello, world.'));
     });
 
     writer.asyncPrint(completer2.future);
     var f2 = writer.asyncToString().then((result) {
-      expect(result).toEqual('hello, world. It is a beautiful day.');
+      expect(result, equals('hello, world. It is a beautiful day.'));
     });
 
     completer2.complete(' It is a beautiful day.');

--- a/modules_dart/transform/test/transform/common/code/ng_deps_code_tests.dart
+++ b/modules_dart/transform/test/transform/common/code/ng_deps_code_tests.dart
@@ -1,16 +1,17 @@
 library angular2.test.transform.common.code.ng_deps_code_tests;
 
 import 'package:analyzer/analyzer.dart';
+import 'package:test/test.dart';
+
 import 'package:angular2/src/transform/common/code/ng_deps_code.dart';
 import 'package:angular2/src/transform/common/model/import_export_model.pb.dart';
 import 'package:angular2/src/transform/common/model/ng_deps_model.pb.dart';
-import 'package:guinness/guinness.dart';
 
 main() => allTests();
 
 void allTests() {
-  describe('writeNgDepsModel', () {
-    it('should output parsable code', () async {
+  group('writeNgDepsModel', () {
+    test('should output parsable code', () async {
       final ngDeps = new NgDepsModel()
         ..libraryUri = 'test.foo'
         ..imports.add(new ImportModel()
@@ -23,12 +24,12 @@ void allTests() {
 
       var compilationUnit = parseCompilationUnit(buf.toString());
 
-      expect(compilationUnit).toBeNotNull();
-      expect(compilationUnit.declarations).toBeNotNull();
-      expect(compilationUnit.declarations.length > 0).toBeTrue();
+      expect(compilationUnit, isNotNull);
+      expect(compilationUnit.declarations, isNotNull);
+      expect(compilationUnit.declarations.length > 0, isTrue);
     });
 
-    it('should output parsable code with deferred imports', () async {
+    test('should output parsable code with deferred imports', () async {
       // Regression test for i/4587.
       final ngDeps = new NgDepsModel()
         ..libraryUri = 'test.foo'
@@ -43,9 +44,9 @@ void allTests() {
 
       var compilationUnit = parseCompilationUnit(buf.toString());
 
-      expect(compilationUnit).toBeNotNull();
-      expect(compilationUnit.declarations).toBeNotNull();
-      expect(compilationUnit.declarations.length > 0).toBeTrue();
+      expect(compilationUnit, isNotNull);
+      expect(compilationUnit.declarations, isNotNull);
+      expect(compilationUnit.declarations.length > 0, isTrue);
     });
   });
 }

--- a/modules_dart/transform/test/transform/common/ng_meta_test.dart
+++ b/modules_dart/transform/test/transform/common/ng_meta_test.dart
@@ -1,9 +1,10 @@
 library angular2.test.transform.common.annotation_matcher_test;
 
+import 'package:test/test.dart';
+
 import 'package:angular2/src/core/render/api.dart';
 import 'package:angular2/src/compiler/directive_metadata.dart';
 import 'package:angular2/src/transform/common/ng_meta.dart';
-import 'package:guinness/guinness.dart';
 
 main() => allTests();
 
@@ -15,18 +16,18 @@ void allTests() {
     CompileDirectiveMetadata.create(type: new CompileTypeMetadata(name: 'N4'))
   ];
 
-  it('should allow empty data.', () {
+  test('should allow empty data.', () {
     var ngMeta = new NgMeta.empty();
-    expect(ngMeta.isEmpty).toBeTrue();
+    expect(ngMeta.isEmpty, isTrue);
   });
 
-  describe('serialization', () {
-    it('should parse empty data correctly.', () {
+  group('serialization', () {
+    test('should parse empty data correctly.', () {
       var ngMeta = new NgMeta.fromJson({});
-      expect(ngMeta.isEmpty).toBeTrue();
+      expect(ngMeta.isEmpty, isTrue);
     });
 
-    it('should be lossless', () {
+    test('should be lossless', () {
       var a = new NgMeta.empty();
       a.identifiers['T0'] = mockDirMetadata[0];
       a.identifiers['T1'] = mockDirMetadata[1];
@@ -42,8 +43,8 @@ void allTests() {
     });
   });
 
-  describe('flatten', () {
-    it('should include recursive aliases.', () {
+  group('flatten', () {
+    test('should include recursive aliases.', () {
       var a = new NgMeta.empty();
       a.identifiers['T0'] = mockDirMetadata[0];
       a.identifiers['T1'] = mockDirMetadata[1];
@@ -54,62 +55,62 @@ void allTests() {
       a.aliases['a3'] = ['T3', 'a2'];
       a.aliases['a4'] = ['a3', 'T0'];
 
-      expect(a.flatten('a4')).toEqual([mockDirMetadata[3], mockDirMetadata[1], mockDirMetadata[0]]);
+      expect(a.flatten('a4'), equals([mockDirMetadata[3], mockDirMetadata[1], mockDirMetadata[0]]));
     });
 
-    it('should detect cycles.', () {
+    test('should detect cycles.', () {
       var a = new NgMeta.empty();
       a.identifiers['T0'] = mockDirMetadata[0];
       a.aliases['a1'] = ['T0', 'a2'];
       a.aliases['a2'] = ['a1'];
 
-      expect(() => a.flatten('a1')).toThrowWith(message: new RegExp('Cycle: a1 -> a2 -> a1.'));
+      expect(() => a.flatten('a1'), throwsA(predicate((ex) => new RegExp('Cycle: a1 -> a2 -> a1.').hasMatch(ex.message))));
     });
 
-    it('should allow duplicates.', () {
+    test('should allow duplicates.', () {
       var a = new NgMeta.empty();
       a.identifiers['T0'] = mockDirMetadata[0];
       a.aliases['a1'] = ['T0', 'a2'];
       a.aliases['a2'] = ['T0'];
 
-      expect(() => a.flatten('a1')).not.toThrow();
+      expect(() => a.flatten('a1'), returnsNormally);
     });
   });
 
-  describe('merge', () {
-    it('should merge all identifiers on addAll', () {
+  group('merge', () {
+    test('should merge all identifiers on addAll', () {
       var a = new NgMeta.empty();
       var b = new NgMeta.empty();
       a.identifiers['T0'] = mockDirMetadata[0];
       b.identifiers['T1'] = mockDirMetadata[1];
       a.addAll(b);
-      expect(a.identifiers).toContain('T1');
-      expect(a.identifiers['T1']).toEqual(mockDirMetadata[1]);
+      expect(a.identifiers, contains('T1'));
+      expect(a.identifiers['T1'], equals(mockDirMetadata[1]));
     });
 
-    it('should merge all aliases on addAll', () {
+    test('should merge all aliases on addAll', () {
       var a = new NgMeta.empty();
       var b = new NgMeta.empty();
       a.aliases['a'] = ['x'];
       b.aliases['b'] = ['y'];
       a.addAll(b);
-      expect(a.aliases).toContain('b');
-      expect(a.aliases['b']).toEqual(['y']);
+      expect(a.aliases, contains('b'));
+      expect(a.aliases['b'], equals(['y']));
     });
   });
 }
 
 _checkSimilar(NgMeta a, NgMeta b) {
-  expect(a.identifiers.length).toEqual(b.identifiers.length);
-  expect(a.aliases.length).toEqual(b.aliases.length);
+  expect(a.identifiers.length, equals(b.identifiers.length));
+  expect(a.aliases.length, equals(b.aliases.length));
   for (var k in a.identifiers.keys) {
-    expect(b.identifiers).toContain(k);
+    expect(b.identifiers, contains(k));
     var at = a.identifiers[k];
     var bt = b.identifiers[k];
-    expect(at.type.name).toEqual(bt.type.name);
+    expect(at.type.name, equals(bt.type.name));
   }
   for (var k in a.aliases.keys) {
-    expect(b.aliases).toContain(k);
-    expect(b.aliases[k]).toEqual(a.aliases[k]);
+    expect(b.aliases, contains(k));
+    expect(b.aliases[k], equals(a.aliases[k]));
   }
 }

--- a/modules_dart/transform/test/transform/common/url_resolver_tests.dart
+++ b/modules_dart/transform/test/transform/common/url_resolver_tests.dart
@@ -1,166 +1,169 @@
 library angular2.test.transform.common.url_resolver_tests;
 
-import 'package:angular2/src/transform/common/url_resolver.dart';
 import 'package:barback/barback.dart';
-import 'package:guinness/guinness.dart';
+import 'package:test/test.dart';
+
+import 'package:angular2/src/transform/common/url_resolver.dart';
 
 main() => allTests();
 
 void allTests() {
   var urlResolver = const TransformerUrlResolver();
 
-  describe('toAssetUri', () {
-    it('should convert `AssetId`s to asset: uris', () {
+  group('toAssetUri', () {
+    test('should convert `AssetId`s to asset: uris', () {
       var assetId = new AssetId('test_package', 'lib/src/impl.dart');
-      expect(toAssetUri(assetId))
-          .toEqual('asset:test_package/lib/src/impl.dart');
+      expect(
+          toAssetUri(assetId), equals('asset:test_package/lib/src/impl.dart'));
     });
 
-    it('should throw if passed a null AssetId', () {
-      expect(() => toAssetUri(null)).toThrowWith(anInstanceOf: ArgumentError);
-    });
-  });
-
-  describe('fromUri', () {
-    it('should convert asset: `uri`s to `AssetId`s', () {
-      expect(fromUri('asset:test_package/lib/src/impl.dart'))
-          .toEqual(new AssetId('test_package', 'lib/src/impl.dart'));
-    });
-
-    it('should convert package: `uri`s to `AssetId`s', () {
-      expect(fromUri('package:test_package/src/impl.dart'))
-          .toEqual(new AssetId('test_package', 'lib/src/impl.dart'));
-    });
-
-    it('should throw if passed a null uri', () {
-      expect(() => fromUri(null)).toThrowWith(anInstanceOf: ArgumentError);
-    });
-
-    it('should throw if passed an empty uri', () {
-      expect(() => fromUri('')).toThrowWith(anInstanceOf: ArgumentError);
+    test('should throw if passed a null AssetId', () {
+      expect(() => toAssetUri(null), throwsArgumentError);
     });
   });
 
-  describe('isDartCoreUri', () {
-    it('should detect dart: uris', () {
-      expect(isDartCoreUri('dart:core')).toBeTrue();
-      expect(isDartCoreUri('dart:convert')).toBeTrue();
-      expect(isDartCoreUri('package:angular2/angular2.dart')).toBeFalse();
-      expect(isDartCoreUri('asset:angular2/lib/angular2.dart')).toBeFalse();
+  group('fromUri', () {
+    test('should convert asset: `uri`s to `AssetId`s', () {
+      expect(fromUri('asset:test_package/lib/src/impl.dart'),
+          equals(new AssetId('test_package', 'lib/src/impl.dart')));
     });
 
-    it('should throw if passed a null uri', () {
-      expect(() => isDartCoreUri(null))
-          .toThrowWith(anInstanceOf: ArgumentError);
+    test('should convert package: `uri`s to `AssetId`s', () {
+      expect(fromUri('package:test_package/src/impl.dart'),
+          equals(new AssetId('test_package', 'lib/src/impl.dart')));
     });
 
-    it('should throw if passed an empty uri', () {
-      expect(() => isDartCoreUri('')).toThrowWith(anInstanceOf: ArgumentError);
+    test('should throw if passed a null uri', () {
+      expect(() => fromUri(null), throwsArgumentError);
+    });
+
+    test('should throw if passed an empty uri', () {
+      expect(() => fromUri(''), throwsArgumentError);
     });
   });
 
-  describe('toAssetScheme', () {
-    it('should throw for relative `Uri`s', () {
-      expect(() => toAssetScheme(Uri.parse('/lib/src/file.dart')))
-          .toThrowWith(anInstanceOf: ArgumentError);
+  group('isDartCoreUri', () {
+    test('should detect dart: uris', () {
+      expect(isDartCoreUri('dart:core'), isTrue);
+      expect(isDartCoreUri('dart:convert'), isTrue);
+      expect(isDartCoreUri('package:angular2/angular2.dart'), isFalse);
+      expect(isDartCoreUri('asset:angular2/lib/angular2.dart'), isFalse);
     });
 
-    it('should convert package: `Uri`s to asset:', () {
-      expect(toAssetScheme(Uri.parse('package:angular2/angular2.dart')))
-          .toEqual(Uri.parse('asset:angular2/lib/angular2.dart'));
+    test('should throw if passed a null uri', () {
+      expect(() => isDartCoreUri(null), throwsArgumentError);
     });
 
-    it('should throw for package: `Uri`s which are too short', () {
-      expect(() => toAssetScheme(Uri.parse('package:angular2')))
-          .toThrowWith(anInstanceOf: FormatException);
+    test('should throw if passed an empty uri', () {
+      expect(() => isDartCoreUri(''), throwsArgumentError);
+    });
+  });
+
+  group('toAssetScheme', () {
+    test('should throw for relative `Uri`s', () {
+      expect(() => toAssetScheme(Uri.parse('/lib/src/file.dart')),
+          throwsArgumentError);
     });
 
-    it('should convert asset: `Uri`s to asset:', () {
-      expect(toAssetScheme(Uri.parse('asset:angular2/lib/angular2.dart')))
-          .toEqual(Uri.parse('asset:angular2/lib/angular2.dart'));
+    test('should convert package: `Uri`s to asset:', () {
+      expect(toAssetScheme(Uri.parse('package:angular2/angular2.dart')),
+          equals(Uri.parse('asset:angular2/lib/angular2.dart')));
     });
 
-    it('should throw for asset: `Uri`s which are too short', () {
-      expect(() => toAssetScheme(Uri.parse('asset:angular2')))
-          .toThrowWith(anInstanceOf: FormatException);
-
-      expect(() => toAssetScheme(Uri.parse('asset:angular2/lib')))
-          .toThrowWith(anInstanceOf: FormatException);
+    test('should throw for package: `Uri`s which are too short', () {
+      expect(() => toAssetScheme(Uri.parse('package:angular2')),
+          throwsFormatException);
     });
 
-    it('should pass through unsupported schemes', () {
+    test('should convert asset: `Uri`s to asset:', () {
+      expect(toAssetScheme(Uri.parse('asset:angular2/lib/angular2.dart')),
+          equals(Uri.parse('asset:angular2/lib/angular2.dart')));
+    });
+
+    test('should throw for asset: `Uri`s which are too short', () {
+      expect(() => toAssetScheme(Uri.parse('asset:angular2')),
+          throwsFormatException);
+
+      expect(() => toAssetScheme(Uri.parse('asset:angular2/lib')),
+          throwsFormatException);
+    });
+
+    test('should pass through unsupported schemes', () {
       var uri = 'http://server.com/style.css';
-      expect('${toAssetScheme(Uri.parse(uri))}').toEqual(uri);
+      expect('${toAssetScheme(Uri.parse(uri))}', equals(uri));
     });
 
-    it('should throw if passed a null uri', () {
-      expect(() => toAssetScheme(null))
-          .toThrowWith(anInstanceOf: ArgumentError);
+    test('should throw if passed a null uri', () {
+      expect(() => toAssetScheme(null), throwsArgumentError);
     });
   });
 
-  describe('resolve', () {
-    it('should resolve package: uris to asset: uris', () {
-      expect(urlResolver.resolve('', 'package:angular2/angular2.dart'))
-          .toEqual('asset:angular2/lib/angular2.dart');
+  group('resolve', () {
+    test('should resolve package: uris to asset: uris', () {
+      expect(urlResolver.resolve('', 'package:angular2/angular2.dart'),
+          equals('asset:angular2/lib/angular2.dart'));
     });
 
-    it('should ignore baseUrl for absolute uris', () {
-      expect(urlResolver.resolve(null, 'package:angular2/angular2.dart'))
-          .toEqual('asset:angular2/lib/angular2.dart');
-      expect(urlResolver.resolve(null, 'asset:angular2/lib/angular2.dart'))
-          .toEqual('asset:angular2/lib/angular2.dart');
+    test('should ignore baseUrl for absolute uris', () {
+      expect(urlResolver.resolve(null, 'package:angular2/angular2.dart'),
+          equals('asset:angular2/lib/angular2.dart'));
+      expect(urlResolver.resolve(null, 'asset:angular2/lib/angular2.dart'),
+          equals('asset:angular2/lib/angular2.dart'));
     });
 
-    it('should resolve asset: uris to asset: uris', () {
-      expect(urlResolver.resolve('', 'asset:angular2/lib/angular2.dart'))
-          .toEqual('asset:angular2/lib/angular2.dart');
+    test('should resolve asset: uris to asset: uris', () {
+      expect(urlResolver.resolve('', 'asset:angular2/lib/angular2.dart'),
+          equals('asset:angular2/lib/angular2.dart'));
     });
 
-    it('should resolve relative uris when baseUrl is package: uri', () {
-      expect(urlResolver.resolve('package:angular2/angular2.dart',
-              'src/transform/transformer.dart'))
-          .toEqual('asset:angular2/lib/src/transform/transformer.dart');
+    test('should resolve relative uris when baseUrl is package: uri', () {
+      expect(
+          urlResolver.resolve('package:angular2/angular2.dart',
+              'src/transform/transformer.dart'),
+          equals('asset:angular2/lib/src/transform/transformer.dart'));
     });
 
-    it('should resolve relative uris when baseUrl is asset: uri', () {
-      expect(urlResolver.resolve('asset:angular2/lib/angular2.dart',
-              'src/transform/transformer.dart'))
-          .toEqual('asset:angular2/lib/src/transform/transformer.dart');
+    test('should resolve relative uris when baseUrl is asset: uri', () {
+      expect(
+          urlResolver.resolve('asset:angular2/lib/angular2.dart',
+              'src/transform/transformer.dart'),
+          equals('asset:angular2/lib/src/transform/transformer.dart'));
     });
 
-    it('should normalize uris', () {
-      expect(urlResolver.resolve('asset:angular2/lib/angular2.dart',
-              'src/transform/../transform/transformer.dart'))
-          .toEqual('asset:angular2/lib/src/transform/transformer.dart');
-      expect(urlResolver.resolve('asset:angular2/lib/src/../angular2.dart',
-              'src/transform/transformer.dart'))
-          .toEqual('asset:angular2/lib/src/transform/transformer.dart');
+    test('should normalize uris', () {
+      expect(
+          urlResolver.resolve('asset:angular2/lib/angular2.dart',
+              'src/transform/../transform/transformer.dart'),
+          equals('asset:angular2/lib/src/transform/transformer.dart'));
+      expect(
+          urlResolver.resolve('asset:angular2/lib/src/../angular2.dart',
+              'src/transform/transformer.dart'),
+          equals('asset:angular2/lib/src/transform/transformer.dart'));
     });
 
-    it('should throw if passed a null uri', () {
-      expect(() => urlResolver.resolve('package:angular2/angular2.dart', null))
-          .toThrowWith(anInstanceOf: ArgumentError);
+    test('should throw if passed a null uri', () {
+      expect(() => urlResolver.resolve('package:angular2/angular2.dart', null),
+          throwsArgumentError);
     });
 
-    it('should gracefully handle an empty uri', () {
-      expect(urlResolver.resolve('package:angular2/angular2.dart', ''))
-          .toEqual('asset:angular2/lib/angular2.dart');
+    test('should gracefully handle an empty uri', () {
+      expect(urlResolver.resolve('package:angular2/angular2.dart', ''),
+          equals('asset:angular2/lib/angular2.dart'));
     });
 
-    it('should throw if passed a relative uri and a null baseUri', () {
-      expect(() => urlResolver.resolve(null, 'angular2/angular2.dart'))
-          .toThrowWith(anInstanceOf: ArgumentError);
+    test('should throw if passed a relative uri and a null baseUri', () {
+      expect(() => urlResolver.resolve(null, 'angular2/angular2.dart'),
+          throwsArgumentError);
     });
 
-    it('should throw if passed a relative uri and an empty baseUri', () {
-      expect(() => urlResolver.resolve('', 'angular2/angular2.dart'))
-          .toThrowWith(anInstanceOf: ArgumentError);
+    test('should throw if passed a relative uri and an empty baseUri', () {
+      expect(() => urlResolver.resolve('', 'angular2/angular2.dart'),
+          throwsArgumentError);
     });
 
-    it('should throw if the resolved uri is relative', () {
-      expect(() => urlResolver.resolve('/angular2/', 'angular2.dart'))
-          .toThrowWith(anInstanceOf: ArgumentError);
+    test('should throw if the resolved uri is relative', () {
+      expect(() => urlResolver.resolve('/angular2/', 'angular2.dart'),
+          throwsArgumentError);
     });
   });
 }

--- a/modules_dart/transform/test/transform/transform.server.spec.dart
+++ b/modules_dart/transform/test/transform/transform.server.spec.dart
@@ -1,32 +1,16 @@
+@TestOn('vm')
 library angular2.test.transform.transform.server.spec;
 
-import 'package:guinness/guinness.dart';
-import 'package:unittest/unittest.dart' hide expect;
-import 'package:unittest/vm_config.dart';
+import 'package:test/test.dart';
 
 import 'common/async_string_writer_tests.dart' as asyncStringWriter;
 import 'common/code/ng_deps_code_tests.dart' as ngDepsCode;
 import 'common/ng_meta_test.dart' as ngMetaTest;
 import 'common/url_resolver_tests.dart' as urlResolver;
-import 'deferred_rewriter/all_tests.dart' as deferredRewriter;
-import 'directive_metadata_linker/all_tests.dart' as directiveMeta;
-import 'directive_processor/all_tests.dart' as directiveProcessor;
-import 'inliner_for_test/all_tests.dart' as inliner;
-import 'reflection_remover/all_tests.dart' as reflectionRemover;
-import 'template_compiler/all_tests.dart' as templateCompiler;
-import 'stylesheet_compiler/all_tests.dart' as stylesheetCompiler;
 
 main() {
-  useVMConfiguration();
-  describe('AsyncStringWriter', asyncStringWriter.allTests);
-  describe('NgDepsCode', ngDepsCode.allTests);
-  describe('NgMeta', ngMetaTest.allTests);
-  describe('Directive Metadata Linker', directiveMeta.allTests);
-  describe('Directive Processor', directiveProcessor.allTests);
-  describe('Inliner For Test', inliner.allTests);
-  describe('Reflection Remover', reflectionRemover.allTests);
-  describe('Template Compiler', templateCompiler.allTests);
-  describe('Deferred Rewriter', deferredRewriter.allTests);
-  describe('Stylesheet Compiler', stylesheetCompiler.allTests);
-  describe('Url Resolver', urlResolver.allTests);
+  group('AsyncStringWriter', asyncStringWriter.allTests);
+  group('NgDepsCode', ngDepsCode.allTests);
+  group('NgMeta', ngMetaTest.allTests);
+  group('Url Resolver', urlResolver.allTests);
 }

--- a/modules_dart/transform/test/transform/transform.unittest.server.spec.dart
+++ b/modules_dart/transform/test/transform/transform.unittest.server.spec.dart
@@ -1,0 +1,24 @@
+library angular2.test.transform.transform.old.spec;
+
+import 'package:guinness/guinness.dart';
+import 'package:unittest/unittest.dart' hide expect;
+import 'package:unittest/vm_config.dart';
+
+import 'deferred_rewriter/all_tests.dart' as deferredRewriter;
+import 'directive_metadata_linker/all_tests.dart' as directiveMeta;
+import 'directive_processor/all_tests.dart' as directiveProcessor;
+import 'inliner_for_test/all_tests.dart' as inliner;
+import 'reflection_remover/all_tests.dart' as reflectionRemover;
+import 'template_compiler/all_tests.dart' as templateCompiler;
+import 'stylesheet_compiler/all_tests.dart' as stylesheetCompiler;
+
+main() {
+  useVMConfiguration();
+  describe('Directive Metadata Linker', directiveMeta.allTests);
+  describe('Directive Processor', directiveProcessor.allTests);
+  describe('Inliner For Test', inliner.allTests);
+  describe('Reflection Remover', reflectionRemover.allTests);
+  describe('Template Compiler', templateCompiler.allTests);
+  describe('Deferred Rewriter', deferredRewriter.allTests);
+  describe('Stylesheet Compiler', stylesheetCompiler.allTests);
+}


### PR DESCRIPTION
Our transformer unit tests currently use package:guinness, which uses
package:unittest under the covers. package:unittest has been updated and
renamed package:test, so for simplicity migrate test to use package:test
syntax.
