### PR TITLE
feat(dart/transform): Avoid `print` in transformer code.

### DIFF
--- a/modules_dart/transform/lib/src/transform/common/async_string_writer.dart
+++ b/modules_dart/transform/lib/src/transform/common/async_string_writer.dart
@@ -1,6 +1,7 @@
 library angular2.transform.common.async_string_writer;
 
 import 'dart:async';
+
 import 'package:analyzer/src/generated/java_core.dart';
 
 /// [PrintWriter] implementation that allows asynchronous printing via
@@ -18,6 +19,7 @@ class AsyncStringWriter extends PrintWriter {
 
   AsyncStringWriter([Object content = ""]) : this._(new StringBuffer(content));
 
+  @override
   void print(x) {
     _curr.write(x);
   }
@@ -54,6 +56,7 @@ class AsyncStringWriter extends PrintWriter {
     }).whenComplete(_semaphoreDecrementAndCleanup);
   }
 
+  @override
   String toString() => _bufs.map((buf) => '$buf').join('(async gap)');
 
   void _semaphoreIncrement() {

--- a/modules_dart/transform/lib/src/transform/common/logging.dart
+++ b/modules_dart/transform/lib/src/transform/common/logging.dart
@@ -1,6 +1,7 @@
 library angular2.src.transform.common.logging;
 
 import 'dart:async';
+import 'dart:io' show stderr;
 
 import 'package:barback/barback.dart';
 import 'package:source_span/source_span.dart';
@@ -49,12 +50,16 @@ void _logElapsed(Stopwatch timer, String operationName, AssetId assetId) {
   log.fine(buf.toString(), asset: assetId);
 }
 
-/// Prints logged messages to the console.
+/// Writes logged messages to the provided [StringSink].
 ///
-/// A simple implementation of [TransformLogger] that prints messages to the
-/// console and discards `asset` and `span` information.
-class PrintLogger implements TransformLogger {
-  void _printWithPrefix(prefix, msg) => print('$prefix: $msg');
+/// A simple implementation of [TransformLogger] that writes messages to a
+/// [StringSink] and discards `asset` and `span` information.
+class SinkLogger implements TransformLogger {
+  final StringSink _sink;
+
+  SinkLogger(this._sink);
+
+  void _printWithPrefix(prefix, msg) => _sink.writeln('$prefix: $msg');
 
   @override
   void info(msg, {AssetId asset, SourceSpan span}) =>
@@ -72,6 +77,14 @@ class PrintLogger implements TransformLogger {
   void error(msg, {AssetId asset, SourceSpan span}) {
     throw new PrintLoggerError(msg, asset, span);
   }
+}
+
+/// Prints logged messages to stderr.
+///
+/// A simple implementation of [TransformLogger] that prints messages to
+/// [stderr] and discards `asset` and `span` information.
+class PrintLogger extends SinkLogger {
+  PrintLogger() : super(stderr);
 }
 
 class PrintLoggerError extends Error {

--- a/modules_dart/transform/lib/src/transform/common/options_reader.dart
+++ b/modules_dart/transform/lib/src/transform/common/options_reader.dart
@@ -1,12 +1,15 @@
 library angular2.transform.common.options_reader;
 
+import 'dart:io';
+
 import 'package:barback/barback.dart';
+
 import 'annotation_matcher.dart';
 import 'mirror_mode.dart';
 import 'options.dart';
 import './url_resolver.dart';
 
-  TransformerOptions parseBarbackSettings(BarbackSettings settings) {
+TransformerOptions parseBarbackSettings(BarbackSettings settings) {
   var config = settings.configuration;
   var entryPoints = _readStringList(config, ENTRY_POINT_PARAM);
   var initReflector =
@@ -79,7 +82,8 @@ List<String> _readStringList(Map config, String paramName) {
     error = true;
   }
   if (error) {
-    print('Invalid value for "$paramName" in the Angular 2 transformer.');
+    stderr.writeln(
+        'Invalid value for "$paramName" in the Angular 2 transformer.');
   }
   return result;
 }
@@ -111,7 +115,7 @@ List<ClassDescriptor> _readCustomAnnotations(Map config) {
     }
   }
   if (error) {
-    print(CUSTOM_ANNOTATIONS_ERROR);
+    stderr.writeln(CUSTOM_ANNOTATIONS_ERROR);
   }
   return descriptors;
 }
@@ -121,7 +125,7 @@ const CUSTOM_ANNOTATIONS_ERROR = '''
   Expected something that looks like the following:
 
   transformers:
-  - angular2:
+  - angular2[/transform/codegen]:
       custom_annotations:
         - name: MyAnnotation
           import: 'package:my_package/my_annotation.dart'


### PR DESCRIPTION
Replace direct uses of `print` in the transformer with explicit uses of
stderr.

Add a few @override annotations for clarification of other `print`
implementations.

Clarify error message on incorrect custom_annotations value.
