### PR TITLE
refactor(router): Remove deprecated 'as' from ‘RouteConfig’

### DIFF
--- a/modules/angular1_router/test/integration/router_spec.js
+++ b/modules/angular1_router/test/integration/router_spec.js
@@ -34,7 +34,7 @@ describe('router', function () {
   it('should bind the component to the current router', function() {
     var router;
     registerComponent('homeCmp', {
-      bindings: { $router: '=' },
+      providers: { $router: '=' },
       controller: function($scope, $element) {
         this.$routerOnActivate = function() {
           router = this.$router;
@@ -148,7 +148,7 @@ describe('router', function () {
   it('should provide the root level router', function() {
     registerComponent('homeCmp', {
       template: 'Home ({{homeCmp.isAdmin}})',
-      bindings: {
+      providers: {
         $router: '<'
       }
     });
@@ -175,8 +175,8 @@ describe('router', function () {
   function registerComponent(name, options) {
 
     var definition = {
-      bindings: options.bindings,
-      controller: getController(options),
+      providers: options.providers,
+      controller: getController(options)
     };
     if (options.template) definition.template = options.template;
     if (options.templateUrl) definition.templateUrl = options.templateUrl;

--- a/modules/angular2/docs/core/02_directives.md
+++ b/modules/angular2/docs/core/02_directives.md
@@ -214,7 +214,7 @@ To better understand the kinds of injections which are supported in Angular we h
 
 ### Injecting Services
 
-Service injection is the most straight forward kind of injection which Angular supports. It involves a component configuring the `bindings` or `viewBindings` and then letting the directive ask for the configured service.
+Service injection is the most straight forward kind of injection which Angular supports. It involves a component configuring the `providers` or `viewProviders` and then letting the directive ask for the configured service.
 
 This example illustrates how to inject `MyService` into `House` directive.
 
@@ -225,7 +225,7 @@ class MyService {}                   | Assume a service which needs to be inject
                                      |
 @Component({                         | Assume a top level application component which
   selector: 'my-app',                | configures the services to be injected.
-  viewBindings: [MyService],         |
+  viewProviders: [MyService],         |
   templateUrl: 'my_app.html',        | Assume we have a template that needs to be
   directives: [House]                | configured with directives to be injected.
 })                                   |
@@ -351,7 +351,7 @@ class Dad {
 
 @Component({
   selector: '[grandpa]',
-  viewBindings: [],
+  viewProviders: [],
   templateUrl: 'grandpa.html',
   directives: [Dad]
 })

--- a/modules/angular2/docs/di/di_advanced.md
+++ b/modules/angular2/docs/di/di_advanced.md
@@ -24,7 +24,7 @@ var inj = Injector.resolveAndCreate([
 var engine = inj.get(ENGINE_KEY);  // no mapping
 ```
 
-Every key has an id, which we utilize to store bindings and instances. So Injector uses keys internally for performance reasons.
+Every key has an id, which we utilize to store providers and instances. So Injector uses keys internally for performance reasons.
 
 ### ProtoInjector and Injector
 
@@ -33,15 +33,15 @@ Often there is a need to create multiple instances of essentially the same injec
 Doing the following would be very inefficient.
 
 ```
-function createComponetInjector(parent, bindings: Binding[]) {
-  return parent.resolveAndCreateChild(bindings);
+function createComponetInjector(parent, providers: Binding[]) {
+  return parent.resolveAndCreateChild(providers);
 }
 ```
 
-This would require us to resolve and store bindings for every single component instance. Instead, we want to resolve and store the bindings for every component type, and create a set of instances for every component. To enable that DI separates the meta information about injectables (Bindings and their dependencies), which are stored in `ProtoInjector`, and injectables themselves, which are stored in `Injector`.
+This would require us to resolve and store providers for every single component instance. Instead, we want to resolve and store the providers for every component type, and create a set of instances for every component. To enable that DI separates the meta information about injectables (providers and their dependencies), which are stored in `ProtoInjector`, and injectables themselves, which are stored in `Injector`.
 
 ```
-var proto = new ProtoInjector(bindings); // done once
+var proto = new ProtoInjector(providers); // done once
 function createComponentInjector(parent, proto) {
   return new Injector(proto, parent);
 }
@@ -74,7 +74,7 @@ Imagine the following scenario:
    Child1    Child2
 ```
 
-Here both Child1 and Child2 are children of ParentInjector. Child2 marks this relationship as host. ParentInjector might want to expose two different sets of bindings for its "regular" children and its "host" children. Bindings visible to "regular" children are called "public" and bindings visible to "host" children are called "private". This is an advanced use case used by Angular, where components can provide different sets of bindings for their children and their view.
+Here both Child1 and Child2 are children of ParentInjector. Child2 marks this relationship as host. ParentInjector might want to expose two different sets of providers for its "regular" children and its "host" children. providers visible to "regular" children are called "public" and providers visible to "host" children are called "private". This is an advanced use case used by Angular, where components can provide different sets of providers for their children and their view.
 
 Let's look at this example.
 
@@ -154,12 +154,12 @@ Now let's see how Angular 2 uses DI behind the scenes.
 
 The right mental model is to think that every DOM element has an Injector. (In practice, only interesting elements containing directives will have an injector, but this is a performance optimization)
 
-There are two properties that can be used to configure DI: bindings and viewBindings.
+There are two properties that can be used to configure DI: providers and viewProviders.
 
-- `bindings` affects the element and its children.
-- `viewBindings` affects the component's view.
+- `providers` affects the element and its children.
+- `viewProviders` affects the component's view.
 
-Every directive can declare injectables via `bindings`, but only components can declare `viewBindings`.
+Every directive can declare injectables via `providers`, but only components can declare `viewProviders`.
 
 Let's look at a complex example that shows how the injector tree gets created.
 
@@ -174,10 +174,10 @@ Both `MyComponent` and `MyDirective` are created on the same element.
 ```
 @Component({
   selector: 'my-component',
-  bindings: [
+  providers: [
     bind('componentService').toValue('Host_MyComponentService')
   ],
-  viewBindings: [
+  viewProviders: [
     bind('viewService').toValue('View_MyComponentService')
   ],
   template: `<needs-view-service></needs-view-service>`,
@@ -187,7 +187,7 @@ class MyComponent {}
 
 @Directive({
   selector: '[my-directive]',
-  bindings: [
+  providers: [
     bind('directiveService').toValue('MyDirectiveService')
   ]
 })
@@ -231,5 +231,5 @@ Injector2 [                                                 Injector3 [
 ]                                                           ]
 ```
 
-As you can see the component and its bindings can be seen by its children and its view. The view bindings can be seen only by the view. And the bindings of other directives can be seen only their children.
+As you can see the component and its providers can be seen by its children and its view. The view providers can be seen only by the view. And the providers of other directives can be seen only their children.
 

--- a/modules/angular2/src/common/forms/directives/default_value_accessor.ts
+++ b/modules/angular2/src/common/forms/directives/default_value_accessor.ts
@@ -21,7 +21,7 @@ const DEFAULT_VALUE_ACCESSOR = CONST_EXPR(new Provider(
   // https://github.com/angular/angular/issues/3011 is implemented
   // selector: '[ngControl],[ngModel],[ngFormControl]',
   host: {'(input)': 'onChange($event.target.value)', '(blur)': 'onTouched()'},
-  bindings: [DEFAULT_VALUE_ACCESSOR]
+  providers: [DEFAULT_VALUE_ACCESSOR]
 })
 export class DefaultValueAccessor implements ControlValueAccessor {
   onChange = (_: any) => {};

--- a/modules/angular2/src/common/forms/directives/ng_control_name.ts
+++ b/modules/angular2/src/common/forms/directives/ng_control_name.ts
@@ -91,7 +91,7 @@ const controlNameBinding =
  */
 @Directive({
   selector: '[ngControl]',
-  bindings: [controlNameBinding],
+  providers: [controlNameBinding],
   inputs: ['name: ngControl', 'model: ngModel'],
   outputs: ['update: ngModelChange'],
   exportAs: 'ngForm'

--- a/modules/angular2/src/common/forms/directives/ng_form.ts
+++ b/modules/angular2/src/common/forms/directives/ng_form.ts
@@ -79,7 +79,7 @@ const formDirectiveProvider =
  */
 @Directive({
   selector: 'form:not([ngNoForm]):not([ngFormModel]),ngForm,[ngForm]',
-  bindings: [formDirectiveProvider],
+  providers: [formDirectiveProvider],
   host: {
     '(submit)': 'onSubmit()',
   },

--- a/modules/angular2/src/common/forms/directives/ng_form_control.ts
+++ b/modules/angular2/src/common/forms/directives/ng_form_control.ts
@@ -77,7 +77,7 @@ const formControlBinding =
  */
 @Directive({
   selector: '[ngFormControl]',
-  bindings: [formControlBinding],
+  providers: [formControlBinding],
   inputs: ['form: ngFormControl', 'model: ngModel'],
   outputs: ['update: ngModelChange'],
   exportAs: 'ngForm'

--- a/modules/angular2/src/common/forms/directives/ng_form_model.ts
+++ b/modules/angular2/src/common/forms/directives/ng_form_model.ts
@@ -96,7 +96,7 @@ const formDirectiveProvider =
  */
 @Directive({
   selector: '[ngFormModel]',
-  bindings: [formDirectiveProvider],
+  providers: [formDirectiveProvider],
   inputs: ['form: ngFormModel'],
   host: {'(submit)': 'onSubmit()'},
   outputs: ['ngSubmit'],

--- a/modules/angular2/src/common/forms/directives/ng_model.ts
+++ b/modules/angular2/src/common/forms/directives/ng_model.ts
@@ -49,7 +49,7 @@ const formControlBinding =
  */
 @Directive({
   selector: '[ngModel]:not([ngControl]):not([ngFormControl])',
-  bindings: [formControlBinding],
+  providers: [formControlBinding],
   inputs: ['model: ngModel'],
   outputs: ['update: ngModelChange'],
   exportAs: 'ngForm'

--- a/modules/angular2/src/common/forms/directives/number_value_accessor.ts
+++ b/modules/angular2/src/common/forms/directives/number_value_accessor.ts
@@ -22,7 +22,7 @@ const NUMBER_VALUE_ACCESSOR = CONST_EXPR(new Provider(
     '(input)': 'onChange($event.target.value)',
     '(blur)': 'onTouched()'
   },
-  bindings: [NUMBER_VALUE_ACCESSOR]
+  providers: [NUMBER_VALUE_ACCESSOR]
 })
 export class NumberValueAccessor implements ControlValueAccessor {
   onChange = (_: any) => {};

--- a/modules/angular2/src/common/forms/directives/select_control_value_accessor.ts
+++ b/modules/angular2/src/common/forms/directives/select_control_value_accessor.ts
@@ -37,7 +37,7 @@ export class NgSelectOption {
 @Directive({
   selector: 'select[ngControl],select[ngFormControl],select[ngModel]',
   host: {'(input)': 'onChange($event.target.value)', '(blur)': 'onTouched()'},
-  bindings: [SELECT_VALUE_ACCESSOR]
+  providers: [SELECT_VALUE_ACCESSOR]
 })
 export class SelectControlValueAccessor implements ControlValueAccessor {
   value: string;

--- a/modules/angular2/src/common/forms/form_builder.ts
+++ b/modules/angular2/src/common/forms/form_builder.ts
@@ -13,7 +13,7 @@ import {ValidatorFn, AsyncValidatorFn} from './directives/validators';
  * ```typescript
  * @Component({
  *   selector: 'my-app',
- *   viewBindings: [FORM_BINDINGS]
+ *   viewProviders: [FORM_BINDINGS]
  *   template: `
  *     <form [ngFormModel]="loginForm">
  *       <p>Login <input ngControl="login"></p>

--- a/modules/angular2/src/core/metadata.dart
+++ b/modules/angular2/src/core/metadata.dart
@@ -23,8 +23,6 @@ class Directive extends DirectiveMetadata {
       @Deprecated('Use `outputs` or `@Output` instead')
       List<String> events,
       Map<String, String> host,
-      @Deprecated('Use `providers` instead')
-      List bindings,
       List providers,
       String exportAs,
       Map<String, dynamic> queries})
@@ -35,7 +33,6 @@ class Directive extends DirectiveMetadata {
             properties: properties,
             events: events,
             host: host,
-            bindings: bindings,
             providers: providers,
             exportAs: exportAs,
             queries: queries);
@@ -54,14 +51,10 @@ class Component extends ComponentMetadata {
       @Deprecated('Use `outputs` or `@Output` instead')
       List<String> events,
       Map<String, String> host,
-      @Deprecated('Use `providers` instead')
-      List bindings,
       List providers,
       String exportAs,
       String moduleId,
       Map<String, dynamic> queries,
-      @Deprecated('Use `viewProviders` instead')
-      List viewBindings,
       List viewProviders,
       ChangeDetectionStrategy changeDetection,
       String templateUrl,
@@ -78,11 +71,9 @@ class Component extends ComponentMetadata {
             properties: properties,
             events: events,
             host: host,
-            bindings: bindings,
             providers: providers,
             exportAs: exportAs,
             moduleId: moduleId,
-            viewBindings: viewBindings,
             viewProviders: viewProviders,
             queries: queries,
             changeDetection: changeDetection,

--- a/modules/angular2/src/core/metadata.ts
+++ b/modules/angular2/src/core/metadata.ts
@@ -143,7 +143,6 @@ export interface DirectiveFactory {
     properties?: string[],
     events?: string[],
     host?: {[key: string]: string},
-    bindings?: any[],
     providers?: any[],
     exportAs?: string,
     queries?: {[key: string]: any}
@@ -155,7 +154,6 @@ export interface DirectiveFactory {
     properties?: string[],
     events?: string[],
     host?: {[key: string]: string},
-    bindings?: any[],
     providers?: any[],
     exportAs?: string,
     queries?: {[key: string]: any}
@@ -201,13 +199,10 @@ export interface ComponentFactory {
     properties?: string[],
     events?: string[],
     host?: {[key: string]: string},
-    /* @deprecated */
-    bindings?: any[],
     providers?: any[],
     exportAs?: string,
     moduleId?: string,
     queries?: {[key: string]: any},
-    viewBindings?: any[],
     viewProviders?: any[],
     changeDetection?: ChangeDetectionStrategy,
     templateUrl?: string,
@@ -225,14 +220,10 @@ export interface ComponentFactory {
     properties?: string[],
     events?: string[],
     host?: {[key: string]: string},
-    /* @deprecated */
-    bindings?: any[],
     providers?: any[],
     exportAs?: string,
     moduleId?: string,
     queries?: {[key: string]: any},
-    /* @deprecated */
-    viewBindings?: any[],
     viewProviders?: any[],
     changeDetection?: ChangeDetectionStrategy,
     templateUrl?: string,

--- a/modules/angular2/src/core/metadata/directives.ts
+++ b/modules/angular2/src/core/metadata/directives.ts
@@ -649,7 +649,7 @@ export class DirectiveMetadata extends InjectableMetadata {
    *
    * @Directive({
    *   selector: 'greet',
-   *   bindings: [
+   *   providers: [
    *     Greeter
    *   ]
    * })
@@ -663,13 +663,9 @@ export class DirectiveMetadata extends InjectableMetadata {
    * ```
    */
   get providers(): any[] {
-    return isPresent(this._bindings) && this._bindings.length > 0 ? this._bindings :
-                                                                    this._providers;
+    return this._providers;
   }
-  /** @deprecated */
-  get bindings(): any[] { return this.providers; }
   private _providers: any[];
-  private _bindings: any[];
 
   /**
    * Defines the name that can be used in the template to assign this directive to a variable.
@@ -731,7 +727,7 @@ export class DirectiveMetadata extends InjectableMetadata {
    */
   queries: {[key: string]: any};
 
-  constructor({selector, inputs, outputs, properties, events, host, bindings, providers, exportAs,
+  constructor({selector, inputs, outputs, properties, events, host, providers, exportAs,
                queries}: {
     selector?: string,
     inputs?: string[],
@@ -740,7 +736,6 @@ export class DirectiveMetadata extends InjectableMetadata {
     events?: string[],
     host?: {[key: string]: string},
     providers?: any[],
-    /** @deprecated */ bindings?: any[],
     exportAs?: string,
     queries?: {[key: string]: any}
   } = {}) {
@@ -754,7 +749,6 @@ export class DirectiveMetadata extends InjectableMetadata {
     this.exportAs = exportAs;
     this.queries = queries;
     this._providers = providers;
-    this._bindings = bindings;
   }
 }
 
@@ -836,12 +830,9 @@ export class ComponentMetadata extends DirectiveMetadata {
    * ```
    */
   get viewProviders(): any[] {
-    return isPresent(this._viewBindings) && this._viewBindings.length > 0 ? this._viewBindings :
-                                                                            this._viewProviders;
+    return this._viewProviders;
   }
-  get viewBindings(): any[] { return this.viewProviders; }
   private _viewProviders: any[];
-  private _viewBindings: any[];
 
   /**
    * The module id of the module that contains the component.
@@ -877,8 +868,8 @@ export class ComponentMetadata extends DirectiveMetadata {
 
   encapsulation: ViewEncapsulation;
 
-  constructor({selector, inputs, outputs, properties, events, host, exportAs, moduleId, bindings,
-               providers, viewBindings, viewProviders,
+  constructor({selector, inputs, outputs, properties, events, host, exportAs, moduleId,
+               providers, viewProviders,
                changeDetection = ChangeDetectionStrategy.Default, queries, templateUrl, template,
                styleUrls, styles, directives, pipes, encapsulation}: {
     selector?: string,
@@ -887,11 +878,9 @@ export class ComponentMetadata extends DirectiveMetadata {
     properties?: string[],
     events?: string[],
     host?: {[key: string]: string},
-    /** @deprecated */ bindings?: any[],
     providers?: any[],
     exportAs?: string,
     moduleId?: string,
-    /** @deprecated */ viewBindings?: any[],
     viewProviders?: any[],
     queries?: {[key: string]: any},
     changeDetection?: ChangeDetectionStrategy,
@@ -911,14 +900,12 @@ export class ComponentMetadata extends DirectiveMetadata {
       events: events,
       host: host,
       exportAs: exportAs,
-      bindings: bindings,
       providers: providers,
       queries: queries
     });
 
     this.changeDetection = changeDetection;
     this._viewProviders = viewProviders;
-    this._viewBindings = viewBindings;
     this.templateUrl = templateUrl;
     this.template = template;
     this.styleUrls = styleUrls;

--- a/modules/angular2/src/mock/directive_resolver_mock.ts
+++ b/modules/angular2/src/mock/directive_resolver_mock.ts
@@ -55,20 +55,6 @@ export class MockDirectiveResolver extends DirectiveResolver {
     });
   }
 
-  /**
-   * @deprecated
-   */
-  setBindingsOverride(type: Type, bindings: any[]): void {
-    this._providerOverrides.set(type, bindings);
-  }
-
-  /**
-   * @deprecated
-   */
-  setViewBindingsOverride(type: Type, viewBindings: any[]): void {
-    this.viewProviderOverrides.set(type, viewBindings);
-  }
-
   setProvidersOverride(type: Type, providers: any[]): void {
     this._providerOverrides.set(type, providers);
   }

--- a/modules/angular2/src/router/directives/router_link.ts
+++ b/modules/angular2/src/router/directives/router_link.ts
@@ -12,7 +12,7 @@ import {Instruction} from '../instruction';
 
  * ```
  * @RouteConfig([
- *   { path: '/user', component: UserCmp, as: 'User' }
+ *   { path: '/user', component: UserCmp, name: 'User' }
  * ]);
  * class MyComp {}
  * ```

--- a/modules/angular2/src/router/route_config/route_config_normalizer.ts
+++ b/modules/angular2/src/router/route_config/route_config_normalizer.ts
@@ -1,7 +1,7 @@
 import {AsyncRoute, AuxRoute, Route, Redirect, RouteDefinition} from './route_config_decorator';
 import {ComponentDefinition} from '../route_definition';
 import {isType, Type} from 'angular2/src/facade/lang';
-import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
+import {BaseException} from 'angular2/src/facade/exceptions';
 import {RouteRegistry} from '../route_registry';
 
 
@@ -32,12 +32,7 @@ export function normalizeRouteConfig(config: RouteDefinition,
     throw new BaseException(
         `Route config should contain exactly one "component", "loader", or "redirectTo" property.`);
   }
-  if (config.as && config.name) {
-    throw new BaseException(`Route config should contain exactly one "as" or "name" property.`);
-  }
-  if (config.as) {
-    config.name = config.as;
-  }
+
   if (config.loader) {
     var wrappedLoader = wrapLoaderToReconfigureRegistry(config.loader, registry);
     return new AsyncRoute({

--- a/modules/angular2/src/router/route_definition.ts
+++ b/modules/angular2/src/router/route_definition.ts
@@ -7,7 +7,7 @@ import {RegexSerializer} from './rules/route_paths/regex_route_path';
  * Supported keys:
  * - `path` or `aux` (requires exactly one of these)
  * - `component`, `loader`,  `redirectTo` (requires exactly one of these)
- * - `name` or `as` (optional) (requires exactly one of these)
+ * - `name` (optional)
  * - `data` (optional)
  *
  * See also {@link Route}, {@link AsyncRoute}, {@link AuxRoute}, and {@link Redirect}.
@@ -20,7 +20,6 @@ export interface RouteDefinition {
   component?: Type | ComponentDefinition;
   loader?: () => Promise<Type>;
   redirectTo?: any[];
-  as?: string;
   name?: string;
   data?: any;
   useAsDefault?: boolean;

--- a/modules/angular2/src/testing/perf_util.ts
+++ b/modules/angular2/src/testing/perf_util.ts
@@ -31,7 +31,7 @@ export function runBenchmark(config) {
             execute: config.work,
             prepare: config.prepare,
             microMetrics: config.microMetrics,
-            bindings: [bind(Options.SAMPLE_DESCRIPTION).toValue(description)]
+            providers: [bind(Options.SAMPLE_DESCRIPTION).toValue(description)]
           });
         });
       });

--- a/modules/angular2/src/testing/test_component_builder.ts
+++ b/modules/angular2/src/testing/test_component_builder.ts
@@ -94,13 +94,13 @@ var _nextRootElementId = 0;
 @Injectable()
 export class TestComponentBuilder {
   /** @internal */
-  _bindingsOverrides = new Map<Type, any[]>();
+  _providersOverrides = new Map<Type, any[]>();
   /** @internal */
   _directiveOverrides = new Map<Type, Map<Type, Type>>();
   /** @internal */
   _templateOverrides = new Map<Type, string>();
   /** @internal */
-  _viewBindingsOverrides = new Map<Type, any[]>();
+  _viewProvidersOverrides = new Map<Type, any[]>();
   /** @internal */
   _viewOverrides = new Map<Type, ViewMetadata>();
 
@@ -182,7 +182,7 @@ export class TestComponentBuilder {
    */
   overrideProviders(type: Type, providers: any[]): TestComponentBuilder {
     var clone = this._clone();
-    clone._bindingsOverrides.set(type, providers);
+    clone._providersOverrides.set(type, providers);
     return clone;
   }
 
@@ -210,15 +210,8 @@ export class TestComponentBuilder {
    */
   overrideViewProviders(type: Type, providers: any[]): TestComponentBuilder {
     var clone = this._clone();
-    clone._viewBindingsOverrides.set(type, providers);
+    clone._viewProvidersOverrides.set(type, providers);
     return clone;
-  }
-
-  /**
-   * @deprecated
-   */
-  overrideViewBindings(type: Type, providers: any[]): TestComponentBuilder {
-    return this.overrideViewProviders(type, providers);
   }
 
   /**
@@ -237,10 +230,10 @@ export class TestComponentBuilder {
           (to, from) => { mockViewResolver.overrideViewDirective(component, from, to); });
     });
 
-    this._bindingsOverrides.forEach((bindings, type) =>
-                                        mockDirectiveResolver.setBindingsOverride(type, bindings));
-    this._viewBindingsOverrides.forEach(
-        (bindings, type) => mockDirectiveResolver.setViewBindingsOverride(type, bindings));
+    this._providersOverrides.forEach((providers, type) =>
+                                        mockDirectiveResolver.setProvidersOverride(type, providers));
+    this._viewProvidersOverrides.forEach(
+        (providers, type) => mockDirectiveResolver.setViewProvidersOverride(type, providers));
 
     var rootElId = `root${_nextRootElementId++}`;
     var rootEl = el(`<div id="${rootElId}"></div>`);

--- a/modules/angular2/test/core/linker/integration_dart_spec.dart
+++ b/modules/angular2/test/core/linker/integration_dart_spec.dart
@@ -250,7 +250,7 @@ class OnChangeComponent implements OnChanges {
     selector: 'component-with-observable-list',
     changeDetection: ChangeDetectionStrategy.OnPush,
     inputs: const ['list'],
-    bindings: const [
+    providers: const [
       const Binding(IterableDiffers,
           toValue: const IterableDiffers(const [
             const ObservableListDiffFactory(),

--- a/modules/angular2/test/router/route_config/route_config_spec.ts
+++ b/modules/angular2/test/router/route_config/route_config_spec.ts
@@ -185,30 +185,6 @@ export function main() {
                      return null;
                    })}));
 
-    it('should throw if a config has an invalid alias name with "as"',
-       inject(
-           [AsyncTestCompleter],
-           (async) => {
-               bootstrap(BadAliasCmp, testBindings)
-                   .catch((e) => {
-                     expect(e.originalException)
-                         .toContainError(
-                             `Route "/child" with name "child" does not begin with an uppercase letter. Route names should be CamelCase like "Child".`);
-                     async.done();
-                     return null;
-                   })}));
-
-    it('should throw if a config has multiple alias properties "as" and "name"',
-       inject([AsyncTestCompleter],
-              (async) => {
-                  bootstrap(MultipleAliasCmp, testBindings)
-                      .catch((e) => {
-                        expect(e.originalException)
-                            .toContainError(
-                                `Route config should contain exactly one "as" or "name" property.`);
-                        async.done();
-                        return null;
-                      })}));
   });
 }
 
@@ -315,24 +291,6 @@ class WrongConfigCmp {
 })
 @RouteConfig([{path: '/child', component: HelloCmp, name: 'child'}])
 class BadAliasNameCmp {
-}
-
-@Component({
-  selector: 'app-cmp',
-  template: `root { <router-outlet></router-outlet> }`,
-  directives: ROUTER_DIRECTIVES
-})
-@RouteConfig([{path: '/child', component: HelloCmp, as: 'child'}])
-class BadAliasCmp {
-}
-
-@Component({
-  selector: 'app-cmp',
-  template: `root { <router-outlet></router-outlet> }`,
-  directives: ROUTER_DIRECTIVES
-})
-@RouteConfig([{path: '/child', component: HelloCmp, as: 'Child', name: 'Child'}])
-class MultipleAliasCmp {
 }
 
 @Component({

--- a/modules/angular2/test/testing/test_component_builder_spec.ts
+++ b/modules/angular2/test/testing/test_component_builder_spec.ts
@@ -83,7 +83,7 @@ class MockFancyService extends FancyService {
 
 @Component({
   selector: 'my-service-comp',
-  bindings: [FancyService],
+  providers: [FancyService],
   template: `injected value: {{fancyService.value}}`
 })
 class TestBindingsComp {
@@ -95,7 +95,7 @@ class TestBindingsComp {
   viewProviders: [FancyService],
   template: `injected value: {{fancyService.value}}`
 })
-class TestViewBindingsComp {
+class TestViewProvidersComp {
   constructor(private fancyService: FancyService) {}
 }
 
@@ -199,12 +199,12 @@ export function main() {
        }));
 
 
-    it('should override a viewBinding',
+    it('should override a viewProvider',
        inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
 
-         tcb.overrideViewProviders(TestViewBindingsComp,
+         tcb.overrideViewProviders(TestViewProvidersComp,
                                    [provide(FancyService, {useClass: MockFancyService})])
-             .createAsync(TestViewBindingsComp)
+             .createAsync(TestViewProvidersComp)
              .then((componentFixture) => {
                componentFixture.detectChanges();
                expect(componentFixture.nativeElement)

--- a/modules/benchpress/docs/index.md
+++ b/modules/benchpress/docs/index.md
@@ -173,7 +173,7 @@ To collect these metrics, you need to execute `console.time('frameCapture')` and
 
 In addition to that, one extra binding needs to be passed to benchpress in tests that want to collect these metrics:
 
-    benchpress.sample(bindings: [bp.bind(bp.Options.CAPTURE_FRAMES).toValue(true)], ... )
+    benchpress.sample(providers: [bp.bind(bp.Options.CAPTURE_FRAMES).toValue(true)], ... )
 
 # Requests Metrics
 
@@ -182,9 +182,9 @@ Benchpress can also record the number of requests sent and count the received "e
 - `receivedData`: number of bytes received since the last navigation start
 - `requestCount`: number of requests sent since the last navigation start
 
-To collect these metrics, you need the following corresponding extra bindings:
+To collect these metrics, you need the following corresponding extra providers:
 
-    benchpress.sample(bindings: [
+    benchpress.sample(providers: [
       bp.bind(bp.Options.RECEIVED_DATA).toValue(true),
       bp.bind(bp.Options.REQUEST_COUNT).toValue(true)
     ], ... )

--- a/modules/benchpress/src/metric/perflog_metric.ts
+++ b/modules/benchpress/src/metric/perflog_metric.ts
@@ -20,7 +20,7 @@ import {Options} from '../common_options';
  */
 export class PerflogMetric extends Metric {
   // TODO(tbosch): use static values when our transpiler supports them
-  static get BINDINGS(): Provider[] { return _PROVIDERS; }
+  static get PROVIDERS(): Provider[] { return _PROVIDERS; }
   // TODO(tbosch): use static values when our transpiler supports them
   static get SET_TIMEOUT(): OpaqueToken { return _SET_TIMEOUT; }
 

--- a/modules/benchpress/src/reporter/console_reporter.ts
+++ b/modules/benchpress/src/reporter/console_reporter.ts
@@ -18,7 +18,7 @@ export class ConsoleReporter extends Reporter {
   // TODO(tbosch): use static values when our transpiler supports them
   static get COLUMN_WIDTH(): OpaqueToken { return _COLUMN_WIDTH; }
   // TODO(tbosch): use static values when our transpiler supports them
-  static get BINDINGS(): Provider[] { return _PROVIDERS; }
+  static get PROVIDERS(): Provider[] { return _PROVIDERS; }
 
 
   static _lpad(value, columnWidth, fill = ' ') {

--- a/modules/benchpress/src/reporter/json_file_reporter.ts
+++ b/modules/benchpress/src/reporter/json_file_reporter.ts
@@ -15,7 +15,7 @@ export class JsonFileReporter extends Reporter {
   // TODO(tbosch): use static values when our transpiler supports them
   static get PATH(): OpaqueToken { return _PATH; }
   // TODO(tbosch): use static values when our transpiler supports them
-  static get BINDINGS(): Provider[] { return _PROVIDERS; }
+  static get PROVIDERS(): Provider[] { return _PROVIDERS; }
 
   _writeFile: Function;
   _path: string;

--- a/modules/benchpress/src/runner.ts
+++ b/modules/benchpress/src/runner.ts
@@ -25,34 +25,34 @@ import {Options} from './common_options';
  * It provides defaults, creates the injector and calls the sampler.
  */
 export class Runner {
-  private _defaultBindings: Provider[];
-  constructor(defaultBindings: Provider[] = null) {
-    if (isBlank(defaultBindings)) {
-      defaultBindings = [];
+  private _defaultProviders: Provider[];
+  constructor(defaultProviders: Provider[] = null) {
+    if (isBlank(defaultProviders)) {
+      defaultProviders = [];
     }
-    this._defaultBindings = defaultBindings;
+    this._defaultProviders = defaultProviders;
   }
 
-  sample({id, execute, prepare, microMetrics, bindings}:
-             {id: string, execute?: any, prepare?: any, microMetrics?: any, bindings?: any}):
+  sample({id, execute, prepare, microMetrics, providers}:
+             {id: string, execute?: any, prepare?: any, microMetrics?: any, providers?: any}):
       Promise<SampleState> {
-    var sampleBindings = [
+    var sampleProviders = [
       _DEFAULT_PROVIDERS,
-      this._defaultBindings,
+      this._defaultProviders,
       bind(Options.SAMPLE_ID).toValue(id),
       bind(Options.EXECUTE).toValue(execute)
     ];
     if (isPresent(prepare)) {
-      sampleBindings.push(bind(Options.PREPARE).toValue(prepare));
+      sampleProviders.push(bind(Options.PREPARE).toValue(prepare));
     }
     if (isPresent(microMetrics)) {
-      sampleBindings.push(bind(Options.MICRO_METRICS).toValue(microMetrics));
+      sampleProviders.push(bind(Options.MICRO_METRICS).toValue(microMetrics));
     }
-    if (isPresent(bindings)) {
-      sampleBindings.push(bindings);
+    if (isPresent(providers)) {
+      sampleProviders.push(providers);
     }
 
-    var inj = Injector.resolveAndCreate(sampleBindings);
+    var inj = Injector.resolveAndCreate(sampleProviders);
     var adapter = inj.get(WebDriverAdapter);
 
     return PromiseWrapper
@@ -67,7 +67,7 @@ export class Runner {
           // TODO vsavkin consider changing it when toAsyncFactory is added back or when child
           // injectors are handled better.
           var injector = Injector.resolveAndCreate([
-            sampleBindings,
+            sampleProviders,
             bind(Options.CAPABILITIES).toValue(capabilities),
             bind(Options.USER_AGENT).toValue(userAgent),
             provide(WebDriverAdapter, {useValue: adapter})
@@ -81,15 +81,15 @@ export class Runner {
 
 var _DEFAULT_PROVIDERS = [
   Options.DEFAULT_PROVIDERS,
-  Sampler.BINDINGS,
-  ConsoleReporter.BINDINGS,
-  RegressionSlopeValidator.BINDINGS,
-  SizeValidator.BINDINGS,
-  ChromeDriverExtension.BINDINGS,
-  FirefoxDriverExtension.BINDINGS,
-  IOsDriverExtension.BINDINGS,
-  PerflogMetric.BINDINGS,
-  SampleDescription.BINDINGS,
+  Sampler.PROVIDERS,
+  ConsoleReporter.PROVIDERS,
+  RegressionSlopeValidator.PROVIDERS,
+  SizeValidator.PROVIDERS,
+  ChromeDriverExtension.PROVIDERS,
+  FirefoxDriverExtension.PROVIDERS,
+  IOsDriverExtension.PROVIDERS,
+  PerflogMetric.PROVIDERS,
+  SampleDescription.PROVIDERS,
   MultiReporter.createBindings([ConsoleReporter]),
   MultiMetric.createBindings([PerflogMetric]),
 

--- a/modules/benchpress/src/sample_description.ts
+++ b/modules/benchpress/src/sample_description.ts
@@ -9,7 +9,7 @@ import {Options} from './common_options';
  */
 export class SampleDescription {
   // TODO(tbosch): use static values when our transpiler supports them
-  static get BINDINGS(): Provider[] { return _PROVIDERS; }
+  static get PROVIDERS(): Provider[] { return _PROVIDERS; }
   description: {[key: string]: any};
 
   constructor(public id: string, descriptions: Array<{[key: string]: any}>,

--- a/modules/benchpress/src/sampler.ts
+++ b/modules/benchpress/src/sampler.ts
@@ -20,7 +20,7 @@ import {MeasureValues} from './measure_values';
  */
 export class Sampler {
   // TODO(tbosch): use static values when our transpiler supports them
-  static get BINDINGS(): Provider[] { return _PROVIDERS; }
+  static get PROVIDERS(): Provider[] { return _PROVIDERS; }
 
   _driver: WebDriverAdapter;
   _metric: Metric;

--- a/modules/benchpress/src/validator/regression_slope_validator.ts
+++ b/modules/benchpress/src/validator/regression_slope_validator.ts
@@ -15,7 +15,7 @@ export class RegressionSlopeValidator extends Validator {
   // TODO(tbosch): use static values when our transpiler supports them
   static get METRIC(): OpaqueToken { return _METRIC; }
   // TODO(tbosch): use static values when our transpiler supports them
-  static get BINDINGS(): Provider[] { return _PROVIDERS; }
+  static get PROVIDERS(): Provider[] { return _PROVIDERS; }
 
   _sampleSize: number;
   _metric: string;

--- a/modules/benchpress/src/validator/size_validator.ts
+++ b/modules/benchpress/src/validator/size_validator.ts
@@ -9,7 +9,7 @@ import {MeasureValues} from '../measure_values';
  */
 export class SizeValidator extends Validator {
   // TODO(tbosch): use static values when our transpiler supports them
-  static get BINDINGS(): Provider[] { return _PROVIDERS; }
+  static get PROVIDERS(): Provider[] { return _PROVIDERS; }
   // TODO(tbosch): use static values when our transpiler supports them
   static get SAMPLE_SIZE() { return _SAMPLE_SIZE; }
 

--- a/modules/benchpress/src/webdriver/chrome_driver_extension.ts
+++ b/modules/benchpress/src/webdriver/chrome_driver_extension.ts
@@ -23,7 +23,7 @@ import {Options} from '../common_options';
  */
 export class ChromeDriverExtension extends WebDriverExtension {
   // TODO(tbosch): use static values when our transpiler supports them
-  static get BINDINGS(): Provider[] { return _PROVIDERS; }
+  static get PROVIDERS(): Provider[] { return _PROVIDERS; }
 
   private _majorChromeVersion: number;
 

--- a/modules/benchpress/src/webdriver/firefox_driver_extension.ts
+++ b/modules/benchpress/src/webdriver/firefox_driver_extension.ts
@@ -4,7 +4,7 @@ import {WebDriverExtension, PerfLogFeatures} from '../web_driver_extension';
 import {WebDriverAdapter} from '../web_driver_adapter';
 
 export class FirefoxDriverExtension extends WebDriverExtension {
-  static get BINDINGS(): Provider[] { return _PROVIDERS; }
+  static get PROVIDERS(): Provider[] { return _PROVIDERS; }
 
   private _profilerStarted: boolean;
 

--- a/modules/benchpress/src/webdriver/ios_driver_extension.ts
+++ b/modules/benchpress/src/webdriver/ios_driver_extension.ts
@@ -7,7 +7,7 @@ import {WebDriverAdapter} from '../web_driver_adapter';
 
 export class IOsDriverExtension extends WebDriverExtension {
   // TODO(tbosch): use static values when our transpiler supports them
-  static get BINDINGS(): Provider[] { return _PROVIDERS; }
+  static get PROVIDERS(): Provider[] { return _PROVIDERS; }
 
   constructor(private _driver: WebDriverAdapter) { super(); }
 

--- a/modules/benchpress/test/firefox_extension/sample_benchmark.ts
+++ b/modules/benchpress/test/firefox_extension/sample_benchmark.ts
@@ -25,7 +25,7 @@ describe('deep tree baseline', function() {
             id: 'baseline',
             execute: function() { $('button')
                                       .click(); },
-            bindings: [benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({depth: 9})]
+            providers: [benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({depth: 9})]
           })
         .then(done, done.fail);
   });

--- a/modules/benchpress/test/metric/perflog_metric_spec.ts
+++ b/modules/benchpress/test/metric/perflog_metric_spec.ts
@@ -48,9 +48,9 @@ export function main() {
     if (isBlank(microMetrics)) {
       microMetrics = StringMapWrapper.create();
     }
-    var bindings = [
+    var providers = [
       Options.DEFAULT_PROVIDERS,
-      PerflogMetric.BINDINGS,
+      PerflogMetric.PROVIDERS,
       bind(Options.MICRO_METRICS).toValue(microMetrics),
       bind(PerflogMetric.SET_TIMEOUT)
           .toValue((fn, millis) => {
@@ -61,18 +61,18 @@ export function main() {
           .toValue(new MockDriverExtension(perfLogs, commandLog, perfLogFeatures))
     ];
     if (isPresent(forceGc)) {
-      bindings.push(bind(Options.FORCE_GC).toValue(forceGc));
+      providers.push(bind(Options.FORCE_GC).toValue(forceGc));
     }
     if (isPresent(captureFrames)) {
-      bindings.push(bind(Options.CAPTURE_FRAMES).toValue(captureFrames));
+      providers.push(bind(Options.CAPTURE_FRAMES).toValue(captureFrames));
     }
     if (isPresent(receivedData)) {
-      bindings.push(bind(Options.RECEIVED_DATA).toValue(receivedData));
+      providers.push(bind(Options.RECEIVED_DATA).toValue(receivedData));
     }
     if (isPresent(requestCount)) {
-      bindings.push(bind(Options.REQUEST_COUNT).toValue(requestCount));
+      providers.push(bind(Options.REQUEST_COUNT).toValue(requestCount));
     }
-    return Injector.resolveAndCreate(bindings).get(PerflogMetric);
+    return Injector.resolveAndCreate(providers).get(PerflogMetric);
   }
 
   describe('perflog metric', () => {

--- a/modules/benchpress/test/reporter/console_reporter_spec.ts
+++ b/modules/benchpress/test/reporter/console_reporter_spec.ts
@@ -37,7 +37,7 @@ export function main() {
         sampleId = 'null';
       }
       var bindings = [
-        ConsoleReporter.BINDINGS,
+        ConsoleReporter.PROVIDERS,
         provide(SampleDescription,
                 {useValue: new SampleDescription(sampleId, descriptions, metrics)}),
         bind(ConsoleReporter.PRINT).toValue((line) => log.push(line))

--- a/modules/benchpress/test/reporter/json_file_reporter_spec.ts
+++ b/modules/benchpress/test/reporter/json_file_reporter_spec.ts
@@ -32,7 +32,7 @@ export function main() {
 
     function createReporter({sampleId, descriptions, metrics, path}) {
       var bindings = [
-        JsonFileReporter.BINDINGS,
+        JsonFileReporter.PROVIDERS,
         provide(SampleDescription,
                 {useValue: new SampleDescription(sampleId, descriptions, metrics)}),
         bind(JsonFileReporter.PATH).toValue(path),

--- a/modules/benchpress/test/runner_spec.ts
+++ b/modules/benchpress/test/runner_spec.ts
@@ -62,7 +62,7 @@ export function main() {
 
     it('should merge SampleDescription.description', inject([AsyncTestCompleter], (async) => {
          createRunner([bind(Options.DEFAULT_DESCRIPTION).toValue({'a': 1})])
-             .sample({id: 'someId', bindings: [bind(Options.SAMPLE_DESCRIPTION).toValue({'b': 2})]})
+             .sample({id: 'someId', providers: [bind(Options.SAMPLE_DESCRIPTION).toValue({'b': 2})]})
              .then((_) => injector.get(SampleDescription))
              .then((desc) => {
                expect(desc.description)
@@ -120,7 +120,7 @@ export function main() {
          ])
              .sample({
                id: 'someId',
-               bindings: [
+               providers: [
                  bind(Options.DEFAULT_DESCRIPTION)
                      .toValue({'a': 2}),
                ]

--- a/modules/benchpress/test/sampler_spec.ts
+++ b/modules/benchpress/test/sampler_spec.ts
@@ -51,9 +51,9 @@ export function main() {
       if (isBlank(driver)) {
         driver = new MockDriverAdapter([]);
       }
-      var bindings = [
+      var providers = [
         Options.DEFAULT_PROVIDERS,
-        Sampler.BINDINGS,
+        Sampler.PROVIDERS,
         provide(Metric, {useValue: metric}),
         provide(Reporter, {useValue: reporter}),
         provide(WebDriverAdapter, {useValue: driver}),
@@ -62,10 +62,10 @@ export function main() {
         bind(Options.NOW).toValue(() => DateWrapper.fromMillis(time++))
       ];
       if (isPresent(prepare)) {
-        bindings.push(bind(Options.PREPARE).toValue(prepare));
+        providers.push(bind(Options.PREPARE).toValue(prepare));
       }
 
-      sampler = Injector.resolveAndCreate(bindings).get(Sampler);
+      sampler = Injector.resolveAndCreate(providers).get(Sampler);
     }
 
     it('should call the prepare and execute callbacks using WebDriverAdapter.waitFor',

--- a/modules/benchpress/test/validator/regression_slope_validator_spec.ts
+++ b/modules/benchpress/test/validator/regression_slope_validator_spec.ts
@@ -26,7 +26,7 @@ export function main() {
 
     function createValidator({size, metric}) {
       validator = Injector.resolveAndCreate([
-                            RegressionSlopeValidator.BINDINGS,
+                            RegressionSlopeValidator.PROVIDERS,
                             bind(RegressionSlopeValidator.METRIC).toValue(metric),
                             bind(RegressionSlopeValidator.SAMPLE_SIZE).toValue(size)
                           ])

--- a/modules/benchpress/test/validator/size_validator_spec.ts
+++ b/modules/benchpress/test/validator/size_validator_spec.ts
@@ -20,7 +20,7 @@ export function main() {
     function createValidator(size) {
       validator =
           Injector.resolveAndCreate(
-                      [SizeValidator.BINDINGS, bind(SizeValidator.SAMPLE_SIZE).toValue(size)])
+                      [SizeValidator.PROVIDERS, bind(SizeValidator.SAMPLE_SIZE).toValue(size)])
               .get(SizeValidator);
     }
 

--- a/modules/benchpress/test/webdriver/chrome_driver_extension_spec.ts
+++ b/modules/benchpress/test/webdriver/chrome_driver_extension_spec.ts
@@ -58,7 +58,7 @@ export function main() {
       }
       log = [];
       extension = Injector.resolveAndCreate([
-                            ChromeDriverExtension.BINDINGS,
+                            ChromeDriverExtension.PROVIDERS,
                             bind(WebDriverAdapter)
                                 .toValue(new MockDriverAdapter(log, perfRecords, messageMethod)),
                             bind(Options.USER_AGENT).toValue(userAgent)

--- a/modules/benchpress/test/webdriver/ios_driver_extension_spec.ts
+++ b/modules/benchpress/test/webdriver/ios_driver_extension_spec.ts
@@ -39,7 +39,7 @@ export function main() {
       log = [];
       extension =
           Injector.resolveAndCreate([
-                    IOsDriverExtension.BINDINGS,
+                    IOsDriverExtension.PROVIDERS,
                     provide(WebDriverAdapter, {useValue: new MockDriverAdapter(log, perfRecords)})
                   ])
               .get(IOsDriverExtension);

--- a/modules/playground/src/person_management/index.ts
+++ b/modules/playground/src/person_management/index.ts
@@ -182,7 +182,7 @@ class PersonsComponent {
 
 @Component({
   selector: 'person-management-app',
-  viewBindings: [DataService],
+  viewProviders: [DataService],
   template: `
     <button (click)="switchToEditName()">Edit Full Name</button>
     <button (click)="switchToPersonList()">Person Array</button>

--- a/protractor-shared.js
+++ b/protractor-shared.js
@@ -225,7 +225,7 @@ exports.createBenchpressRunner = function(options) {
     benchpress.bind(benchpress.Options.FORCE_GC).toValue(argv['force-gc']),
     benchpress.bind(benchpress.Options.DEFAULT_DESCRIPTION)
         .toValue({'lang': options.lang, 'runId': runId}),
-    benchpress.JsonFileReporter.BINDINGS,
+    benchpress.JsonFileReporter.PROVIDERS,
     benchpress.bind(benchpress.JsonFileReporter.PATH).toValue(resultsFolder)
   ];
   if (!argv['dryrun']) {


### PR DESCRIPTION
BREAKING CHANGE
Remove deprecated 'as' from ‘RouteConfig’ in favour of ‘name’
Replace all 'bindings' with 'providers' and 'viewBindings' with 'viewProviders'
#7564
