### PR TITLE
docs(DIMetadata): Remove unnecessary decorator for clarification

### DIFF
--- a/modules/angular2/src/core/di/metadata.ts
+++ b/modules/angular2/src/core/di/metadata.ts
@@ -87,7 +87,6 @@ export class DependencyMetadata {
  * ### Example ([live demo](http://plnkr.co/edit/Wk4DMQ?p=preview))
  *
  * ```typescript
- * @Injectable()
  * class UsefulService {}
  *
  * @Injectable()


### PR DESCRIPTION
The decorator `Injectable` is needed only when there are dependency for current class, the example used it even for service with no dependency, it will be confusing for the actual usage.
