### PR TITLE
fix(upgrade): support deferred bootstrap

### DIFF
--- a/modules/angular2/src/upgrade/angular_js.ts
+++ b/modules/angular2/src/upgrade/angular_js.ts
@@ -103,6 +103,7 @@ function noNg() {
 
 var angular: {
   bootstrap: (e: Element, modules: string[], config: IAngularBootstrapConfig) => void,
+  resumeBootstrap?: (extraModules?: string[]) => void,
   module: (prefix: string, dependencies?: string[]) => IModule,
   element: (e: Element) => IAugmentedJQuery,
   version: {major: number}
@@ -118,6 +119,7 @@ try {
 }
 
 export var bootstrap = angular.bootstrap;
+export var getResumeBootstrap = () => angular.resumeBootstrap;
 export var module = angular.module;
 export var element = angular.element;
 export var version = angular.version;

--- a/modules/angular2/src/upgrade/upgrade_adapter.ts
+++ b/modules/angular2/src/upgrade/upgrade_adapter.ts
@@ -308,9 +308,8 @@ export class UpgradeAdapter {
     var rootScopePrototype: any;
     var rootScope: angular.IRootScopeService;
     var hostViewFactoryRefMap: HostViewFactoryRefMap = {};
-    var ng1Module = angular.module(this.idPrefix, modules);
-    var ng1compilePromise: Promise<any> = null;
-    ng1Module.value(NG2_INJECTOR, injector)
+    angular.module(this.idPrefix, modules)
+        .value(NG2_INJECTOR, injector)
         .value(NG2_ZONE, ngZone)
         .value(NG2_COMPILER, compiler)
         .value(NG2_HOST_VIEW_FACTORY_REF_MAP, hostViewFactoryRefMap)
@@ -340,26 +339,27 @@ export class UpgradeAdapter {
             ng1Injector = injector;
             ObservableWrapper.subscribe(ngZone.onTurnDone,
                                         (_) => ngZone.runOutsideAngular(() => rootScope.$apply()));
-            ng1compilePromise =
+            var ng2compilePromise = this.compileNg2Components(compiler, hostViewFactoryRefMap);
+            var ng1compilePromise =
                 UpgradeNg1ComponentAdapterBuilder.resolve(this.downgradedComponents, injector);
+            Promise.all([ng2compilePromise, ng1compilePromise])
+                .then(() => {
+                  ngZone.run(() => {
+                    if (rootScopePrototype) {
+                      rootScopePrototype.$apply = original$applyFn;  // restore original $apply
+                      while (delayApplyExps.length) {
+                        rootScope.$apply(delayApplyExps.shift());
+                      }
+                      (<any>upgrade)._bootstrapDone(applicationRef, ng1Injector);
+                      rootScopePrototype = null;
+                    }
+                  });
+                }, onError);
           }
         ]);
 
     angular.element(element).data(controllerKey(NG2_INJECTOR), injector);
     ngZone.run(() => { angular.bootstrap(element, [this.idPrefix], config); });
-    Promise.all([this.compileNg2Components(compiler, hostViewFactoryRefMap), ng1compilePromise])
-        .then(() => {
-          ngZone.run(() => {
-            if (rootScopePrototype) {
-              rootScopePrototype.$apply = original$applyFn;  // restore original $apply
-              while (delayApplyExps.length) {
-                rootScope.$apply(delayApplyExps.shift());
-              }
-              (<any>upgrade)._bootstrapDone(applicationRef, ng1Injector);
-              rootScopePrototype = null;
-            }
-          });
-        }, onError);
     return upgrade;
   }
 

--- a/modules/angular2/test/upgrade/upgrade_spec.ts
+++ b/modules/angular2/test/upgrade/upgrade_spec.ts
@@ -559,6 +559,28 @@ export function main() {
          }));
     });
 
+    describe('bootstrap', () => {
+
+      it('should support deferred bootstrap', inject([AsyncTestCompleter], (async) => {
+           var adapter = new UpgradeAdapter();
+           var module = angular.module('myExample', []);
+
+           window.name = 'NG_DEFER_BOOTSTRAP! test';
+           var element = html(`<div>{{ 'ng1' }}</div>`);
+           adapter.bootstrap(element, ['myExample'])
+               .ready((ref) => {
+                 expect(multiTrim(document.body.textContent)).toEqual("ng1");
+                 ref.dispose();
+                 async.done();
+               });
+           setTimeout(() => {
+             var resumeBootstrap = angular.getResumeBootstrap();
+             resumeBootstrap();
+           }, 0);
+         }));
+
+    });
+
     describe('examples', () => {
       it('should verify UpgradeAdapter example', inject([AsyncTestCompleter], (async) => {
            var adapter = new UpgradeAdapter();

--- a/modules/playground/e2e_test/upgrade/upgrade_spec.dart
+++ b/modules/playground/e2e_test/upgrade/upgrade_spec.dart
@@ -1,0 +1,3 @@
+library playground.e2e_test.upgrade.upgrade_spec;
+
+main() {}

--- a/modules/playground/e2e_test/upgrade/upgrade_spec.ts
+++ b/modules/playground/e2e_test/upgrade/upgrade_spec.ts
@@ -1,0 +1,17 @@
+import {verifyNoBrowserErrors} from 'angular2/src/testing/e2e_util';
+
+describe('Upgrade', function() {
+  var URL = 'playground/src/upgrade/index.html';
+
+  beforeEach(() => browser.rootEl = 'body');  // Force Protractor to NG1 mode
+  afterEach(() => browser.rootEl = null);
+
+  it('should work', () => {
+    browser.get(URL);
+    verifyNoBrowserErrors();
+
+    expect(element(by.css('.greeting')).getText()).toEqual('Greetings from World!');
+    expect(element(by.css('.title')).getText()).toEqual('Title: World');
+  });
+
+});

--- a/modules/playground/src/upgrade/index.html
+++ b/modules/playground/src/upgrade/index.html
@@ -12,7 +12,7 @@
   </style>
 <body>
   <upgrade-app ng-controller="Index" [user]="name" (reset)="name=''">
-    Your name: <input ngModel="name">
+    Your name: <input ng-model="name">
     <hr>
     <span class="greeting">Greetings from {{name}}!</span>
   </upgrade-app>

--- a/protractor-dart2js.conf.js
+++ b/protractor-dart2js.conf.js
@@ -7,6 +7,7 @@ config.exclude.push(
   'dist/js/cjs/playground/e2e_test/sourcemap/sourcemap_spec.js',
   'dist/js/cjs/playground/e2e_test/http/http_spec.js',
   'dist/js/cjs/playground/e2e_test/jsonp/jsonp_spec.js',
+  'dist/js/cjs/playground/e2e_test/upgrade/upgrade_spec.js',
   // TODO: remove this line when largetable dart has been added
   'dist/js/cjs/benchmarks_external/e2e_test/largetable_perf.js',
   'dist/js/cjs/benchmarks_external/e2e_test/polymer_tree_perf.js',
@@ -15,4 +16,3 @@ config.exclude.push(
 );
 
 data.createBenchpressRunner({ lang: 'dart' });
-

--- a/tools/broccoli/html-replace/SCRIPTS.html
+++ b/tools/broccoli/html-replace/SCRIPTS.html
@@ -19,6 +19,7 @@
       '/bundle/angular2.dev.js',
       '/bundle/http.js',
       '/bundle/router.dev.js',
+      '/bundle/upgrade.dev.js',
       '/rxjs/bundles/Rx.js'
     ];
   } else {

--- a/tools/broccoli/trees/dart_tree.ts
+++ b/tools/broccoli/trees/dart_tree.ts
@@ -25,8 +25,10 @@ var global_excludes = [
   'payload_tests/**/ts/**/*',
   'playground/src/http/**/*',
   'playground/src/jsonp/**/*',
+  'playground/src/upgrade/**/*',
   'playground/test/http/**/*',
-  'playground/test/jsonp/**/*'
+  'playground/test/jsonp/**/*',
+  'playground/test/upgrade/**/*'
 ];
 
 


### PR DESCRIPTION
Have UpgradeAdapter wait for Angular 1 to bootstrap before running
delayed $applys.

This fixes the use of UpgradeAdapter with Protractor.

Closes #6547
