### PR TITLE
docs(API): correct formatting of EmbeddedViewRef API doc example

### DIFF
--- a/modules/@angular/core/src/linker/view_ref.ts
+++ b/modules/@angular/core/src/linker/view_ref.ts
@@ -32,7 +32,7 @@ export abstract class ViewRef {
  * </ul>
  * ```
  *
- * ... we have two {@link TemplateRef}s:
+ * We have two {@link TemplateRef}s:
  *
  * Outer {@link TemplateRef}:
  * ```


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... docs update

**What is the current behavior?** (You can also link to an open issue here)
API doc example of EmbeddedViewRef is _NOT_ correctly formatted

> ![image](https://cloud.githubusercontent.com/assets/5074211/15173977/ea450f68-177c-11e6-9ae8-21e5e24950ec.png)

**What is the new behavior?**
API doc example of EmbeddedViewRef is correctly formatted

> ![image](https://cloud.githubusercontent.com/assets/5074211/15174006/131bca4e-177d-11e6-8029-5df793e6e5e2.png)

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

remove ... from EmbeddedViewRef API example doc comments
