### PR TITLE
fix(Request): Change Request.text's return type to string

### DIFF
--- a/modules/angular2/src/http/static_request.ts
+++ b/modules/angular2/src/http/static_request.ts
@@ -90,5 +90,5 @@ export class Request {
    * empty
    * string.
    */
-  text(): String { return isPresent(this._body) ? this._body.toString() : ''; }
+  text(): string { return isPresent(this._body) ? this._body.toString() : ''; }
 }


### PR DESCRIPTION
Change the return typing for the .text method to `string` so typescript treats it
like a normal string.
