### PR TITLE
I18n expansion syntax

### DIFF
--- a/modules/angular2/src/compiler/directive_normalizer.ts
+++ b/modules/angular2/src/compiler/directive_normalizer.ts
@@ -23,6 +23,8 @@ import {
   HtmlAttrAst,
   HtmlAst,
   HtmlCommentAst,
+  HtmlExpansionAst,
+  HtmlExpansionCaseAst,
   htmlVisitAll
 } from './html_ast';
 import {HtmlParser} from './html_parser';
@@ -158,4 +160,7 @@ class TemplatePreparseVisitor implements HtmlAstVisitor {
   visitComment(ast: HtmlCommentAst, context: any): any { return null; }
   visitAttr(ast: HtmlAttrAst, context: any): any { return null; }
   visitText(ast: HtmlTextAst, context: any): any { return null; }
+  visitExpansion(ast: HtmlExpansionAst, context: any): any { return null; }
+
+  visitExpansionCase(ast: HtmlExpansionCaseAst, context: any): any { return null; }
 }

--- a/modules/angular2/src/compiler/html_ast.ts
+++ b/modules/angular2/src/compiler/html_ast.ts
@@ -12,6 +12,24 @@ export class HtmlTextAst implements HtmlAst {
   visit(visitor: HtmlAstVisitor, context: any): any { return visitor.visitText(this, context); }
 }
 
+export class HtmlExpansionAst implements HtmlAst {
+  constructor(public switchValue: string, public type: string, public cases: HtmlExpansionCaseAst[],
+              public sourceSpan: ParseSourceSpan, public switchValueSourceSpan: ParseSourceSpan) {}
+  visit(visitor: HtmlAstVisitor, context: any): any {
+    return visitor.visitExpansion(this, context);
+  }
+}
+
+export class HtmlExpansionCaseAst implements HtmlAst {
+  constructor(public value: string, public expression: HtmlAst[],
+              public sourceSpan: ParseSourceSpan, public valueSourceSpan: ParseSourceSpan,
+              public expSourceSpan: ParseSourceSpan) {}
+
+  visit(visitor: HtmlAstVisitor, context: any): any {
+    return visitor.visitExpansionCase(this, context);
+  }
+}
+
 export class HtmlAttrAst implements HtmlAst {
   constructor(public name: string, public value: string, public sourceSpan: ParseSourceSpan) {}
   visit(visitor: HtmlAstVisitor, context: any): any { return visitor.visitAttr(this, context); }
@@ -34,6 +52,8 @@ export interface HtmlAstVisitor {
   visitAttr(ast: HtmlAttrAst, context: any): any;
   visitText(ast: HtmlTextAst, context: any): any;
   visitComment(ast: HtmlCommentAst, context: any): any;
+  visitExpansion(ast: HtmlExpansionAst, context: any): any;
+  visitExpansionCase(ast: HtmlExpansionCaseAst, context: any): any;
 }
 
 export function htmlVisitAll(visitor: HtmlAstVisitor, asts: HtmlAst[], context: any = null): any[] {

--- a/modules/angular2/src/compiler/html_lexer.ts
+++ b/modules/angular2/src/compiler/html_lexer.ts
@@ -25,6 +25,11 @@ export enum HtmlTokenType {
   ATTR_NAME,
   ATTR_VALUE,
   DOC_TYPE,
+  EXPANSION_FORM_START,
+  EXPANSION_CASE_VALUE,
+  EXPANSION_CASE_EXP_START,
+  EXPANSION_CASE_EXP_END,
+  EXPANSION_FORM_END,
   EOF
 }
 
@@ -43,8 +48,10 @@ export class HtmlTokenizeResult {
   constructor(public tokens: HtmlToken[], public errors: HtmlTokenError[]) {}
 }
 
-export function tokenizeHtml(sourceContent: string, sourceUrl: string): HtmlTokenizeResult {
-  return new _HtmlTokenizer(new ParseSourceFile(sourceContent, sourceUrl)).tokenize();
+export function tokenizeHtml(sourceContent: string, sourceUrl: string,
+                             tokenizeExpansionForms: boolean = false): HtmlTokenizeResult {
+  return new _HtmlTokenizer(new ParseSourceFile(sourceContent, sourceUrl), tokenizeExpansionForms)
+      .tokenize();
 }
 
 const $EOF = 0;
@@ -75,6 +82,9 @@ const $GT = 62;
 const $QUESTION = 63;
 const $LBRACKET = 91;
 const $RBRACKET = 93;
+const $LBRACE = 123;
+const $RBRACE = 125;
+const $COMMA = 44;
 const $A = 65;
 const $F = 70;
 const $X = 88;
@@ -108,16 +118,20 @@ class _HtmlTokenizer {
   private length: number;
   // Note: this is always lowercase!
   private peek: number = -1;
+  private nextPeek: number = -1;
   private index: number = -1;
   private line: number = 0;
   private column: number = -1;
   private currentTokenStart: ParseLocation;
   private currentTokenType: HtmlTokenType;
 
+  private inExpansionCase: boolean = false;
+  private inExpansionForm: boolean = false;
+
   tokens: HtmlToken[] = [];
   errors: HtmlTokenError[] = [];
 
-  constructor(private file: ParseSourceFile) {
+  constructor(private file: ParseSourceFile, private tokenizeExpansionForms: boolean) {
     this.input = file.content;
     this.length = file.content.length;
     this._advance();
@@ -149,6 +163,18 @@ class _HtmlTokenizer {
           } else {
             this._consumeTagOpen(start);
           }
+        } else if (isSpecialFormStart(this.peek, this.nextPeek) && this.tokenizeExpansionForms) {
+          this._consumeExpansionFormStart();
+
+        } else if (this.peek === $EQ && this.tokenizeExpansionForms) {
+          this._consumeExpansionCaseStart();
+
+        } else if (this.peek === $RBRACE && this.inExpansionCase && this.tokenizeExpansionForms) {
+          this._consumeExpansionCaseEnd();
+
+        } else if (this.peek === $RBRACE && !this.inExpansionCase && this.tokenizeExpansionForms) {
+          this._consumeExpansionFormEnd();
+
         } else {
           this._consumeText();
         }
@@ -218,6 +244,8 @@ class _HtmlTokenizer {
     }
     this.index++;
     this.peek = this.index >= this.length ? $EOF : StringWrapper.charCodeAt(this.input, this.index);
+    this.nextPeek =
+        this.index + 1 >= this.length ? $EOF : StringWrapper.charCodeAt(this.input, this.index + 1);
   }
 
   private _attemptCharCode(charCode: number): boolean {
@@ -506,18 +534,107 @@ class _HtmlTokenizer {
     this._endToken(prefixAndName);
   }
 
+  private _consumeExpansionFormStart() {
+    this._beginToken(HtmlTokenType.EXPANSION_FORM_START, this._getLocation());
+    this._requireCharCode($LBRACE);
+    this._endToken([]);
+
+    this._beginToken(HtmlTokenType.RAW_TEXT, this._getLocation());
+    let condition = this._readUntil($COMMA);
+    this._endToken([condition], this._getLocation());
+    this._requireCharCode($COMMA);
+    this._attemptCharCodeUntilFn(isNotWhitespace);
+
+    this._beginToken(HtmlTokenType.RAW_TEXT, this._getLocation());
+    let type = this._readUntil($COMMA);
+    this._endToken([type], this._getLocation());
+    this._requireCharCode($COMMA);
+    this._attemptCharCodeUntilFn(isNotWhitespace);
+
+    this.inExpansionForm = true;
+  }
+
+  private _consumeExpansionCaseStart() {
+    this._requireCharCode($EQ);
+
+    this._beginToken(HtmlTokenType.EXPANSION_CASE_VALUE, this._getLocation());
+    let value = this._readUntil($LBRACE).trim();
+    this._endToken([value], this._getLocation());
+    this._attemptCharCodeUntilFn(isNotWhitespace);
+
+    this._beginToken(HtmlTokenType.EXPANSION_CASE_EXP_START, this._getLocation());
+    this._requireCharCode($LBRACE);
+    this._endToken([], this._getLocation());
+    this._attemptCharCodeUntilFn(isNotWhitespace);
+
+    this.inExpansionCase = true;
+  }
+
+  private _consumeExpansionCaseEnd() {
+    this._beginToken(HtmlTokenType.EXPANSION_CASE_EXP_END, this._getLocation());
+    this._requireCharCode($RBRACE);
+    this._endToken([], this._getLocation());
+    this._attemptCharCodeUntilFn(isNotWhitespace);
+
+    this.inExpansionCase = false;
+  }
+
+  private _consumeExpansionFormEnd() {
+    this._beginToken(HtmlTokenType.EXPANSION_FORM_END, this._getLocation());
+    this._requireCharCode($RBRACE);
+    this._endToken([]);
+
+    this.inExpansionForm = false;
+  }
+
   private _consumeText() {
     var start = this._getLocation();
     this._beginToken(HtmlTokenType.TEXT, start);
-    var parts = [this._readChar(true)];
-    while (!isTextEnd(this.peek)) {
+
+    var parts = [];
+    let interpolation = false;
+
+    if (this.peek === $LBRACE && this.nextPeek === $LBRACE) {
       parts.push(this._readChar(true));
+      parts.push(this._readChar(true));
+      interpolation = true;
+    } else {
+      parts.push(this._readChar(true));
+    }
+
+    while (!this.isTextEnd(interpolation)) {
+      if (this.peek === $LBRACE && this.nextPeek === $LBRACE) {
+        parts.push(this._readChar(true));
+        parts.push(this._readChar(true));
+        interpolation = true;
+      } else if (this.peek === $RBRACE && this.nextPeek === $RBRACE && interpolation) {
+        parts.push(this._readChar(true));
+        parts.push(this._readChar(true));
+        interpolation = false;
+      } else {
+        parts.push(this._readChar(true));
+      }
     }
     this._endToken([this._processCarriageReturns(parts.join(''))]);
   }
 
+  private isTextEnd(interpolation: boolean): boolean {
+    if (this.peek === $LT || this.peek === $EOF) return true;
+    if (this.tokenizeExpansionForms) {
+      if (isSpecialFormStart(this.peek, this.nextPeek)) return true;
+      if (this.peek === $RBRACE && !interpolation && this.inExpansionForm) return true;
+    }
+    return false;
+  }
+
   private _savePosition(): number[] {
     return [this.peek, this.index, this.column, this.line, this.tokens.length];
+  }
+
+  private _readUntil(char: number): string {
+    let start = this.index;
+    this._attemptUntilChar(char);
+    return this.input.substring(start, this.index);
   }
 
   private _restorePosition(position: number[]): void {
@@ -558,8 +675,8 @@ function isNamedEntityEnd(code: number): boolean {
   return code == $SEMICOLON || code == $EOF || !isAsciiLetter(code);
 }
 
-function isTextEnd(code: number): boolean {
-  return code === $LT || code === $EOF;
+function isSpecialFormStart(peek: number, nextPeek: number): boolean {
+  return peek === $LBRACE && nextPeek != $LBRACE;
 }
 
 function isAsciiLetter(code: number): boolean {

--- a/modules/angular2/src/compiler/html_parser.ts
+++ b/modules/angular2/src/compiler/html_parser.ts
@@ -150,7 +150,7 @@ class TreeBuilder {
       // parse everything in between { and }
       let parsedExp = new TreeBuilder(exp).build();
       if (parsedExp.errors.length > 0) {
-        this.errors = this.errors.concat(parsedExp.errors);
+        this.errors = this.errors.concat(<HtmlTreeError[]>parsedExp.errors);
         return;
       }
 

--- a/modules/angular2/src/compiler/legacy_template.ts
+++ b/modules/angular2/src/compiler/legacy_template.ts
@@ -88,7 +88,8 @@ export class LegacyHtmlAstTransformer implements HtmlAstVisitor {
 
   visitExpansion(ast: HtmlExpansionAst, context: any): any {
     let cases = ast.cases.map(c => c.visit(this, null));
-    return new HtmlExpansionAst(ast.switchValue, ast.type, cases, ast.sourceSpan);
+    return new HtmlExpansionAst(ast.switchValue, ast.type, cases, ast.sourceSpan,
+                                ast.switchValueSourceSpan);
   }
 
   visitExpansionCase(ast: HtmlExpansionCaseAst, context: any): any { return ast; }

--- a/modules/angular2/src/compiler/legacy_template.ts
+++ b/modules/angular2/src/compiler/legacy_template.ts
@@ -14,6 +14,8 @@ import {
   HtmlElementAst,
   HtmlTextAst,
   HtmlCommentAst,
+  HtmlExpansionAst,
+  HtmlExpansionCaseAst,
   HtmlAst
 } from './html_ast';
 import {HtmlParser, HtmlParseTreeResult} from './html_parser';
@@ -83,6 +85,13 @@ export class LegacyHtmlAstTransformer implements HtmlAstVisitor {
   }
 
   visitText(ast: HtmlTextAst, context: any): HtmlTextAst { return ast; }
+
+  visitExpansion(ast: HtmlExpansionAst, context: any): any {
+    let cases = ast.cases.map(c => c.visit(this, null));
+    return new HtmlExpansionAst(ast.switchValue, ast.type, cases, ast.sourceSpan);
+  }
+
+  visitExpansionCase(ast: HtmlExpansionCaseAst, context: any): any { return ast; }
 
   private _rewriteLongSyntax(ast: HtmlAttrAst): HtmlAttrAst {
     let m = RegExpWrapper.firstMatch(LONG_SYNTAX_REGEXP, ast.name);
@@ -211,9 +220,10 @@ export class LegacyHtmlAstTransformer implements HtmlAstVisitor {
 
 @Injectable()
 export class LegacyHtmlParser extends HtmlParser {
-  parse(sourceContent: string, sourceUrl: string): HtmlParseTreeResult {
+  parse(sourceContent: string, sourceUrl: string,
+        parseExpansionForms: boolean = false): HtmlParseTreeResult {
     let transformer = new LegacyHtmlAstTransformer();
-    let htmlParseTreeResult = super.parse(sourceContent, sourceUrl);
+    let htmlParseTreeResult = super.parse(sourceContent, sourceUrl, parseExpansionForms);
 
     let rootNodes = htmlParseTreeResult.rootNodes.map(node => node.visit(transformer, null));
 

--- a/modules/angular2/src/compiler/template_parser.ts
+++ b/modules/angular2/src/compiler/template_parser.ts
@@ -254,6 +254,10 @@ class TemplateParseVisitor implements HtmlAstVisitor {
     }
   }
 
+  visitExpansion(ast: HtmlExpansionAst, context: any): any { return null; }
+
+  visitExpansionCase(ast: HtmlExpansionCaseAst, context: any): any { return null; }
+
   visitText(ast: HtmlTextAst, parent: ElementContext): any {
     var ngContentIndex = parent.findNgContentIndex(TEXT_CSS_SELECTOR);
     var expr = this._parseInterpolation(ast.value, ast.sourceSpan);
@@ -270,7 +274,7 @@ class TemplateParseVisitor implements HtmlAstVisitor {
 
   visitComment(ast: HtmlCommentAst, context: any): any { return null; }
 
-  visitElement(element: HtmlElementAst, component: ElementContext): any {
+  visitElement(element: HtmlElementAst, parent: ElementContext): any {
     var nodeName = element.name;
     var preparsedElement = preparseElement(element);
     if (preparsedElement.type === PreparsedElementType.SCRIPT ||
@@ -773,7 +777,6 @@ class NonBindableVisitor implements HtmlAstVisitor {
     return new TextAst(ast.value, ngContentIndex, ast.sourceSpan);
   }
   visitExpansion(ast: HtmlExpansionAst, context: any): any { return ast; }
-
   visitExpansionCase(ast: HtmlExpansionCaseAst, context: any): any { return ast; }
 }
 

--- a/modules/angular2/src/compiler/template_parser.ts
+++ b/modules/angular2/src/compiler/template_parser.ts
@@ -64,6 +64,8 @@ import {
   HtmlAttrAst,
   HtmlTextAst,
   HtmlCommentAst,
+  HtmlExpansionAst,
+  HtmlExpansionCaseAst,
   htmlVisitAll
 } from './html_ast';
 
@@ -268,7 +270,7 @@ class TemplateParseVisitor implements HtmlAstVisitor {
 
   visitComment(ast: HtmlCommentAst, context: any): any { return null; }
 
-  visitElement(element: HtmlElementAst, parent: ElementContext): any {
+  visitElement(element: HtmlElementAst, component: ElementContext): any {
     var nodeName = element.name;
     var preparsedElement = preparseElement(element);
     if (preparsedElement.type === PreparsedElementType.SCRIPT ||
@@ -770,6 +772,9 @@ class NonBindableVisitor implements HtmlAstVisitor {
     var ngContentIndex = parent.findNgContentIndex(TEXT_CSS_SELECTOR);
     return new TextAst(ast.value, ngContentIndex, ast.sourceSpan);
   }
+  visitExpansion(ast: HtmlExpansionAst, context: any): any { return ast; }
+
+  visitExpansionCase(ast: HtmlExpansionCaseAst, context: any): any { return ast; }
 }
 
 class BoundElementOrDirectiveProperty {

--- a/modules/angular2/src/i18n/expander.ts
+++ b/modules/angular2/src/i18n/expander.ts
@@ -1,0 +1,95 @@
+import {
+  HtmlAst,
+  HtmlAstVisitor,
+  HtmlElementAst,
+  HtmlAttrAst,
+  HtmlTextAst,
+  HtmlCommentAst,
+  HtmlExpansionAst,
+  HtmlExpansionCaseAst,
+  htmlVisitAll
+} from 'angular2/src/compiler/html_ast';
+
+import {BaseException} from 'angular2/src/facade/exceptions';
+
+/**
+ * Expands special forms into elements.
+ *
+ * For example,
+ *
+ * ```
+ * { messages.length, plural,
+ *   =0 {zero}
+ *   =1 {one}
+ *   =other {more than one}
+ * }
+ * ```
+ *
+ * will be expanded into
+ *
+ * ```
+ * <ul [ngPlural]="messages.length">
+ *   <template [ngPluralCase]="0"><li i18n="plural_0">zero</li></template>
+ *   <template [ngPluralCase]="1"><li i18n="plural_1">one</li></template>
+ *   <template [ngPluralCase]="other"><li i18n="plural_other">more than one</li></template>
+ * </ul>
+ * ```
+ */
+export class Expander implements HtmlAstVisitor {
+  constructor() {}
+
+  visitElement(ast: HtmlElementAst, context: any): any {
+    return new HtmlElementAst(ast.name, ast.attrs, htmlVisitAll(this, ast.children), ast.sourceSpan,
+                              ast.startSourceSpan, ast.endSourceSpan);
+  }
+
+  visitAttr(ast: HtmlAttrAst, context: any): any { return ast; }
+
+  visitText(ast: HtmlTextAst, context: any): any { return ast; }
+
+  visitComment(ast: HtmlCommentAst, context: any): any { return ast; }
+
+  visitExpansion(ast: HtmlExpansionAst, context: any): any {
+    return ast.type == "plural" ? _expandPluralForm(ast) : _expandDefaultForm(ast);
+  }
+
+  visitExpansionCase(ast: HtmlExpansionCaseAst, context: any): any {
+    throw new BaseException("Should not be reached");
+  }
+}
+
+function _expandPluralForm(ast: HtmlExpansionAst): HtmlElementAst {
+  let children = ast.cases.map(
+      c => new HtmlElementAst(
+          `template`,
+          [
+            new HtmlAttrAst("[ngPluralCase]", c.value, c.valueSourceSpan),
+          ],
+          [
+            new HtmlElementAst(
+                `li`, [new HtmlAttrAst("i18n", `${ast.type}_${c.value}`, c.valueSourceSpan)],
+                c.expression, c.sourceSpan, c.sourceSpan, c.sourceSpan)
+          ],
+          c.sourceSpan, c.sourceSpan, c.sourceSpan));
+  let switchAttr = new HtmlAttrAst("[ngPlural]", ast.switchValue, ast.switchValueSourceSpan);
+  return new HtmlElementAst("ul", [switchAttr], children, ast.sourceSpan, ast.sourceSpan,
+                            ast.sourceSpan);
+}
+
+function _expandDefaultForm(ast: HtmlExpansionAst): HtmlElementAst {
+  let children = ast.cases.map(
+      c => new HtmlElementAst(
+          `template`,
+          [
+            new HtmlAttrAst("[ngSwitchWhen]", c.value, c.valueSourceSpan),
+          ],
+          [
+            new HtmlElementAst(
+                `li`, [new HtmlAttrAst("i18n", `${ast.type}_${c.value}`, c.valueSourceSpan)],
+                c.expression, c.sourceSpan, c.sourceSpan, c.sourceSpan)
+          ],
+          c.sourceSpan, c.sourceSpan, c.sourceSpan));
+  let switchAttr = new HtmlAttrAst("[ngSwitch]", ast.switchValue, ast.switchValueSourceSpan);
+  return new HtmlElementAst("ul", [switchAttr], children, ast.sourceSpan, ast.sourceSpan,
+                            ast.sourceSpan);
+}

--- a/modules/angular2/src/i18n/message_extractor.ts
+++ b/modules/angular2/src/i18n/message_extractor.ts
@@ -13,6 +13,7 @@ import {isPresent, isBlank} from 'angular2/src/facade/lang';
 import {StringMapWrapper} from 'angular2/src/facade/collection';
 import {Parser} from 'angular2/src/compiler/expression_parser/parser';
 import {Message, id} from './message';
+import {Expander} from './expander';
 import {
   I18nError,
   Part,
@@ -121,13 +122,18 @@ export class MessageExtractor {
     this.messages = [];
     this.errors = [];
 
-    let res = this._htmlParser.parse(template, sourceUrl);
+    let res = this._htmlParser.parse(template, sourceUrl, true);
     if (res.errors.length > 0) {
       return new ExtractionResult([], res.errors);
     } else {
-      this._recurse(res.rootNodes);
+      this._recurse(this._expandNodes(res.rootNodes));
       return new ExtractionResult(this.messages, this.errors);
     }
+  }
+
+  private _expandNodes(nodes: HtmlAst[]): HtmlAst[] {
+    let e = new Expander();
+    return htmlVisitAll(e, nodes);
   }
 
   private _extractMessagesFromPart(p: Part): void {

--- a/modules/angular2/src/i18n/message_extractor.ts
+++ b/modules/angular2/src/i18n/message_extractor.ts
@@ -13,7 +13,7 @@ import {isPresent, isBlank} from 'angular2/src/facade/lang';
 import {StringMapWrapper} from 'angular2/src/facade/collection';
 import {Parser} from 'angular2/src/compiler/expression_parser/parser';
 import {Message, id} from './message';
-import {Expander} from './expander';
+import {expandNodes} from './expander';
 import {
   I18nError,
   Part,
@@ -126,14 +126,9 @@ export class MessageExtractor {
     if (res.errors.length > 0) {
       return new ExtractionResult([], res.errors);
     } else {
-      this._recurse(this._expandNodes(res.rootNodes));
+      this._recurse(expandNodes(res.rootNodes).nodes);
       return new ExtractionResult(this.messages, this.errors);
     }
-  }
-
-  private _expandNodes(nodes: HtmlAst[]): HtmlAst[] {
-    let e = new Expander();
-    return htmlVisitAll(e, nodes);
   }
 
   private _extractMessagesFromPart(p: Part): void {

--- a/modules/angular2/src/i18n/shared.ts
+++ b/modules/angular2/src/i18n/shared.ts
@@ -6,6 +6,8 @@ import {
   HtmlAttrAst,
   HtmlTextAst,
   HtmlCommentAst,
+  HtmlExpansionAst,
+  HtmlExpansionCaseAst,
   htmlVisitAll
 } from 'angular2/src/compiler/html_ast';
 import {isPresent, isBlank, StringWrapper} from 'angular2/src/facade/lang';
@@ -178,6 +180,10 @@ class _StringifyVisitor implements HtmlAstVisitor {
   }
 
   visitComment(ast: HtmlCommentAst, context: any): any { return ""; }
+
+  visitExpansion(ast: HtmlExpansionAst, context: any): any { return null; }
+
+  visitExpansionCase(ast: HtmlExpansionCaseAst, context: any): any { return null; }
 
   private _join(strs: string[], str: string): string {
     return strs.filter(s => s.length > 0).join(str);

--- a/modules/angular2/test/compiler/html_ast_spec_utils.ts
+++ b/modules/angular2/test/compiler/html_ast_spec_utils.ts
@@ -6,6 +6,8 @@ import {
   HtmlAttrAst,
   HtmlTextAst,
   HtmlCommentAst,
+  HtmlExpansionAst,
+  HtmlExpansionCaseAst,
   htmlVisitAll
 } from 'angular2/src/compiler/html_ast';
 import {ParseError, ParseLocation} from 'angular2/src/compiler/parse_util';
@@ -66,6 +68,19 @@ class _Humanizer implements HtmlAstVisitor {
 
   visitComment(ast: HtmlCommentAst, context: any): any {
     var res = this._appendContext(ast, [HtmlCommentAst, ast.value, this.elDepth]);
+    this.result.push(res);
+    return null;
+  }
+
+  visitExpansion(ast: HtmlExpansionAst, context: any): any {
+    var res = this._appendContext(ast, [HtmlExpansionAst, ast.switchValue, ast.type]);
+    this.result.push(res);
+    htmlVisitAll(this, ast.cases);
+    return null;
+  }
+
+  visitExpansionCase(ast: HtmlExpansionCaseAst, context: any): any {
+    var res = this._appendContext(ast, [HtmlExpansionCaseAst, ast.value]);
     this.result.push(res);
     return null;
   }

--- a/modules/angular2/test/compiler/html_lexer_spec.ts
+++ b/modules/angular2/test/compiler/html_lexer_spec.ts
@@ -646,6 +646,31 @@ export function main() {
               [HtmlTokenType.EOF]
             ]);
       });
+
+      it("should parse nested expansion forms", () => {
+        expect(tokenizeAndHumanizeParts(`{one.two, three, =4 { {xx, yy, =x {one}} }}`, true))
+            .toEqual([
+              [HtmlTokenType.EXPANSION_FORM_START],
+              [HtmlTokenType.RAW_TEXT, 'one.two'],
+              [HtmlTokenType.RAW_TEXT, 'three'],
+              [HtmlTokenType.EXPANSION_CASE_VALUE, '4'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_START],
+
+              [HtmlTokenType.EXPANSION_FORM_START],
+              [HtmlTokenType.RAW_TEXT, 'xx'],
+              [HtmlTokenType.RAW_TEXT, 'yy'],
+              [HtmlTokenType.EXPANSION_CASE_VALUE, 'x'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_START],
+              [HtmlTokenType.TEXT, 'one'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_END],
+              [HtmlTokenType.EXPANSION_FORM_END],
+              [HtmlTokenType.TEXT, ' '],
+
+              [HtmlTokenType.EXPANSION_CASE_EXP_END],
+              [HtmlTokenType.EXPANSION_FORM_END],
+              [HtmlTokenType.EOF]
+            ]);
+      });
     });
 
     describe('errors', () => {

--- a/modules/angular2/test/compiler/html_lexer_spec.ts
+++ b/modules/angular2/test/compiler/html_lexer_spec.ts
@@ -576,6 +576,78 @@ export function main() {
 
     });
 
+    describe("expansion forms", () => {
+      it("should parse an expansion form", () => {
+        expect(tokenizeAndHumanizeParts('{one.two, three, =4 {four} =5 {five} }', true))
+            .toEqual([
+              [HtmlTokenType.EXPANSION_FORM_START],
+              [HtmlTokenType.RAW_TEXT, 'one.two'],
+              [HtmlTokenType.RAW_TEXT, 'three'],
+              [HtmlTokenType.EXPANSION_CASE_VALUE, '4'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_START],
+              [HtmlTokenType.TEXT, 'four'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_END],
+              [HtmlTokenType.EXPANSION_CASE_VALUE, '5'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_START],
+              [HtmlTokenType.TEXT, 'five'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_END],
+              [HtmlTokenType.EXPANSION_FORM_END],
+              [HtmlTokenType.EOF]
+            ]);
+      });
+
+      it("should parse an expansion form with text elements surrounding it", () => {
+        expect(tokenizeAndHumanizeParts('before{one.two, three, =4 {four}}after', true))
+            .toEqual([
+              [HtmlTokenType.TEXT, "before"],
+              [HtmlTokenType.EXPANSION_FORM_START],
+              [HtmlTokenType.RAW_TEXT, 'one.two'],
+              [HtmlTokenType.RAW_TEXT, 'three'],
+              [HtmlTokenType.EXPANSION_CASE_VALUE, '4'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_START],
+              [HtmlTokenType.TEXT, 'four'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_END],
+              [HtmlTokenType.EXPANSION_FORM_END],
+              [HtmlTokenType.TEXT, "after"],
+              [HtmlTokenType.EOF]
+            ]);
+      });
+
+      it("should parse an expansion forms with elements in it", () => {
+        expect(tokenizeAndHumanizeParts('{one.two, three, =4 {four <b>a</b>}}', true))
+            .toEqual([
+              [HtmlTokenType.EXPANSION_FORM_START],
+              [HtmlTokenType.RAW_TEXT, 'one.two'],
+              [HtmlTokenType.RAW_TEXT, 'three'],
+              [HtmlTokenType.EXPANSION_CASE_VALUE, '4'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_START],
+              [HtmlTokenType.TEXT, 'four '],
+              [HtmlTokenType.TAG_OPEN_START, null, 'b'],
+              [HtmlTokenType.TAG_OPEN_END],
+              [HtmlTokenType.TEXT, 'a'],
+              [HtmlTokenType.TAG_CLOSE, null, 'b'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_END],
+              [HtmlTokenType.EXPANSION_FORM_END],
+              [HtmlTokenType.EOF]
+            ]);
+      });
+
+      it("should parse an expansion forms with interpolation in it", () => {
+        expect(tokenizeAndHumanizeParts('{one.two, three, =4 {four {{a}}}}', true))
+            .toEqual([
+              [HtmlTokenType.EXPANSION_FORM_START],
+              [HtmlTokenType.RAW_TEXT, 'one.two'],
+              [HtmlTokenType.RAW_TEXT, 'three'],
+              [HtmlTokenType.EXPANSION_CASE_VALUE, '4'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_START],
+              [HtmlTokenType.TEXT, 'four {{a}}'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_END],
+              [HtmlTokenType.EXPANSION_FORM_END],
+              [HtmlTokenType.EOF]
+            ]);
+      });
+    });
+
     describe('errors', () => {
       it('should include 2 lines of context in message', () => {
         let src = "111\n222\n333\nE\n444\n555\n666\n";
@@ -604,8 +676,9 @@ export function main() {
   });
 }
 
-function tokenizeWithoutErrors(input: string): HtmlToken[] {
-  var tokenizeResult = tokenizeHtml(input, 'someUrl');
+function tokenizeWithoutErrors(input: string,
+                               tokenizeExpansionForms: boolean = false): HtmlToken[] {
+  var tokenizeResult = tokenizeHtml(input, 'someUrl', tokenizeExpansionForms);
   if (tokenizeResult.errors.length > 0) {
     var errorString = tokenizeResult.errors.join('\n');
     throw new BaseException(`Unexpected parse errors:\n${errorString}`);
@@ -613,8 +686,9 @@ function tokenizeWithoutErrors(input: string): HtmlToken[] {
   return tokenizeResult.tokens;
 }
 
-function tokenizeAndHumanizeParts(input: string): any[] {
-  return tokenizeWithoutErrors(input).map(token => [<any>token.type].concat(token.parts));
+function tokenizeAndHumanizeParts(input: string, tokenizeExpansionForms: boolean = false): any[] {
+  return tokenizeWithoutErrors(input, tokenizeExpansionForms)
+      .map(token => [<any>token.type].concat(token.parts));
 }
 
 function tokenizeAndHumanizeSourceSpans(input: string): any[] {

--- a/modules/angular2/test/compiler/html_parser_spec.ts
+++ b/modules/angular2/test/compiler/html_parser_spec.ts
@@ -18,7 +18,9 @@ import {
   HtmlAttrAst,
   HtmlTextAst,
   HtmlCommentAst,
-  htmlVisitAll
+  htmlVisitAll,
+  HtmlExpansionAst,
+  HtmlExpansionCaseAst
 } from 'angular2/src/compiler/html_ast';
 import {ParseError, ParseLocation} from 'angular2/src/compiler/parse_util';
 import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './html_ast_spec_utils';
@@ -227,7 +229,7 @@ export function main() {
               .toEqual([[HtmlElementAst, 'template', 0], [HtmlAttrAst, 'k', 'v']]);
         });
 
-        it('should support mamespace', () => {
+        it('should support namespace', () => {
           expect(humanizeDom(parser.parse('<svg:use xlink:href="Port" />', 'TestComp')))
               .toEqual([[HtmlElementAst, '@svg:use', 0], [HtmlAttrAst, '@xlink:href', 'Port']]);
         });
@@ -237,6 +239,54 @@ export function main() {
         it('should preserve comments', () => {
           expect(humanizeDom(parser.parse('<!-- comment --><div></div>', 'TestComp')))
               .toEqual([[HtmlCommentAst, 'comment', 0], [HtmlElementAst, 'div', 0]]);
+        });
+      });
+
+      describe("expansion forms", () => {
+        it("should parse out expansion forms", () => {
+          let parsed = parser.parse(`<div>before{messages.length, plural, =0 {You have <b>no</b> messages} =1 {One {{message}}}}after</div>`,
+                                    'TestComp', true);
+
+          expect(humanizeDom(parsed))
+              .toEqual([
+                [HtmlElementAst, 'div', 0],
+                [HtmlTextAst, 'before', 1],
+                [HtmlExpansionAst, 'messages.length', 'plural'],
+                [HtmlExpansionCaseAst, '0'],
+                [HtmlExpansionCaseAst, '1'],
+                [HtmlTextAst, 'after', 1]
+              ]);
+
+          let cases = (<any>parsed.rootNodes[0]).children[1].cases;
+
+          expect(humanizeDom(new HtmlParseTreeResult(cases[0].expression, [])))
+              .toEqual([
+                [HtmlTextAst, 'You have ', 0],
+                [HtmlElementAst, 'b', 0],
+                [HtmlTextAst, 'no', 1],
+                [HtmlTextAst, ' messages', 0],
+              ]);
+
+          expect(humanizeDom(new HtmlParseTreeResult(cases[1].expression, [])))
+              .toEqual([[HtmlTextAst, 'One {{message}}', 0]]);
+        });
+
+        it("should error when expansion form is not closed", () => {
+          let p = parser.parse(`{messages.length, plural, =0 {one}`, 'TestComp', true);
+          expect(humanizeErrors(p.errors))
+              .toEqual([[null, "Invalid expansion form. Missing '}'.", '0:34']]);
+        });
+
+        it("should error when expansion case is not closed", () => {
+          let p = parser.parse(`{messages.length, plural, =0 {one`, 'TestComp', true);
+          expect(humanizeErrors(p.errors))
+              .toEqual([[null, "Invalid expansion form. Missing '}'.", '0:29']]);
+        });
+
+        it("should error when invalid html in the case", () => {
+          let p = parser.parse(`{messages.length, plural, =0 {<b/>}`, 'TestComp', true);
+          expect(humanizeErrors(p.errors))
+              .toEqual([['b', 'Only void and foreign elements can be self closed "b"', '0:30']]);
         });
       });
 

--- a/modules/angular2/test/compiler/html_parser_spec.ts
+++ b/modules/angular2/test/compiler/html_parser_spec.ts
@@ -271,6 +271,27 @@ export function main() {
               .toEqual([[HtmlTextAst, 'One {{message}}', 0]]);
         });
 
+        it("should parse out nested expansion forms", () => {
+          let parsed = parser.parse(`{messages.length, plural, =0 { {p.gender, gender, =m {m}} }}`,
+                                    'TestComp', true);
+
+
+          expect(humanizeDom(parsed))
+              .toEqual([
+                [HtmlExpansionAst, 'messages.length', 'plural'],
+                [HtmlExpansionCaseAst, '0'],
+              ]);
+
+          let firstCase = (<any>parsed.rootNodes[0]).cases[0];
+
+          expect(humanizeDom(new HtmlParseTreeResult(firstCase.expression, [])))
+              .toEqual([
+                [HtmlExpansionAst, 'p.gender', 'gender'],
+                [HtmlExpansionCaseAst, 'm'],
+                [HtmlTextAst, ' ', 0],
+              ]);
+        });
+
         it("should error when expansion form is not closed", () => {
           let p = parser.parse(`{messages.length, plural, =0 {one}`, 'TestComp', true);
           expect(humanizeErrors(p.errors))

--- a/modules/angular2/test/i18n/i18n_html_parser_spec.ts
+++ b/modules/angular2/test/i18n/i18n_html_parser_spec.ts
@@ -188,7 +188,7 @@ export function main() {
       expect(res[1].sourceSpan.start.offset).toEqual(10);
     });
 
-    it("should handle the plural special form", () => {
+    it("should handle the plural expansion form", () => {
       let translations: {[key: string]: string} = {};
       translations[id(new Message('zero<ph name="e1">bold</ph>', "plural_0", null))] =
           'ZERO<ph name="e1">BOLD</ph>';
@@ -200,11 +200,36 @@ export function main() {
             [HtmlElementAst, 'ul', 0],
             [HtmlAttrAst, '[ngPlural]', 'messages.length'],
             [HtmlElementAst, 'template', 1],
-            [HtmlAttrAst, '[ngPluralCase]', '0'],
+            [HtmlAttrAst, 'ngPluralCase', '0'],
             [HtmlElementAst, 'li', 2],
             [HtmlTextAst, 'ZERO', 3],
             [HtmlElementAst, 'b', 3],
             [HtmlTextAst, 'BOLD', 4]
+          ]);
+    });
+
+    it("should handle nested expansion forms", () => {
+      let translations: {[key: string]: string} = {};
+      translations[id(new Message('m', "gender_m", null))] = 'M';
+
+      let res = parse(`{messages.length, plural, =0 { {p.gender, gender, =m {m}} }}`, translations);
+
+      expect(humanizeDom(res))
+          .toEqual([
+            [HtmlElementAst, 'ul', 0],
+            [HtmlAttrAst, '[ngPlural]', 'messages.length'],
+            [HtmlElementAst, 'template', 1],
+            [HtmlAttrAst, 'ngPluralCase', '0'],
+            [HtmlElementAst, 'li', 2],
+
+            [HtmlElementAst, 'ul', 3],
+            [HtmlAttrAst, '[ngSwitch]', 'p.gender'],
+            [HtmlElementAst, 'template', 4],
+            [HtmlAttrAst, 'ngSwitchWhen', 'm'],
+            [HtmlElementAst, 'li', 5],
+            [HtmlTextAst, 'M', 6],
+
+            [HtmlTextAst, ' ', 3]
           ]);
     });
 
@@ -258,7 +283,7 @@ export function main() {
             [HtmlElementAst, 'ul', 0],
             [HtmlAttrAst, '[ngSwitch]', 'person.gender'],
             [HtmlElementAst, 'template', 1],
-            [HtmlAttrAst, '[ngSwitchWhen]', 'male'],
+            [HtmlAttrAst, 'ngSwitchWhen', 'male'],
             [HtmlElementAst, 'li', 2],
             [HtmlTextAst, 'M', 3],
           ]);
@@ -273,13 +298,13 @@ export function main() {
       it("should error when no matching message (attr)", () => {
         let mid = id(new Message("some message", null, null));
         expect(humanizeErrors(parse("<div value='some message' i18n-value></div>", {}).errors))
-            .toEqual([`Cannot find message for id '${mid}'`]);
+            .toEqual([`Cannot find message for id '${mid}', content 'some message'.`]);
       });
 
       it("should error when no matching message (text)", () => {
         let mid = id(new Message("some message", null, null));
         expect(humanizeErrors(parse("<div i18n>some message</div>", {}).errors))
-            .toEqual([`Cannot find message for id '${mid}'`]);
+            .toEqual([`Cannot find message for id '${mid}', content 'some message'.`]);
       });
 
       it("should error when a non-placeholder element appears in translation", () => {

--- a/modules/angular2/test/i18n/message_extractor_spec.ts
+++ b/modules/angular2/test/i18n/message_extractor_spec.ts
@@ -176,6 +176,24 @@ export function main() {
           ]);
     });
 
+    it("should extract messages from special forms", () => {
+      let res = extractor.extract(`
+        <div>
+          {messages.length, plural,
+             =0 {You have <b>no</b> messages}
+             =1 {You have one message}
+          }
+        </div>
+      `,
+                                  "someurl");
+
+      expect(res.messages)
+          .toEqual([
+            new Message('You have <ph name="e1">no</ph> messages', "plural_0", null),
+            new Message('You have one message', "plural_1", null)
+          ]);
+    });
+
     it("should remove duplicate messages", () => {
       let res = extractor.extract(`
          <!-- i18n: meaning|desc1 -->message<!-- /i18n -->


### PR DESCRIPTION
Add support for 

```
{messages.length, plural,
  =0 {zero}
  =1 {one}
  =other {more than 1}
}
```
