### PR TITLE
refactor(Router): rename RouteConfig to Routes

### DIFF
--- a/modules/angular1_router/src/module_template.js
+++ b/modules/angular1_router/src/module_template.js
@@ -24,7 +24,7 @@ function $locationHashPrefixProvider($locationProvider) {
       hashPrefix = prefix;
     }
     return hashPrefixFn(prefix);
-  }
+  };
 
   // Return the final hashPrefix as the value of this service
   this.$get = function() { return hashPrefix; };
@@ -92,8 +92,15 @@ function routerFactory($q, $location, $browser, $rootScope, $injector, $routerRo
         return;
       }
       var controller = getComponentConstructor(component);
-      if (angular.isArray(controller.$routeConfig)) {
-        controller.$routeConfig.forEach(function (config) {
+      var routes;
+      if (angular.isArray(controller.$routes)) {
+        routes = controller.$routes;
+      } else if (angular.isArray(controller.$routeConfig)) {
+        routes = controller.$routeConfig;
+        console.log('$routeConfig is deprecated. Use $routes instead');
+      }
+      if (routes) {
+        routes.forEach(function (config) {
           var loader = config.loader;
           if (isPresent(loader)) {
             config = angular.extend({}, config, { loader: () => $injector.invoke(loader) });

--- a/modules/angular1_router/test/integration/animation_spec.js
+++ b/modules/angular1_router/test/integration/animation_spec.js
@@ -90,8 +90,8 @@ describe('ngOutlet animations', function () {
     if (options.$canActivate) {
       factory.$canActivate = options.$canActivate;
     }
-    if (options.$routeConfig) {
-      factory.$routeConfig = options.$routeConfig;
+    if (options.$routes) {
+      factory.$routes = options.$routes;
     }
 
     $compileProvider.directive(name, factory);

--- a/modules/angular1_router/test/integration/lifecycle_hook_spec.js
+++ b/modules/angular1_router/test/integration/lifecycle_hook_spec.js
@@ -190,7 +190,7 @@ describe('Navigation lifecycle', function () {
 
     registerComponent('reuseCmp', {
       template: 'reuse {<ng-outlet></ng-outlet>}',
-      $routeConfig: [
+      $routes: [
         {path: '/a', component: 'oneCmp'},
         {path: '/b', component: 'twoCmp'}
       ],
@@ -232,7 +232,7 @@ describe('Navigation lifecycle', function () {
     }
     registerComponent('reuseCmp', {
       template: 'reuse {<ng-outlet></ng-outlet>}',
-      $routeConfig: [
+      $routes: [
         {path: '/a', component: 'oneCmp'},
         {path: '/b', component: 'twoCmp'}
       ],
@@ -468,8 +468,8 @@ describe('Navigation lifecycle', function () {
     if (options.$canActivate) {
       controller.$canActivate = options.$canActivate;
     }
-    if (options.$routeConfig) {
-      controller.$routeConfig = options.$routeConfig;
+    if (options.$routes) {
+      controller.$routes = options.$routes;
     }
 
     $compileProvider.directive(name, factory);

--- a/modules/angular1_router/test/integration/navigation_spec.js
+++ b/modules/angular1_router/test/integration/navigation_spec.js
@@ -100,7 +100,7 @@ describe('navigation', function () {
     }
     registerDirective('parentCmp', {
       template: 'parent { <ng-outlet></ng-outlet> }',
-      $routeConfig: [
+      $routes: [
         { path: '/user/:name', component: 'userCmp' }
       ],
       controller: ParentController
@@ -126,7 +126,7 @@ describe('navigation', function () {
   it('should work with nested outlets', function () {
     registerDirective('childCmp', {
       template: '<div>inner { <div ng-outlet></div> }</div>',
-      $routeConfig: [
+      $routes: [
         { path: '/b', component: 'oneCmp' }
       ]
     });
@@ -145,7 +145,7 @@ describe('navigation', function () {
   it('should work when parent route has empty path', inject(function ($location) {
     registerComponent('childCmp', {
       template: '<div>inner { <div ng-outlet></div> }</div>',
-      $routeConfig: [
+      $routes: [
         { path: '/b', component: 'oneCmp' }
       ]
     });
@@ -166,7 +166,7 @@ describe('navigation', function () {
   it('should work with recursive nested outlets', function () {
     registerDirective('recurCmp', {
       template: '<div>recur { <div ng-outlet></div> }</div>',
-      $routeConfig: [
+      $routes: [
         { path: '/recur', component: 'recurCmp' },
         { path: '/end', component: 'oneCmp' }
       ]});
@@ -230,7 +230,7 @@ describe('navigation', function () {
   it('should change location to the canonical route with nested components', inject(function ($location) {
     registerDirective('childRouter', {
       template: '<div>inner { <div ng-outlet></div> }</div>',
-      $routeConfig: [
+      $routes: [
         { path: '/new-child', component: 'oneCmp', name: 'NewChild'},
         { path: '/new-child-two', component: 'twoCmp', name: 'NewChildTwo'}
       ]
@@ -349,7 +349,7 @@ describe('navigation', function () {
   }
 
   function applyStaticProperties(target, options) {
-    ['$canActivate', '$routeConfig'].forEach(function(property) {
+    ['$canActivate', '$routes'].forEach(function(property) {
       if (options[property]) {
         target[property] = options[property];
       }

--- a/modules/angular1_router/test/integration/router_spec.js
+++ b/modules/angular1_router/test/integration/router_spec.js
@@ -16,7 +16,7 @@ describe('router', function () {
 
     registerComponent('app', {
       template: '<div ng-outlet></div>',
-      $routeConfig: [
+      $routes: [
         { path: '/', component: 'homeCmp' }
       ]
     });
@@ -45,7 +45,7 @@ describe('router', function () {
 
     registerComponent('app', {
       template: '<div ng-outlet></div>',
-      $routeConfig: [
+      $routes: [
         { path: '/', component: 'homeCmp' }
       ]
     });
@@ -73,7 +73,7 @@ describe('router', function () {
 
     registerComponent('app', {
       template: '<div ng-outlet></div>',
-      $routeConfig: [
+      $routes: [
         { path: '/', loader: function($q) { return $q.when('homeCmp'); }, data: { isAdmin: true } }
       ]
     });
@@ -99,7 +99,7 @@ describe('router', function () {
 
     registerComponent('app', {
       template: '<div ng-outlet></div>',
-      $routeConfig: [
+      $routes: [
         { path: '/', component: 'homeCmp' }
       ]
     });
@@ -128,7 +128,7 @@ describe('router', function () {
 
     registerComponent('app', {
       template: '<div ng-outlet></div>',
-      $routeConfig: [
+      $routes: [
         { path: '/', component: 'homeCmp', name: 'Home' }
       ]
     });
@@ -155,7 +155,7 @@ describe('router', function () {
 
     registerComponent('app', {
       template: '<div ng-outlet></div>',
-      $routeConfig: [
+      $routes: [
         { path: '/', component: 'homeCmp', name: 'Home' }
       ]
     });
@@ -208,7 +208,7 @@ describe('router', function () {
   }
 
   function applyStaticProperties(target, options) {
-    ['$canActivate', '$routeConfig'].forEach(function(property) {
+    ['$canActivate', '$routes'].forEach(function(property) {
       if (options[property]) {
         target[property] = options[property];
       }

--- a/modules/angular1_router/test/util.es5.js
+++ b/modules/angular1_router/test/util.es5.js
@@ -48,7 +48,7 @@ function provideHelpers(fn, preInject) {
         ctrl = function () {};
       } else if (angular.isArray(config)) {
         ctrl = function () {};
-        ctrl.$routeConfig = config;
+        ctrl.$routes = config;
       } else if (typeof config === 'function') {
         ctrl = config;
       } else {

--- a/modules/angular2/docs/cheatsheet/routing.md
+++ b/modules/angular2/docs/cheatsheet/routing.md
@@ -2,31 +2,31 @@
 Routing and navigation
 @cheatsheetIndex 10
 @description
-{@target ts}`import {RouteConfig, ROUTER_DIRECTIVES, ROUTER_PROVIDERS, ...} from 'angular2/router';`{@endtarget}
+{@target ts}`import {Routes, ROUTER_DIRECTIVES, ROUTER_PROVIDERS, ...} from 'angular2/router';`{@endtarget}
 {@target js}Available from the `ng.router` namespace{@endtarget}
 {@target dart}`import 'package:angular2/angular2.dart';`{@endtarget}
 
 
 @cheatsheetItem
 syntax(ts):
-`@RouteConfig([
+`@Routes([
   { path: '/:myParam', component: MyComponent, name: 'MyCmp' },
   { path: '/staticPath', component: ..., name: ...},
   { path: '/*wildCardParam', component: ..., name: ...}
 ])
-class MyComponent() {}`|`@RouteConfig`
+class MyComponent() {}`|`@Routes`
 syntax(js):
-`var MyComponent = ng.router.RouteConfig([
+`var MyComponent = ng.router.Routes([
   { path: '/:myParam', component: MyComponent, name: 'MyCmp' },
   { path: '/staticPath', component: ..., name: ...},
   { path: '/*wildCardParam', component: ..., name: ...}
 ]).Class({
   constructor: function() {}
-});`|`ng.router.RouteConfig`
+});`|`ng.router.Routes`
 syntax(dart):
-`@RouteConfig(const [
+`@Routes(const [
   const Route(path: '/:myParam', component: MyComponent, name: 'MyCmp' ),
-])`|`@RouteConfig`
+])`|`@Routes`
 description:
 Configures routes for the decorated component. Supports static, parameterized, and wildcard routes.
 

--- a/modules/angular2/examples/router/ts/can_activate/can_activate_example.ts
+++ b/modules/angular2/examples/router/ts/can_activate/can_activate_example.ts
@@ -2,7 +2,7 @@ import {provide, Component} from 'angular2/core';
 import {bootstrap} from 'angular2/platform/browser';
 import {
   CanActivate,
-  RouteConfig,
+  Routes,
   ComponentInstruction,
   APP_BASE_HREF,
   ROUTER_DIRECTIVES
@@ -43,7 +43,7 @@ class HomeCmp {
   `,
   directives: [ROUTER_DIRECTIVES]
 })
-@RouteConfig([
+@Routes([
   {path: '/user-settings/:id', component: ControlPanelCmp, name: 'ControlPanelCmp'},
   {path: '/', component: HomeCmp, name: 'HomeCmp'}
 ])

--- a/modules/angular2/examples/router/ts/can_deactivate/can_deactivate_example.ts
+++ b/modules/angular2/examples/router/ts/can_deactivate/can_deactivate_example.ts
@@ -2,7 +2,7 @@ import {provide, Component} from 'angular2/core';
 import {bootstrap} from 'angular2/platform/browser';
 import {
   CanDeactivate,
-  RouteConfig,
+  Routes,
   RouteParams,
   ComponentInstruction,
   ROUTER_DIRECTIVES,
@@ -53,7 +53,7 @@ class NoteIndexCmp {
   `,
   directives: [ROUTER_DIRECTIVES]
 })
-@RouteConfig([
+@Routes([
   {path: '/note/:id', component: NoteCmp, name: 'NoteCmp'},
   {path: '/', component: NoteIndexCmp, name: 'NoteIndexCmp'}
 ])

--- a/modules/angular2/examples/router/ts/on_activate/on_activate_example.ts
+++ b/modules/angular2/examples/router/ts/on_activate/on_activate_example.ts
@@ -3,7 +3,7 @@ import {bootstrap} from 'angular2/platform/browser';
 import {
   OnActivate,
   ComponentInstruction,
-  RouteConfig,
+  Routes,
   ROUTER_DIRECTIVES,
   APP_BASE_HREF
 } from 'angular2/router';
@@ -19,7 +19,7 @@ class ChildCmp {
     <p>{{log}}</p>`,
   directives: [ROUTER_DIRECTIVES]
 })
-@RouteConfig([{path: '/child', name: 'Child', component: ChildCmp}])
+@Routes([{path: '/child', name: 'Child', component: ChildCmp}])
 class ParentCmp implements OnActivate {
   log: string = '';
 
@@ -47,7 +47,7 @@ class ParentCmp implements OnActivate {
   `,
   directives: [ROUTER_DIRECTIVES]
 })
-@RouteConfig([{path: '/parent/...', name: 'Parent', component: ParentCmp}])
+@Routes([{path: '/parent/...', name: 'Parent', component: ParentCmp}])
 export class AppCmp {
 }
 

--- a/modules/angular2/examples/router/ts/on_deactivate/on_deactivate_example.ts
+++ b/modules/angular2/examples/router/ts/on_deactivate/on_deactivate_example.ts
@@ -3,7 +3,7 @@ import {bootstrap} from 'angular2/platform/browser';
 import {
   OnDeactivate,
   ComponentInstruction,
-  RouteConfig,
+  Routes,
   ROUTER_DIRECTIVES,
   APP_BASE_HREF
 } from 'angular2/router';
@@ -46,7 +46,7 @@ class MyCmp implements OnDeactivate {
   `,
   directives: [ROUTER_DIRECTIVES]
 })
-@RouteConfig([
+@Routes([
   {path: '/', component: MyCmp, name: 'HomeCmp'},
   {path: '/:param', component: MyCmp, name: 'ParamCmp'}
 ])

--- a/modules/angular2/examples/router/ts/reuse/reuse_example.ts
+++ b/modules/angular2/examples/router/ts/reuse/reuse_example.ts
@@ -2,7 +2,7 @@ import {Component, provide} from 'angular2/core';
 import {bootstrap} from 'angular2/platform/browser';
 import {
   CanActivate,
-  RouteConfig,
+  Routes,
   ComponentInstruction,
   ROUTER_DIRECTIVES,
   APP_BASE_HREF,
@@ -44,7 +44,7 @@ class MyCmp implements CanReuse,
   `,
   directives: [ROUTER_DIRECTIVES]
 })
-@RouteConfig([
+@Routes([
   {path: '/', component: MyCmp, name: 'HomeCmp'},
   {path: '/:name', component: MyCmp, name: 'HomeCmp'}
 ])

--- a/modules/angular2/router.ts
+++ b/modules/angular2/router.ts
@@ -36,10 +36,10 @@ import {CONST_EXPR} from './src/facade/lang';
  *
  * ```
  * import {Component} from 'angular2/core';
- * import {ROUTER_DIRECTIVES, ROUTER_PROVIDERS, RouteConfig} from 'angular2/router';
+ * import {ROUTER_DIRECTIVES, ROUTER_PROVIDERS, Routes} from 'angular2/router';
  *
  * @Component({directives: [ROUTER_DIRECTIVES]})
- * @RouteConfig([
+ * @Routes([
  *  {...},
  * ])
  * class AppCmp {

--- a/modules/angular2/src/router/directives/router_link.ts
+++ b/modules/angular2/src/router/directives/router_link.ts
@@ -11,7 +11,7 @@ import {Instruction} from '../instruction';
  * Consider the following route configuration:
 
  * ```
- * @RouteConfig([
+ * @Routes([
  *   { path: '/user', component: UserCmp, as: 'User' }
  * ]);
  * class MyComp {}

--- a/modules/angular2/src/router/instruction.ts
+++ b/modules/angular2/src/router/instruction.ts
@@ -14,11 +14,11 @@ import {PromiseWrapper} from 'angular2/src/facade/async';
  * ```
  * import {Component} from 'angular2/core';
  * import {bootstrap} from 'angular2/platform/browser';
- * import {Router, ROUTER_DIRECTIVES, ROUTER_PROVIDERS, RouteConfig, RouteParams} from
+ * import {Router, ROUTER_DIRECTIVES, ROUTER_PROVIDERS, Routes, RouteParams} from
  * 'angular2/router';
  *
  * @Component({directives: [ROUTER_DIRECTIVES]})
- * @RouteConfig([
+ * @Routes([
  *  {path: '/user/:id', component: UserCmp, name: 'UserCmp'},
  * ])
  * class AppCmp {}
@@ -50,11 +50,11 @@ export class RouteParams {
  * ```
  * import {Component} from 'angular2/core';
  * import {bootstrap} from 'angular2/platform/browser';
- * import {Router, ROUTER_DIRECTIVES, ROUTER_PROVIDERS, RouteConfig, RouteData} from
+ * import {Router, ROUTER_DIRECTIVES, ROUTER_PROVIDERS, Routes, RouteData} from
  * 'angular2/router';
  *
  * @Component({directives: [ROUTER_DIRECTIVES]})
- * @RouteConfig([
+ * @Routes([
  *  {path: '/user/:id', component: UserCmp, name: 'UserCmp', data: {isAdmin: true}},
  * ])
  * class AppCmp {}
@@ -93,10 +93,10 @@ export var BLANK_ROUTE_DATA = new RouteData();
  * ```
  * import {Component} from 'angular2/core';
  * import {bootstrap} from 'angular2/platform/browser';
- * import {Router, ROUTER_DIRECTIVES, ROUTER_PROVIDERS, RouteConfig} from 'angular2/router';
+ * import {Router, ROUTER_DIRECTIVES, ROUTER_PROVIDERS, Routes} from 'angular2/router';
  *
  * @Component({directives: [ROUTER_DIRECTIVES]})
- * @RouteConfig([
+ * @Routes([
  *  {...},
  * ])
  * class AppCmp {

--- a/modules/angular2/src/router/location/hash_location_strategy.ts
+++ b/modules/angular2/src/router/location/hash_location_strategy.ts
@@ -25,14 +25,14 @@ import {PlatformLocation} from './platform_location';
  * import {
  *   ROUTER_DIRECTIVES,
  *   ROUTER_PROVIDERS,
- *   RouteConfig,
+ *   Routes,
  *   Location,
  *   LocationStrategy,
  *   HashLocationStrategy
  * } from 'angular2/router';
  *
  * @Component({directives: [ROUTER_DIRECTIVES]})
- * @RouteConfig([
+ * @Routes([
  *  {...},
  * ])
  * class AppCmp {

--- a/modules/angular2/src/router/location/location.ts
+++ b/modules/angular2/src/router/location/location.ts
@@ -25,12 +25,12 @@ import {Injectable, Inject} from 'angular2/core';
  * import {
  *   ROUTER_DIRECTIVES,
  *   ROUTER_PROVIDERS,
- *   RouteConfig,
+ *   Routes,
  *   Location
  * } from 'angular2/router';
  *
  * @Component({directives: [ROUTER_DIRECTIVES]})
- * @RouteConfig([
+ * @Routes([
  *  {...},
  * ])
  * class AppCmp {

--- a/modules/angular2/src/router/location/location_strategy.ts
+++ b/modules/angular2/src/router/location/location_strategy.ts
@@ -42,10 +42,10 @@ export abstract class LocationStrategy {
  *
  * ```
  * import {Component} from 'angular2/core';
- * import {ROUTER_DIRECTIVES, ROUTER_PROVIDERS, RouteConfig} from 'angular2/router';
+ * import {ROUTER_DIRECTIVES, ROUTER_PROVIDERS, Routes} from 'angular2/router';
  *
  * @Component({directives: [ROUTER_DIRECTIVES]})
- * @RouteConfig([
+ * @Routes([
  *  {...},
  * ])
  * class AppCmp {

--- a/modules/angular2/src/router/location/path_location_strategy.ts
+++ b/modules/angular2/src/router/location/path_location_strategy.ts
@@ -34,12 +34,12 @@ import {PlatformLocation, UrlChangeListener} from './platform_location';
  *   APP_BASE_HREF
  *   ROUTER_DIRECTIVES,
  *   ROUTER_PROVIDERS,
- *   RouteConfig,
+ *   Routes,
  *   Location
  * } from 'angular2/router';
  *
  * @Component({directives: [ROUTER_DIRECTIVES]})
- * @RouteConfig([
+ * @Routes([
  *  {...},
  * ])
  * class AppCmp {

--- a/modules/angular2/src/router/route_config/route_config_decorator.dart
+++ b/modules/angular2/src/router/route_config/route_config_decorator.dart
@@ -1,3 +1,16 @@
 library angular2.router.route_config_decorator;
 
+import './route_config_impl.dart';
 export './route_config_impl.dart';
+
+/**
+ * Use [Routes] instead.
+ *
+ * The `RouteConfig` decorator defines routes for a given component.
+ *
+ * It takes an array of [RouteDefinition]s.
+ */
+@deprecated
+class RouteConfig extends Routes {
+  const RouteConfig(List<RouteDefinition> configs) : super(configs);
+}

--- a/modules/angular2/src/router/route_config/route_config_decorator.ts
+++ b/modules/angular2/src/router/route_config/route_config_decorator.ts
@@ -1,13 +1,40 @@
-import {RouteConfig as RouteConfigAnnotation, RouteDefinition} from './route_config_impl';
+import {Routes as RoutesAnnotation, RouteDefinition} from './route_config_impl';
 import {makeDecorator} from 'angular2/src/core/util/decorators';
 
 export {Route, Redirect, AuxRoute, AsyncRoute, RouteDefinition} from './route_config_impl';
 
-// Copied from RouteConfig in route_config_impl.
 /**
+ * The `Routes` decorator defines routes for a given component.
+ *
+ * It takes an array of {@link RouteDefinition}s.
+ */
+export var Routes: (configs: RouteDefinition[]) => ClassDecorator = makeDecorator(RoutesAnnotation);
+
+
+/**
+ * Use {@link Routes} instead.
+ *
  * The `RouteConfig` decorator defines routes for a given component.
  *
  * It takes an array of {@link RouteDefinition}s.
+ *
+ * @deprecated
+ */
+class RouteConfigAnnotation extends RoutesAnnotation {
+  constructor(configs: RouteDefinition[]) {
+    super(configs);
+    console.log(`@RouteConfig is deprecated use @Routes instead`);
+  }
+}
+
+/**
+ * Use {@link Routes} instead.
+ *
+ * The `RouteConfig` decorator defines routes for a given component.
+ *
+ * It takes an array of {@link RouteDefinition}s.
+ *
+ * @deprecated
  */
 export var RouteConfig: (configs: RouteDefinition[]) => ClassDecorator =
     makeDecorator(RouteConfigAnnotation);

--- a/modules/angular2/src/router/route_config/route_config_impl.ts
+++ b/modules/angular2/src/router/route_config/route_config_impl.ts
@@ -7,12 +7,12 @@ export {RouteDefinition} from '../route_definition';
 var __make_dart_analyzer_happy: Promise<any> = null;
 
 /**
- * The `RouteConfig` decorator defines routes for a given component.
+ * The `Routes` decorator defines routes for a given component.
  *
  * It takes an array of {@link RouteDefinition}s.
  */
 @CONST()
-export class RouteConfig {
+export class Routes {
   constructor(public configs: RouteDefinition[]) {}
 }
 
@@ -49,9 +49,9 @@ export abstract class AbstractRoute implements RouteDefinition {
  *
  * ### Example
  * ```
- * import {RouteConfig, Route} from 'angular2/router';
+ * import {Routes, Route} from 'angular2/router';
  *
- * @RouteConfig([
+ * @Routes([
  *   new Route({path: '/home', component: HomeCmp, name: 'HomeCmp' })
  * ])
  * class MyApp {}
@@ -87,9 +87,9 @@ export class Route extends AbstractRoute {
  *
  * ### Example
  * ```
- * import {RouteConfig, AuxRoute} from 'angular2/router';
+ * import {Routes, AuxRoute} from 'angular2/router';
  *
- * @RouteConfig([
+ * @Routes([
  *   new AuxRoute({path: '/home', component: HomeCmp})
  * ])
  * class MyApp {}
@@ -127,9 +127,9 @@ export class AuxRoute extends AbstractRoute {
  *
  * ### Example
  * ```
- * import {RouteConfig, AsyncRoute} from 'angular2/router';
+ * import {Routes, AsyncRoute} from 'angular2/router';
  *
- * @RouteConfig([
+ * @Routes([
  *   new AsyncRoute({path: '/home', loader: () => Promise.resolve(MyLoadedCmp), name:
  * 'MyLoadedCmp'})
  * ])
@@ -166,9 +166,9 @@ export class AsyncRoute extends AbstractRoute {
  *
  * ### Example
  * ```
- * import {RouteConfig, Route, Redirect} from 'angular2/router';
+ * import {Routes, Route, Redirect} from 'angular2/router';
  *
- * @RouteConfig([
+ * @Routes([
  *   new Redirect({path: '/', redirectTo: ['/Home'] }),
  *   new Route({path: '/home', component: HomeCmp, name: 'Home'})
  * ])

--- a/modules/angular2/src/router/route_definition.ts
+++ b/modules/angular2/src/router/route_definition.ts
@@ -2,7 +2,7 @@ import {CONST, Type} from 'angular2/src/facade/lang';
 import {RegexSerializer} from './rules/route_paths/regex_route_path';
 
 /**
- * `RouteDefinition` defines a route within a {@link RouteConfig} decorator.
+ * `RouteDefinition` defines a route within a {@link Routes} decorator.
  *
  * Supported keys:
  * - `path` or `aux` (requires exactly one of these)

--- a/modules/angular2/src/router/route_registry.ts
+++ b/modules/angular2/src/router/route_registry.ts
@@ -18,7 +18,7 @@ import {reflector} from 'angular2/src/core/reflection/reflection';
 import {Injectable, Inject, OpaqueToken} from 'angular2/core';
 
 import {
-  RouteConfig,
+  Routes,
   AsyncRoute,
   Route,
   AuxRoute,
@@ -52,7 +52,7 @@ var _resolveToNull = PromiseWrapper.resolve<Instruction>(null);
 // export type LinkItemArray = Array<LinkItem>;
 
 /**
- * Token used to bind the component with the top-level {@link RouteConfig}s for the
+ * Token used to bind the component with the top-level {@link Routes}s for the
  * application.
  *
  * ### Example ([live demo](http://plnkr.co/edit/iRUP8B5OUbxCWQ3AcIDm))
@@ -62,11 +62,11 @@ var _resolveToNull = PromiseWrapper.resolve<Instruction>(null);
  * import {
  *   ROUTER_DIRECTIVES,
  *   ROUTER_PROVIDERS,
- *   RouteConfig
+ *   Routes
  * } from 'angular2/router';
  *
  * @Component({directives: [ROUTER_DIRECTIVES]})
- * @RouteConfig([
+ * @Routes([
  *  {...},
  * ])
  * class AppCmp {
@@ -140,7 +140,7 @@ export class RouteRegistry {
       for (var i = 0; i < annotations.length; i++) {
         var annotation = annotations[i];
 
-        if (annotation instanceof RouteConfig) {
+        if (annotation instanceof Routes) {
           let routeCfgs: RouteDefinition[] = annotation.configs;
           routeCfgs.forEach(config => this.config(component, config));
         }
@@ -549,7 +549,7 @@ function assertTerminalComponent(component, path) {
     for (var i = 0; i < annotations.length; i++) {
       var annotation = annotations[i];
 
-      if (annotation instanceof RouteConfig) {
+      if (annotation instanceof Routes) {
         throw new BaseException(
             `Child routes are not allowed for "${path}". Use "..." on the parent's route path.`);
       }

--- a/modules/angular2/src/router/router_providers.ts
+++ b/modules/angular2/src/router/router_providers.ts
@@ -14,11 +14,11 @@ import {PlatformLocation} from './location/platform_location';
  * import {
  *   ROUTER_DIRECTIVES,
  *   ROUTER_PROVIDERS,
- *   RouteConfig
+ *   Routes
  * } from 'angular2/router';
  *
  * @Component({directives: [ROUTER_DIRECTIVES]})
- * @RouteConfig([
+ * @Routes([
  *  {...},
  * ])
  * class AppCmp {

--- a/modules/angular2/test/router/integration/bootstrap_spec.ts
+++ b/modules/angular2/test/router/integration/bootstrap_spec.ts
@@ -21,7 +21,7 @@ import {Console} from 'angular2/src/core/console';
 import {provide, ViewChild, AfterViewInit} from 'angular2/core';
 import {DOCUMENT} from 'angular2/src/platform/dom/dom_tokens';
 import {
-  RouteConfig,
+  Routes,
   Route,
   Redirect,
   AuxRoute
@@ -263,7 +263,7 @@ class Hello2Cmp {
   template: `outer { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([new Route({path: '/', component: HelloCmp})])
+@Routes([new Route({path: '/', component: HelloCmp})])
 class AppCmp {
   constructor(public router: Router, public location: LocationStrategy) {}
 }
@@ -276,7 +276,7 @@ class AppCmp {
     <router-outlet name="pony"></router-outlet>`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([
+@Routes([
   new Route({path: '/rainbow', component: HelloCmp}),
   new AuxRoute({name: 'pony', path: 'pony', component: Hello2Cmp})
 ])
@@ -294,7 +294,7 @@ class AppWithViewChildren implements AfterViewInit {
   template: `parent { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([new Route({path: '/child', component: HelloCmp})])
+@Routes([new Route({path: '/child', component: HelloCmp})])
 class ParentCmp {
 }
 
@@ -303,7 +303,7 @@ class ParentCmp {
   template: `super-parent { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([new Route({path: '/child', component: Hello2Cmp})])
+@Routes([new Route({path: '/child', component: Hello2Cmp})])
 class SuperParentCmp {
 }
 
@@ -312,7 +312,7 @@ class SuperParentCmp {
   template: `root { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([
+@Routes([
   new Route({path: '/parent/...', component: ParentCmp}),
   new Route({path: '/super-parent/...', component: SuperParentCmp})
 ])
@@ -331,7 +331,7 @@ class QSCmp {
   template: `<router-outlet></router-outlet>`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([new Route({path: '/qs', component: QSCmp})])
+@Routes([new Route({path: '/qs', component: QSCmp})])
 class QueryStringAppCmp {
   constructor(public router: Router, public location: LocationStrategy) {}
 }
@@ -346,7 +346,7 @@ class BrokenCmp {
   template: `outer { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([new Route({path: '/cause-error', component: BrokenCmp})])
+@Routes([new Route({path: '/cause-error', component: BrokenCmp})])
 class BrokenAppCmp {
   constructor(public router: Router, public location: LocationStrategy) {}
 }

--- a/modules/angular2/test/router/integration/impl/aux_route_spec_impl.ts
+++ b/modules/angular2/test/router/integration/impl/aux_route_spec_impl.ts
@@ -20,7 +20,7 @@ import {provide, Component, Injector, Inject} from 'angular2/core';
 
 import {Router, ROUTER_DIRECTIVES, RouteParams, RouteData, Location} from 'angular2/router';
 import {
-  RouteConfig,
+  Routes,
   Route,
   AuxRoute,
   Redirect
@@ -241,7 +241,7 @@ class ModalCmp {
                 'aux {<router-outlet name="modal"></router-outlet>}',
   directives: [ROUTER_DIRECTIVES],
 })
-@RouteConfig([
+@Routes([
   new Route({path: '/hello', component: HelloCmp, name: 'Hello'}),
   new AuxRoute({path: '/modal', component: ModalCmp, name: 'Aux'})
 ])

--- a/modules/angular2/test/router/integration/impl/fixture_components.ts
+++ b/modules/angular2/test/router/integration/impl/fixture_components.ts
@@ -3,7 +3,7 @@ import {
   AsyncRoute,
   Route,
   Redirect,
-  RouteConfig,
+  Routes,
   RouteParams,
   RouteData,
   ROUTER_DIRECTIVES
@@ -49,7 +49,7 @@ export function userCmpLoader() {
   template: `inner { <router-outlet></router-outlet> }`,
   directives: [ROUTER_DIRECTIVES],
 })
-@RouteConfig([new Route({path: '/b', component: HelloCmp, name: 'Child'})])
+@Routes([new Route({path: '/b', component: HelloCmp, name: 'Child'})])
 export class ParentCmp {
 }
 
@@ -63,7 +63,7 @@ export function parentCmpLoader() {
   template: `inner { <router-outlet></router-outlet> }`,
   directives: [ROUTER_DIRECTIVES],
 })
-@RouteConfig([new AsyncRoute({path: '/b', loader: helloCmpLoader, name: 'Child'})])
+@Routes([new AsyncRoute({path: '/b', loader: helloCmpLoader, name: 'Child'})])
 export class AsyncParentCmp {
 }
 
@@ -76,8 +76,7 @@ export function asyncParentCmpLoader() {
   template: `inner { <router-outlet></router-outlet> }`,
   directives: [ROUTER_DIRECTIVES],
 })
-@RouteConfig(
-    [new AsyncRoute({path: '/b', loader: helloCmpLoader, name: 'Child', useAsDefault: true})])
+@Routes([new AsyncRoute({path: '/b', loader: helloCmpLoader, name: 'Child', useAsDefault: true})])
 export class AsyncDefaultParentCmp {
 }
 
@@ -91,7 +90,7 @@ export function asyncDefaultParentCmpLoader() {
   template: `inner { <router-outlet></router-outlet> }`,
   directives: [ROUTER_DIRECTIVES],
 })
-@RouteConfig([new Route({path: '/b', component: HelloCmp, name: 'Child', useAsDefault: true})])
+@Routes([new Route({path: '/b', component: HelloCmp, name: 'Child', useAsDefault: true})])
 export class ParentWithDefaultCmp {
 }
 
@@ -105,7 +104,7 @@ export function parentWithDefaultCmpLoader() {
   template: `team {{id}} | user { <router-outlet></router-outlet> }`,
   directives: [ROUTER_DIRECTIVES],
 })
-@RouteConfig([new Route({path: '/user/:name', component: UserCmp, name: 'User'})])
+@Routes([new Route({path: '/user/:name', component: UserCmp, name: 'User'})])
 export class TeamCmp {
   id: string;
   constructor(params: RouteParams) { this.id = params.get('id'); }
@@ -116,7 +115,7 @@ export class TeamCmp {
   template: `team {{id}} | user { <router-outlet></router-outlet> }`,
   directives: [ROUTER_DIRECTIVES],
 })
-@RouteConfig([new AsyncRoute({path: '/user/:name', loader: userCmpLoader, name: 'User'})])
+@Routes([new AsyncRoute({path: '/user/:name', loader: userCmpLoader, name: 'User'})])
 export class AsyncTeamCmp {
   id: string;
   constructor(params: RouteParams) { this.id = params.get('id'); }
@@ -138,13 +137,13 @@ export function asyncRouteDataCmp() {
 }
 
 @Component({selector: 'redirect-to-parent-cmp', template: 'redirect-to-parent'})
-@RouteConfig([new Redirect({path: '/child-redirect', redirectTo: ['../HelloSib']})])
+@Routes([new Redirect({path: '/child-redirect', redirectTo: ['../HelloSib']})])
 export class RedirectToParentCmp {
 }
 
 
 @Component({selector: 'dynamic-loader-cmp', template: `{ <div #viewport></div> }`})
-@RouteConfig([new Route({path: '/', component: HelloCmp})])
+@Routes([new Route({path: '/', component: HelloCmp})])
 export class DynamicLoaderCmp {
   private _componentRef: ComponentRef = null;
   constructor(private _dynamicComponentLoader: DynamicComponentLoader,

--- a/modules/angular2/test/router/integration/lifecycle_hook_spec.ts
+++ b/modules/angular2/test/router/integration/lifecycle_hook_spec.ts
@@ -26,7 +26,7 @@ import {
 
 import {Router, RouterOutlet, RouterLink, RouteParams} from 'angular2/router';
 import {
-  RouteConfig,
+  Routes,
   Route,
   AuxRoute,
   AsyncRoute,
@@ -408,7 +408,7 @@ class ActivateCmp implements OnActivate {
   template: `parent {<router-outlet></router-outlet>}`,
   directives: [RouterOutlet]
 })
-@RouteConfig([new Route({path: '/child-activate', component: ActivateCmp})])
+@Routes([new Route({path: '/child-activate', component: ActivateCmp})])
 class ParentActivateCmp implements OnActivate {
   routerOnActivate(next: ComponentInstruction, prev: ComponentInstruction): Promise<any> {
     completer = PromiseWrapper.completer();
@@ -438,7 +438,7 @@ class WaitDeactivateCmp implements OnDeactivate {
   template: `parent {<router-outlet></router-outlet>}`,
   directives: [RouterOutlet]
 })
-@RouteConfig([new Route({path: '/child-deactivate', component: WaitDeactivateCmp})])
+@Routes([new Route({path: '/child-deactivate', component: WaitDeactivateCmp})])
 class ParentDeactivateCmp implements OnDeactivate {
   routerOnDeactivate(next: ComponentInstruction, prev: ComponentInstruction) {
     logHook('parent deactivate', next, prev);
@@ -450,7 +450,7 @@ class ParentDeactivateCmp implements OnDeactivate {
   template: `reuse {<router-outlet></router-outlet>}`,
   directives: [RouterOutlet]
 })
-@RouteConfig([new Route({path: '/a', component: A}), new Route({path: '/b', component: B})])
+@Routes([new Route({path: '/a', component: A}), new Route({path: '/b', component: B})])
 class ReuseCmp implements OnReuse,
     CanReuse {
   constructor() { cmpInstanceCount += 1; }
@@ -465,7 +465,7 @@ class ReuseCmp implements OnReuse,
   template: `reuse {<router-outlet></router-outlet>}`,
   directives: [RouterOutlet]
 })
-@RouteConfig([new Route({path: '/a', component: A}), new Route({path: '/b', component: B})])
+@Routes([new Route({path: '/a', component: A}), new Route({path: '/b', component: B})])
 class NeverReuseCmp implements OnReuse,
     CanReuse {
   constructor() { cmpInstanceCount += 1; }
@@ -480,7 +480,7 @@ class NeverReuseCmp implements OnReuse,
   template: `routerCanActivate {<router-outlet></router-outlet>}`,
   directives: [RouterOutlet]
 })
-@RouteConfig([new Route({path: '/a', component: A}), new Route({path: '/b', component: B})])
+@Routes([new Route({path: '/a', component: A}), new Route({path: '/b', component: B})])
 @CanActivate(CanActivateCmp.routerCanActivate)
 class CanActivateCmp {
   static routerCanActivate(next: ComponentInstruction,
@@ -496,7 +496,7 @@ class CanActivateCmp {
   template: `routerCanDeactivate {<router-outlet></router-outlet>}`,
   directives: [RouterOutlet]
 })
-@RouteConfig([new Route({path: '/a', component: A}), new Route({path: '/b', component: B})])
+@Routes([new Route({path: '/a', component: A}), new Route({path: '/b', component: B})])
 class CanDeactivateCmp implements CanDeactivate {
   routerCanDeactivate(next: ComponentInstruction, prev: ComponentInstruction): Promise<boolean> {
     completer = PromiseWrapper.completer();
@@ -532,7 +532,7 @@ class AllHooksChildCmp implements CanDeactivate, OnDeactivate, OnActivate {
   template: `<router-outlet></router-outlet>`,
   directives: [RouterOutlet]
 })
-@RouteConfig([new Route({path: '/child', component: AllHooksChildCmp})])
+@Routes([new Route({path: '/child', component: AllHooksChildCmp})])
 @CanActivate(AllHooksParentCmp.routerCanActivate)
 class AllHooksParentCmp implements CanDeactivate,
     OnDeactivate, OnActivate {
@@ -592,7 +592,7 @@ class ReuseHooksCmp implements OnActivate, OnReuse, OnDeactivate, CanReuse, CanD
   template: `<router-outlet></router-outlet>`,
   directives: [RouterOutlet]
 })
-@RouteConfig([
+@Routes([
   new Route({path: '/a', component: A}),
   new Route({path: '/on-activate', component: ActivateCmp}),
   new Route({path: '/parent-activate/...', component: ParentActivateCmp}),

--- a/modules/angular2/test/router/integration/navigation_spec.ts
+++ b/modules/angular2/test/router/integration/navigation_spec.ts
@@ -20,7 +20,7 @@ import {PromiseWrapper} from 'angular2/src/facade/async';
 
 import {Router, RouterOutlet, RouterLink, RouteParams, RouteData, Location} from 'angular2/router';
 import {
-  RouteConfig,
+  Routes,
   Route,
   AuxRoute,
   AsyncRoute,
@@ -256,7 +256,7 @@ function parentLoader() {
   template: `inner { <router-outlet></router-outlet> }`,
   directives: [RouterOutlet],
 })
-@RouteConfig([
+@Routes([
   new Route({path: '/b', component: HelloCmp}),
   new Route({path: '/', component: HelloCmp}),
 ])
@@ -269,7 +269,7 @@ class ParentCmp {
   template: `team {{id}} { <router-outlet></router-outlet> }`,
   directives: [RouterOutlet],
 })
-@RouteConfig([new Route({path: '/user/:name', component: UserCmp})])
+@Routes([new Route({path: '/user/:name', component: UserCmp})])
 class TeamCmp {
   id: string;
   constructor(params: RouteParams) {

--- a/modules/angular2/test/router/integration/redirect_route_spec.ts
+++ b/modules/angular2/test/router/integration/redirect_route_spec.ts
@@ -17,7 +17,7 @@ import {
 
 import {Router, RouterOutlet, RouterLink, RouteParams, RouteData, Location} from 'angular2/router';
 import {
-  RouteConfig,
+  Routes,
   Route,
   AuxRoute,
   AsyncRoute,

--- a/modules/angular2/test/router/integration/router_link_spec.ts
+++ b/modules/angular2/test/router/integration/router_link_spec.ts
@@ -35,7 +35,7 @@ import {
   AuxRoute,
   Route,
   RouteParams,
-  RouteConfig,
+  Routes,
   ROUTER_DIRECTIVES,
   ROUTER_PRIMARY_COMPONENT
 } from 'angular2/router';
@@ -439,7 +439,7 @@ function parentCmpLoader() {
                <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([
+@Routes([
   new Route({path: '/grandchild', component: HelloCmp, name: 'Grandchild'}),
   new Route({path: '/better-grandchild', component: Hello2Cmp, name: 'BetterGrandchild'})
 ])
@@ -452,7 +452,7 @@ class ParentCmp {
     <router-outlet></router-outlet>`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([new Route({path: '/page/:number', component: SiblingPageCmp, name: 'Page'})])
+@Routes([new Route({path: '/page/:number', component: SiblingPageCmp, name: 'Page'})])
 class BookCmp {
   title: string;
   constructor(params: RouteParams) { this.title = params.get('title'); }
@@ -464,7 +464,7 @@ class BookCmp {
     <router-outlet></router-outlet>`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([new Route({path: '/page/:number', component: SiblingPageCmp, name: 'Page'})])
+@Routes([new Route({path: '/page/:number', component: SiblingPageCmp, name: 'Page'})])
 class NoPrefixBookCmp {
   title: string;
   constructor(params: RouteParams) { this.title = params.get('title'); }
@@ -476,7 +476,7 @@ class NoPrefixBookCmp {
     <router-outlet></router-outlet>`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([new Route({path: '/page/:number', component: SiblingPageCmp, name: 'Book'})])
+@Routes([new Route({path: '/page/:number', component: SiblingPageCmp, name: 'Book'})])
 class AmbiguousBookCmp {
   title: string;
   constructor(params: RouteParams) { this.title = params.get('title'); }
@@ -489,7 +489,7 @@ class AmbiguousBookCmp {
     <router-outlet></router-outlet> | aside <router-outlet name="aside"></router-outlet>`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([
+@Routes([
   new Route({path: '/', component: HelloCmp, name: 'Hello'}),
   new AuxRoute({path: '/aside', component: Hello2Cmp, name: 'Aside'})
 ])

--- a/modules/angular2/test/router/route_config/route_config_spec.ts
+++ b/modules/angular2/test/router/route_config/route_config_spec.ts
@@ -19,13 +19,7 @@ import {provide} from 'angular2/core';
 import {DOCUMENT} from 'angular2/src/platform/dom/dom_tokens';
 import {Type, IS_DART} from 'angular2/src/facade/lang';
 
-import {
-  ROUTER_PROVIDERS,
-  Router,
-  RouteConfig,
-  APP_BASE_HREF,
-  ROUTER_DIRECTIVES
-} from 'angular2/router';
+import {ROUTER_PROVIDERS, Router, Routes, APP_BASE_HREF, ROUTER_DIRECTIVES} from 'angular2/router';
 
 import {ExceptionHandler} from 'angular2/src/facade/exceptions';
 import {LocationStrategy} from 'angular2/src/router/location/location_strategy';
@@ -44,7 +38,7 @@ class DummyConsole implements Console {
 }
 
 export function main() {
-  describe('RouteConfig with POJO arguments', () => {
+  describe('Routes with POJO arguments', () => {
     var fakeDoc, el, testBindings;
     beforeEach(() => {
       fakeDoc = DOM.createHtmlDocument();
@@ -222,7 +216,7 @@ class HelloCmp {
   template: `root { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([
+@Routes([
   {path: '/before', redirectTo: ['Hello']},
   {path: '/after', component: HelloCmp, name: 'Hello'}
 ])
@@ -239,7 +233,7 @@ function HelloLoader(): Promise<any> {
   template: `root { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([
+@Routes([
   {path: '/hello', component: {type: 'loader', loader: HelloLoader}},
 ])
 class AsyncAppCmp {
@@ -251,7 +245,7 @@ class AsyncAppCmp {
   template: `root { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([
+@Routes([
   {path: '/hello', loader: HelloLoader},
 ])
 class ConciseAsyncAppCmp {
@@ -263,7 +257,7 @@ class ConciseAsyncAppCmp {
   template: `root { <router-outlet></router-outlet> } aside { <router-outlet name="aside"></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([{path: '/hello', component: HelloCmp}, {aux: 'aside', component: HelloCmp}])
+@Routes([{path: '/hello', component: HelloCmp}, {aux: 'aside', component: HelloCmp}])
 class AuxAppCmp {
   constructor(public router: Router, public location: LocationStrategy) {}
 }
@@ -273,7 +267,7 @@ class AuxAppCmp {
   template: `root { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([
+@Routes([
   {path: '/hello', component: {type: 'constructor', constructor: HelloCmp}},
 ])
 class ExplicitConstructorAppCmp {
@@ -285,7 +279,7 @@ class ExplicitConstructorAppCmp {
   template: `parent { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([{path: '/child', component: HelloCmp}])
+@Routes([{path: '/child', component: HelloCmp}])
 class ParentCmp {
 }
 
@@ -294,7 +288,7 @@ class ParentCmp {
   template: `root { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([{path: '/parent/...', component: ParentCmp}])
+@Routes([{path: '/parent/...', component: ParentCmp}])
 class HierarchyAppCmp {
   constructor(public router: Router, public location: LocationStrategy) {}
 }
@@ -304,7 +298,7 @@ class HierarchyAppCmp {
   template: `root { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([{path: '/hello'}])
+@Routes([{path: '/hello'}])
 class WrongConfigCmp {
 }
 
@@ -313,7 +307,7 @@ class WrongConfigCmp {
   template: `root { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([{path: '/child', component: HelloCmp, name: 'child'}])
+@Routes([{path: '/child', component: HelloCmp, name: 'child'}])
 class BadAliasNameCmp {
 }
 
@@ -322,7 +316,7 @@ class BadAliasNameCmp {
   template: `root { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([{path: '/child', component: HelloCmp, as: 'child'}])
+@Routes([{path: '/child', component: HelloCmp, as: 'child'}])
 class BadAliasCmp {
 }
 
@@ -331,7 +325,7 @@ class BadAliasCmp {
   template: `root { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([{path: '/child', component: HelloCmp, as: 'Child', name: 'Child'}])
+@Routes([{path: '/child', component: HelloCmp, as: 'Child', name: 'Child'}])
 class MultipleAliasCmp {
 }
 
@@ -340,7 +334,7 @@ class MultipleAliasCmp {
   template: `root { <router-outlet></router-outlet> }`,
   directives: ROUTER_DIRECTIVES
 })
-@RouteConfig([
+@Routes([
   {path: '/hello', component: {type: 'intentionallyWrongComponentType', constructor: HelloCmp}},
 ])
 class WrongComponentTypeCmp {

--- a/modules/angular2/test/router/route_registry_spec.ts
+++ b/modules/angular2/test/router/route_registry_spec.ts
@@ -15,7 +15,7 @@ import {Type, IS_DART} from 'angular2/src/facade/lang';
 
 import {RouteRegistry} from 'angular2/src/router/route_registry';
 import {
-  RouteConfig,
+  Routes,
   Route,
   Redirect,
   AuxRoute,
@@ -334,40 +334,38 @@ function asyncChildLoader() {
 
 class RootHostCmp {}
 
-@RouteConfig([new AsyncRoute({path: '/second', loader: asyncChildLoader})])
+@Routes([new AsyncRoute({path: '/second', loader: asyncChildLoader})])
 class DummyAsyncCmp {
 }
 
 class DummyCmpA {}
 class DummyCmpB {}
 
-@RouteConfig(
-    [new Route({path: '/third', component: DummyCmpB, name: 'ThirdCmp', useAsDefault: true})])
+@Routes([new Route({path: '/third', component: DummyCmpB, name: 'ThirdCmp', useAsDefault: true})])
 class DefaultRouteCmp {
 }
 
-@RouteConfig([new Route({path: '/', component: DummyCmpB, name: 'ThirdCmp'})])
+@Routes([new Route({path: '/', component: DummyCmpB, name: 'ThirdCmp'})])
 class SingleSlashChildCmp {
 }
 
 
-@RouteConfig([
+@Routes([
   new Route(
       {path: '/second/...', component: DefaultRouteCmp, name: 'SecondCmp', useAsDefault: true})
 ])
 class MultipleDefaultCmp {
 }
 
-@RouteConfig(
-    [new Route({path: '/second', component: DummyCmpB, name: 'SecondCmp', useAsDefault: true})])
+@Routes([new Route({path: '/second', component: DummyCmpB, name: 'SecondCmp', useAsDefault: true})])
 class ParentWithDefaultRouteCmp {
 }
 
-@RouteConfig([new Route({path: '/second', component: DummyCmpB, name: 'SecondCmp'})])
+@Routes([new Route({path: '/second', component: DummyCmpB, name: 'SecondCmp'})])
 class DummyParentCmp {
 }
 
 
-@RouteConfig([new Route({path: '/second/:param', component: DummyCmpB, name: 'SecondCmp'})])
+@Routes([new Route({path: '/second/:param', component: DummyCmpB, name: 'SecondCmp'})])
 class DummyParentParamCmp {
 }

--- a/modules/angular2/test/router/router_spec.ts
+++ b/modules/angular2/test/router/router_spec.ts
@@ -22,7 +22,7 @@ import {Location} from 'angular2/src/router/location/location';
 
 import {RouteRegistry, ROUTER_PRIMARY_COMPONENT} from 'angular2/src/router/route_registry';
 import {
-  RouteConfig,
+  Routes,
   AsyncRoute,
   Route,
   Redirect
@@ -324,7 +324,7 @@ function loader(): Promise<Type> {
 
 class DummyComponent {}
 
-@RouteConfig([new Route({path: '/second', component: DummyComponent, name: 'SecondCmp'})])
+@Routes([new Route({path: '/second', component: DummyComponent, name: 'SecondCmp'})])
 class DummyParentComp {
 }
 

--- a/modules/playground/src/hash_routing/index.ts
+++ b/modules/playground/src/hash_routing/index.ts
@@ -1,7 +1,7 @@
 import {Component, provide} from 'angular2/core';
 import {bootstrap} from 'angular2/platform/browser';
 import {
-  RouteConfig,
+  Routes,
   Route,
   ROUTER_PROVIDERS,
   ROUTER_DIRECTIVES,
@@ -35,7 +35,7 @@ class GoodByeCmp {
   `,
   directives: [ROUTER_DIRECTIVES]
 })
-@RouteConfig([
+@Routes([
   new Route({path: '/', component: HelloCmp, name: 'HelloCmp'}),
   new Route({path: '/bye', component: GoodByeCmp, name: 'GoodbyeCmp'})
 ])

--- a/modules/playground/src/routing/inbox-app.ts
+++ b/modules/playground/src/routing/inbox-app.ts
@@ -1,7 +1,7 @@
 import {Component, Injectable} from 'angular2/core';
 import {
   RouterLink,
-  RouteConfig,
+  Routes,
   Router,
   Route,
   RouterOutlet,
@@ -144,7 +144,7 @@ class DraftsCmp {
   templateUrl: 'inbox-app.html',
   directives: [RouterOutlet, RouterLink]
 })
-@RouteConfig([
+@Routes([
   new Route({path: '/', component: InboxCmp, name: 'Inbox'}),
   new Route({path: '/drafts', component: DraftsCmp, name: 'Drafts'}),
   new Route({path: '/detail/:id', component: InboxDetailCmp, name: 'DetailPage'})

--- a/modules/playground/src/web_workers/router/index_common.ts
+++ b/modules/playground/src/web_workers/router/index_common.ts
@@ -2,10 +2,10 @@ import {Component} from 'angular2/core';
 import {Start} from './components/start';
 import {About} from './components/about';
 import {Contact} from './components/contact';
-import {ROUTER_DIRECTIVES, RouteConfig, Route} from 'angular2/router';
+import {ROUTER_DIRECTIVES, Routes, Route} from 'angular2/router';
 
 @Component({selector: 'app', directives: [ROUTER_DIRECTIVES], templateUrl: 'app.html'})
-@RouteConfig([
+@Routes([
   new Route({path: '/', component: Start, name: "Start"}),
   new Route({path: '/contact', component: Contact, name: "Contact"}),
   new Route({path: '/about', component: About, name: "About"})


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

The `@RouteConfig` annotation has been renamed to `@Routes` (`@RouteConfig` is still available for now but deprecated)
- **Other information**:

fixes #7723

RouteConfig is still supported but deprecated and will be removed in a future release.
