### PR TITLE
Handle unrecognized instructions in router

### DIFF
--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -432,6 +432,10 @@ export class RootRouter extends Router {
           .then((instruction) => {
             this.navigateByInstruction(instruction, isPresent(change['pop']))
                 .then((_) => {
+                  // Instruction was not recognized, return immediately.
+                  if (instruction == null) {
+                    return;
+                  }
                   // this is a popstate event; no need to change the URL
                   if (isPresent(change['pop']) && change['type'] != 'hashchange') {
                     return;


### PR DESCRIPTION
This is currently throwing a null error when the instruction is not recognized by the router, and AFAICT there is no way to catch that.
