### PR TITLE
chore(tests): lengthen timeout for templateUrl test

### DIFF
--- a/modules/angular2/test/testing/testing_public_spec.ts
+++ b/modules/angular2/test/testing/testing_public_spec.ts
@@ -478,6 +478,6 @@ export function main() {
                expect(componentFixture.debugElement.nativeElement)
                    .toHaveText('from external template\n');
              });
-       }));
+       }), 10000);  // Long timeout here because this test makes an actual XHR, and is slow on Edge.
   });
 }


### PR DESCRIPTION
This was flaking on Travis occasionally because the TestComponentBuilder
is actually doing an XHR, and it was slow on the Edge browser.
