### PR TITLE
fix(forms): async validator-directives process Observables correctly

### DIFF
--- a/modules/@angular/common/src/forms-deprecated/directives/normalize_validator.ts
+++ b/modules/@angular/common/src/forms-deprecated/directives/normalize_validator.ts
@@ -12,7 +12,7 @@ export function normalizeValidator(validator: ValidatorFn | Validator): Validato
 
 export function normalizeAsyncValidator(validator: AsyncValidatorFn | Validator): AsyncValidatorFn {
   if ((<Validator>validator).validate !== undefined) {
-    return (c: AbstractControl) => Promise.resolve((<Validator>validator).validate(c));
+    return (c: AbstractControl) => (<Validator>validator).validate(c);
   } else {
     return <AsyncValidatorFn>validator;
   }

--- a/modules/@angular/common/test/forms-deprecated/validators_spec.ts
+++ b/modules/@angular/common/test/forms-deprecated/validators_spec.ts
@@ -1,9 +1,11 @@
 import {AbstractControl, Control, ControlArray, ControlGroup, Validators} from '@angular/common/src/forms-deprecated';
 import {Log, fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {afterEach, beforeEach, ddescribe, describe, expect, iit, it, xit} from '@angular/core/testing/testing_internal';
+import {Observable} from 'rxjs/Observable';
 
 import {EventEmitter, ObservableWrapper, TimerWrapper} from '../../src/facade/async';
 import {PromiseWrapper} from '../../src/facade/promise';
+import {normalizeAsyncValidator} from '../../src/forms-deprecated/directives/normalize_validator';
 
 export function main() {
   function validator(key: string, error: any) {
@@ -11,6 +13,18 @@ export function main() {
       var r = {};
       (r as any /** TODO #9100 */)[key] = error;
       return r;
+    }
+  }
+
+  class AsyncValidatorDirective {
+    constructor(private expected: string, private error: any) {}
+
+    validate(c: any): {[key: string]: any;} {
+      return Observable.create((obs: any) => {
+        const error = this.expected !== c.value ? this.error : null;
+        obs.next(error);
+        obs.complete();
+      });
     }
   }
 
@@ -79,6 +93,17 @@ export function main() {
         });
       });
     });
+
+    it('should normalize and evaluate async validator-directives correctly', fakeAsync(() => {
+         const c = Validators.composeAsync(
+             [normalizeAsyncValidator(new AsyncValidatorDirective('expected', {'one': true}))]);
+
+         let value: any = null;
+         c(new Control()).then((v: any) => value = v);
+         tick(1);
+
+         expect(value).toEqual({'one': true});
+       }));
 
     describe('compose', () => {
       it('should return null when given null',

--- a/modules/@angular/forms/src/directives/normalize_validator.ts
+++ b/modules/@angular/forms/src/directives/normalize_validator.ts
@@ -12,7 +12,7 @@ export function normalizeValidator(validator: ValidatorFn | Validator): Validato
 
 export function normalizeAsyncValidator(validator: AsyncValidatorFn | Validator): AsyncValidatorFn {
   if ((<Validator>validator).validate !== undefined) {
-    return (c: AbstractControl) => Promise.resolve((<Validator>validator).validate(c));
+    return (c: AbstractControl) => (<Validator>validator).validate(c);
   } else {
     return <AsyncValidatorFn>validator;
   }

--- a/modules/@angular/forms/test/validators_spec.ts
+++ b/modules/@angular/forms/test/validators_spec.ts
@@ -1,7 +1,9 @@
 import {Log, fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {afterEach, beforeEach, ddescribe, describe, expect, iit, it, xit} from '@angular/core/testing/testing_internal';
 import {AbstractControl, FormControl, Validators} from '@angular/forms';
+import {Observable} from 'rxjs/Observable';
 
+import {normalizeAsyncValidator} from '../src/directives/normalize_validator';
 import {EventEmitter, ObservableWrapper, TimerWrapper} from '../src/facade/async';
 import {PromiseWrapper} from '../src/facade/promise';
 
@@ -11,6 +13,18 @@ export function main() {
       var r = {};
       (r as any /** TODO #9100 */)[key] = error;
       return r;
+    }
+  }
+
+  class AsyncValidatorDirective {
+    constructor(private expected: string, private error: any) {}
+
+    validate(c: any): {[key: string]: any;} {
+      return Observable.create((obs: any) => {
+        const error = this.expected !== c.value ? this.error : null;
+        obs.next(error);
+        obs.complete();
+      });
     }
   }
 
@@ -139,12 +153,22 @@ export function main() {
            expect(value).toEqual({'one': true, 'two': true});
          }));
 
+      it('should normalize and evaluate async validator-directives correctly', fakeAsync(() => {
+           const c = Validators.composeAsync(
+               [normalizeAsyncValidator(new AsyncValidatorDirective('expected', {'one': true}))]);
+
+           let value: any = null;
+           c(new FormControl()).then((v: any) => value = v);
+           tick(1);
+
+           expect(value).toEqual({'one': true});
+         }));
+
       it('should return null when no errors', fakeAsync(() => {
            var c = Validators.composeAsync([asyncValidator('expected', {'one': true})]);
 
            var value: any /** TODO #9100 */ = null;
            (<Promise<any>>c(new FormControl('expected'))).then(v => value = v);
-
            tick(1);
 
            expect(value).toEqual(null);


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix
- **What is the current behavior?** (You can also link to an open issue here)

Currently Async Validator-Directives are not able to return Observables. 

https://github.com/angular/angular/issues/8022
- **What is the new behavior (if this is a feature change)?**

Async Validator-Directives can now return Observables as well as Promises
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  
  No
- **Other information**:

while normalizing async-validators the return value of validator-directives was erroneously resolved by `Promise.resolve`. This prevented async-validator-directives to work with Observables correctly

Closes https://github.com/angular/angular/issues/8022
