### PR TITLE
fix(headers): browser header responses differ

### DIFF
--- a/modules/angular2/src/http/headers.ts
+++ b/modules/angular2/src/http/headers.ts
@@ -70,7 +70,7 @@ export class Headers {
     return headersString.trim()
         .split('\n')
         .map(val => val.split(':'))
-        .map(([key, ...parts]) => ([key.trim(), parts.join(':').trim()]))
+        .map(([key, ...parts]) => ([key.trim().toLowerCase(), parts.join(':').trim()]))
         .reduce((headers, [key, value]) => !headers.set(key, value) && headers, new Headers());
   }
 


### PR DESCRIPTION
Firefox returns headers with case intact, Chrome returns lowercase headers. This normalises the response between browsers.

Before this pull request

``` typescript
// This works in Firefox
let length: string = response.headers.get('Content-Length');

// This works in Chrome
let length: string = response.headers.get('content-length');
```
