### PR TITLE
refactor(async_pipe): use subscription strategy interface

### DIFF
--- a/modules/angular2/src/common/pipes/async_pipe.ts
+++ b/modules/angular2/src/common/pipes/async_pipe.ts
@@ -11,7 +11,13 @@ import {
 
 import {InvalidPipeArgumentException} from './invalid_pipe_argument_exception';
 
-class ObservableStrategy {
+interface SubscriptionStrategy {
+  createSubscription(async: any, updateLatestValue: any): any;
+  dispose(subscription: any): void;
+  onDestroy(subscription: any): void;
+}
+
+class ObservableStrategy implements SubscriptionStrategy {
   createSubscription(async: any, updateLatestValue: any): any {
     return ObservableWrapper.subscribe(async, updateLatestValue, e => { throw e; });
   }
@@ -21,7 +27,7 @@ class ObservableStrategy {
   onDestroy(subscription: any): void { ObservableWrapper.dispose(subscription); }
 }
 
-class PromiseStrategy {
+class PromiseStrategy implements SubscriptionStrategy {
   createSubscription(async: Promise<any>, updateLatestValue: (v: any) => any): any {
     return async.then(updateLatestValue);
   }
@@ -65,7 +71,7 @@ export class AsyncPipe implements PipeTransform, OnDestroy {
   _subscription: Object = null;
   /** @internal */
   _obj: Observable<any>| Promise<any>| EventEmitter<any> = null;
-  private _strategy: any = null;
+  private _strategy: SubscriptionStrategy = null;
   /** @internal */
   public _ref: ChangeDetectorRef;
   constructor(_ref: ChangeDetectorRef) { this._ref = _ref; }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Refactoring. Introduced a new TypeScript Interface for the async pipe.
- **What is the current behavior?** (You can also link to an open issue here)
  no changes
- **What is the new behavior (if this is a feature change)?**
  no changes
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  no
- **Other information**:
  The strategies for Promise and Observable based subscriptions
  have (nearly) the same method signatures. They should implement
  a common interface.
  The return type of `_selectStrategy()` cannot be changed to `SubscriptionStrategy`, because the interface is private. 
