### PR TITLE
fix(router/parsing): change route rule error to say PascalCase not CamelCase

### DIFF
--- a/modules/angular2/src/router/rules/rule_set.ts
+++ b/modules/angular2/src/router/rules/rule_set.ts
@@ -53,7 +53,7 @@ export class RuleSet {
     if (isPresent(config.name) && config.name[0].toUpperCase() != config.name[0]) {
       let suggestedName = config.name[0].toUpperCase() + config.name.substring(1);
       throw new BaseException(
-          `Route "${config.path}" with name "${config.name}" does not begin with an uppercase letter. Route names should be CamelCase like "${suggestedName}".`);
+          `Route "${config.path}" with name "${config.name}" does not begin with an uppercase letter. Route names should be PascalCase like "${suggestedName}".`);
     }
 
     if (config instanceof AuxRoute) {

--- a/modules/angular2/test/router/route_config/route_config_spec.ts
+++ b/modules/angular2/test/router/route_config/route_config_spec.ts
@@ -180,7 +180,7 @@ export function main() {
                    .catch((e) => {
                      expect(e.originalException)
                          .toContainError(
-                             `Route "/child" with name "child" does not begin with an uppercase letter. Route names should be CamelCase like "Child".`);
+                             `Route "/child" with name "child" does not begin with an uppercase letter. Route names should be PascalCase like "Child".`);
                      async.done();
                      return null;
                    })}));
@@ -193,7 +193,7 @@ export function main() {
                    .catch((e) => {
                      expect(e.originalException)
                          .toContainError(
-                             `Route "/child" with name "child" does not begin with an uppercase letter. Route names should be CamelCase like "Child".`);
+                             `Route "/child" with name "child" does not begin with an uppercase letter. Route names should be PascalCase like "Child".`);
                      async.done();
                      return null;
                    })}));

--- a/modules/angular2/test/router/rules/rule_set_spec.ts
+++ b/modules/angular2/test/router/rules/rule_set_spec.ts
@@ -169,7 +169,7 @@ export function main() {
       expect(() => recognizer.config(
                  new Route({path: 'app/user/:name', component: DummyCmpA, name: 'user'})))
           .toThrowError(
-              `Route "app/user/:name" with name "user" does not begin with an uppercase letter. Route names should be CamelCase like "User".`);
+              `Route "app/user/:name" with name "user" does not begin with an uppercase letter. Route names should be PascalCase like "User".`);
     });
 
 


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Bug fix
- **What is the current behavior?** (You can also link to an open issue here)
  The error for incorrectly formed routes says they should be camel case (#7851.)
- **What is the new behavior (if this is a feature change)?**
  The error now says PascalCase
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  No
- **Other information**:
