### PR TITLE
refactor(NgControlName): exportAs ngControl instead of ngForm

### DIFF
--- a/modules/angular2/src/common/forms/directives/ng_control_name.ts
+++ b/modules/angular2/src/common/forms/directives/ng_control_name.ts
@@ -93,7 +93,7 @@ const controlNameBinding =
   bindings: [controlNameBinding],
   inputs: ['name: ngControl', 'model: ngModel'],
   outputs: ['update: ngModelChange'],
-  exportAs: 'ngForm'
+  exportAs: 'ngControl'
 })
 export class NgControlName extends NgControl implements OnChanges,
     OnDestroy {


### PR DESCRIPTION
Closes #7236

BREAKING CHANGE: `NgControlName` now exports as `ngControl`

To migrate the code follow the example below:

Before:

```
<form>
  <input ngControl="name" #name="ngForm">
</form>
```

After:

```
<form>
  <input ngContorl="name" #name="ngControl">
</form>
```
