### PR TITLE
test(security): test case for quoted URL values.

### DIFF
--- a/modules/@angular/platform-browser/test/security/style_sanitizer_spec.ts
+++ b/modules/@angular/platform-browser/test/security/style_sanitizer_spec.ts
@@ -32,8 +32,16 @@ export function main() {
     });
     t.it('sanitizes URLs', () => {
       expectSanitize('url(foo/bar.png)').toEqual('url(foo/bar.png)');
+      expectSanitize('url( foo/bar.png\n )').toEqual('url( foo/bar.png\n )');
       expectSanitize('url(javascript:evil())').toEqual('unsafe');
       expectSanitize('url(strangeprotocol:evil)').toEqual('unsafe');
+    });
+    t.it('accepts quoted URLs', () => {
+      expectSanitize('url("foo/bar.png")').toEqual('url("foo/bar.png")');
+      expectSanitize(`url('foo/bar.png')`).toEqual(`url('foo/bar.png')`);
+      expectSanitize(`url(  'foo/bar.png'\n )`).toEqual(`url(  'foo/bar.png'\n )`);
+      expectSanitize('url("javascript:evil()")').toEqual('unsafe');
+      expectSanitize('url( " javascript:evil() " )').toEqual('unsafe');
     });
   });
 }


### PR DESCRIPTION
Test case that fixes #8701. This is already supported with the latest sanitizer
changes, but it's good to have an explicit test case.
