### PR TITLE
fix(forms): update accessor value when native select value changes

### DIFF
--- a/modules/@angular/common/src/forms/directives/select_control_value_accessor.ts
+++ b/modules/@angular/common/src/forms/directives/select_control_value_accessor.ts
@@ -68,7 +68,10 @@ export class SelectControlValueAccessor implements ControlValueAccessor {
   }
 
   registerOnChange(fn: (value: any) => any): void {
-    this.onChange = (valueString: string) => { fn(this._getOptionValue(valueString)); };
+    this.onChange = (valueString: string) => {
+      this.value = valueString;
+      fn(this._getOptionValue(valueString));
+    };
   }
   registerOnTouched(fn: () => any): void { this.onTouched = fn; }
 

--- a/modules/@angular/common/test/forms/integration_spec.ts
+++ b/modules/@angular/common/test/forms/integration_spec.ts
@@ -585,7 +585,7 @@ export function main() {
                         });
                   }));
 
-        it("when new options are added",
+        it("when new options are added (selection through the model)",
            inject([TestComponentBuilder, AsyncTestCompleter],
                   (tcb: TestComponentBuilder, async) => {
                     var t = `<div>
@@ -614,6 +614,39 @@ export function main() {
                           async.done();
                         });
                   }));
+
+        it("when new options are added (selection through the UI)",
+            inject([TestComponentBuilder, AsyncTestCompleter],
+                (tcb: TestComponentBuilder, async) => {
+                  var t = `<div>
+                      <select [(ngModel)]="selectedCity">
+                        <option *ngFor="let c of list" [ngValue]="c">{{c['name']}}</option>
+                      </select>
+                  </div>`;
+
+                  tcb.overrideTemplate(MyComp8, t)
+                      .createAsync(MyComp8)
+                      .then((fixture) => {
+
+                        var testComp: MyComp8 = fixture.debugElement.componentInstance;
+                        testComp.list = [{"name": "SF"}, {"name": "NYC"}];
+                        testComp.selectedCity = testComp.list[0];
+                        fixture.detectChanges();
+
+                        var select = fixture.debugElement.query(By.css("select"));
+                        var ny = fixture.debugElement.queryAll(By.css("option"))[1];
+
+                        select.nativeElement.value = "1: Object";
+                        dispatchEvent(select.nativeElement, "change");
+                        testComp.list.push({"name": "Buffalo"});
+                        fixture.detectChanges();
+
+                        expect(select.nativeElement.value).toEqual("1: Object");
+                        expect(ny.nativeElement.selected).toBe(true);
+                        async.done();
+                      });
+                }));
+
 
         it("when options are removed",
            inject([TestComponentBuilder, AsyncTestCompleter],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?** 

Issue: https://github.com/angular/angular/issues/8710

Currently, the SelectControlValueAccessor's value is only updated by ngModel changes, not by changes in the UI.   So if you update the value through the UI, then try to do something like add a new option, it will fall back to the original value (bc it was never updated).

**What is the new behavior?**

SelectControlValueAccessor's value is updated appropriately by ngModel and when the value in the UI changes.
