### PR TITLE
fix(typings): publish es6 typings rather than postinstall.

### DIFF
--- a/modules/angular2/package.json
+++ b/modules/angular2/package.json
@@ -8,12 +8,6 @@
   "license": "<%= packageJson.license %>",
   "repository": <%= JSON.stringify(packageJson.repository) %>,
   "devDependencies": <%= JSON.stringify(packageJson.defaultDevDependencies) %>,
-  "dependencies": {
-    "typings": "0.6.6"
-  },
-  "scripts": {
-    "postinstall": "typings install --ambient --name es6-promise github:DefinitelyTyped/DefinitelyTyped/es6-promise/es6-promise.d.ts#830e8ebd9ef137d039d5c7ede24a421f08595f83; typings install --ambient --name es6-collections github:DefinitelyTyped/DefinitelyTyped/es6-collections/es6-collections.d.ts#9f97e2a2bc1f502550c9b4fcaad1c48df5521d37"
-  },
   "peerDependencies": {
     "es6-promise": "<%= packageJson.dependencies['es6-promise'] %>",
     "es6-shim": "<%= packageJson.dependencies['es6-shim'] %>",

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -1451,6 +1451,14 @@
         }
       }
     },
+    "broccoli-file-creator": {
+      "version": "1.1.0",
+      "dependencies": {
+        "rsvp": {
+          "version": "3.0.21"
+        }
+      }
+    },
     "broccoli-filter": {
       "version": "0.1.14",
       "dependencies": {
@@ -4809,7 +4817,7 @@
       "version": "1.1.5"
     },
     "rxjs": {
-      "version": "5.0.0-beta.0"
+      "version": "5.0.0-beta.2"
     },
     "sass-graph": {
       "version": "2.0.1",
@@ -5824,9 +5832,9 @@
       }
     },
     "zone.js": {
-      "version": "0.5.13"
+      "version": "0.5.14"
     }
   },
   "name": "angular-srcs",
-  "version": "2.0.0-beta.3"
+  "version": "2.0.0-beta.5"
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.5",
   "dependencies": {
     "abbrev": {
       "version": "1.0.7",
@@ -2260,6 +2260,18 @@
           "version": "3.10.0",
           "from": "yargs@>=3.10.0 <3.11.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+        }
+      }
+    },
+    "broccoli-file-creator": {
+      "version": "1.1.0",
+      "from": "broccoli-file-creator@latest",
+      "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-1.1.0.tgz",
+      "dependencies": {
+        "rsvp": {
+          "version": "3.0.21",
+          "from": "rsvp@>=3.0.6 <3.1.0",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.21.tgz"
         }
       }
     },
@@ -7667,9 +7679,9 @@
       "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.1.5.tgz"
     },
     "rxjs": {
-      "version": "5.0.0-beta.0",
-      "from": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.0.tgz",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.0.tgz"
+      "version": "5.0.0-beta.2",
+      "from": "rxjs@5.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.2.tgz"
     },
     "sass-graph": {
       "version": "2.0.1",
@@ -8524,24 +8536,24 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "from": "source-map@>=0.4.2 <0.5.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
         },
         "source-map-support": {
           "version": "0.3.3",
-          "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
+          "from": "source-map-support@>=0.3.1 <0.4.0",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+              "from": "source-map@0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz"
             }
           }
         },
         "typescript": {
           "version": "1.7.3",
-          "from": "https://registry.npmjs.org/typescript/-/typescript-1.7.3.tgz",
+          "from": "typescript@1.7.3",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.7.3.tgz"
         }
       }
@@ -8699,7 +8711,7 @@
     },
     "typescript": {
       "version": "1.7.5",
-      "from": "typescript@>=1.7.3 <2.0.0",
+      "from": "typescript@>=1.7.0 <1.8.0",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.7.5.tgz"
     },
     "ua-parser-js": {
@@ -9291,9 +9303,9 @@
       }
     },
     "zone.js": {
-      "version": "0.5.13",
-      "from": "https://registry.npmjs.org/zone.js/-/zone.js-0.5.13.tgz",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.5.13.tgz"
+      "version": "0.5.14",
+      "from": "zone.js@0.5.14",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.5.14.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.3",
     "reflect-metadata": "0.1.2",
-    "rxjs": "^5.0.0-beta.2",
-    "zone.js": "^0.5.14"
+    "rxjs": "5.0.0-beta.2",
+    "zone.js": "0.5.14"
   },
   "devDependencies": {
     "angular": "^1.5.0",
@@ -45,6 +45,7 @@
     "base64-js": "^0.0.8",
     "bower": "^1.3.12",
     "broccoli": "^0.16.9",
+    "broccoli-file-creator": "^1.1.0",
     "broccoli-funnel": "^1.0.1",
     "broccoli-slow-trees": "1.x.x",
     "broccoli-stew": "^0.2.1",
@@ -111,8 +112,8 @@
     "systemjs": "0.18.10",
     "systemjs-builder": "^0.10.3",
     "through2": "^0.6.5",
-    "ts2dart": "^0.7.22",
     "ts-api-guardian": "0.0.2",
+    "ts2dart": "^0.7.22",
     "tsd": "^0.6.5-beta",
     "tslint": "^3.2.1",
     "typescript": "^1.7.3",

--- a/tools/broccoli/trees/node_tree.ts
+++ b/tools/broccoli/trees/node_tree.ts
@@ -9,6 +9,7 @@ var path = require('path');
 import renderLodashTemplate from '../broccoli-lodash';
 import replace from '../broccoli-replace';
 var stew = require('broccoli-stew');
+var writeFile = require('broccoli-file-creator');
 
 var projectRootDir = path.normalize(path.join(__dirname, '..', '..', '..', '..'));
 
@@ -118,7 +119,17 @@ module.exports = function makeNodeTree(projects, destinationPath) {
   var srcPkgJsons = extractPkgJsons(srcTree, BASE_PACKAGE_JSON);
   var testPkgJsons = extractPkgJsons(testTree, BASE_PACKAGE_JSON);
 
-  var nodeTree = mergeTrees([compiledTree, srcDocs, testDocs, srcPkgJsons, testPkgJsons]);
+  // Copy es6 typings so quickstart doesn't require typings install
+  let typingsTree = new Funnel('modules', {
+    include: [
+      'angular2/typings/es6-collections/es6-collections.d.ts',
+      'angular2/typings/es6-promise/es6-promise.d.ts',
+    ]});
+  typingsTree = mergeTrees([typingsTree, writeFile('angular2/typings/browser.d.ts',
+    `///<reference path="./es6-collections/es6-collections.d.ts"/>
+     ///<reference path="./es6-promise/es6-promise.d.ts"/>`)]);
+
+  var nodeTree = mergeTrees([compiledTree, srcDocs, testDocs, srcPkgJsons, testPkgJsons, typingsTree]);
 
   // Transform all tests to make them runnable in node
   nodeTree = replace(nodeTree, {


### PR DESCRIPTION
Despite local testing, multiple users failed to run the postinstall to install typings.
Instead, we can distribute the typings we installed locally.

Fixes #7000 

cc @IgorMinar 
