### PR TITLE
chore(tools): Remove use of TypeChecker from metadata collector.

### DIFF
--- a/modules/@angular/compiler_cli/integrationtest/test/basic_spec.ts
+++ b/modules/@angular/compiler_cli/integrationtest/test/basic_spec.ts
@@ -27,7 +27,7 @@ describe("template codegen output", () => {
     expect(fs.existsSync(metadataOutput)).toBeTruthy();
     const output = fs.readFileSync(metadataOutput, {encoding: 'utf-8'});
     expect(output).toContain('"decorators":');
-    expect(output).toContain('"name":"Component","module":"@angular/core"');
+    expect(output).toContain('"module":"@angular/core","name":"Component"');
   });
 
   it("should write .d.ts files", () => {

--- a/modules/@angular/compiler_cli/src/codegen.ts
+++ b/modules/@angular/compiler_cli/src/codegen.ts
@@ -62,17 +62,21 @@ export class CodeGenerator {
 
   private readComponents(absSourcePath: string) {
     const result: Promise<compiler.CompileDirectiveMetadata>[] = [];
-    const metadata = this.staticReflector.getModuleMetadata(absSourcePath);
-    if (!metadata) {
+    const moduleMetadata = this.staticReflector.getModuleMetadata(absSourcePath);
+    if (!moduleMetadata) {
       console.log(`WARNING: no metadata found for ${absSourcePath}`);
       return result;
     }
-
-    const symbols = Object.keys(metadata['metadata']);
+    const metadata = moduleMetadata['metadata'];
+    const symbols = metadata && Object.keys(metadata);
     if (!symbols || !symbols.length) {
       return result;
     }
     for (const symbol of symbols) {
+      if (metadata[symbol] && metadata[symbol].__symbolic == 'error') {
+        // Ignore symbols that are only included to record error information.
+        continue;
+      }
       const staticType = this.reflectorHost.findDeclaration(absSourcePath, symbol, absSourcePath);
       let directive: compiler.CompileDirectiveMetadata;
       directive = this.resolver.maybeGetDirectiveMetadata(<any>staticType);

--- a/modules/@angular/compiler_cli/src/reflector_host.ts
+++ b/modules/@angular/compiler_cli/src/reflector_host.ts
@@ -153,7 +153,7 @@ export class NodeReflectorHost implements StaticReflectorHost, ImportGenerator {
     if (!sf) {
       throw new Error(`Source file ${filePath} not present in program.`);
     }
-    const metadata = this.metadataCollector.getMetadata(sf, this.program.getTypeChecker());
+    const metadata = this.metadataCollector.getMetadata(sf);
     return metadata;
   }
 

--- a/modules/@angular/compiler_cli/src/static_reflector.ts
+++ b/modules/@angular/compiler_cli/src/static_reflector.ts
@@ -359,6 +359,8 @@ export class StaticReflector implements ReflectorReader {
               } else {
                 return context;
               }
+             case "error":
+              throw new Error(expression['message']);
           }
           return null;
         }

--- a/tools/@angular/tsc-wrapped/src/compiler_host.ts
+++ b/tools/@angular/tsc-wrapped/src/compiler_host.ts
@@ -67,8 +67,7 @@ export class MetadataWriterHost extends DelegatingHost {
     // released
     if (/*DTS*/ /\.js$/.test(emitFilePath)) {
       const path = emitFilePath.replace(/*DTS*/ /\.js$/, '.metadata.json');
-      const metadata =
-          this.metadataCollector.getMetadata(sourceFile, this.program.getTypeChecker());
+      const metadata = this.metadataCollector.getMetadata(sourceFile);
       if (metadata && metadata.metadata) {
         const metadataText = JSON.stringify(metadata);
         writeFileSync(path, metadataText, {encoding: 'utf-8'});

--- a/tools/@angular/tsc-wrapped/src/symbols.ts
+++ b/tools/@angular/tsc-wrapped/src/symbols.ts
@@ -1,36 +1,99 @@
 import * as ts from 'typescript';
 
-// TOOD: Remove when tools directory is upgraded to support es6 target
-interface Map<K, V> {
-  has(v: V): boolean;
-  set(k: K, v: V): void;
-  get(k: K): V;
-}
-interface MapConstructor {
-  new<K, V>(): Map<K, V>;
-}
-declare var Map: MapConstructor;
+import {MetadataValue} from './schema';
 
-var a: Array<number>;
-
-/**
- * A symbol table of ts.Symbol to a folded value used during expression folding in Evaluator.
- *
- * This is a thin wrapper around a Map<> using the first declaration location instead of the symbol
- * itself as the key. In the TypeScript binder and type checker, mulitple symbols are sometimes
- * created for a symbol depending on what scope it is in (e.g. export vs. local). Using the
- * declaration node as the key results in these duplicate symbols being treated as identical.
- */
 export class Symbols {
-  private map = new Map<ts.Node, any>();
+  private _symbols: Map<string, MetadataValue>;
 
-  public has(symbol: ts.Symbol): boolean { return this.map.has(symbol.getDeclarations()[0]); }
+  constructor(private sourceFile: ts.SourceFile) {}
 
-  public set(symbol: ts.Symbol, value: any): void {
-    this.map.set(symbol.getDeclarations()[0], value);
+  resolve(name: string): MetadataValue|undefined { return this.symbols.get(name); }
+
+  define(name: string, value: MetadataValue) { this.symbols.set(name, value); }
+
+  has(name: string): boolean { return this.symbols.has(name); }
+
+  private get symbols(): Map<string, MetadataValue> {
+    let result = this._symbols;
+    if (!result) {
+      result = this._symbols = new Map();
+      populateBuiltins(result);
+      this.buildImports();
+    }
+    return result;
   }
 
-  public get(symbol: ts.Symbol): any { return this.map.get(symbol.getDeclarations()[0]); }
+  private buildImports(): void {
+    let symbols = this._symbols;
+    // Collect the imported symbols into this.symbols
+    const stripQuotes = (s: string) => s.replace(/^['"]|['"]$/g, '');
+    const visit = (node: ts.Node) => {
+      switch (node.kind) {
+        case ts.SyntaxKind.ImportEqualsDeclaration:
+          const importEqualsDeclaration = <ts.ImportEqualsDeclaration>node;
+          if (importEqualsDeclaration.moduleReference.kind ===
+              ts.SyntaxKind.ExternalModuleReference) {
+            const externalReference =
+                <ts.ExternalModuleReference>importEqualsDeclaration.moduleReference;
+            // An `import <identifier> = require(<module-specifier>);
+            const from = stripQuotes(externalReference.expression.getText());
+            symbols.set(importEqualsDeclaration.name.text, {__symbolic: 'reference', module: from});
+          } else {
+            symbols.set(
+                importEqualsDeclaration.name.text,
+                {__symbolic: 'error', message: `Unsupported import syntax`});
+          }
+          break;
+        case ts.SyntaxKind.ImportDeclaration:
+          const importDecl = <ts.ImportDeclaration>node;
+          if (!importDecl.importClause) {
+            // An `import <module-specifier>` clause which does not bring symbols into scope.
+            break;
+          }
+          const from = stripQuotes(importDecl.moduleSpecifier.getText());
+          if (importDecl.importClause.name) {
+            // An `import <identifier> form <module-specifier>` clause. Record the defualt symbol.
+            symbols.set(
+                importDecl.importClause.name.text,
+                {__symbolic: 'reference', module: from, default: true});
+          }
+          const bindings = importDecl.importClause.namedBindings;
+          if (bindings) {
+            switch (bindings.kind) {
+              case ts.SyntaxKind.NamedImports:
+                // An `import { [<identifier> [, <identifier>] } from <module-specifier>` clause
+                for (let binding of (<ts.NamedImports>bindings).elements) {
+                  symbols.set(binding.name.text, {
+                    __symbolic: 'reference',
+                    module: from,
+                    name: binding.propertyName ? binding.propertyName.text : binding.name.text
+                  });
+                }
+                break;
+              case ts.SyntaxKind.NamespaceImport:
+                // An `input * as <identifier> from <module-specifier>` clause.
+                symbols.set(
+                    (<ts.NamespaceImport>bindings).name.text,
+                    {__symbolic: 'reference', module: from});
+                break;
+            }
+          }
+          break;
+      }
+      ts.forEachChild(node, visit);
+    };
+    if (this.sourceFile) {
+      ts.forEachChild(this.sourceFile, visit);
+    }
+  }
+}
 
-  static empty: Symbols = new Symbols();
+function populateBuiltins(symbols: Map<string, MetadataValue>) {
+  // From lib.core.d.ts (all "define const")
+  ['Object', 'Function', 'String', 'Number', 'Array', 'Boolean', 'Map', 'NaN', 'Infinity', 'Math',
+   'Date', 'RegExp', 'Error', 'Error', 'EvalError', 'RangeError', 'ReferenceError', 'SyntaxError',
+   'TypeError', 'URIError', 'JSON', 'ArrayBuffer', 'DataView', 'Int8Array', 'Uint8Array',
+   'Uint8ClampedArray', 'Uint16Array', 'Int16Array', 'Int32Array', 'Uint32Array', 'Float32Array',
+   'Float64Array']
+      .forEach(name => symbols.set(name, {__symbolic: 'reference', name}));
 }

--- a/tools/@angular/tsc-wrapped/test/symbols.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/symbols.spec.ts
@@ -1,29 +1,125 @@
 import * as ts from 'typescript';
+
+import {isMetadataGlobalReferenceExpression} from '../src/schema';
 import {Symbols} from '../src/symbols';
-import {MockSymbol, MockVariableDeclaration} from './typescript.mocks';
+
+import {Directory, Host, expectNoDiagnostics} from './typescript.mocks';
 
 describe('Symbols', () => {
   let symbols: Symbols;
   const someValue = 'some-value';
-  const someSymbol = MockSymbol.of('some-symbol');
-  const aliasSymbol = new MockSymbol('some-symbol', someSymbol.getDeclarations()[0]);
-  const missingSymbol = MockSymbol.of('some-other-symbol');
 
-  beforeEach(() => symbols = new Symbols());
+  beforeEach(() => symbols = new Symbols(null));
 
-  it('should be able to add a symbol', () => symbols.set(someSymbol, someValue));
+  it('should be able to add a symbol', () => symbols.define('someSymbol', someValue));
 
-  beforeEach(() => symbols.set(someSymbol, someValue));
+  beforeEach(() => symbols.define('someSymbol', someValue));
 
-  it('should be able to `has` a symbol', () => expect(symbols.has(someSymbol)).toBeTruthy());
+  it('should be able to `has` a symbol', () => expect(symbols.has('someSymbol')).toBeTruthy());
   it('should be able to `get` a symbol value',
-     () => expect(symbols.get(someSymbol)).toBe(someValue));
-  it('should be able to `has` an alias symbol',
-     () => expect(symbols.has(aliasSymbol)).toBeTruthy());
+     () => expect(symbols.resolve('someSymbol')).toBe(someValue));
   it('should be able to `get` a symbol value',
-     () => expect(symbols.get(aliasSymbol)).toBe(someValue));
+     () => expect(symbols.resolve('someSymbol')).toBe(someValue));
   it('should be able to determine symbol is missing',
-     () => expect(symbols.has(missingSymbol)).toBeFalsy());
+     () => expect(symbols.has('missingSymbol')).toBeFalsy());
   it('should return undefined from `get` for a missing symbol',
-     () => expect(symbols.get(missingSymbol)).toBeUndefined());
+     () => expect(symbols.resolve('missingSymbol')).toBeUndefined());
+
+  let host: ts.LanguageServiceHost;
+  let service: ts.LanguageService;
+  let program: ts.Program;
+  let expressions: ts.SourceFile;
+  let imports: ts.SourceFile;
+
+  beforeEach(() => {
+    host = new Host(FILES, ['consts.ts', 'expressions.ts', 'imports.ts']);
+    service = ts.createLanguageService(host);
+    program = service.getProgram();
+    expressions = program.getSourceFile('expressions.ts');
+    imports = program.getSourceFile('imports.ts');
+  });
+
+  it('should not have syntax errors in the test sources', () => {
+    expectNoDiagnostics(service.getCompilerOptionsDiagnostics());
+    for (const sourceFile of program.getSourceFiles()) {
+      expectNoDiagnostics(service.getSyntacticDiagnostics(sourceFile.fileName));
+    }
+  });
+
+  it('should be able to find the source files', () => {
+    expect(expressions).toBeDefined();
+    expect(imports).toBeDefined();
+  })
+
+  it('should be able to create symbols for a source file', () => {
+    let symbols = new Symbols(expressions);
+    expect(symbols).toBeDefined();
+  });
+
+
+  it('should be able to find symbols in expression', () => {
+    let symbols = new Symbols(expressions);
+    expect(symbols.has('someName')).toBeTruthy();
+    expect(symbols.resolve('someName'))
+        .toEqual({__symbolic: 'reference', module: './consts', name: 'someName'});
+    expect(symbols.has('someBool')).toBeTruthy();
+    expect(symbols.resolve('someBool'))
+        .toEqual({__symbolic: 'reference', module: './consts', name: 'someBool'});
+  });
+
+  it('should be able to detect a * import', () => {
+    let symbols = new Symbols(imports);
+    expect(symbols.resolve('b')).toEqual({__symbolic: 'reference', module: 'b'});
+  });
+
+  it('should be able to detect importing a default export', () => {
+    let symbols = new Symbols(imports);
+    expect(symbols.resolve('d')).toEqual({__symbolic: 'reference', module: 'd', default: true});
+  });
+
+  it('should be able to import a renamed symbol', () => {
+    let symbols = new Symbols(imports);
+    expect(symbols.resolve('g')).toEqual({__symbolic: 'reference', name: 'f', module: 'f'});
+  });
+
+  it('should be able to resolve any symbol in core global scope', () => {
+    let core = program.getSourceFiles().find(source => source.fileName.endsWith('lib.d.ts'));
+    expect(core).toBeDefined();
+    let visit = (node: ts.Node): boolean => {
+      switch (node.kind) {
+        case ts.SyntaxKind.VariableStatement:
+        case ts.SyntaxKind.VariableDeclarationList:
+          return ts.forEachChild(node, visit);
+        case ts.SyntaxKind.VariableDeclaration:
+          const variableDeclaration = <ts.VariableDeclaration>node;
+          const nameNode = <ts.Identifier>variableDeclaration.name;
+          const name = nameNode.text;
+          const result = symbols.resolve(name);
+          expect(isMetadataGlobalReferenceExpression(result) && result.name).toEqual(name);
+
+          // Ignore everything after Float64Array as it is IE specific.
+          return name === 'Float64Array';
+      }
+      return false;
+    };
+    ts.forEachChild(core, visit);
+  });
 });
+
+const FILES: Directory = {
+  'consts.ts': `
+    export var someName = 'some-name';
+    export var someBool = true;
+    export var one = 1;
+    export var two = 2;
+  `,
+  'expressions.ts': `
+    import {someName, someBool, one, two} from './consts';
+  `,
+  'imports.ts': `
+    import * as b from 'b';
+    import 'c';
+    import d from 'd';
+    import {f as g} from 'f';
+  `
+};

--- a/tools/broccoli/broccoli-typescript.ts
+++ b/tools/broccoli/broccoli-typescript.ts
@@ -121,7 +121,6 @@ class DiffingTSCompiler implements DiffingBroccoliPlugin {
       this.doFullBuild();
     } else {
       let program = this.tsService.getProgram();
-      let typeChecker = program.getTypeChecker();
       tsEmitInternal = false;
       pathsToEmit.forEach((tsFilePath) => {
         let output = this.tsService.getEmitOutput(tsFilePath);
@@ -139,7 +138,7 @@ class DiffingTSCompiler implements DiffingBroccoliPlugin {
             fs.writeFileSync(o.name, this.fixSourceMapSources(o.text), FS_OPTS);
             if (endsWith(o.name, '.d.ts')) {
               const sourceFile = program.getSourceFile(tsFilePath);
-              this.emitMetadata(o.name, sourceFile, typeChecker);
+              this.emitMetadata(o.name, sourceFile);
             }
           });
         }
@@ -210,7 +209,7 @@ class DiffingTSCompiler implements DiffingBroccoliPlugin {
         const originalFile = absoluteFilePath.replace(this.tsOpts.outDir, this.tsOpts.rootDir)
                                  .replace(/\.d\.ts$/, '.ts');
         const sourceFile = program.getSourceFile(originalFile);
-        this.emitMetadata(absoluteFilePath, sourceFile, typeChecker);
+        this.emitMetadata(absoluteFilePath, sourceFile);
       }
     });
 
@@ -256,10 +255,9 @@ class DiffingTSCompiler implements DiffingBroccoliPlugin {
    * Emit a .metadata.json file to correspond to the .d.ts file if the module contains classes that
    * use decorators or exported constants.
    */
-  private emitMetadata(
-      dtsFileName: string, sourceFile: ts.SourceFile, typeChecker: ts.TypeChecker) {
+  private emitMetadata(dtsFileName: string, sourceFile: ts.SourceFile) {
     if (sourceFile) {
-      const metadata = this.metadataCollector.getMetadata(sourceFile, typeChecker);
+      const metadata = this.metadataCollector.getMetadata(sourceFile);
       if (metadata && metadata.metadata) {
         const metadataText = JSON.stringify(metadata);
         const metadataFileName = dtsFileName.replace(/\.d.ts$/, '.metadata.json');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

**What is the current behavior?** (You can also link to an open issue here)
#8893
#8894

**What is the new behavior?**
Produces metadata files without using the type checker.

**Does this PR introduce a breaking change?**
- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

The `TypeChecker` parameter to the `MetadataCollector` was removed. Uses of the `MetadataCollector` will need to be updated.

**Other information**:

The metadata collector was modified to look up references in the
import list instead of resolving the symbol using the `TypeChecker
making the use of the TypeChecker vestigial. This change removes
all uses of the TypeChecker.

Modified the schema to be able to record global and local (non-module
specific references).
