### PR TITLE
refactor(compiler): remove obsolete @View-related code

### DIFF
--- a/modules/@angular/compiler/src/view_resolver.ts
+++ b/modules/@angular/compiler/src/view_resolver.ts
@@ -42,45 +42,17 @@ export class ViewResolver {
   /** @internal */
   _resolve(component: Type): ViewMetadata {
     var compMeta: ComponentMetadata;
-    var viewMeta: ViewMetadata;
 
     this._reflector.annotations(component).forEach(m => {
-      if (m instanceof ViewMetadata) {
-        viewMeta = m;
-      }
       if (m instanceof ComponentMetadata) {
         compMeta = m;
       }
     });
 
     if (isPresent(compMeta)) {
-      if (isBlank(compMeta.template) && isBlank(compMeta.templateUrl) && isBlank(viewMeta)) {
+      if (isBlank(compMeta.template) && isBlank(compMeta.templateUrl)) {
         throw new BaseException(
             `Component '${stringify(component)}' must have either 'template' or 'templateUrl' set.`);
-
-      } else if (isPresent(compMeta.template) && isPresent(viewMeta)) {
-        this._throwMixingViewAndComponent("template", component);
-
-      } else if (isPresent(compMeta.templateUrl) && isPresent(viewMeta)) {
-        this._throwMixingViewAndComponent("templateUrl", component);
-
-      } else if (isPresent(compMeta.directives) && isPresent(viewMeta)) {
-        this._throwMixingViewAndComponent("directives", component);
-
-      } else if (isPresent(compMeta.pipes) && isPresent(viewMeta)) {
-        this._throwMixingViewAndComponent("pipes", component);
-
-      } else if (isPresent(compMeta.encapsulation) && isPresent(viewMeta)) {
-        this._throwMixingViewAndComponent("encapsulation", component);
-
-      } else if (isPresent(compMeta.styles) && isPresent(viewMeta)) {
-        this._throwMixingViewAndComponent("styles", component);
-
-      } else if (isPresent(compMeta.styleUrls) && isPresent(viewMeta)) {
-        this._throwMixingViewAndComponent("styleUrls", component);
-
-      } else if (isPresent(viewMeta)) {
-        return viewMeta;
 
       } else {
         return new ViewMetadata({
@@ -95,19 +67,9 @@ export class ViewResolver {
         });
       }
     } else {
-      if (isBlank(viewMeta)) {
         throw new BaseException(
             `Could not compile '${stringify(component)}' because it is not a component.`);
-      } else {
-        return viewMeta;
-      }
     }
-    return null;
   }
 
-  /** @internal */
-  _throwMixingViewAndComponent(propertyName: string, component: Type): void {
-    throw new BaseException(
-        `Component '${stringify(component)}' cannot have both '${propertyName}' and '@View' set at the same time"`);
-  }
 }

--- a/modules/@angular/compiler/test/view_resolver_spec.ts
+++ b/modules/@angular/compiler/test/view_resolver_spec.ts
@@ -12,25 +12,7 @@ class SomePipe {}
   pipes: [SomePipe],
   styles: ["some styles"]
 })
-class ComponentWithView {
-}
-
-@Component({
-  selector: 'sample',
-  template: "some template",
-  directives: [SomeDir],
-  pipes: [SomePipe],
-  styles: ["some styles"]
-})
 class ComponentWithTemplate {
-}
-
-@Component({selector: 'sample', template: "some template"})
-class ComponentWithViewTemplate {
-}
-
-@Component({selector: 'sample', templateUrl: "some template url", template: "some template"})
-class ComponentWithViewTemplateUrl {
 }
 
 @Component({selector: 'sample'})
@@ -57,13 +39,13 @@ export function main() {
           }));
     });
 
-    it('should throw when Component has no View decorator and no template is set', () => {
+    it('should throw when Component has neither template nor templateUrl set', () => {
       expect(() => resolver.resolve(ComponentWithoutView))
           .toThrowErrorWith(
               "Component 'ComponentWithoutView' must have either 'template' or 'templateUrl' set");
     });
 
-    it('should throw when simple class has no View decorator and no template is set', () => {
+    it('should throw when simple class has no component decorator', () => {
       expect(() => resolver.resolve(SimpleClass))
           .toThrowErrorWith("Could not compile 'SimpleClass' because it is not a component.");
     });


### PR DESCRIPTION
Some dead code removal - the removed code was related to `@View` but since `@View` is gone it is not needed any more. Found when poking around Query-related code.
