### PR TITLE
fix(compiler): Improved error reporting of the static reflector.

### DIFF
--- a/modules/@angular/compiler-cli/test/static_reflector_spec.ts
+++ b/modules/@angular/compiler-cli/test/static_reflector_spec.ts
@@ -109,6 +109,11 @@ describe('StaticReflector', () => {
     expect(parameters).toEqual([]);
   });
 
+  it('should provide context for errors reported by the collector', () => {
+    let SomeClass = host.findDeclaration('src/error-reporting', 'SomeClass');
+    expect(() => reflector.annotations(SomeClass)).toThrow(new Error('Error encountered resolving symbol values statically. A reasonable error message (position 12:33 in the original .ts file), resolving symbol ErrorSym in /tmp/src/error-references.d.ts, resolving symbol Link2 in /tmp/src/error-references.d.ts, resolving symbol Link1 in /tmp/src/error-references.d.ts, resolving symbol SomeClass in /tmp/src/error-reporting.d.ts, resolving symbol SomeClass in /tmp/src/error-reporting.d.ts'));
+  });
+
   it('should simplify primitive into itself', () => {
     expect(simplify(noContext, 1)).toBe(1);
     expect(simplify(noContext, true)).toBe(true);
@@ -537,6 +542,58 @@ class MockReflectorHost implements StaticReflectorHost {
       },
       '/src/extern.d.ts': {"__symbolic": "module", "version": 1, metadata: {s: "s"}},
       '/tmp/src/version-error.d.ts': {"__symbolic": "module", "version": 100, metadata: {e: "s"}},
+      '/tmp/src/error-reporting.d.ts': {
+        __symbolic: "module",
+        version: 1,
+        metadata: {
+          SomeClass: {
+            __symbolic: "class",
+            decorators: [
+              {
+                __symbolic: "call",
+                expression: {
+                  __symbolic: "reference",
+                  name: "Component",
+                  module: "angular2/src/core/metadata"
+                },
+                arguments: [
+                  {
+                    directives: [
+                      {
+                        __symbolic: "reference",
+                        module: "src/error-references",
+                        name: "Link1",
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+          }
+        }
+      },
+      '/tmp/src/error-references.d.ts': {
+        __symbolic: "module",
+        version: 1,
+        metadata: {
+          Link1: {
+            __symbolic: "reference",
+            module: "src/error-references",
+            name: "Link2"
+          },
+          Link2: {
+            __symbolic: "reference",
+            module: "src/error-references",
+            name: "ErrorSym"
+          },
+          ErrorSym: {
+            __symbolic: "error",
+            message: "A reasonable error message",
+            line: 12,
+            character: 33
+          }
+        }
+      }
     };
     return data[moduleId];
   }

--- a/tools/@angular/tsc-wrapped/src/schema.ts
+++ b/tools/@angular/tsc-wrapped/src/schema.ts
@@ -191,7 +191,30 @@ export function isMetadataSymbolicSelectExpression(value: any):
 
 export interface MetadataError {
   __symbolic: 'error';
+
+  /**
+   * This message should be short and relatively discriptive and should be fixed once it is created.
+   * If the reader doesn't recognize the message, it will display the message unmodified. If the
+   * reader recognizes the error message is it free to use substitute message the is more
+   * descriptive and/or localized.
+   */
   message: string;
+
+  /**
+   * The line number of the error in the .ts file the metadata was created for.
+   */
+  line?: number;
+
+  /**
+   * The number of utf8 code-units from the beginning of the file of the error.
+   */
+  character?: number;
+
+  /**
+   * Context information that can be used to generate a more descriptive error message. The content
+   * of the context is dependent on the error message.
+   */
+  context?: {[name: string]: string};
 }
 export function isMetadataError(value: any): value is MetadataError {
   return value && value.__symbolic === 'error';

--- a/tools/@angular/tsc-wrapped/test/collector.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/collector.spec.ts
@@ -33,6 +33,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
+      version: 1,
       metadata: {
         HeroDetailComponent: {
           __symbolic: 'class',
@@ -73,6 +74,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
+      version: 1,
       metadata: {
         AppComponent: {
           __symbolic: 'class',
@@ -126,6 +128,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
+      version: 1,
       metadata: {
         HEROES: [
           {'id': 11, 'name': 'Mr. Nice'}, {'id': 12, 'name': 'Narco'},
@@ -206,26 +209,37 @@ describe('Collector', () => {
     let metadata = collector.getMetadata(unsupported1);
     expect(metadata).toEqual({
       __symbolic: 'module',
+      version: 1,
       metadata: {
         a: {
-          __symbolc: 'error',
-          message: 'Destructuring declarations cannot be referenced statically'
+          __symbolic: 'error',
+          message: 'Destructuring declarations cannot be referenced statically',
+          line: 1,
+          character: 16
         },
         b: {
-          __symbolc: 'error',
-          message: 'Destructuring declarations cannot be referenced statically'
+          __symbolic: 'error',
+          message: 'Destructuring declarations cannot be referenced statically',
+          line: 1,
+          character: 18
         },
         c: {
-          __symbolc: 'error',
-          message: 'Destructuring declarations cannot be referenced statically'
+          __symbolic: 'error',
+          message: 'Destructuring declarations cannot be referenced statically',
+          line: 2,
+          character: 16
         },
         d: {
-          __symbolc: 'error',
-          message: 'Destructuring declarations cannot be referenced statically'
+          __symbolic: 'error',
+          message: 'Destructuring declarations cannot be referenced statically',
+          line: 2,
+          character: 18
         },
         e: {
           __symbolic: 'error',
-          message: 'Only intialized variables and constants can be referenced statically'
+          message: 'Only intialized variables and constants can be referenced statically',
+          line: 3,
+          character: 14
         }
       }
     });
@@ -237,8 +251,12 @@ describe('Collector', () => {
     let barClass = <ClassMetadata>metadata.metadata['Bar'];
     let ctor = <ConstructorMetadata>barClass.members['__ctor__'][0];
     let parameter = ctor.parameters[0];
-    expect(parameter).toEqual(
-        {__symbolic: 'error', message: 'Reference to non-exported class Foo'});
+    expect(parameter).toEqual({
+      __symbolic: 'error',
+      message: 'Reference to non-exported class Foo',
+      line: 1,
+      character: 45
+    });
   });
 });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Errors generated by the `StaticReflector` used during offline compilation does not produce context to diagnose the reason the error occurred. E.g. #8978.

**What is the new behavior?**

Improved the error message by including more information, including positional information and well as provide more context when the error message is generated.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:

StaticReflector provides more context on errors reported by the
collector.

The metadata collector now records the line and character of the node that
caused it to report the error.

Includes other minor fixes to error reporting and a wording change.
