### PR TITLE
feat(benchpress): add custom user metric to benchpress

### DIFF
--- a/modules/benchmarks/e2e_test/page_load_perf.dart
+++ b/modules/benchmarks/e2e_test/page_load_perf.dart
@@ -1,0 +1,3 @@
+library benchmarks.e2e_test.page_load_perf;
+
+main() {}

--- a/modules/benchmarks/e2e_test/page_load_perf.ts
+++ b/modules/benchmarks/e2e_test/page_load_perf.ts
@@ -1,0 +1,30 @@
+import {verifyNoBrowserErrors} from 'angular2/src/testing/perf_util';
+
+describe('ng2 largetable benchmark', function() {
+
+  var URL = 'benchmarks/src/page_load/page_load.html';
+  var runner = global['benchpressRunner'];
+
+  afterEach(verifyNoBrowserErrors);
+
+
+  it('should log the load time', function(done) {
+    runner.sample({
+            id: 'loadTime',
+            prepare: null,
+            microMetrics: null,
+            userMetrics: {loadTime: 'The time in milliseconds to bootstrap'},
+            bindings:
+                [benchpress.bind(benchpress.RegressionSlopeValidator.METRIC).toValue('loadTime')],
+            execute: () => { browser.get(URL); }
+          })
+        .then(report => {
+          expect(report.completeSample.length).toBeGreaterThan(4);
+          expect(report.completeSample.filter(val => typeof val.values.loadTime === 'number' &&
+                                                     val.values.loadTime > 0)
+                     .length)
+              .toBeGreaterThan(4);
+        })
+        .then(done);
+  });
+});

--- a/modules/benchmarks/pubspec.yaml
+++ b/modules/benchmarks/pubspec.yaml
@@ -26,6 +26,7 @@ transformers:
         - web/src/naive_infinite_scroll/index.dart
         - web/src/static_tree/tree_benchmark.dart
         - web/src/tree/tree_benchmark.dart
+        - web/src/page_load/page_load.dart
 - $dart2js:
     $include: web/src/**
     minify: false

--- a/modules/benchmarks/src/index.html
+++ b/modules/benchmarks/src/index.html
@@ -32,6 +32,9 @@
     <li>
       <a href="costs/index.html">Benchmarks measuring costs of things</a>
     </li>
+    <li>
+      <a href="page_load/page_load.html">Benchmark measuring time to bootstrap</a>
+    </li>
   </ul>
 </body>
 </html>

--- a/modules/benchmarks/src/page_load/page_load.html
+++ b/modules/benchmarks/src/page_load/page_load.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<body>
+
+<h2>Angular2 page load benchmark</h2>
+
+<div>
+<app></app>
+</div>
+
+$SCRIPTS$
+</body>
+</html>

--- a/modules/benchmarks/src/page_load/page_load.ts
+++ b/modules/benchmarks/src/page_load/page_load.ts
@@ -1,0 +1,9 @@
+import {Component} from 'angular2/core';
+import {bootstrap} from 'angular2/platform/browser';
+
+@Component({selector: 'app', template: '<h1>Page Load Time</h1>'})
+class App {
+}
+
+bootstrap(App)
+    .then(() => { (<any>window).loadTime = Date.now() - performance.timing.navigationStart; });

--- a/modules/benchpress/common.ts
+++ b/modules/benchpress/common.ts
@@ -17,6 +17,7 @@ export {Runner} from './src/runner';
 export {Options} from './src/common_options';
 export {MeasureValues} from './src/measure_values';
 export {MultiMetric} from './src/metric/multi_metric';
+export {UserMetric} from './src/metric/user_metric';
 export {MultiReporter} from './src/reporter/multi_reporter';
 
 export {bind, provide, Injector, OpaqueToken} from 'angular2/src/core/di';

--- a/modules/benchpress/docs/index.md
+++ b/modules/benchpress/docs/index.md
@@ -160,6 +160,43 @@ runner.sample({
 When looking into the DevTools Timeline, we see a marker as well:
 ![Marked Timeline](marked_timeline.png)
 
+### Custom Metrics Without Using `console.time`
+
+It's also possible to measure any "user metric" within the browser
+by setting a numeric value on the `window` object. For example:
+
+```js
+bootstrap(App)
+  .then(() => {
+    window.timeToBootstrap = Date.now() - performance.timing.navigationStart;
+  });
+```
+
+A test driver for this user metric could be written as follows:
+
+```js
+
+describe('home page load', function() {
+  it('should log load time for a 2G connection', done => {
+    runner.sample({
+      execute: () => {
+        browser.get(`http://localhost:8080`);
+      },
+      userMetrics: {
+        timeToBootstrap: 'The time in milliseconds to bootstrap'
+      },
+      bindings: [
+        bind(RegressionSlopeValidator.METRIC).toValue('timeToBootstrap')
+      ]
+    }).then(done);
+  });
+});
+```
+
+Using this strategy, benchpress will wait until the specified property name,
+`timeToBootstrap` in this case, is defined as a number on the `window` object
+inside the application under test.
+
 # Smoothness Metrics
 
 Benchpress can also measure the "smoothness" of scrolling and animations. In order to do that, the following set of metrics can be collected by benchpress:

--- a/modules/benchpress/src/metric/user_metric.ts
+++ b/modules/benchpress/src/metric/user_metric.ts
@@ -1,0 +1,69 @@
+import {bind, Provider, OpaqueToken} from 'angular2/src/core/di';
+import {PromiseWrapper} from 'angular2/src/facade/async';
+import {StringMapWrapper} from 'angular2/src/facade/collection';
+
+import {Metric} from '../metric';
+import {WebDriverAdapter} from '../web_driver_adapter';
+
+var Observable = require('rxjs').Observable;
+
+var _USER_PROPERTIES = new OpaqueToken('UserMetric.properties');
+
+export class UserProperty {
+  constructor(public name: string, public description: string) {}
+}
+
+export class UserMetric extends Metric {
+  static createBindings(properties: {[key: string]: string}): Provider[] {
+    return [
+      bind(_USER_PROPERTIES)
+          .toFactory(() => StringMapWrapper.keys(properties)
+                               .map(propName => new UserProperty(propName, properties[propName]))),
+      bind(UserMetric)
+          .toFactory((properties, wdAdapter) => new UserMetric(properties, wdAdapter),
+                     [_USER_PROPERTIES, WebDriverAdapter])
+    ];
+  }
+  constructor(private _properties: UserProperty[], private _wdAdapter: WebDriverAdapter) {
+    super();
+  }
+
+  /**
+   * Starts measuring
+   */
+  beginMeasure(): Promise<any> { return PromiseWrapper.resolve(true); }
+
+  /**
+   * Ends measuring.
+   */
+  endMeasure(): Promise<{[key: string]: any}> {
+    return Observable.interval(100)
+        .switchMap(() => Observable.fromPromise(Promise.all(this._properties.map(prop => {
+          return this._wdAdapter.executeScript(`return window.${prop.name}`);
+        }))))
+        .filter((values: any[]) => values.filter(val => typeof val !== 'number').length === 0)
+        .do(() => {
+          this._properties.forEach(prop =>
+                                       this._wdAdapter.executeScript(`delete window.${prop.name}`));
+        })
+        .map(propertyValues => this._properties.reduce(
+                 (prev, curr, i) => {
+                   prev[curr.name] = propertyValues[i];
+                   return prev;
+                 },
+                 {}))
+        .take(1)
+        .toPromise();
+  }
+
+  /**
+   * Describes the metrics provided by this metric implementation.
+   * (e.g. units, ...)
+   */
+  describe(): {[key: string]: any} {
+    return this._properties.reduce((prev, curr, i) => {
+      prev[curr.name] = curr.description;
+      return prev;
+    }, {});
+  }
+}

--- a/modules/benchpress/src/runner.ts
+++ b/modules/benchpress/src/runner.ts
@@ -10,6 +10,7 @@ import {SizeValidator} from './validator/size_validator';
 import {Validator} from './validator';
 import {PerflogMetric} from './metric/perflog_metric';
 import {MultiMetric} from './metric/multi_metric';
+import {UserMetric} from './metric/user_metric';
 import {ChromeDriverExtension} from './webdriver/chrome_driver_extension';
 import {FirefoxDriverExtension} from './webdriver/firefox_driver_extension';
 import {IOsDriverExtension} from './webdriver/ios_driver_extension';
@@ -33,24 +34,38 @@ export class Runner {
     this._defaultBindings = defaultBindings;
   }
 
-  sample({id, execute, prepare, microMetrics, bindings}:
-             {id: string, execute?: any, prepare?: any, microMetrics?: any, bindings?: any}):
-      Promise<SampleState> {
+  sample({id, execute, prepare, microMetrics, bindings, userMetrics}: {
+    id: string,
+    execute?: any,
+    prepare?: any,
+    microMetrics?: any,
+    bindings?: any,
+    userMetrics?: any
+  }): Promise<SampleState> {
     var sampleBindings = [
       _DEFAULT_PROVIDERS,
       this._defaultBindings,
       bind(Options.SAMPLE_ID).toValue(id),
       bind(Options.EXECUTE).toValue(execute)
     ];
+    var multiMetrics = [];
+
     if (isPresent(prepare)) {
       sampleBindings.push(bind(Options.PREPARE).toValue(prepare));
     }
     if (isPresent(microMetrics)) {
-      sampleBindings.push(bind(Options.MICRO_METRICS).toValue(microMetrics));
+      multiMetrics.push(PerflogMetric)
+          sampleBindings.push(bind(Options.MICRO_METRICS).toValue(microMetrics));
     }
     if (isPresent(bindings)) {
       sampleBindings.push(bindings);
     }
+    if (isPresent(userMetrics)) {
+      multiMetrics.push(UserMetric);
+      sampleBindings.push(benchpress.UserMetric.createBindings(userMetrics));
+    }
+
+    sampleBindings.push(benchpress.MultiMetric.createBindings(multiMetrics));
 
     var inj = Injector.resolveAndCreate(sampleBindings);
     var adapter = inj.get(WebDriverAdapter);
@@ -91,7 +106,6 @@ var _DEFAULT_PROVIDERS = [
   PerflogMetric.BINDINGS,
   SampleDescription.BINDINGS,
   MultiReporter.createBindings([ConsoleReporter]),
-  MultiMetric.createBindings([PerflogMetric]),
 
   Reporter.bindTo(MultiReporter),
   Validator.bindTo(RegressionSlopeValidator),

--- a/modules/benchpress/test/metric/user_metric_spec.ts
+++ b/modules/benchpress/test/metric/user_metric_spec.ts
@@ -1,0 +1,113 @@
+import {
+  afterEach,
+  AsyncTestCompleter,
+  beforeEach,
+  ddescribe,
+  describe,
+  expect,
+  iit,
+  inject,
+  it,
+  xit
+} from 'angular2/testing_internal';
+
+import {StringMapWrapper} from 'angular2/src/facade/collection';
+import {PromiseWrapper} from 'angular2/src/facade/async';
+import {isPresent, isBlank, Json} from 'angular2/src/facade/lang';
+
+import {
+  Metric,
+  MultiMetric,
+  PerflogMetric,
+  UserMetric,
+  WebDriverAdapter,
+  WebDriverExtension,
+  PerfLogFeatures,
+  bind,
+  provide,
+  Injector,
+  Options
+} from 'benchpress/common';
+
+import {TraceEventFactory} from '../trace_event_factory';
+
+export function main() {
+  var commandLog: any[];
+  var eventFactory = new TraceEventFactory('timeline', 'pid0');
+
+  function createMetric(perfLogs, perfLogFeatures,
+                        {userMetrics, forceGc, captureFrames, receivedData, requestCount}: {
+                          userMetrics?: {[key: string]: string},
+                          forceGc?: boolean,
+                          captureFrames?: boolean,
+                          receivedData?: boolean,
+                          requestCount?: boolean
+                        } = {}) {
+    commandLog = [];
+    if (isBlank(perfLogFeatures)) {
+      perfLogFeatures =
+          new PerfLogFeatures({render: true, gc: true, frameCapture: true, userTiming: true});
+    }
+    if (isBlank(userMetrics)) {
+      userMetrics = StringMapWrapper.create();
+    }
+    var bindings = [
+      provide(WebDriverAdapter,
+              {useFactory: () => new MockDriverAdapter([], [], 'Tracing.dataCollected')}),
+      Options.DEFAULT_PROVIDERS,
+      MultiMetric.createBindings([UserMetric]),
+      UserMetric.createBindings(userMetrics)
+    ];
+    return Injector.resolveAndCreate(bindings).get(UserMetric);
+  }
+
+  describe('user metric', () => {
+
+    function sortedKeys(stringMap) {
+      var res = [];
+      StringMapWrapper.forEach(stringMap, (_, key) => { res.push(key); });
+      res.sort();
+      return res;
+    }
+
+    it('should describe itself based on microMetrics', () => {
+      expect(createMetric([[]], new PerfLogFeatures(), {userMetrics: {'loadTime': 'time to load'}})
+                 .describe())
+          .toEqual({'loadTime': 'time to load'});
+    });
+
+    describe('endMeasure', () => {
+      it('should stop measuring when all properties have numeric values',
+         inject([AsyncTestCompleter], (async) => {
+           var metric = createMetric(
+               [[]], new PerfLogFeatures(),
+               {userMetrics: {'loadTime': 'time to load', 'content': 'time to see content'}});
+           metric.beginMeasure()
+               .then((_) => metric.endMeasure())
+               .then((values) => {
+                 expect(values.loadTime).toBe(25);
+                 expect(values.content).toBe(250);
+                 async.done();
+               });
+
+           (<any>metric)._wdAdapter.data.loadTime = 25;
+           // Wait before setting 2nd property.
+           setTimeout(() => { (<any>metric)._wdAdapter.data.content = 250; }, 50);
+
+         }), 600);
+    });
+  });
+}
+
+class MockDriverAdapter extends WebDriverAdapter {
+  data: any = {};
+  constructor(private _log: any[], private _events: any[], private _messageMethod: string) {
+    super();
+  }
+
+  executeScript(script: string): any {
+    // Just handles `return window.propName` scripts
+    if (!(/^return window\..*$/).test(script)) return;
+    return Promise.resolve(this.data[/^return window\.(.*)$/.exec(script)[1]]);
+  }
+}

--- a/protractor-shared.js
+++ b/protractor-shared.js
@@ -239,7 +239,6 @@ exports.createBenchpressRunner = function(options) {
     bindings.push(benchpress.Validator.bindTo(benchpress.SizeValidator));
     bindings.push(benchpress.bind(benchpress.SizeValidator.SAMPLE_SIZE).toValue(1));
     bindings.push(benchpress.MultiReporter.createBindings([]));
-    bindings.push(benchpress.MultiMetric.createBindings([]));
   }
 
   global.benchpressRunner = new benchpress.Runner(bindings);

--- a/tools/broccoli/trees/browser_tree.ts
+++ b/tools/broccoli/trees/browser_tree.ts
@@ -24,6 +24,7 @@ const kServedPaths = [
   'benchmarks/src/element_injector',
   'benchmarks/src/largetable',
   'benchmarks/src/naive_infinite_scroll',
+  'benchmarks/src/page_load',
   'benchmarks/src/tree',
   'benchmarks/src/static_tree',
 


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  A feature to be able to measure and report any user-defined numeric value within an application.
- **What is the current behavior?** (You can also link to an open issue here)
  Applications can currently only report items that can be measured with `console.time` and `console.timeEnd`, but some metrics aren't able to be measured this way, such as page load time. I.e. I want to measure the delta between `performance.timing.navigationStart` and `Date.now()` as soon as the user sees content, or as soon as the user can interact with the application.
- **What is the new behavior (if this is a feature change)?**

The new behavior allows defining one or more global properties in the application context to wait until they are defined, and then include the value in the report. Inside the application, all that is required is to set `window[propertyName]` to a numeric value when the data becomes available.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
- **Other information**:

CC @tbosch @ochafik 
