### PR TITLE
docs(ViewQuery): fix typo in documentation

### DIFF
--- a/modules/angular2/src/core/metadata/di.ts
+++ b/modules/angular2/src/core/metadata/di.ts
@@ -253,7 +253,7 @@ export class ContentChildMetadata extends QueryMetadata {
  * class MyComponent {
  *   shown: boolean;
  *
- *   constructor(private @Query(Item) items:QueryList<Item>) {
+ *   constructor(private @ViewQuery(Item) items:QueryList<Item>) {
  *     items.changes.subscribe(() => console.log(items.length));
  *   }
  * }


### PR DESCRIPTION
fixes documentation typo that confusingly refers to `@Query` rather than `@ViewQuery`.
