### PR TITLE
fix(typescript): strip abstract keyword from properties in .d.ts

### DIFF
--- a/tools/broccoli/trees/node_tree.ts
+++ b/tools/broccoli/trees/node_tree.ts
@@ -152,7 +152,10 @@ module.exports = function makeNodeTree(projects, destinationPath) {
   compiledTree = replace(compiledTree, {
     files: ['**/*.d.ts'],
     patterns: [
+      // all readonly keywords
       {match: /^(\s*(static\s+|private\s+)*)readonly\s+/mg, replacement: "$1"},
+      // abstract properties (but not methods or classes)
+      {match: /^(\s+)abstract\s+([^\(\n]*$)/mg, replacement: "$1$2"},
     ]
   });
 


### PR DESCRIPTION
Tested by running this with a different replacement marker string and grepping all .d.ts files for that marker, to be sure it only triggers on the two lines in `angular2/src/alt_router/metadata/metadata.d.ts`
