### PR TITLE
G3_MASTER: Ignore unused import strong-mode warnings in generated Dart code

### DIFF
--- a/modules_dart/transform/lib/src/transform/common/code/ng_deps_code.dart
+++ b/modules_dart/transform/lib/src/transform/common/code/ng_deps_code.dart
@@ -127,6 +127,8 @@ class NgDepsWriter extends Object
       : this.buffer = buffer != null ? buffer : new StringBuffer();
 }
 
+const _ignoredProblems = const <String>['UNUSED_IMPORT', 'UNUSED_SHOWN_NAME'];
+
 abstract class NgDepsWriterMixin
     implements
         AnnotationWriterMixin,
@@ -137,6 +139,11 @@ abstract class NgDepsWriterMixin
   StringBuffer get buffer;
 
   void writeNgDepsModel(NgDepsModel model) {
+    // Avoid strong-mode warnings about unused imports.
+    for (var problem in _ignoredProblems) {
+      buffer.writeln('// @ignoreProblemForFile $problem');
+    }
+
     if (model.libraryUri.isNotEmpty) {
       buffer.writeln('library ${model.libraryUri}${TEMPLATE_EXTENSION};\n');
     }

--- a/modules_dart/transform/test/transform/integration/deferred_files/expected/bar.template.dart
+++ b/modules_dart/transform/test/transform/integration/deferred_files/expected/bar.template.dart
@@ -1,3 +1,5 @@
+// @ignoreProblemForFile UNUSED_IMPORT
+// @ignoreProblemForFile UNUSED_SHOWN_NAME
 library bar.template.dart;
 
 import 'bar.dart';

--- a/modules_dart/transform/test/transform/integration/directive_chain_files/expected/bar.template.dart
+++ b/modules_dart/transform/test/transform/integration/directive_chain_files/expected/bar.template.dart
@@ -1,3 +1,5 @@
+// @ignoreProblemForFile UNUSED_IMPORT
+// @ignoreProblemForFile UNUSED_SHOWN_NAME
 library bar.template.dart;
 
 import 'bar.dart';

--- a/modules_dart/transform/test/transform/integration/directive_dep_files/expected/bar.template.dart
+++ b/modules_dart/transform/test/transform/integration/directive_dep_files/expected/bar.template.dart
@@ -1,3 +1,5 @@
+// @ignoreProblemForFile UNUSED_IMPORT
+// @ignoreProblemForFile UNUSED_SHOWN_NAME
 library bar.template.dart;
 
 import 'bar.dart';

--- a/modules_dart/transform/test/transform/integration/empty_ng_deps_files/expected/foo.template.dart
+++ b/modules_dart/transform/test/transform/integration/empty_ng_deps_files/expected/foo.template.dart
@@ -1,3 +1,5 @@
+// @ignoreProblemForFile UNUSED_IMPORT
+// @ignoreProblemForFile UNUSED_SHOWN_NAME
 library bar.template.dart;
 
 import 'foo.dart';

--- a/modules_dart/transform/test/transform/integration/event_getter_files/expected/bar.template.dart
+++ b/modules_dart/transform/test/transform/integration/event_getter_files/expected/bar.template.dart
@@ -1,3 +1,5 @@
+// @ignoreProblemForFile UNUSED_IMPORT
+// @ignoreProblemForFile UNUSED_SHOWN_NAME
 library bar.template.dart;
 
 import 'bar.dart';

--- a/modules_dart/transform/test/transform/integration/list_of_types_files/expected/bar.template.dart
+++ b/modules_dart/transform/test/transform/integration/list_of_types_files/expected/bar.template.dart
@@ -1,3 +1,5 @@
+// @ignoreProblemForFile UNUSED_IMPORT
+// @ignoreProblemForFile UNUSED_SHOWN_NAME
 library bar.template.dart;
 
 import 'bar.dart';

--- a/modules_dart/transform/test/transform/integration/override_annotation_files/expected/bar.template.dart
+++ b/modules_dart/transform/test/transform/integration/override_annotation_files/expected/bar.template.dart
@@ -1,3 +1,5 @@
+// @ignoreProblemForFile UNUSED_IMPORT
+// @ignoreProblemForFile UNUSED_SHOWN_NAME
 library bar.template.dart;
 
 import 'bar.dart';

--- a/modules_dart/transform/test/transform/integration/queries_class_annotation_files/expected/bar.template.dart
+++ b/modules_dart/transform/test/transform/integration/queries_class_annotation_files/expected/bar.template.dart
@@ -1,3 +1,5 @@
+// @ignoreProblemForFile UNUSED_IMPORT
+// @ignoreProblemForFile UNUSED_SHOWN_NAME
 library bar.template.dart;
 
 import 'bar.dart';

--- a/modules_dart/transform/test/transform/integration/queries_prop_annotation_files/expected/bar.template.dart
+++ b/modules_dart/transform/test/transform/integration/queries_prop_annotation_files/expected/bar.template.dart
@@ -1,3 +1,5 @@
+// @ignoreProblemForFile UNUSED_IMPORT
+// @ignoreProblemForFile UNUSED_SHOWN_NAME
 library bar.template.dart;
 
 import 'bar.dart';

--- a/modules_dart/transform/test/transform/integration/simple_annotation_files/expected/bar.template.dart
+++ b/modules_dart/transform/test/transform/integration/simple_annotation_files/expected/bar.template.dart
@@ -1,3 +1,5 @@
+// @ignoreProblemForFile UNUSED_IMPORT
+// @ignoreProblemForFile UNUSED_SHOWN_NAME
 library bar.template.dart;
 
 import 'bar.dart';

--- a/modules_dart/transform/test/transform/integration/simple_annotation_files/expected/index.template.dart
+++ b/modules_dart/transform/test/transform/integration/simple_annotation_files/expected/index.template.dart
@@ -1,3 +1,5 @@
+// @ignoreProblemForFile UNUSED_IMPORT
+// @ignoreProblemForFile UNUSED_SHOWN_NAME
 library web_foo.template.dart;
 
 import 'index.dart';

--- a/modules_dart/transform/test/transform/integration/synthetic_ctor_files/expected/bar.template.dart
+++ b/modules_dart/transform/test/transform/integration/synthetic_ctor_files/expected/bar.template.dart
@@ -1,3 +1,5 @@
+// @ignoreProblemForFile UNUSED_IMPORT
+// @ignoreProblemForFile UNUSED_SHOWN_NAME
 library bar.template.dart;
 
 import 'bar.dart';

--- a/modules_dart/transform/test/transform/integration/two_annotations_files/expected/bar.template.dart
+++ b/modules_dart/transform/test/transform/integration/two_annotations_files/expected/bar.template.dart
@@ -1,3 +1,5 @@
+// @ignoreProblemForFile UNUSED_IMPORT
+// @ignoreProblemForFile UNUSED_SHOWN_NAME
 library bar.template.dart;
 
 import 'bar.dart';

--- a/modules_dart/transform/test/transform/integration/two_deps_files/expected/bar.template.dart
+++ b/modules_dart/transform/test/transform/integration/two_deps_files/expected/bar.template.dart
@@ -1,3 +1,5 @@
+// @ignoreProblemForFile UNUSED_IMPORT
+// @ignoreProblemForFile UNUSED_SHOWN_NAME
 library bar.template.dart;
 
 import 'bar.dart';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Generated code triggers lots of unused import warnings with `dartanalyzer --strong`.

**What is the new behavior?**

Unused imports and unused "shown" names in imports in generated are silently ignored by the Dart analyzer in strong-mode.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:
