### PR TITLE
fix(HTMLParser): properly report errors for not properly closed tags

### DIFF
--- a/modules/@angular/compiler/src/html_parser.ts
+++ b/modules/@angular/compiler/src/html_parser.ts
@@ -295,7 +295,9 @@ class TreeBuilder {
     var fullName =
         getElementFullName(endTagToken.parts[0], endTagToken.parts[1], this._getParentElement());
 
-    this._getParentElement().endSourceSpan = endTagToken.sourceSpan;
+    if (this._getParentElement()) {
+      this._getParentElement().endSourceSpan = endTagToken.sourceSpan;
+    }
 
     if (getHtmlTagDefinition(fullName).isVoid) {
       this.errors.push(

--- a/modules/@angular/compiler/test/html_parser_spec.ts
+++ b/modules/@angular/compiler/test/html_parser_spec.ts
@@ -343,6 +343,12 @@ export function main() {
           expect(humanizeErrors(errors)).toEqual([['p', 'Unexpected closing tag "p"', '0:5']]);
         });
 
+        it('should report subsequent open tags without proper close tag', () => {
+          let errors = parser.parse('<div</div>', 'TestComp').errors;
+          expect(errors.length).toEqual(1);
+          expect(humanizeErrors(errors)).toEqual([['div', 'Unexpected closing tag "div"', '0:4']]);
+        });
+
         it('should report closing tag for void elements', () => {
           let errors = parser.parse('<input></input>', 'TestComp').errors;
           expect(errors.length).toEqual(1);


### PR DESCRIPTION
Fixes #7849
