### PR TITLE
feat(shadow_css): add encapsulation support for CSS @supports at-rule

### DIFF
--- a/modules/angular2/src/compiler/shadow_css.ts
+++ b/modules/angular2/src/compiler/shadow_css.ts
@@ -332,7 +332,7 @@ export class ShadowCss {
       if (rule.selector[0] != '@' || rule.selector.startsWith('@page')) {
         selector =
             this._scopeSelector(rule.selector, scopeSelector, hostSelector, this.strictStyling);
-      } else if (rule.selector.startsWith('@media')) {
+      } else if (rule.selector.startsWith('@media') || rule.selector.startsWith('@supports')) {
         content = this._scopeSelectors(rule.content, scopeSelector, hostSelector);
       }
       return new CssRule(selector, content);

--- a/modules/angular2/test/compiler/shadow_css_spec.ts
+++ b/modules/angular2/test/compiler/shadow_css_spec.ts
@@ -62,6 +62,12 @@ export function main() {
       expect(s(css, 'a')).toEqual(expected);
     });
 
+    it('should handle support rules', () => {
+      var css = '@supports (display: flex) {section {display: flex;}}';
+      var expected = '@supports (display:flex) {section[a] {display:flex;}}';
+      expect(s(css, 'a')).toEqual(expected);
+    });
+
     // Check that the browser supports unprefixed CSS animation
     it('should handle keyframes rules', () => {
       var css = '@keyframes foo {0% {transform:translate(-50%) scaleX(0);}}';


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Feature: CSS @supports at-rule encapsulation support. 
- **What is the current behavior?** (You can also link to an open issue here)
  #7944
- **What is the new behavior (if this is a feature change)?**
  Component styles within @supports at-rule are now encapsulated
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  No breaking changes
- **Other information**:
  I think this feature is assumed since other at-rules like @media already support encapsulation

Closes #7944 
# ngcontrib
