### PR TITLE
feat(alt_router): expose ROUTER_FAKE_PROVIDERS as a part of "angular2…

### DIFF
--- a/modules/angular2/alt_router/testing.ts
+++ b/modules/angular2/alt_router/testing.ts
@@ -1,0 +1,1 @@
+export * from 'angular2/src/alt_router/router_testing_providers';

--- a/modules/angular2/src/alt_router/router_testing_providers.ts
+++ b/modules/angular2/src/alt_router/router_testing_providers.ts
@@ -14,6 +14,11 @@ function routerFactory(componentResolver: ComponentResolver, urlSerializer: Rout
                     location);
 }
 
+/**
+ * Providers for fake router dependecies.
+ * This allows TestComponentBuilder to create components with RouterLink and RouterOutlet directives
+ * without the test writer needing to override them.
+ */
 export const ROUTER_FAKE_PROVIDERS: any[] = /*@ts2dart_const*/ [
   RouterOutletMap,
   /* @ts2dart_Provider */ {provide: Location, useClass: SpyLocation},


### PR DESCRIPTION
…/alt_router/testing"
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

New feature
- **What is the current behavior?** (You can also link to an open issue here)

`ROUTER_FAKE_PROVIDERS` isn't exposed as a part of public module. only in `angular2/src/alt_router/router_testing_providers`.
- **What is the new behavior (if this is a feature change)?**

make new public module; `angular2/alt_router/testing`
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
- **Other information**:

some documentation is added.
