### PR TITLE
fix(upgrade): make upgradeAdapter upgrade angular 1 components correctly

### DIFF
--- a/modules/angular2/src/upgrade/angular_js.ts
+++ b/modules/angular2/src/upgrade/angular_js.ts
@@ -64,6 +64,7 @@ export interface IComponent {
   bindings?: Object;
   controller?: any;
   controllerAs?: string;
+  require?: any;
   template?: any;
   templateUrl?: any;
   transclude?: any;

--- a/modules/angular2/src/upgrade/angular_js.ts
+++ b/modules/angular2/src/upgrade/angular_js.ts
@@ -1,6 +1,7 @@
 export interface IModule {
   config(fn: any): IModule;
   directive(selector: string, factory: any): IModule;
+  component(selector: string, component: IComponent): IModule;
   controller(name: string, type: any): IModule;
   factory(key: string, factoryFn: any): IModule;
   value(key: string, value: any): IModule;
@@ -58,6 +59,14 @@ export interface IDirectivePrePost {
 export interface IDirectiveLinkFn {
   (scope: IScope, instanceElement: IAugmentedJQuery, instanceAttributes: IAttributes,
    controller: any, transclude: ITranscludeFunction): void;
+}
+export interface IComponent {
+  bindings?: Object;
+  controller?: any;
+  controllerAs?: string;
+  template?: any;
+  templateUrl?: any;
+  transclude?: any;
 }
 export interface IAttributes { $observe(attr: string, fn: (v: string) => void): void; }
 export interface ITranscludeFunction {

--- a/modules/angular2/src/upgrade/upgrade_ng1_adapter.ts
+++ b/modules/angular2/src/upgrade/upgrade_ng1_adapter.ts
@@ -53,6 +53,7 @@ export class UpgradeNg1ComponentAdapterBuilder {
                       self.outputs, self.propertyOutputs, self.checkProperties, self.propertyMap);
                 }
               ],
+              ngOnInit: function() { /* needs to be here for ng2 to properly detect it */ },
               ngOnChanges: function() { /* needs to be here for ng2 to properly detect it */ },
               ngDoCheck: function() { /* needs to be here for ng2 to properly detect it */ }
             });
@@ -106,6 +107,8 @@ export class UpgradeNg1ComponentAdapterBuilder {
               this.propertyMap[outputName] = localName;
             // don't break; let it fall through to '@'
             case '@':
+            // handle the '<' binding of angular 1.5 components
+            case '<':
               this.inputs.push(inputName);
               this.inputsRename.push(inputNameRename);
               this.propertyMap[inputName] = localName;
@@ -228,6 +231,13 @@ class UpgradeNg1ComponentAdapter implements OnChanges, DoCheck {
     for (var k = 0; k < propOuts.length; k++) {
       this[propOuts[k]] = new EventEmitter();
       this.checkLastValues.push(INITIAL_VALUE);
+    }
+  }
+
+
+  ngOnInit() {
+    if (this.destinationObj.$onInit) {
+      this.destinationObj.$onInit();
     }
   }
 

--- a/modules/angular2/test/upgrade/upgrade_spec.ts
+++ b/modules/angular2/test/upgrade/upgrade_spec.ts
@@ -523,6 +523,65 @@ export function main() {
                });
          }));
 
+      it('should call $onInit of components', inject([AsyncTestCompleter], (async) => {
+           var adapter = new UpgradeAdapter();
+           var ng1Module = angular.module('ng1', []);
+           var valueToFind = '$onInit';
+
+           var ng1 = {
+             bindings: {},
+             template: '{{$ctrl.value}}',
+             controller: Class(
+                 {constructor: function() {}, $onInit: function() { this.value = valueToFind; }})
+           };
+           ng1Module.component('ng1', ng1);
+
+           var Ng2 = Component({
+                       selector: 'ng2',
+                       template: '<ng1></ng1>',
+                       directives: [adapter.upgradeNg1Component('ng1')]
+                     }).Class({constructor: function() {}});
+           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+
+           var element = html(`<div><ng2></ng2></div>`);
+           adapter.bootstrap(element, ['ng1'])
+               .ready((ref) => {
+                 expect(multiTrim(document.body.textContent)).toEqual(valueToFind);
+                 ref.dispose();
+                 async.done();
+               });
+         }));
+
+      it('should bind input properties (<) of components', inject([AsyncTestCompleter], (async) => {
+           var adapter = new UpgradeAdapter();
+           var ng1Module = angular.module('ng1', []);
+
+           var ng1 = {
+             bindings: {personProfile: '<'},
+             template: 'Hello {{$ctrl.personProfile.firstName}} {{$ctrl.personProfile.lastName}}',
+             controller: Class({constructor: function() {}})
+           };
+           ng1Module.component('ng1', ng1);
+
+           var Ng2 =
+               Component({
+                 selector: 'ng2',
+                 template: '<ng1 [personProfile]="goku"></ng1>',
+                 directives: [adapter.upgradeNg1Component('ng1')]
+               })
+                   .Class({
+                     constructor: function() { this.goku = {firstName: 'GOKU', lastName: 'SAN'}; }
+                   });
+           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+
+           var element = html(`<div><ng2></ng2></div>`);
+           adapter.bootstrap(element, ['ng1'])
+               .ready((ref) => {
+                 expect(multiTrim(document.body.textContent)).toEqual(`Hello GOKU SAN`);
+                 ref.dispose();
+                 async.done();
+               });
+         }));
     });
 
     describe('injection', () => {


### PR DESCRIPTION
With this fix, the $onInit function of an upgraded angular 1 component is called and input bindings (<) are created.
