### PR TITLE
fix(Router): better error message when passing undefined component

### DIFF
--- a/modules/angular2/src/router/route_config/route_config_normalizer.ts
+++ b/modules/angular2/src/router/route_config/route_config_normalizer.ts
@@ -1,6 +1,6 @@
 import {AsyncRoute, AuxRoute, Route, Redirect, RouteDefinition} from './route_config_decorator';
 import {ComponentDefinition} from '../route_definition';
-import {isType, Type} from 'angular2/src/facade/lang';
+import {isType, Type, isPresent} from 'angular2/src/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
 import {RouteRegistry} from '../route_registry';
 
@@ -26,6 +26,11 @@ export function normalizeRouteConfig(config: RouteDefinition,
   }
   if (config instanceof Route || config instanceof Redirect || config instanceof AuxRoute) {
     return <RouteDefinition>config;
+  }
+
+  if (config.hasOwnProperty('component') && !isPresent(config.component)) {
+    throw new BaseException(
+        `Route '${config.name}' expected a valid component, got ${config.component}.`);
   }
 
   if ((+!!config.component) + (+!!config.redirectTo) + (+!!config.loader) != 1) {

--- a/modules/angular2/test/router/route_config/route_config_spec.ts
+++ b/modules/angular2/test/router/route_config/route_config_spec.ts
@@ -172,6 +172,17 @@ export function main() {
                      return null;
                    })}));
 
+    it('should throw if a config component is undefined',
+       inject([AsyncTestCompleter],
+              (async) => {bootstrap(UndefinedComponentTypeCmp, testBindings)
+                              .catch((e) => {
+                                expect(e.originalException)
+                                    .toContainError(
+                                        `Route 'Hello' expected a valid component, got undefined.`);
+                                async.done();
+                                return null;
+                              })}));
+
     it('should throw if a config has an invalid alias name',
        inject(
            [AsyncTestCompleter],
@@ -344,4 +355,15 @@ class MultipleAliasCmp {
   {path: '/hello', component: {type: 'intentionallyWrongComponentType', constructor: HelloCmp}},
 ])
 class WrongComponentTypeCmp {
+}
+
+@Component({
+  selector: 'app-cmp',
+  template: `root { <router-outlet></router-outlet> }`,
+  directives: ROUTER_DIRECTIVES
+})
+@RouteConfig([
+  {path: '/hello', component: undefined, name: 'Hello'},
+])
+class UndefinedComponentTypeCmp {
 }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Improves error message
- **What is the current behavior?** (You can also link to an open issue here)

Consider the following snippet

```
// existing.class.ts
export class ExistingClass {}

// app.ts
import {NonExistingClass} from './existing.class';
@Component({
  selector: 'my-app',
  template : '<router-outlet></router-outlet>'
})
@RouteConfig([
  {path : '/', component: NonExistingClass, useAsDefault: true}
])
class App {}
```

This will throw with 

```
Error: Route config should contain exactly one "component", "loader", or "redirectTo" property.
```

_[plnkr](http://plnkr.co/edit/BZa9r9I6pryn8AGCX0L6?p=preview) example_

The error is a little bit confusing. I am specifying a component, why does it say that I didn't specify one? The problem is that `NonExistingClass`, as the name states, it's undefined, it doesn't exist, 

[This condition](https://github.com/angular/angular/blob/master/modules/angular2/src/router/route_config/route_config_normalizer.ts#L31) is executed whether there's a component property with an undefined value, or simply there's no component property at all.
- **What is the new behavior (if this is a feature change)?**

This PR makes the error message more specific and clear since it checks if the property exists and in case of an undefined value will throw

```
Route config expected a valid component, got undefined.
```

With this I know that I'm passing an undefined component somewhere so now I know how to debug it.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
- **Other information**:

Some toolings can help to prevent these kind of errors, but I consider still better to be more specific.

cc @btford
