### PR TITLE
fix(dart) reverts `protobuf` to last working version

### DIFF
--- a/modules/angular2/pubspec.yaml
+++ b/modules/angular2/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   logging: '>=0.9.0 <0.12.0'
   observe: '^0.13.1'
   path: '^1.0.0'
-  protobuf: '^0.5.0'
+  protobuf: '0.5.1'
   source_span: '^1.0.0'
   stack_trace: '^1.1.1'
   build: '>=0.0.1'


### PR DESCRIPTION
A new version of `protobuf` released on Friday has caused dart builds to fail.  The version of `protobuf` has been set to the last working version and dart builds appear to be working again.
