### PR TITLE
fix(ngRouteShim): update anchors to function similar to angular 1.x 

### DIFF
--- a/modules/angular1_router/src/ng_route_shim.js
+++ b/modules/angular1_router/src/ng_route_shim.js
@@ -281,7 +281,9 @@
           }
 
           var href = element.attr(hrefAttrName);
-          if (href && $rootRouter.recognize(href)) {
+          var target = element.attr('target');
+          
+          if (href && $rootRouter.recognize(href) && !['_blank', '_parent', '_self', '_top'].contains(target)) {
             $rootRouter.navigateByUrl(href);
             event.preventDefault();
           }

--- a/modules/angular1_router/src/ng_route_shim.js
+++ b/modules/angular1_router/src/ng_route_shim.js
@@ -282,8 +282,9 @@
 
           var href = element.attr(hrefAttrName);
           var target = element.attr('target');
+          var isExternal = (['_blank', '_parent', '_self', '_top'].indexOf(target) > -1);          
           
-          if (href && $rootRouter.recognize(href) && !['_blank', '_parent', '_self', '_top'].contains(target)) {
+          if (href && $rootRouter.recognize(href) && !isExternal) {
             $rootRouter.navigateByUrl(href);
             event.preventDefault();
           }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug Fix.
- **What is the current behavior?** (You can also link to an open issue here)

Anchors with a target set call rootRouter navigate which results in no action.
- **What is the new behavior (if this is a feature change)?**

Anchors with a target set will not call rootRouter and will not stop the anchor action.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.
- **Other information**:

No tests or Docs were needed to be added or updated.  Very minor change.
