### PR TITLE
chore(build): Clean-up TypeScript build

### DIFF
--- a/tools/broccoli/trees/browser_tree.ts
+++ b/tools/broccoli/trees/browser_tree.ts
@@ -113,13 +113,18 @@ module.exports = function makeBrowserTree(options, destinationPath) {
                    {include: ['**/**'], exclude: ['e2e_test/**'], destDir: '/benchpress/'});
   }
 
+  let externalTypings =
+      new Funnel('node_modules', {include: ['rxjs/**/*.d.ts', 'zone.js/**/*.d.ts']});
+
+
   var modulesTree = mergeTrees([
     angular2Tree,
     benchmarksTree,
     benchmarksExternalTree,
     payloadTestsTree,
     playgroundTree,
-    benchpressTree
+    benchpressTree,
+    externalTypings,
   ]);
 
   var es6PolyfillTypings =


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore
- **What is the current behavior?** (You can also link to an open issue here)

Broccoli builds refer to files outside the input tree requiring custom file name resolution.
- **What is the new behavior (if this is a feature change)?**

Broccoli builds only refer to files in the input tree and no longer require custom file name resolution.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.
- **Other information**:

The TypeScript parser now only references files that are in broccoli trees.
