### PR TITLE
docs(CHANGELOG): add more info about Karma config for breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,9 +59,10 @@ After:
 ```
 fakeAsync(inject([...], (...) => {...}))
 ```
-You will also need to add the dependency
-`'node_modules/zone.js/dist/fake-async-test.js'`
-as a served file in your Karma or other test configuration.
+You will also need to add the following dependencies:
+* `'node_modules/zone.js/dist/async-test.js'`
+* `'node_modules/zone.js/dist/fake-async-test.js'`
+as a served files in your Karma or other test configuration.
 
 * - Injector was renamed into `ReflectiveInjector`,
   as `Injector` is only an abstract class with one method on it


### PR DESCRIPTION
It looks like CHANGELOG re-generation commited via 140a878a3d48a62bbef4e3ce68f054791cdce618 removed additions done by @juliemr via 39eb34739a9cd5bbff930dd2c12c5199ee108f94. This PR brings back the detailed info.
