### PR TITLE
build(serve): added cors support for the js.server task

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "chokidar": "^1.1.0",
     "clang-format": "^1.0.32",
     "conventional-changelog": "^0.2.1",
+    "cors": "^2.7.1",
     "firefox-profile": "^0.3.4",
     "fs-extra": "^0.26.3",
     "glob": "^4.0.6",

--- a/tools/build/jsserve.js
+++ b/tools/build/jsserve.js
@@ -1,5 +1,6 @@
 var onHeaders = require('on-headers');
 var proxy = require('proxy-middleware');
+var cors = require('cors');
 var url = require('url');
 
 module.exports = function(gulp, plugins, config) {
@@ -14,13 +15,14 @@ module.exports = function(gulp, plugins, config) {
         var middlewares =
             config.proxies.map(function(entry) { return makeProxy(entry.route, entry.url); });
         middlewares.push(connect.favicon());
+        middlewares.push(cors());
         // pub serve can't give the right content-type header for jsonp requests
         // so we must turn off Chromium strict MIME type checking
         // see https://github.com/angular/angular/issues/3030#issuecomment-123453168
         middlewares.unshift(stripHeader('x-content-type-options'));
         return middlewares;
       }
-    })();
+    });
   };
 };
 


### PR DESCRIPTION
Added and used the cors middleware:
- add the module as a dev depedency in the package.json file
- require the module in the jsserve.js file
- add the module in the middleware list

Closes #7273
