### PR TITLE
refactor(dart/transform): Use targeted transformers

### DIFF
--- a/modules/angular2_material/pubspec.yaml
+++ b/modules/angular2_material/pubspec.yaml
@@ -17,4 +17,4 @@ dependency_overrides:
 dev_dependencies:
   guinness2: '0.0.4'
 transformers:
-- angular2
+- angular2/transform/codegen

--- a/modules/benchmarks/pubspec.yaml
+++ b/modules/benchmarks/pubspec.yaml
@@ -15,8 +15,9 @@ dependency_overrides:
   angular2:
     path: ../angular2
 transformers:
-- angular2:
-    entry_points:
+- angular2/transform/codegen
+- angular2/transform/reflection_remover:
+    $include:
         - web/src/compiler/compiler_benchmark.dart
         - web/src/costs/index.dart
         - web/src/di/di_benchmark.dart

--- a/modules/playground/pubspec.yaml
+++ b/modules/playground/pubspec.yaml
@@ -17,9 +17,10 @@ dependency_overrides:
     path: ../angular2_material
   matcher: '0.12.0+1'
 transformers:
-- angular2:
+- angular2/transform/codegen:
     platform_directives: 'package:angular2/src/common/directives.dart#CORE_DIRECTIVES'
-    entry_points:
+- angular2/transform/reflection_remover:
+    $include:
         - web/src/animate/index.dart
         - web/src/async/index.dart
         - web/src/gestures/index.dart
@@ -54,6 +55,10 @@ transformers:
         - web/src/web_workers/router/index.dart
         - web/src/web_workers/router/background_index.dart
         - web/src/zippy_component/index.dart
+- angular2/transform/deferred_rewriter:
+    # No playground apps use deferred imports, but in general
+    # all libraries with deferred imports should be included.
+    $include: []
 
 - $dart2js:
     $include:

--- a/modules_dart/payload/hello_world/pubspec.yaml
+++ b/modules_dart/payload/hello_world/pubspec.yaml
@@ -9,11 +9,10 @@ dependency_overrides:
   angular2:
     path: ../../../dist/dart/angular2
 transformers:
-- angular2:
+- angular2/transform/codegen:
     platform_directives: 'package:angular2/src/common/directives.dart#CORE_DIRECTIVES'
-    entry_points:
-        - web/index.dart
-
+- angular2/transform/reflection_remover:
+    $include: [web/index.dart]
 - $dart2js:
     minify: true
     commandLineOptions:


### PR DESCRIPTION
/cc @juliemr 

TL;DR: Modify pubspec.yaml files to use the recommended "targeted"
transformers. The unified "simple" angular2 transformer still works as
always, but we want to encourage use of the targeted transformers
whereever possible.

See [the wiki](https://github.com/angular/angular/wiki/Advanced-Transformer-Configuration)
for details about targeted transformers.

See #1872
