### PR TITLE
fix(upgrade): make ngUpgrade work with testability API

### DIFF
--- a/modules/angular2/src/upgrade/angular_js.ts
+++ b/modules/angular2/src/upgrade/angular_js.ts
@@ -97,16 +97,33 @@ export interface IControllerService {
 
 export interface IInjectorService { get(key: string): any; }
 
+export interface ITestabilityService {
+  findBindings(element: Element, expression: string, opt_exactMatch?: boolean): Element[];
+  findModels(element: Element, expression: string, opt_exactMatch?: boolean): Element[];
+  getLocation(): string;
+  setLocation(url: string): void;
+  whenStable(callback: Function): void;
+}
+
 function noNg() {
   throw new Error('AngularJS v1.x is not loaded!');
 }
 
-var angular: {
-  bootstrap: (e: Element, modules: string[], config: IAngularBootstrapConfig) => void,
-  module: (prefix: string, dependencies?: string[]) => IModule,
-  element: (e: Element) => IAugmentedJQuery,
-  version: {major: number}
-} = <any>{bootstrap: noNg, module: noNg, element: noNg, version: noNg};
+var angular:
+    {
+      bootstrap: (e: Element, modules: string[], config: IAngularBootstrapConfig) => void,
+      module: (prefix: string, dependencies?: string[]) => IModule,
+      element: (e: Element) => IAugmentedJQuery,
+      version: {major: number}, resumeBootstrap?: () => void,
+      getTestability: (e: Element) => ITestabilityService
+    } = <any>{
+      bootstrap: noNg,
+      module: noNg,
+      element: noNg,
+      version: noNg,
+      resumeBootstrap: noNg,
+      getTestability: noNg
+    };
 
 
 try {
@@ -121,3 +138,5 @@ export var bootstrap = angular.bootstrap;
 export var module = angular.module;
 export var element = angular.element;
 export var version = angular.version;
+export var resumeBootstrap = angular.resumeBootstrap;
+export var getTestability = angular.getTestability;

--- a/modules/angular2/src/upgrade/constants.ts
+++ b/modules/angular2/src/upgrade/constants.ts
@@ -12,4 +12,5 @@ export const NG1_HTTP_BACKEND = '$httpBackend';
 export const NG1_INJECTOR = '$injector';
 export const NG1_PARSE = '$parse';
 export const NG1_TEMPLATE_CACHE = '$templateCache';
+export const NG1_TESTABILITY = '$$testability';
 export const REQUIRE_INJECTOR = '^' + NG2_INJECTOR;

--- a/modules/angular2/src/upgrade/upgrade_adapter.ts
+++ b/modules/angular2/src/upgrade/upgrade_adapter.ts
@@ -10,8 +10,10 @@ import {
   HostViewFactoryRef,
   Provider,
   Type,
+  Testability,
   APPLICATION_COMMON_PROVIDERS
 } from 'angular2/core';
+import {global} from 'angular2/src/facade/lang';
 import {ObservableWrapper} from 'angular2/src/facade/async';
 import {BROWSER_PROVIDERS, BROWSER_APP_PROVIDERS} from 'angular2/platform/browser';
 
@@ -23,6 +25,7 @@ import {
   NG1_PARSE,
   NG1_ROOT_SCOPE,
   NG1_SCOPE,
+  NG1_TESTABILITY,
   NG2_APP_VIEW_MANAGER,
   NG2_COMPILER,
   NG2_INJECTOR,
@@ -309,6 +312,7 @@ export class UpgradeAdapter {
     var rootScope: angular.IRootScopeService;
     var hostViewFactoryRefMap: HostViewFactoryRefMap = {};
     var ng1Module = angular.module(this.idPrefix, modules);
+    var ng1BootstrapPromise: Promise<any> = null;
     var ng1compilePromise: Promise<any> = null;
     ng1Module.value(NG2_INJECTOR, injector)
         .value(NG2_ZONE, ngZone)
@@ -331,23 +335,68 @@ export class UpgradeAdapter {
                 return rootScope = rootScopeDelegate;
               }
             ]);
-          }
-        ])
-        .run([
-          '$injector',
-          '$rootScope',
-          (injector: angular.IInjectorService, rootScope: angular.IRootScopeService) => {
-            ng1Injector = injector;
-            ObservableWrapper.subscribe(ngZone.onMicrotaskEmpty,
-                                        (_) => ngZone.runOutsideAngular(() => rootScope.$apply()));
-            ng1compilePromise =
-                UpgradeNg1ComponentAdapterBuilder.resolve(this.downgradedComponents, injector);
+            provide.decorator(NG1_TESTABILITY, [
+              '$delegate',
+              function(testabilityDelegate: angular.ITestabilityService) {
+                var ng2Testability: Testability = injector.get(Testability);
+
+                var origonalWhenStable: Function = testabilityDelegate.whenStable;
+                var newWhenStable = (callback: Function): void => {
+                  var whenStableContext: any = this;
+                  origonalWhenStable.call(this, function() {
+                    if (ng2Testability.isStable()) {
+                      callback.apply(this, arguments);
+                    } else {
+                      ng2Testability.whenStable(newWhenStable.bind(whenStableContext, callback));
+                    }
+                  });
+                };
+
+                testabilityDelegate.whenStable = newWhenStable;
+                return testabilityDelegate;
+              }
+            ]);
           }
         ]);
 
+    ng1compilePromise = new Promise((resolve, reject) => {
+      ng1Module.run([
+        '$injector',
+        '$rootScope',
+        (injector: angular.IInjectorService, rootScope: angular.IRootScopeService) => {
+          ng1Injector = injector;
+          ObservableWrapper.subscribe(ngZone.onMicrotaskEmpty,
+                                      (_) => ngZone.runOutsideAngular(() => rootScope.$apply()));
+          UpgradeNg1ComponentAdapterBuilder.resolve(this.downgradedComponents, injector)
+              .then(resolve, reject);
+        }
+      ]);
+    });
+
+    // Make sure resumeBootstrap() only exists if the current bootstrap is deferred
+    var windowAngular = (<any>global).angular;
+    windowAngular.resumeBootstrap = undefined;
+
     angular.element(element).data(controllerKey(NG2_INJECTOR), injector);
     ngZone.run(() => { angular.bootstrap(element, [this.idPrefix], config); });
-    Promise.all([this.compileNg2Components(compiler, hostViewFactoryRefMap), ng1compilePromise])
+    ng1BootstrapPromise = new Promise((resolve, reject) => {
+      if (windowAngular.resumeBootstrap) {
+        var originalResumeBootstrap: () => void = windowAngular.resumeBootstrap;
+        windowAngular.resumeBootstrap = function() {
+          windowAngular.resumeBootstrap = originalResumeBootstrap;
+          windowAngular.resumeBootstrap.apply(this, arguments);
+          resolve();
+        };
+      } else {
+        resolve();
+      }
+    });
+
+    Promise.all([
+             this.compileNg2Components(compiler, hostViewFactoryRefMap),
+             ng1BootstrapPromise,
+             ng1compilePromise
+           ])
         .then(() => {
           ngZone.run(() => {
             if (rootScopePrototype) {


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

(Docs not really relevant in this case)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This change makes the testability API work with hybrid apps.  Specifically, it fixes deferred bootstrapping and waiting on ng2 components within ng1 apps
- **What is the current behavior?** (You can also link to an open issue here)

Currently deferred bootstrapping causes ngUpgrade to hang, and if an ng2 component uses `setTimeout` or the like the hybrid app's testability checks will totally ignore the fact that its ng2 components aren't yet stable
- **What is the new behavior (if this is a feature change)?**

Now deferred bootstrapping works, and the testability API will check both ng1 and ng2 stability
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Only if someone is relying on their hybrid app to crash!
- **Other information**:

I have almost zero typescript knowledge so please tell me how to fix any style problems.  I did compile/run tests though.
