### PR TITLE
Remove es6 promise

### DIFF
--- a/modules/angular2/docs/bundles/overview.md
+++ b/modules/angular2/docs/bundles/overview.md
@@ -72,7 +72,7 @@ An example of an Angular 2 project built with WebPack can be found in the [angul
 
 Polyfills are required for Angular 2 to function properly (the exact list depends on the browser used) and external dependencies ([zone.js](https://github.com/angular/zone.js)).
 To ease setup of Angular 2 applications there is one file - `angular2-polyfills.js` - that combines:
-* a pollyfill mandatory for all browsers: [reflect-metadata](https://www.npmjs.com/package/reflect-metadata)
+* a polyfill mandatory for all browsers: [reflect-metadata](https://www.npmjs.com/package/reflect-metadata)
 * [zone.js](https://github.com/angular/zone.js)     
 
 **Note**: `angular2-polyfills.js` contains code that should be loaded into the browser as the very first code of the web application even before the module loader. The preferred solution is to load the mentioned file in a `script` tag as early as possible. 

--- a/modules/angular2/package.json
+++ b/modules/angular2/package.json
@@ -9,7 +9,6 @@
   "repository": <%= JSON.stringify(packageJson.repository) %>,
   "devDependencies": <%= JSON.stringify(packageJson.defaultDevDependencies) %>,
   "peerDependencies": {
-    "es6-promise": "<%= packageJson.dependencies['es6-promise'] %>",
     "es6-shim": "<%= packageJson.dependencies['es6-shim'] %>",
     "reflect-metadata": "<%= packageJson.dependencies['reflect-metadata'] %>",
     "rxjs": "<%= packageJson.dependencies['rxjs'] %>",

--- a/modules/benchpress/package.json
+++ b/modules/benchpress/package.json
@@ -10,7 +10,6 @@
   "repository": <%= JSON.stringify(packageJson.repository) %>,
   "dependencies": {
     "angular2": "<%= packageJson.version %>",
-    "es6-promise": "<%= packageJson.dependencies['es6-promise'] %>",
     "es6-shim": "<%= packageJson.dependencies['es6-shim'] %>",
     "reflect-metadata": "<%= packageJson.dependencies['reflect-metadata'] %>",
     "rxjs": "<%= packageJson.dependencies['rxjs'] %>",

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -2083,9 +2083,6 @@
     "es6-module-loader": {
       "version": "0.17.9"
     },
-    "es6-promise": {
-      "version": "3.0.2"
-    },
     "es6-shim": {
       "version": "0.35.0"
     },

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -5836,5 +5836,5 @@
     }
   },
   "name": "angular-srcs",
-  "version": "2.0.0-beta.10"
+  "version": "2.0.0-beta.11"
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3279,11 +3279,6 @@
       "from": "es6-module-loader@>=0.17.4 <0.18.0",
       "resolved": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.17.9.tgz"
     },
-    "es6-promise": {
-      "version": "3.0.2",
-      "from": "es6-promise@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
-    },
     "es6-shim": {
       "version": "0.35.0",
       "from": "es6-shim@0.35.0",
@@ -9310,7 +9305,8 @@
     },
     "zone.js": {
       "version": "0.6.4",
-      "from": "zone.js@0.6.4"
+      "from": "zone.js@0.6.4",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.6.4.tgz"
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.11",
   "dependencies": {
     "abbrev": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "test": "gulp test.all.js && gulp test.all.dart"
   },
   "dependencies": {
-    "es6-promise": "^3.0.2",
     "es6-shim": "^0.35.0",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.2",


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  drop obsolete es6-promise dependency
## \* **What is the current behavior?** (You can also link to an open issue here)
## \* **What is the new behavior (if this is a feature change)?**
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  not really. projects that already require es6-promise polyfill will now contain unnecessary dependency which should be removed if only everygreen browsers are targeted by the app.
- **Other information**:
