### PR TITLE
fix(compiler): Added support for '* as m' style imports.

### DIFF
--- a/modules/@angular/compiler-cli/integrationtest/src/features.ts
+++ b/modules/@angular/compiler-cli/integrationtest/src/features.ts
@@ -1,5 +1,5 @@
 import {Component, Inject, OpaqueToken} from '@angular/core';
-import {NgIf} from '@angular/common';
+import * as common from '@angular/common';
 
 export const SOME_OPAQUE_TOKEN = new OpaqueToken('opaqueToken');
 
@@ -9,7 +9,7 @@ export const SOME_OPAQUE_TOKEN = new OpaqueToken('opaqueToken');
   providers: [
     {provide: 'strToken', useValue: 'strValue'},
     {provide: SOME_OPAQUE_TOKEN, useValue: 10},
-    {provide: 'reference', useValue: NgIf},
+    {provide: 'reference', useValue: common.NgIf},
     {provide: 'complexToken', useValue: {a: 1, b: ['test', SOME_OPAQUE_TOKEN]}},
   ]
 })
@@ -23,7 +23,7 @@ export class CompWithProviders {
     <input #a>{{a.value}}
     <div *ngIf="true">{{a.value}}</div>
   `,
-  directives: [NgIf]
+  directives: [common.NgIf]
 })
 export class CompWithReferences {
 }

--- a/tools/@angular/tsc-wrapped/src/schema.ts
+++ b/tools/@angular/tsc-wrapped/src/schema.ts
@@ -165,6 +165,7 @@ export interface MetadataImportedDefaultReferenceExpression extends MetadataSymb
   module: string;
   default:
     boolean;
+    arguments?: MetadataValue[];
 }
 export function isMetadataImportDefaultReference(value: any):
     value is MetadataImportedDefaultReferenceExpression {

--- a/tools/@angular/tsc-wrapped/test/evaluator.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/evaluator.spec.ts
@@ -156,31 +156,29 @@ describe('Evaluator', () => {
       character: 10
     });
     let fDecl = findVar(errors, 'f');
-    expect(evaluator.evaluateNode(fDecl.initializer)).toEqual({
-      __symbolic: 'error',
-      message:
-          'Functions cannot be evaluated statically; consider replacing with a reference to an exported function',
-      line: 6,
-      character: 11
-    });
+    expect(evaluator.evaluateNode(fDecl.initializer))
+        .toEqual(
+            {__symbolic: 'error', message: 'Function call not supported', line: 6, character: 11});
     let eDecl = findVar(errors, 'e');
     expect(evaluator.evaluateNode(eDecl.type)).toEqual({
       __symbolic: 'error',
-      message: 'Could not resolve type NotFound',
+      message: 'Could not resolve type',
       line: 7,
-      character: 10
+      character: 10,
+      context: {typeName: 'NotFound'}
     });
     let sDecl = findVar(errors, 's');
     expect(evaluator.evaluateNode(sDecl.initializer)).toEqual({
       __symbolic: 'error',
-      message: 'Name expected a string or an identifier but received "1"',
+      message: 'Name expected',
       line: 8,
-      character: 13
+      character: 13,
+      context: {received: '1'}
     });
     let tDecl = findVar(errors, 't');
     expect(evaluator.evaluateNode(tDecl.initializer)).toEqual({
       __symbolic: 'error',
-      message: 'Expression form not supported statically',
+      message: 'Expression form not supported',
       line: 9,
       character: 11
     });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The collector would report an error for type references of the form `a.b` if `a` even if `a` was an imported module. 

**What is the new behavior?**

The collector now translates qualified access to a module symbol as a special case and translates them into import references.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:

Also includes fixes for broken test.
