### PR TITLE
fix(ngc): import tsc-wrapped from @angular scope

### DIFF
--- a/modules/@angular/compiler_cli/index.ts
+++ b/modules/@angular/compiler_cli/index.ts
@@ -1,3 +1,3 @@
 export {CodeGenerator} from './src/codegen';
 export {NodeReflectorHost} from './src/reflector_host';
-export * from 'tsc-wrapped';
+export * from '@angular/tsc-wrapped';

--- a/modules/@angular/compiler_cli/integrationtest/tsconfig.json
+++ b/modules/@angular/compiler_cli/integrationtest/tsconfig.json
@@ -17,7 +17,8 @@
         "lib": ["es6", "dom"],
         "baseUrl": ".",
         "paths": {
-          "@angular/*": ["../../../../dist/all/@angular/*"]
+          "@angular/*": ["../../../../dist/all/@angular/*"],
+          "@angular/tsc-wrapped": ["../../../../dist/tools/tsc-wrapped"]
         }
     }
 }

--- a/modules/@angular/compiler_cli/src/codegen.ts
+++ b/modules/@angular/compiler_cli/src/codegen.ts
@@ -4,7 +4,7 @@
  */
 import * as ts from 'typescript';
 import * as path from 'path';
-import {AngularCompilerOptions} from 'tsc-wrapped';
+import {AngularCompilerOptions} from '@angular/tsc-wrapped';
 
 import * as compiler from '@angular/compiler';
 import {ViewEncapsulation} from '@angular/core';

--- a/modules/@angular/compiler_cli/src/main.ts
+++ b/modules/@angular/compiler_cli/src/main.ts
@@ -4,7 +4,7 @@
 import 'reflect-metadata';
 
 import * as ts from 'typescript';
-import * as tsc from 'tsc-wrapped';
+import * as tsc from '@angular/tsc-wrapped';
 
 import {CodeGenerator} from './codegen';
 

--- a/modules/@angular/compiler_cli/src/reflector_host.ts
+++ b/modules/@angular/compiler_cli/src/reflector_host.ts
@@ -1,6 +1,6 @@
 import {StaticReflectorHost, StaticSymbol} from './static_reflector';
 import * as ts from 'typescript';
-import {AngularCompilerOptions, MetadataCollector, ModuleMetadata} from 'tsc-wrapped';
+import {AngularCompilerOptions, MetadataCollector, ModuleMetadata} from '@angular/tsc-wrapped';
 import * as fs from 'fs';
 import * as path from 'path';
 import {ImportGenerator, AssetUrl} from './compiler_private';

--- a/modules/@angular/compiler_cli/tsconfig-es5.json
+++ b/modules/@angular/compiler_cli/tsconfig-es5.json
@@ -15,7 +15,7 @@
           "@angular/compiler": ["../../../dist/packages-dist/compiler"],
           "@angular/platform-server": ["../../../dist/packages-dist/platform-server"],
           "@angular/platform-browser": ["../../../dist/packages-dist/platform-browser"],
-          "tsc-wrapped": ["../../../dist/tools/tsc-wrapped"]
+          "@angular/tsc-wrapped": ["../../../dist/tools/tsc-wrapped"]
         },
         "experimentalDecorators": true,
         "rootDir": ".",

--- a/modules/tsconfig.json
+++ b/modules/tsconfig.json
@@ -14,7 +14,7 @@
       "selenium-webdriver": ["../node_modules/@types/selenium-webdriver/index.d.ts"],
       "rxjs/*": ["../node_modules/rxjs/*"],
       "@angular/*": ["./@angular/*"],
-      "tsc-wrapped": ["../dist/tools/tsc-wrapped"]
+      "@angular/tsc-wrapped": ["../dist/tools/tsc-wrapped"]
     },
     "rootDir": ".",
     "inlineSourceMap": true,


### PR DESCRIPTION
We have no tests to cover this, since we use our own pathMapping everywhere that we import :(
