### PR TITLE
fix(7837): MetadataCollector takes no parameters for the constructor.

### DIFF
--- a/tools/broccoli/broccoli-typescript.ts
+++ b/tools/broccoli/broccoli-typescript.ts
@@ -93,7 +93,7 @@ class DiffingTSCompiler implements DiffingBroccoliPlugin {
     this.tsServiceHost = new CustomLanguageServiceHost(this.tsOpts, this.rootFilePaths,
                                                        this.fileRegistry, this.inputPath);
     this.tsService = ts.createLanguageService(this.tsServiceHost, ts.createDocumentRegistry());
-    this.metadataCollector = new MetadataCollector(this.tsService);
+    this.metadataCollector = new MetadataCollector();
   }
 
 

--- a/tools/metadata/src/collector.ts
+++ b/tools/metadata/src/collector.ts
@@ -48,7 +48,7 @@ function moduleNameFromBaseName(moduleFileName: string, baseFileName: string): s
  * Collect decorator metadata from a TypeScript module.
  */
 export class MetadataCollector {
-  constructor(private service: ts.LanguageService) {}
+  constructor() {}
 
   /**
    * Returns a JSON.stringify friendly form describing the decorators of the exported classes from
@@ -58,7 +58,7 @@ export class MetadataCollector {
     const locals = new Symbols();
     const moduleNameOf = (fileName: string) =>
         moduleNameFromBaseName(fileName, sourceFile.fileName);
-    const evaluator = new Evaluator(this.service, typeChecker, locals, moduleNameOf);
+    const evaluator = new Evaluator(typeChecker, locals, moduleNameOf);
 
     function objFromDecorator(decoratorNode: ts.Decorator): MetadataSymbolicExpression {
       return <MetadataSymbolicExpression>evaluator.evaluateNode(decoratorNode.expression);

--- a/tools/metadata/src/evaluator.ts
+++ b/tools/metadata/src/evaluator.ts
@@ -63,8 +63,8 @@ function isDefined(obj: any): boolean {
  * possible.
  */
 export class Evaluator {
-  constructor(private service: ts.LanguageService, private typeChecker: ts.TypeChecker,
-              private symbols: Symbols, private moduleNameOf: (fileName: string) => string) {}
+  constructor(private typeChecker: ts.TypeChecker, private symbols: Symbols,
+              private moduleNameOf: (fileName: string) => string) {}
 
   // TODO: Determine if the first declaration is deterministic.
   private symbolFileName(symbol: ts.Symbol): string {

--- a/tools/metadata/test/collector.spec.ts
+++ b/tools/metadata/test/collector.spec.ts
@@ -18,7 +18,7 @@ describe('Collector', () => {
     service = ts.createLanguageService(host);
     program = service.getProgram();
     typeChecker = program.getTypeChecker();
-    collector = new MetadataCollector(service);
+    collector = new MetadataCollector();
   });
 
   it('should not have errors in test data', () => { expectValidSources(service, program); });

--- a/tools/metadata/test/evaluator.spec.ts
+++ b/tools/metadata/test/evaluator.spec.ts
@@ -18,7 +18,7 @@ describe('Evaluator', () => {
     program = service.getProgram();
     typeChecker = program.getTypeChecker();
     symbols = new Symbols();
-    evaluator = new Evaluator(service, typeChecker, symbols, f => f);
+    evaluator = new Evaluator(typeChecker, symbols, f => f);
   });
 
   it('should not have typescript errors in test data', () => {


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Removes an unused parameter from `MetadataCollector`.
- **What is the current behavior?** (You can also link to an open issue here)
  `MetadataCollector` requires a `ts.LanguageService` as a parameter to its constructor.
- **What is the new behavior (if this is a feature change)?**
  `MetadataCollector` takes no parameters to its constructor.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  #7837
