### PR TITLE
feat(response): the statusText isn't set on XHR responses

### DIFF
--- a/modules/angular2/src/http/backends/xhr_backend.ts
+++ b/modules/angular2/src/http/backends/xhr_backend.ts
@@ -45,6 +45,7 @@ export class XHRConnection implements Connection {
 
         // normalize IE9 bug (http://bugs.jquery.com/ticket/1450)
         let status: number = _xhr.status === 1223 ? 204 : _xhr.status;
+        let statusText: string = _xhr.statusText;
 
         // fix status code when it is 0 (0 status is undocumented).
         // Occurs when accessing file resources or on Android 4.1 stock browser
@@ -52,7 +53,7 @@ export class XHRConnection implements Connection {
         if (status === 0) {
           status = body ? 200 : 0;
         }
-        var responseOptions = new ResponseOptions({body, status, headers, url});
+        var responseOptions = new ResponseOptions({body, status, statusText, headers, url});
         if (isPresent(baseResponseOptions)) {
           responseOptions = baseResponseOptions.merge(responseOptions);
         }

--- a/modules/angular2/test/http/backends/xhr_backend_spec.ts
+++ b/modules/angular2/test/http/backends/xhr_backend_spec.ts
@@ -40,6 +40,7 @@ class MockBrowserXHR extends BrowserXhr {
   setRequestHeader: any;
   callbacks = new Map<string, Function>();
   status: number;
+  statusText: string;
   responseHeaders: string;
   responseURL: string;
   constructor() {
@@ -52,6 +53,8 @@ class MockBrowserXHR extends BrowserXhr {
   }
 
   setStatusCode(status: number) { this.status = status; }
+
+  setStatusText(statusText: string) { this.statusText = statusText; }
 
   setResponse(value: string) { this.response = value; }
 
@@ -177,8 +180,10 @@ export function main() {
       it('should return the correct status code',
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
            var statusCode = 418;
-           var connection = new XHRConnection(sampleRequest, new MockBrowserXHR(),
-                                              new ResponseOptions({status: statusCode}));
+           var statusText = 'some';
+           var connection =
+               new XHRConnection(sampleRequest, new MockBrowserXHR(),
+                                 new ResponseOptions({status: statusCode, statusText: statusText}));
 
            connection.response.subscribe(
                (res: Response) => {
@@ -186,10 +191,12 @@ export function main() {
                },
                errRes => {
                  expect(errRes.status).toBe(statusCode);
+                 expect(errRes.statusText).toBe(statusText);
                  async.done();
                });
 
            existingXHRs[0].setStatusCode(statusCode);
+           existingXHRs[0].setStatusText(statusText);
            existingXHRs[0].dispatchEvent('load');
          }));
 


### PR DESCRIPTION
Add a `toString` method to the `Response` class displaying status / status and
the URL of the request.

Closes: https://github.com/angular/http/issues/89
