### PR TITLE
feat(common): DatePipe supports ISO string

### DIFF
--- a/modules/angular2/src/common/pipes/date_pipe.ts
+++ b/modules/angular2/src/common/pipes/date_pipe.ts
@@ -2,6 +2,7 @@ import {
   isDate,
   isNumber,
   isPresent,
+  isString,
   Date,
   DateWrapper,
   CONST,
@@ -33,8 +34,9 @@ var defaultLocale: string = 'en-US';
  *
  *     expression | date[:format]
  *
- * where `expression` is a date object or a number (milliseconds since UTC epoch) and
- * `format` indicates which date/time components to include:
+ * where `expression` is a date object or a number (milliseconds since UTC epoch) or an ISO string
+ * (https://www.w3.org/TR/NOTE-datetime) and `format` indicates which date/time components to
+ * include:
  *
  *  | Component | Symbol | Short Form   | Long Form         | Numeric   | 2-digit   |
  *  |-----------|:------:|--------------|-------------------|-----------|-----------|
@@ -111,6 +113,8 @@ export class DatePipe implements PipeTransform {
     var pattern: string = isPresent(args) && args.length > 0 ? args[0] : 'mediumDate';
     if (isNumber(value)) {
       value = DateWrapper.fromMillis(value);
+    } else if (isString(value)) {
+      value = DateWrapper.fromISOString(value);
     }
     if (StringMapWrapper.contains(DatePipe._ALIASES, pattern)) {
       pattern = <string>StringMapWrapper.get(DatePipe._ALIASES, pattern);
@@ -118,5 +122,13 @@ export class DatePipe implements PipeTransform {
     return DateFormatter.format(value, defaultLocale, pattern);
   }
 
-  supports(obj: any): boolean { return isDate(obj) || isNumber(obj); }
+  supports(obj: any): boolean {
+    if (isDate(obj) || isNumber(obj)) {
+      return true;
+    }
+    if (isString(obj) && isDate(DateWrapper.fromISOString(obj))) {
+      return true;
+    }
+    return false;
+  }
 }

--- a/modules/angular2/test/common/pipes/date_pipe_spec.ts
+++ b/modules/angular2/test/common/pipes/date_pipe_spec.ts
@@ -30,10 +30,13 @@ export function main() {
     describe("supports", () => {
       it("should support date", () => { expect(pipe.supports(date)).toBe(true); });
       it("should support int", () => { expect(pipe.supports(123456789)).toBe(true); });
+      it("should support ISO string",
+         () => { expect(pipe.supports("2015-06-15T21:43:11Z")).toBe(true); });
 
       it("should not support other objects", () => {
         expect(pipe.supports(new Object())).toBe(false);
         expect(pipe.supports(null)).toBe(false);
+        expect(pipe.supports("")).toBe(false);
       });
     });
 


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature
- **What is the current behavior?** (You can also link to an open issue here)

`DatePipe` supports only `Date` or `number` value. But Angular 1's `date` accepts ISO string value.
- **What is the new behavior (if this is a feature change)?**

`DatePipe` supports ISO string value.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No. Just new feature.
- **Other information**:

[AngularJS: API: date](https://docs.angularjs.org/api/ng/filter/date)
