### PR TITLE
fix(metadata): error on non-exported dangling refs

### DIFF
--- a/tools/metadata/src/evaluator.ts
+++ b/tools/metadata/src/evaluator.ts
@@ -97,6 +97,9 @@ export class Evaluator {
           }
         }
       }
+      if (!module && !this.symbols.has(symbol)) {
+        throw new Error(`dangling reference to ${name}, does it need to be exported?`);
+      }
       return {__symbolic: "reference", name, module};
     }
   }

--- a/tools/metadata/test/evaluator.spec.ts
+++ b/tools/metadata/test/evaluator.spec.ts
@@ -117,7 +117,7 @@ describe('Evaluator', () => {
     expect(evaluator.evaluateNode(findVar(forwardRef, 'bFalse').initializer)).toEqual(false);
   });
 
-  fit('should return new expressions', () => {
+  it('should return new expressions', () => {
     evaluator =
         new Evaluator(typeChecker, symbols, [{from: './classes', namedImports: [{name: 'Value'}]}]);
     var newExpression = program.getSourceFile('newExpression.ts');
@@ -183,7 +183,7 @@ const FILES: Directory = {
     export var bShiftLeft = 1 << 2;              // 0x04
     export var bShiftRight = -1 >> 2;            // -1
     export var bShiftRightU = -1 >>> 2;          // 0x3fffffff
-    
+
     export var recursiveA = recursiveB;
     export var recursiveB = recursiveA;
   `,


### PR DESCRIPTION
Also fix an `oops` where tools tests were short-circuited with an `fit`
