### PR TITLE
feat(TAG_DEFINITIONS): include <meta> and <base>

### DIFF
--- a/modules/angular2/src/compiler/html_tags.ts
+++ b/modules/angular2/src/compiler/html_tags.ts
@@ -327,6 +327,8 @@ export class HtmlTagDefinition {
 // see http://www.w3.org/TR/html51/syntax.html#optional-tags
 // This implementation does not fully conform to the HTML5 spec.
 var TAG_DEFINITIONS: {[key: string]: HtmlTagDefinition} = {
+  'base': new HtmlTagDefinition({isVoid: true}),
+  'meta': new HtmlTagDefinition({isVoid: true}),
   'area': new HtmlTagDefinition({isVoid: true}),
   'embed': new HtmlTagDefinition({isVoid: true}),
   'link': new HtmlTagDefinition({isVoid: true}),


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  fix template parser from not understanding `<base>` and `<meta>` tags
- **What is the current behavior?** (You can also link to an open issue here)
  HTML template parser doesn't recognize the element tags as self-closing
- **What is the new behavior (if this is a feature change)?**
  allows for `<base>` and `<meta>` to be self-closing
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  N/A
- **Other information**:

needed to parse index.html as a component template
