### PR TITLE
Adding additional info of breaking changes in b16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ fakeAsync(inject([...], (...) => {...}))
 ```
 
 * - pipes now take a variable number of arguments, and not an array that contains all arguments.
+* - In upgrade, `HostViewFactoryRefMap` was renamed to `ComponentFactoryRefMap`
 
 
 <a name="2.0.0-beta.15"></a>


### PR DESCRIPTION
In beta 16 `HostViewFactoryRefMap` was renamed and not documented. This is required for some advanced ng1 + ng2 setups using lazy-loading. 

Details: https://github.com/ocombe/ocLazyLoad/issues/288
