### PR TITLE
fix(tests): remove payload size check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ env:
     - MODE=build_only
     - MODE=typescript_next
     - MODE=lint
-    - MODE=payload
 
 matrix:
   allow_failures:


### PR DESCRIPTION
We just keep upping the size, so this test is not serving any real purpose at the moment.
