### PR TITLE
fix(di): type error in InvalidProviderError

### DIFF
--- a/modules/angular2/src/core/di/exceptions.ts
+++ b/modules/angular2/src/core/di/exceptions.ts
@@ -174,8 +174,7 @@ export class InstantiationError extends WrappedException {
  */
 export class InvalidProviderError extends BaseException {
   constructor(provider) {
-    super("Invalid provider - only instances of Provider and Type are allowed, got: " +
-          provider.toString());
+    super(`Invalid provider - only instances of Provider and Type are allowed, got: ${provider}`);
   }
 }
 


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes a type error when trying to throw a human readable error.
- **What is the current behavior?** (You can also link to an open issue here)

```
TypeError: Cannot read property 'toString' of undefined
          at new InvalidProviderError (/coolproject/node_modules/angular2/src/core/di/exceptions.js:180:21)
          at /coolproject/node_modules/angular2/src/core/di/provider.js:447:19
          at Array.forEach (native)
          at Array.forEach (/coolproject/node_modules/es6-shim/es6-shim.js:1107:14)
          at _normalizeProviders (/coolproject/node_modules/angular2/src/core/di/provider.js:433:15)
          at Object.resolveProviders (/coolproject/node_modules/angular2/src/core/di/provider.js:391:22)
          at Function.Injector.resolve (/coolproject/node_modules/angular2/src/core/di/injector.js:425:27)
          at Injector.resolveAndCreateChild (/coolproject/node_modules/angular2/src/core/di/injector.js:610:42)

```
- **What is the new behavior (if this is a feature change)?**

```
ORIGINAL EXCEPTION: Invalid provider - only instances of Provider and Type are allowed, got: undefined
      ORIGINAL STACKTRACE:
      Error: Invalid provider - only instances of Provider and Type are allowed, got: undefined
          at InvalidProviderError.BaseException [as constructor] (/coolproject/node_modules/angular2/src/facade/exceptions.js:16:23)
          at new InvalidProviderError (/coolproject/node_modules/angular2/src/core/di/exceptions.js:179:14)
          at /coolproject/node_modules/angular2/src/core/di/provider.js:447:19

```
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
- **Other information**:
