### PR TITLE
fix(compiler): Throw error when variables with identical names are de…

### DIFF
--- a/modules/angular2/src/compiler/template_parser.ts
+++ b/modules/angular2/src/compiler/template_parser.ts
@@ -166,6 +166,7 @@ class TemplateParseVisitor implements HtmlAstVisitor {
   directivesIndex = new Map<CompileDirectiveMetadata, number>();
   ngContentCount: number = 0;
   pipesByName: Map<string, CompilePipeMetadata>;
+  parsedVariables: string[] = [];
 
   constructor(public providerViewContext: ProviderViewContext,
               directives: CompileDirectiveMetadata[], pipes: CompilePipeMetadata[],
@@ -486,6 +487,12 @@ class TemplateParseVisitor implements HtmlAstVisitor {
     if (identifier.indexOf('-') > -1) {
       this._reportError(`"-" is not allowed in variable names`, sourceSpan);
     }
+
+    if (this.parsedVariables.indexOf(identifier) > -1) {
+      this._reportError(`Variable "#${identifier}" is defined multiple times`, sourceSpan);
+    }
+    this.parsedVariables.push(identifier);
+
     targetVars.push(new VariableAst(identifier, value, sourceSpan));
   }
 

--- a/modules/angular2/test/compiler/template_parser_spec.ts
+++ b/modules/angular2/test/compiler/template_parser_spec.ts
@@ -780,6 +780,12 @@ There is no directive with "exportAs" set to "dirA" ("<div [ERROR ->]#a="dirA"><
 "-" is not allowed in variable names ("<div [ERROR ->]#a-b></div>"): TestComp@0:5`);
         });
 
+        it('should report duplicate variable names', () => {
+          expect(() => parse('<div #a></div><div #a></div>', []))
+              .toThrowError(`Template parse errors:
+Variable "#a" is defined multiple times ("<div #a></div><div [ERROR ->]#a></div>"): TestComp@0:19`);
+        });
+
         it('should allow variables with values that dont match a directive on embedded template elements',
            () => {
              expect(humanizeTplAst(parse('<template #a="b"></template>', [])))

--- a/modules/angular2/test/core/linker/query_integration_spec.ts
+++ b/modules/angular2/test/core/linker/query_integration_spec.ts
@@ -290,7 +290,7 @@ export function main() {
       it('should contain all content children',
          inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
            var template =
-               '<needs-content-children-read #q text="ca"><div #q text="cb"></div></needs-content-children-read>';
+               '<needs-content-children-read #q text="ca"><div #w text="cb"></div></needs-content-children-read>';
 
            tcb.overrideTemplate(MyComp, template)
                .createAsync(MyComp)
@@ -1018,7 +1018,7 @@ class NeedsTpl {
 
 @Component({selector: 'needs-content-children-read', template: ''})
 class NeedsContentChildrenWithRead {
-  @ContentChildren('q', {read: TextDirective}) textDirChildren: QueryList<TextDirective>;
+  @ContentChildren('q,w', {read: TextDirective}) textDirChildren: QueryList<TextDirective>;
   @ContentChildren('nonExisting', {read: TextDirective}) nonExistingVar: QueryList<TextDirective>;
 }
 
@@ -1030,11 +1030,11 @@ class NeedsContentChildWithRead {
 
 @Component({
   selector: 'needs-view-children-read',
-  template: '<div #q text="va"></div><div #q text="vb"></div>',
+  template: '<div #q text="va"></div><div #w text="vb"></div>',
   directives: [TextDirective]
 })
 class NeedsViewChildrenWithRead {
-  @ViewChildren('q', {read: TextDirective}) textDirChildren: QueryList<TextDirective>;
+  @ViewChildren('q,w', {read: TextDirective}) textDirChildren: QueryList<TextDirective>;
   @ViewChildren('nonExisting', {read: TextDirective}) nonExistingVar: QueryList<TextDirective>;
 }
 


### PR DESCRIPTION
This PR closes #6492 as the compiler now throws an error if two variables with identical names are declared in a template.
