### PR TITLE
add details to DehydratedException that hint at the source of the error

### DIFF
--- a/modules/angular2/src/core/change_detection/abstract_change_detector.ts
+++ b/modules/angular2/src/core/change_detection/abstract_change_detector.ts
@@ -73,7 +73,7 @@ export class AbstractChangeDetector<T> implements ChangeDetector {
 
   handleEvent(eventName: string, elIndex: number, event: any): boolean {
     if (!this.hydrated()) {
-      this.throwDehydratedError();
+      this.throwDehydratedError(`${this.id} -> ${eventName}`);
     }
     try {
       var locals = new Map<string, any>();
@@ -130,7 +130,7 @@ export class AbstractChangeDetector<T> implements ChangeDetector {
   // facilitate error reporting.
   detectChangesInRecords(throwOnChange: boolean): void {
     if (!this.hydrated()) {
-      this.throwDehydratedError();
+      this.throwDehydratedError(this.id);
     }
     try {
       this.detectChangesInRecordsInternal(throwOnChange);
@@ -362,7 +362,7 @@ export class AbstractChangeDetector<T> implements ChangeDetector {
                                                               oldValue, newValue, null);
   }
 
-  throwDehydratedError(): void { throw new DehydratedException(); }
+  throwDehydratedError(detail: string): void { throw new DehydratedException(detail); }
 
   private _currentBinding(): BindingTarget {
     return this.bindingTargets[this.propertyBindingIndex];

--- a/modules/angular2/src/core/change_detection/exceptions.ts
+++ b/modules/angular2/src/core/change_detection/exceptions.ts
@@ -91,7 +91,7 @@ export class ChangeDetectionError extends WrappedException {
  * This is an internal Angular error.
  */
 export class DehydratedException extends BaseException {
-  constructor() { super('Attempt to use a dehydrated detector.'); }
+  constructor(details: string) { super(`Attempt to use a dehydrated detector: ${details}`); }
 }
 
 /**


### PR DESCRIPTION
### Purpose

When an application throws dehydrated exception errors, there is no information that hints at which piece of code is having issues. The `AbstractChangeDetector` instance has information that could make debugging easier.

Current:

```
Uncaught Attempt to use a dehydrated detector.
Uncaught Attempt to use a dehydrated detector.
Uncaught Attempt to use a dehydrated detector.
Uncaught Attempt to use a dehydrated detector.
Uncaught Attempt to use a dehydrated detector.
```

Proposed:

```
Uncaught Attempt to use a dehydrated detector: HostMdBackdrop_0 -> onHiding
Uncaught Attempt to use a dehydrated detector: HostMdBackdrop_0 -> onHiding
Uncaught Attempt to use a dehydrated detector: TestComponent_0 -> valueChange
Uncaught Attempt to use a dehydrated detector: MdSidenavContainer_0 -> onShown
Uncaught Attempt to use a dehydrated detector: TestComponent_0 -> onShown
```
