### PR TITLE
fix(angular_1_router): Renamed transpiled require functions

### DIFF
--- a/modules/angular1_router/build.js
+++ b/modules/angular1_router/build.js
@@ -48,9 +48,10 @@ function main(modulesDirectory) {
  */
 var IMPORT_RE = new RegExp("import \\{?([\\w\\n_, ]+)\\}? from '(.+)';?", 'g');
 var INJECT_RE = new RegExp("@Inject\\(ROUTER_PRIMARY_COMPONENT\\)", 'g');
-var IMJECTABLE_RE = new RegExp("@Injectable\\(\\)", 'g');
+var INJECTABLE_RE = new RegExp("@Injectable\\(\\)", 'g');
+var REQUIRE_RE = new RegExp("require\\('(.*?)'\\);", 'g');
 function transform(contents) {
-  contents = contents.replace(INJECT_RE, '').replace(IMJECTABLE_RE, '');
+  contents = contents.replace(INJECT_RE, '').replace(INJECTABLE_RE, '');
   contents = contents.replace(IMPORT_RE, function (match, imports, includePath) {
     //TODO: remove special-case
     if (isFacadeModule(includePath) || includePath === './router_outlet') {
@@ -58,10 +59,15 @@ function transform(contents) {
     }
     return match;
   });
-  return ts.transpile(contents, {
+  contents = ts.transpile(contents, {
     target: ts.ScriptTarget.ES5,
     module: ts.ModuleKind.CommonJS
   });
+
+  // Rename require functions from transpiled imports
+  contents = contents.replace(REQUIRE_RE, 'routerRequire(\'$1\');');
+
+  return contents;
 }
 
 function isFacadeModule(modulePath) {

--- a/modules/angular1_router/src/module_template.js
+++ b/modules/angular1_router/src/module_template.js
@@ -17,7 +17,7 @@ function routerFactory($q, $location, $$directiveIntrospector, $browser, $rootSc
     OpaqueToken: function () {},
     Inject: function () {}
   };
-  var require = function () {return exports;};
+  var routerRequire = function () {return exports;};
 
   // When this file is processed, the line below is replaced with
   // the contents of the compiled TypeScript classes.


### PR DESCRIPTION
Closes #6914 

The require function was causing failures when using bundlers such as Browserify and SystemJS.

cc: @petebacondarwin 
