### PR TITLE
Correcting the postinstall script command line

### DIFF
--- a/modules/angular2/package.json
+++ b/modules/angular2/package.json
@@ -12,7 +12,7 @@
     "typings": "0.6.6"
   },
   "scripts": {
-    "postinstall": "typings install --ambient --name es6-promise github:DefinitelyTyped/DefinitelyTyped/es6-promise/es6-promise.d.ts#830e8ebd9ef137d039d5c7ede24a421f08595f83; typings install --ambient --name es6-collections github:DefinitelyTyped/DefinitelyTyped/es6-collections/es6-collections.d.ts#9f97e2a2bc1f502550c9b4fcaad1c48df5521d37"
+    "postinstall": "typings install --ambient --name es6-promise github:DefinitelyTyped/DefinitelyTyped/es6-promise/es6-promise.d.ts#830e8ebd9ef137d039d5c7ede24a421f08595f83 & typings install --ambient --name es6-collections github:DefinitelyTyped/DefinitelyTyped/es6-collections/es6-collections.d.ts#9f97e2a2bc1f502550c9b4fcaad1c48df5521d37"
   },
   "peerDependencies": {
     "es6-promise": "<%= packageJson.dependencies['es6-promise'] %>",


### PR DESCRIPTION
For some reason typings is reading "typings install ... github:DefinitelyTyped/...#hash; typings install ... github:DefinitelyTyped/..#hash" wrong and tries to retrieve " https://raw.githubusercontent.com/DefinitelyTyped/.../hash;/.../file.d.ts" from github which does not work.
Please notice the place of the ';' in the commandline as well on the url.
To fix this just chain the two typings installations with & which also ensures that the first command have to work.
