### PR TITLE
fix IE11 template compilation

### DIFF
--- a/modules/angular2/src/facade/lang.ts
+++ b/modules/angular2/src/facade/lang.ts
@@ -179,6 +179,9 @@ export function stringify(token): string {
   }
 
   var res = token.toString();
+  if (typeof token === "function") {
+    return res.substr("function ".length, res.indexOf("()") - "function ".length);
+  }
   var newLineIndex = res.indexOf("\n");
   return (newLineIndex === -1) ? res : res.substring(0, newLineIndex);
 }


### PR DESCRIPTION
fix IE11 -> an error ocurred during the template compilation : "SyntaxError : Expected ';'"
the file angular2.dev.js must be regenerated.

explanations : the function prototype does not contains a name property, so the toString() result is used, but the name generated contains the keywork 'function' and space caracters. The name generated can not be injected like this.

a capture of the bug :
![capture_angular2ie11fix](https://cloud.githubusercontent.com/assets/4851282/12844141/eedd09a6-cbfd-11e5-9286-9f8601cdaf39.PNG)
