### PR TITLE
fix(runtime_metadata): correct error messages

### DIFF
--- a/modules/angular2/src/compiler/runtime_metadata.ts
+++ b/modules/angular2/src/compiler/runtime_metadata.ts
@@ -164,7 +164,7 @@ export class RuntimeMetadataResolver {
     for (var i = 0; i < directives.length; i++) {
       if (!isValidType(directives[i])) {
         throw new BaseException(
-            `Unexpected directive value '${stringify(directives[i])}' on the View of component '${stringify(component)}'`);
+            `Unexpected directive value '${stringify(directives[i])}' on the directives property of component '${stringify(component)}'`);
       }
     }
 
@@ -177,7 +177,7 @@ export class RuntimeMetadataResolver {
     for (var i = 0; i < pipes.length; i++) {
       if (!isValidType(pipes[i])) {
         throw new BaseException(
-            `Unexpected piped value '${stringify(pipes[i])}' on the View of component '${stringify(component)}'`);
+            `Unexpected pipe value '${stringify(pipes[i])}' on the pipes property of component '${stringify(component)}'`);
       }
     }
     return pipes.map(type => this.getPipeMetadata(type));

--- a/modules/angular2/test/core/linker/integration_spec.ts
+++ b/modules/angular2/test/core/linker/integration_spec.ts
@@ -1391,7 +1391,7 @@ function declareTests(isJit: boolean) {
 
            PromiseWrapper.catchError(tcb.createAsync(MyComp), (e) => {
              expect(e.message).toEqual(
-                 `Unexpected directive value 'null' on the View of component '${stringify(MyComp)}'`);
+                 `Unexpected directive value 'null' on the directives property of component '${stringify(MyComp)}'`);
              async.done();
              return null;
            });
@@ -1504,7 +1504,7 @@ function declareTests(isJit: boolean) {
 
              PromiseWrapper.catchError(tcb.createAsync(MyComp), (e) => {
                expect(e.message).toEqual(
-                   `Unexpected directive value 'undefined' on the View of component '${stringify(MyComp)}'`);
+                   `Unexpected directive value 'undefined' on the directives property of component '${stringify(MyComp)}'`);
                async.done();
                return null;
              });


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Fix errors messages
- **What is the current behavior?** (You can also link to an open issue here)

The error messages mention `View` referencing `@View`
- **What is the new behavior (if this is a feature change)?**

`@View` was dropped, it makes no sense to keep the error message as it is right now. 

Now the error messages reference the corresponding property on Component, although it may sound too repetitive. I'm open to leave the message as `Unexpected directive/pipe ... on Component` instead, but I thought being more specific is better.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
- **Other information**:
