### PR TITLE
fix(select): update option value name from ng-value to ngValue

### DIFF
--- a/modules/angular2/src/common/forms/directives/select_control_value_accessor.ts
+++ b/modules/angular2/src/common/forms/directives/select_control_value_accessor.ts
@@ -98,7 +98,7 @@ export class NgSelectOption implements OnDestroy {
     if (isPresent(this._select)) this.id = this._select._registerOption();
   }
 
-  @Input('ng-value')
+  @Input('ngValue')
   set ngValue(value: any) {
     if (this._select == null) return;
     this._select._optionMap.set(this.id, value);

--- a/modules/angular2/test/common/forms/integration_spec.ts
+++ b/modules/angular2/test/common/forms/integration_spec.ts
@@ -438,7 +438,7 @@ export function main() {
                   (tcb: TestComponentBuilder, async) => {
                     var t = `<div>
                       <select [(ngModel)]="selectedCity">
-                        <option *ngFor="#c of list" [ng-value]="c">{{c['name']}}</option>
+                        <option *ngFor="#c of list" [ngValue]="c">{{c['name']}}</option>
                       </select>
                   </div>`;
 
@@ -470,7 +470,7 @@ export function main() {
                   (tcb: TestComponentBuilder, async) => {
                     var t = `<div>
                       <select [(ngModel)]="selectedCity">
-                        <option *ngFor="#c of list" [ng-value]="c">{{c['name']}}</option>
+                        <option *ngFor="#c of list" [ngValue]="c">{{c['name']}}</option>
                       </select>
                   </div>`;
 
@@ -498,7 +498,7 @@ export function main() {
                   (tcb: TestComponentBuilder, async) => {
                     var t = `<div>
                       <select [(ngModel)]="selectedCity">
-                        <option *ngFor="#c of list" [ng-value]="c">{{c}}</option>
+                        <option *ngFor="#c of list" [ngValue]="c">{{c}}</option>
                       </select>
                   </div>`;
                     tcb.overrideTemplate(MyComp, t).createAsync(MyComp).then((fixture) => {
@@ -524,7 +524,7 @@ export function main() {
                   (tcb: TestComponentBuilder, async) => {
                     var t = `<div>
                       <select [(ngModel)]="selectedCity">
-                        <option *ngFor="#c of list; trackBy:customTrackBy" [ng-value]="c">{{c}}</option>
+                        <option *ngFor="#c of list; trackBy:customTrackBy" [ngValue]="c">{{c}}</option>
                       </select>
                   </div>`;
 
@@ -554,7 +554,7 @@ export function main() {
                   (tcb: TestComponentBuilder, async) => {
                     var t = `<div>
                       <select [(ngModel)]="selectedCity">
-                        <option *ngFor="#c of list" [ng-value]="c">{{c}}</option>
+                        <option *ngFor="#c of list" [ngValue]="c">{{c}}</option>
                       </select>
                   </div>`;
 
@@ -583,7 +583,7 @@ export function main() {
                   (tcb: TestComponentBuilder, async) => {
                     var t = `<div>
                       <select [(ngModel)]="selectedCity">
-                        <option *ngFor="#c of list" [ng-value]="c">{{c['name']}}</option>
+                        <option *ngFor="#c of list" [ngValue]="c">{{c['name']}}</option>
                       </select>
                   </div>`;
 


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Changes name of option value binding from `ng-value` to `ngValue`.
- **What is the current behavior?** (You can also link to an open issue here)
  Old code you'd write for option values that are objects:

``` html
<select [(ngModel)]="selectedCity">
   <option *ngFor="#city of cities" [ng-value]="city">{{city.name}}</option>
</select>
```

``` typescript
class MyComp {
   selectedCity: Object;
   cities: Object[] = [
      {name: "SF"},
      {name: "NYC"}
   ];
}
```
- **What is the new behavior (if this is a feature change)?**

New code you'd write for option values that are objects:

``` html
<select [(ngModel)]="selectedCity">
   <option *ngFor="#city of cities" [ngValue]="city">{{city.name}}</option>
</select>
```

``` typescript
class MyComp {
   selectedCity: Object;
   cities: Object[] = [
      {name: "SF"},
      {name: "NYC"}
   ];
}
```
- **Does this PR introduce a breaking change?** 

Yes, technically, but `ng-value` was introduced 10 minutes ago. 
