### PR TITLE
chore(gulpfile): turn off mangle for prod bundles

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1203,7 +1203,8 @@ gulp.task('!bundle.js.prod', ['build.js.prod'], function() {
 // minified production build
 gulp.task('!bundle.js.min', ['build.js.prod'], function() {
   var bundler = require('./tools/build/bundle');
-  var bundlerConfig = {sourceMaps: true, minify: true};
+  var bundlerConfig =
+      {sourceMaps: true, minify: true, mangle: false, uglify: {compress: {keep_fnames: true}}};
 
   return bundler.bundle(bundleConfig, NG2_BUNDLE_CONTENT, './dist/build/angular2.min.js',
                         bundlerConfig)


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  fix
- **What is the current behavior?** (You can also link to an open issue here)
  problems with templates invoking props after the class is mangled
- **What is the new behavior (if this is a feature change)?**
  unmangle minified code
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  larger minified bundles
