### PR TITLE
chore(tsickle): remove redundant jsdoc types

### DIFF
--- a/modules/@angular/compiler/src/url_resolver.ts
+++ b/modules/@angular/compiler/src/url_resolver.ts
@@ -50,10 +50,6 @@ export class UrlResolver {
    * `baseUrl` and `url`,
    * - if `url` is absolute (it has a scheme: 'http://', 'https://' or start with '/'), the `url` is
    * returned as is (ignoring the `baseUrl`)
-   *
-   * @param {string} baseUrl
-   * @param {string} url
-   * @returns {string} the resolved URL
    */
   resolve(baseUrl: string, url: string): string {
     var resolvedUrl = url;
@@ -95,16 +91,16 @@ export function getUrlScheme(url: string): string {
  * No encoding is performed.  Any component may be omitted as either null or
  * undefined.
  *
- * @param {?string=} opt_scheme The scheme such as 'http'.
- * @param {?string=} opt_userInfo The user name before the '@'.
- * @param {?string=} opt_domain The domain such as 'www.google.com', already
+ * @param opt_scheme The scheme such as 'http'.
+ * @param opt_userInfo The user name before the '@'.
+ * @param opt_domain The domain such as 'www.google.com', already
  *     URI-encoded.
- * @param {(string|null)=} opt_port The port number.
- * @param {?string=} opt_path The path, already URI-encoded.  If it is not
+ * @param opt_port The port number.
+ * @param opt_path The path, already URI-encoded.  If it is not
  *     empty, it must begin with a slash.
- * @param {?string=} opt_queryData The URI-encoded query data.
- * @param {?string=} opt_fragment The URI-encoded fragment identifier.
- * @return {string} The fully combined URI.
+ * @param opt_queryData The URI-encoded query data.
+ * @param opt_fragment The URI-encoded fragment identifier.
+ * @return The fully combined URI.
  */
 function _buildFromEncodedParts(opt_scheme?: string, opt_userInfo?: string, opt_domain?: string,
                                 opt_port?: string, opt_path?: string, opt_queryData?: string,
@@ -247,8 +243,8 @@ enum _ComponentIndex {
  * goog.uri.utils.split(someStr)[goog.uri.utils.CompontentIndex.QUERY_DATA];
  * </pre>
  *
- * @param {string} uri The URI string to examine.
- * @return {!Array.<string|undefined>} Each component still URI-encoded.
+ * @param uri The URI string to examine.
+ * @return Each component still URI-encoded.
  *     Each component that is present will contain the encoded value, whereas
  *     components that are not present will be undefined or empty, depending
  *     on the browser's regular expression implementation.  Never null, since
@@ -262,8 +258,8 @@ function _split(uri: string): Array<string | any> {
   * Removes dot segments in given path component, as described in
   * RFC 3986, section 5.2.4.
   *
-  * @param {string} path A non-empty path component.
-  * @return {string} Path component with removed dot segments.
+  * @param path A non-empty path component.
+  * @return Path component with removed dot segments.
   */
 function _removeDotSegments(path: string): string {
   if (path == '/') return '/';
@@ -306,8 +302,6 @@ function _removeDotSegments(path: string): string {
 /**
  * Takes an array of the parts from split and canonicalizes the path part
  * and then joins all the parts.
- * @param {Array.<string?>} parts
- * @return {string}
  */
 function _joinAndCanonicalizePath(parts: any[]): string {
   var path = parts[_ComponentIndex.Path];
@@ -321,9 +315,8 @@ function _joinAndCanonicalizePath(parts: any[]): string {
 
 /**
  * Resolves a URL.
- * @param {string} base The URL acting as the base URL.
- * @param {string} to The URL to resolve.
- * @return {string}
+ * @param base The URL acting as the base URL.
+ * @param to The URL to resolve.
  */
 function _resolveUrl(base: string, url: string): string {
   var parts = _split(encodeURI(url));

--- a/modules/@angular/compiler/testing/test_component_builder.ts
+++ b/modules/@angular/compiler/testing/test_component_builder.ts
@@ -240,11 +240,6 @@ export class TestComponentBuilder {
   /**
    * Overrides only the html of a {@link ComponentMetadata}.
    * All the other properties of the component's {@link ViewMetadata} are preserved.
-   *
-   * @param {Type} component
-   * @param {string} html
-   *
-   * @return {TestComponentBuilder}
    */
   overrideTemplate(componentType: Type, template: string): TestComponentBuilder {
     let clone = this._clone();
@@ -254,11 +249,6 @@ export class TestComponentBuilder {
 
   /**
    * Overrides a component's {@link ViewMetadata}.
-   *
-   * @param {Type} component
-   * @param {view} View
-   *
-   * @return {TestComponentBuilder}
    */
   overrideView(componentType: Type, view: ViewMetadata): TestComponentBuilder {
     let clone = this._clone();
@@ -268,12 +258,6 @@ export class TestComponentBuilder {
 
   /**
    * Overrides the directives from the component {@link ViewMetadata}.
-   *
-   * @param {Type} component
-   * @param {Type} from
-   * @param {Type} to
-   *
-   * @return {TestComponentBuilder}
    */
   overrideDirective(componentType: Type, from: Type, to: Type): TestComponentBuilder {
     let clone = this._clone();
@@ -295,11 +279,6 @@ export class TestComponentBuilder {
    * The providers specified via this method are appended to the existing `providers` causing the
    * duplicated providers to
    * be overridden.
-   *
-   * @param {Type} component
-   * @param {any[]} providers
-   *
-   * @return {TestComponentBuilder}
    */
   overrideProviders(type: Type, providers: any[]): TestComponentBuilder {
     let clone = this._clone();
@@ -323,11 +302,6 @@ export class TestComponentBuilder {
    * The providers specified via this method are appended to the existing `providers` causing the
    * duplicated providers to
    * be overridden.
-   *
-   * @param {Type} component
-   * @param {any[]} providers
-   *
-   * @return {TestComponentBuilder}
    */
   overrideViewProviders(type: Type, providers: any[]): TestComponentBuilder {
     let clone = this._clone();
@@ -354,8 +328,6 @@ export class TestComponentBuilder {
 
   /**
    * Builds and returns a ComponentFixture.
-   *
-   * @return {Promise<ComponentFixture>}
    */
   createAsync(rootComponentType: Type): Promise<ComponentFixture<any>> {
     let noNgZone = IS_DART || this._injector.get(ComponentFixtureNoNgZone, false);

--- a/modules/@angular/compiler/testing/view_resolver_mock.ts
+++ b/modules/@angular/compiler/testing/view_resolver_mock.ts
@@ -19,9 +19,6 @@ export class MockViewResolver extends ViewResolver {
 
   /**
    * Overrides the {@link ViewMetadata} for a component.
-   *
-   * @param {Type} component
-   * @param {ViewDefinition} view
    */
   setView(component: Type, view: ViewMetadata): void {
     this._checkOverrideable(component);
@@ -30,9 +27,6 @@ export class MockViewResolver extends ViewResolver {
 
   /**
    * Overrides the inline template for a component - other configuration remains unchanged.
-   *
-   * @param {Type} component
-   * @param {string} template
    */
   setInlineTemplate(component: Type, template: string): void {
     this._checkOverrideable(component);
@@ -41,10 +35,6 @@ export class MockViewResolver extends ViewResolver {
 
   /**
    * Overrides a directive from the component {@link ViewMetadata}.
-   *
-   * @param {Type} component
-   * @param {Type} from
-   * @param {Type} to
    */
   overrideViewDirective(component: Type, from: Type, to: Type): void {
     this._checkOverrideable(component);
@@ -66,9 +56,6 @@ export class MockViewResolver extends ViewResolver {
    *   see `setView`.
    * - Override the directives, see `overrideViewDirective`.
    * - Override the @View definition, see `setInlineTemplate`.
-   *
-   * @param component
-   * @returns {ViewDefinition}
    */
   resolve(component: Type): ViewMetadata {
     var view = this._viewCache.get(component);
@@ -113,8 +100,6 @@ export class MockViewResolver extends ViewResolver {
    *
    * Then it should not be possible to override the component configuration after the component
    * has been compiled.
-   *
-   * @param {Type} component
    */
   _checkOverrideable(component: Type): void {
     var cached = this._viewCache.get(component);

--- a/modules/@angular/core/src/zone/ng_zone.ts
+++ b/modules/@angular/core/src/zone/ng_zone.ts
@@ -106,10 +106,6 @@ export class NgZone {
   /** @internal */
   private _onErrorEvents: EventEmitter<any> = new EventEmitter(false);
 
-  /**
-   * @param {bool} enableLongStackTrace whether to enable long stack trace. They should only be
-   *               enabled in development mode as they significantly impact perf.
-   */
   constructor({enableLongStackTrace = false}) {
     this._zoneImpl = new NgZoneImpl({
       trace: enableLongStackTrace,

--- a/modules/@angular/core/testing/fake_async.ts
+++ b/modules/@angular/core/testing/fake_async.ts
@@ -75,7 +75,6 @@ export function clearPendingTimers(): void {
  *
  * {@example testing/ts/fake_async.ts region='basic'}
  *
- * @param {number} millis Number of millisecond, defaults to 0
  */
 export function tick(millis: number = 0): void {
   _getFakeAsyncZoneSpec().tick(millis);

--- a/modules/@angular/core/testing/test_injector.ts
+++ b/modules/@angular/core/testing/test_injector.ts
@@ -124,9 +124,6 @@ export function resetBaseTestProviders() {
  * eventually
  *   becomes `it('...', @Inject (object: AClass, async: AsyncTestCompleter) => { ... });`
  *
- * @param {Array} tokens
- * @param {Function} fn
- * @return {Function}
  */
 export function inject(tokens: any[], fn: Function): Function {
   let testInjector = getTestInjector();
@@ -190,9 +187,6 @@ export function withProviders(providers: () => any) {
  * })
  * ```
  *
- * @param {Array} tokens
- * @param {Function} fn
- * @return {Function}
  */
 export function injectAsync(tokens: any[], fn: Function): Function {
   return async(inject(tokens, fn));


### PR DESCRIPTION
tsickle doesn't like them, and anyway they are bound to get out-of-sync with the inline TS types
