### PR TITLE
refactor(dart/transform): Remove deprecated angular2/bootstrap

### DIFF
--- a/modules/angular2/bootstrap.ts
+++ b/modules/angular2/bootstrap.ts
@@ -1,6 +1,0 @@
-/**
- * See {@link bootstrap} for more information.
- * @deprecated
- */
-export {bootstrap} from 'angular2/platform/browser';
-export {AngularEntrypoint} from 'angular2/src/core/angular_entrypoint';

--- a/modules/angular2/bootstrap_static.ts
+++ b/modules/angular2/bootstrap_static.ts
@@ -1,6 +1,0 @@
-/**
- * See {@link bootstrap} for more information.
- * @deprecated
- */
-export {bootstrapStatic} from 'angular2/platform/browser_static';
-export {AngularEntrypoint} from 'angular2/src/core/angular_entrypoint';

--- a/modules_dart/transform/lib/src/transform/common/annotation_matcher.dart
+++ b/modules_dart/transform/lib/src/transform/common/annotation_matcher.dart
@@ -15,7 +15,6 @@ const _INJECTABLES = const [
   const ClassDescriptor('Injectable', 'package:angular2/core.dart'),
   const ClassDescriptor('Injectable', 'package:angular2/src/core/di.dart'),
   const ClassDescriptor('Injectable', 'package:angular2/angular2.dart'),
-  const ClassDescriptor('Injectable', 'package:angular2/bootstrap_static.dart'),
   const ClassDescriptor(
       'Injectable', 'package:angular2/web_worker/worker.dart'),
 ];
@@ -65,7 +64,6 @@ const _PIPES = const [
 const _VIEWS = const [
   const ClassDescriptor('View', 'package:angular2/angular2.dart'),
   const ClassDescriptor('View', 'package:angular2/web_worker/worker.dart'),
-  const ClassDescriptor('View', 'package:angular2/bootstrap_static.dart'),
   const ClassDescriptor('View', 'package:angular2/core.dart'),
   const ClassDescriptor('View', 'package:angular2/src/core/metadata/view.dart'),
   const ClassDescriptor('View', 'package:angular2/src/core/metadata.dart'),
@@ -74,9 +72,6 @@ const _VIEWS = const [
 const _ENTRYPOINTS = const [
   const ClassDescriptor('AngularEntrypoint', 'package:angular2/angular2.dart'),
   const ClassDescriptor('AngularEntrypoint', 'package:angular2/core.dart'),
-  const ClassDescriptor('AngularEntrypoint', 'package:angular2/bootstrap.dart'),
-  const ClassDescriptor(
-      'AngularEntrypoint', 'package:angular2/bootstrap_static.dart'),
   const ClassDescriptor(
       'AngularEntrypoint', 'package:angular2/platform/browser.dart'),
   const ClassDescriptor(

--- a/modules_dart/transform/lib/src/transform/common/mirror_matcher.dart
+++ b/modules_dart/transform/lib/src/transform/common/mirror_matcher.dart
@@ -3,14 +3,11 @@ library angular2.transform.common.mirror_matcher;
 import 'package:analyzer/src/generated/ast.dart';
 import 'package:angular2/src/transform/common/names.dart';
 
-/// Files from which `bootstrap` is exported.
+/// File from which `bootstrap` is exported.
 ///
-/// These files transitively imports dart:mirrors.
-/// They should be replaced with [BOOTSTRAP_STATIC_URI] in production apps.
-const _BOOTSTRAP_URIS = const <String>[
-  'package:angular2/bootstrap.dart',
-  'package:angular2/platform/browser.dart',
-];
+/// This file transitively imports dart:mirrors.
+/// It should be replaced with [BOOTSTRAP_STATIC_URI] in production apps.
+const _BOOTSTRAP_URI = 'package:angular2/platform/browser.dart';
 
 /// File from which `ReflectionCapabilities` is exported.
 ///
@@ -23,7 +20,7 @@ const _REFLECTION_CAPABILITIES_URI =
 /// File from which `bootstrapStatic` is exported.
 ///
 /// This file does not transitively import dart:mirrors.
-/// It should be used in place of [_BOOTSTRAP_URIS] in production apps.
+/// It should be used in place of [_BOOTSTRAP_URI] in production apps.
 const BOOTSTRAP_STATIC_URI = 'package:angular2/platform/browser_static.dart';
 
 /// Syntactially checks for code related to the use of `dart:mirrors`.
@@ -42,5 +39,5 @@ class MirrorMatcher {
   }
 
   bool hasBootstrapUri(UriBasedDirective node) =>
-      _BOOTSTRAP_URIS.contains(node.uri.stringValue);
+      _BOOTSTRAP_URI == node.uri.stringValue;
 }

--- a/modules_dart/transform/test/transform/reflection_remover/all_tests.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/all_tests.dart
@@ -71,17 +71,6 @@ void allTests() {
   });
 
   describe('`bootstrap` import and call', () {
-    // TODO(kegluneq): Remove when we remove angular2/bootstrap.dart
-    it('deprecated import should be rewritten to `bootstrapStatic`.', () {
-      final bootstrapCode =
-          readFile('reflection_remover/deprecated_bootstrap_files/index.dart')
-              .replaceAll('\r\n', '\n');
-      var output = new Rewriter(bootstrapCode, codegen, entrypointMatcher,
-              writeStaticInit: true)
-          .rewrite(parseCompilationUnit(bootstrapCode));
-      expect(output).toEqual(bootstrap_expected.code);
-    });
-
     it('should be rewritten to `bootstrapStatic`.', () {
       final bootstrapCode =
           readFile('reflection_remover/bootstrap_files/index.dart')

--- a/modules_dart/transform/test/transform/reflection_remover/deprecated_bootstrap_files/index.dart
+++ b/modules_dart/transform/test/transform/reflection_remover/deprecated_bootstrap_files/index.dart
@@ -1,7 +1,0 @@
-library web_foo;
-
-import 'package:angular2/platform/browser.dart';
-
-void main() async {
-  var appRef = await bootstrap(MyComponent);
-}

--- a/tools/broccoli/html-replace/SCRIPTS.html
+++ b/tools/broccoli/html-replace/SCRIPTS.html
@@ -9,7 +9,6 @@
     // not even be in src/*. Move them!
     'angular2/src/testing/benchmark_util',
     'angular2/src/facade/browser',
-    'angular2/bootstrap',
     'rxjs'
   ];
   if (@@USE_BUNDLES) {

--- a/tools/broccoli/html-replace/SCRIPTS_benchmarks.html
+++ b/tools/broccoli/html-replace/SCRIPTS_benchmarks.html
@@ -10,7 +10,6 @@
     // not even be in src/*. Move them!
     'angular2/src/testing/benchmark_util',
     'angular2/src/facade/browser',
-    'angular2/bootstrap',
     'rxjs'
   ];
   if (@@USE_BUNDLES) {


### PR DESCRIPTION
/cc @IgorMinar, to be committed after https://github.com/angular/angular/pull/7647

BREAKING CHANGE

Remove the deprecated angular2/bootstrap.ts &
angular2/bootstrap_static.ts libraries.

Browser entry points should import angular2/platform/browser which
supplies the `bootstrap` function.
