### PR TITLE
fix(router): ensuring matchUrl() read query params even when the next URL segment is null

### DIFF
--- a/modules/angular2/src/router/rules/route_paths/param_route_path.ts
+++ b/modules/angular2/src/router/rules/route_paths/param_route_path.ts
@@ -113,10 +113,10 @@ export class ParamRoutePath implements RoutePath {
     for (var i = 0; i < this._segments.length; i += 1) {
       var pathSegment = this._segments[i];
 
-      currentUrlSegment = nextUrlSegment;
       if (pathSegment instanceof ContinuationPathSegment) {
         break;
       }
+      currentUrlSegment = nextUrlSegment;
 
       if (isPresent(currentUrlSegment)) {
         // the star segment consumes all of the remaining URL, including matrix params

--- a/modules/angular2/test/router/route_registry_spec.ts
+++ b/modules/angular2/test/router/route_registry_spec.ts
@@ -298,19 +298,20 @@ export function main() {
        }));
 
     it('should match query params on the root component even when the next URL segment is null',
-      inject([AsyncTestCompleter], (async) => {
-        registry.config(RootHostCmp, new Route({ path: '/first/...', component: SingleSlashChildCmp }));
+       inject([AsyncTestCompleter], (async) => {
+         registry.config(RootHostCmp,
+                         new Route({path: '/first/...', component: SingleSlashChildCmp}));
 
-        registry.recognize('/first?comments=all', [])
-          .then((instruction) => {
-            expect(instruction.component.componentType).toBe(SingleSlashChildCmp);
-            expect(instruction.component.params).toEqual({ 'comments': 'all' });
+         registry.recognize('/first?comments=all', [])
+             .then((instruction) => {
+               expect(instruction.component.componentType).toBe(SingleSlashChildCmp);
+               expect(instruction.component.params).toEqual({'comments': 'all'});
 
-            expect(instruction.child.component.componentType).toBe(DummyCmpB);
-            expect(instruction.child.component.params).toEqual({});
-            async.done();
-          });
-      }));
+               expect(instruction.child.component.componentType).toBe(DummyCmpB);
+               expect(instruction.child.component.params).toEqual({});
+               async.done();
+             });
+       }));
 
     it('should generate URLs with matrix and query params', () => {
       registry.config(

--- a/modules/angular2/test/router/route_registry_spec.ts
+++ b/modules/angular2/test/router/route_registry_spec.ts
@@ -297,6 +297,21 @@ export function main() {
              });
        }));
 
+    it('should match query params on the root component even when the next URL segment is null',
+      inject([AsyncTestCompleter], (async) => {
+        registry.config(RootHostCmp, new Route({ path: '/first/...', component: SingleSlashChildCmp }));
+
+        registry.recognize('/first?comments=all', [])
+          .then((instruction) => {
+            expect(instruction.component.componentType).toBe(SingleSlashChildCmp);
+            expect(instruction.component.params).toEqual({ 'comments': 'all' });
+
+            expect(instruction.child.component.componentType).toBe(DummyCmpB);
+            expect(instruction.child.component.params).toEqual({});
+            async.done();
+          });
+      }));
+
     it('should generate URLs with matrix and query params', () => {
       registry.config(
           RootHostCmp,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  A Bug fix.
- **What is the current behavior?** (You can also link to an open issue here)
  In case of the 2nd depth(ROOT is the 1st depth) **single slash child routing**(url instanceof RootUrl && url.child === null), _matchUrl()_ method won't read query params, as the break for the _for_ statement is after '_currentUrlSegment = nextUrlSegment_' assignment statement.
- **What is the new behavior (if this is a feature change)?**
  _matchUrl()_ method will read query params properly in case of the 2nd depth **single slash child routing** as well.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  No.
- **Other information**:
