### PR TITLE
fix(router): replace state when path is equal to current path

### DIFF
--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -151,7 +151,7 @@ export class Router {
         (change) => { this._navigate(this._urlSerializer.parse(change['url']), change['pop']); });
   }
 
-  private _navigate(url: UrlTree, pop?: boolean): Promise<void> {
+  private _navigate(url: UrlTree, preventPushState?: boolean): Promise<void> {
     this._urlTree = url;
     return recognize(this._componentResolver, this._rootComponentType, url, this._routeTree)
       .then(currTree => {
@@ -160,8 +160,13 @@ export class Router {
           .then(updated => {
             if (updated) {
               this._routeTree = currTree;
-              if (isBlank(pop) || !pop) {
-                this._location.go(this._urlSerializer.serialize(this._urlTree));
+              if (isBlank(preventPushState) || !preventPushState) {
+                let path = this._urlSerializer.serialize(this._urlTree);
+                if (this._location.isCurrentPathEqualTo(path)) {
+                  this._location.replaceState(path);
+                } else {
+                  this._location.go(path);
+                }
               }
               this._changes.emit(null);
             }

--- a/modules/@angular/router/test/integration_spec.ts
+++ b/modules/@angular/router/test/integration_spec.ts
@@ -252,6 +252,24 @@ export function main() {
            advance(fixture);
            expect(fixture.debugElement.nativeElement).toHaveText('link');
          })));
+
+      it('should replace state when path is equal to current path',
+        fakeAsync(inject([Router, TestComponentBuilder, Location], (router, tcb, location) => {
+          let fixture = tcb.createFakeAsync(RootCmp);
+
+          router.navigateByUrl('/team/33/simple');
+          advance(fixture);
+
+          router.navigateByUrl('/team/22/user/victor');
+          advance(fixture);
+
+          router.navigateByUrl('/team/22/user/victor');
+          advance(fixture);
+
+          location.back();
+          advance(fixture);
+          expect(location.path()).toEqual('/team/33/simple');
+        })));
     }
   });
 }


### PR DESCRIPTION
Same as 2bf21e174747052c7628eb9c50654fc1738a17a2 but for new router.

This also fixes an issue where when application loads it clears forward history
because Router constructor calls navigateByUrl which was causing a push state to happen.
