### PR TITLE
fix(ngUpgrade): prevent digest already in progress errors

### DIFF
--- a/modules/@angular/upgrade/src/angular_js.ts
+++ b/modules/@angular/upgrade/src/angular_js.ts
@@ -26,6 +26,7 @@ export interface IRootScopeService {
   $apply(): any;
   $apply(exp: string): any;
   $apply(exp: Function): any;
+  $applyAsync(): any;
   $$childTail: IScope;
   $$childHead: IScope;
   $$nextSibling: IScope;

--- a/modules/@angular/upgrade/src/upgrade_adapter.ts
+++ b/modules/@angular/upgrade/src/upgrade_adapter.ts
@@ -366,7 +366,7 @@ export class UpgradeAdapter {
         (injector: angular.IInjectorService, rootScope: angular.IRootScopeService) => {
           ng1Injector = injector;
           ngZone.onMicrotaskEmpty.subscribe(
-              {next: (_) => ngZone.runOutsideAngular(() => rootScope.$apply())});
+              {next: (_) => ngZone.runOutsideAngular(() => rootScope.$applyAsync())});
           UpgradeNg1ComponentAdapterBuilder.resolve(this.downgradedComponents, injector)
               .then(resolve, reject);
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Under certain conditions ngUpgrade will throw "digest already in progress" errors. Seems to be related to overlapping digest cycles between ngUpgrade and the Angular 1 application.
Repro here:
https://github.com/angular/angular/issues/8951

**What is the new behavior?**
By using $applyAsync, digest cycles will no longer overlap since Angular will check if a digest cycle is already in progress before triggering a new one. If a digest is already a progress the ngUpgrade update will just join the existing cycle.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
