### PR TITLE
feature(async): allow usage of any Observable that implements [Symbol.observable]

### DIFF
--- a/modules/@angular/core/test/facade/observable_spec.ts
+++ b/modules/@angular/core/test/facade/observable_spec.ts
@@ -10,7 +10,8 @@ import {
 } from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 
-import {Observable, Subject, EventEmitter, PromiseWrapper} from '../../src/facade/async';
+import {Observable, Subject, EventEmitter, PromiseWrapper, ObservableWrapper} from '../../src/facade/async';
+import {from as mFrom} from 'most'
 
 export function main() {
   describe("Observable", () => {
@@ -57,5 +58,22 @@ export function main() {
 
          }));
     });
+  });
+
+  describe('Observable interop', () => {
+
+    it('should support most.js observables', (done) => {
+
+      let log = [];
+      ObservableWrapper.subscribe(mFrom([1, 2, 3, 4]), (value) => {
+        log.push(value);
+      }, (err) => {}, () => {
+        expect(log).toEqual([1,2,3,4]);
+        done();
+      });
+
+    });
+
+
   });
 }

--- a/modules/@angular/facade/src/async.ts
+++ b/modules/@angular/facade/src/async.ts
@@ -5,10 +5,12 @@ import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 
 import {PromiseObservable} from 'rxjs/observable/PromiseObservable';
+import {FromObservable} from 'rxjs/observable/FromObservable';
 import {toPromise} from 'rxjs/operator/toPromise';
 
 export {Observable} from 'rxjs/Observable';
 export {Subject} from 'rxjs/Subject';
+import * as $$observable from 'symbol-observable'
 
 export class TimerWrapper {
   static setTimeout(fn: (...args: any[]) => void, millis: number): number {
@@ -28,10 +30,12 @@ export class ObservableWrapper {
                       onComplete: () => void = () => {}): Object {
     onError = (typeof onError === "function") && onError || noop;
     onComplete = (typeof onComplete === "function") && onComplete || noop;
-    return emitter.subscribe({next: onNext, error: onError, complete: onComplete});
+    return FromObservable.create(emitter).subscribe({next: onNext, error: onError, complete: onComplete});
   }
 
-  static isObservable(obs: any): boolean { return !!obs.subscribe; }
+  static isObservable(obs: any): boolean {
+    return (obs instanceof Observable) || obs[$$observable];
+   }
 
   /**
    * Returns whether `obs` has any subscribers listening to events.

--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -24,6 +24,12 @@
     "@types/selenium-webdriver": {
       "version": "2.44.20-alpha"
     },
+    "@most/multicast": {
+      "version": "1.1.4"
+    },
+    "@most/prelude": {
+      "version": "1.2.0"
+    },
     "abbrev": {
       "version": "1.0.7"
     },
@@ -4004,6 +4010,9 @@
     "morgan": {
       "version": "1.6.1"
     },
+    "most": {
+      "version": "0.19.6"
+    },
     "mozilla-toolkit-versioning": {
       "version": "0.0.2"
     },
@@ -4707,7 +4716,7 @@
       "version": "1.1.5"
     },
     "rxjs": {
-      "version": "5.0.0-beta.6"
+      "version": "5.0.0-beta.8"
     },
     "sass-graph": {
       "version": "2.0.1",
@@ -5015,6 +5024,9 @@
     },
     "supports-color": {
       "version": "0.2.0"
+    },
+    "symbol-observable": {
+      "version": "0.2.4"
     },
     "symlink-or-copy": {
       "version": "1.0.1"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -42,6 +42,16 @@
       "from": "@types/selenium-webdriver@latest",
       "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.44.20-alpha.tgz"
     },
+    "@most/multicast": {
+      "version": "1.1.4",
+      "from": "@most/multicast@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/@most/multicast/-/multicast-1.1.4.tgz"
+    },
+    "@most/prelude": {
+      "version": "1.2.0",
+      "from": "@most/prelude@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/@most/prelude/-/prelude-1.2.0.tgz"
+    },
     "abbrev": {
       "version": "1.0.7",
       "from": "abbrev@>=1.0.0 <2.0.0",
@@ -6360,6 +6370,11 @@
       "from": "morgan@>=1.6.1 <1.7.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz"
     },
+    "most": {
+      "version": "0.19.6",
+      "from": "most@latest",
+      "resolved": "https://registry.npmjs.org/most/-/most-0.19.6.tgz"
+    },
     "mozilla-toolkit-versioning": {
       "version": "0.0.2",
       "from": "mozilla-toolkit-versioning@0.0.2",
@@ -7503,9 +7518,9 @@
       "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.1.5.tgz"
     },
     "rxjs": {
-      "version": "5.0.0-beta.6",
-      "from": "rxjs@5.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.6.tgz"
+      "version": "5.0.0-beta.8",
+      "from": "rxjs@5.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.8.tgz"
     },
     "sass-graph": {
       "version": "2.0.1",
@@ -7995,6 +8010,11 @@
       "version": "0.2.0",
       "from": "supports-color@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+    },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "from": "symbol-observable@>=0.2.4 <0.3.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz"
     },
     "symlink-or-copy": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "es6-shim": "^0.35.0",
     "reflect-metadata": "^0.1.3",
-    "rxjs": "5.0.0-beta.6",
+    "rxjs": "5.0.0-beta.8",
     "zone.js": "^0.6.12"
   },
   "devDependencies": {
@@ -85,6 +85,7 @@
     "minimatch": "^3.0.0",
     "minimist": "^1.2.0",
     "mock-fs": "^3.6.0",
+    "most": "^0.19.6",
     "node-uuid": "1.4.x",
     "on-headers": "^1.0.0",
     "parse5": "1.3.2",


### PR DESCRIPTION
- upgrade RxJS to beta8
- allows AsyncPipe etc to accept any Observable that implements the ES7 Observable [Symbol.observable] interop hook.

Closes #8848 
