### PR TITLE
fix(7877): StaticReflector returns empty results instead of undefined.

### DIFF
--- a/modules/angular2/src/compiler/static_reflector.ts
+++ b/modules/angular2/src/compiler/static_reflector.ts
@@ -90,6 +90,8 @@ export class StaticReflector {
         annotations = (<any[]>classMetadata['decorators'])
                           .map(decorator => this.convertKnownDecorator(type.moduleId, decorator))
                           .filter(decorator => isPresent(decorator));
+      } else {
+        annotations = [];
       }
       this.annotationCache.set(type, annotations);
     }
@@ -101,6 +103,9 @@ export class StaticReflector {
     if (!isPresent(propMetadata)) {
       let classMetadata = this.getTypeMetadata(type);
       propMetadata = this.getPropertyMetadata(type.moduleId, classMetadata['members']);
+      if (!isPresent(propMetadata)) {
+        propMetadata = {};
+      }
       this.propertyCache.set(type, propMetadata);
     }
     return propMetadata;
@@ -110,12 +115,20 @@ export class StaticReflector {
     let parameters = this.parameterCache.get(type);
     if (!isPresent(parameters)) {
       let classMetadata = this.getTypeMetadata(type);
-      let ctorData = classMetadata['members']['__ctor__'];
-      if (isPresent(ctorData)) {
-        let ctor = (<any[]>ctorData).find(a => a['__symbolic'] === 'constructor');
-        parameters = this.simplify(type.moduleId, ctor['parameters']);
-        this.parameterCache.set(type, parameters);
+      if (isPresent(classMetadata)) {
+        let members = classMetadata['members'];
+        if (isPresent(members)) {
+          let ctorData = members['__ctor__'];
+          if (isPresent(ctorData)) {
+            let ctor = (<any[]>ctorData).find(a => a['__symbolic'] === 'constructor');
+            parameters = this.simplify(type.moduleId, ctor['parameters']);
+          }
+        }
       }
+      if (!isPresent(parameters)) {
+        parameters = [];
+      }
+      this.parameterCache.set(type, parameters);
     }
     return parameters;
   }
@@ -290,7 +303,7 @@ export class StaticReflector {
       });
       return result;
     }
-    return null;
+    return {};
   }
 
   // clang-format off

--- a/modules/angular2/test/compiler/static_reflector_spec.ts
+++ b/modules/angular2/test/compiler/static_reflector_spec.ts
@@ -60,6 +60,15 @@ export function main() {
       expect(annotation.selector).toEqual('my-hero-detail');
     });
 
+    it('should get and empty annotation list for an unknown class', () => {
+      let host = new MockReflectorHost();
+      let reflector = new StaticReflector(host);
+
+      let UnknownClass = reflector.getStaticType('./app/app.component', 'UnknownClass');
+      let annotations = reflector.annotations(UnknownClass);
+      expect(annotations).toEqual([]);
+    });
+
     it('should get propMetadata for HeroDetailComponent', () => {
       let host = new MockReflectorHost();
       let reflector = new StaticReflector(host);
@@ -68,6 +77,24 @@ export function main() {
           reflector.getStaticType('./app/hero-detail.component', 'HeroDetailComponent');
       let props = reflector.propMetadata(HeroDetailComponent);
       expect(props['hero']).toBeTruthy();
+    });
+
+    it('should get an empty object from propMetadata for an unknown class', () => {
+      let host = new MockReflectorHost();
+      let reflector = new StaticReflector(host);
+
+      let UnknownClass = reflector.getStaticType('./app/app.component', 'UnknownClass');
+      let properties = reflector.propMetadata(UnknownClass);
+      expect(properties).toEqual({});
+    });
+
+    it('should get empty parameters list for an unknown class ', () => {
+      let host = new MockReflectorHost();
+      let reflector = new StaticReflector(host);
+
+      let UnknownClass = reflector.getStaticType('./app/app.component', 'UnknownClass');
+      let parameters = reflector.parameters(UnknownClass);
+      expect(parameters).toEqual([]);
     });
 
     it('should simplify primitive into itself', () => {


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix
- **What is the current behavior?** (You can also link to an open issue here)
#7877
- **What is the new behavior (if this is a feature change)?**

More accurately duplicates `Reflector` behavior when passed types with no metadata.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.
- **Other information**:

Reflector always returns either an empty object or an empty list if no
metadata is recorded for the class. StaticReflector matches this
behavior.
