### PR TITLE
fix: remove typescript references to d.ts files from benchpress and e2e tests

### DIFF
--- a/modules/benchpress/benchpress.ts
+++ b/modules/benchpress/benchpress.ts
@@ -1,5 +1,3 @@
-/// <reference path="../angular2/typings/node/node.d.ts" />
-
 import {bind, provide} from 'angular2/src/core/di';
 import {Options} from './common';
 

--- a/modules/benchpress/src/firefox_extension/lib/main.ts
+++ b/modules/benchpress/src/firefox_extension/lib/main.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../../../angular2/typings/node/node.d.ts" />
-
 var {Cc, Ci, Cu} = require('chrome');
 var os = Cc['@mozilla.org/observer-service;1'].getService(Ci.nsIObserverService);
 var ParserUtil = require('./parser_util');

--- a/modules/benchpress/src/firefox_extension/lib/parser_util.ts
+++ b/modules/benchpress/src/firefox_extension/lib/parser_util.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../../../angular2/typings/node/node.d.ts" />
-
 /**
  * @param {Object} perfProfile The perf profile JSON object.
  * @return {Object[]} An array of recognized events that are captured

--- a/modules/benchpress/test/firefox_extension/conf.ts
+++ b/modules/benchpress/test/firefox_extension/conf.ts
@@ -1,4 +1,3 @@
-/// <reference path="../../../angular2/typings/node/node.d.ts" />
 require('es6-shim/es6-shim.js');
 require('reflect-metadata');
 var testHelper = require('../../src/firefox_extension/lib/test_helper.js');

--- a/modules/benchpress/test/firefox_extension/spec.ts
+++ b/modules/benchpress/test/firefox_extension/spec.ts
@@ -1,7 +1,3 @@
-/// <reference path="../../../angular2/typings/node/node.d.ts" />
-/// <reference path="../../../angular2/typings/angular-protractor/angular-protractor.d.ts" />
-/// <reference path="../../../angular2/typings/jasmine/jasmine.d.ts" />
-
 var assertEventsContainsName = function(events, eventName) {
   var found = false;
   for (var i = 0; i < events.length; ++i) {

--- a/modules/playground/e2e_test/http/http_spec.ts
+++ b/modules/playground/e2e_test/http/http_spec.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../../angular2/typings/jasmine/jasmine.d.ts" />
-
 import {verifyNoBrowserErrors} from 'angular2/src/testing/e2e_util';
 
 describe('http', function() {

--- a/modules/playground/e2e_test/jsonp/jsonp_spec.ts
+++ b/modules/playground/e2e_test/jsonp/jsonp_spec.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../../angular2/typings/jasmine/jasmine.d.ts" />
-
 import {verifyNoBrowserErrors} from 'angular2/src/testing/e2e_util';
 
 describe('jsonp', function() {


### PR DESCRIPTION
using "/// <reference" is incorrect because it makes our code non-portable. The correct solution is to provide
these typings as ambient typings as an additional entry point - which we already do.
