### PR TITLE
feat(Compiler): Allow overriding the projection selector

### DIFF
--- a/modules/angular2/src/compiler/template_preparser.ts
+++ b/modules/angular2/src/compiler/template_preparser.ts
@@ -11,12 +11,14 @@ const LINK_STYLE_REL_VALUE = 'stylesheet';
 const STYLE_ELEMENT = 'style';
 const SCRIPT_ELEMENT = 'script';
 const NG_NON_BINDABLE_ATTR = 'ngNonBindable';
+const NG_PROJECT_AS = 'ngProjectAs';
 
 export function preparseElement(ast: HtmlElementAst): PreparsedElement {
   var selectAttr = null;
   var hrefAttr = null;
   var relAttr = null;
   var nonBindable = false;
+  var projectAs: string = null;
   ast.attrs.forEach(attr => {
     let lcAttrName = attr.name.toLowerCase();
     if (lcAttrName == NG_CONTENT_SELECT_ATTR) {
@@ -27,6 +29,10 @@ export function preparseElement(ast: HtmlElementAst): PreparsedElement {
       relAttr = attr.value;
     } else if (attr.name == NG_NON_BINDABLE_ATTR) {
       nonBindable = true;
+    } else if (attr.name == NG_PROJECT_AS) {
+      if (attr.value.length > 0) {
+        projectAs = attr.value;
+      }
     }
   });
   selectAttr = normalizeNgContentSelect(selectAttr);
@@ -41,7 +47,7 @@ export function preparseElement(ast: HtmlElementAst): PreparsedElement {
   } else if (nodeName == LINK_ELEMENT && relAttr == LINK_STYLE_REL_VALUE) {
     type = PreparsedElementType.STYLESHEET;
   }
-  return new PreparsedElement(type, selectAttr, hrefAttr, nonBindable);
+  return new PreparsedElement(type, selectAttr, hrefAttr, nonBindable, projectAs);
 }
 
 export enum PreparsedElementType {
@@ -54,7 +60,7 @@ export enum PreparsedElementType {
 
 export class PreparsedElement {
   constructor(public type: PreparsedElementType, public selectAttr: string, public hrefAttr: string,
-              public nonBindable: boolean) {}
+              public nonBindable: boolean, public projectAs: string) {}
 }
 
 

--- a/modules/angular2/test/compiler/template_parser_spec.ts
+++ b/modules/angular2/test/compiler/template_parser_spec.ts
@@ -686,6 +686,39 @@ There is no directive with "exportAs" set to "dirA" ("<div [ERROR ->]#a="dirA"><
                                                [createComp('div', ['*'])])))
             .toEqual([['div', null], ['#text({{hello}})', 0], ['span', 0]]);
       });
+
+      it('should match the element when there is an inline template', () => {
+        expect(humanizeContentProjection(
+                   parse('<div><b *ngIf="cond"></b></div>', [createComp('div', ['a', 'b']), ngIf])))
+            .toEqual([['div', null], ['template', 1], ['b', null]]);
+      });
+
+      describe('ngProjectAs', () => {
+        it('should override elements', () => {
+          expect(humanizeContentProjection(
+                     parse('<div><a ngProjectAs="b"></a></div>', [createComp('div', ['a', 'b'])])))
+              .toEqual([['div', null], ['a', 1]]);
+        });
+
+        it('should override <ng-content>', () => {
+          expect(humanizeContentProjection(
+                     parse('<div><ng-content ngProjectAs="b"></ng-content></div>',
+                           [createComp('div', ['ng-content', 'b'])])))
+              .toEqual([['div', null], ['ng-content', 1]]);
+        });
+
+        it('should override <template>', () => {
+          expect(humanizeContentProjection(parse('<div><template ngProjectAs="b"></template></div>',
+                                                 [createComp('div', ['template', 'b'])])))
+              .toEqual([['div', null], ['template', 1]]);
+        });
+
+        it('should override inline templates', () => {
+          expect(humanizeContentProjection(parse('<div><a *ngIf="cond" ngProjectAs="b"></a></div>',
+                                                 [createComp('div', ['a', 'b']), ngIf])))
+              .toEqual([['div', null], ['template', 1], ['a', null]]);
+        });
+      });
     });
 
     describe('splitClasses', () => {

--- a/modules/angular2/test/compiler/template_preparser_spec.ts
+++ b/modules/angular2/test/compiler/template_preparser_spec.ts
@@ -26,7 +26,7 @@ export function main() {
     beforeEach(inject([HtmlParser], (_htmlParser: HtmlParser) => { htmlParser = _htmlParser; }));
 
     function preparse(html: string): PreparsedElement {
-      return preparseElement(htmlParser.parse(html, '').rootNodes[0]);
+      return preparseElement(htmlParser.parse(html, 'TestComp').rootNodes[0]);
     }
 
     it('should detect script elements', inject([HtmlParser], (htmlParser: HtmlParser) => {
@@ -54,5 +54,8 @@ export function main() {
          expect(preparse('<ng-content select="*">').selectAttr).toEqual('*');
        }));
 
+    it('should extract ngProjectAs value', () => {
+      expect(preparse('<p ngProjectAs="el[attr].class"></p>').projectAs).toEqual('el[attr].class');
+    });
   });
 }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: 
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

```
BREAKING CHANGE:

For static content projection, elements with *-directives are now matched against the element itself vs the template before.

    <p *ngIf="condition" foo></p>

Before:

    // Use the implicit template for projection
    <ng-content select="template"></ng-content>

After:

    // Use the actual element for projection
    <ng-content select="p[foo]"></ng-content>
```
