### PR TITLE
chore(security): fix CHANGELOG formatting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - HTML, style values, and URLs are now automatically sanitized. Values that do not match are escaped
   or ignored. When binding a URL or style property that would get ignored, bind to a value
   explicitly marked as safe instead by injection the DOM sanitization service:
+  
   ```
   class MyComponent {
     constructor(sanitizer: DomSanitizationService) {


### PR DESCRIPTION
Turns out the fenced code block needs to be in its own paragraph.
