### PR TITLE
chore(compiler): Expose types needed by the language service

### DIFF
--- a/modules/@angular/compiler/private_export.ts
+++ b/modules/@angular/compiler/private_export.ts
@@ -4,6 +4,7 @@ import * as metadata_resolver from './src/metadata_resolver';
 import * as html_parser from './src/html_parser';
 import * as directive_normalizer from './src/directive_normalizer';
 import * as lexer from './src/expression_parser/lexer';
+import * as parse_util from './src/parse_util';
 import * as parser from './src/expression_parser/parser';
 import * as template_parser from './src/template_parser';
 import * as dom_element_schema_registry from './src/schema/dom_element_schema_registry';
@@ -39,8 +40,25 @@ export namespace __compiler_private__ {
   export type Parser = parser.Parser;
   export var Parser = parser.Parser;
 
+  export type ParseLocation = parse_util.ParseLocation;
+  export var ParseLocation = parse_util.ParseLocation;
+
+  export type ParseError = parse_util.ParseError;
+  export var ParseError = parse_util.ParseError;
+
+  export type ParseErrorLevel = parse_util.ParseErrorLevel;
+  export var ParseErrorLevel = parse_util.ParseErrorLevel;
+
+  export type ParseSourceFile = parse_util.ParseSourceFile;
+  export var ParseSourceFile = parse_util.ParseSourceFile;
+
+  export type ParseSourceSpan = parse_util.ParseSourceSpan;
+  export var ParseSourceSpan = parse_util.ParseSourceSpan;
+
   export type TemplateParser = template_parser.TemplateParser;
   export var TemplateParser = template_parser.TemplateParser;
+
+  export type TemplateParseResult = template_parser.TemplateParseResult;
 
   export type DomElementSchemaRegistry = dom_element_schema_registry.DomElementSchemaRegistry;
   export var DomElementSchemaRegistry = dom_element_schema_registry.DomElementSchemaRegistry;

--- a/modules/@angular/compiler_cli/index.ts
+++ b/modules/@angular/compiler_cli/index.ts
@@ -1,3 +1,4 @@
 export {CodeGenerator} from './src/codegen';
 export {NodeReflectorHost} from './src/reflector_host';
+export {StaticReflector, StaticReflectorHost, StaticSymbol} from './src/static_reflector';
 export * from '@angular/tsc-wrapped';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

Exposing internal types needed by the language service.

**What is the current behavior?** (You can also link to an open issue here)

Accessing ParseError and StaticReflector, etc. require deep link import 

**What is the new behavior?**

ParseError and StaticReflector can be access through _compiler_private_.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

The language service needs access to the parser error ranges and
the static reflector.
