### PR TITLE
docs(markdown): update markdown headers

### DIFF
--- a/modules/angular2/src/common/directives/ng_for.ts
+++ b/modules/angular2/src/common/directives/ng_for.ts
@@ -21,7 +21,7 @@ import {BaseException} from "../../facade/exceptions";
  * each instantiated template inherits from the outer context with the given loop variable set
  * to the current item from the iterable.
  *
- * # Local Variables
+ * ### Local Variables
  *
  * `NgFor` provides several exported values that can be aliased to local variables:
  *
@@ -33,7 +33,7 @@ import {BaseException} from "../../facade/exceptions";
  * * `even` will be set to a boolean value indicating whether this item has an even index.
  * * `odd` will be set to a boolean value indicating whether this item has an odd index.
  *
- * # Change Propagation
+ * ### Change Propagation
  *
  * When the contents of the iterator changes, `NgFor` makes the corresponding changes to the DOM:
  *
@@ -56,7 +56,7 @@ import {BaseException} from "../../facade/exceptions";
  * elements were deleted and all new elements inserted). This is an expensive operation and should
  * be avoided if possible.
  *
- * # Syntax
+ * ### Syntax
  *
  * - `<li *ngFor="#item of items; #i = index">...</li>`
  * - `<li template="ngFor #item of items; #i = index">...</li>`

--- a/modules/angular2/src/common/directives/ng_switch.ts
+++ b/modules/angular2/src/common/directives/ng_switch.ts
@@ -21,7 +21,7 @@ export class SwitchView {
  * `NgSwitch` simply inserts nested elements based on which match expression matches the value
  * obtained from the evaluated switch expression. In other words, you define a container element
  * (where you place the directive with a switch expression on the
- * **`[ngSwitch]="..."` attribute**), define any inner elements inside of the directive and
+ * `[ngSwitch]="..."` attribute), define any inner elements inside of the directive and
  * place a `[ngSwitchWhen]` attribute per element.
  *
  * The `ngSwitchWhen` property is used to inform `NgSwitch` which element to display when the

--- a/modules/angular2/src/common/forms/directives/ng_form_control.ts
+++ b/modules/angular2/src/common/forms/directives/ng_form_control.ts
@@ -57,7 +57,7 @@ const formControlBinding =
  * }
  *  ```
  *
- * ###ngModel
+ * ### ngModel
  *
  * We can also use `ngModel` to bind a domain model to the form.
  *


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Minor update ng_form_control.ts, there is a missing space between `###` and `ngModel`. 

@naomiblack we are also decreasing the size of the headers inside the documentation from h1s to h3s.
- **What is the current behavior?** (You can also link to an open issue here)
  Looks like this in production:
  ![screenshot 2016-04-09 16 29 18](https://cloud.githubusercontent.com/assets/1329167/14406233/3e73c618-fe70-11e5-9853-8749b3f17497.png)
  Notice the markdown in the subtitle ngModel.
- **What is the new behavior (if this is a feature change)?**
  This is how it looks after adding the missing space.
  ![screenshot 2016-04-09 16 29 05](https://cloud.githubusercontent.com/assets/1329167/14406238/508826d2-fe70-11e5-855f-5e3ff714f109.png)
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  Rebuild documentation for angular.io
