### PR TITLE
refactor(dart/transform): AnnotationMatcher tests

### DIFF
--- a/modules_dart/transform/test/transform/common/annotation_matcher_test.dart
+++ b/modules_dart/transform/test/transform/common/annotation_matcher_test.dart
@@ -1,10 +1,12 @@
 library angular2.test.transform.common.annotation_matcher_test;
 
 import 'dart:async';
+
 import 'package:analyzer/analyzer.dart';
-import 'package:angular2/src/transform/common/annotation_matcher.dart';
 import 'package:barback/barback.dart' show AssetId;
-import 'package:guinness/guinness.dart';
+import 'package:test/test.dart';
+
+import 'package:angular2/src/transform/common/annotation_matcher.dart';
 
 main() {
   allTests();
@@ -39,66 +41,69 @@ var foo;
 ''');
 
 void allTests() {
-  it('should be able to match basic annotations.', () {
+  test('should be able to match basic annotations.', () {
     var matcher = new AnnotationMatcher()
-      ..add(const AnnotationDescriptor('Test', 'package:test/test.dart', null));
+      ..add(const ClassDescriptor('Test', 'package:test/test.dart'));
     var visitor = new MatchRecordingVisitor(matcher);
     simpleAst.accept(visitor);
-    expect(visitor.matches.length).toBe(1);
+    expect(visitor.matches.length, equals(1));
   });
 
-  it('should be able to match namespaced annotations.', () {
+  test('should be able to match namespaced annotations.', () {
     var matcher = new AnnotationMatcher()
-      ..add(const AnnotationDescriptor('Test', 'package:test/test.dart', null));
+      ..add(const ClassDescriptor('Test', 'package:test/test.dart'));
     var visitor = new MatchRecordingVisitor(matcher);
     namespacedAst.accept(visitor);
-    expect(visitor.matches.length).toBe(1);
+    expect(visitor.matches.length, equals(1));
   });
 
-  it('should be able to match relative imports.', () {
+  test('should be able to match relative imports.', () {
     var matcher = new AnnotationMatcher()
-      ..add(const AnnotationDescriptor('Test', 'package:test/test.dart', null));
+      ..add(const ClassDescriptor('Test', 'package:test/test.dart'));
     var visitor =
         new MatchRecordingVisitor(matcher, new AssetId('test', 'lib/foo.dart'));
     relativePathAst.accept(visitor);
-    expect(visitor.matches.length).toBe(1);
+    expect(visitor.matches.length, equals(1));
   });
 
-  it('should be able to match relative imports with a namespace.', () {
+  test('should be able to match relative imports with a namespace.', () {
     var matcher = new AnnotationMatcher()
-      ..add(const AnnotationDescriptor('Test', 'package:test/test.dart', null));
+      ..add(const ClassDescriptor('Test', 'package:test/test.dart'));
     var visitor =
         new MatchRecordingVisitor(matcher, new AssetId('test', 'lib/foo.dart'));
     namespacedRelativePathAst.accept(visitor);
-    expect(visitor.matches.length).toBe(1);
+    expect(visitor.matches.length, equals(1));
   });
 
-  it('should not match annotations if the import is missing.', () {
+  test('should not match annotations if the import is missing.', () {
     var matcher = new AnnotationMatcher()
-      ..add(const AnnotationDescriptor('Test', 'package:test/foo.dart', null));
+      ..add(const ClassDescriptor('Test', 'package:test/foo.dart'));
     var visitor = new MatchRecordingVisitor(matcher);
     simpleAst.accept(visitor);
-    expect(visitor.matches.isEmpty).toBeTrue();
+    expect(visitor.matches.isEmpty, isTrue);
   });
 
-  it('should not match annotations if the name is different.', () {
+  test('should not match annotations if the name is different.', () {
     var matcher = new AnnotationMatcher()
-      ..add(const AnnotationDescriptor('Foo', 'package:test/test.dart', null));
+      ..add(const ClassDescriptor('Foo', 'package:test/test.dart'));
     var visitor = new MatchRecordingVisitor(matcher);
     simpleAst.accept(visitor);
-    expect(visitor.matches.isEmpty).toBeTrue();
+    expect(visitor.matches.isEmpty, isTrue);
   });
 }
 
 class MatchRecordingVisitor extends RecursiveAstVisitor {
   final AssetId assetId;
   final AnnotationMatcher matcher;
-  final List<Annotation> matches = [];
+  final matches = <Annotation>[];
 
-  MatchRecordingVisitor(this.matcher, [this.assetId]) : super();
+  MatchRecordingVisitor(this.matcher, [AssetId assetId])
+      : super(),
+        this.assetId =
+            assetId != null ? assetId : new AssetId('a', 'lib/a.dart');
 
   @override
   void visitAnnotation(Annotation annotation) {
-    if (matcher.hasMatch(annotation, assetId)) matches.add(annotation);
+    if (matcher.hasMatch(annotation.name, assetId)) matches.add(annotation);
   }
 }

--- a/modules_dart/transform/test/transform/transform.server.spec.dart
+++ b/modules_dart/transform/test/transform/transform.server.spec.dart
@@ -3,12 +3,14 @@ library angular2.test.transform.transform.server.spec;
 
 import 'package:test/test.dart';
 
+import 'common/annotation_matcher_test.dart' as annotationMatcher;
 import 'common/async_string_writer_tests.dart' as asyncStringWriter;
 import 'common/code/ng_deps_code_tests.dart' as ngDepsCode;
 import 'common/ng_meta_test.dart' as ngMetaTest;
 import 'common/url_resolver_tests.dart' as urlResolver;
 
 main() {
+  group('AnnotationMatcher', annotationMatcher.allTests);
   group('AsyncStringWriter', asyncStringWriter.allTests);
   group('NgDepsCode', ngDepsCode.allTests);
   group('NgMeta', ngMetaTest.allTests);


### PR DESCRIPTION
/cc @juliemr 

These tests were previously not being run.

Bring them up to modern usage, move them to package:test, and include
them in transform.server.spec.dart.
