### PR TITLE
chore(build): short-circuit npm install if node_modules are healthy

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "url": "https://github.com/angular/angular.git"
   },
   "scripts": {
-    "preinstall": "node tools/npm/check-node-modules",
     "postinstall": "node tools/npm/copy-npm-shrinkwrap"
   },
   "dependencies": {

--- a/scripts/ci-lite/install.sh
+++ b/scripts/ci-lite/install.sh
@@ -27,13 +27,8 @@ echo 'travis_fold:end:install-npm'
 
 
 # Install all npm dependencies according to shrinkwrap.json
-#   note: package.json contain preinstall and postintall hooks that can short-circuit
-#         the installation if node_modules is up to date
 echo 'travis_fold:start:install.node_modules'
-if [[ ${TRAVIS} ]]; then
-  node tools/npm/check-node-modules --purge
-fi
-npm install
+node tools/npm/check-node-modules --purge || npm install
 echo 'travis_fold:end:install.node_modules'
 
 

--- a/tools/npm/check-node-modules
+++ b/tools/npm/check-node-modules
@@ -4,13 +4,9 @@ var checkNpm = require('./check-node-modules.js');
 
 var purgeIfStale = (process.argv.indexOf('--purge') !== -1);
 
-if (process.env.TRAVIS && !purgeIfStale) {
-  process.exit(0);
-}
-
 // check-node-modules will exit(1) if we don't need to install to short-circuit `npm install`
 // see .travis.yml's `install` block to see the reason for this
 var nodeModulesOK = checkNpm(true, purgeIfStale);
 
-process.exit( nodeModulesOK || purgeIfStale ? 0 : 1);
+process.exit( nodeModulesOK ? 0 : 1);
 

--- a/tools/npm/check-node-modules.js
+++ b/tools/npm/check-node-modules.js
@@ -18,12 +18,7 @@ function checkNodeModules(logOutput, purgeIfStale) {
     if (logOutput) console.error(':-( npm dependencies are stale or in an in unknown state!');
     if (purgeIfStale) {
       if (logOutput) console.log('    purging...');
-
-      var nodeModulesPath = path.join(PROJECT_ROOT, 'node_modules');
-
-      if (fs.existsSync(nodeModulesPath)) {
-        _deleteDir(nodeModulesPath);
-      }
+      _deleteDir(path.join(PROJECT_ROOT, 'node_modules'));
     }
   }
 


### PR DESCRIPTION
Params destructing doesn't work on node 5.4.1 (one we are using) so we need to wait for a nicer syntax for the `checkNodeModules` arguments.
