### PR TITLE
docs(EventEmitter): fix small typos and extend docs to contain info about output payload

### DIFF
--- a/modules/angular2/src/facade/async.ts
+++ b/modules/angular2/src/facade/async.ts
@@ -61,11 +61,11 @@ export class ObservableWrapper {
 }
 
 /**
- * Use by directives and components to emit custom Events.
+ * Used by directives and components to emit custom Events.
  *
  * ### Examples
  *
- * In the following example, `Zippy` alternatively emits `open` and `close` events when its
+ * In the following example, `Zippy` either emits `open` or `close` events, depending on `this.visible`, when its
  * title gets clicked:
  *
  * ```
@@ -94,7 +94,13 @@ export class ObservableWrapper {
  * }
  * ```
  *
- * Use Rx.Observable but provides an adapter to make it work as specified here:
+ * The events payload can be accessed the parameter `$event` on the components output event handler:
+ *
+ * ```
+ * <zippy (open)="onOpen($event)" (close)="onClose($event)"></zippy>
+ * ```
+ *
+ * Uses Rx.Observable but provides an adapter to make it work as specified here:
  * https://github.com/jhusain/observable-spec
  *
  * Once a reference implementation of the spec is available, switch to it.

--- a/modules/angular2/src/facade/async.ts
+++ b/modules/angular2/src/facade/async.ts
@@ -94,7 +94,7 @@ export class ObservableWrapper {
  * }
  * ```
  *
- * The events payload can be accessed the parameter `$event` on the components output event handler:
+ * The events payload can be accessed by the parameter `$event` on the components output event handler:
  *
  * ```
  * <zippy (open)="onOpen($event)" (close)="onClose($event)"></zippy>


### PR DESCRIPTION
docs(EventEmitter): fix small typos and extend docs to contain info about output payload

the docs should probably be more informative about handling an events output. Right now there is no information on handling the output and/or receiving the events payload

Closes angular.io #907 
