### PR TITLE
refactor(ApplicationRef): invoke APP_INITIALIZER after ApplicationRef before bootstrap

### DIFF
--- a/modules/@angular/core/test/application_ref_spec.ts
+++ b/modules/@angular/core/test/application_ref_spec.ts
@@ -106,7 +106,7 @@ export function main() {
            }]);
            expect(() => app.bootstrap(someCompFactory))
                .toThrowError(
-                   'Cannot bootstrap as there are still asynchronous initializers running. Wait for them using waitForAsyncInitializers().');
+                   'Cannot bootstrap as there are still asynchronous initializers running. Wait for them using runInitializers().');
          }));
     });
   });

--- a/modules/@angular/core/testing/mock_application_ref.ts
+++ b/modules/@angular/core/testing/mock_application_ref.ts
@@ -26,7 +26,7 @@ export class MockApplicationRef extends ApplicationRef {
 
   run(callback: Function): any { return null; }
 
-  waitForAsyncInitializers(): Promise<any> { return null; }
+  runInitializers(): Promise<any>|any { return null; }
 
   dispose(): void {}
 

--- a/modules/@angular/platform-browser-dynamic/index.ts
+++ b/modules/@angular/platform-browser-dynamic/index.ts
@@ -134,7 +134,8 @@ export function bootstrapWorkerUi(
   // Return a promise so that we keep the same semantics as Dart,
   // and we might want to wait for the app side to come up
   // in the future...
-  return PromiseWrapper.resolve(app.get(ApplicationRef));
+  let appRef: ApplicationRef = app.get(ApplicationRef);
+  return PromiseWrapper.resolve(appRef.runInitializers()).then(() => appRef);
 }
 
 

--- a/modules/@angular/platform-browser/test/browser/bootstrap_spec.ts
+++ b/modules/@angular/platform-browser/test/browser/bootstrap_spec.ts
@@ -242,14 +242,17 @@ export function main() {
          ]));
          expect(log.result()).toEqual('platform_init1; platform_init2');
          log.clear();
-         var a = ReflectiveInjector.resolveAndCreate(
+         let a = ReflectiveInjector.resolveAndCreate(
              [
                BROWSER_APP_PROVIDERS,
                {provide: APP_INITIALIZER, useValue: log.fn('app_init1'), multi: true},
                {provide: APP_INITIALIZER, useValue: log.fn('app_init2'), multi: true}
              ],
              p.injector);
-         a.get(ApplicationRef);
+         expect(log.result()).toEqual('');
+
+         let appRef = a.get(ApplicationRef);
+         appRef.runInitializers();
 
          expect(log.result()).toEqual('app_init1; app_init2');
        }));

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -122,7 +122,7 @@ export declare abstract class ApplicationRef {
     abstract registerDisposeListener(dispose: () => void): void;
     abstract run(callback: Function): any;
     abstract tick(): void;
-    abstract waitForAsyncInitializers(): Promise<any>;
+    abstract runInitializers(): Promise<any> | any;
 }
 
 /** @experimental */


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
APP_INITIALIZER are invoked during creation of platform/app injectors

**What is the new behavior?**
invoke APP_INITIALIZER after creation of platform/app injectors

**Does this PR introduce a breaking change?**
- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
invoke APP_INITIALIZER after ApplicationRef but before bootstrap

**Other information**:
possible close #9101 
