### PR TITLE
fix(http) : set response.ok based on given status code

### DIFF
--- a/modules/angular2/src/http/static_response.ts
+++ b/modules/angular2/src/http/static_response.ts
@@ -76,6 +76,7 @@ export class Response {
   constructor(responseOptions: ResponseOptions) {
     this._body = responseOptions.body;
     this.status = responseOptions.status;
+    this.ok = (this.status >= 200 && this.status <= 299);
     this.statusText = responseOptions.statusText;
     this.headers = responseOptions.headers;
     this.type = responseOptions.type;

--- a/modules/angular2/test/http/static_response_spec.ts
+++ b/modules/angular2/test/http/static_response_spec.ts
@@ -1,0 +1,24 @@
+import {
+  describe,
+  expect,
+  it,
+} from 'angular2/testing_internal';
+
+import {ResponseOptions} from 'angular2/src/http/base_response_options';
+import {Response} from 'angular2/src/http/static_response';
+
+
+
+export function main() {
+  describe('Response', () => {
+    it('should be ok for 200 statuses', () => {
+      expect(new Response(new ResponseOptions({status: 200})).ok).toEqual(true);
+      expect(new Response(new ResponseOptions({status: 299})).ok).toEqual(true);
+    });
+
+    it('should not be ok for non 200 statuses', () => {
+      expect(new Response(new ResponseOptions({status: 199})).ok).toEqual(false);
+      expect(new Response(new ResponseOptions({status: 300})).ok).toEqual(false);
+    });
+  });
+}


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  bug fix
- **What is the current behavior?** (You can also link to an open issue here)
  response.ok is not defined
- **What is the new behavior (if this is a feature change)?**
  response.ok is set to true if status is 200-299 (as already documented)

closes #6503
