### PR TITLE
refactor(testing): type beforeEachProviders

### DIFF
--- a/modules/@angular/core/testing/testing.ts
+++ b/modules/@angular/core/testing/testing.ts
@@ -86,7 +86,7 @@ jsmBeforeEach(() => { testInjector.reset(); });
  *
  * {@example testing/ts/testing.ts region='beforeEachProviders'}
  */
-export function beforeEachProviders(fn): void {
+export function beforeEachProviders(fn: () => Array<any>): void {
   jsmBeforeEach(() => {
     var providers = fn();
     if (!providers) return;


### PR DESCRIPTION
these are valid otherwise

``` typescript
beforeEachProviders(1)
beforeEachProviders('wat')
beforeEachProviders([
  Http
])
```

passing an array is a gotcha rather than a function that returns an array
