### PR TITLE
fix(MockBackend): move import of ReplaySubject under src/

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1304,10 +1304,10 @@ gulp.task('!bundles.js.umd', ['build.js.dev'], function() {
       externals: {
         'rxjs/Observable': 'umd Rx',
         'rxjs/Subject': 'umd Rx',
-        'rxjs/subject/ReplaySubject': {
-          commonjs: 'rxjs/subject/ReplaySubject',
-          commonjs2: 'rxjs/subject/ReplaySubject',
-          amd: 'rxjs/subject/ReplaySubject',
+        'rxjs/ReplaySubject': {
+          commonjs: 'rxjs/ReplaySubject',
+          commonjs2: 'rxjs/ReplaySubject',
+          amd: 'rxjs/ReplaySubject',
           root: ['Rx']
         },
         'rxjs/operator/take': {

--- a/modules/angular2/src/http/backends/mock_backend.ts
+++ b/modules/angular2/src/http/backends/mock_backend.ts
@@ -6,7 +6,7 @@ import {Connection, ConnectionBackend} from '../interfaces';
 import {isPresent} from 'angular2/src/facade/lang';
 import {BaseException, WrappedException} from 'angular2/src/facade/exceptions';
 import {Subject} from 'rxjs/Subject';
-import {ReplaySubject} from 'rxjs/subject/ReplaySubject';
+import {ReplaySubject} from 'rxjs/ReplaySubject';
 import {take} from 'rxjs/operator/take';
 
 /**

--- a/modules/angular2/test/http/backends/mock_backend_spec.ts
+++ b/modules/angular2/test/http/backends/mock_backend_spec.ts
@@ -22,7 +22,7 @@ import {Map} from 'angular2/src/facade/collection';
 import {RequestOptions, BaseRequestOptions} from 'angular2/src/http/base_request_options';
 import {BaseResponseOptions, ResponseOptions} from 'angular2/src/http/base_response_options';
 import {ResponseType} from 'angular2/src/http/enums';
-import {ReplaySubject} from 'rxjs/subject/ReplaySubject';
+import {ReplaySubject} from 'rxjs/ReplaySubject';
 
 export function main() {
   describe('MockBackend', () => {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "es6-shim": "^0.35.0",
     "reflect-metadata": "0.1.2",
-    "rxjs": "5.0.0-beta.2",
+    "rxjs": "5.0.0-beta.6",
     "zone.js": "^0.6.10"
   },
   "devDependencies": {


### PR DESCRIPTION
rxjs moved Subjects under /src since beta.6 
This fixes #8036
See ReactiveX/rxjs#1557
