### PR TITLE
feat(testing): add Done provider for tests that need more async control

### DIFF
--- a/modules/angular2/examples/testing/ts/testing.ts
+++ b/modules/angular2/examples/testing/ts/testing.ts
@@ -8,6 +8,7 @@ import {
   beforeEach,
   afterEach,
   beforeEachProviders,
+  Done,
   inject
 } from 'angular2/testing';
 import {provide} from 'angular2/core';
@@ -86,5 +87,18 @@ describe('some component', () => {
                         // This test can leave the database in a dirty state.
                         // The afterEach will ensure it gets reset.
                     });
+});
+// #enddocregion
+
+// #docregion Done
+describe('some component', () => {
+  it('uses a periodic timer',
+     inject([MyService, Done],
+            (service: MyService, done: any) => {
+                // This test can call 'done' or 'done.fail' like a normal Jasmine test.
+                // service.startPeriodicTimer();
+                // service.onThirdIteration(done);
+                // service.onError(done.fail);
+            }));
 });
 // #enddocregion

--- a/modules/angular2/test/testing/testing_public_spec.ts
+++ b/modules/angular2/test/testing/testing_public_spec.ts
@@ -11,7 +11,8 @@ import {
   async,
   withProviders,
   beforeEachProviders,
-  TestComponentBuilder
+  TestComponentBuilder,
+  Done
 } from 'angular2/testing';
 
 import {Injectable, bind} from 'angular2/core';
@@ -136,6 +137,13 @@ export function main() {
 
       it('should use set up providers',
          inject([FancyService], (service) => { expect(service.value).toEqual('real value'); }));
+
+      it('should allow manual use of the done fn', inject([FancyService, Done], (service, done) => {
+           service.getTimeoutValue().then((value) => {
+             expect(value).toEqual('timeout value');
+             done();
+           });
+         }));
 
       it('should wait until returned promises', async(inject([FancyService], (service) => {
            service.getAsyncValue().then((value) => { expect(value).toEqual('async value'); });


### PR DESCRIPTION
If the async test zone (e.g. `async(inject(...))`) won't work for
your tests, add the option to defer to the Jasmine done function
within inject.

Usage:

``` js
it('does stuff', inject([Service, Done], (service, done) {
  service.doStuff().whenFinished(done);
}));
```

Closes #8156 
