### PR TITLE
feat(ViewEncapsulation): introduce the EmulatedLegacy value.

### DIFF
--- a/modules/angular2/src/compiler/style_compiler.ts
+++ b/modules/angular2/src/compiler/style_compiler.ts
@@ -29,12 +29,12 @@ export class StyleCompiler {
   compileComponentRuntime(template: CompileTemplateMetadata): Promise<Array<string | any[]>> {
     var styles = template.styles;
     var styleAbsUrls = template.styleUrls;
-    return this._loadStyles(styles, styleAbsUrls,
-                            template.encapsulation === ViewEncapsulation.Emulated);
+    var shim = this._shouldShim(template.encapsulation);
+    return this._loadStyles(styles, styleAbsUrls, shim);
   }
 
   compileComponentCodeGen(template: CompileTemplateMetadata): SourceExpression {
-    var shim = template.encapsulation === ViewEncapsulation.Emulated;
+    var shim = this._shouldShim(template.encapsulation);
     return this._styleCodeGen(template.styles, template.styleUrls, shim);
   }
 
@@ -98,6 +98,11 @@ export class StyleCompiler {
 
   private _shimIfNeeded(style: string, shim: boolean): string {
     return shim ? this._shadowCss.shimCssText(style, CONTENT_ATTR, HOST_ATTR) : style;
+  }
+
+  private _shouldShim(encapsulation: ViewEncapsulation): boolean {
+    return encapsulation === ViewEncapsulation.Emulated ||
+           encapsulation === ViewEncapsulation.EmulatedLegacy;
   }
 
   private _createModuleUrl(stylesheetUrl: string, shim: boolean): string {

--- a/modules/angular2/src/compiler/template_normalizer.ts
+++ b/modules/angular2/src/compiler/template_normalizer.ts
@@ -71,8 +71,9 @@ export class TemplateNormalizer {
     });
 
     var encapsulation = templateMeta.encapsulation;
-    if (encapsulation === ViewEncapsulation.Emulated && allResolvedStyles.length === 0 &&
-        allStyleAbsUrls.length === 0) {
+    if ((encapsulation === ViewEncapsulation.Emulated ||
+         encapsulation === ViewEncapsulation.EmulatedLegacy) &&
+        allResolvedStyles.length === 0 && allStyleAbsUrls.length === 0) {
       encapsulation = ViewEncapsulation.None;
     }
     return new CompileTemplateMetadata({

--- a/modules/angular2/src/core/metadata/view.ts
+++ b/modules/angular2/src/core/metadata/view.ts
@@ -16,6 +16,13 @@ export enum ViewEncapsulation {
    */
   Emulated,
   /**
+   * Similar to Emulated but the selectors after `:host` and `:host-context` are not scoped to the
+   * component. That is `:host .foo` can select nodes of child components.
+   *
+   * @deprecated
+   */
+  EmulatedLegacy,
+  /**
    * Use the native encapsulation mechanism of the renderer.
    *
    * For the DOM this means using [Shadow DOM](https://w3c.github.io/webcomponents/spec/shadow/) and
@@ -28,9 +35,12 @@ export enum ViewEncapsulation {
   None
 }
 
-export var VIEW_ENCAPSULATION_VALUES =
-    [ViewEncapsulation.Emulated, ViewEncapsulation.Native, ViewEncapsulation.None];
-
+export var VIEW_ENCAPSULATION_VALUES = [
+  ViewEncapsulation.Emulated,
+  ViewEncapsulation.EmulatedLegacy,
+  ViewEncapsulation.Native,
+  ViewEncapsulation.None
+];
 
 /**
  * Metadata properties available for configuring Views.

--- a/modules/angular2/src/platform/dom/dom_renderer.ts
+++ b/modules/angular2/src/platform/dom/dom_renderer.ts
@@ -64,10 +64,12 @@ export class DomRenderer implements Renderer {
 
   constructor(private _rootRenderer: DomRootRenderer, private componentProto: RenderComponentType) {
     this._styles = _flattenStyles(componentProto.id, componentProto.styles, []);
-    if (componentProto.encapsulation !== ViewEncapsulation.Native) {
+    var encapsulation = componentProto.encapsulation;
+    if (encapsulation !== ViewEncapsulation.Native) {
       this._rootRenderer.sharedStylesHost.addStyles(this._styles);
     }
-    if (this.componentProto.encapsulation === ViewEncapsulation.Emulated) {
+    if (encapsulation === ViewEncapsulation.Emulated ||
+        encapsulation === ViewEncapsulation.EmulatedLegacy) {
       this._contentAttr = _shimContentAttribute(componentProto.id);
       this._hostAttr = _shimHostAttribute(componentProto.id);
     } else {

--- a/modules/angular2/test/compiler/style_compiler_spec.ts
+++ b/modules/angular2/test/compiler/style_compiler_spec.ts
@@ -122,44 +122,46 @@ export function main() {
       });
 
       describe('with shim', () => {
-        var encapsulation = ViewEncapsulation.Emulated;
+        [ViewEncapsulation.Emulated, ViewEncapsulation.EmulatedLegacy].forEach((encapsulation) => {
+          it('should compile plain css rules', inject([AsyncTestCompleter], (async) => {
+               compile(['div {\ncolor: red;\n}', 'span {\ncolor: blue;\n}'], [], encapsulation)
+                   .then(styles => {
+                     compareStyles(styles, [
+                       'div[_ngcontent-%COMP%] {\ncolor: red;\n}',
+                       'span[_ngcontent-%COMP%] {\ncolor: blue;\n}'
+                     ]);
+                     async.done();
+                   });
+             }));
 
-        it('should compile plain css rules', inject([AsyncTestCompleter], (async) => {
-             compile(['div {\ncolor: red;\n}', 'span {\ncolor: blue;\n}'], [], encapsulation)
-                 .then(styles => {
-                   compareStyles(styles, [
-                     'div[_ngcontent-%COMP%] {\ncolor: red;\n}',
-                     'span[_ngcontent-%COMP%] {\ncolor: blue;\n}'
-                   ]);
-                   async.done();
-                 });
-           }));
-
-        it('should allow to import rules', inject([AsyncTestCompleter], (async) => {
-             compile(['div {\ncolor: red;\n}'], [IMPORT_ABS_STYLESHEET_URL], encapsulation)
-                 .then(styles => {
-                   compareStyles(styles, [
-                     'div[_ngcontent-%COMP%] {\ncolor: red;\n}',
-                     ['span[_ngcontent-%COMP%] {color: blue}']
-                   ]);
-                   async.done();
-                 });
-           }));
-
-        it('should allow to import rules transitively', inject([AsyncTestCompleter], (async) => {
-             compile(['div {\ncolor: red;\n}'], [IMPORT_ABS_STYLESHEET_URL_WITH_IMPORT],
-                     encapsulation)
-                 .then(styles => {
-                   compareStyles(styles, [
-                     'div[_ngcontent-%COMP%] {\ncolor: red;\n}',
-                     [
-                       'a[_ngcontent-%COMP%] {color: green}',
+          it('should allow to import rules', inject([AsyncTestCompleter], (async) => {
+               compile(['div {\ncolor: red;\n}'], [IMPORT_ABS_STYLESHEET_URL], encapsulation)
+                   .then(styles => {
+                     compareStyles(styles, [
+                       'div[_ngcontent-%COMP%] {\ncolor: red;\n}',
                        ['span[_ngcontent-%COMP%] {color: blue}']
-                     ]
-                   ]);
-                   async.done();
-                 });
-           }));
+                     ]);
+                     async.done();
+                   });
+             }));
+
+          it('should allow to import rules transitively', inject([AsyncTestCompleter], (async) => {
+               compile(['div {\ncolor: red;\n}'], [IMPORT_ABS_STYLESHEET_URL_WITH_IMPORT],
+                       encapsulation)
+                   .then(styles => {
+                     compareStyles(styles, [
+                       'div[_ngcontent-%COMP%] {\ncolor: red;\n}',
+                       [
+                         'a[_ngcontent-%COMP%] {color: green}',
+                         ['span[_ngcontent-%COMP%] {color: blue}']
+                       ]
+                     ]);
+                     async.done();
+                   });
+             }));
+
+        });
+
       });
 
       it('should cache stylesheets for parallel requests', inject([AsyncTestCompleter], (async) => {
@@ -243,29 +245,29 @@ export function main() {
       });
 
       describe('with shim', () => {
-        var encapsulation = ViewEncapsulation.Emulated;
+        [ViewEncapsulation.Emulated, ViewEncapsulation.EmulatedLegacy].forEach((encapsulation) => {
+          it('should compile plain css ruless', inject([AsyncTestCompleter], (async) => {
+               compile(['div {\ncolor: red;\n}', 'span {\ncolor: blue;\n}'], [], encapsulation)
+                   .then(styles => {
+                     compareStyles(styles, [
+                       'div[_ngcontent-%COMP%] {\ncolor: red;\n}',
+                       'span[_ngcontent-%COMP%] {\ncolor: blue;\n}'
+                     ]);
+                     async.done();
+                   });
+             }));
 
-        it('should compile plain css ruless', inject([AsyncTestCompleter], (async) => {
-             compile(['div {\ncolor: red;\n}', 'span {\ncolor: blue;\n}'], [], encapsulation)
-                 .then(styles => {
-                   compareStyles(styles, [
-                     'div[_ngcontent-%COMP%] {\ncolor: red;\n}',
-                     'span[_ngcontent-%COMP%] {\ncolor: blue;\n}'
-                   ]);
-                   async.done();
-                 });
-           }));
-
-        it('should allow to import rules', inject([AsyncTestCompleter], (async) => {
-             compile(['div {color: red}'], [IMPORT_ABS_STYLESHEET_URL], encapsulation)
-                 .then(styles => {
-                   compareStyles(styles, [
-                     'div[_ngcontent-%COMP%] {color: red}',
-                     ['span[_ngcontent-%COMP%] {\ncolor: blue;\n}']
-                   ]);
-                   async.done();
-                 });
-           }), 1000);
+          it('should allow to import rules', inject([AsyncTestCompleter], (async) => {
+               compile(['div {color: red}'], [IMPORT_ABS_STYLESHEET_URL], encapsulation)
+                   .then(styles => {
+                     compareStyles(styles, [
+                       'div[_ngcontent-%COMP%] {color: red}',
+                       ['span[_ngcontent-%COMP%] {\ncolor: blue;\n}']
+                     ]);
+                     async.done();
+                   });
+             }), 1000);
+        });
       });
     });
 

--- a/modules/angular2/test/compiler/template_normalizer_spec.ts
+++ b/modules/angular2/test/compiler/template_normalizer_spec.ts
@@ -161,7 +161,7 @@ export function main() {
     });
 
     describe('normalizeLoadedTemplate', () => {
-      it('should store the viewEncapsulationin the result',
+      it('should store the viewEncapsulation in the result',
          inject([TemplateNormalizer], (normalizer: TemplateNormalizer) => {
 
            var viewEncapsulation = ViewEncapsulation.Native;
@@ -301,6 +301,16 @@ export function main() {
            var template = normalizer.normalizeLoadedTemplate(
                dirType, new CompileTemplateMetadata(
                             {encapsulation: ViewEncapsulation.Emulated, styles: [], styleUrls: []}),
+               '', 'package:some/module/id');
+           expect(template.encapsulation).toEqual(ViewEncapsulation.None);
+         }));
+
+      it('should normalize ViewEncapsulation.EmulatedLegacy to ViewEncapsulation.None if there are no styles nor stylesheets',
+         inject([TemplateNormalizer], (normalizer: TemplateNormalizer) => {
+           var template = normalizer.normalizeLoadedTemplate(
+               dirType,
+               new CompileTemplateMetadata(
+                   {encapsulation: ViewEncapsulation.EmulatedLegacy, styles: [], styleUrls: []}),
                '', 'package:some/module/id');
            expect(template.encapsulation).toEqual(ViewEncapsulation.None);
          }));

--- a/modules/angular2/test/public_api_spec.ts
+++ b/modules/angular2/test/public_api_spec.ts
@@ -1350,6 +1350,7 @@ var NG_CORE = [
   */
   'ViewContainerRef.length',
   'ViewEncapsulation#Emulated',
+  'ViewEncapsulation#EmulatedLegacy',
   'ViewEncapsulation#Native',
   'ViewEncapsulation#None',
   'ViewEncapsulation#values',

--- a/tools/public_api_guard/public_api_spec.ts
+++ b/tools/public_api_guard/public_api_spec.ts
@@ -468,6 +468,7 @@ const CORE = [
   'ViewDecorator.View(obj:{templateUrl?:string, template?:string, directives?:Array<Type|any[]>, pipes?:Array<Type|any[]>, renderer?:string, styles?:string[], styleUrls?:string[]}):ViewDecorator',
   'ViewEncapsulation',
   'ViewEncapsulation.Emulated',
+  'ViewEncapsulation.EmulatedLegacy',
   'ViewEncapsulation.Native',
   'ViewEncapsulation.None',
   'ViewFactory',


### PR DESCRIPTION
ref https://github.com/angular/angular/issues/5390

The Emulated mode will be updated to properly shim selectors after :host so that they don't cross child component shadow boundaries. This will be a breaking change.

The EmulatedLegacy mode has the same semantics has the current Emulated mode.
