### PR TITLE
build: FYI, upgrade karma version into 0.13.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "jasmine": "^2.4.1",
     "jpm": "1.0.0",
     "js-yaml": "^3.2.7",
-    "karma": "^0.13.17",
+    "karma": "^0.13.20",
     "karma-browserstack-launcher": "^0.1.9",
     "karma-chrome-launcher": "^0.2.0",
     "karma-jasmine": "^0.3.6",


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  FYI and build dependency update.
  Upgrade karma version into 0.13.20.
- **What is the current behavior?** (You can also link to an open issue here)
  Unit test failure(`$(npm bin)/gulp test.all.js`) in Microsoft Windows OS.
  Since Node v5.6.0, karma <0.13.20 doesn't work properly in Microsoft Windows OS.
  It shows `The header content contains invalid characters.` error.
  https://github.com/karma-runner/karma/pull/1884
  https://github.com/karma-runner/karma/issues/1994
- **What is the new behavior (if this is a feature change)?**
  Unit test success in Microsoft Windows OS even with Node v5.6.0.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  No.
- **Other information**:
