### PR TITLE
fix(pipes): handle undefined value in slice

### DIFF
--- a/modules/@angular/common/src/pipes/slice_pipe.ts
+++ b/modules/@angular/common/src/pipes/slice_pipe.ts
@@ -42,6 +42,8 @@ import {InvalidPipeArgumentException} from './invalid_pipe_argument_exception';
  * When operating on a [List], the returned list is always a copy even when all
  * the elements are being returned.
  *
+ * When operating on a blank value, returns it.
+ *
  * ## List Example
  *
  * This `ngFor` example:
@@ -62,10 +64,10 @@ import {InvalidPipeArgumentException} from './invalid_pipe_argument_exception';
 @Injectable()
 export class SlicePipe implements PipeTransform {
   transform(value: any, start: number, end: number = null): any {
+    if (isBlank(value)) return value;
     if (!this.supports(value)) {
       throw new InvalidPipeArgumentException(SlicePipe, value);
     }
-    if (isBlank(value)) return value;
     if (isString(value)) {
       return StringWrapper.slice(value, start, end);
     }

--- a/modules/@angular/common/test/pipes/slice_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/slice_pipe_spec.ts
@@ -41,6 +41,9 @@ export function main() {
 
     describe("transform", () => {
 
+      it('should return null if the value is null',
+         () => { expect(pipe.transform(null, [4, 2])).toBe(null); });
+
       it('should return all items after START index when START is positive and END is omitted',
          () => {
            expect(pipe.transform(list, 3)).toEqual([4, 5]);


### PR DESCRIPTION
Currently (beta.6), if the `slice` pipe is used with an undefined value, the app throws an `InvalidArgumentException` and breaks:

```
Invalid argument 'undefined' for pipe 'SlicePipe'
```

Checking for blank value before checking the argument validity fixes the problem.
