### PR TITLE
Issue 7084 - fix the compiler's "is recursive" check

### DIFF
--- a/modules/@angular/compiler/src/runtime_compiler.ts
+++ b/modules/@angular/compiler/src/runtime_compiler.ts
@@ -115,7 +115,9 @@ export class RuntimeCompiler implements ComponentResolver {
           this._metadataResolver.getViewDirectivesMetadata(dep.comp.type.runtime);
       var childViewPipes: CompilePipeMetadata[] =
           this._metadataResolver.getViewPipesMetadata(dep.comp.type.runtime);
-      var childIsRecursive = ListWrapper.contains(childCompilingComponentsPath, childCacheKey);
+      var childIsRecursive = childCompilingComponentsPath.indexOf(childCacheKey) > -1 ||
+          childViewDirectives.some(
+              dir => childCompilingComponentsPath.indexOf(dir.type.runtime) > -1);
       childCompilingComponentsPath.push(childCacheKey);
 
       var childComp = this._loadAndCompileComponent(

--- a/modules/@angular/core/test/linker/regression_integration_spec.ts
+++ b/modules/@angular/core/test/linker/regression_integration_spec.ts
@@ -4,7 +4,7 @@ import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 
 import {IS_DART} from '../../src/facade/lang';
 
-import {Component, Pipe, PipeTransform, provide, ViewMetadata, OpaqueToken, Injector} from '@angular/core';
+import {Component, Pipe, PipeTransform, provide, ViewMetadata, PLATFORM_PIPES, OpaqueToken, Injector, forwardRef} from '@angular/core';
 import {NgIf, NgClass} from '@angular/common';
 import {CompilerConfig} from '@angular/compiler';
 
@@ -162,8 +162,7 @@ function declareTests({useJit}: {useJit: boolean}) {
 
     it('should support ngClass before a component and content projection inside of an ngIf',
        inject(
-           [TestComponentBuilder, AsyncTestCompleter],
-           (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
+           [TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async: any) => {
              tcb.overrideView(
                     MyComp1, new ViewMetadata({
                       template: `A<cmp-content *ngIf="true" [ngClass]="'red'">B</cmp-content>C`,
@@ -177,6 +176,15 @@ function declareTests({useJit}: {useJit: boolean}) {
                  });
            }));
 
+    it('should handle mutual recursion entered from multiple sides - #7084',
+       inject(
+           [TestComponentBuilder, AsyncTestCompleter], (tcb: TestComponentBuilder, async: any) => {
+             tcb.createAsync(FakeRecursiveComp).then((fixture) => {
+               fixture.detectChanges();
+               expect(fixture.nativeElement).toHaveText('[]');
+               async.done();
+             });
+           }));
 
   });
 }
@@ -198,4 +206,38 @@ class CustomPipe implements PipeTransform {
 
 @Component({selector: 'cmp-content', template: `<ng-content></ng-content>`})
 class CmpWithNgContent {
+}
+
+@Component({
+  selector: 'left',
+  template: `L<right *ngIf="false"></right>`,
+  directives: [
+    NgIf,
+    forwardRef(() => RightComp),
+  ]
+})
+class LeftComp {
+}
+
+@Component({
+  selector: 'right',
+  template: `R<left *ngIf="false"></left>`,
+  directives: [
+    NgIf,
+    forwardRef(() => LeftComp),
+  ]
+})
+class RightComp {
+}
+
+@Component({
+  selector: 'fakeRecursiveComp',
+  template: `[<left *ngIf="false"></left><right *ngIf="false"></right>]`,
+  directives: [
+    NgIf,
+    forwardRef(() => LeftComp),
+    forwardRef(() => RightComp),
+  ]
+})
+export class FakeRecursiveComp {
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format

I'm not sure if there's much to add in terms of documentation for this fix. Feel free to correct.

I've written a test (based on the Plunker reproduction in the original issue), but I don't see a spec file for the `runtime_compiler` anymore. Moreover, I don't think my reproduction really qualifies as a compiler unit test, since it's a bit bigger in scope. So I'm not quite sure where you guys would prefer to have me put it -- I'd be glad to get some feedback on this then add it in as desired.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)

See [7084](https://github.com/angular/angular/issues/7084): the compiler currently judges some mutually recursive component structures as non-recursive, which causes it to await non-resolving promises. As a result, in production it hangs without errors, in tests, `createAsync` just times out to Jasmine.

**What is the new behavior?**

I let the compiler check the current component's descendants as well, so as to reclassify the misjudged cases as recursive. This way, it no longer hangs/errors.

**Does this PR introduce a breaking change?**
- [x] No

**Other information**:

From what I can see, the offline compiler has no similar check. I also haven't found equivalent Dart code.

Note I have not yet re-run the test as asked in the guidelines. Like for [some other](https://github.com/angular/angular/issues/8517) non-Mac users (environment: Windows 10 + Vagrant Ubuntu VM that break on symlinks), building and running the test suite has proven a major barrier for me. I apologize for this, and hope Travis will do for now.
