### PR TITLE
fix(ChangeDetectorJITGenerator): split generated dehydration code

### DIFF
--- a/modules/angular2/src/compiler/change_detector_compiler.ts
+++ b/modules/angular2/src/compiler/change_detector_compiler.ts
@@ -22,9 +22,9 @@ import {Codegen} from 'angular2/src/transform/template_compiler/change_detector_
 import {MODULE_SUFFIX} from './util';
 import {Injectable} from 'angular2/src/core/di';
 
-const ABSTRACT_CHANGE_DETECTOR = "AbstractChangeDetector";
-const UTIL = "ChangeDetectionUtil";
-const CHANGE_DETECTOR_STATE = "ChangeDetectorState";
+export const ABSTRACT_CHANGE_DETECTOR = "AbstractChangeDetector";
+export const UTIL = "ChangeDetectionUtil";
+export const CHANGE_DETECTOR_STATE = "ChangeDetectorState";
 
 export const CHANGE_DETECTION_JIT_IMPORTS = CONST_EXPR({
   'AbstractChangeDetector': AbstractChangeDetector,
@@ -32,13 +32,13 @@ export const CHANGE_DETECTION_JIT_IMPORTS = CONST_EXPR({
   'ChangeDetectorState': ChangeDetectorState
 });
 
-var ABSTRACT_CHANGE_DETECTOR_MODULE = moduleRef(
+export var ABSTRACT_CHANGE_DETECTOR_MODULE = moduleRef(
     `package:angular2/src/core/change_detection/abstract_change_detector${MODULE_SUFFIX}`);
-var UTIL_MODULE =
+export var UTIL_MODULE =
     moduleRef(`package:angular2/src/core/change_detection/change_detection_util${MODULE_SUFFIX}`);
-var PREGEN_PROTO_CHANGE_DETECTOR_MODULE = moduleRef(
+export var PREGEN_PROTO_CHANGE_DETECTOR_MODULE = moduleRef(
     `package:angular2/src/core/change_detection/pregen_proto_change_detector${MODULE_SUFFIX}`);
-var CONSTANTS_MODULE =
+export var CONSTANTS_MODULE =
     moduleRef(`package:angular2/src/core/change_detection/constants${MODULE_SUFFIX}`);
 
 @Injectable()

--- a/modules/angular2/src/core/change_detection/change_detection_jit_generator.ts
+++ b/modules/angular2/src/core/change_detection/change_detection_jit_generator.ts
@@ -498,4 +498,7 @@ export class ChangeDetectorJITGenerator {
     `;
     return retVal;
   }
+
+  /** @internal */
+  _getCodegenNameUtil(): CodegenNameUtil { return this._names; }
 }

--- a/modules/angular2/test/core/change_detection/codegen_name_util_spec.dart
+++ b/modules/angular2/test/core/change_detection/codegen_name_util_spec.dart
@@ -1,0 +1,3 @@
+main() {
+  return;
+}

--- a/modules/angular2/test/core/change_detection/codegen_name_util_spec.ts
+++ b/modules/angular2/test/core/change_detection/codegen_name_util_spec.ts
@@ -1,0 +1,86 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  inject,
+  beforeEachProviders
+} from 'angular2/testing_internal';
+
+import {provide} from 'angular2/src/core/di';
+import {CONST_EXPR, stringify, IS_DART} from 'angular2/src/facade/lang';
+import {ChangeDetectionCompiler} from 'angular2/src/compiler/change_detector_compiler';
+import {CompileTypeMetadata} from 'angular2/src/compiler/directive_metadata';
+import {TemplateParser} from 'angular2/src/compiler/template_parser';
+
+import {
+  ChangeDetectorGenConfig,
+  ChangeDetectionStrategy
+} from 'angular2/src/core/change_detection/change_detection';
+
+import {TEST_PROVIDERS} from '../../compiler/test_bindings';
+import {MODULE_SUFFIX} from 'angular2/src/compiler/util';
+import {createChangeDetectorDefinitions} from "angular2/src/compiler/change_definition_factory";
+import {
+  UTIL_MODULE,
+  ABSTRACT_CHANGE_DETECTOR_MODULE,
+  CHANGE_DETECTOR_STATE,
+  ABSTRACT_CHANGE_DETECTOR,
+  CONSTANTS_MODULE,
+  UTIL
+} from "angular2/src/compiler/change_detector_compiler";
+import {
+  ChangeDetectorJITGenerator
+} from "angular2/src/core/change_detection/change_detection_jit_generator";
+
+// Attention: These module names have to correspond to real modules!
+var THIS_MODULE_ID = 'angular2/test/compiler/change_detector_compiler_spec';
+var THIS_MODULE_URL = `package:${THIS_MODULE_ID}${MODULE_SUFFIX}`;
+
+export function main() {
+  // Dart's isolate support is broken, and these tests will be obsolote soon with
+  if (IS_DART) {
+    return;
+  }
+  describe('CodegenNameUtil', () => {
+    var changeDetectorGenConfig = new ChangeDetectorGenConfig(true, false, false);
+    beforeEachProviders(() => [
+      TEST_PROVIDERS,
+      provide(ChangeDetectorGenConfig, {useValue: changeDetectorGenConfig})
+    ]);
+
+    var parser: TemplateParser;
+
+    beforeEach(inject([TemplateParser], (_parser) => { parser = _parser; }));
+
+    function createAndRunGenerator(templateBindings: number, maxChunkSize: number) {
+      var lines = [];
+      for (var i = 0; i < templateBindings; i++) {
+        lines.push(`<input type="text" [foo]="c${i}">`)
+      }
+      var type =
+          new CompileTypeMetadata({name: stringify(SomeComponent), moduleUrl: THIS_MODULE_URL});
+      var parsedTemplate = parser.parse(lines.join(), CONST_EXPR([]), [], 'TestComp');
+
+      var changeDetectorJITGenerator = new ChangeDetectorJITGenerator(
+          createChangeDetectorDefinitions(type, ChangeDetectionStrategy.Default,
+                                          new ChangeDetectorGenConfig(true, false, false),
+                                          parsedTemplate)[0],
+          `${UTIL_MODULE}${UTIL}`, `${ABSTRACT_CHANGE_DETECTOR_MODULE}${ABSTRACT_CHANGE_DETECTOR}`,
+          `${CONSTANTS_MODULE}${CHANGE_DETECTOR_STATE}`);
+      return changeDetectorJITGenerator._getCodegenNameUtil()
+          .genDehydrateFields(maxChunkSize)
+          .split('\n');
+    };
+
+    it('should not throw on a large number of elements', () => {
+      expect(createAndRunGenerator(1, 1).length).toBe(1);
+      expect(createAndRunGenerator(10, 1).length).toBe(10);
+      expect(createAndRunGenerator(11, 10).length).toBe(2);
+      expect(createAndRunGenerator(21, 10).length).toBe(3);
+      expect(createAndRunGenerator(500, 100).length).toBe(5);
+    });
+  });
+}
+
+class SomeComponent {}


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Fix ChangeDetectorJITGenerator
- **What is the current behavior?** (You can also link to an open issue here)
  #3558
- **What is the new behavior (if this is a feature change)?**
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- **Other information**:

Currently generated dehydration code builds a mass assignment to `ChangeDetectionUtil.uninitialized`.
This can cause a RangeError when there's a large number of fields.
Now the assignments are broken up into chunks with configurable size and a default of 100.

Closes #3558
