### PR TITLE
feat(http): add the ability to pass a reviver function to response json method

### DIFF
--- a/modules/angular2/src/facade/lang.ts
+++ b/modules/angular2/src/facade/lang.ts
@@ -391,7 +391,9 @@ export function print(obj: Error | Object) {
 
 // Can't be all uppercase as our transpiler would think it is a special directive...
 export class Json {
-  static parse(s: string): Object { return _global.JSON.parse(s); }
+  static parse(s: string, reviver?: (key: string, value: any) => any): Object {
+    return _global.JSON.parse(s, reviver);
+  }
   static stringify(data: Object): string {
     // Dart doesn't take 3 arguments
     return _global.JSON.stringify(data, null, 2);

--- a/modules/angular2/src/http/static_response.ts
+++ b/modules/angular2/src/http/static_response.ts
@@ -91,12 +91,16 @@ export class Response {
   /**
    * Attempts to return body as parsed `JSON` object, or raises an exception.
    */
-  json(): any {
+  json(reviver?: (key: string, value: any) => any): any {
     var jsonResponse: string | Object;
     if (isJsObject(this._body)) {
       jsonResponse = this._body;
     } else if (isString(this._body)) {
-      jsonResponse = Json.parse(<string>this._body);
+      if (isPresent(reviver)) {
+        jsonResponse = Json.parse(<string>this._body, reviver);
+      } else {
+        jsonResponse = Json.parse(<string>this._body);
+      }
     }
     return jsonResponse;
   }

--- a/modules/angular2/test/facade/lang_spec.ts
+++ b/modules/angular2/test/facade/lang_spec.ts
@@ -1,11 +1,22 @@
-import {describe, it, expect, beforeEach, ddescribe, iit, xit, el} from 'angular2/testing_internal';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  ddescribe,
+  iit,
+  xit,
+  el,
+  SpyObject
+} from 'angular2/testing_internal';
 import {
   isPresent,
   RegExpWrapper,
   RegExpMatcherWrapper,
   StringWrapper,
   CONST_EXPR,
-  hasConstructor
+  hasConstructor,
+  Json
 } from 'angular2/src/facade/lang';
 
 class MySuperclass {}
@@ -130,6 +141,25 @@ export function main() {
 
       it("should be false for subtypes",
          () => { expect(hasConstructor(new MySubclass(), MySuperclass)).toEqual(false); });
+    });
+  });
+
+  describe('Json', () => {
+    var s;
+
+    describe('parse', () => {
+      beforeEach(() => { s = '{"1": 1, "2": 2, "3": { "4": 4, "5": { "6": 6 } } }'; });
+
+      it('should parse the JSON string',
+         () => { expect(Json.parse(s)).toEqual({1: 1, 2: 2, 3: {4: 4, 5: {6: 6}}}); });
+
+      it('should parse the JSON string with revival callback', () => {
+        var spy = new SpyObject();
+        var revivalSpy = spy.spy('revival').and.callFake((key, value) => { return value; });
+
+        expect(Json.parse(s, revivalSpy)).toEqual({1: 1, 2: 2, 3: {4: 4, 5: {6: 6}}});
+        expect(revivalSpy).toHaveBeenCalled();
+      });
     });
   });
 }


### PR DESCRIPTION
Add the ability to pass a reviver function to json method of the HTTP responses:
- Add an optional parameter `revival` to the json method
- Update the Json.parse method accordingly since the previous json method is based on it
- Added tests for the Json.parse method

Closes: https://github.com/angular/http/issues/84
