### PR TITLE
fix(upgrade): allow deeper nesting of ng2 components/directives

### DIFF
--- a/modules/@angular/upgrade/src/upgrade_adapter.ts
+++ b/modules/@angular/upgrade/src/upgrade_adapter.ts
@@ -547,8 +547,6 @@ function ng1ComponentDirective(info: ComponentInfo, idPrefix: string): Function 
   function directiveFactory(ng1Injector: angular.IInjectorService,
                             componentFactoryRefMap: ComponentFactoryRefMap,
                             parse: angular.IParseService): angular.IDirective {
-    var componentFactory: ComponentFactory<any> = componentFactoryRefMap[info.selector];
-    if (!componentFactory) throw new Error('Expecting ComponentFactory for: ' + info.selector);
     var idCount = 0;
     return {
       restrict: 'E',
@@ -556,6 +554,9 @@ function ng1ComponentDirective(info: ComponentInfo, idPrefix: string): Function 
       link: {
         post: (scope: angular.IScope, element: angular.IAugmentedJQuery, attrs: angular.IAttributes,
                parentInjector: any, transclude: angular.ITranscludeFunction): void => {
+          var componentFactory: ComponentFactory<any> = componentFactoryRefMap[info.selector];
+          if (!componentFactory) throw new Error('Expecting ComponentFactory for: ' + info.selector);
+
           var domElement = <any>element[0];
           if (parentInjector === null) {
             parentInjector = ng1Injector.get(NG2_INJECTOR);

--- a/modules/@angular/upgrade/test/upgrade_spec.ts
+++ b/modules/@angular/upgrade/test/upgrade_spec.ts
@@ -4,7 +4,7 @@ import {UpgradeAdapter} from "@angular/upgrade";
 import * as angular from "@angular/upgrade/src/angular_js";
 
 export function main() {
-  ddescribe('adapter: ng1 to ng2', () => {
+  describe('adapter: ng1 to ng2', () => {
     it('should have angular 1 loaded', () => expect(angular.version.major).toBe(1));
 
     it('should instantiate ng2 in ng1 template and project content',

--- a/modules/@angular/upgrade/test/upgrade_spec.ts
+++ b/modules/@angular/upgrade/test/upgrade_spec.ts
@@ -4,7 +4,7 @@ import {UpgradeAdapter} from "@angular/upgrade";
 import * as angular from "@angular/upgrade/src/angular_js";
 
 export function main() {
-  describe('adapter: ng1 to ng2', () => {
+  ddescribe('adapter: ng1 to ng2', () => {
     it('should have angular 1 loaded', () => expect(angular.version.major).toBe(1));
 
     it('should instantiate ng2 in ng1 template and project content',
@@ -706,6 +706,45 @@ export function main() {
                .ready((ref) => {
                  expect(multiTrim(document.body.textContent)).toEqual(`Hello GOKU SAN`);
                  ref.dispose();
+                 async.done();
+               });
+         }));
+
+       it('should support ng2 > ng1 > ng2', inject([AsyncTestCompleter], (async) => {
+           var adapter = new UpgradeAdapter();
+           var ng1Module = angular.module('ng1', []);
+
+           var ng1 = {
+             template: 'ng1(<ng2b></ng2b>)',
+           };
+           ng1Module.component('ng1', ng1);
+
+           var Ng2a =
+             Component({
+               selector: 'ng2a',
+               template: 'ng2a(<ng1></ng1>)',
+               directives: [adapter.upgradeNg1Component('ng1')]
+             })
+                 .Class({
+                   constructor: function() {}
+                 });
+           ng1Module.directive('ng2a', adapter.downgradeNg2Component(Ng2a));
+
+           var Ng2b =
+             Component({
+               selector: 'ng2b',
+               template: 'ng2b',
+               directives: []
+             })
+                 .Class({
+                   constructor: function() {}
+                 });
+           ng1Module.directive('ng2b', adapter.downgradeNg2Component(Ng2b));
+
+           var element = html(`<div><ng2a></ng2a></div>`);
+           adapter.bootstrap(element, ['ng1'])
+               .ready((ref) => {
+                 expect(multiTrim(document.body.textContent)).toEqual('ng2a(ng1(ng2b))');
                  async.done();
                });
          }));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Currently, ngUpgrade has issues with deep nesting of ng2 components which has the following sequence:

downgraded ng2 -> upgraded ng1 -> downgraded ng2

An error is thrown during bootstrap

**What is the new behavior?**

This sequence succeeds, produces the correct output.

Fixes #8929

**Does this PR introduce a breaking change?**
- [ ] Yes
- [ x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

The issues occurs because when attempting to resolve an ng1 upgraded component (UpgradeNg1ComponentAdapterBuilder.resolve), $compile is called on its template, causing angular 1 to attempt to instantiate the downgraded ng2 directive. However, at the time the ng2 component hasn't been resolved (UpgradeAdapter.prototype.compileNg2Components), which means calling the DDO function fails when it can't find the resolved ng2 component.

The solution (albeit imperfect -- but I can't find a better one) is to delay looking up the resolved ng2 component until the directive's post link function, which is actually the first time it's needed.

This fixes #8929 
