### PR TITLE
build(npm): update rxjs version to 5.0.0-beta.5

### DIFF
--- a/modules/angular2/src/http/backends/mock_backend.ts
+++ b/modules/angular2/src/http/backends/mock_backend.ts
@@ -6,7 +6,7 @@ import {Connection, ConnectionBackend} from '../interfaces';
 import {isPresent} from 'angular2/src/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
 import {Subject} from 'rxjs/Subject';
-import {ReplaySubject} from 'rxjs/subject/ReplaySubject';
+import {ReplaySubject} from 'rxjs/ReplaySubject';
 import {take} from 'rxjs/operator/take';
 
 /**

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -4817,7 +4817,7 @@
       "version": "1.1.5"
     },
     "rxjs": {
-      "version": "5.0.0-beta.2"
+      "version": "5.0.0-beta.5"
     },
     "sass-graph": {
       "version": "2.0.1",
@@ -5836,5 +5836,5 @@
     }
   },
   "name": "angular-srcs",
-  "version": "2.0.0-beta.11"
+  "version": "2.0.0-beta.13"
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "2.0.0-beta.11",
+  "version": "2.0.0-beta.13",
   "dependencies": {
     "abbrev": {
       "version": "1.0.7",
@@ -7679,9 +7679,9 @@
       "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.1.5.tgz"
     },
     "rxjs": {
-      "version": "5.0.0-beta.2",
-      "from": "rxjs@5.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.2.tgz"
+      "version": "5.0.0-beta.5",
+      "from": "rxjs@5.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.5.tgz"
     },
     "sass-graph": {
       "version": "2.0.1",
@@ -9305,7 +9305,8 @@
     },
     "zone.js": {
       "version": "0.6.6",
-      "from": "zone.js@0.6.6"
+      "from": "zone.js@0.6.6",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.6.6.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "es6-shim": "^0.35.0",
     "reflect-metadata": "0.1.2",
-    "rxjs": "5.0.0-beta.2",
+    "rxjs": "5.0.0-beta.5",
     "zone.js": "^0.6.6"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR will not yet work because of typings issues. RxJS requires `Symbol` and `Iterable` to be present in `Observable.ts`, which are not present in our build. From a quick search, there are no individual typings files published to DefinitelyTyped to satisfy these requirements.

Proposed solution after discussing with @alexeagle: Update angular/angular to TS@next, which includes library files for symbol and iterable, which we could include in our own build, and also re-distributed in our npm package.

CC @robwormald @blesh @IgorMinar 
