### PR TITLE
(docs) Fix pony greeting equivalence

### DIFF
--- a/modules/angular2/docs/cheatsheet/template-syntax.md
+++ b/modules/angular2/docs/cheatsheet/template-syntax.md
@@ -38,7 +38,7 @@ syntax:
 `<div title="Hello {{ponyName}}">`|`{{ponyName}}`
 description:
 Binds a property to an interpolated string, e.g. "Hello Seabiscuit". Equivalent to:
-`<div [title]="'Hello' + ponyName">`
+`<div [title]="'Hello ' + ponyName">`
 
 @cheatsheetItem
 syntax:


### PR DESCRIPTION
Cheatsheet claims equivalence between two statements which are not equivalent
