### PR TITLE
feat(DomAdapter): allow "global" for getGlobalEventTarget

### DIFF
--- a/modules/angular2/src/platform/browser/browser_adapter.dart
+++ b/modules/angular2/src/platform/browser/browser_adapter.dart
@@ -438,7 +438,7 @@ class BrowserDomAdapter extends GenericBrowserDomAdapter {
   }
 
   getGlobalEventTarget(String target) {
-    if (target == "window") {
+    if (target == "window" || target == "global") {
       return window;
     } else if (target == "document") {
       return document;

--- a/modules/angular2/src/platform/browser/browser_adapter.ts
+++ b/modules/angular2/src/platform/browser/browser_adapter.ts
@@ -309,11 +309,11 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     return key;
   }
   getGlobalEventTarget(target: string): EventTarget {
-    if (target == "window") {
+    if (target === "window" || target === "global") {
       return window;
-    } else if (target == "document") {
+    } else if (target === "document") {
       return document;
-    } else if (target == "body") {
+    } else if (target === "body") {
       return document.body;
     }
   }

--- a/modules/angular2/src/platform/server/parse5_adapter.ts
+++ b/modules/angular2/src/platform/server/parse5_adapter.ts
@@ -531,11 +531,11 @@ export class Parse5DomAdapter extends DomAdapter {
   supportsDOMEvents(): boolean { return false; }
   supportsNativeShadowDOM(): boolean { return false; }
   getGlobalEventTarget(target: string): any {
-    if (target == "window") {
+    if (target === "window" || target === "global") {
       return (<any>this.defaultDoc())._window;
-    } else if (target == "document") {
+    } else if (target === "document") {
       return this.defaultDoc();
-    } else if (target == "body") {
+    } else if (target === "body") {
       return this.defaultDoc().body;
     }
   }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  allows the user to bind to global events using the `"global"` name as an alias to `"window"`
