### PR TITLE
Docs(changeLog.md) remove breaking changes section information which was displaying twice.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,19 +39,6 @@ is:
 }
 ```
 
-* The recently added binding of the current router to the current component
-has been renamed from `router` to `$router`.
-So now the recommended set up for your bindings in your routed component
-is:
-```js
-{
-  ...
-  bindings: {
-    $router: '<'
-  }
-}
-```
-
 
 
 <a name="2.0.0-beta.8"></a>


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  I have changed duplication of same information shown in Angular2 2.0.0-beta.9 (2016-03-09) CHANGELOG.md in breaking changes  section.
- **What is the current behavior?** (You can also link to an open issue here)
  breaking changes section was displaying information twice.
- **What is the new behavior (if this is a feature change)?**
  Now, it will show it single time.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  **NO**

2.0.0-beta.9 (2016-03-09) breaking changes section was  displaying same information two(2) times. changed it.
