### PR TITLE
docs(DEVELOPER.md): state that git-clang-format must be in PATH

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -260,6 +260,10 @@ to some whitespace difference.
     $ chmod u+x !$
 ```
 
+**NOTE**: To use ```git clang-format``` use have to make sure that ```git-clang-format``` is in your
+```PATH```. The easiest way is probably to just ```npm install -g clang-format``` as it comes with
+```git-clang-format```.
+
 * **WebStorm** can run clang-format on the current file.
   1. Under Preferences, open Tools > External Tools.
   1. Plus icon to Create Tool


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  docs update
- **What is the current behavior?** (You can also link to an open issue here)
  To use `git clang-format` your have to make sure that `git-clang-format` is in your path.
  This PR adds a small NOTE so that people are aware of that fact.
