### PR TITLE
feat(parser): TemplateParser.tryParse() returns both the AST and errors

### DIFF
--- a/modules/angular2/src/compiler/template_parser.ts
+++ b/modules/angular2/src/compiler/template_parser.ts
@@ -83,6 +83,10 @@ export class TemplateParseError extends ParseError {
   constructor(message: string, span: ParseSourceSpan) { super(span, message); }
 }
 
+export class TemplateParseResult {
+  constructor(public templateAst?: TemplateAst[], public errors?: ParseError[]) {}
+}
+
 @Injectable()
 export class TemplateParser {
   constructor(private _exprParser: Parser, private _schemaRegistry: ElementSchemaRegistry,
@@ -91,20 +95,29 @@ export class TemplateParser {
 
   parse(template: string, directives: CompileDirectiveMetadata[], pipes: CompilePipeMetadata[],
         templateUrl: string): TemplateAst[] {
+    var result = this.tryParse(template, directives, pipes, templateUrl);
+    if (isPresent(result.errors)) {
+      var errorString = result.errors.join('\n');
+      throw new BaseException(`Template parse errors:\n${errorString}`);
+    }
+    return result.templateAst;
+  }
+
+  tryParse(template: string, directives: CompileDirectiveMetadata[], pipes: CompilePipeMetadata[],
+           templateUrl: string): TemplateParseResult {
     var parseVisitor =
         new TemplateParseVisitor(directives, pipes, this._exprParser, this._schemaRegistry);
     var htmlAstWithErrors = this._htmlParser.parse(template, templateUrl);
     var result = htmlVisitAll(parseVisitor, htmlAstWithErrors.rootNodes, EMPTY_COMPONENT);
     var errors: ParseError[] = htmlAstWithErrors.errors.concat(parseVisitor.errors);
     if (errors.length > 0) {
-      var errorString = errors.join('\n');
-      throw new BaseException(`Template parse errors:\n${errorString}`);
+      return new TemplateParseResult(result, errors);
     }
     if (isPresent(this.transforms)) {
       this.transforms.forEach(
           (transform: TemplateAstVisitor) => { result = templateVisitAll(transform, result); });
     }
-    return result;
+    return new TemplateParseResult(result);
   }
 }
 


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds `tryParse()` to `TemplateParser` that always returns an AST even if there are errors.
- **What is the current behavior?** (You can also link to an open issue here)

`TemplateParser` has a method `parse()` that throws when the template has errors. 
- **What is the new behavior (if this is a feature change)?**

`TemplateParser` as a method `tryParse()` that always returns an AST even if there are errors.

The language service (#7482) needs the AST even if there are errors.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.
