### PR TITLE
(fix) MockCOnnection.mockError also accepts a Response

### DIFF
--- a/modules/@angular/http/test/backends/mock_backend_spec.ts
+++ b/modules/@angular/http/test/backends/mock_backend_spec.ts
@@ -74,6 +74,13 @@ export function main() {
          connection.mockError(new Error('nope'));
        }));
 
+   it('should allow responding after subscription with a Repsonse',
+      inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+        let connection: MockConnection = backend.createConnection(sampleRequest1);
+        connection.response.subscribe(null, () => { async.done(); });
+        connection.mockError(sampleResponse1);
+      }));
+
     it('should not throw when there are no unresolved requests',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          let connection: MockConnection = backend.createConnection(sampleRequest1);

--- a/modules/@angular/http/testing/mock_backend.ts
+++ b/modules/@angular/http/testing/mock_backend.ts
@@ -76,12 +76,12 @@ export class MockConnection implements Connection {
     // }
   }
 
-  // TODO(jeffbcross): consider using Response type
+
   /**
-   * Emits the provided error object as an error to the {@link Response} {@link EventEmitter}
+   * Emits the provided error or repsonse object as an error to the {@link Response} {@link EventEmitter}
    * returned
    * from {@link Http}.
-   * 
+   *
    * ### Example
    *
    * ```
@@ -90,9 +90,15 @@ export class MockConnection implements Connection {
    * http.request('data.json').subscribe(res => res, err => console.log(err)));
    * connection.mockError(new Error('error'));
    * ```
-   * 
+   *
+   * ```
+   * var connection;
+   * backend.connections.subscribe(c => connection = c);
+   * http.request('data.json').error(res => console.error(res.json())));
+   * connection.mockError(new Response(new ResponseOptions({ status: 500, body: {errorMessage:'some mock error'} }))); //logs '{errorMessage:'some mock error'}'
+   * ``
    */
-  mockError(err?: Error) {
+  mockError(err?: Error | Response) {
     // Matches XHR semantics
     this.readyState = ReadyState.Done;
     this.response.error(err);


### PR DESCRIPTION
- updates check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  fix + resolves a TODO in the code base

**Does this PR introduce a breaking change?**
- [x] No
- **What is the current behavior?** (You can also link to an open issue here)
  MockConnection.mockError only accepts an Error
- **What is the new behavior (if this is a feature change)?**
  MockConnection.mockError now also accepts a Response object (so that people can test non-200 level status codes in their responses
