### PR TITLE
fix(build): ignore Dart warnings for external code.

### DIFF
--- a/tools/build/dartanalyzer.js
+++ b/tools/build/dartanalyzer.js
@@ -200,6 +200,11 @@ _AnalyzerOutputLine.prototype = {
       return true;
     }
 
+    // Don't worry about warnings in external code.
+    if (this.sourcePath.match(/benchmarks_external/i)) {
+      return true;
+    }
+
     if (this.errorCode.match(/UNUSED_SHOWN_NAME/i)) {
       // TODO: Narrow this ignore down to test code only.
       // See https://github.com/angular/angular/issues/8044


### PR DESCRIPTION
Dart's analyzer is catching more errors, but we don't want to report them for external code.
