### PR TITLE
Remove forward slashes and equal signs as delimiters in query parameter values

### DIFF
--- a/modules/angular2/src/router/url_parser.ts
+++ b/modules/angular2/src/router/url_parser.ts
@@ -69,6 +69,11 @@ function matchUrlSegment(str: string): string {
   var match = RegExpWrapper.firstMatch(SEGMENT_RE, str);
   return isPresent(match) ? match[0] : '';
 }
+var QUERY_PARAM_VALUE_RE = RegExpWrapper.create('^[^\\(\\)\\?;&#]+');
+function matchUrlQueryParamValue(str: string): string {
+  var match = RegExpWrapper.firstMatch(QUERY_PARAM_VALUE_RE, str);
+  return isPresent(match) ? match[0] : '';
+}
 
 export class UrlParser {
   private _remaining: string;
@@ -148,10 +153,10 @@ export class UrlParser {
   parseQueryParams(): {[key: string]: any} {
     var params = {};
     this.capture('?');
-    this.parseParam(params);
+    this.parseQueryParam(params);
     while (this._remaining.length > 0 && this.peekStartsWith('&')) {
       this.capture('&');
-      this.parseParam(params);
+      this.parseQueryParam(params);
     }
     return params;
   }
@@ -175,6 +180,25 @@ export class UrlParser {
     if (this.peekStartsWith('=')) {
       this.capture('=');
       var valueMatch = matchUrlSegment(this._remaining);
+      if (isPresent(valueMatch)) {
+        value = valueMatch;
+        this.capture(value);
+      }
+    }
+
+    params[key] = value;
+  }
+
+  parseQueryParam(params: { [key: string]: any }): void {
+    var key = matchUrlSegment(this._remaining);
+    if (isBlank(key)) {
+      return;
+    }
+    this.capture(key);
+    var value: any = true;
+    if (this.peekStartsWith('=')) {
+      this.capture('=');
+      var valueMatch = matchUrlQueryParamValue(this._remaining);
       if (isPresent(valueMatch)) {
         value = valueMatch;
         this.capture(value);

--- a/modules/angular2/test/router/url_parser_spec.ts
+++ b/modules/angular2/test/router/url_parser_spec.ts
@@ -124,5 +124,9 @@ export function main() {
       var url = urlParser.parse('hello/there;sort=asc(modal)?friend=true');
       expect(url.toString()).toEqual('hello/there;sort=asc(modal)?friend=true');
     });
+    it('should allow slashes within query parameters', () => {
+      var url = urlParser.parse('hello?code=4/B8o0n_Y7XZTb-pVKBw5daZyGAUbMljyLf7uNgTy6ja8&scope=https://www.googleapis.com/auth/analytics');
+      expect(url.toString()).toEqual('hello?code=4/B8o0n_Y7XZTb-pVKBw5daZyGAUbMljyLf7uNgTy6ja8&scope=https://www.googleapis.com/auth/analytics');
+    });
   });
 }


### PR DESCRIPTION
Right now, url query parameter  values are matched using the matchUrlSegement method in the UrlParser. This method returns all characters of a string that are not classified as delimiters in the semgement regular expression `SEGMENT_RE`. One of the delimiters defined here is a forward slash, which makes sense, since the forward slash is a delimiter when it comes to segmenting the url path. 

However, within url queries, a forward slash is allowed and should not be handled as a delimiter. The best real world example I can give is an oAuth2 request to Google, which returns an authorization code via url query parameters. The redirect_url called by Google could look something like this:

`http://your-host.com/oauth2callback/googleanalytics?code=4/B8o0n_Y7XZTb-pVKBw5daZyGAUbMljyLf7uNgTy6ja8&scope=https://www.googleapis.com/auth/analytics#`

Both, the authorization code and the scope parameter returned by Google contain forward slashes.
However, up until now, the url parser would parse the url and only recognize `code=4` as a parameter and ignore the rest of the string, since the rest of the url string would not match the query string conventions. 

This is a bug which is addressed with this pull request. 

NOTE: I also removed the equals sign (=) from the query value delimiter list. I was not sure about the other delimiters "(" ")" ";" and "#". Maybe they can also be removed as delimiters for query parameter values, but I'm not sure here.  
