### PR TITLE
fix(metadata): emit metadata rooted at 'angular2'

### DIFF
--- a/tools/broccoli/broccoli-typescript.ts
+++ b/tools/broccoli/broccoli-typescript.ts
@@ -88,7 +88,16 @@ class DiffingTSCompiler implements DiffingBroccoliPlugin {
     this.tsServiceHost = new CustomLanguageServiceHost(this.tsOpts, this.rootFilePaths,
                                                        this.fileRegistry, this.inputPath);
     this.tsService = ts.createLanguageService(this.tsServiceHost, ts.createDocumentRegistry());
-    this.metadataCollector = new MetadataCollector();
+    this.metadataCollector = new MetadataCollector({
+      // Since our code isn't under a node_modules directory, we need to reverse the module
+      // resolution to get metadata rooted at 'angular2'.
+      // see https://github.com/angular/angular/issues/8144
+      reverseModuleResolution(fileName: string) {
+        if (/\.tmp\/angular2/.test(fileName)) {
+          return fileName.substr(fileName.lastIndexOf('.tmp/angular2/') + 5).replace(/\.ts$/, '');
+        }
+      }
+    });
   }
 
 


### PR DESCRIPTION
fixes #8144 

Note the underlying problem was that the test fixture has all files under a `node_modules` directory, which is a special case in the MetadataCollector (now the default `MetadataCollectorHost`)

Note that this is the same change to `MetadataCollector` that I need to land the offline compiler cli change.
