### PR TITLE
fix(shims): fix parsing in Function.name in the IE shim

### DIFF
--- a/modules/angular2/src/testing/shims_for_IE.js
+++ b/modules/angular2/src/testing/shims_for_IE.js
@@ -3,7 +3,7 @@
 if (!Object.hasOwnProperty('name')) {
   Object.defineProperty(Function.prototype, 'name', {
     get: function() {
-      var matches = this.toString().match(/^\s*function\s*(\S*)\s*\(/);
+      var matches = this.toString().match(/^\s*function\s*([^\s(]+)/);
       var name = matches && matches.length > 1 ? matches[1] : "";
       // For better performance only parse once, and then cache the
       // result through a new accessor for repeated access.


### PR DESCRIPTION
This PR fixes a bug in the `Function.prototype.name` shim in `shims_for_IE.js`.

Without this fix, given a function: `function GetAnswer(){return(42);}` the value returned by `GetAnswer.name` is `GetAnswer(){return` instead of `GetAnswer`. This breaks some minified scripts, e.g. ng2-bootstrap's Typeahead component.

The new regular expression is copied from the accepted answer to the Stack Overflow question that is mentioned in the source code. The previous regex is from the runner up answer.
