### PR TITLE
URLSearchParams not encoding output on toString()

### DIFF
--- a/modules/angular2/src/http/url_search_params.ts
+++ b/modules/angular2/src/http/url_search_params.ts
@@ -122,7 +122,7 @@ export class URLSearchParams {
 
   toString(): string {
     var paramsList: string[] = [];
-    this.paramsMap.forEach((values, k) => { values.forEach(v => paramsList.push(k + '=' + v)); });
+    this.paramsMap.forEach((values, k) => { values.forEach(v => paramsList.push(k + '=' + encodeURIComponent(v))); });
     return paramsList.join('&');
   }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
  Bug fix
- **What is the current behavior?**
  URLSearchParams not encoding output

Values need to be encoded on `toString()`
