### PR TITLE
fix(http): respect custom Content-Type header in XHRConnection

### DIFF
--- a/modules/@angular/http/src/backends/xhr_backend.ts
+++ b/modules/@angular/http/src/backends/xhr_backend.ts
@@ -108,7 +108,7 @@ export class XHRConnection implements Connection {
 
   setDetectedContentType(req: any /** TODO #9100 */, _xhr: any /** TODO #9100 */) {
     // Skip if a custom Content-Type header is provided
-    if (isPresent(req.headers) && isPresent(req.headers['Content-Type'])) {
+    if (isPresent(req.headers) && isPresent(req.headers.get('Content-Type'))) {
       return;
     }
 

--- a/modules/@angular/http/test/backends/xhr_backend_spec.ts
+++ b/modules/@angular/http/test/backends/xhr_backend_spec.ts
@@ -212,6 +212,18 @@ export function main() {
         expect(setRequestHeaderSpy).toHaveBeenCalledWith('X-Multi', 'a,b');
       });
 
+      it('should skip content type detection if custom content type header is set', () => {
+        let headers = new Headers({'Content-Type': 'text/plain'});
+        let body = {test: 'val'};
+        let base = new BaseRequestOptions();
+        let connection = new XHRConnection(
+            new Request(base.merge(new RequestOptions({body: body, headers: headers}))),
+            new MockBrowserXHR());
+        connection.response.subscribe();
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('Content-Type', 'text/plain');
+        expect(setRequestHeaderSpy).not.toHaveBeenCalledWith('Content-Type', 'application/json');
+      });
+
       it('should use object body and detect content type header to the request', () => {
         var body = {test: 'val'};
         var base = new BaseRequestOptions();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix

Issue: #9130.

**Does this PR introduce a breaking change?**
- [x] No

Commit message:

Fix a bug due to which setting a custom Content-Type header in the
Request led to multiple Content-Types being set on the sent
XMLHttpRequest: first the detected content type based on the request
body, followed by the custom set content type.

Fix #9130.
