### PR TITLE
fix(publish): remove .js.map files from publishing files

### DIFF
--- a/modules/@angular/common/tsconfig-es2015.json
+++ b/modules/@angular/common/tsconfig-es2015.json
@@ -14,8 +14,6 @@
       "@angular/core": ["../../../dist/packages-dist/core"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es2015"
   },
   "files": [

--- a/modules/@angular/common/tsconfig-es5.json
+++ b/modules/@angular/common/tsconfig-es5.json
@@ -14,8 +14,6 @@
       "@angular/core": ["../../../dist/packages-dist/core/"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es5"
   },
   "files": [

--- a/modules/@angular/compiler/tsconfig-es2015.json
+++ b/modules/@angular/compiler/tsconfig-es2015.json
@@ -15,8 +15,6 @@
       "@angular/core/testing": ["../../../dist/packages-dist/core/testing"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es2015"
   },
   "files": [

--- a/modules/@angular/compiler/tsconfig-es5.json
+++ b/modules/@angular/compiler/tsconfig-es5.json
@@ -15,8 +15,6 @@
       "@angular/core/testing": ["../../../dist/packages-dist/core/testing"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es5"
   },
   "files": [

--- a/modules/@angular/core/tsconfig-es2015.json
+++ b/modules/@angular/core/tsconfig-es2015.json
@@ -14,8 +14,6 @@
       "rxjs/*": ["../../../node_modules/rxjs/*"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": "",
     "target": "es2015"
   },
   "files": [

--- a/modules/@angular/core/tsconfig-es5.json
+++ b/modules/@angular/core/tsconfig-es5.json
@@ -14,8 +14,6 @@
       "rxjs/*": ["../../../node_modules/rxjs/*"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": "",
     "target": "es5"
   },
   "files": [

--- a/modules/@angular/http/tsconfig-es2015.json
+++ b/modules/@angular/http/tsconfig-es2015.json
@@ -14,8 +14,6 @@
       "@angular/core": ["../../../dist/packages-dist/core"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es2015"
   },
   "files": [

--- a/modules/@angular/http/tsconfig-es5.json
+++ b/modules/@angular/http/tsconfig-es5.json
@@ -14,8 +14,6 @@
       "@angular/core": ["../../../dist/packages-dist/core"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es5"
   },
   "files": [

--- a/modules/@angular/platform-browser-dynamic/tsconfig-es2015.json
+++ b/modules/@angular/platform-browser-dynamic/tsconfig-es2015.json
@@ -19,8 +19,6 @@
       "@angular/platform-browser/testing": ["../../../dist/packages-dist/platform-browser/testing"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es2015"
   },
   "files": [

--- a/modules/@angular/platform-browser-dynamic/tsconfig-es5.json
+++ b/modules/@angular/platform-browser-dynamic/tsconfig-es5.json
@@ -19,8 +19,6 @@
       "@angular/platform-browser/testing": ["../../../dist/packages-dist/platform-browser/testing"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es5"
   },
   "files": [

--- a/modules/@angular/platform-browser/tsconfig-es2015.json
+++ b/modules/@angular/platform-browser/tsconfig-es2015.json
@@ -20,8 +20,6 @@
       "@angular/compiler/testing": ["../../../dist/packages-dist/compiler/testing"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es2015"
   },
   "files": [

--- a/modules/@angular/platform-browser/tsconfig-es5.json
+++ b/modules/@angular/platform-browser/tsconfig-es5.json
@@ -20,8 +20,6 @@
       "@angular/compiler/testing": ["../../../dist/packages-dist/compiler/testing"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es5"
   },
   "files": [

--- a/modules/@angular/platform-server/tsconfig-es2015.json
+++ b/modules/@angular/platform-server/tsconfig-es2015.json
@@ -17,8 +17,6 @@
       "@angular/platform-browser": ["../../../dist/packages-dist/platform-browser/"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es2015"
   },
   "files": [

--- a/modules/@angular/platform-server/tsconfig-es5.json
+++ b/modules/@angular/platform-server/tsconfig-es5.json
@@ -17,8 +17,6 @@
       "@angular/platform-browser": ["../../../dist/packages-dist/platform-browser"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es5"
   },
   "files": [

--- a/modules/@angular/router-deprecated/tsconfig-es2015.json
+++ b/modules/@angular/router-deprecated/tsconfig-es2015.json
@@ -16,8 +16,6 @@
       "@angular/platform-browser": ["../../../dist/packages-dist/platform-browser"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es2015"
   },
   "files": [

--- a/modules/@angular/router-deprecated/tsconfig-es5.json
+++ b/modules/@angular/router-deprecated/tsconfig-es5.json
@@ -16,8 +16,6 @@
       "@angular/platform-browser": ["../../../dist/packages-dist/platform-browser/"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es5"
   },
   "files": [

--- a/modules/@angular/router/tsconfig-es2015.json
+++ b/modules/@angular/router/tsconfig-es2015.json
@@ -17,8 +17,6 @@
       "@angular/platform-browser": ["../../../dist/packages-dist/platform-browser/"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es2015"
   },
   "files": [

--- a/modules/@angular/router/tsconfig-es5.json
+++ b/modules/@angular/router/tsconfig-es5.json
@@ -17,8 +17,6 @@
       "@angular/platform-browser": ["../../../dist/packages-dist/platform-browser/"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es5"
   },
   "files": [

--- a/modules/@angular/upgrade/tsconfig-es2015.json
+++ b/modules/@angular/upgrade/tsconfig-es2015.json
@@ -18,8 +18,6 @@
       "@angular/platform-browser-dynamic": ["../../../dist/packages-dist/platform-browser-dynamic"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es2015"
   },
   "files": [

--- a/modules/@angular/upgrade/tsconfig-es5.json
+++ b/modules/@angular/upgrade/tsconfig-es5.json
@@ -18,8 +18,6 @@
       "@angular/platform-browser-dynamic": ["../../../dist/packages-dist/platform-browser-dynamic"]
     },
     "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": ".",
     "target": "es5"
   },
   "files": [


### PR DESCRIPTION
- **What is the current behavior?** (You can also link to an open issue here)

with webpack, many many warnings occur.

```
WARNING in ./~/@angular/compiler/src/config.js
Cannot find source file '/Users/iminar/Dev/angular/modules/@angular/compiler//src/config.ts':
```

new npm packages contain source map files. 
- **What is the new behavior (if this is a feature change)?**

remove `.js.map` files before publish
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No
- **Other information**:
