### PR TITLE
feat(gestures): allow override of Hammer defaults

### DIFF
--- a/modules/angular2/src/platform/browser_common.ts
+++ b/modules/angular2/src/platform/browser_common.ts
@@ -30,6 +30,10 @@ import {BrowserDomAdapter} from './browser/browser_adapter';
 import {BrowserGetTestability} from 'angular2/src/platform/browser/testability';
 import {wtfInit} from 'angular2/src/core/profile/wtf_init';
 import {EventManager, EVENT_MANAGER_PLUGINS} from "angular2/src/platform/dom/events/event_manager";
+import {
+  HAMMER_GESTURE_CONFIG,
+  HammerGestureConfig
+} from 'angular2/src/platform/dom/events/hammer_gestures';
 import {ELEMENT_PROBE_PROVIDERS} from 'angular2/platform/common_dom';
 export {DOCUMENT} from 'angular2/src/platform/dom/dom_tokens';
 export {Title} from 'angular2/src/platform/browser/title';
@@ -41,6 +45,7 @@ export {
 } from 'angular2/platform/common_dom';
 export {BrowserDomAdapter} from './browser/browser_adapter';
 export {enableDebugTools, disableDebugTools} from 'angular2/src/platform/browser/tools/tools';
+export {HAMMER_GESTURE_CONFIG, HammerGestureConfig} from './dom/events/hammer_gestures';
 
 /**
  * A set of providers to initialize the Angular platform in a web browser.
@@ -77,6 +82,7 @@ export const BROWSER_APP_COMMON_PROVIDERS: Array<any /*Type | Provider | any[]*/
   new Provider(EVENT_MANAGER_PLUGINS, {useClass: DomEventsPlugin, multi: true}),
   new Provider(EVENT_MANAGER_PLUGINS, {useClass: KeyEventsPlugin, multi: true}),
   new Provider(EVENT_MANAGER_PLUGINS, {useClass: HammerGesturesPlugin, multi: true}),
+  new Provider(HAMMER_GESTURE_CONFIG, {useClass: HammerGestureConfig}),
   new Provider(DomRootRenderer, {useClass: DomRootRenderer_}),
   new Provider(RootRenderer, {useExisting: DomRootRenderer}),
   new Provider(SharedStylesHost, {useExisting: DomSharedStylesHost}),

--- a/modules/angular2/src/platform/dom/events/hammer_gestures.ts
+++ b/modules/angular2/src/platform/dom/events/hammer_gestures.ts
@@ -1,12 +1,42 @@
 import {HammerGesturesPluginCommon} from './hammer_common';
-import {isPresent} from 'angular2/src/facade/lang';
+import {isPresent, CONST_EXPR} from 'angular2/src/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
-import {Injectable} from 'angular2/src/core/di';
+import {Injectable, Inject, OpaqueToken} from 'angular2/core';
+
+export const HAMMER_GESTURE_CONFIG: OpaqueToken =
+    CONST_EXPR(new OpaqueToken("HammerGestureConfig"));
+
+export interface HammerInstance {
+  on(eventName: string, callback: Function): void;
+  off(eventName: string, callback: Function): void;
+}
+
+@Injectable()
+export class HammerGestureConfig {
+  events: string[] = [];
+
+  overrides: {[key: string]: Object} = {};
+
+  buildHammer(element: HTMLElement): HammerInstance {
+    var mc = new Hammer(element);
+
+    mc.get('pinch').set({enable: true});
+    mc.get('rotate').set({enable: true});
+
+    for (let eventName in this.overrides) {
+      mc.get(eventName).set(this.overrides[eventName]);
+    }
+
+    return mc;
+  }
+}
 
 @Injectable()
 export class HammerGesturesPlugin extends HammerGesturesPluginCommon {
+  constructor(@Inject(HAMMER_GESTURE_CONFIG) private _config: HammerGestureConfig) { super(); }
+
   supports(eventName: string): boolean {
-    if (!super.supports(eventName)) return false;
+    if (!super.supports(eventName) && !this.isCustomEvent(eventName)) return false;
 
     if (!isPresent(window['Hammer'])) {
       throw new BaseException(`Hammer.js is not loaded, can not bind ${eventName} event`);
@@ -19,14 +49,14 @@ export class HammerGesturesPlugin extends HammerGesturesPluginCommon {
     var zone = this.manager.getZone();
     eventName = eventName.toLowerCase();
 
-    return zone.runOutsideAngular(function() {
+    return zone.runOutsideAngular(() => {
       // Creating the manager bind events, must be done outside of angular
-      var mc = new Hammer(element);
-      mc.get('pinch').set({enable: true});
-      mc.get('rotate').set({enable: true});
+      var mc = this._config.buildHammer(element);
       var callback = function(eventObj) { zone.run(function() { handler(eventObj); }); };
       mc.on(eventName, callback);
       return () => { mc.off(eventName, callback); };
     });
   }
+
+  isCustomEvent(eventName: string): boolean { return this._config.events.indexOf(eventName) > -1; }
 }

--- a/modules/angular2/src/platform/worker_render_common.ts
+++ b/modules/angular2/src/platform/worker_render_common.ts
@@ -48,6 +48,7 @@ import {
 import {Serializer} from 'angular2/src/web_workers/shared/serializer';
 import {ON_WEB_WORKER} from 'angular2/src/web_workers/shared/api';
 import {RenderStore} from 'angular2/src/web_workers/shared/render_store';
+import {HAMMER_GESTURE_CONFIG, HammerGestureConfig} from './dom/events/hammer_gestures';
 
 export const WORKER_SCRIPT: OpaqueToken = CONST_EXPR(new OpaqueToken("WebWorkerScript"));
 
@@ -77,6 +78,7 @@ export const WORKER_RENDER_APPLICATION_COMMON: Array<any /*Type | Provider | any
   new Provider(EVENT_MANAGER_PLUGINS, {useClass: DomEventsPlugin, multi: true}),
   new Provider(EVENT_MANAGER_PLUGINS, {useClass: KeyEventsPlugin, multi: true}),
   new Provider(EVENT_MANAGER_PLUGINS, {useClass: HammerGesturesPlugin, multi: true}),
+  new Provider(HAMMER_GESTURE_CONFIG, {useClass: HammerGestureConfig}),
   new Provider(DomRootRenderer, {useClass: DomRootRenderer_}),
   new Provider(RootRenderer, {useExisting: DomRootRenderer}),
   new Provider(SharedStylesHost, {useExisting: DomSharedStylesHost}),


### PR DESCRIPTION
WIP: not ready for review
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  This PR enables the overriding of Hammer default thresholds when using gestures.
- **What is the current behavior?** (You can also link to an open issue here)
  If you want to listen to Hammer gestures, you have to either keep the existing configuration or create your own Hammer event plugin with the configuration you want. This requires quite a bit of extra work if you just want to tweak a distance threshold.
- **What is the new behavior (if this is a feature change)?**
  You can now override the default Hammer config by defining your own HammerGestureConfig and adding it as a provider.  

main.ts

``` typescript
bootstrap(MyApp, [
   provide(HAMMER_GESTURE_CONFIG, {useClass: MyHammerConfig})
])
```

Then, in your class, set an `overrides` object with the event names and your changes:

MyHammerConfig.ts

``` typescript
export class MyHammerConfig extends HammerGestureConfig  {
   overrides = {
      'pan': {threshold: 5},
      'swipe': {velocity: 0.5}
   }
}
```

If you want more control, you can instantiate Hammer any way you like by defining a `buildHammer` method that returns a Hammer instance instead (ignoring overrides object):

MyHammerConfig.ts

``` typescript
export class MyHammerConfig {
   buildHammer(element: HTMLElement): Object {
      var mc = new Hammer(element);

      // custom configuration
      mc.get('pan').set({threshold: 5});

      return mc;
   }
}
```
- **Does this PR introduce a breaking change?**

No, existing code should not have to change.
