### PR TITLE
feat(common/datePipe):fix date formatter correct pattern сloses #7008

### DIFF
--- a/modules/@angular/common/test/pipes/date_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/date_pipe_spec.ts
@@ -61,17 +61,25 @@ export function main() {
         });
 
         it('should format common multi component patterns', () => {
+          expect(pipe.transform(date, 'E, M/d/y')).toEqual('Mon, 6/15/2015');
+          expect(pipe.transform(date, 'E, M/d')).toEqual('Mon, 6/15');
+          expect(pipe.transform(date, 'MMM d')).toEqual('Jun 15');
+          expect(pipe.transform(date, 'dd/MM/yyyy')).toEqual('15/06/2015');
+          expect(pipe.transform(date, 'MM/dd/yyyy')).toEqual('06/15/2015');
           expect(pipe.transform(date, 'yMEd')).toEqual('Mon, 6/15/2015');
           expect(pipe.transform(date, 'MEd')).toEqual('Mon, 6/15');
           expect(pipe.transform(date, 'MMMd')).toEqual('Jun 15');
           expect(pipe.transform(date, 'yMMMMEEEEd')).toEqual('Monday, June 15, 2015');
           expect(pipe.transform(date, 'jms')).toEqual('9:43:11 PM');
           expect(pipe.transform(date, 'ms')).toEqual('43:11');
+          expect(pipe.transform(date, 'jm')).toEqual('9:43');
         });
 
         it('should format with pattern aliases', () => {
           expect(pipe.transform(date, 'medium')).toEqual('Jun 15, 2015, 9:43:11 PM');
           expect(pipe.transform(date, 'short')).toEqual('6/15/2015, 9:43 PM');
+          expect(pipe.transform(date, 'dd/MM/yyyy')).toEqual('15/06/2015');
+          expect(pipe.transform(date, 'MM/dd/yyyy')).toEqual('06/15/2015');
           expect(pipe.transform(date, 'fullDate')).toEqual('Monday, June 15, 2015');
           expect(pipe.transform(date, 'longDate')).toEqual('June 15, 2015');
           expect(pipe.transform(date, 'mediumDate')).toEqual('Jun 15, 2015');


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Fix for issue when date pipe not correctly formatted, closes #7008
- add regular expression to parse date parts
- add date part creator function
- replace tokens in pattern to parsed parts
- **What is the current behavior?** (You can also link to an open issue here)
  See plnkr:
  _http://plnkr.co/edit/nNpBNaB8z7DEnZdpj7gM?p=preview_
  Currently formatter only looking on your locale and what you pass in pattern string not how (MM dd yyyy and dd MM yyyy is really same pattern for him). It have no affect to any formatting inside this pattern. In a fact it strongly coupled to https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat global object. 
- **What is the new behavior (if this is a feature change)?**
  We parse pattern to date token, which materialized according to passed date and current locale (with DateTimeFormat global object as well). After parsing and materializing date parts we replace tokens to materialized parts.
  See plnkr:
  _http://plnkr.co/edit/BVfVx27Ko76PQPOu8Xl7?p=preview_
  There is new version of date pipe that show how new formatter works
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  no
- **Other information**:
