### PR TITLE
chore(build.sh): make tsc-wrapped installable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ mkdir -p ./dist/all/
 TSCONFIG=./tools/tsconfig.json
 echo "====== (all)COMPILING: \$(npm bin)/tsc -p ${TSCONFIG} ====="
 $(npm bin)/tsc -p ${TSCONFIG}
-
+cp ./tools/@angular/tsc-wrapped/package.json ./dist/tools/@angular/tsc-wrapped
 
 echo "====== Copying files needed for e2e tests ====="
 cp -r ./modules/playground ./dist/all/


### PR DESCRIPTION
`scripts/ci-lite/offline_compiler_test.sh` would fail to install tsc-wrapped due to the missing `package.json`.

Note: the CI script had already been updated to copy file.
