### PR TITLE
docs(ContentChild): add example with refs

### DIFF
--- a/modules/angular2/src/core/metadata.ts
+++ b/modules/angular2/src/core/metadata.ts
@@ -1087,11 +1087,20 @@ export var ContentChildren: ContentChildrenFactory = makePropDecorator(ContentCh
  * })
  * class SomeDir {
  *   @ContentChild(ChildDirective) contentChild;
+ *   @ContentChild('container_ref') containerChild
  *
  *   ngAfterContentInit() {
  *     // contentChild is set
+ *     // containerChild is set
  *   }
  * }
+ * ```
+ * 
+ * ```html
+ * <container #container_ref>
+ *   <item>a</item>
+ *   <item>b</item>
+ * </container>
  * ```
  */
 export var ContentChild: ContentChildFactory = makePropDecorator(ContentChildMetadata);


### PR DESCRIPTION
Add missing example on how ContentChild works with refs
Closes angular#7160
