### PR TITLE
feat(Control): Add ng-empty-value detection

### DIFF
--- a/modules/angular2/src/common/forms/directives/ng_control_status.ts
+++ b/modules/angular2/src/common/forms/directives/ng_control_status.ts
@@ -42,6 +42,6 @@ export class NgControlStatus {
     return isPresent(this._cd.control) ? !this._cd.control.valid : false;
   }
   get ngClassEmptyValue(): boolean {
-    return isPresent(this._cd.control) ? isEmptyValue(this._cd.control.value) : true;
+    return isPresent(this._cd.control) ? this._cd.control.empty : true;
   }
 }

--- a/modules/angular2/src/common/forms/directives/ng_control_status.ts
+++ b/modules/angular2/src/common/forms/directives/ng_control_status.ts
@@ -14,7 +14,8 @@ import {isBlank, isPresent} from 'angular2/src/facade/lang';
     '[class.ng-pristine]': 'ngClassPristine',
     '[class.ng-dirty]': 'ngClassDirty',
     '[class.ng-valid]': 'ngClassValid',
-    '[class.ng-invalid]': 'ngClassInvalid'
+    '[class.ng-invalid]': 'ngClassInvalid',
+    '[class.ng-empty-value]': 'ngClassEmptyValue'
   }
 })
 export class NgControlStatus {
@@ -39,5 +40,8 @@ export class NgControlStatus {
   }
   get ngClassInvalid(): boolean {
     return isPresent(this._cd.control) ? !this._cd.control.valid : false;
+  }
+  get ngClassEmptyValue(): boolean {
+    return isPresent(this._cd.control) ? isEmptyValue(this._cd.control.value) : true;
   }
 }

--- a/modules/angular2/src/common/forms/model.ts
+++ b/modules/angular2/src/common/forms/model.ts
@@ -1,4 +1,4 @@
-import {isPresent, isBlank, normalizeBool} from 'angular2/src/facade/lang';
+import {isPresent, isBlank, isEmptyValue, normalizeBool} from 'angular2/src/facade/lang';
 import {Observable, EventEmitter, ObservableWrapper} from 'angular2/src/facade/async';
 import {PromiseWrapper} from 'angular2/src/facade/promise';
 import {StringMapWrapper, ListWrapper} from 'angular2/src/facade/collection';
@@ -59,6 +59,7 @@ export abstract class AbstractControl {
   private _valueChanges: EventEmitter<any>;
   private _statusChanges: EventEmitter<any>;
   private _status: string;
+  private _empty: boolean = true;
   private _errors: {[key: string]: any};
   private _pristine: boolean = true;
   private _touched: boolean = false;
@@ -72,6 +73,8 @@ export abstract class AbstractControl {
   get status(): string { return this._status; }
 
   get valid(): boolean { return this._status === VALID; }
+  
+  get empty(): boolean { return this._empty; }
 
   /**
    * Returns the errors of this control.
@@ -123,6 +126,7 @@ export abstract class AbstractControl {
 
     this._errors = this._runValidator();
     this._status = this._calculateStatus();
+    this._empty = isEmptyValue(this._value);
 
     if (this._status == VALID || this._status == PENDING) {
       this._runAsyncValidator(emitEvent);

--- a/modules/angular2/src/facade/lang.ts
+++ b/modules/angular2/src/facade/lang.ts
@@ -124,6 +124,29 @@ export function isBlank(obj: any): boolean {
   return obj === undefined || obj === null;
 }
 
+export function isEmptyValue(val): boolean {
+  if (val === undefined) {
+    return true;
+  }
+  if (val === null) {
+    return true;
+  }
+  if (val === '') {
+    return true;
+  }
+  if (typeof val === 'string') {
+    if (String.prototype.trim) {
+      val = val.trim();
+    } else {
+      val = val.replace(/^\s+|\s+$/g, '');
+    }
+  }
+  if (val.length !== undefined) {
+    return val.length === 0;
+  }
+  return false;
+};
+
 export function isBoolean(obj: any): boolean {
   return typeof obj === "boolean";
 }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Feature addition for controls.  Makes up for the short-comings of the CSS :empty selector.  Valuable for textareas and input fields that can be empty.  Useful for people who need styling for when a field is empty but not invalid.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  No
- **Other Notes**
  `isEmptyValue` is from [Aurelia's Validation module](https://github.com/aurelia/validation/blob/0a7a57fed00452202ca8e8634b993d4712337619/dist/amd/utilities.js#L26)
