### PR TITLE
fix(IE): make shim work with instrumented code

### DIFF
--- a/modules/angular2/src/testing/shims_for_IE.js
+++ b/modules/angular2/src/testing/shims_for_IE.js
@@ -3,7 +3,7 @@
 if (!Object.hasOwnProperty('name')) {
   Object.defineProperty(Function.prototype, 'name', {
     get: function() {
-      var matches = this.toString().match(/^\s*function\s*(\S*)\s*\(/);
+      var matches = this.toString().match(/^\s*function\s*((?![0-9])[a-zA-Z0-9_$]*)\s*\(/);
       var name = matches && matches.length > 1 ? matches[1] : "";
       // For better performance only parse once, and then cache the
       // result through a new accessor for repeated access.


### PR DESCRIPTION
- the function name patch from stack overflow has a regexp that is too liberal.
- related to #6501
