### PR TITLE
fix(angular1_router): ngLink should not throw an error if routeParams…

### DIFF
--- a/modules/angular1_router/src/ng_outlet.ts
+++ b/modules/angular1_router/src/ng_outlet.ts
@@ -211,6 +211,10 @@ function ngLinkDirective($rootRouter, $parse) {
     let link = attrs.ngLink || '';
 
     function getLink(params) {
+      if (!params) {
+        return;
+      }
+
       navigationInstruction = router.generate(params);
 
       scope.$watch(function() { return router.isRouteActive(navigationInstruction); },

--- a/modules/angular1_router/test/ng_link_spec.js
+++ b/modules/angular1_router/test/ng_link_spec.js
@@ -140,6 +140,18 @@ describe('ngLink', function () {
       navigateTo('/');
       expect(elt.find('a').attr('class')).toBe('ng-link-active');
     });
+
+    it('should not add a href if link attributes are undefined', function () {
+      setup({baseHref: baseHref, html5Mode: html5Mode, hashPrefix: hashPrefix});
+      configureRouter([
+        { path: '/a', component: 'oneCmp' },
+        { path: '/b', component: 'twoCmp', name: 'Two' }
+      ]);
+
+      var elt = compile('<a ng-link="something.undefined">link</a> | outer { <div ng-outlet></div> }');
+      navigateTo('/a');
+      expect(elt.find('a').hasAttr('href')).toBeFalsy();
+    });
   }
 
   function registerComponent(name, template, controller) {


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Bug fix
- **What is the current behavior?** (You can also link to an open issue here)
  If the route params are undefined an exception is thrown.
- **What is the new behavior (if this is a feature change)?**
  No Exception is thrown. Instead the `href` attribute is not set, which matches the behaviour of ngHref.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  No.

CC: @mischi
