### PR TITLE
fix(metadata): Do not attach module names to metadata.

### DIFF
--- a/modules/angular2/src/compiler/static_reflector.ts
+++ b/modules/angular2/src/compiler/static_reflector.ts
@@ -1,12 +1,8 @@
-import {ListWrapper, StringMapWrapper} from 'angular2/src/facade/collection';
+import {StringMapWrapper} from 'angular2/src/facade/collection';
 import {
   isArray,
-  isBlank,
-  isNumber,
   isPresent,
   isPrimitive,
-  isString,
-  Type
 } from 'angular2/src/facade/lang';
 import {
   AttributeMetadata,
@@ -35,13 +31,19 @@ import {ReflectorReader} from 'angular2/src/core/reflection/reflector_reader';
  */
 export interface StaticReflectorHost {
   /**
-   *  Return a ModuleMetadata for the give module.
+   *  Return a ModuleMetadata for the given module.
    *
-   * @param moduleId is a string identifier for a module in the form that would expected in a
-   *                 module import of an import statement.
+   * @param moduleId is a string identifier for a module as an absolute path.
    * @returns the metadata for the given module.
    */
   getMetadataFor(moduleId: string): {[key: string]: any};
+
+  /**
+   * Resolve a module from an import statement form to an absolute path.
+   * @param moduleName the location imported from
+   * @param containingFile for relative imports, the path of the file containing the import
+   */
+  resolveModule(moduleName: string, containingFile?: string): string;
 }
 
 /**
@@ -68,10 +70,10 @@ export class StaticReflector implements ReflectorReader {
   importUri(typeOrFunc: any): string { return (<StaticType>typeOrFunc).moduleId; }
 
   /**
-   * getStatictype produces a Type whose metadata is known but whose implementation is not loaded.
+   * getStaticType produces a Type whose metadata is known but whose implementation is not loaded.
    * All types passed to the StaticResolver should be pseudo-types returned by this method.
    *
-   * @param moduleId the module identifier as would be passed to an import statement.
+   * @param moduleId the module identifier as an absolute path.
    * @param name the name of the type.
    */
   public getStaticType(moduleId: string, name: string): StaticType {
@@ -137,7 +139,7 @@ export class StaticReflector implements ReflectorReader {
 
   private conversionMap = new Map<StaticType, (moduleContext: string, expression: any) => any>();
   private initializeConversionMap(): any {
-    let core_metadata = 'angular2/src/core/metadata';
+    let core_metadata = this.host.resolveModule('angular2/src/core/metadata');
     let conversionMap = this.conversionMap;
     conversionMap.set(this.getStaticType(core_metadata, 'Directive'),
                       (moduleContext, expression) => {
@@ -272,7 +274,7 @@ export class StaticReflector implements ReflectorReader {
     if (isMetadataSymbolicCallExpression(expression)) {
       let target = expression['expression'];
       if (isMetadataSymbolicReferenceExpression(target)) {
-        let moduleId = this.normalizeModuleName(moduleContext, target['module']);
+        let moduleId = this.host.resolveModule(target['module'], moduleContext);
         return this.getStaticType(moduleId, target['name']);
       }
     }
@@ -417,7 +419,7 @@ export class StaticReflector implements ReflectorReader {
               return null;
             case "reference":
               let referenceModuleName =
-                  _this.normalizeModuleName(moduleContext, expression['module']);
+                  _this.host.resolveModule(expression['module'], moduleContext);
               let referenceModule = _this.getModuleMetadata(referenceModuleName);
               let referenceValue = referenceModule['metadata'][expression['name']];
               if (isClassMetadata(referenceValue)) {
@@ -440,6 +442,9 @@ export class StaticReflector implements ReflectorReader {
     return simplify(value);
   }
 
+  /**
+   * @param module an absolute path to a module file.
+   */
   public getModuleMetadata(module: string): {[key: string]: any} {
     let moduleMetadata = this.metadataCache.get(module);
     if (!isPresent(moduleMetadata)) {
@@ -460,13 +465,6 @@ export class StaticReflector implements ReflectorReader {
     }
     return result;
   }
-
-  private normalizeModuleName(from: string, to: string): string {
-    if (to.startsWith('.')) {
-      return pathTo(from, to);
-    }
-    return to;
-  }
 }
 
 function isMetadataSymbolicCallExpression(expression: any): boolean {
@@ -480,36 +478,4 @@ function isMetadataSymbolicReferenceExpression(expression: any): boolean {
 
 function isClassMetadata(expression: any): boolean {
   return !isPrimitive(expression) && !isArray(expression) && expression['__symbolic'] == 'class';
-}
-
-function splitPath(path: string): string[] {
-  return path.split(/\/|\\/g);
-}
-
-function resolvePath(pathParts: string[]): string {
-  let result = [];
-  ListWrapper.forEachWithIndex(pathParts, (part, index) => {
-    switch (part) {
-      case '':
-      case '.':
-        if (index > 0) return;
-        break;
-      case '..':
-        if (index > 0 && result.length != 0) result.pop();
-        return;
-    }
-    result.push(part);
-  });
-  return result.join('/');
-}
-
-function pathTo(from: string, to: string): string {
-  let result = to;
-  if (to.startsWith('.')) {
-    let fromParts = splitPath(from);
-    fromParts.pop();  // remove the file name.
-    let toParts = splitPath(to);
-    result = resolvePath(fromParts.concat(toParts));
-  }
-  return result;
 }

--- a/tools/broccoli/broccoli-typescript.ts
+++ b/tools/broccoli/broccoli-typescript.ts
@@ -88,16 +88,7 @@ class DiffingTSCompiler implements DiffingBroccoliPlugin {
     this.tsServiceHost = new CustomLanguageServiceHost(this.tsOpts, this.rootFilePaths,
                                                        this.fileRegistry, this.inputPath);
     this.tsService = ts.createLanguageService(this.tsServiceHost, ts.createDocumentRegistry());
-    this.metadataCollector = new MetadataCollector({
-      // Since our code isn't under a node_modules directory, we need to reverse the module
-      // resolution to get metadata rooted at 'angular2'.
-      // see https://github.com/angular/angular/issues/8144
-      reverseModuleResolution(fileName: string) {
-        if (/\.tmp\/angular2/.test(fileName)) {
-          return fileName.substr(fileName.lastIndexOf('.tmp/angular2/') + 5).replace(/\.ts$/, '');
-        }
-      }
-    });
+    this.metadataCollector = new MetadataCollector();
   }
 
 

--- a/tools/metadata/src/schema.ts
+++ b/tools/metadata/src/schema.ts
@@ -1,8 +1,5 @@
-// TODO: fix typings for __symbolic once angular moves to 1.8
-
 export interface ModuleMetadata {
-  __symbolic: string;  // "module";
-  module: string;
+  __symbolic: "module";
   metadata: {[name: string]: (ClassMetadata | MetadataValue)};
 }
 export function isModuleMetadata(value: any): value is ModuleMetadata {
@@ -10,7 +7,7 @@ export function isModuleMetadata(value: any): value is ModuleMetadata {
 }
 
 export interface ClassMetadata {
-  __symbolic: string;  // "class";
+  __symbolic: "class";
   decorators?: MetadataSymbolicExpression[];
   members?: MetadataMap;
 }
@@ -21,7 +18,7 @@ export function isClassMetadata(value: any): value is ClassMetadata {
 export interface MetadataMap { [name: string]: MemberMetadata[]; }
 
 export interface MemberMetadata {
-  __symbolic: string;  // "constructor" | "method" | "property";
+  __symbolic: "constructor" | "method" | "property";
   decorators?: MetadataSymbolicExpression[];
 }
 export function isMemberMetadata(value: any): value is MemberMetadata {
@@ -37,7 +34,7 @@ export function isMemberMetadata(value: any): value is MemberMetadata {
 }
 
 export interface MethodMetadata extends MemberMetadata {
-  // __symbolic: "constructor" | "method";
+  __symbolic: "constructor" | "method";
   parameterDecorators?: MetadataSymbolicExpression[][];
 }
 export function isMethodMetadata(value: any): value is MemberMetadata {
@@ -45,7 +42,7 @@ export function isMethodMetadata(value: any): value is MemberMetadata {
 }
 
 export interface ConstructorMetadata extends MethodMetadata {
-  // __symbolic: "constructor";
+  __symbolic: "constructor";
   parameters?: MetadataSymbolicExpression[];
 }
 export function isConstructorMetadata(value: any): value is ConstructorMetadata {
@@ -60,7 +57,7 @@ export interface MetadataObject { [name: string]: MetadataValue; }
 export interface MetadataArray { [name: number]: MetadataValue; }
 
 export interface MetadataSymbolicExpression {
-  __symbolic: string;  // "binary" | "call" | "index" | "pre" | "reference" | "select"
+  __symbolic: "binary" | "call" | "index" | "pre" | "reference" | "select"
 }
 export function isMetadataSymbolicExpression(value: any): value is MetadataSymbolicExpression {
   if (value) {
@@ -78,10 +75,9 @@ export function isMetadataSymbolicExpression(value: any): value is MetadataSymbo
 }
 
 export interface MetadataSymbolicBinaryExpression extends MetadataSymbolicExpression {
-  // __symbolic: "binary";
-  operator: string;  // "&&" | "||" | "|" | "^" | "&" | "==" | "!=" | "===" | "!==" | "<" | ">" |
-                     // "<=" | ">=" | "instanceof" | "in" | "as" | "<<" | ">>" | ">>>" | "+" | "-" |
-                     // "*" | "/" | "%" | "**";
+  __symbolic: "binary";
+  operator: "&&" | "||" | "|" | "^" | "&" | "==" | "!=" | "===" | "!==" | "<" | ">" | "<=" | ">=" |
+      "instanceof" | "in" | "as" | "<<" | ">>" | ">>>" | "+" | "-" | "*" | "/" | "%" | "**";
   left: MetadataValue;
   right: MetadataValue;
 }
@@ -91,7 +87,7 @@ export function isMetadataSymbolicBinaryExpression(
 }
 
 export interface MetadataSymbolicIndexExpression extends MetadataSymbolicExpression {
-  // __symbolic: "index";
+  __symbolic: "index";
   expression: MetadataValue;
   index: MetadataValue;
 }
@@ -101,7 +97,7 @@ export function isMetadataSymbolicIndexExpression(
 }
 
 export interface MetadataSymbolicCallExpression extends MetadataSymbolicExpression {
-  // __symbolic: "call";
+  __symbolic: "call";
   expression: MetadataValue;
   arguments?: MetadataValue[];
 }
@@ -111,8 +107,8 @@ export function isMetadataSymbolicCallExpression(
 }
 
 export interface MetadataSymbolicPrefixExpression extends MetadataSymbolicExpression {
-  // __symbolic: "pre";
-  operator: string;  // "+" | "-" | "~" | "!";
+  __symbolic: "pre";
+  operator: "+" | "-" | "~" | "!";
   operand: MetadataValue;
 }
 export function isMetadataSymbolicPrefixExpression(
@@ -121,7 +117,7 @@ export function isMetadataSymbolicPrefixExpression(
 }
 
 export interface MetadataSymbolicReferenceExpression extends MetadataSymbolicExpression {
-  // __symbolic: "reference";
+  __symbolic: "reference";
   name: string;
   module: string;
 }
@@ -131,7 +127,7 @@ export function isMetadataSymbolicReferenceExpression(
 }
 
 export interface MetadataSymbolicSelectExpression extends MetadataSymbolicExpression {
-  // __symbolic: "select";
+  __symbolic: "select";
   expression: MetadataValue;
   name: string;
 }

--- a/tools/metadata/test/evaluator.spec.ts
+++ b/tools/metadata/test/evaluator.spec.ts
@@ -18,7 +18,7 @@ describe('Evaluator', () => {
     program = service.getProgram();
     typeChecker = program.getTypeChecker();
     symbols = new Symbols();
-    evaluator = new Evaluator(typeChecker, symbols, f => f);
+    evaluator = new Evaluator(typeChecker, symbols, []);
   });
 
   it('should not have typescript errors in test data', () => {
@@ -97,9 +97,9 @@ describe('Evaluator', () => {
   it('should report recursive references as symbolic', () => {
     var expressions = program.getSourceFile('expressions.ts');
     expect(evaluator.evaluateNode(findVar(expressions, 'recursiveA').initializer))
-        .toEqual({__symbolic: "reference", name: "recursiveB", module: "expressions.ts"});
+        .toEqual({__symbolic: "reference", name: "recursiveB", module: undefined});
     expect(evaluator.evaluateNode(findVar(expressions, 'recursiveB').initializer))
-        .toEqual({__symbolic: "reference", name: "recursiveA", module: "expressions.ts"});
+        .toEqual({__symbolic: "reference", name: "recursiveA", module: undefined});
   });
 });
 
@@ -160,4 +160,4 @@ const FILES: Directory = {
 
     @Pipe({name: someName, pure: someBool})
     export class B {}`
-}
+};


### PR DESCRIPTION
The filename contains the module name as resolved by users, so the top-level module name is uneeded.
Module names on references are replaced by capturing the import syntax from the module.
This allows readers of the metadata to do the module resolution themselves.

Fixes #8225
