### PR TITLE
fix(test-runner): make karma internal reporter compatible with 0.13.20

### DIFF
--- a/tools/karma/reporter.js
+++ b/tools/karma/reporter.js
@@ -52,7 +52,7 @@ var createErrorFormatter = function (basePath, emitter, SourceMapConsumer) {
 
 var InternalAngularReporter = function (config, emitter) {
   var formatter = createErrorFormatter(config.basePath, emitter, SourceMapConsumer);
-  DotsReporter.call(this, formatter, false)
+  DotsReporter.call(this, formatter, false, config.colors)
 }
 InternalAngularReporter.$inject = ['config', 'emitter']
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

See #8942 
The karma test runner is not producing any output since upgrading to 0.13.20

**What is the new behavior?**

Fixes #8942 

Output is restored.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [ X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

causes internal reporter to produce output messages again after upgrade to 0.13.20
