### PR TITLE
fix(ddc): roll to latest ddc and fix new errors

### DIFF
--- a/modules/angular2/src/core/application_ref.ts
+++ b/modules/angular2/src/core/application_ref.ts
@@ -250,7 +250,7 @@ export class PlatformRef_ extends PlatformRef {
         provide(ApplicationRef, {useFactory: (): ApplicationRef => app, deps: []})
       ]);
 
-      var exceptionHandler: Function;
+      var exceptionHandler: ExceptionHandler;
       try {
         injector = this.injector.resolveAndCreateChild(providers);
         exceptionHandler = injector.get(ExceptionHandler);

--- a/modules/angular2/src/core/reflection/reflection_capabilities.dart
+++ b/modules/angular2/src/core/reflection/reflection_capabilities.dart
@@ -246,8 +246,8 @@ class ReflectionCapabilities implements PlatformReflectionCapabilities {
   List _convertParameter(ParameterMirror p) {
     var t = p.type;
     var res = (!t.hasReflectedType || t.reflectedType == dynamic)
-        ? []
-        : [t.reflectedType];
+        ? <Object>[]
+        : <Object>[t.reflectedType];
     res.addAll(p.metadata.map((m) => m.reflectee));
     return res;
   }

--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -317,7 +317,9 @@ export class Router {
         return false;
       }
       if (isPresent(this._childRouter)) {
-        return this._childRouter._routerCanDeactivate(childInstruction);
+        // TODO: ideally, this closure would map to async-await in Dart.
+        // For now, casting to any to suppress an error.
+        return <any>this._childRouter._routerCanDeactivate(childInstruction);
       }
       return true;
     });

--- a/scripts/ci/build_dart_ddc.sh
+++ b/scripts/ci/build_dart_ddc.sh
@@ -12,10 +12,10 @@ source $SCRIPT_DIR/env_dart.sh
 cd $REPO_ROOT_DIR
 
 # Variables
-DDC_TOTAL_WARNING_CAP="210"
+DDC_TOTAL_WARNING_CAP="100"
 DDC_TOTAL_ERROR_CAP="0"
 DDC_DIR=`pwd`/tmp/dev_compiler
-DDC_VERSION="0.1.23"
+DDC_VERSION="0.1.24"
 
 # Get DDC
 mkdir -p tmp

--- a/scripts/ci/build_dart_ddc.sh
+++ b/scripts/ci/build_dart_ddc.sh
@@ -15,7 +15,7 @@ cd $REPO_ROOT_DIR
 DDC_TOTAL_WARNING_CAP="210"
 DDC_TOTAL_ERROR_CAP="0"
 DDC_DIR=`pwd`/tmp/dev_compiler
-DDC_VERSION="0.1.20"
+DDC_VERSION="0.1.23"
 
 # Get DDC
 mkdir -p tmp


### PR DESCRIPTION
Roll to DDC 0.1.24 and fix corresponding errors.  Tighten the DDC warning limit to 100.  This PR will also fix an issue running the ddc e2e test with the latest Dart SDK.
