### PR TITLE
feat(ChangeDetectorRef): make detectChanges() correct

### DIFF
--- a/modules/@angular/core/src/linker/view.ts
+++ b/modules/@angular/core/src/linker/view.ts
@@ -279,8 +279,7 @@ export abstract class AppView<T> {
 
   detectChanges(throwOnChange: boolean): void {
     var s = _scope_check(this.clazz);
-    if (this.cdMode === ChangeDetectionStrategy.Detached ||
-        this.cdMode === ChangeDetectionStrategy.Checked ||
+    if (this.cdMode === ChangeDetectionStrategy.Checked ||
         this.cdState === ChangeDetectorState.Errored)
       return;
     if (this.destroyed) {
@@ -304,13 +303,17 @@ export abstract class AppView<T> {
 
   detectContentChildrenChanges(throwOnChange: boolean) {
     for (var i = 0; i < this.contentChildren.length; ++i) {
-      this.contentChildren[i].detectChanges(throwOnChange);
+      var child = this.contentChildren[i];
+      if (child.cdMode === ChangeDetectionStrategy.Detached) continue;
+      child.detectChanges(throwOnChange);
     }
   }
 
   detectViewChildrenChanges(throwOnChange: boolean) {
     for (var i = 0; i < this.viewChildren.length; ++i) {
-      this.viewChildren[i].detectChanges(throwOnChange);
+      var child = this.viewChildren[i];
+      if (child.cdMode === ChangeDetectionStrategy.Detached) continue;
+      child.detectChanges(throwOnChange);
     }
   }
 


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

`ChangeDetectorRef.detectChanges()` is skipped if it is detached.

**What is the new behavior?**

`ChangeDetectorRef.detectChanges()` executes detection even if it is detached.

**Does this PR introduce a breaking change?**
No

**Other information**:

Close #8597 
