### PR TITLE
feat(http): added withCredentials support

### DIFF
--- a/modules/angular2/src/http/backends/xhr_backend.ts
+++ b/modules/angular2/src/http/backends/xhr_backend.ts
@@ -32,6 +32,9 @@ export class XHRConnection implements Connection {
     this.response = new Observable((responseObserver: Observer<Response>) => {
       let _xhr: XMLHttpRequest = browserXHR.build();
       _xhr.open(RequestMethod[req.method].toUpperCase(), req.url);
+      if (isPresent(req.withCredentials)) {
+        _xhr.withCredentials = req.withCredentials;
+      }
       // load event handler
       let onLoad = () => {
         // responseText is the old-school way of retrieving response (supported by IE8 & 9)

--- a/modules/angular2/src/http/base_request_options.ts
+++ b/modules/angular2/src/http/base_request_options.ts
@@ -53,7 +53,11 @@ export class RequestOptions {
    * Search parameters to be included in a {@link Request}.
    */
   search: URLSearchParams;
-  constructor({method, headers, body, url, search}: RequestOptionsArgs = {}) {
+  /**
+   * Enable use credentials for a {@link Request}.
+   */
+  withCredentials: boolean;
+  constructor({method, headers, body, url, search, withCredentials}: RequestOptionsArgs = {}) {
     this.method = isPresent(method) ? normalizeMethodName(method) : null;
     this.headers = isPresent(headers) ? headers : null;
     this.body = isPresent(body) ? body : null;
@@ -61,6 +65,7 @@ export class RequestOptions {
     this.search = isPresent(search) ? (isString(search) ? new URLSearchParams(<string>(search)) :
                                                           <URLSearchParams>(search)) :
                                       null;
+    this.withCredentials = isPresent(withCredentials) ? withCredentials : null;
   }
 
   /**
@@ -97,7 +102,10 @@ export class RequestOptions {
       search: isPresent(options) && isPresent(options.search) ?
                   (isString(options.search) ? new URLSearchParams(<string>(options.search)) :
                                               (<URLSearchParams>(options.search)).clone()) :
-                  this.search
+                  this.search,
+      withCredentials: isPresent(options) && isPresent(options.withCredentials) ?
+                           options.withCredentials :
+                           this.withCredentials
     });
   }
 }

--- a/modules/angular2/src/http/http.ts
+++ b/modules/angular2/src/http/http.ts
@@ -22,7 +22,8 @@ function mergeOptions(defaultOpts: BaseRequestOptions, providedOpts: RequestOpti
       url: providedOpts.url || url,
       search: providedOpts.search,
       headers: providedOpts.headers,
-      body: providedOpts.body
+      body: providedOpts.body,
+      withCredentials: providedOpts.withCredentials
     }));
   }
   if (isPresent(method)) {

--- a/modules/angular2/src/http/interfaces.ts
+++ b/modules/angular2/src/http/interfaces.ts
@@ -33,6 +33,7 @@ export interface RequestOptionsArgs {
   headers?: Headers;
   // TODO: Support Blob, ArrayBuffer, JSON, URLSearchParams, FormData
   body?: string;
+  withCredentials?: boolean;
 }
 
 /**

--- a/modules/angular2/src/http/static_request.ts
+++ b/modules/angular2/src/http/static_request.ts
@@ -61,6 +61,8 @@ export class Request {
   url: string;
   // TODO: support URLSearchParams | FormData | Blob | ArrayBuffer
   private _body: string;
+  /** Enable use credentials */
+  withCredentials: boolean;
   constructor(requestOptions: RequestArgs) {
     // TODO: assert that url is present
     let url = requestOptions.url;
@@ -82,6 +84,7 @@ export class Request {
     // Defaults to 'omit', consistent with browser
     // TODO(jeffbcross): implement behavior
     this.headers = new Headers(requestOptions.headers);
+    this.withCredentials = requestOptions.withCredentials;
   }
 
 

--- a/modules/angular2/src/testing/testing_internal.ts
+++ b/modules/angular2/src/testing/testing_internal.ts
@@ -31,6 +31,7 @@ export class AsyncTestCompleter {
   done(): void { this._done(); }
 }
 
+console.log(browserDetection);
 var jsmBeforeEach = _global.beforeEach;
 var jsmDescribe = _global.describe;
 var jsmDDescribe = _global.fdescribe;

--- a/modules/angular2/test/http/backends/xhr_backend_spec.ts
+++ b/modules/angular2/test/http/backends/xhr_backend_spec.ts
@@ -42,6 +42,7 @@ class MockBrowserXHR extends BrowserXhr {
   status: number;
   responseHeaders: string;
   responseURL: string;
+  withCredentials: boolean;
   constructor() {
     super();
     var spy = new SpyObject();
@@ -105,6 +106,7 @@ export function main() {
     describe('XHRConnection', () => {
       it('should use the injected BaseResponseOptions to create the response',
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+           console.log('test1');
            var connection = new XHRConnection(sampleRequest, new MockBrowserXHR(),
                                               new ResponseOptions({type: ResponseType.Error}));
            connection.response.subscribe((res: Response) => {
@@ -326,6 +328,27 @@ export function main() {
 
                                  connection.response.subscribe((res: Response) => {
                                    expect(res.url).toEqual('http://somedomain.com');
+                                   async.done();
+                                 });
+
+           existingXHRs[0].setResponseHeaders(responseHeaders);
+           existingXHRs[0].setStatusCode(statusCode);
+           existingXHRs[0].dispatchEvent('load');
+         }));
+
+      it('should set withCredentials to true when defined in request options for CORS situations',
+         inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+           var statusCode = 200;
+           sampleRequest.withCredentials = true;
+           var mockXhr = new MockBrowserXHR();
+           var connection =
+               new XHRConnection(sampleRequest, mockXhr, new ResponseOptions({status: statusCode}));
+           var responseHeaders = `X-Request-URL: http://somedomain.com
+           Foo: Bar`
+
+                                 connection.response.subscribe((res: Response) => {
+                                   expect(res.url).toEqual('http://somedomain.com');
+                                   expect(existingXHRs[0].withCredentials).toBeTruthy();
                                    async.done();
                                  });
 


### PR DESCRIPTION
Taken into account the withCredentials property within the request options:
- added corresponding property in the RequestOptions class
- added corresponding property in the Request class
- handle this property when merging options
- set the withCredentials property on the XHR object when specified

Added a test in the xhr_backend_spec.ts to check that the property is actually
set on the XHR object

Closes https://github.com/angular/http/issues/65
