### PR TITLE
docs(http.ts): fix MockBackend example

### DIFF
--- a/modules/angular2/src/http/backends/mock_backend.ts
+++ b/modules/angular2/src/http/backends/mock_backend.ts
@@ -131,9 +131,9 @@ export class MockBackend implements ConnectionBackend {
    * ### Example
    *
    * ```
-   * import {Http, BaseRequestOptions} from 'angular2/http';
+   * import {Http, BaseRequestOptions, Response} from 'angular2/http';
    * import {MockBackend} from 'angular2/http/testing';
-   * import {Injector} from 'angular2/core';
+   * import {Injector, provide} from 'angular2/core';
    *
    * it('should get a response', () => {
    *   var connection; //this will be set when a new connection is emitted from the backend.
@@ -142,7 +142,7 @@ export class MockBackend implements ConnectionBackend {
    *     MockBackend,
    *     provide(Http, {useFactory: (backend, options) => {
    *       return new Http(backend, options);
-   *     }, deps: [MockBackend, BaseRequestOptions]}]);
+   *     }, deps: [MockBackend, BaseRequestOptions]})]);
    *   var backend = injector.get(MockBackend);
    *   var http = injector.get(Http);
    *   backend.connections.subscribe(c => connection = c);


### PR DESCRIPTION
Added `Response` & `provide` imports.
Syntax error fix: missing `)`.
