### PR TITLE
feat(tests): add ROUTER_FAKE_PROVIDERS to angular2/alt_router/router_…

### DIFF
--- a/modules/angular2/src/alt_router/router_testing_providers.ts
+++ b/modules/angular2/src/alt_router/router_testing_providers.ts
@@ -1,0 +1,27 @@
+import {SpyLocation} from 'angular2/src/mock/location_mock';
+import {Location} from 'angular2/platform/common';
+import {Router, RouterOutletMap} from './router';
+import {RouterUrlSerializer, DefaultRouterUrlSerializer} from './router_url_serializer';
+import {Component, ComponentResolver} from 'angular2/core';
+
+@Component({selector: 'fake-app-root-comp', template: `<span></span>`})
+class FakeAppRootCmp {
+}
+
+function routerFactory(componentResolver: ComponentResolver, urlSerializer: RouterUrlSerializer,
+                       routerOutletMap: RouterOutletMap, location: Location): Router {
+  return new Router(null, FakeAppRootCmp, componentResolver, urlSerializer, routerOutletMap,
+                    location);
+}
+
+export const ROUTER_FAKE_PROVIDERS: any[] = /*@ts2dart_const*/ [
+  RouterOutletMap,
+  /* @ts2dart_Provider */ {provide: Location, useClass: SpyLocation},
+  /* @ts2dart_Provider */ {provide: RouterUrlSerializer, useClass: DefaultRouterUrlSerializer},
+  /* @ts2dart_Provider */ {
+    provide: Router,
+    useFactory: routerFactory,
+    deps: /*@ts2dart_const*/
+        [ComponentResolver, RouterUrlSerializer, RouterOutletMap, Location]
+  },
+];

--- a/modules/angular2/test/testing/testing_public_browser_spec.ts
+++ b/modules/angular2/test/testing/testing_public_browser_spec.ts
@@ -15,6 +15,10 @@ import {
   tick
 } from 'angular2/testing';
 
+import {ROUTER_FAKE_PROVIDERS} from 'angular2/src/alt_router/router_testing_providers';
+import {ROUTER_DIRECTIVES, Routes, Route} from 'angular2/alt_router';
+
+
 import {Injectable, bind, Directive, Component, ViewMetadata} from 'angular2/core';
 import {PromiseWrapper} from 'angular2/src/facade/promise';
 import {XHR} from 'angular2/src/compiler/xhr';
@@ -38,6 +42,18 @@ class ExternalTemplateComp {
 
 @Component({selector: 'bad-template-comp', templateUrl: 'non-existant.html'})
 class BadTemplateUrl {
+}
+
+@Component({
+  selector: 'test-router-cmp',
+  template: `<a [routerLink]="['One']">one</a> <a [routerLink]="['Two']">two</a><router-outlet></router-outlet>`,
+  directives: [ROUTER_DIRECTIVES]
+})
+@Routes([
+  new Route({path: '/One', component: BadTemplateUrl}),
+  new Route({path: '/Two', component: ExternalTemplateComp}),
+])
+class TestRouterComponent {
 }
 
 // Tests for angular2/testing bundle specific to the browser environment.
@@ -160,5 +176,15 @@ export function main() {
                       })),
          10000);  // Long timeout here because this test makes an actual XHR, and is slow on Edge.
     });
+  });
+
+  describe('apps with router components', () => {
+    beforeEachProviders(() => [ROUTER_FAKE_PROVIDERS]);
+
+    it('should build without a problem',
+       async(inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {
+         tcb.createAsync(TestRouterComponent)
+             .then((fixture) => { expect(fixture.nativeElement).toHaveText('one two'); });
+       })));
   });
 }


### PR DESCRIPTION
This change adds providers for fake router dependencies.
This allows TestComponentBuilder to create components with RouterLink and RouterOutlet directives
without the test writer needing to override them.
