### PR TITLE
refactor(testing): Refactor test_component_builder to remove DOM depe…

### DIFF
--- a/modules/angular2/platform/testing/browser_static.ts
+++ b/modules/angular2/platform/testing/browser_static.ts
@@ -20,7 +20,12 @@ import {MockNgZone} from 'angular2/src/mock/ng_zone_mock';
 import {XHRImpl} from "angular2/src/platform/browser/xhr_impl";
 import {XHR} from 'angular2/compiler';
 
-import {TestComponentBuilder} from 'angular2/src/testing/test_component_builder';
+import {
+  TestComponentRenderer,
+  TestComponentBuilder
+} from 'angular2/src/testing/test_component_builder';
+
+import {DOMTestComponentRenderer} from 'angular2/src/testing/dom_test_component_renderer';
 
 import {BrowserDetection} from 'angular2/src/testing/utils';
 
@@ -51,6 +56,7 @@ export const ADDITIONAL_TEST_BROWSER_PROVIDERS: Array<any /*Type | Provider | an
       new Provider(DirectiveResolver, {useClass: MockDirectiveResolver}),
       new Provider(ViewResolver, {useClass: MockViewResolver}),
       Log,
+      new Provider(TestComponentRenderer, {useClass: DOMTestComponentRenderer}),
       TestComponentBuilder,
       new Provider(NgZone, {useClass: MockNgZone}),
       new Provider(LocationStrategy, {useClass: MockLocationStrategy}),

--- a/modules/angular2/platform/testing/server.ts
+++ b/modules/angular2/platform/testing/server.ts
@@ -18,7 +18,11 @@ import {MockViewResolver} from 'angular2/src/mock/view_resolver_mock';
 import {MockLocationStrategy} from 'angular2/src/mock/mock_location_strategy';
 import {MockNgZone} from 'angular2/src/mock/ng_zone_mock';
 
-import {TestComponentBuilder} from 'angular2/src/testing/test_component_builder';
+import {
+  TestComponentRenderer,
+  TestComponentBuilder
+} from 'angular2/src/testing/test_component_builder';
+import {DOMTestComponentRenderer} from 'angular2/src/testing/dom_test_component_renderer';
 import {XHR} from 'angular2/src/compiler/xhr';
 import {BrowserDetection} from 'angular2/src/testing/utils';
 
@@ -84,6 +88,7 @@ export const TEST_SERVER_APPLICATION_PROVIDERS: Array<any /*Type | Provider | an
       new Provider(DirectiveResolver, {useClass: MockDirectiveResolver}),
       new Provider(ViewResolver, {useClass: MockViewResolver}),
       Log,
+      new Provider(TestComponentRenderer, {useClass: DOMTestComponentRenderer}),
       TestComponentBuilder,
       new Provider(NgZone, {useClass: MockNgZone}),
       new Provider(LocationStrategy, {useClass: MockLocationStrategy}),

--- a/modules/angular2/src/testing/dom_test_component_renderer.ts
+++ b/modules/angular2/src/testing/dom_test_component_renderer.ts
@@ -1,0 +1,25 @@
+import {Inject, Injectable} from 'angular2/src/core/di';
+import {DOCUMENT} from 'angular2/src/platform/dom/dom_tokens';
+import {DOM} from 'angular2/src/platform/dom/dom_adapter';
+
+import {TestComponentRenderer} from './test_component_builder';
+import {el} from './utils';
+
+/**
+ * A DOM based implementation of the TestComponentRenderer.
+ */
+@Injectable()
+export class DOMTestComponentRenderer extends TestComponentRenderer {
+  constructor(@Inject(DOCUMENT) private _doc) { super(); }
+
+  insertRootElement(rootElementId: string) {
+    var rootEl = el(`<div id="${rootElementId}"></div>`);
+
+    // TODO(juliemr): can/should this be optional?
+    var oldRoots = DOM.querySelectorAll(this._doc, '[id^=root]');
+    for (var i = 0; i < oldRoots.length; i++) {
+      DOM.remove(oldRoots[i]);
+    }
+    DOM.appendChild(this._doc.body, rootEl);
+  }
+}

--- a/modules/angular2/src/testing/test_component_builder.ts
+++ b/modules/angular2/src/testing/test_component_builder.ts
@@ -15,14 +15,16 @@ import {Type, isPresent, isBlank} from 'angular2/src/facade/lang';
 import {PromiseWrapper} from 'angular2/src/facade/async';
 import {ListWrapper, MapWrapper} from 'angular2/src/facade/collection';
 
-import {el} from './utils';
-
-import {DOCUMENT} from 'angular2/src/platform/dom/dom_tokens';
-import {DOM} from 'angular2/src/platform/dom/dom_adapter';
-
 import {DebugNode, DebugElement, getDebugNode} from 'angular2/src/core/debug/debug_node';
 
 import {tick} from './fake_async';
+
+/**
+ * An abstract class for inserting the root test component element in a platform independent way.
+ */
+export class TestComponentRenderer {
+  insertRootElement(rootElementId: string) {}
+}
 
 /**
  * Fixture for debugging and testing a component.
@@ -242,16 +244,9 @@ export class TestComponentBuilder {
     this._viewBindingsOverrides.forEach(
         (bindings, type) => mockDirectiveResolver.setViewBindingsOverride(type, bindings));
 
+    var testComponentRenderer: TestComponentRenderer = this._injector.get(TestComponentRenderer);
     var rootElId = `root${_nextRootElementId++}`;
-    var rootEl = el(`<div id="${rootElId}"></div>`);
-    var doc = this._injector.get(DOCUMENT);
-
-    // TODO(juliemr): can/should this be optional?
-    var oldRoots = DOM.querySelectorAll(doc, '[id^=root]');
-    for (var i = 0; i < oldRoots.length; i++) {
-      DOM.remove(oldRoots[i]);
-    }
-    DOM.appendChild(doc.body, rootEl);
+    testComponentRenderer.insertRootElement(rootElId);
 
     var promise: Promise<ComponentRef> =
         this._injector.get(DynamicComponentLoader)


### PR DESCRIPTION
TestComponentBuilder now uses injected TestComponentRenderer which will be provided by the DOMTestComponentRenderer on platforms that provide some sort of DOM.
