### PR TITLE
fix(change_detection): ChangeDetectorRef reattach should restore original mode

### DIFF
--- a/modules/@angular/core/src/linker/view_ref.ts
+++ b/modules/@angular/core/src/linker/view_ref.ts
@@ -80,7 +80,13 @@ export abstract class EmbeddedViewRef<C> extends ViewRef {
 }
 
 export class ViewRef_<C> implements EmbeddedViewRef<C>, ChangeDetectorRef {
-  constructor(private _view: AppView<C>) { this._view = _view; }
+  /** @internal */
+  _originalMode: ChangeDetectionStrategy;
+
+  constructor(private _view: AppView<C>) {
+    this._view = _view;
+    this._originalMode = this._view.cdMode;
+  }
 
   get internalView(): AppView<C> { return this._view; }
 
@@ -95,7 +101,7 @@ export class ViewRef_<C> implements EmbeddedViewRef<C>, ChangeDetectorRef {
   detectChanges(): void { this._view.detectChanges(false); }
   checkNoChanges(): void { this._view.detectChanges(true); }
   reattach(): void {
-    this._view.cdMode = ChangeDetectionStrategy.CheckAlways;
+    this._view.cdMode = this._originalMode;
     this.markForCheck();
   }
 


### PR DESCRIPTION
After using ChangeDetectorRef detach, it should keep the ChangeDetector mode so that it is restored after calling reattach.

See http://plnkr.co/edit/8FnczklxX1WlRfWpquvM?p=preview to reproduce.

closes #7078
