### PR TITLE
chore(build): Produce .d.ts files for build tools

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1093,25 +1093,26 @@ gulp.task('!build.tools', function() {
                    .pipe(tsc({
                      target: 'ES5',
                      module: 'commonjs',
+                     declaration: true,
                      // Don't use the version of typescript that gulp-typescript depends on
                      // see https://github.com/ivogabe/gulp-typescript#typescript-version
                      typescript: require('typescript')
-                   }))
-                   .on('error',
-                       function(error) {
-                         // nodejs doesn't propagate errors from the src stream into the final
-                         // stream so we are
-                         // forwarding the error into the final stream
-                         stream.emit('error', error);
-                       })
-                   .pipe(sourcemaps.write('.'))
-                   .pipe(gulp.dest('dist/tools'))
-                   .on('end', function() {
-                     var AngularBuilder =
-                         require('./dist/tools/broccoli/angular_builder').AngularBuilder;
-                     angularBuilder =
-                         new AngularBuilder({outputPath: 'dist', dartSDK: DART_SDK, logs: logs});
-                   });
+                   }));
+  stream =
+      merge2([stream.js.pipe(gulp.dest('dist/tools')), stream.dts.pipe(gulp.dest('dist/tools'))])
+          .on('error',
+              function(error) {
+                // nodejs doesn't propagate errors from the src stream into the final
+                // stream so we are
+                // forwarding the error into the final stream
+                stream.emit('error', error);
+              })
+          .pipe(sourcemaps.write('.'))
+          .on('end', function() {
+            var AngularBuilder = require('./dist/tools/broccoli/angular_builder').AngularBuilder;
+            angularBuilder =
+                new AngularBuilder({outputPath: 'dist', dartSDK: DART_SDK, logs: logs});
+          });
 
   return stream;
 });

--- a/tools/broccoli/angular_builder.ts
+++ b/tools/broccoli/angular_builder.ts
@@ -6,17 +6,16 @@ var path = require('path');
 var printSlowTrees = require('broccoli-slow-trees');
 var Q = require('q');
 
-type ProjectMap = {
+export type ProjectMap = {
   [key: string]: boolean
 };
 
-type Options = {
+export type Options = {
   projects: ProjectMap;
-noTypeChecks: boolean;
-generateEs6: boolean;
-useBundles: boolean;
-}
-;
+  noTypeChecks: boolean;
+  generateEs6: boolean;
+  useBundles: boolean;
+};
 
 /**
  * BroccoliBuilder facade for all of our build pipelines.

--- a/tools/broccoli/broccoli-lodash.ts
+++ b/tools/broccoli/broccoli-lodash.ts
@@ -4,7 +4,7 @@ import path = require('path');
 var _ = require('lodash');
 import {wrapDiffingPlugin, DiffingBroccoliPlugin, DiffResult} from './diffing-broccoli-plugin';
 
-interface LodashRendererOptions {
+export interface LodashRendererOptions {
   encoding?: string;
   context?: any;
   // files option unsupported --- use Funnel on inputTree instead.

--- a/tools/broccoli/broccoli-merge-trees.ts
+++ b/tools/broccoli/broccoli-merge-trees.ts
@@ -6,9 +6,7 @@ import {wrapDiffingPlugin, DiffingBroccoliPlugin, DiffResult} from './diffing-br
 
 var isWindows = process.platform === 'win32';
 
-interface MergeTreesOptions {
-  overwrite?: boolean;
-}
+export interface MergeTreesOptions { overwrite?: boolean; }
 
 function outputFileSync(sourcePath, destPath) {
   let dirname = path.dirname(destPath);

--- a/tools/broccoli/broccoli-tree-stabilizer.ts
+++ b/tools/broccoli/broccoli-tree-stabilizer.ts
@@ -40,6 +40,6 @@ class TreeStabilizer implements BroccoliTree {
 }
 
 
-export default function stabilizeTree(inputTree) {
+export default function stabilizeTree(inputTree): BroccoliTree {
   return new TreeStabilizer(inputTree);
 }

--- a/tools/broccoli/diffing-broccoli-plugin.ts
+++ b/tools/broccoli/diffing-broccoli-plugin.ts
@@ -33,7 +33,7 @@ export interface DiffingBroccoliPlugin {
 }
 
 
-type DiffingPluginWrapperFactory = (inputTrees: (BroccoliTree | BroccoliTree[]), options?) =>
+export type DiffingPluginWrapperFactory = (inputTrees: (BroccoliTree | BroccoliTree[]), options?) =>
     BroccoliTree;
 
 


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR changes the build for `tools` to produce `.d.ts` files for its modules.
- **What is the current behavior?** (You can also link to an open issue here)

The build doesn't produce `.d.ts` files for modules under `tools`.
- **What is the new behavior (if this is a feature change)?**

Produces `.d.ts` files for modules under `tools`.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.
- **Other information**:
