### PR TITLE
feat(compiler): Added support for limit function evaluator statically.

### DIFF
--- a/modules/@angular/compiler-cli/integrationtest/src/features.ts
+++ b/modules/@angular/compiler-cli/integrationtest/src/features.ts
@@ -1,6 +1,8 @@
 import * as common from '@angular/common';
 import {Component, Inject, OpaqueToken} from '@angular/core';
 
+import {wrapInArray} from './funcs';
+
 export const SOME_OPAQUE_TOKEN = new OpaqueToken('opaqueToken');
 
 @Component({
@@ -23,7 +25,7 @@ export class CompWithProviders {
     <input #a>{{a.value}}
     <div *ngIf="true">{{a.value}}</div>
   `,
-  directives: [common.NgIf]
+  directives: [wrapInArray(common.NgIf)]
 })
 export class CompWithReferences {
 }

--- a/modules/@angular/compiler-cli/integrationtest/src/funcs.ts
+++ b/modules/@angular/compiler-cli/integrationtest/src/funcs.ts
@@ -1,0 +1,3 @@
+export function wrapInArray(value: any): any[] {
+  return [value];
+}

--- a/modules/@angular/compiler-cli/src/reflector_host.ts
+++ b/modules/@angular/compiler-cli/src/reflector_host.ts
@@ -29,6 +29,7 @@ export class ReflectorHost implements StaticReflectorHost, ImportGenerator {
       coreDecorators: '@angular/core/src/metadata',
       diDecorators: '@angular/core/src/di/decorators',
       diMetadata: '@angular/core/src/di/metadata',
+      diOpaqueToken: '@angular/core/src/di/opaque_token',
       animationMetadata: '@angular/core/src/animation/metadata',
       provider: '@angular/core/src/di/provider'
     };

--- a/tools/@angular/tsc-wrapped/src/schema.ts
+++ b/tools/@angular/tsc-wrapped/src/schema.ts
@@ -61,6 +61,15 @@ export function isConstructorMetadata(value: any): value is ConstructorMetadata 
   return value && value.__symbolic === 'constructor';
 }
 
+export interface FunctionMetadata {
+  __symbolic: 'function';
+  parameters: string[];
+  result: MetadataValue;
+}
+export function isFunctionMetadata(value: any): value is FunctionMetadata {
+  return value && value.__symbolic === 'function';
+}
+
 export type MetadataValue = string | number | boolean | MetadataObject | MetadataArray |
     MetadataSymbolicExpression | MetadataError;
 
@@ -69,7 +78,7 @@ export interface MetadataObject { [name: string]: MetadataValue; }
 export interface MetadataArray { [name: number]: MetadataValue; }
 
 export interface MetadataSymbolicExpression {
-  __symbolic: 'binary'|'call'|'index'|'new'|'pre'|'reference'|'select'
+  __symbolic: 'binary'|'call'|'index'|'new'|'pre'|'reference'|'select'|'spread'
 }
 export function isMetadataSymbolicExpression(value: any): value is MetadataSymbolicExpression {
   if (value) {
@@ -81,6 +90,7 @@ export function isMetadataSymbolicExpression(value: any): value is MetadataSymbo
       case 'pre':
       case 'reference':
       case 'select':
+      case 'spread':
         return true;
     }
   }
@@ -188,6 +198,15 @@ export interface MetadataSymbolicSelectExpression extends MetadataSymbolicExpres
 export function isMetadataSymbolicSelectExpression(value: any):
     value is MetadataSymbolicSelectExpression {
   return value && value.__symbolic === 'select';
+}
+
+export interface MetadataSymbolicSpreadExpression extends MetadataSymbolicExpression {
+  __symbolic: 'spread';
+  expression: MetadataValue;
+}
+export function isMetadataSymbolicSpreadExpression(value: any):
+    value is MetadataSymbolicSpreadExpression {
+  return value && value.__symbolic === 'spread';
 }
 
 export interface MetadataError {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The compiler reports call not supported on all functions that are not explicitly listed in the white list of functions.

**What is the new behavior?**

Expands this to include functions that only return an expression and the expression can be resolved (with parameter substitution) statically.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

**Other information**:

Now allows collecting and evaluating functions that only return a
value. The value can reference parameters of the function.
