### PR TITLE
docs(browser.ts): update bootstrap injector override argument name

### DIFF
--- a/modules/angular2/platform/browser.ts
+++ b/modules/angular2/platform/browser.ts
@@ -70,7 +70,7 @@ export const BROWSER_APP_PROVIDERS: Array<any /*Type | Provider | any[]*/> = CON
  *     to be upgraded into the angular component.
  *  2. It creates a new child injector (from the platform injector). Optionally, you can
  *     also override the injector configuration for an app by invoking `bootstrap` with the
- *     `componentInjectableBindings` argument.
+ *     `customProviders` argument.
  *  3. It creates a new `Zone` and connects it to the angular application's change detection
  *     domain instance.
  *  4. It creates an emulated or shadow DOM on the selected component's host element and loads the


### PR DESCRIPTION
It seems that the argument name was changed but the documentation was not updated.
