### PR TITLE
chore(build): Remove circular dependency in Angular 2 ES5 output.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -344,9 +344,8 @@ gulp.task('lint', ['build.tools'], function() {
 gulp.task('build/checkCircularDependencies', function(done) {
   var madge = require('madge');
 
-  var dependencyObject = madge(CONFIG.dest.js.dev.es5, {
+  var dependencyObject = madge([CONFIG.dest.js.dev.es5], {
     format: 'cjs',
-    paths: [CONFIG.dest.js.dev.es5],
     extensions: ['.js'],
     onParseFile: function(data) { data.src = data.src.replace(/\/\* circular \*\//g, "//"); }
   });

--- a/modules/angular2/src/facade/base_wrapped_exception.dart
+++ b/modules/angular2/src/facade/base_wrapped_exception.dart
@@ -1,0 +1,17 @@
+library angular.core.facade.base_wrapped_exception;
+
+/**
+ * A base class for the WrappedException that can be used to identify
+ * a WrappedException from ExceptionHandler without adding circular
+ * dependency.
+ */
+class BaseWrappedException extends Error {
+  BaseWrappedException();
+
+  get originalException => null;
+  get originalStack => null;
+
+  String get message => '';
+  String get wrapperMessage => '';
+  dynamic get context => null;
+}

--- a/modules/angular2/src/facade/base_wrapped_exception.ts
+++ b/modules/angular2/src/facade/base_wrapped_exception.ts
@@ -1,0 +1,15 @@
+/**
+ * A base class for the WrappedException that can be used to identify
+ * a WrappedException from ExceptionHandler without adding circular
+ * dependency.
+ */
+export class BaseWrappedException extends Error {
+  constructor(message: string) { super(message); }
+
+  get wrapperMessage(): string { return ''; }
+  get wrapperStack(): any { return null; }
+  get originalException(): any { return null; }
+  get originalStack(): any { return null; }
+  get context(): any { return null; }
+  get message(): string { return ''; }
+}

--- a/modules/angular2/src/facade/exception_handler.ts
+++ b/modules/angular2/src/facade/exception_handler.ts
@@ -1,5 +1,5 @@
 import {isPresent, isBlank, print} from 'angular2/src/facade/lang';
-import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
+import {BaseWrappedException} from 'angular2/src/facade/base_wrapped_exception';
 import {ListWrapper, isListLikeIterable} from 'angular2/src/facade/collection';
 
 class _ArrayLogger {
@@ -80,7 +80,8 @@ export class ExceptionHandler {
 
   /** @internal */
   _extractMessage(exception: any): string {
-    return exception instanceof WrappedException ? exception.wrapperMessage : exception.toString();
+    return exception instanceof BaseWrappedException ? exception.wrapperMessage :
+                                                       exception.toString();
   }
 
   /** @internal */
@@ -92,7 +93,7 @@ export class ExceptionHandler {
   /** @internal */
   _findContext(exception: any): any {
     try {
-      if (!(exception instanceof WrappedException)) return null;
+      if (!(exception instanceof BaseWrappedException)) return null;
       return isPresent(exception.context) ? exception.context :
                                             this._findContext(exception.originalException);
     } catch (e) {
@@ -103,10 +104,10 @@ export class ExceptionHandler {
 
   /** @internal */
   _findOriginalException(exception: any): any {
-    if (!(exception instanceof WrappedException)) return null;
+    if (!(exception instanceof BaseWrappedException)) return null;
 
     var e = exception.originalException;
-    while (e instanceof WrappedException && isPresent(e.originalException)) {
+    while (e instanceof BaseWrappedException && isPresent(e.originalException)) {
       e = e.originalException;
     }
 
@@ -115,13 +116,13 @@ export class ExceptionHandler {
 
   /** @internal */
   _findOriginalStack(exception: any): any {
-    if (!(exception instanceof WrappedException)) return null;
+    if (!(exception instanceof BaseWrappedException)) return null;
 
     var e = exception;
     var stack = exception.originalStack;
-    while (e instanceof WrappedException && isPresent(e.originalException)) {
+    while (e instanceof BaseWrappedException && isPresent(e.originalException)) {
       e = e.originalException;
-      if (e instanceof WrappedException && isPresent(e.originalException)) {
+      if (e instanceof BaseWrappedException && isPresent(e.originalException)) {
         stack = e.originalStack;
       }
     }

--- a/modules/angular2/src/facade/exceptions.dart
+++ b/modules/angular2/src/facade/exceptions.dart
@@ -1,5 +1,6 @@
 library angular.core.facade.exceptions;
 
+import 'base_wrapped_exception.dart';
 import 'exception_handler.dart';
 export 'exception_handler.dart';
 
@@ -15,7 +16,7 @@ class BaseException extends Error {
   }
 }
 
-class WrappedException extends Error {
+class WrappedException extends BaseWrappedException {
   final dynamic _context;
   final String _wrapperMessage;
   final originalException;
@@ -27,7 +28,7 @@ class WrappedException extends Error {
       this.originalStack,
       this._context]);
 
-  get message {
+  String get message {
     return ExceptionHandler.exceptionToString(this);
   }
 

--- a/modules/angular2/src/facade/exceptions.ts
+++ b/modules/angular2/src/facade/exceptions.ts
@@ -1,3 +1,4 @@
+import {BaseWrappedException} from './base_wrapped_exception';
 import {ExceptionHandler} from './exception_handler';
 
 export {ExceptionHandler} from './exception_handler';
@@ -15,7 +16,7 @@ export class BaseException extends Error {
 /**
  * Wraps an exception and provides additional context or information.
  */
-export class WrappedException extends Error {
+export class WrappedException extends BaseWrappedException {
   private _wrapperStack: any;
 
   constructor(private _wrapperMessage: string, private _originalException, private _originalStack?,

--- a/modules/angular2/src/router/router_providers.ts
+++ b/modules/angular2/src/router/router_providers.ts
@@ -1,5 +1,4 @@
-// import {ROUTER_PROVIDERS_COMMON} from './router_providers_common';
-import {ROUTER_PROVIDERS_COMMON} from 'angular2/router';
+import {ROUTER_PROVIDERS_COMMON} from './router_providers_common';
 import {Provider} from 'angular2/core';
 import {CONST_EXPR} from 'angular2/src/facade/lang';
 import {BrowserPlatformLocation} from './browser_platform_location';


### PR DESCRIPTION
Remove couple of circular dependency between modules in Angular 2 ES5 output caused by exception_handler.ts and router_providers.ts.

Fix the build/checkCircularDependency gulp task to call madge properly to detect the circular deps.
