### PR TITLE
feat(datePipe): numeric string support

### DIFF
--- a/modules/@angular/common/src/pipes/date_pipe.ts
+++ b/modules/@angular/common/src/pipes/date_pipe.ts
@@ -1,7 +1,7 @@
 import {Pipe, PipeTransform} from '@angular/core';
-import {isDate, isNumber, isString, DateWrapper, isBlank,} from '../facade/lang';
-import {DateFormatter} from '../facade/intl';
 import {StringMapWrapper} from '../facade/collection';
+import {DateFormatter} from '../facade/intl';
+import {DateWrapper, NumberWrapper, isBlank, isDate, isString} from '../facade/lang';
 import {InvalidPipeArgumentException} from './invalid_pipe_argument_exception';
 
 // TODO: move to a global configurable location along with other i18n components.
@@ -98,8 +98,8 @@ export class DatePipe implements PipeTransform {
       throw new InvalidPipeArgumentException(DatePipe, value);
     }
 
-    if (isNumber(value)) {
-      value = DateWrapper.fromMillis(value);
+    if (NumberWrapper.isNumeric(value)) {
+      value = DateWrapper.fromMillis(NumberWrapper.parseInt(value, 10));
     } else if (isString(value)) {
       value = DateWrapper.fromISOString(value);
     }
@@ -110,7 +110,7 @@ export class DatePipe implements PipeTransform {
   }
 
   private supports(obj: any): boolean {
-    if (isDate(obj) || isNumber(obj)) {
+    if (isDate(obj) || NumberWrapper.isNumeric(obj)) {
       return true;
     }
     if (isString(obj) && isDate(DateWrapper.fromISOString(obj))) {

--- a/modules/@angular/common/test/pipes/date_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/date_pipe_spec.ts
@@ -24,6 +24,9 @@ export function main() {
       describe('supports', () => {
         it('should support date', () => { expect(() => pipe.transform(date)).not.toThrow(); });
         it('should support int', () => { expect(() => pipe.transform(123456789)).not.toThrow(); });
+        it('should support numeric strings',
+           () => { expect(() => pipe.transform('123456789')).not.toThrow(); });
+
         it('should support ISO string',
            () => { expect(() => pipe.transform('2015-06-15T21:43:11Z')).not.toThrow(); });
 

--- a/modules/@angular/facade/src/lang.dart
+++ b/modules/@angular/facade/src/lang.dart
@@ -189,6 +189,13 @@ class NumberWrapper {
 
   static double get NaN => double.NAN;
 
+  static bool isNumeric(value) {
+    if(value == null) {
+      return false;
+    }
+    return double.parse(value, (e) => null) != null;
+  }
+
   static bool isNaN(num value) => value.isNaN;
 
   static bool isInteger(value) => value is int;

--- a/modules/@angular/facade/src/lang.ts
+++ b/modules/@angular/facade/src/lang.ts
@@ -320,6 +320,8 @@ export class NumberWrapper {
 
   static get NaN(): number { return NaN; }
 
+  static isNumeric(value: any): boolean { return !isNaN(value - parseFloat(value)); }
+
   static isNaN(value: any): boolean { return isNaN(value); }
 
   static isInteger(value: any): boolean { return Number.isInteger(value); }

--- a/modules/@angular/facade/test/lang_spec.ts
+++ b/modules/@angular/facade/test/lang_spec.ts
@@ -1,6 +1,5 @@
 import {beforeEach, ddescribe, describe, expect, iit, it, xit} from '@angular/core/testing';
-
-import {RegExpMatcherWrapper, RegExpWrapper, StringWrapper, hasConstructor, isPresent, resolveEnumToken} from '../src/lang';
+import {NumberWrapper, RegExpMatcherWrapper, RegExpWrapper, StringWrapper, hasConstructor, isPresent, resolveEnumToken} from '../src/lang';
 
 enum UsefulEnum {
   MyToken,
@@ -48,6 +47,28 @@ export function main() {
     it('should support const expressions both in TS and Dart', () => {
       const numbers = /*@ts2dart_const*/[1, 2, 3];
       expect(numbers).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('Number', () => {
+    describe('isNumeric', () => {
+      it('should return true when passing correct numeric string',
+         () => { expect(NumberWrapper.isNumeric('2')).toBe(true); });
+
+      it('should return true when passing correct double string',
+         () => { expect(NumberWrapper.isNumeric('1.123')).toBe(true); });
+
+      it('should return true when passing correct negative string',
+         () => { expect(NumberWrapper.isNumeric('-2')).toBe(true); });
+
+      it('should return true when passing correct scientific notation string',
+         () => { expect(NumberWrapper.isNumeric('1e5')).toBe(true); });
+
+      it('should return false when passing incorrect numeric',
+         () => { expect(NumberWrapper.isNumeric('a')).toBe(false); });
+
+      it('should return false when passing parseable but non numeric',
+         () => { expect(NumberWrapper.isNumeric('2a')).toBe(false); });
     });
   });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Numeric string is not supported. 

**What is the new behavior?**

Numeric string would successfully transformed by date pipe.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This is really small PR. I not sure does this behavior should exist, but ng1 work with numeric strings.
Related to #3261

cc @mhevery
