### PR TITLE
docs: fix syntax errors in HostBinding metadata example

### DIFF
--- a/modules/angular2/src/core/metadata.ts
+++ b/modules/angular2/src/core/metadata.ts
@@ -1419,8 +1419,8 @@ export var Output: OutputMetadataFactory = makePropDecorator(OutputMetadata);
  * @Directive({selector: '[ngModel]'})
  * class NgModelStatus {
  *   constructor(public control:NgModel) {}
- *   @HostBinding('[class.valid]') get valid { return this.control.valid; }
- *   @HostBinding('[class.invalid]') get invalid { return this.control.invalid; }
+ *   @HostBinding('class.valid') get valid() { return this.control.valid; }
+ *   @HostBinding('class.invalid') get invalid() { return this.control.invalid; }
  * }
  *
  * @Component({


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [n/a] Tests for the changes have been added (for bug fixes / features)
- [n/a] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Corrects two syntax errors in the example code HostBindingMetadata - namely, the getters are missing parentheses and the brackets in the HostBinding decorators are erroneous. 
- **What is the current behavior?** (You can also link to an open issue here)
  Example code does not compile (and if it did, the host bindings would throw) .
- **What is the new behavior (if this is a feature change)?**
  Example code compiles and does not throw. 
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  No
- **Other information**:

add missing parentheses to getters, remove erroneous brackets in HostBindings
