### PR TITLE
fix change event not fired in IE and FF

### DIFF
--- a/modules/angular2/src/common/forms/directives/select_control_value_accessor.ts
+++ b/modules/angular2/src/common/forms/directives/select_control_value_accessor.ts
@@ -39,7 +39,7 @@ function _extractId(valueString: string): string {
  */
 @Directive({
   selector: 'select[ngControl],select[ngFormControl],select[ngModel]',
-  host: {'(input)': 'onChange($event.target.value)', '(blur)': 'onTouched()'},
+  host: {'(change)': 'onChange($event.target.value)', '(blur)': 'onTouched()'},
   providers: [SELECT_VALUE_ACCESSOR]
 })
 export class SelectControlValueAccessor implements ControlValueAccessor {

--- a/modules/angular2/test/common/forms/integration_spec.ts
+++ b/modules/angular2/test/common/forms/integration_spec.ts
@@ -425,7 +425,7 @@ export function main() {
                expect(sfOption.nativeElement.selected).toBe(true);
 
                select.nativeElement.value = "NYC";
-               dispatchEvent(select.nativeElement, "input");
+               dispatchEvent(select.nativeElement, "change");
 
                expect(fixture.debugElement.componentInstance.form.value).toEqual({"city": 'NYC'});
                expect(sfOption.nativeElement.selected).toBe(false);
@@ -480,7 +480,7 @@ export function main() {
                       expect(nycOption.nativeElement.selected).toBe(true);
 
                       select.nativeElement.value = "2: Object";
-                      dispatchEvent(select.nativeElement, "input");
+                      dispatchEvent(select.nativeElement, "change");
                       fixture.detectChanges();
                       TimerWrapper.setTimeout(() => {
                         expect(testComp.selectedCity['name']).toEqual("Buffalo");


### PR DESCRIPTION
fixes the following issues:
https://github.com/angular/angular/issues/7092
https://github.com/angular/angular/issues/6721
https://github.com/angular/angular/issues/6573

by using the "change"-event instead of the "input"-event (which seems to be unreliable in IE and FF)
