### PR TITLE
fix(async) invalid path for fromPromise in RxJS

### DIFF
--- a/modules/angular2/src/facade/async.ts
+++ b/modules/angular2/src/facade/async.ts
@@ -9,7 +9,7 @@ import {Subject} from 'rxjs/Subject';
 import {Subscription} from 'rxjs/Subscription';
 import {Operator} from 'rxjs/Operator';
 
-import {PromiseObservable} from 'rxjs/observable/fromPromise';
+import {PromiseObservable} from 'rxjs/add/observable/fromPromise';
 import {toPromise} from 'rxjs/operator/toPromise';
 
 export {Observable} from 'rxjs/Observable';


### PR DESCRIPTION
angular2@2.0.0-beta.5
rxjs@5.0,0-beta.2

`fromPromise` was moved to the `add` folder.
