### PR TITLE
feat(router): Added route name to component instruction

### DIFF
--- a/modules/angular2/src/router/instruction.ts
+++ b/modules/angular2/src/router/instruction.ts
@@ -310,7 +310,7 @@ export class ComponentInstruction {
    */
   constructor(public urlPath: string, public urlParams: string[], data: RouteData,
               public componentType, public terminal: boolean, public specificity: string,
-              public params: {[key: string]: string} = null) {
+              public params: {[key: string]: string} = null, public name: string = null) {
     this.routeData = isPresent(data) ? data : BLANK_ROUTE_DATA;
   }
 }

--- a/modules/angular2/src/router/rules/route_handlers/async_route_handler.ts
+++ b/modules/angular2/src/router/rules/route_handlers/async_route_handler.ts
@@ -10,7 +10,8 @@ export class AsyncRouteHandler implements RouteHandler {
   componentType: Type;
   public data: RouteData;
 
-  constructor(private _loader: () => Promise<Type>, data: {[key: string]: any} = null) {
+  constructor(private _loader: () => Promise<Type>, data: {[key: string]: any} = null,
+              public name: string = null) {
     this.data = isPresent(data) ? new RouteData(data) : BLANK_ROUTE_DATA;
   }
 

--- a/modules/angular2/src/router/rules/route_handlers/route_handler.ts
+++ b/modules/angular2/src/router/rules/route_handlers/route_handler.ts
@@ -5,4 +5,5 @@ export interface RouteHandler {
   componentType: Type;
   resolveComponentType(): Promise<any>;
   data: RouteData;
+  name: string;
 }

--- a/modules/angular2/src/router/rules/route_handlers/sync_route_handler.ts
+++ b/modules/angular2/src/router/rules/route_handlers/sync_route_handler.ts
@@ -11,7 +11,7 @@ export class SyncRouteHandler implements RouteHandler {
   /** @internal */
   _resolvedComponent: Promise<any> = null;
 
-  constructor(public componentType: Type, data?: {[key: string]: any}) {
+  constructor(public componentType: Type, data?: {[key: string]: any}, public name: string = null) {
     this._resolvedComponent = PromiseWrapper.resolve(componentType);
     this.data = isPresent(data) ? new RouteData(data) : BLANK_ROUTE_DATA;
   }

--- a/modules/angular2/src/router/rules/rule_set.ts
+++ b/modules/angular2/src/router/rules/rule_set.ts
@@ -57,7 +57,7 @@ export class RuleSet {
     }
 
     if (config instanceof AuxRoute) {
-      handler = new SyncRouteHandler(config.component, config.data);
+      handler = new SyncRouteHandler(config.component, config.data, config.name);
       let routePath = this._getRoutePath(config);
       let auxRule = new RouteRule(routePath, handler);
       this.auxRulesByPath.set(routePath.toString(), auxRule);
@@ -78,10 +78,10 @@ export class RuleSet {
     }
 
     if (config instanceof Route) {
-      handler = new SyncRouteHandler(config.component, config.data);
+      handler = new SyncRouteHandler(config.component, config.data, config.name);
       useAsDefault = isPresent(config.useAsDefault) && config.useAsDefault;
     } else if (config instanceof AsyncRoute) {
-      handler = new AsyncRouteHandler(config.loader, config.data);
+      handler = new AsyncRouteHandler(config.loader, config.data, config.name);
       useAsDefault = isPresent(config.useAsDefault) && config.useAsDefault;
     }
     let routePath = this._getRoutePath(config);

--- a/modules/angular2/src/router/rules/rules.ts
+++ b/modules/angular2/src/router/rules/rules.ts
@@ -112,7 +112,7 @@ export class RouteRule implements AbstractRule {
     }
     var instruction =
         new ComponentInstruction(urlPath, urlParams, this.handler.data, this.handler.componentType,
-                                 this.terminal, this.specificity, params);
+                                 this.terminal, this.specificity, params, this.handler.name);
     this._cache.set(hashKey, instruction);
 
     return instruction;

--- a/modules/angular2/test/router/rules/rule_set_spec.ts
+++ b/modules/angular2/test/router/rules/rule_set_spec.ts
@@ -225,6 +225,13 @@ export function main() {
                });
          }));
     });
+
+    it('should provide the route name on the component instruction', () => {
+      recognizer.config(new Route({path: 'home/page', component: DummyCmpA, name: 'HomePage'}));
+
+      var result = recognizer.generate('HomePage', {});
+      expect(result.name).toEqual('HomePage');
+    });
   });
 }
 


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature
- **What is the current behavior?** (You can also link to an open issue here)

The component instruction does not include the name provided for the route
- **What is the new behavior (if this is a feature change)?**

Provides the component instruction with the route name. This allows to the user to differentiate between different route names that use the same route component. Also makes it easier to build a breadcrumb component from instructions.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
- **Other information**:

Closes #7509

cc: @petebacondarwin @btford 
