### PR TITLE
fix(typings): publish es6 typings rather than postinstall.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ tmp
 *.js.map
 
 # Or type definitions we mirror from github
+# (NB: these lines are removed in publish-build-artifacts.sh)
 **/typings/**/*.d.ts
 **/typings/tsd.cached.json
 

--- a/scripts/publish/publish-build-artifacts.sh
+++ b/scripts/publish/publish-build-artifacts.sh
@@ -41,7 +41,7 @@ function publishRepo {
   # copy over build artifacts into the repo directory
   rm -rf $REPO_DIR/*
   cp -R $ARTIFACTS_DIR/* $REPO_DIR/
-  cp .gitignore $REPO_DIR/
+  grep -v /typings/ .gitignore > $REPO_DIR/.gitignore
   echo `date` > $REPO_DIR/BUILD_INFO
   echo $SHA >> $REPO_DIR/BUILD_INFO
 


### PR DESCRIPTION
Despite local testing, multiple users failed to run the postinstall to install typings.
Instead, we can distribute the typings we installed locally.

This is an alternative to #7003.
This also reverts rxjs to beta.1 since we have errors using beta.2, being addressed
in #7001.

Fixes #7000
