### PR TITLE
Bump reflect-metadata to 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.3",
-    "reflect-metadata": "0.1.2",
+    "reflect-metadata": "0.1.3",
     "rxjs": "5.0.0-beta.2",
     "zone.js": "^0.6.4"
   },


### PR DESCRIPTION
This PR bumps the `reflect-metadata` version to latest ( 0.1.3 ). 

Per release notes: 

> Includes several minor, non-breaking changes to type information.

I've been running 0.1.3 in my setup for a week now with no negative side-affects. I'd like to propose to bump this to keep a2 on latest dep.
