### PR TITLE
docs(Date pipe format): set a newest documentation about date format

### DIFF
--- a/modules/@angular/common/src/pipes/date_pipe.ts
+++ b/modules/@angular/common/src/pipes/date_pipe.ts
@@ -53,7 +53,7 @@ var defaultLocale: string = 'en-US';
  * punctuations, ...) and details of the formatting will be dependent on the locale.
  * On the other hand in Dart version, you can also include quoted text as well as some extra
  * date/time components such as quarter. For more information see:
- * https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/intl/intl.DateFormat.
+ * https://www.dartdocs.org/documentation/intl/0.13.0/intl/DateFormat-class.html
  *
  * `format` can also be one of the following predefined formats:
  *


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other... Please describe: Change the documentation referent related with the date in date_pipe

**What is the current behavior?** (You can also link to an open issue here)
The current documentation is not longer available (https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/intl/intl.DateFormat)

**What is the new behavior?**
Update to the new documenta link version (https://www.dartdocs.org/documentation/intl/0.13.0/intl/DateFormat-class.html)

**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

docs(Date pipe format): set a newest documentation about date format

Change the link of the Dart date format because the oldest version is not longert available:
*Before: https://www.dartdocs.org/documentation/intl/0.13.0/intl/DateFormat-class.html
*After: https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/intl/intl.DateFormat.
