### PR TITLE
fix(compiler): Throw error if component-selector is unsupported

### DIFF
--- a/modules/angular2/test/compiler/selector_spec.ts
+++ b/modules/angular2/test/compiler/selector_spec.ts
@@ -339,6 +339,22 @@ export function main() {
       expect(cssSelectors[2].element).toEqual('textbox');
       expect(cssSelectors[2].notSelectors[0].classNames).toEqual(['special']);
     });
+
+    it('should throw when unsupported selectors are used', () => {
+      const errorMessage = 'Unsupported selector';
+
+      expect(() => { CssSelector.parse('descendent selector'); }).toThrowError(errorMessage);
+
+      expect(() => { CssSelector.parse('child > selector'); }).toThrowError(errorMessage);
+
+      expect(() => { CssSelector.parse('sibling selector'); }).toThrowError(errorMessage);
+
+      expect(() => { CssSelector.parse('[fancy^="attribute selectors"]'); })
+          .toThrowError(errorMessage);
+
+      expect(() => { CssSelector.parse('pseudo-classes:hover'); }).toThrowError(errorMessage);
+    });
+
   });
 
   describe('CssSelector.getMatchingElementTemplate', () => {


### PR DESCRIPTION
This closes issue #6600 and gets us one step closer to the Release Candidate milestone.

An error is now being thrown in case an unsupported selector is used.
