### PR TITLE
fix(core): properly evaluate expressions with conditional and boolean…

### DIFF
--- a/modules/angular2/src/compiler/output/abstract_emitter.ts
+++ b/modules/angular2/src/compiler/output/abstract_emitter.ts
@@ -264,11 +264,13 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
   abstract visitExternalExpr(ast: o.ExternalExpr, ctx: EmitterVisitorContext): any;
 
   visitConditionalExpr(ast: o.ConditionalExpr, ctx: EmitterVisitorContext): any {
+    ctx.print(`(`);
     ast.condition.visitExpression(this, ctx);
     ctx.print('? ');
     ast.trueCase.visitExpression(this, ctx);
     ctx.print(': ');
     ast.falseCase.visitExpression(this, ctx);
+    ctx.print(`)`);
     return null;
   }
   visitNotExpr(ast: o.NotExpr, ctx: EmitterVisitorContext): any {

--- a/modules/angular2/test/compiler/output/dart_emitter_spec.ts
+++ b/modules/angular2/test/compiler/output/dart_emitter_spec.ts
@@ -136,7 +136,7 @@ export function main() {
       expect(emitStmt(o.not(someVar).toStmt())).toEqual('!someVar;');
       expect(
           emitStmt(someVar.conditional(o.variable('trueCase'), o.variable('falseCase')).toStmt()))
-          .toEqual('someVar? trueCase: falseCase;');
+          .toEqual('(someVar? trueCase: falseCase);');
 
       expect(emitStmt(lhs.equals(rhs).toStmt())).toEqual('(lhs == rhs);');
       expect(emitStmt(lhs.notEquals(rhs).toStmt())).toEqual('(lhs != rhs);');

--- a/modules/angular2/test/compiler/output/js_emitter_spec.ts
+++ b/modules/angular2/test/compiler/output/js_emitter_spec.ts
@@ -125,7 +125,7 @@ export function main() {
       expect(emitStmt(o.not(someVar).toStmt())).toEqual('!someVar;');
       expect(
           emitStmt(someVar.conditional(o.variable('trueCase'), o.variable('falseCase')).toStmt()))
-          .toEqual('someVar? trueCase: falseCase;');
+          .toEqual('(someVar? trueCase: falseCase);');
 
       expect(emitStmt(lhs.equals(rhs).toStmt())).toEqual('(lhs == rhs);');
       expect(emitStmt(lhs.notEquals(rhs).toStmt())).toEqual('(lhs != rhs);');

--- a/modules/angular2/test/compiler/output/ts_emitter_spec.ts
+++ b/modules/angular2/test/compiler/output/ts_emitter_spec.ts
@@ -126,7 +126,7 @@ export function main() {
       expect(emitStmt(o.not(someVar).toStmt())).toEqual('!someVar;');
       expect(
           emitStmt(someVar.conditional(o.variable('trueCase'), o.variable('falseCase')).toStmt()))
-          .toEqual('someVar? trueCase: falseCase;');
+          .toEqual('(someVar? trueCase: falseCase);');
 
       expect(emitStmt(lhs.equals(rhs).toStmt())).toEqual('(lhs == rhs);');
       expect(emitStmt(lhs.notEquals(rhs).toStmt())).toEqual('(lhs != rhs);');

--- a/modules/angular2/test/core/linker/regression_integration_spec.ts
+++ b/modules/angular2/test/core/linker/regression_integration_spec.ts
@@ -71,7 +71,35 @@ function declareTests(isJit: boolean) {
                  async.done();
                });
          }));
+    });
 
+    describe('expressions', () => {
+
+      it('should evaluate conditional and boolean operators with right precedence - #8244',
+         inject([TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async) => {
+           tcb.overrideView(MyComp,
+                            new ViewMetadata({template: `{{'red' + (true ? ' border' : '')}}`}))
+               .createAsync(MyComp)
+               .then((fixture) => {
+                 fixture.detectChanges();
+                 expect(fixture.nativeElement).toHaveText('red border');
+                 async.done();
+               });
+         }));
+
+      if (!IS_DART) {
+        it('should evaluate conditional and unary operators with right precedence - #8235',
+           inject([TestComponentBuilder, AsyncTestCompleter],
+                  (tcb: TestComponentBuilder, async) => {
+                    tcb.overrideView(MyComp, new ViewMetadata({template: `{{!null?.length}}`}))
+                        .createAsync(MyComp)
+                        .then((fixture) => {
+                          fixture.detectChanges();
+                          expect(fixture.nativeElement).toHaveText('true');
+                          async.done();
+                        });
+                  }));
+      }
     });
 
     describe('providers', () => {


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ x] Tests for the changes have been added (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix
- **What is the current behavior?** (You can also link to an open issue here)

Expressions mixing conditional and Boolean operators (ex.: `{{'red' + (true ? ' border' : '')}}`) are not evaluated properly. See #8244 for more details
- **What is the new behavior (if this is a feature change)?**

Expressions mixing conditional and Boolean operators (ex.: `{{'red' + (true ? ' border' : '')}}`) are evaluated properly.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.
- **Other information**:

Fixes #8235
Fixes #8244
