### PR TITLE
docs(Query): Fixed typo in documentation

### DIFF
--- a/modules/angular2/src/core/metadata.ts
+++ b/modules/angular2/src/core/metadata.ts
@@ -988,7 +988,7 @@ export var Attribute: AttributeFactory = makeParamDecorator(AttributeMetadata);
  *   <div #findme>...</div>
  * </seeker>
  *
- * @Component({ selector: 'foo' })
+ * @Component({ selector: 'seeker' })
  * class seeker {
  *   constructor(@Query('findme') elList: QueryList<ElementRef>) {...}
  * }
@@ -1006,7 +1006,7 @@ export var Attribute: AttributeFactory = makeParamDecorator(AttributeMetadata);
  * </seeker>
  *
  *  @Component({
- *   selector: 'foo'
+ *   selector: 'seeker'
  * })
  * class Seeker {
  *   constructor(@Query('findMe, findMeToo') elList: QueryList<ElementRef>) {...}


### PR DESCRIPTION
fixes seeker selector from `foo` to `seeker` in the Query documentation example
