### PR TITLE
DO NOT MERGE: feat(polyfills): add IE-specific shims to angular2-polyfills.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1350,6 +1350,7 @@ gulp.task('!bundle.ng.polyfills', ['clean'],
           function() { return addDevDependencies('angular2-polyfills.js'); });
 
 var JS_DEV_DEPS = [
+  'modules/angular2/src/testing/shims_for_IE.js',
   licenseWrap('node_modules/zone.js/LICENSE', true),
   'node_modules/zone.js/dist/zone-microtask.js',
   'node_modules/zone.js/dist/long-stack-trace-zone.js',


### PR DESCRIPTION
angular2-polyfills.js now contains shims for:
- function.name (all IE)
- URL polyfill for SystemJS (all IE)
- classList (IE9)
- RequestAnimationFrame (IE9, Android 4.1, 4.2, 4.3)
