### PR TITLE
feat(forms): allow ngModel to register with parent form

### DIFF
--- a/modules/@angular/common/src/forms/directives/form_interface.ts
+++ b/modules/@angular/common/src/forms/directives/form_interface.ts
@@ -15,7 +15,7 @@ export interface Form {
   /**
    * Add a control to this form.
    */
-  addControl(dir: NgControl): void;
+  addControl(dir: NgControl): Control;
 
   /**
    * Remove a control from this form.

--- a/modules/@angular/common/src/forms/directives/ng_form.ts
+++ b/modules/@angular/common/src/forms/directives/ng_form.ts
@@ -109,14 +109,15 @@ export class NgForm extends ControlContainer implements Form {
 
   get controls(): {[key: string]: AbstractControl} { return this.form.controls; }
 
-  addControl(dir: NgControl): void {
+  addControl(dir: NgControl): Control {
+    const ctrl = new Control();
     PromiseWrapper.scheduleMicrotask(() => {
-      var container = this._findContainer(dir.path);
-      var ctrl = new Control();
+      const container = this._findContainer(dir.path);
       setUpControl(ctrl, dir);
       container.registerControl(dir.name, ctrl);
       ctrl.updateValueAndValidity({emitEvent: false});
     });
+    return ctrl;
   }
 
   getControl(dir: NgControl): Control { return <Control>this.form.find(dir.path); }

--- a/modules/@angular/common/src/forms/directives/ng_form_model.ts
+++ b/modules/@angular/common/src/forms/directives/ng_form_model.ts
@@ -138,11 +138,12 @@ export class NgFormModel extends ControlContainer implements Form,
 
   get path(): string[] { return []; }
 
-  addControl(dir: NgControl): void {
-    var ctrl: any = this.form.find(dir.path);
+  addControl(dir: NgControl): Control {
+    const ctrl: any = this.form.find(dir.path);
     setUpControl(ctrl, dir);
     ctrl.updateValueAndValidity({emitEvent: false});
     this.directives.push(dir);
+    return ctrl;
   }
 
   getControl(dir: NgControl): Control { return <Control>this.form.find(dir.path); }

--- a/modules/@angular/common/test/forms-deprecated/directives_spec.ts
+++ b/modules/@angular/common/test/forms-deprecated/directives_spec.ts
@@ -4,7 +4,7 @@ import {fakeAsync, flushMicrotasks, Log, tick,} from '@angular/core/testing';
 
 import {SpyNgControl, SpyValueAccessor} from '../spies';
 
-import {ControlGroup, Control, NgControlName, NgControlGroup, NgFormModel, ControlValueAccessor, Validators, NgForm, NgModel, NgFormControl, NgControl, DefaultValueAccessor, CheckboxControlValueAccessor, SelectControlValueAccessor, Validator} from '@angular/common';
+import {ControlGroup, Control, NgControlName, NgControlGroup, NgFormModel, ControlValueAccessor, Validators, NgForm, NgModel, NgFormControl, NgControl, DefaultValueAccessor, CheckboxControlValueAccessor, SelectControlValueAccessor, Validator} from '@angular/common/src/forms-deprecated';
 
 
 import {selectValueAccessor, composeValidators} from '@angular/common/src/forms-deprecated/directives/shared';

--- a/modules/@angular/common/test/forms/directives_spec.ts
+++ b/modules/@angular/common/test/forms/directives_spec.ts
@@ -409,8 +409,8 @@ export function main() {
       var ngModel: any /** TODO #9100 */;
 
       beforeEach(() => {
-        ngModel =
-            new NgModel([Validators.required], [asyncValidator('expected')], [defaultAccessor]);
+        ngModel = new NgModel(
+            null, [Validators.required], [asyncValidator('expected')], [defaultAccessor]);
         ngModel.valueAccessor = new DummyControlValueAccessor();
       });
 


### PR DESCRIPTION
This PR gives ngModel the ability to register with a parent form.  

Previously, ngModel would only validate individually.   So with something like this:

``` ts
<form #f="ngForm">
   <input name="first" [(ngModel)]="person.firstName" required #first="ngForm">
</form>

{{ f.value | json }}    // {}
{{ f.valid }}     // true
{{ first.value }}  //  null
{{ first.valid }}   // false
```

`f.valid` would always be true because the ngModel validated separately from the form.  

Now when ngModel has a parent form, it's included in the aggregate form validity and value.  e.g.:

``` ts
<form #f="ngForm">
   <input name="first" [(ngModel)]="person.firstName" required #first="ngForm">
</form>

{{ f.value | json }}    // {first: ''}
{{ f.valid }}     // false
{{ first.value }}  //  null
{{ first.valid }}   // false
```

Note: this is _only_ in the new forms module, not forms-deprecated (the forms folder available by default).
