### PR TITLE
fix(router): handle unrecognized instructions

### DIFF
--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -431,7 +431,11 @@ export class RootRouter extends Router {
       this.recognize(change['url'])
           .then((instruction) => {
             this.navigateByInstruction(instruction, isPresent(change['pop']))
-                .then((_) => {
+                .then((result) => {
+                  if (result == false) {
+                    // Instruction was not recognized.
+                    return;
+                  }
                   // this is a popstate event; no need to change the URL
                   if (isPresent(change['pop']) && change['type'] != 'hashchange') {
                     return;


### PR DESCRIPTION
Fixes: #7349

This is currently throwing a null error when the instruction is not
recognized by the router, and AFAICT there is no way to catch that.
