### PR TITLE
build(broccoli): AngularBuilder compiles with TypeScript 1.8+.

### DIFF
--- a/tools/broccoli/angular_builder.d.ts
+++ b/tools/broccoli/angular_builder.d.ts
@@ -1,5 +1,0 @@
-interface AngularBuilderOptions {
-  outputPath: string;
-  dartSDK?: any;
-  logs?: any;
-}

--- a/tools/broccoli/angular_builder.ts
+++ b/tools/broccoli/angular_builder.ts
@@ -17,6 +17,12 @@ export type Options = {
   useBundles: boolean;
 };
 
+export interface AngularBuilderOptions {
+  outputPath: string;
+  dartSDK?: any;
+  logs?: any;
+}
+
 /**
  * BroccoliBuilder facade for all of our build pipelines.
  */

--- a/tools/broccoli/trees/dart_tree.ts
+++ b/tools/broccoli/trees/dart_tree.ts
@@ -1,5 +1,4 @@
 /// <reference path="../../typings/node/node.d.ts" />
-/// <reference path="../angular_builder.d.ts" />
 'use strict';
 
 import {MultiCopy} from './../multi_copy';
@@ -12,6 +11,7 @@ var stew = require('broccoli-stew');
 import ts2dart from '../broccoli-ts2dart';
 import dartfmt from '../broccoli-dartfmt';
 import replace from '../broccoli-replace';
+import {AngularBuilderOptions} from '../angular_builder';
 
 var global_excludes = [
   'angular2/examples/**/ts/**/*',


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore
- **What is the current behavior?** (You can also link to an open issue here)

Building AngularBuilder works in 1.7 but not 1.8
- **What is the new behavior (if this is a feature change)?**

Building AngularBuilder now works in 1.8
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

None.
- **Other information**:

Beginning with 1.8, if a modules has both a .ts and .d.ts file, the .js file is not written.
