### PR TITLE
adds 'repository' metadata to npm modules

### DIFF
--- a/modules/@angular/common/package.json
+++ b/modules/@angular/common/package.json
@@ -9,5 +9,9 @@
   "license": "MIT",
   "peerDependencies": {
     "@angular/core": "$$ANGULAR_VERSION$$"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular.git"
   }
 }

--- a/modules/@angular/compiler/package.json
+++ b/modules/@angular/compiler/package.json
@@ -9,5 +9,9 @@
   "license": "MIT",
   "peerDependencies": {
     "@angular/core": "$$ANGULAR_VERSION$$"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular.git"
   }
 }

--- a/modules/@angular/core/package.json
+++ b/modules/@angular/core/package.json
@@ -10,5 +10,9 @@
   "peerDependencies": {
     "rxjs": "5.0.0-beta.6",
     "zone.js": "^0.6.6"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular.git"
   }
 }

--- a/modules/@angular/http/package.json
+++ b/modules/@angular/http/package.json
@@ -10,5 +10,9 @@
   "peerDependencies": {
     "rxjs": "5.0.0-beta.6",
     "@angular/core": "$$ANGULAR_VERSION$$"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular.git"
   }
 }

--- a/modules/@angular/platform-browser-dynamic/package.json
+++ b/modules/@angular/platform-browser-dynamic/package.json
@@ -12,5 +12,9 @@
     "@angular/common": "$$ANGULAR_VERSION$$",
     "@angular/compiler": "$$ANGULAR_VERSION$$",
     "@angular/platform-browser": "$$ANGULAR_VERSION$$"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular.git"
   }
 }

--- a/modules/@angular/platform-browser/package.json
+++ b/modules/@angular/platform-browser/package.json
@@ -11,5 +11,9 @@
     "@angular/core": "$$ANGULAR_VERSION$$",
     "@angular/common": "$$ANGULAR_VERSION$$",
     "@angular/compiler": "$$ANGULAR_VERSION$$"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular.git"
   }
 }

--- a/modules/@angular/platform-server/package.json
+++ b/modules/@angular/platform-server/package.json
@@ -15,5 +15,9 @@
   },
   "dependencies": {
     "parse5": "1.3.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular.git"
   }
 }

--- a/modules/@angular/router-deprecated/package.json
+++ b/modules/@angular/router-deprecated/package.json
@@ -11,5 +11,9 @@
     "@angular/core": "$$ANGULAR_VERSION$$",
     "@angular/common": "$$ANGULAR_VERSION$$",
     "@angular/platform-browser": "$$ANGULAR_VERSION$$"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular.git"
   }
 }

--- a/modules/@angular/router/package.json
+++ b/modules/@angular/router/package.json
@@ -11,5 +11,9 @@
     "@angular/core": "$$ANGULAR_VERSION$$",
     "@angular/common": "$$ANGULAR_VERSION$$",
     "@angular/platform-browser": "$$ANGULAR_VERSION$$"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular.git"
   }
 }

--- a/modules/@angular/upgrade/package.json
+++ b/modules/@angular/upgrade/package.json
@@ -10,5 +10,9 @@
     "@angular/core": "$$ANGULAR_VERSION$$",
     "@angular/compiler": "$$ANGULAR_VERSION$$",
     "@angular/platform-browser": "$$ANGULAR_VERSION$$"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular.git"
   }
 }

--- a/modules/rollup-test/package.json
+++ b/modules/rollup-test/package.json
@@ -26,5 +26,9 @@
     "rxjs-es": "^5.0.0-beta.6",
     "typescript": "^1.9.0-dev.20160423",
     "uglify-js": "^2.6.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular.git"
   }
 }


### PR DESCRIPTION
This is a bugfix.
It fixes #8571 
The missing `repository` metadata has been added to `package.json` files.
It's not a breaking change.
