### PR TITLE
fix(dart/payload): Fix runtime error in hello_world payload app

### DIFF
--- a/modules_dart/payload/hello_world/web/index.dart
+++ b/modules_dart/payload/hello_world/web/index.dart
@@ -17,7 +17,7 @@ class GreetingService {
 @Directive(selector: "[red]")
 class RedDec {
   RedDec(ElementRef el, Renderer renderer) {
-    renderer.setElementStyle(el, "color", "red");
+    renderer.setElementStyle(el.nativeElement, "color", "red");
   }
 }
 


### PR DESCRIPTION
The hello_world app used to measure Dart payload size was broken by a
change in
https://github.com/angular/angular/commit/7ae23adaff2990cf6022af9792c449730d451d1d.

This breakage does not materially affect the size of the generated code,
(before fix: 298819, after fix: 298825), and since it was a runtime
error it was not noticed & not a problem.

Update the app to work again.
