### PR TITLE
fix(angular_1_router): Removed arrow function from module template

### DIFF
--- a/modules/angular1_router/src/module_template.js
+++ b/modules/angular1_router/src/module_template.js
@@ -96,7 +96,7 @@ function routerFactory($q, $location, $browser, $rootScope, $injector, $routerRo
         controller.$routeConfig.forEach(function (config) {
           var loader = config.loader;
           if (isPresent(loader)) {
-            config = angular.extend({}, config, { loader: () => $injector.invoke(loader) });
+            config = angular.extend({}, config, { loader: function() { return $injector.invoke(loader); } });
           }
           that.config(component, config);
         });


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix
- **What is the current behavior?** (You can also link to an open issue here)

Angular 1 Router breaks in IE due to fat arrow function not being transpiled
- **What is the new behavior (if this is a feature change)?**

Allows angular 1 router to function in IE without breaking
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
- **Other information**:

Closes #7913 #8074

cc: @petebacondarwin 
