### PR TITLE
fix(upgrade): fallback to root ng2 injector when element is compiled …

### DIFF
--- a/modules/@angular/upgrade/src/constants.ts
+++ b/modules/@angular/upgrade/src/constants.ts
@@ -12,4 +12,4 @@ export const NG1_INJECTOR = '$injector';
 export const NG1_PARSE = '$parse';
 export const NG1_TEMPLATE_CACHE = '$templateCache';
 export const NG1_TESTABILITY = '$$testability';
-export const REQUIRE_INJECTOR = '^' + NG2_INJECTOR;
+export const REQUIRE_INJECTOR = '?^' + NG2_INJECTOR;

--- a/modules/@angular/upgrade/src/downgrade_ng2_adapter.ts
+++ b/modules/@angular/upgrade/src/downgrade_ng2_adapter.ts
@@ -42,7 +42,7 @@ export class DowngradeNg2ComponentAdapter {
     this.contentInsertionPoint = document.createComment('ng1 insertion point');
 
     this.componentRef =
-        this.componentFactory.create(childInjector, [[this.contentInsertionPoint]], '#' + this.id);
+        this.componentFactory.create(childInjector, [[this.contentInsertionPoint]], this.element[0]);
     this.changeDetector = this.componentRef.changeDetectorRef;
     this.component = this.componentRef.instance;
   }

--- a/modules/@angular/upgrade/src/upgrade_adapter.ts
+++ b/modules/@angular/upgrade/src/upgrade_adapter.ts
@@ -540,8 +540,9 @@ interface ComponentFactoryRefMap {
 }
 
 function ng1ComponentDirective(info: ComponentInfo, idPrefix: string): Function {
-  (<any>directiveFactory).$inject = [NG2_COMPONENT_FACTORY_REF_MAP, NG1_PARSE];
-  function directiveFactory(componentFactoryRefMap: ComponentFactoryRefMap,
+  (<any>directiveFactory).$inject = [NG1_INJECTOR, NG2_COMPONENT_FACTORY_REF_MAP, NG1_PARSE];
+  function directiveFactory(ng1Injector: angular.IInjectorService,
+                            componentFactoryRefMap: ComponentFactoryRefMap,
                             parse: angular.IParseService): angular.IDirective {
     var componentFactory: ComponentFactory<any> = componentFactoryRefMap[info.selector];
     if (!componentFactory) throw new Error('Expecting ComponentFactory for: ' + info.selector);
@@ -553,6 +554,9 @@ function ng1ComponentDirective(info: ComponentInfo, idPrefix: string): Function 
         post: (scope: angular.IScope, element: angular.IAugmentedJQuery, attrs: angular.IAttributes,
                parentInjector: any, transclude: angular.ITranscludeFunction): void => {
           var domElement = <any>element[0];
+          if (parentInjector === null) {
+            parentInjector = ng1Injector.get(NG2_INJECTOR);
+          }
           var facade =
               new DowngradeNg2ComponentAdapter(idPrefix + (idCount++), info, element, attrs, scope,
                                                <Injector>parentInjector, parse, componentFactory);

--- a/modules/@angular/upgrade/test/upgrade_spec.ts
+++ b/modules/@angular/upgrade/test/upgrade_spec.ts
@@ -256,6 +256,37 @@ export function main() {
                         async.done();
                       })});
          }));
+
+
+      it('should fallback to the root ng2.injector when compiled outside the dom',
+        inject([AsyncTestCompleter], (async) => {
+          var adapter: UpgradeAdapter = new UpgradeAdapter();
+          var ng1Module = angular.module('ng1', []);
+
+          ng1Module.directive('ng1', ['$compile', ($compile) => {
+            return {
+              link: function($scope, $element, $attrs) {
+                var compiled = $compile("<ng2></ng2>");
+                var template = compiled($scope);
+                $element.append(template);
+              }
+            };
+          }]);
+
+          var Ng2 = Component({ selector: 'ng2', template: 'test' })
+            .Class({
+              constructor: function() { }
+            });
+          ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+          var element = html('<ng1></ng1>');
+          adapter.bootstrap(element, ['ng1'])
+            .ready((ref) => {
+              expect(multiTrim(document.body.textContent))
+                .toEqual('test');
+              ref.dispose();
+              async.done();
+            });
+        }));
     });
 
     describe('upgrade ng1 component', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [X ] Tests for the changes have been added (for bug fixes / features)
- [X ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

See #6655 

Currently, when a downgraded ng2 directive is compiled in a context where it hasn't yet been inserted into the dom (specific case is ui-router), it throws an error because it cannot satisfy the 'require' attribute of the DDO because it's looking for a parent element with an ng2 Injector on it.

**What is the new behavior?**

The 'require' attribute is still present on the DDO for a downgraded NG2 component, but it is optional. If a parent injector cannot be found, a fallback is made to the root ng2 Injector for the original bootstrapped element.

This way, NG2's hierarchical injection is preserved for the regular case, but a downgraded ng2 component can still be used inside a ui-router view, or other common case where a template is compiled before it's inserted in the dom. This is not a bad outcome ultimately -- because you'd only need a hierarchical injector if there where another ng2 element among the ancestors of a ui-view. That would be a bad idea anyway because then you'd have to attempt to upgrade the ui-view directive to work in an ng2 component's template. Based on the docs for upgrading ng1 components, it seems like that wouldn't work (ui-view uses a compile attribute among other things).

**Does this PR introduce a breaking change?**
- [ ] Yes
- [X ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

…outside the document

Currently downgraded ng2 elements fail inside a ui-router view because they are unable
to require an ng2 Injector via the require attribute of the DDO, because ui-router compiles
its templates before they are inserted in a ui-view. This adds a "fallback" behavior if
a parent injector cannot be found to go to the root ng2 Injector.
