### PR TITLE
fix(DI): make DI work on Components/Directives inherited from Angular

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,7 @@ ln -s ../../../../node_modules/base64-js/lib/b64.js .
 ln -s ../../../../node_modules/reflect-metadata/Reflect.js .
 ln -s ../../../../node_modules/rxjs .
 ln -s ../../../../node_modules/angular/angular.js .
+ln -s ../../../../node_modules/typescript/lib/typescript.js .
 cd -
 
 

--- a/modules/@angular/core/src/reflection/reflection_capabilities.ts
+++ b/modules/@angular/core/src/reflection/reflection_capabilities.ts
@@ -122,8 +122,19 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
       return (<any>typeOrFunc).parameters;
     }
 
+    var ownParamAnnotations;
+    var ownParamTypes;
+    if (isPresent(this._reflect) && isPresent(this._reflect.getMetadata)) {
+      ownParamAnnotations = this._reflect.getOwnMetadata('parameters', typeOrFunc);
+      ownParamTypes = this._reflect.getOwnMetadata('design:paramtypes', typeOrFunc);
+    } else {
+      ownParamTypes = ownParamAnnotations = null;
+    }
+
     // API of tsickle for lowering decorators to properties on the class.
-    if (isPresent((<any>typeOrFunc).ctorParameters)) {
+    if (isPresent((<any>typeOrFunc).ctorParameters)
+      && !isPresent(ownParamAnnotations)
+      && !isPresent(ownParamTypes)) {
       let ctorParameters = (<any>typeOrFunc).ctorParameters;
       let paramTypes = ctorParameters.map(ctorParam => ctorParam && ctorParam.type);
       let paramAnnotations = ctorParameters.map(
@@ -139,6 +150,7 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
         return this._zipTypesAndAnnotations(paramTypes, paramAnnotations);
       }
     }
+
     // The array has to be filled with `undefined` because holes would be skipped by `some`
     let parameters = new Array((<any>typeOrFunc.length));
     parameters.fill(undefined);
@@ -155,8 +167,15 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
       return annotations;
     }
 
+    var ownAnnotations;
+    if (isPresent(this._reflect) && isPresent(this._reflect.getMetadata)) {
+      ownAnnotations = this._reflect.getOwnMetadata('annotations', typeOrFunc);
+    } else {
+      ownAnnotations = null;
+    }
+
     // API of tsickle for lowering decorators to properties on the class.
-    if (isPresent((<any>typeOrFunc).decorators)) {
+    if (isPresent((<any>typeOrFunc).decorators) && !isPresent(ownAnnotations)) {
       return convertTsickleDecoratorIntoMetadata((<any>typeOrFunc).decorators);
     }
 
@@ -178,8 +197,15 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
       return propMetadata;
     }
 
+    var ownPropMetadata;
+    if (isPresent(this._reflect) && isPresent(this._reflect.getMetadata)) {
+      ownPropMetadata = this._reflect.getOwnMetadata('propMetadata', typeOrFunc);
+    } else {
+      ownPropMetadata = null;
+    }
+
     // API of tsickle for lowering decorators to properties on the class.
-    if (isPresent((<any>typeOrFunc).propDecorators)) {
+    if (isPresent((<any>typeOrFunc).propDecorators) && !isPresent(ownPropMetadata)) {
       let propDecorators = (<any>typeOrFunc).propDecorators;
       let propMetadata = <{[key: string]: any[]}>{};
       Object.keys(propDecorators)

--- a/modules/playground/e2e_test/inherit_from_angular/inherit_from_angular_spec.dart
+++ b/modules/playground/e2e_test/inherit_from_angular/inherit_from_angular_spec.dart
@@ -1,0 +1,3 @@
+library playground.e2e_test.inherit_from_angular.inherit_from_angular_spec;
+
+main() {}

--- a/modules/playground/e2e_test/inherit_from_angular/inherit_from_angular_spec.ts
+++ b/modules/playground/e2e_test/inherit_from_angular/inherit_from_angular_spec.ts
@@ -1,0 +1,22 @@
+import {verifyNoBrowserErrors} from '@angular/platform-browser/testing_e2e';
+
+describe('inherit from angular', function() {
+
+  afterEach(verifyNoBrowserErrors);
+
+  describe('inherit from angular app', function() {
+    var URL = 'all/playground/src/inherit_from_angular/index.html';
+
+    it('should display that the service was injected properly', function() {
+      browser.get(URL);
+
+      expect(getComponentText('my-app', '.service')).toEqual('Your service is present');
+    });
+  });
+
+});
+
+function getComponentText(selector, innerSelector) {
+  return browser.executeScript('return document.querySelector("' + selector + '").querySelector("' +
+                               innerSelector + '").textContent');
+}

--- a/modules/playground/src/inherit_from_angular/index.html
+++ b/modules/playground/src/inherit_from_angular/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+  <title>Extending Angular</title>
+<body>
+  <my-app>
+    Loading...
+  </my-app>
+
+  <script src='/all/playground/vendor/es6-shim.js'></script>;
+  <script src='/all/playground/vendor/zone.js'></script>;
+  <script src='/all/playground/vendor/long-stack-trace-zone.js'></script>;
+  <script src='/all/playground/vendor/system.src.js'></script>;
+  <script src='/all/playground/vendor/Reflect.js'></script>;
+  <script src='/all/playground/vendor/rxjs/bundles/Rx.js'></script>;
+  <script src='/all/playground/vendor/typescript.js'></script>;
+  <script type="text/javascript">
+
+      System.config({
+        transpiler: 'typescript',
+        typescriptOptions: {
+          emitDecoratorMetadata: true
+        },
+        map: {
+          'index': 'index.ts',
+          '@angular/core': '/packages-dist/core/bundles/core.umd.js',
+          '@angular/common': '/packages-dist/common/bundles/common.umd.js',
+          '@angular/compiler': '/packages-dist/compiler/bundles/compiler.umd.js',
+          '@angular/platform-browser': '/packages-dist/platform-browser/bundles/platform-browser.umd.js',
+          '@angular/http': '/packages-dist/http/bundles/http.umd.js',
+          '@angular/upgrade': '/packages-dist/upgrade/bundles/upgrade.umd.js',
+          '@angular/router': '/packages-dist/router/bundles/router.umd.js',
+          '@angular/router-deprecated': '/packages-dist/router-deprecated/bundles/router-deprecated.umd.js',
+          '@angular/core/src/facade': '/all/@angular/core/src/facade',
+          'rxjs': location.pathname.replace(/\w+\.html$/i, '') + 'rxjs'
+        },
+        packages: {
+          'app': {defaultExtension: 'js'},
+          '@angular/core/src/facade': {defaultExtension: 'js'}
+        }
+      });
+
+      System.import('index').then(function(m) { m.main(); }, console.error.bind(console));
+
+  </script>
+
+</body>
+</html>

--- a/modules/playground/src/inherit_from_angular/index.ts
+++ b/modules/playground/src/inherit_from_angular/index.ts
@@ -1,0 +1,43 @@
+//main entry point
+import {bootstrap} from '@angular/platform-browser';
+import { Directive, Component, ViewContainerRef, TemplateRef, Injectable } from '@angular/core';
+import { NgIf } from '@angular/common';
+
+@Injectable()
+class MyService { }
+
+@Directive({
+  selector: '[ngIfService]'
+})
+class NgIfService extends NgIf {
+  constructor(_viewContainerRef: ViewContainerRef, _templateRef: TemplateRef<Object>, myService: MyService) {
+    super(_viewContainerRef, _templateRef);
+    console.log(myService);
+    if (myService) {
+      Object.getOwnPropertyDescriptor(NgIf.prototype, 'ngIf').set.apply(this, [true])
+    } else {
+      Object.getOwnPropertyDescriptor(NgIf.prototype, 'ngIf').set.apply(this, [false])
+    }
+  }
+}
+
+@Component({
+  selector: 'my-app',
+  providers: [MyService],
+  template: `
+    <div>
+      <h2>Hello</h2>
+      <div class="service" *ngIfService>Your service is present</div>
+    </div>
+  `,
+  directives: [NgIfService]
+})
+class App {
+  constructor() {
+  }
+}
+
+
+export function main() {
+  bootstrap(App)
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [X ] Tests for the changes have been added (for bug fixes / features)
- [X ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

See #8700 
When an application attempts to extend a built-in Angular 2 Component, Directive, or Service, unless it is using the Angular Template Compiler instead of the vanilla Typescript, DI does not work properly

**What is the new behavior?**

Fixes #8700
An application can extend a built-in Angular 2 Component, Directive, or Service, using a standard typescript compiler and DI will still work.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [ X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Makes it DI work when inheriting Components/Directives/Services from built-in Angular 2
Components/Directives/Services while using standard typescript compiler

Fixes #8700 

Explanation of fix:

Currently, the reflector always prioritizes the properties emitted by tsickle over any metadata generated through decorators. In a scenario where one is extending a built Angular 2 component, while using standard typescript compilation, it will have tsickle properties from the built-in component and decorator metadata from the extending component. The solution is to use the Reflect.metadata API's getOwnMetadata method to see if metadata is present on the subclass that extends Angular, and prioritize that metadata over tsickle properties if it is present.

Building a test for this was not trivial, and the only way I could think to do it was with an E2E_test -- see modules/playground/inherit_from_angular. This also neccesitated modifiying the build script to copy the typescript library to dist/all/playground/vendor.

There may be code clean-up neccesary here - I am open to suggestions. But this at minimum illustrates the problem and one path to a solution.
