### PR TITLE
docs(linker): document the injector argument as mandatory

### DIFF
--- a/modules/@angular/core/src/linker/dynamic_component_loader.ts
+++ b/modules/@angular/core/src/linker/dynamic_component_loader.ts
@@ -21,8 +21,7 @@ export abstract class DynamicComponentLoader {
    *
    * If needed, the component's selector can be overridden via `overrideSelector`.
    *
-   * You can optionally provide `injector` and this {@link Injector} will be used to instantiate the
-   * Component.
+   * A provided {@link Injector} will be used to instantiate the Component.
    *
    * To be notified when this Component instance is destroyed, you can also optionally provide
    * `onDispose` callback.


### PR DESCRIPTION
DCL is deprecated but since people seem to be confused by the current doc....

Fixes #8600
