### PR TITLE
fix(Router): replace state when normalized path is equal to current normalized path

### DIFF
--- a/modules/angular1_router/lib/facades.es5
+++ b/modules/angular1_router/lib/facades.es5
@@ -313,8 +313,17 @@ Location.prototype.subscribe = function () {
 Location.prototype.path = function () {
   return $location.url();
 };
+Location.prototype.isCurrentPathEqualTo = function (path, query) {
+  if (query === void 0) { query = ''; }
+  return this.path() === (path + query);
+};
 Location.prototype.go = function (path, query) {
   return $location.url(path + query);
+};
+Location.prototype.replaceState = function (path, query) {
+  if (query === void 0) { query = ''; }
+  $location.url(path + query);
+  $location.replace();
 };
 Location.prototype.prepareExternalUrl = function(url) {
   if (url.length > 0 && !url.startsWith('/')) {

--- a/modules/angular2/src/mock/location_mock.ts
+++ b/modules/angular2/src/mock/location_mock.ts
@@ -24,6 +24,14 @@ export class SpyLocation implements Location {
 
   path(): string { return this._path; }
 
+  isCurrentPathEqualTo(path: string, query: string = ''): boolean {
+    var givenPath = path.endsWith('/') ? path.substring(0, path.length - 1) : path;
+    var currPath =
+        this.path().endsWith('/') ? this.path().substring(0, this.path().length - 1) : this.path();
+
+    return currPath == givenPath + (query.length > 0 ? ('?' + query) : '');
+  }
+
   simulateUrlPop(pathname: string) {
     ObservableWrapper.callEmit(this._subject, {'url': pathname, 'pop': true});
   }
@@ -56,6 +64,9 @@ export class SpyLocation implements Location {
 
   replaceState(path: string, query: string = '') {
     path = this.prepareExternalUrl(path);
+    if (this._path == path && this._query == query) {
+      return;
+    }
     this._path = path;
     this._query = query;
 

--- a/modules/angular2/src/router/location/location.ts
+++ b/modules/angular2/src/router/location/location.ts
@@ -1,4 +1,4 @@
-import {LocationStrategy} from './location_strategy';
+import {LocationStrategy, normalizeQueryParams} from './location_strategy';
 import {EventEmitter, ObservableWrapper} from 'angular2/src/facade/async';
 import {Injectable, Inject} from 'angular2/core';
 
@@ -61,6 +61,13 @@ export class Location {
    * Returns the normalized URL path.
    */
   path(): string { return this.normalize(this.platformStrategy.path()); }
+
+  /**
+   * Normalizes the given path and compares to the current normalized path.
+   */
+  isCurrentPathEqualTo(path: string, query: string = ''): boolean {
+    return this.path() == this.normalize(path + normalizeQueryParams(query));
+  }
 
   /**
    * Given a string representing a URL, returns the normalized URL path without leading or

--- a/modules/angular2/src/router/router.ts
+++ b/modules/angular2/src/router/router.ts
@@ -496,7 +496,11 @@ export class RootRouter extends Router {
     }
     var promise = super.commit(instruction);
     if (!_skipLocationChange) {
-      promise = promise.then((_) => { this._location.go(emitPath, emitQuery); });
+      if (this._location.isCurrentPathEqualTo(emitPath, emitQuery)) {
+        promise = promise.then((_) => { this._location.replaceState(emitPath, emitQuery); });
+      } else {
+        promise = promise.then((_) => { this._location.go(emitPath, emitQuery); });
+      }
     }
     return promise;
   }

--- a/modules/angular2/test/router/integration/navigation_spec.ts
+++ b/modules/angular2/test/router/integration/navigation_spec.ts
@@ -131,6 +131,22 @@ export function main() {
              });
        }));
 
+
+    it('should replace state when normalized paths are equal',
+       inject([AsyncTestCompleter, Location], (async, location) => {
+         compile(tcb)
+             .then((rtc) => {fixture = rtc})
+             .then((_) => location.setInitialPath("/test/"))
+             .then((_) => rtr.config([new Route({path: '/test', component: HelloCmp})]))
+             .then((_) => rtr.navigateByUrl('/test'))
+             .then((_) => {
+               fixture.detectChanges();
+               expect(fixture.debugElement.nativeElement).toHaveText('hello');
+               expect(location.urlChanges).toEqual(['replace: /test']);
+               async.done();
+             });
+       }));
+
     it('should reuse common parent components', inject([AsyncTestCompleter], (async) => {
          compile(tcb)
              .then((rtc) => {fixture = rtc})


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix
- **What is the current behavior?** (You can also link to an open issue here)
#7829
- **What is the new behavior (if this is a feature change)?**
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
- **Other information**:

Make sure the same path is not added multiple times to the history.
It is replacing the state, instead of skipping it completely,
because the current path in the browser might not be normalized,
while the given one is normalized.

Closes #7829
