### PR TITLE
docs(DynamicComponentLoader): move examples to ngOnInit

### DIFF
--- a/modules/angular2/src/core/linker/dynamic_component_loader.ts
+++ b/modules/angular2/src/core/linker/dynamic_component_loader.ts
@@ -63,7 +63,7 @@ export abstract class DynamicComponentLoader {
    * ```
    */
   abstract loadAsRoot(type: Type, overrideSelectorOrNode: string | any, injector: Injector,
-                      onDispose?: () => void, projectableNodes?: any[][]): Promise<ComponentRef>;
+    onDispose?: () => void, projectableNodes?: any[][]): Promise<ComponentRef>;
 
 
   /**
@@ -99,6 +99,37 @@ export abstract class DynamicComponentLoader {
    * bootstrap(MyApp);
    * ```
    *
+   * We can also use an element from the view
+   *
+   * ### Example
+   *
+   * ```
+   * @Component({
+   *   selector: 'child-component',
+   *   template: 'Child'
+   * })
+   * class ChildComponent {
+   * }
+   *
+   * @Component({
+   *   selector: 'my-app',
+   *   template: '<div #container></div>'
+   * })
+   * class MyApp implements AfterViewInit {
+   * 
+   *   @ViewChild('container', {read : ViewContainerRef}) container: ViewContainerRef;
+   *   
+   *   constructor(this.dcl: DynamicComponentLoader) {
+   *   }
+   *
+   *   ngAfterViewInit() {
+   *     this.dcl.loadNextToLocation(ChildComponent, this.container);
+   *   }
+   * }
+   *
+   * bootstrap(MyApp);
+   * ```
+   *
    * Resulting DOM:
    *
    * ```
@@ -107,8 +138,8 @@ export abstract class DynamicComponentLoader {
    * ```
    */
   abstract loadNextToLocation(type: Type, location: ViewContainerRef,
-                              providers?: ResolvedReflectiveProvider[],
-                              projectableNodes?: any[][]): Promise<ComponentRef>;
+    providers?: ResolvedReflectiveProvider[],
+    projectableNodes?: any[][]): Promise<ComponentRef>;
 }
 
 @Injectable()
@@ -116,11 +147,11 @@ export class DynamicComponentLoader_ extends DynamicComponentLoader {
   constructor(private _compiler: ComponentResolver) { super(); }
 
   loadAsRoot(type: Type, overrideSelectorOrNode: string | any, injector: Injector,
-             onDispose?: () => void, projectableNodes?: any[][]): Promise<ComponentRef> {
+    onDispose?: () => void, projectableNodes?: any[][]): Promise<ComponentRef> {
     return this._compiler.resolveComponent(type).then(componentFactory => {
       var componentRef = componentFactory.create(
-          injector, projectableNodes,
-          isPresent(overrideSelectorOrNode) ? overrideSelectorOrNode : componentFactory.selector);
+        injector, projectableNodes,
+        isPresent(overrideSelectorOrNode) ? overrideSelectorOrNode : componentFactory.selector);
       if (isPresent(onDispose)) {
         componentRef.onDestroy(onDispose);
       }
@@ -129,15 +160,15 @@ export class DynamicComponentLoader_ extends DynamicComponentLoader {
   }
 
   loadNextToLocation(type: Type, location: ViewContainerRef,
-                     providers: ResolvedReflectiveProvider[] = null,
-                     projectableNodes: any[][] = null): Promise<ComponentRef> {
+    providers: ResolvedReflectiveProvider[] = null,
+    projectableNodes: any[][] = null): Promise<ComponentRef> {
     return this._compiler.resolveComponent(type).then(componentFactory => {
       var contextInjector = location.parentInjector;
       var childInjector = isPresent(providers) && providers.length > 0 ?
-                              ReflectiveInjector.fromResolvedProviders(providers, contextInjector) :
-                              contextInjector;
+        ReflectiveInjector.fromResolvedProviders(providers, contextInjector) :
+        contextInjector;
       return location.createComponent(componentFactory, location.length, childInjector,
-                                      projectableNodes);
+        projectableNodes);
     });
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features) (no need to but I had to mark it so it doesn't show as an incomplete task)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Documentation update

**What is the current behavior? (You can also link to an open issue here)**

The [current state](https://angular.io/docs/ts/latest/api/core/DynamicComponentLoader-class.html) of the examples in the doc shows that we can use DynamicComponentLoader in the constructor. 
This is causing issues, see https://github.com/angular/angular/issues/7334 and this [SO question](http://stackoverflow.com/q/35508458/4933038)

**What is the new behavior (if this is a feature change)?**

This changed in beta.1, the view is no longer accessible in the constructor. 
See [breaking changes section](https://github.com/angular/angular/blob/master/CHANGELOG.md#200-beta1-catamorphic-involution-2016-01-08).

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**

Not a breaking change regarding DCL functionality, but the user has to move the code from the constructor to ngOnInit.

**Other information:** -
