### PR TITLE
chore(TypeScript): Change comments in #9100 to single asterisks

### DIFF
--- a/modules/@angular/common/src/directives/ng_for.ts
+++ b/modules/@angular/common/src/directives/ng_for.ts
@@ -137,7 +137,7 @@ export class NgFor implements DoCheck {
       viewRef.context.count = ilen;
     }
 
-    changes.forEachIdentityChange((record: any /** TODO #9100 */) => {
+    changes.forEachIdentityChange((record: any /* TODO #9100 */) => {
       var viewRef = <EmbeddedViewRef<NgForRow>>this._viewContainer.get(record.currentIndex);
       viewRef.context.$implicit = record.item;
     });

--- a/modules/@angular/common/test/forms-deprecated/directives_spec.ts
+++ b/modules/@angular/common/test/forms-deprecated/directives_spec.ts
@@ -13,10 +13,10 @@ import {PromiseWrapper} from '../../src/facade/promise';
 import {SimpleChange} from '@angular/core/src/change_detection';
 
 class DummyControlValueAccessor implements ControlValueAccessor {
-  writtenValue: any /** TODO #9100 */;
+  writtenValue: any /* TODO #9100 */;
 
-  registerOnChange(fn: any /** TODO #9100 */) {}
-  registerOnTouched(fn: any /** TODO #9100 */) {}
+  registerOnChange(fn: any /* TODO #9100 */) {}
+  registerOnTouched(fn: any /* TODO #9100 */) {}
 
   writeValue(obj: any): void { this.writtenValue = obj; }
 }
@@ -25,8 +25,8 @@ class CustomValidatorDirective implements Validator {
   validate(c: Control): {[key: string]: any} { return {'custom': true}; }
 }
 
-function asyncValidator(expected: any /** TODO #9100 */, timeout = 0) {
-  return (c: any /** TODO #9100 */) => {
+function asyncValidator(expected: any /* TODO #9100 */, timeout = 0) {
+  return (c: any /* TODO #9100 */) => {
     var completer = PromiseWrapper.completer();
     var res = c.value != expected ? {'async': true} : null;
     if (timeout == 0) {
@@ -91,14 +91,14 @@ export function main() {
 
       describe('composeValidators', () => {
         it('should compose functions', () => {
-          var dummy1 = (_: any /** TODO #9100 */) => ({'dummy1': true});
-          var dummy2 = (_: any /** TODO #9100 */) => ({'dummy2': true});
+          var dummy1 = (_: any /* TODO #9100 */) => ({'dummy1': true});
+          var dummy2 = (_: any /* TODO #9100 */) => ({'dummy2': true});
           var v = composeValidators([dummy1, dummy2]);
           expect(v(new Control(''))).toEqual({'dummy1': true, 'dummy2': true});
         });
 
         it('should compose validator directives', () => {
-          var dummy1 = (_: any /** TODO #9100 */) => ({'dummy1': true});
+          var dummy1 = (_: any /* TODO #9100 */) => ({'dummy1': true});
           var v = composeValidators([dummy1, new CustomValidatorDirective()]);
           expect(v(new Control(''))).toEqual({'dummy1': true, 'custom': true});
         });
@@ -106,9 +106,9 @@ export function main() {
     });
 
     describe('NgFormModel', () => {
-      var form: any /** TODO #9100 */;
+      var form: any /* TODO #9100 */;
       var formModel: ControlGroup;
-      var loginControlDir: any /** TODO #9100 */;
+      var loginControlDir: any /* TODO #9100 */;
 
       beforeEach(() => {
         form = new NgFormModel([], []);
@@ -186,7 +186,7 @@ export function main() {
       });
 
       describe('addControlGroup', () => {
-        var matchingPasswordsValidator = (g: any /** TODO #9100 */) => {
+        var matchingPasswordsValidator = (g: any /* TODO #9100 */) => {
           if (g.controls['password'].value != g.controls['passwordConfirm'].value) {
             return {'differentPasswords': true};
           } else {
@@ -241,7 +241,7 @@ export function main() {
         });
 
         it('should set up a sync validator', () => {
-          var formValidator = (c: any /** TODO #9100 */) => ({'custom': true});
+          var formValidator = (c: any /* TODO #9100 */) => ({'custom': true});
           var f = new NgFormModel([formValidator], []);
           f.form = formModel;
           f.ngOnChanges({'form': new SimpleChange(null, null)});
@@ -262,10 +262,10 @@ export function main() {
     });
 
     describe('NgForm', () => {
-      var form: any /** TODO #9100 */;
+      var form: any /* TODO #9100 */;
       var formModel: ControlGroup;
-      var loginControlDir: any /** TODO #9100 */;
-      var personControlGroupDir: any /** TODO #9100 */;
+      var loginControlDir: any /* TODO #9100 */;
+      var personControlGroupDir: any /* TODO #9100 */;
 
       beforeEach(() => {
         form = new NgForm([], []);
@@ -321,7 +321,7 @@ export function main() {
       });
 
       it('should set up sync validator', fakeAsync(() => {
-           var formValidator = (c: any /** TODO #9100 */) => ({'custom': true});
+           var formValidator = (c: any /* TODO #9100 */) => ({'custom': true});
            var f = new NgForm([formValidator], []);
 
            tick();
@@ -339,8 +339,8 @@ export function main() {
     });
 
     describe('NgControlGroup', () => {
-      var formModel: any /** TODO #9100 */;
-      var controlGroupDir: any /** TODO #9100 */;
+      var formModel: any /* TODO #9100 */;
+      var controlGroupDir: any /* TODO #9100 */;
 
       beforeEach(() => {
         formModel = new ControlGroup({'login': new Control(null)});
@@ -364,9 +364,9 @@ export function main() {
     });
 
     describe('NgFormControl', () => {
-      var controlDir: any /** TODO #9100 */;
-      var control: any /** TODO #9100 */;
-      var checkProperties = function(control: any /** TODO #9100 */) {
+      var controlDir: any /* TODO #9100 */;
+      var control: any /* TODO #9100 */;
+      var checkProperties = function(control: any /* TODO #9100 */) {
         expect(controlDir.control).toBe(control);
         expect(controlDir.value).toBe(control.value);
         expect(controlDir.valid).toBe(control.valid);
@@ -406,7 +406,7 @@ export function main() {
     });
 
     describe('NgModel', () => {
-      var ngModel: any /** TODO #9100 */;
+      var ngModel: any /* TODO #9100 */;
 
       beforeEach(() => {
         ngModel =
@@ -441,8 +441,8 @@ export function main() {
     });
 
     describe('NgControlName', () => {
-      var formModel: any /** TODO #9100 */;
-      var controlNameDir: any /** TODO #9100 */;
+      var formModel: any /* TODO #9100 */;
+      var controlNameDir: any /* TODO #9100 */;
 
       beforeEach(() => {
         formModel = new Control('name');

--- a/modules/@angular/common/test/forms-deprecated/form_builder_spec.ts
+++ b/modules/@angular/common/test/forms-deprecated/form_builder_spec.ts
@@ -4,11 +4,11 @@ import {afterEach, beforeEach, ddescribe, describe, expect, iit, it, xit} from '
 import {PromiseWrapper} from '../../src/facade/promise';
 
 export function main() {
-  function syncValidator(_: any /** TODO #9100 */): any /** TODO #9100 */ { return null; }
-  function asyncValidator(_: any /** TODO #9100 */) { return PromiseWrapper.resolve(null); }
+  function syncValidator(_: any /* TODO #9100 */): any /* TODO #9100 */ { return null; }
+  function asyncValidator(_: any /* TODO #9100 */) { return PromiseWrapper.resolve(null); }
 
   describe('Form Builder', () => {
-    var b: any /** TODO #9100 */;
+    var b: any /* TODO #9100 */;
 
     beforeEach(() => { b = new FormBuilder(); });
 

--- a/modules/@angular/common/test/forms-deprecated/integration_spec.ts
+++ b/modules/@angular/common/test/forms-deprecated/integration_spec.ts
@@ -561,7 +561,7 @@ export function main() {
                       </select>
                   </div>`;
 
-             var fixture: any /** TODO #9100 */;
+             var fixture: any /* TODO #9100 */;
              tcb.overrideTemplate(MyComp8, t)
                  .createAsync(MyComp8)
                  .then((compFixture) => fixture = compFixture);
@@ -897,7 +897,7 @@ export function main() {
                     <input type="text" ngControl="login" uniq-login-validator="expected">
                  </div>`;
 
-           var rootTC: any /** TODO #9100 */;
+           var rootTC: any /* TODO #9100 */;
            tcb.overrideTemplate(MyComp8, t).createAsync(MyComp8).then((root) => rootTC = root);
            tick();
 
@@ -952,7 +952,7 @@ export function main() {
                   <input type="text" ngControl="login">
                  </div>`;
 
-           var fixture: any /** TODO #9100 */;
+           var fixture: any /* TODO #9100 */;
            tcb.overrideTemplate(MyComp8, t).createAsync(MyComp8).then((root) => fixture = root);
            tick();
 
@@ -1465,17 +1465,17 @@ export function main() {
   host: {'(input)': 'handleOnInput($event.target.value)', '[value]': 'value'}
 })
 class WrappedValue implements ControlValueAccessor {
-  value: any /** TODO #9100 */;
+  value: any /* TODO #9100 */;
   onChange: Function;
 
   constructor(cd: NgControl) { cd.valueAccessor = this; }
 
-  writeValue(value: any /** TODO #9100 */) { this.value = `!${value}!`; }
+  writeValue(value: any /* TODO #9100 */) { this.value = `!${value}!`; }
 
-  registerOnChange(fn: any /** TODO #9100 */) { this.onChange = fn; }
-  registerOnTouched(fn: any /** TODO #9100 */) {}
+  registerOnChange(fn: any /* TODO #9100 */) { this.onChange = fn; }
+  registerOnTouched(fn: any /* TODO #9100 */) {}
 
-  handleOnInput(value: any /** TODO #9100 */) {
+  handleOnInput(value: any /* TODO #9100 */) {
     this.onChange(value.substring(1, value.length - 1));
   }
 }
@@ -1487,11 +1487,11 @@ class MyInput implements ControlValueAccessor {
 
   constructor(cd: NgControl) { cd.valueAccessor = this; }
 
-  writeValue(value: any /** TODO #9100 */) { this.value = `!${value}!`; }
+  writeValue(value: any /* TODO #9100 */) { this.value = `!${value}!`; }
 
-  registerOnChange(fn: any /** TODO #9100 */) { ObservableWrapper.subscribe(this.onInput, fn); }
+  registerOnChange(fn: any /* TODO #9100 */) { ObservableWrapper.subscribe(this.onInput, fn); }
 
-  registerOnTouched(fn: any /** TODO #9100 */) {}
+  registerOnTouched(fn: any /* TODO #9100 */) {}
 
   dispatchChangeEvent() {
     ObservableWrapper.callEmit(this.onInput, this.value.substring(1, this.value.length - 1));
@@ -1499,7 +1499,7 @@ class MyInput implements ControlValueAccessor {
 }
 
 function uniqLoginAsyncValidator(expectedValue: string) {
-  return (c: any /** TODO #9100 */) => {
+  return (c: any /* TODO #9100 */) => {
     var completer = PromiseWrapper.completer();
     var res = (c.value == expectedValue) ? null : {'uniqLogin': true};
     completer.resolve(res);
@@ -1533,9 +1533,9 @@ class LoginIsEmptyValidator {
   }]
 })
 class UniqLoginValidator implements Validator {
-  @Input('uniq-login-validator') expected: any /** TODO #9100 */;
+  @Input('uniq-login-validator') expected: any /* TODO #9100 */;
 
-  validate(c: any /** TODO #9100 */) { return uniqLoginAsyncValidator(this.expected)(c); }
+  validate(c: any /* TODO #9100 */) { return uniqLoginAsyncValidator(this.expected)(c); }
 }
 
 @Component({
@@ -1555,7 +1555,7 @@ class MyComp8 {
   customTrackBy(index: number, obj: any): number { return index; };
 }
 
-function sortedClassList(el: any /** TODO #9100 */) {
+function sortedClassList(el: any /* TODO #9100 */) {
   var l = getDOM().classList(el);
   ListWrapper.sort(l);
   return l;

--- a/modules/@angular/common/test/forms-deprecated/model_spec.ts
+++ b/modules/@angular/common/test/forms-deprecated/model_spec.ts
@@ -7,11 +7,11 @@ import {PromiseWrapper} from '../../src/facade/promise';
 import {TimerWrapper, ObservableWrapper, EventEmitter} from '../../src/facade/async';
 
 export function main() {
-  function asyncValidator(expected: any /** TODO #9100 */, timeouts = /*@ts2dart_const*/ {}) {
-    return (c: any /** TODO #9100 */) => {
+  function asyncValidator(expected: any /* TODO #9100 */, timeouts = /*@ts2dart_const*/ {}) {
+    return (c: any /* TODO #9100 */) => {
       var completer = PromiseWrapper.completer();
-      var t = isPresent((timeouts as any /** TODO #9100 */)[c.value]) ?
-          (timeouts as any /** TODO #9100 */)[c.value] :
+      var t = isPresent((timeouts as any /* TODO #9100 */)[c.value]) ?
+          (timeouts as any /* TODO #9100 */)[c.value] :
           0;
       var res = c.value != expected ? {'async': true} : null;
 
@@ -25,7 +25,7 @@ export function main() {
     };
   }
 
-  function asyncValidatorReturningObservable(c: any /** TODO #9100 */) {
+  function asyncValidatorReturningObservable(c: any /* TODO #9100 */) {
     var e = new EventEmitter();
     PromiseWrapper.scheduleMicrotask(() => ObservableWrapper.callEmit(e, {'async': true}));
     return e;
@@ -132,7 +132,7 @@ export function main() {
       });
 
       describe('updateValue', () => {
-        var g: any /** TODO #9100 */, c: any /** TODO #9100 */;
+        var g: any /* TODO #9100 */, c: any /* TODO #9100 */;
         beforeEach(() => {
           c = new Control('oldValue');
           g = new ControlGroup({'one': c});
@@ -144,8 +144,8 @@ export function main() {
         });
 
         it('should invoke ngOnChanges if it is present', () => {
-          var ngOnChanges: any /** TODO #9100 */;
-          c.registerOnChange((v: any /** TODO #9100 */) => ngOnChanges = ['invoked', v]);
+          var ngOnChanges: any /* TODO #9100 */;
+          c.registerOnChange((v: any /* TODO #9100 */) => ngOnChanges = ['invoked', v]);
 
           c.updateValue('newValue');
 
@@ -153,8 +153,8 @@ export function main() {
         });
 
         it('should not invoke on change when explicitly specified', () => {
-          var onChange: any /** TODO #9100 */ = null;
-          c.registerOnChange((v: any /** TODO #9100 */) => onChange = ['invoked', v]);
+          var onChange: any /* TODO #9100 */ = null;
+          c.registerOnChange((v: any /* TODO #9100 */) => onChange = ['invoked', v]);
 
           c.updateValue('newValue', {emitModelToViewChange: false});
 
@@ -189,7 +189,7 @@ export function main() {
       });
 
       describe('valueChanges & statusChanges', () => {
-        var c: any /** TODO #9100 */;
+        var c: any /* TODO #9100 */;
 
         beforeEach(() => { c = new Control('old', Validators.required); });
 
@@ -216,7 +216,7 @@ export function main() {
         it('should fire an event after the status has been updated to pending', fakeAsync(() => {
              var c = new Control('old', Validators.required, asyncValidator('expected'));
 
-             var log: any[] /** TODO #9100 */ = [];
+             var log: any[] /* TODO #9100 */ = [];
              ObservableWrapper.subscribe(c.valueChanges, (value) => log.push(`value: '${value}'`));
              ObservableWrapper.subscribe(
                  c.statusChanges, (status) => log.push(`status: '${status}'`));
@@ -247,7 +247,7 @@ export function main() {
         if (!IS_DART) {
           it('should update set errors and status before emitting an event',
              inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-               c.valueChanges.subscribe((value: any /** TODO #9100 */) => {
+               c.valueChanges.subscribe((value: any /* TODO #9100 */) => {
                  expect(c.valid).toEqual(false);
                  expect(c.errors).toEqual({'required': true});
                  async.done();
@@ -372,7 +372,7 @@ export function main() {
 
       describe('errors', () => {
         it('should run the validator when the value changes', () => {
-          var simpleValidator = (c: any /** TODO #9100 */) =>
+          var simpleValidator = (c: any /* TODO #9100 */) =>
               c.controls['one'].value != 'correct' ? {'broken': true} : null;
 
           var c = new Control(null);
@@ -391,7 +391,7 @@ export function main() {
       });
 
       describe('dirty', () => {
-        var c: any /** TODO #9100 */, g: any /** TODO #9100 */;
+        var c: any /* TODO #9100 */, g: any /* TODO #9100 */;
 
         beforeEach(() => {
           c = new Control('value');
@@ -409,7 +409,7 @@ export function main() {
 
       describe('optional components', () => {
         describe('contains', () => {
-          var group: any /** TODO #9100 */;
+          var group: any /* TODO #9100 */;
 
           beforeEach(() => {
             group = new ControlGroup(
@@ -465,7 +465,7 @@ export function main() {
       });
 
       describe('valueChanges', () => {
-        var g: any /** TODO #9100 */, c1: any /** TODO #9100 */, c2: any /** TODO #9100 */;
+        var g: any /* TODO #9100 */, c1: any /* TODO #9100 */, c2: any /* TODO #9100 */;
 
         beforeEach(() => {
           c1 = new Control('old1');
@@ -522,7 +522,7 @@ export function main() {
 
         it('should fire an event every time a control is updated',
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-             var loggedValues: any[] /** TODO #9100 */ = [];
+             var loggedValues: any[] /* TODO #9100 */ = [];
 
              ObservableWrapper.subscribe(g.valueChanges, (value) => {
                loggedValues.push(value);
@@ -603,7 +603,7 @@ export function main() {
     describe('ControlArray', () => {
       describe('adding/removing', () => {
         var a: ControlArray;
-        var c1: any /** TODO #9100 */, c2: any /** TODO #9100 */, c3: any /** TODO #9100 */;
+        var c1: any /* TODO #9100 */, c2: any /* TODO #9100 */, c3: any /* TODO #9100 */;
 
         beforeEach(() => {
           a = new ControlArray([]);
@@ -652,7 +652,7 @@ export function main() {
 
       describe('errors', () => {
         it('should run the validator when the value changes', () => {
-          var simpleValidator = (c: any /** TODO #9100 */) =>
+          var simpleValidator = (c: any /* TODO #9100 */) =>
               c.controls[0].value != 'correct' ? {'broken': true} : null;
 
           var c = new Control(null);
@@ -720,7 +720,7 @@ export function main() {
 
       describe('valueChanges', () => {
         var a: ControlArray;
-        var c1: any /** TODO #9100 */, c2: any /** TODO #9100 */;
+        var c1: any /* TODO #9100 */, c2: any /* TODO #9100 */;
 
         beforeEach(() => {
           c1 = new Control('old1');

--- a/modules/@angular/common/test/forms-deprecated/validators_spec.ts
+++ b/modules/@angular/common/test/forms-deprecated/validators_spec.ts
@@ -9,7 +9,7 @@ export function main() {
   function validator(key: string, error: any) {
     return function(c: AbstractControl) {
       var r = {};
-      (r as any /** TODO #9100 */)[key] = error;
+      (r as any /* TODO #9100 */)[key] = error;
       return r;
     }
   }
@@ -106,8 +106,8 @@ export function main() {
     });
 
     describe('composeAsync', () => {
-      function asyncValidator(expected: any /** TODO #9100 */, response: any /** TODO #9100 */) {
-        return (c: any /** TODO #9100 */) => {
+      function asyncValidator(expected: any /* TODO #9100 */, response: any /* TODO #9100 */) {
+        return (c: any /* TODO #9100 */) => {
           var emitter = new EventEmitter();
           var res = c.value != expected ? response : null;
 
@@ -130,7 +130,7 @@ export function main() {
              asyncValidator('expected', {'one': true}), asyncValidator('expected', {'two': true})
            ]);
 
-           var value: any /** TODO #9100 */ = null;
+           var value: any /* TODO #9100 */ = null;
            (<Promise<any>>c(new Control('invalid'))).then(v => value = v);
 
            tick(1);
@@ -141,7 +141,7 @@ export function main() {
       it('should return null when no errors', fakeAsync(() => {
            var c = Validators.composeAsync([asyncValidator('expected', {'one': true})]);
 
-           var value: any /** TODO #9100 */ = null;
+           var value: any /* TODO #9100 */ = null;
            (<Promise<any>>c(new Control('expected'))).then(v => value = v);
 
            tick(1);
@@ -152,7 +152,7 @@ export function main() {
       it('should ignore nulls', fakeAsync(() => {
            var c = Validators.composeAsync([asyncValidator('expected', {'one': true}), null]);
 
-           var value: any /** TODO #9100 */ = null;
+           var value: any /* TODO #9100 */ = null;
            (<Promise<any>>c(new Control('invalid'))).then(v => value = v);
 
            tick(1);

--- a/modules/@angular/common/test/forms/directives_spec.ts
+++ b/modules/@angular/common/test/forms/directives_spec.ts
@@ -15,8 +15,8 @@ import {SimpleChange} from '@angular/core/src/change_detection';
 class DummyControlValueAccessor implements ControlValueAccessor {
   writtenValue: any;
 
-  registerOnChange(fn: any /** TODO #9100 */) {}
-  registerOnTouched(fn: any /** TODO #9100 */) {}
+  registerOnChange(fn: any /* TODO #9100 */) {}
+  registerOnTouched(fn: any /* TODO #9100 */) {}
 
   writeValue(obj: any): void { this.writtenValue = obj; }
 }
@@ -25,8 +25,8 @@ class CustomValidatorDirective implements Validator {
   validate(c: FormControl): {[key: string]: any} { return {'custom': true}; }
 }
 
-function asyncValidator(expected: any /** TODO #9100 */, timeout = 0) {
-  return (c: any /** TODO #9100 */) => {
+function asyncValidator(expected: any /* TODO #9100 */, timeout = 0) {
+  return (c: any /* TODO #9100 */) => {
     var completer = PromiseWrapper.completer();
     var res = c.value != expected ? {'async': true} : null;
     if (timeout == 0) {
@@ -91,14 +91,14 @@ export function main() {
 
       describe('composeValidators', () => {
         it('should compose functions', () => {
-          var dummy1 = (_: any /** TODO #9100 */) => ({'dummy1': true});
-          var dummy2 = (_: any /** TODO #9100 */) => ({'dummy2': true});
+          var dummy1 = (_: any /* TODO #9100 */) => ({'dummy1': true});
+          var dummy2 = (_: any /* TODO #9100 */) => ({'dummy2': true});
           var v = composeValidators([dummy1, dummy2]);
           expect(v(new FormControl(''))).toEqual({'dummy1': true, 'dummy2': true});
         });
 
         it('should compose validator directives', () => {
-          var dummy1 = (_: any /** TODO #9100 */) => ({'dummy1': true});
+          var dummy1 = (_: any /* TODO #9100 */) => ({'dummy1': true});
           var v = composeValidators([dummy1, new CustomValidatorDirective()]);
           expect(v(new FormControl(''))).toEqual({'dummy1': true, 'custom': true});
         });
@@ -106,9 +106,9 @@ export function main() {
     });
 
     describe('formGroup', () => {
-      var form: any /** TODO #9100 */;
+      var form: any /* TODO #9100 */;
       var formModel: FormGroup;
-      var loginControlDir: any /** TODO #9100 */;
+      var loginControlDir: any /* TODO #9100 */;
 
       beforeEach(() => {
         form = new FormGroupDirective([], []);
@@ -186,7 +186,7 @@ export function main() {
       });
 
       describe('addFormGroup', () => {
-        var matchingPasswordsValidator = (g: any /** TODO #9100 */) => {
+        var matchingPasswordsValidator = (g: any /* TODO #9100 */) => {
           if (g.controls['password'].value != g.controls['passwordConfirm'].value) {
             return {'differentPasswords': true};
           } else {
@@ -241,7 +241,7 @@ export function main() {
         });
 
         it('should set up a sync validator', () => {
-          var formValidator = (c: any /** TODO #9100 */) => ({'custom': true});
+          var formValidator = (c: any /* TODO #9100 */) => ({'custom': true});
           var f = new FormGroupDirective([formValidator], []);
           f.form = formModel;
           f.ngOnChanges({'form': new SimpleChange(null, null)});
@@ -262,10 +262,10 @@ export function main() {
     });
 
     describe('NgForm', () => {
-      var form: any /** TODO #9100 */;
+      var form: any /* TODO #9100 */;
       var formModel: FormGroup;
-      var loginControlDir: any /** TODO #9100 */;
-      var personControlGroupDir: any /** TODO #9100 */;
+      var loginControlDir: any /* TODO #9100 */;
+      var personControlGroupDir: any /* TODO #9100 */;
 
       beforeEach(() => {
         form = new NgForm([], []);
@@ -321,7 +321,7 @@ export function main() {
       });
 
       it('should set up sync validator', fakeAsync(() => {
-           var formValidator = (c: any /** TODO #9100 */) => ({'custom': true});
+           var formValidator = (c: any /* TODO #9100 */) => ({'custom': true});
            var f = new NgForm([formValidator], []);
 
            tick();
@@ -339,8 +339,8 @@ export function main() {
     });
 
     describe('NgControlGroup', () => {
-      var formModel: any /** TODO #9100 */;
-      var controlGroupDir: any /** TODO #9100 */;
+      var formModel: any /* TODO #9100 */;
+      var controlGroupDir: any /* TODO #9100 */;
 
       beforeEach(() => {
         formModel = new FormGroup({'login': new FormControl(null)});
@@ -364,9 +364,9 @@ export function main() {
     });
 
     describe('FormControlDirective', () => {
-      var controlDir: any /** TODO #9100 */;
-      var control: any /** TODO #9100 */;
-      var checkProperties = function(control: any /** TODO #9100 */) {
+      var controlDir: any /* TODO #9100 */;
+      var control: any /* TODO #9100 */;
+      var checkProperties = function(control: any /* TODO #9100 */) {
         expect(controlDir.control).toBe(control);
         expect(controlDir.value).toBe(control.value);
         expect(controlDir.valid).toBe(control.valid);
@@ -406,7 +406,7 @@ export function main() {
     });
 
     describe('NgModel', () => {
-      var ngModel: any /** TODO #9100 */;
+      var ngModel: any /* TODO #9100 */;
 
       beforeEach(() => {
         ngModel = new NgModel(
@@ -441,8 +441,8 @@ export function main() {
     });
 
     describe('FormControlName', () => {
-      var formModel: any /** TODO #9100 */;
-      var controlNameDir: any /** TODO #9100 */;
+      var formModel: any /* TODO #9100 */;
+      var controlNameDir: any /* TODO #9100 */;
 
       beforeEach(() => {
         formModel = new FormControl('name');

--- a/modules/@angular/common/test/forms/form_builder_spec.ts
+++ b/modules/@angular/common/test/forms/form_builder_spec.ts
@@ -4,11 +4,11 @@ import {afterEach, beforeEach, ddescribe, describe, expect, iit, it, xit} from '
 import {PromiseWrapper} from '../../src/facade/promise';
 
 export function main() {
-  function syncValidator(_: any /** TODO #9100 */): any /** TODO #9100 */ { return null; }
-  function asyncValidator(_: any /** TODO #9100 */) { return PromiseWrapper.resolve(null); }
+  function syncValidator(_: any /* TODO #9100 */): any /* TODO #9100 */ { return null; }
+  function asyncValidator(_: any /* TODO #9100 */) { return PromiseWrapper.resolve(null); }
 
   describe('Form Builder', () => {
-    var b: any /** TODO #9100 */;
+    var b: any /* TODO #9100 */;
 
     beforeEach(() => { b = new FormBuilder(); });
 

--- a/modules/@angular/common/test/forms/integration_spec.ts
+++ b/modules/@angular/common/test/forms/integration_spec.ts
@@ -561,7 +561,7 @@ export function main() {
                       </select>
                   </div>`;
 
-             var fixture: any /** TODO #9100 */;
+             var fixture: any /* TODO #9100 */;
              tcb.overrideTemplate(MyComp8, t)
                  .createAsync(MyComp8)
                  .then((compFixture) => fixture = compFixture);
@@ -900,7 +900,7 @@ export function main() {
                     <input type="text" formControlName="login" uniq-login-validator="expected">
                  </div>`;
 
-           var rootTC: any /** TODO #9100 */;
+           var rootTC: any /* TODO #9100 */;
            tcb.overrideTemplate(MyComp8, t).createAsync(MyComp8).then((root) => rootTC = root);
            tick();
 
@@ -956,7 +956,7 @@ export function main() {
                   <input type="text" formControlName="login">
                  </div>`;
 
-           var fixture: any /** TODO #9100 */;
+           var fixture: any /* TODO #9100 */;
            tcb.overrideTemplate(MyComp8, t).createAsync(MyComp8).then((root) => fixture = root);
            tick();
 
@@ -1507,17 +1507,17 @@ export function main() {
   host: {'(input)': 'handleOnInput($event.target.value)', '[value]': 'value'}
 })
 class WrappedValue implements ControlValueAccessor {
-  value: any /** TODO #9100 */;
+  value: any /* TODO #9100 */;
   onChange: Function;
 
   constructor(cd: NgControl) { cd.valueAccessor = this; }
 
-  writeValue(value: any /** TODO #9100 */) { this.value = `!${value}!`; }
+  writeValue(value: any /* TODO #9100 */) { this.value = `!${value}!`; }
 
-  registerOnChange(fn: any /** TODO #9100 */) { this.onChange = fn; }
-  registerOnTouched(fn: any /** TODO #9100 */) {}
+  registerOnChange(fn: any /* TODO #9100 */) { this.onChange = fn; }
+  registerOnTouched(fn: any /* TODO #9100 */) {}
 
-  handleOnInput(value: any /** TODO #9100 */) {
+  handleOnInput(value: any /* TODO #9100 */) {
     this.onChange(value.substring(1, value.length - 1));
   }
 }
@@ -1529,11 +1529,11 @@ class MyInput implements ControlValueAccessor {
 
   constructor(cd: NgControl) { cd.valueAccessor = this; }
 
-  writeValue(value: any /** TODO #9100 */) { this.value = `!${value}!`; }
+  writeValue(value: any /* TODO #9100 */) { this.value = `!${value}!`; }
 
-  registerOnChange(fn: any /** TODO #9100 */) { ObservableWrapper.subscribe(this.onInput, fn); }
+  registerOnChange(fn: any /* TODO #9100 */) { ObservableWrapper.subscribe(this.onInput, fn); }
 
-  registerOnTouched(fn: any /** TODO #9100 */) {}
+  registerOnTouched(fn: any /* TODO #9100 */) {}
 
   dispatchChangeEvent() {
     ObservableWrapper.callEmit(this.onInput, this.value.substring(1, this.value.length - 1));
@@ -1541,7 +1541,7 @@ class MyInput implements ControlValueAccessor {
 }
 
 function uniqLoginAsyncValidator(expectedValue: string) {
-  return (c: any /** TODO #9100 */) => {
+  return (c: any /* TODO #9100 */) => {
     var completer = PromiseWrapper.completer();
     var res = (c.value == expectedValue) ? null : {'uniqLogin': true};
     completer.resolve(res);
@@ -1575,9 +1575,9 @@ class LoginIsEmptyValidator {
   }]
 })
 class UniqLoginValidator implements Validator {
-  @Input('uniq-login-validator') expected: any /** TODO #9100 */;
+  @Input('uniq-login-validator') expected: any /* TODO #9100 */;
 
-  validate(c: any /** TODO #9100 */) { return uniqLoginAsyncValidator(this.expected)(c); }
+  validate(c: any /* TODO #9100 */) { return uniqLoginAsyncValidator(this.expected)(c); }
 }
 
 @Component({
@@ -1598,7 +1598,7 @@ class MyComp8 {
   customTrackBy(index: number, obj: any): number { return index; };
 }
 
-function sortedClassList(el: any /** TODO #9100 */) {
+function sortedClassList(el: any /* TODO #9100 */) {
   var l = getDOM().classList(el);
   ListWrapper.sort(l);
   return l;

--- a/modules/@angular/common/test/forms/model_spec.ts
+++ b/modules/@angular/common/test/forms/model_spec.ts
@@ -7,11 +7,11 @@ import {PromiseWrapper} from '../../src/facade/promise';
 import {TimerWrapper, ObservableWrapper, EventEmitter} from '../../src/facade/async';
 
 export function main() {
-  function asyncValidator(expected: any /** TODO #9100 */, timeouts = /*@ts2dart_const*/ {}) {
-    return (c: any /** TODO #9100 */) => {
+  function asyncValidator(expected: any /* TODO #9100 */, timeouts = /*@ts2dart_const*/ {}) {
+    return (c: any /* TODO #9100 */) => {
       var completer = PromiseWrapper.completer();
-      var t = isPresent((timeouts as any /** TODO #9100 */)[c.value]) ?
-          (timeouts as any /** TODO #9100 */)[c.value] :
+      var t = isPresent((timeouts as any /* TODO #9100 */)[c.value]) ?
+          (timeouts as any /* TODO #9100 */)[c.value] :
           0;
       var res = c.value != expected ? {'async': true} : null;
 
@@ -25,7 +25,7 @@ export function main() {
     };
   }
 
-  function asyncValidatorReturningObservable(c: any /** TODO #9100 */) {
+  function asyncValidatorReturningObservable(c: any /* TODO #9100 */) {
     var e = new EventEmitter();
     PromiseWrapper.scheduleMicrotask(() => ObservableWrapper.callEmit(e, {'async': true}));
     return e;
@@ -132,7 +132,7 @@ export function main() {
       });
 
       describe('updateValue', () => {
-        var g: any /** TODO #9100 */, c: any /** TODO #9100 */;
+        var g: any /* TODO #9100 */, c: any /* TODO #9100 */;
         beforeEach(() => {
           c = new FormControl('oldValue');
           g = new FormGroup({'one': c});
@@ -144,8 +144,8 @@ export function main() {
         });
 
         it('should invoke ngOnChanges if it is present', () => {
-          var ngOnChanges: any /** TODO #9100 */;
-          c.registerOnChange((v: any /** TODO #9100 */) => ngOnChanges = ['invoked', v]);
+          var ngOnChanges: any /* TODO #9100 */;
+          c.registerOnChange((v: any /* TODO #9100 */) => ngOnChanges = ['invoked', v]);
 
           c.updateValue('newValue');
 
@@ -153,8 +153,8 @@ export function main() {
         });
 
         it('should not invoke on change when explicitly specified', () => {
-          var onChange: any /** TODO #9100 */ = null;
-          c.registerOnChange((v: any /** TODO #9100 */) => onChange = ['invoked', v]);
+          var onChange: any /* TODO #9100 */ = null;
+          c.registerOnChange((v: any /* TODO #9100 */) => onChange = ['invoked', v]);
 
           c.updateValue('newValue', {emitModelToViewChange: false});
 
@@ -189,7 +189,7 @@ export function main() {
       });
 
       describe('valueChanges & statusChanges', () => {
-        var c: any /** TODO #9100 */;
+        var c: any /* TODO #9100 */;
 
         beforeEach(() => { c = new FormControl('old', Validators.required); });
 
@@ -216,7 +216,7 @@ export function main() {
         it('should fire an event after the status has been updated to pending', fakeAsync(() => {
              var c = new FormControl('old', Validators.required, asyncValidator('expected'));
 
-             var log: any[] /** TODO #9100 */ = [];
+             var log: any[] /* TODO #9100 */ = [];
              ObservableWrapper.subscribe(c.valueChanges, (value) => log.push(`value: '${value}'`));
              ObservableWrapper.subscribe(
                  c.statusChanges, (status) => log.push(`status: '${status}'`));
@@ -247,7 +247,7 @@ export function main() {
         if (!IS_DART) {
           it('should update set errors and status before emitting an event',
              inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-               c.valueChanges.subscribe((value: any /** TODO #9100 */) => {
+               c.valueChanges.subscribe((value: any /* TODO #9100 */) => {
                  expect(c.valid).toEqual(false);
                  expect(c.errors).toEqual({'required': true});
                  async.done();
@@ -374,7 +374,7 @@ export function main() {
 
       describe('errors', () => {
         it('should run the validator when the value changes', () => {
-          var simpleValidator = (c: any /** TODO #9100 */) =>
+          var simpleValidator = (c: any /* TODO #9100 */) =>
               c.controls['one'].value != 'correct' ? {'broken': true} : null;
 
           var c = new FormControl(null);
@@ -393,7 +393,7 @@ export function main() {
       });
 
       describe('dirty', () => {
-        var c: any /** TODO #9100 */, g: any /** TODO #9100 */;
+        var c: any /* TODO #9100 */, g: any /* TODO #9100 */;
 
         beforeEach(() => {
           c = new FormControl('value');
@@ -411,7 +411,7 @@ export function main() {
 
       describe('optional components', () => {
         describe('contains', () => {
-          var group: any /** TODO #9100 */;
+          var group: any /* TODO #9100 */;
 
           beforeEach(() => {
             group = new FormGroup(
@@ -470,7 +470,7 @@ export function main() {
       });
 
       describe('valueChanges', () => {
-        var g: any /** TODO #9100 */, c1: any /** TODO #9100 */, c2: any /** TODO #9100 */;
+        var g: any /* TODO #9100 */, c1: any /* TODO #9100 */, c2: any /* TODO #9100 */;
 
         beforeEach(() => {
           c1 = new FormControl('old1');
@@ -527,7 +527,7 @@ export function main() {
 
         it('should fire an event every time a control is updated',
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-             var loggedValues: any[] /** TODO #9100 */ = [];
+             var loggedValues: any[] /* TODO #9100 */ = [];
 
              ObservableWrapper.subscribe(g.valueChanges, (value) => {
                loggedValues.push(value);
@@ -608,7 +608,7 @@ export function main() {
     describe('FormArray', () => {
       describe('adding/removing', () => {
         var a: FormArray;
-        var c1: any /** TODO #9100 */, c2: any /** TODO #9100 */, c3: any /** TODO #9100 */;
+        var c1: any /* TODO #9100 */, c2: any /* TODO #9100 */, c3: any /* TODO #9100 */;
 
         beforeEach(() => {
           a = new FormArray([]);
@@ -657,7 +657,7 @@ export function main() {
 
       describe('errors', () => {
         it('should run the validator when the value changes', () => {
-          var simpleValidator = (c: any /** TODO #9100 */) =>
+          var simpleValidator = (c: any /* TODO #9100 */) =>
               c.controls[0].value != 'correct' ? {'broken': true} : null;
 
           var c = new FormControl(null);
@@ -725,7 +725,7 @@ export function main() {
 
       describe('valueChanges', () => {
         var a: FormArray;
-        var c1: any /** TODO #9100 */, c2: any /** TODO #9100 */;
+        var c1: any /* TODO #9100 */, c2: any /* TODO #9100 */;
 
         beforeEach(() => {
           c1 = new FormControl('old1');

--- a/modules/@angular/common/test/forms/validators_spec.ts
+++ b/modules/@angular/common/test/forms/validators_spec.ts
@@ -9,7 +9,7 @@ export function main() {
   function validator(key: string, error: any) {
     return function(c: AbstractControl) {
       var r = {};
-      (r as any /** TODO #9100 */)[key] = error;
+      (r as any /* TODO #9100 */)[key] = error;
       return r;
     }
   }
@@ -107,8 +107,8 @@ export function main() {
     });
 
     describe('composeAsync', () => {
-      function asyncValidator(expected: any /** TODO #9100 */, response: any /** TODO #9100 */) {
-        return (c: any /** TODO #9100 */) => {
+      function asyncValidator(expected: any /* TODO #9100 */, response: any /* TODO #9100 */) {
+        return (c: any /* TODO #9100 */) => {
           var emitter = new EventEmitter();
           var res = c.value != expected ? response : null;
 
@@ -131,7 +131,7 @@ export function main() {
              asyncValidator('expected', {'one': true}), asyncValidator('expected', {'two': true})
            ]);
 
-           var value: any /** TODO #9100 */ = null;
+           var value: any /* TODO #9100 */ = null;
            (<Promise<any>>c(new FormControl('invalid'))).then(v => value = v);
 
            tick(1);
@@ -142,7 +142,7 @@ export function main() {
       it('should return null when no errors', fakeAsync(() => {
            var c = Validators.composeAsync([asyncValidator('expected', {'one': true})]);
 
-           var value: any /** TODO #9100 */ = null;
+           var value: any /* TODO #9100 */ = null;
            (<Promise<any>>c(new FormControl('expected'))).then(v => value = v);
 
            tick(1);
@@ -153,7 +153,7 @@ export function main() {
       it('should ignore nulls', fakeAsync(() => {
            var c = Validators.composeAsync([asyncValidator('expected', {'one': true}), null]);
 
-           var value: any /** TODO #9100 */ = null;
+           var value: any /* TODO #9100 */ = null;
            (<Promise<any>>c(new FormControl('invalid'))).then(v => value = v);
 
            tick(1);

--- a/modules/@angular/common/test/pipes/async_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/async_pipe_spec.ts
@@ -13,9 +13,9 @@ export function main() {
   describe('AsyncPipe', () => {
 
     describe('Observable', () => {
-      var emitter: any /** TODO #9100 */;
-      var pipe: any /** TODO #9100 */;
-      var ref: any /** TODO #9100 */;
+      var emitter: any /* TODO #9100 */;
+      var pipe: any /* TODO #9100 */;
+      var ref: any /* TODO #9100 */;
       var message = new Object();
 
       beforeEach(() => {

--- a/modules/@angular/common/test/pipes/date_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/date_pipe_spec.ts
@@ -7,8 +7,8 @@ import {DateWrapper} from '../../src/facade/lang';
 
 export function main() {
   describe('DatePipe', () => {
-    var date: any /** TODO #9100 */;
-    var pipe: any /** TODO #9100 */;
+    var date: any /* TODO #9100 */;
+    var pipe: any /* TODO #9100 */;
 
     beforeEach(() => {
       date = DateWrapper.create(2015, 6, 15, 21, 43, 11);

--- a/modules/@angular/common/test/pipes/i18n_plural_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/i18n_plural_pipe_spec.ts
@@ -4,7 +4,7 @@ import {afterEach, beforeEach, ddescribe, describe, expect, iit, it, xit} from '
 
 export function main() {
   describe('I18nPluralPipe', () => {
-    var pipe: any /** TODO #9100 */;
+    var pipe: any /* TODO #9100 */;
     var mapping = {'=0': 'No messages.', '=1': 'One message.', 'other': 'There are some messages.'};
     var interpolatedMapping = {
       '=0': 'No messages.',
@@ -39,7 +39,7 @@ export function main() {
       });
 
       it('should use \'other\' if value is undefined', () => {
-        var messageLength: any /** TODO #9100 */;
+        var messageLength: any /* TODO #9100 */;
         var val = pipe.transform(messageLength, interpolatedMapping);
         expect(val).toEqual('There are  messages, that is .');
       });

--- a/modules/@angular/common/test/pipes/i18n_select_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/i18n_select_pipe_spec.ts
@@ -4,7 +4,7 @@ import {afterEach, beforeEach, ddescribe, describe, expect, iit, it, xit} from '
 
 export function main() {
   describe('I18nSelectPipe', () => {
-    var pipe: any /** TODO #9100 */;
+    var pipe: any /* TODO #9100 */;
     var mapping = {'male': 'Invite him.', 'female': 'Invite her.', 'other': 'Invite them.'};
 
     beforeEach(() => { pipe = new I18nSelectPipe(); });
@@ -29,7 +29,7 @@ export function main() {
       });
 
       it('should use \'other\' if value is undefined', () => {
-        var gender: any /** TODO #9100 */;
+        var gender: any /* TODO #9100 */;
         var val = pipe.transform(gender, mapping);
         expect(val).toEqual('Invite them.');
       });

--- a/modules/@angular/common/test/pipes/json_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/json_pipe_spec.ts
@@ -9,9 +9,9 @@ import {JsonPipe} from '@angular/common';
 export function main() {
   describe('JsonPipe', () => {
     var regNewLine = '\n';
-    var inceptionObj: any /** TODO #9100 */;
-    var inceptionObjString: any /** TODO #9100 */;
-    var pipe: any /** TODO #9100 */;
+    var inceptionObj: any /* TODO #9100 */;
+    var inceptionObjString: any /* TODO #9100 */;
+    var pipe: any /* TODO #9100 */;
 
     function normalize(obj: string): string { return StringWrapper.replace(obj, regNewLine, ''); }
 

--- a/modules/@angular/common/test/pipes/lowercase_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/lowercase_pipe_spec.ts
@@ -3,9 +3,9 @@ import {afterEach, beforeEach, ddescribe, describe, expect, iit, it, xit} from '
 
 export function main() {
   describe('LowerCasePipe', () => {
-    var upper: any /** TODO #9100 */;
-    var lower: any /** TODO #9100 */;
-    var pipe: any /** TODO #9100 */;
+    var upper: any /* TODO #9100 */;
+    var lower: any /* TODO #9100 */;
+    var pipe: any /* TODO #9100 */;
 
     beforeEach(() => {
       lower = 'something';

--- a/modules/@angular/common/test/pipes/number_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/number_pipe_spec.ts
@@ -9,7 +9,7 @@ export function main() {
     // https://github.com/angular/angular/issues/3333
     if (browserDetection.supportsIntlApi) {
       describe('DecimalPipe', () => {
-        var pipe: any /** TODO #9100 */;
+        var pipe: any /* TODO #9100 */;
 
         beforeEach(() => { pipe = new DecimalPipe(); });
 
@@ -30,7 +30,7 @@ export function main() {
       });
 
       describe('PercentPipe', () => {
-        var pipe: any /** TODO #9100 */;
+        var pipe: any /* TODO #9100 */;
 
         beforeEach(() => { pipe = new PercentPipe(); });
 
@@ -46,7 +46,7 @@ export function main() {
       });
 
       describe('CurrencyPipe', () => {
-        var pipe: any /** TODO #9100 */;
+        var pipe: any /* TODO #9100 */;
 
         beforeEach(() => { pipe = new CurrencyPipe(); });
 

--- a/modules/@angular/common/test/pipes/replace_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/replace_pipe_spec.ts
@@ -7,8 +7,8 @@ import {RegExpWrapper, StringJoiner} from '../../src/facade/lang';
 export function main() {
   describe('ReplacePipe', () => {
     var someNumber: number;
-    var str: any /** TODO #9100 */;
-    var pipe: any /** TODO #9100 */;
+    var str: any /* TODO #9100 */;
+    var pipe: any /* TODO #9100 */;
 
     beforeEach(() => {
       someNumber = 42;
@@ -42,7 +42,7 @@ export function main() {
 
         var result3 = pipe.transform(str, RegExpWrapper.create('a', 'i'), '_');
 
-        var f = ((x: any /** TODO #9100 */) => { return 'Adams!'; });
+        var f = ((x: any /* TODO #9100 */) => { return 'Adams!'; });
 
         var result4 = pipe.transform(str, 'Adams', f);
 

--- a/modules/@angular/common/test/pipes/slice_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/slice_pipe_spec.ts
@@ -10,8 +10,8 @@ import {SlicePipe} from '@angular/common';
 export function main() {
   describe('SlicePipe', () => {
     var list: number[];
-    var str: any /** TODO #9100 */;
-    var pipe: any /** TODO #9100 */;
+    var str: any /* TODO #9100 */;
+    var pipe: any /* TODO #9100 */;
 
     beforeEach(() => {
       list = [1, 2, 3, 4, 5];

--- a/modules/@angular/common/test/pipes/uppercase_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/uppercase_pipe_spec.ts
@@ -3,9 +3,9 @@ import {afterEach, beforeEach, ddescribe, describe, expect, iit, it, xit} from '
 
 export function main() {
   describe('UpperCasePipe', () => {
-    var upper: any /** TODO #9100 */;
-    var lower: any /** TODO #9100 */;
-    var pipe: any /** TODO #9100 */;
+    var upper: any /* TODO #9100 */;
+    var lower: any /* TODO #9100 */;
+    var pipe: any /* TODO #9100 */;
 
     beforeEach(() => {
       lower = 'something';

--- a/modules/@angular/compiler/src/animation/animation_parser.ts
+++ b/modules/@angular/compiler/src/animation/animation_parser.ts
@@ -13,7 +13,7 @@ const _TERMINAL_KEYFRAME = 1;
 const _ONE_SECOND = 1000;
 
 export class AnimationParseError extends ParseError {
-  constructor(message: any /** TODO #9100 */) { super(null, message); }
+  constructor(message: any /* TODO #9100 */) { super(null, message); }
   toString(): string { return `${this.msg}`; }
 }
 
@@ -26,7 +26,7 @@ export function parseAnimationEntry(entry: CompileAnimationEntryMetadata): Parse
   var stateStyles: {[key: string]: AnimationStylesAst} = {};
   var transitions: CompileAnimationStateTransitionMetadata[] = [];
 
-  var stateDeclarationAsts: any[] /** TODO #9100 */ = [];
+  var stateDeclarationAsts: any[] /* TODO #9100 */ = [];
   entry.definitions.forEach(def => {
     if (def instanceof CompileAnimationStateDeclarationMetadata) {
       _parseAnimationDeclarationStates(def, errors).forEach(ast => {
@@ -69,7 +69,7 @@ function _parseAnimationStateTransition(
     stateStyles: {[key: string]: AnimationStylesAst},
     errors: AnimationParseError[]): AnimationStateTransitionAst {
   var styles = new StylesCollection();
-  var transitionExprs: any[] /** TODO #9100 */ = [];
+  var transitionExprs: any[] /* TODO #9100 */ = [];
   var transitionStates = transitionStateMetadata.stateChangeExpr.split(/\s*,\s*/);
   transitionStates.forEach(expr => {
     _parseAnimationTransitionExpr(expr, errors).forEach(transExpr => {
@@ -92,7 +92,7 @@ function _parseAnimationStateTransition(
 
 function _parseAnimationTransitionExpr(
     eventStr: string, errors: AnimationParseError[]): AnimationStateTransitionExpression[] {
-  var expressions: any[] /** TODO #9100 */ = [];
+  var expressions: any[] /* TODO #9100 */ = [];
   var match = eventStr.match(/^(\*|[-\w]+)\s*(<?[=-]>)\s*(\*|[-\w]+)$/);
   if (!isPresent(match) || match.length < 4) {
     errors.push(new AnimationParseError(`the provided ${eventStr} is not of a supported format`));
@@ -130,7 +130,7 @@ function _normalizeAnimationEntry(entry: CompileAnimationMetadata | CompileAnima
 function _normalizeStyleMetadata(
     entry: CompileAnimationStyleMetadata, stateStyles: {[key: string]: AnimationStylesAst},
     errors: AnimationParseError[]): Array<{[key: string]: string | number}> {
-  var normalizedStyles: any[] /** TODO #9100 */ = [];
+  var normalizedStyles: any[] /* TODO #9100 */ = [];
   entry.styles.forEach(styleEntry => {
     if (isString(styleEntry)) {
       ListWrapper.addAll(
@@ -270,7 +270,7 @@ function _parseAnimationKeyframes(
 
   var limit = totalEntries - 1;
   var margin = totalOffsets == 0 ? (1 / limit) : 0;
-  var rawKeyframes: any[] /** TODO #9100 */ = [];
+  var rawKeyframes: any[] /* TODO #9100 */ = [];
   var index = 0;
   var doSortKeyframes = false;
   var lastOffset = 0;
@@ -280,7 +280,7 @@ function _parseAnimationKeyframes(
     styleMetadata.styles.forEach(entry => {
       StringMapWrapper.forEach(
           <{[key: string]: string | number}>entry,
-          (value: any /** TODO #9100 */, prop: any /** TODO #9100 */) => {
+          (value: any /* TODO #9100 */, prop: any /* TODO #9100 */) => {
             if (prop != 'offset') {
               keyframeStyles[prop] = value;
             }
@@ -302,7 +302,7 @@ function _parseAnimationKeyframes(
     ListWrapper.sort(rawKeyframes, (a, b) => a[0] <= b[0] ? -1 : 1);
   }
 
-  var i: any /** TODO #9100 */;
+  var i: any /* TODO #9100 */;
   var firstKeyframe = rawKeyframes[0];
   if (firstKeyframe[0] != _INITIAL_KEYFRAME) {
     ListWrapper.insert(rawKeyframes, 0, firstKeyframe = [_INITIAL_KEYFRAME, {}]);
@@ -321,24 +321,22 @@ function _parseAnimationKeyframes(
     let entry = rawKeyframes[i];
     let styles = entry[1];
 
-    StringMapWrapper.forEach(
-        styles, (value: any /** TODO #9100 */, prop: any /** TODO #9100 */) => {
-          if (!isPresent(firstKeyframeStyles[prop])) {
-            firstKeyframeStyles[prop] = FILL_STYLE_FLAG;
-          }
-        });
+    StringMapWrapper.forEach(styles, (value: any /* TODO #9100 */, prop: any /* TODO #9100 */) => {
+      if (!isPresent(firstKeyframeStyles[prop])) {
+        firstKeyframeStyles[prop] = FILL_STYLE_FLAG;
+      }
+    });
   }
 
   for (i = limit - 1; i >= 0; i--) {
     let entry = rawKeyframes[i];
     let styles = entry[1];
 
-    StringMapWrapper.forEach(
-        styles, (value: any /** TODO #9100 */, prop: any /** TODO #9100 */) => {
-          if (!isPresent(lastKeyframeStyles[prop])) {
-            lastKeyframeStyles[prop] = value;
-          }
-        });
+    StringMapWrapper.forEach(styles, (value: any /* TODO #9100 */, prop: any /* TODO #9100 */) => {
+      if (!isPresent(lastKeyframeStyles[prop])) {
+        lastKeyframeStyles[prop] = value;
+      }
+    });
   }
 
   return rawKeyframes.map(
@@ -348,14 +346,14 @@ function _parseAnimationKeyframes(
 function _parseTransitionAnimation(
     entry: CompileAnimationMetadata, currentTime: number, collectedStyles: StylesCollection,
     stateStyles: {[key: string]: AnimationStylesAst}, errors: AnimationParseError[]): AnimationAst {
-  var ast: any /** TODO #9100 */;
+  var ast: any /* TODO #9100 */;
   var playTime = 0;
   var startingTime = currentTime;
   if (entry instanceof CompileAnimationWithStepsMetadata) {
     var maxDuration = 0;
-    var steps: any[] /** TODO #9100 */ = [];
+    var steps: any[] /* TODO #9100 */ = [];
     var isGroup = entry instanceof CompileAnimationGroupMetadata;
-    var previousStyles: any /** TODO #9100 */;
+    var previousStyles: any /* TODO #9100 */;
     entry.steps.forEach(entry => {
       // these will get picked up by the next step...
       var time = isGroup ? startingTime : currentTime;
@@ -364,7 +362,7 @@ function _parseTransitionAnimation(
           // by this point we know that we only have stringmap values
           var map = <{[key: string]: string | number}>stylesEntry;
           StringMapWrapper.forEach(
-              map, (value: any /** TODO #9100 */, prop: any /** TODO #9100 */) => {
+              map, (value: any /* TODO #9100 */, prop: any /* TODO #9100 */) => {
                 collectedStyles.insertAtTime(prop, time, value);
               });
         });
@@ -405,7 +403,7 @@ function _parseTransitionAnimation(
     var timings = _parseTimeExpression(entry.timings, errors);
     var styles = entry.styles;
 
-    var keyframes: any /** TODO #9100 */;
+    var keyframes: any /* TODO #9100 */;
     if (styles instanceof CompileAnimationKeyframesSequenceMetadata) {
       keyframes =
           _parseAnimationKeyframes(styles, currentTime, collectedStyles, stateStyles, errors);
@@ -423,9 +421,9 @@ function _parseTransitionAnimation(
     currentTime += playTime;
 
     keyframes.forEach(
-        (keyframe: any /** TODO #9100 */) => keyframe.styles.styles.forEach(
-            (entry: any /** TODO #9100 */) => StringMapWrapper.forEach(
-                entry, (value: any /** TODO #9100 */, prop: any /** TODO #9100 */) =>
+        (keyframe: any /* TODO #9100 */) => keyframe.styles.styles.forEach(
+            (entry: any /* TODO #9100 */) => StringMapWrapper.forEach(
+                entry, (value: any /* TODO #9100 */, prop: any /* TODO #9100 */) =>
                            collectedStyles.insertAtTime(prop, currentTime, value))));
   } else {
     // if the code reaches this stage then an error
@@ -502,12 +500,12 @@ function _createStartKeyframeFromEndKeyframe(
   var values: {[key: string]: string | number} = {};
   var endTime = startTime + duration;
   endKeyframe.styles.styles.forEach((styleData: {[key: string]: string | number}) => {
-    StringMapWrapper.forEach(styleData, (val: any /** TODO #9100 */, prop: any /** TODO #9100 */) => {
+    StringMapWrapper.forEach(styleData, (val: any /* TODO #9100 */, prop: any /* TODO #9100 */) => {
       if (prop == 'offset') return;
 
       var resultIndex = collectedStyles.indexOfAtOrBeforeTime(prop, startTime);
-      var resultEntry: any /** TODO #9100 */, nextEntry: any /** TODO #9100 */,
-          value: any /** TODO #9100 */;
+      var resultEntry: any /* TODO #9100 */, nextEntry: any /* TODO #9100 */,
+          value: any /* TODO #9100 */;
       if (isPresent(resultIndex)) {
         resultEntry = collectedStyles.getByIndex(prop, resultIndex);
         value = resultEntry.value;

--- a/modules/@angular/compiler/src/compile_metadata.ts
+++ b/modules/@angular/compiler/src/compile_metadata.ts
@@ -28,7 +28,7 @@ export abstract class CompileMetadataWithType extends CompileMetadataWithIdentif
 }
 
 export function metadataFromJson(data: {[key: string]: any}): any {
-  return (_COMPILE_METADATA_FROM_JSON as any /** TODO #9100 */)[data['class']](data);
+  return (_COMPILE_METADATA_FROM_JSON as any /* TODO #9100 */)[data['class']](data);
 }
 
 export class CompileAnimationEntryMetadata {
@@ -479,7 +479,7 @@ export class CompileTokenMap<VALUE> {
   get(token: CompileTokenMetadata): VALUE {
     var rk = token.runtimeCacheKey;
     var ak = token.assetCacheKey;
-    var result: any /** TODO #9100 */;
+    var result: any /* TODO #9100 */;
     if (isPresent(rk)) {
       result = this._valueMap.get(rk);
     }

--- a/modules/@angular/compiler/src/config.ts
+++ b/modules/@angular/compiler/src/config.ts
@@ -40,9 +40,9 @@ export abstract class RenderTypes {
 
 export class DefaultRenderTypes implements RenderTypes {
   renderer = Identifiers.Renderer;
-  renderText: any /** TODO #9100 */ = null;
-  renderElement: any /** TODO #9100 */ = null;
-  renderComment: any /** TODO #9100 */ = null;
-  renderNode: any /** TODO #9100 */ = null;
-  renderEvent: any /** TODO #9100 */ = null;
+  renderText: any /* TODO #9100 */ = null;
+  renderElement: any /* TODO #9100 */ = null;
+  renderComment: any /* TODO #9100 */ = null;
+  renderNode: any /* TODO #9100 */ = null;
+  renderEvent: any /* TODO #9100 */ = null;
 }

--- a/modules/@angular/compiler/src/css/lexer.ts
+++ b/modules/@angular/compiler/src/css/lexer.ts
@@ -83,7 +83,7 @@ export class CssScannerError extends BaseException {
   public rawMessage: string;
   public message: string;
 
-  constructor(public token: CssToken, message: any /** TODO #9100 */) {
+  constructor(public token: CssToken, message: any /* TODO #9100 */) {
     super('Css Parse Error: ' + message);
     this.rawMessage = message;
   }
@@ -197,7 +197,7 @@ export class CssScanner {
       next = new CssToken(0, 0, 0, CssTokenType.EOF, 'end of file');
     }
 
-    var isMatchingType: any /** TODO #9100 */;
+    var isMatchingType: any /* TODO #9100 */;
     if (type == CssTokenType.IdentifierOrNumber) {
       // TODO (matsko): implement array traversal for lookup here
       isMatchingType = next.type == CssTokenType.Number || next.type == CssTokenType.Identifier;
@@ -209,7 +209,7 @@ export class CssScanner {
     // mode so that the parser can recover...
     this.setMode(mode);
 
-    var error: any /** TODO #9100 */ = null;
+    var error: any /* TODO #9100 */ = null;
     if (!isMatchingType || (isPresent(value) && value != next.strValue)) {
       var errorMessage = resolveEnumToken(CssTokenType, next.type) + ' does not match expected ' +
           resolveEnumToken(CssTokenType, type) + ' value';
@@ -688,7 +688,7 @@ function isValidCssCharacter(code: number, mode: CssLexerMode): boolean {
   }
 }
 
-function charCode(input: any /** TODO #9100 */, index: any /** TODO #9100 */): number {
+function charCode(input: any /* TODO #9100 */, index: any /* TODO #9100 */): number {
   return index >= input.length ? $EOF : StringWrapper.charCodeAt(input, index);
 }
 
@@ -696,7 +696,7 @@ function charStr(code: number): string {
   return StringWrapper.fromCharCode(code);
 }
 
-export function isNewline(code: any /** TODO #9100 */): boolean {
+export function isNewline(code: any /* TODO #9100 */): boolean {
   switch (code) {
     case $FF:
     case $CR:

--- a/modules/@angular/compiler/src/css/parser.ts
+++ b/modules/@angular/compiler/src/css/parser.ts
@@ -150,8 +150,8 @@ export class CssParser {
   }
 
   /** @internal */
-  _parseStyleSheet(delimiters: any /** TODO #9100 */): CssStyleSheetAST {
-    var results: any[] /** TODO #9100 */ = [];
+  _parseStyleSheet(delimiters: any /* TODO #9100 */): CssStyleSheetAST {
+    var results: any[] /* TODO #9100 */ = [];
     this._scanner.consumeEmptyStatements();
     while (this._scanner.peek != $EOF) {
       this._scanner.setMode(CssLexerMode.BLOCK);
@@ -178,7 +178,7 @@ export class CssParser {
         token.type == CssTokenType.AtKeyword,
         `The CSS Rule ${token.strValue} is not a valid [@] rule.`, token);
 
-    var block: any /** TODO #9100 */, type = this._resolveBlockType(token);
+    var block: any /* TODO #9100 */, type = this._resolveBlockType(token);
     switch (type) {
       case BlockType.Charset:
       case BlockType.Namespace:
@@ -213,7 +213,7 @@ export class CssParser {
 
       // if a custom @rule { ... } is used it should still tokenize the insides
       default:
-        var listOfTokens: any[] /** TODO #9100 */ = [];
+        var listOfTokens: any[] /* TODO #9100 */ = [];
         this._scanner.setMode(CssLexerMode.ALL);
         this._error(
             generateErrorMessage(
@@ -247,7 +247,7 @@ export class CssParser {
   _parseSelectors(delimiters: number): CssSelectorAST[] {
     delimiters = bitWiseOr([delimiters, LBRACE_DELIM]);
 
-    var selectors: any[] /** TODO #9100 */ = [];
+    var selectors: any[] /* TODO #9100 */ = [];
     var isParsingSelectors = true;
     while (isParsingSelectors) {
       selectors.push(this._parseSelector(delimiters));
@@ -292,7 +292,7 @@ export class CssParser {
 
     this._consume(CssTokenType.Character, '{');
 
-    var definitions: any[] /** TODO #9100 */ = [];
+    var definitions: any[] /* TODO #9100 */ = [];
     while (!characterContainsDelimiter(this._scanner.peek, delimiters)) {
       definitions.push(this._parseKeyframeDefinition(delimiters));
     }
@@ -304,7 +304,7 @@ export class CssParser {
 
   /** @internal */
   _parseKeyframeDefinition(delimiters: number): CssKeyframeDefinitionAST {
-    var stepTokens: any[] /** TODO #9100 */ = [];
+    var stepTokens: any[] /* TODO #9100 */ = [];
     delimiters = bitWiseOr([delimiters, LBRACE_DELIM]);
     while (!characterContainsDelimiter(this._scanner.peek, delimiters)) {
       stepTokens.push(this._parseKeyframeLabel(bitWiseOr([delimiters, COMMA_DELIM])));
@@ -328,11 +328,11 @@ export class CssParser {
     delimiters = bitWiseOr([delimiters, COMMA_DELIM, LBRACE_DELIM]);
     this._scanner.setMode(CssLexerMode.SELECTOR);
 
-    var selectorCssTokens: any[] /** TODO #9100 */ = [];
+    var selectorCssTokens: any[] /* TODO #9100 */ = [];
     var isComplex = false;
-    var wsCssToken: any /** TODO #9100 */;
+    var wsCssToken: any /* TODO #9100 */;
 
-    var previousToken: any /** TODO #9100 */;
+    var previousToken: any /* TODO #9100 */;
     var parenCount = 0;
     while (!characterContainsDelimiter(this._scanner.peek, delimiters)) {
       var code = this._scanner.peek;
@@ -425,10 +425,10 @@ export class CssParser {
     this._scanner.setMode(CssLexerMode.STYLE_VALUE);
 
     var strValue = '';
-    var tokens: any[] /** TODO #9100 */ = [];
+    var tokens: any[] /* TODO #9100 */ = [];
     var previous: CssToken;
     while (!characterContainsDelimiter(this._scanner.peek, delimiters)) {
-      var token: any /** TODO #9100 */;
+      var token: any /* TODO #9100 */;
       if (isPresent(previous) && previous.type == CssTokenType.Identifier &&
           this._scanner.peek == $LPAREN) {
         token = this._consume(CssTokenType.Character, '(');
@@ -475,7 +475,7 @@ export class CssParser {
 
   /** @internal */
   _collectUntilDelim(delimiters: number, assertType: CssTokenType = null): CssToken[] {
-    var tokens: any[] /** TODO #9100 */ = [];
+    var tokens: any[] /* TODO #9100 */ = [];
     while (!characterContainsDelimiter(this._scanner.peek, delimiters)) {
       var val = isPresent(assertType) ? this._consume(assertType) : this._scan();
       tokens.push(val);
@@ -492,7 +492,7 @@ export class CssParser {
     this._consume(CssTokenType.Character, '{');
     this._scanner.consumeEmptyStatements();
 
-    var results: any[] /** TODO #9100 */ = [];
+    var results: any[] /* TODO #9100 */ = [];
     while (!characterContainsDelimiter(this._scanner.peek, delimiters)) {
       results.push(this._parseRule(delimiters));
     }
@@ -514,7 +514,7 @@ export class CssParser {
     this._consume(CssTokenType.Character, '{');
     this._scanner.consumeEmptyStatements();
 
-    var definitions: any[] /** TODO #9100 */ = [];
+    var definitions: any[] /* TODO #9100 */ = [];
     while (!characterContainsDelimiter(this._scanner.peek, delimiters)) {
       definitions.push(this._parseDefinition(delimiters));
       this._scanner.consumeEmptyStatements();
@@ -533,7 +533,7 @@ export class CssParser {
     this._scanner.setMode(CssLexerMode.STYLE_BLOCK);
 
     var prop = this._consume(CssTokenType.Identifier);
-    var parseValue: any /** TODO #9100 */, value: any /** TODO #9100 */ = null;
+    var parseValue: any /* TODO #9100 */, value: any /* TODO #9100 */ = null;
 
     // the colon value separates the prop from the style.
     // there are a few cases as to what could happen if it
@@ -627,7 +627,7 @@ export class CssKeyframeRuleAST extends CssBlockRuleAST {
 }
 
 export class CssKeyframeDefinitionAST extends CssBlockRuleAST {
-  public steps: any /** TODO #9100 */;
+  public steps: any /* TODO #9100 */;
   constructor(_steps: CssToken[], block: CssBlockAST) {
     super(BlockType.Keyframes, block, mergeTokens(_steps, ','));
     this.steps = _steps;
@@ -677,7 +677,7 @@ export class CssDefinitionAST extends CssAST {
 }
 
 export class CssSelectorAST extends CssAST {
-  public strValue: any /** TODO #9100 */;
+  public strValue: any /* TODO #9100 */;
   constructor(public tokens: CssToken[], public isComplex: boolean = false) {
     super();
     this.strValue = tokens.map(token => token.strValue).join('');
@@ -709,6 +709,6 @@ export class CssParseError extends ParseError {
 }
 
 export class CssUnknownTokenListAST extends CssRuleAST {
-  constructor(public name: any /** TODO #9100 */, public tokens: CssToken[]) { super(); }
+  constructor(public name: any /* TODO #9100 */, public tokens: CssToken[]) { super(); }
   visit(visitor: CssASTVisitor, context?: any) { visitor.visitUnkownRule(this, context); }
 }

--- a/modules/@angular/compiler/src/directive_lifecycle_reflector.ts
+++ b/modules/@angular/compiler/src/directive_lifecycle_reflector.ts
@@ -26,7 +26,7 @@ const LIFECYCLE_PROPS: Map<any, string> = MapWrapper.createFromPairs([
   [LifecycleHooks.AfterViewChecked, 'ngAfterViewChecked'],
 ]);
 
-export function hasLifecycleHook(hook: LifecycleHooks, token: any /** TODO #9100 */): boolean {
+export function hasLifecycleHook(hook: LifecycleHooks, token: any /* TODO #9100 */): boolean {
   var lcInterface = LIFECYCLE_INTERFACES.get(hook);
   var lcProp = LIFECYCLE_PROPS.get(hook);
   return reflector.hasLifecycleHook(token, lcInterface, lcProp);

--- a/modules/@angular/compiler/src/directive_resolver.ts
+++ b/modules/@angular/compiler/src/directive_resolver.ts
@@ -48,8 +48,8 @@ export class DirectiveResolver {
   private _mergeWithPropertyMetadata(
       dm: DirectiveMetadata, propertyMetadata: {[key: string]: any[]},
       directiveType: Type): DirectiveMetadata {
-    var inputs: any[] /** TODO #9100 */ = [];
-    var outputs: any[] /** TODO #9100 */ = [];
+    var inputs: any[] /* TODO #9100 */ = [];
+    var outputs: any[] /* TODO #9100 */ = [];
     var host: {[key: string]: string} = {};
     var queries: {[key: string]: any} = {};
 
@@ -109,7 +109,7 @@ export class DirectiveResolver {
       queries: {[key: string]: any}, directiveType: Type): DirectiveMetadata {
     var mergedInputs = isPresent(dm.inputs) ? ListWrapper.concat(dm.inputs, inputs) : inputs;
 
-    var mergedOutputs: any /** TODO #9100 */;
+    var mergedOutputs: any /* TODO #9100 */;
     if (isPresent(dm.outputs)) {
       dm.outputs.forEach((propName: string) => {
         if (ListWrapper.contains(outputs, propName)) {

--- a/modules/@angular/compiler/src/metadata_resolver.ts
+++ b/modules/@angular/compiler/src/metadata_resolver.ts
@@ -97,8 +97,8 @@ export class CompileMetadataResolver {
     if (isBlank(meta)) {
       var dirMeta = this._directiveResolver.resolve(directiveType);
       var templateMeta: cpl.CompileTemplateMetadata = null;
-      var changeDetectionStrategy: any /** TODO #9100 */ = null;
-      var viewProviders: any[] /** TODO #9100 */ = [];
+      var changeDetectionStrategy: any /* TODO #9100 */ = null;
+      var viewProviders: any[] /* TODO #9100 */ = [];
       var moduleUrl = staticTypeModuleUrl(directiveType);
       if (dirMeta instanceof ComponentMetadata) {
         assertArrayOfStrings('styles', dirMeta.styles);
@@ -124,12 +124,12 @@ export class CompileMetadataResolver {
         moduleUrl = componentModuleUrl(this._reflector, directiveType, cmpMeta);
       }
 
-      var providers: any[] /** TODO #9100 */ = [];
+      var providers: any[] /* TODO #9100 */ = [];
       if (isPresent(dirMeta.providers)) {
         providers = this.getProvidersMetadata(dirMeta.providers);
       }
-      var queries: any[] /** TODO #9100 */ = [];
-      var viewQueries: any[] /** TODO #9100 */ = [];
+      var queries: any[] /* TODO #9100 */ = [];
+      var viewQueries: any[] /* TODO #9100 */ = [];
       if (isPresent(dirMeta.queries)) {
         queries = this.getQueriesMetadata(dirMeta.queries, false, directiveType);
         viewQueries = this.getQueriesMetadata(dirMeta.queries, true, directiveType);
@@ -246,7 +246,7 @@ export class CompileMetadataResolver {
       let isOptional = false;
       let query: QueryMetadata = null;
       let viewQuery: ViewQueryMetadata = null;
-      var token: any /** TODO #9100 */ = null;
+      var token: any /* TODO #9100 */ = null;
       if (isArray(param)) {
         (<any[]>param).forEach((paramEntry) => {
           if (paramEntry instanceof HostMetadata) {
@@ -305,7 +305,7 @@ export class CompileMetadataResolver {
 
   getTokenMetadata(token: any): cpl.CompileTokenMetadata {
     token = resolveForwardRef(token);
-    var compileToken: any /** TODO #9100 */;
+    var compileToken: any /* TODO #9100 */;
     if (isString(token)) {
       compileToken = new cpl.CompileTokenMetadata({value: token});
     } else {
@@ -337,7 +337,7 @@ export class CompileMetadataResolver {
   }
 
   getProviderMetadata(provider: Provider): cpl.CompileProviderMetadata {
-    var compileDeps: any /** TODO #9100 */;
+    var compileDeps: any /* TODO #9100 */;
     if (isPresent(provider.useClass)) {
       compileDeps = this.getDependenciesMetadata(provider.useClass, provider.dependencies);
     } else if (isPresent(provider.useFactory)) {
@@ -362,9 +362,9 @@ export class CompileMetadataResolver {
   getQueriesMetadata(
       queries: {[key: string]: QueryMetadata}, isViewQuery: boolean,
       directiveType: Type): cpl.CompileQueryMetadata[] {
-    var compileQueries: any[] /** TODO #9100 */ = [];
+    var compileQueries: any[] /* TODO #9100 */ = [];
     StringMapWrapper.forEach(
-        queries, (query: any /** TODO #9100 */, propertyName: any /** TODO #9100 */) => {
+        queries, (query: any /* TODO #9100 */, propertyName: any /* TODO #9100 */) => {
           if (query.isViewQuery === isViewQuery) {
             compileQueries.push(this.getQueryMetadata(query, propertyName, directiveType));
           }
@@ -374,7 +374,7 @@ export class CompileMetadataResolver {
 
   getQueryMetadata(q: QueryMetadata, propertyName: string, typeOrFunc: Type|Function):
       cpl.CompileQueryMetadata {
-    var selectors: any /** TODO #9100 */;
+    var selectors: any /* TODO #9100 */;
     if (q.isVarBindingQuery) {
       selectors = q.varBindings.map(varName => this.getTokenMetadata(varName));
     } else {
@@ -395,7 +395,7 @@ export class CompileMetadataResolver {
 }
 
 function flattenDirectives(view: ViewMetadata, platformDirectives: any[]): Type[] {
-  let directives: any[] /** TODO #9100 */ = [];
+  let directives: any[] /* TODO #9100 */ = [];
   if (isPresent(platformDirectives)) {
     flattenArray(platformDirectives, directives);
   }
@@ -406,7 +406,7 @@ function flattenDirectives(view: ViewMetadata, platformDirectives: any[]): Type[
 }
 
 function flattenPipes(view: ViewMetadata, platformPipes: any[]): Type[] {
-  let pipes: any[] /** TODO #9100 */ = [];
+  let pipes: any[] /* TODO #9100 */ = [];
   if (isPresent(platformPipes)) {
     flattenArray(platformPipes, pipes);
   }

--- a/modules/@angular/compiler/src/output/abstract_emitter.ts
+++ b/modules/@angular/compiler/src/output/abstract_emitter.ts
@@ -276,7 +276,7 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
   abstract visitDeclareFunctionStmt(stmt: o.DeclareFunctionStmt, context: any): any;
 
   visitBinaryOperatorExpr(ast: o.BinaryOperatorExpr, ctx: EmitterVisitorContext): any {
-    var opStr: any /** TODO #9100 */;
+    var opStr: any /* TODO #9100 */;
     switch (ast.operator) {
       case o.BinaryOperator.Equals:
         opStr = '==';
@@ -360,7 +360,7 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     var useNewLine = ast.entries.length > 1;
     ctx.print(`{`, useNewLine);
     ctx.incIndent();
-    this.visitAllObjects((entry: any /** TODO #9100 */) => {
+    this.visitAllObjects((entry: any /* TODO #9100 */) => {
       ctx.print(`${escapeSingleQuoteString(entry[0], this._escapeDollarInStrings)}: `);
       entry[1].visitExpression(this, ctx);
     }, ast.entries, ctx, ',', useNewLine);
@@ -373,7 +373,7 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
       expressions: o.Expression[], ctx: EmitterVisitorContext, separator: string,
       newLine: boolean = false): void {
     this.visitAllObjects(
-        (expr: any /** TODO #9100 */) => expr.visitExpression(this, ctx), expressions, ctx,
+        (expr: any /* TODO #9100 */) => expr.visitExpression(this, ctx), expressions, ctx,
         separator, newLine);
   }
 
@@ -401,7 +401,7 @@ export function escapeSingleQuoteString(input: string, escapeDollar: boolean): a
     return null;
   }
   var body = StringWrapper.replaceAllMapped(
-      input, _SINGLE_QUOTE_ESCAPE_STRING_RE, (match: any /** TODO #9100 */) => {
+      input, _SINGLE_QUOTE_ESCAPE_STRING_RE, (match: any /* TODO #9100 */) => {
         if (match[0] == '$') {
           return escapeDollar ? '\\$' : '$';
         } else if (match[0] == '\n') {

--- a/modules/@angular/compiler/src/output/abstract_js_emitter.ts
+++ b/modules/@angular/compiler/src/output/abstract_js_emitter.ts
@@ -137,11 +137,11 @@ export abstract class AbstractJsEmitterVisitor extends AbstractEmitterVisitor {
   }
 
   private _visitParams(params: o.FnParam[], ctx: EmitterVisitorContext): void {
-    this.visitAllObjects((param: any /** TODO #9100 */) => ctx.print(param.name), params, ctx, ',');
+    this.visitAllObjects((param: any /* TODO #9100 */) => ctx.print(param.name), params, ctx, ',');
   }
 
   getBuiltinMethodName(method: o.BuiltinMethod): string {
-    var name: any /** TODO #9100 */;
+    var name: any /* TODO #9100 */;
     switch (method) {
       case o.BuiltinMethod.ConcatArray:
         name = 'concat';

--- a/modules/@angular/compiler/src/output/dart_emitter.ts
+++ b/modules/@angular/compiler/src/output/dart_emitter.ts
@@ -35,7 +35,7 @@ export function debugOutputAstAsDart(ast: o.Statement | o.Expression | o.Type | 
 export class DartEmitter implements OutputEmitter {
   constructor(private _importGenerator: ImportGenerator) {}
   emitStatements(moduleUrl: string, stmts: o.Statement[], exportedVars: string[]): string {
-    var srcParts: any[] /** TODO #9100 */ = [];
+    var srcParts: any[] /* TODO #9100 */ = [];
     // Note: We are not creating a library here as Dart does not need it.
     // Dart analzyer might complain about it though.
 
@@ -191,7 +191,7 @@ class _DartEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisito
   }
 
   getBuiltinMethodName(method: o.BuiltinMethod): string {
-    var name: any /** TODO #9100 */;
+    var name: any /* TODO #9100 */;
     switch (method) {
       case o.BuiltinMethod.ConcatArray:
         name = '.addAll';
@@ -267,7 +267,7 @@ class _DartEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisito
     return null;
   }
   visitBuiltintType(type: o.BuiltinType, ctx: EmitterVisitorContext): any {
-    var typeStr: any /** TODO #9100 */;
+    var typeStr: any /* TODO #9100 */;
     switch (type.name) {
       case o.BuiltinTypeName.Bool:
         typeStr = 'bool';
@@ -319,7 +319,7 @@ class _DartEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisito
   }
 
   private _visitParams(params: o.FnParam[], ctx: EmitterVisitorContext): void {
-    this.visitAllObjects((param: any /** TODO #9100 */) => {
+    this.visitAllObjects((param: any /* TODO #9100 */) => {
       if (isPresent(param.type)) {
         param.type.visitType(this, ctx);
         ctx.print(' ');
@@ -345,7 +345,7 @@ class _DartEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisito
     if (isPresent(typeParams) && typeParams.length > 0) {
       ctx.print(`<`);
       this.visitAllObjects(
-          (type: any /** TODO #9100 */) => type.visitType(this, ctx), typeParams, ctx, ',');
+          (type: any /* TODO #9100 */) => type.visitType(this, ctx), typeParams, ctx, ',');
       ctx.print(`>`);
     }
   }

--- a/modules/@angular/compiler/src/output/dart_imports.ts
+++ b/modules/@angular/compiler/src/output/dart_imports.ts
@@ -32,7 +32,7 @@ export function getRelativePath(modulePath: string, importedPath: string): strin
   var importedParts = importedPath.split(_PATH_SEP_RE);
   var longestPrefix = getLongestPathSegmentPrefix(moduleParts, importedParts);
 
-  var resultParts: any[] /** TODO #9100 */ = [];
+  var resultParts: any[] /* TODO #9100 */ = [];
   var goParentCount = moduleParts.length - 1 - longestPrefix;
   for (var i = 0; i < goParentCount; i++) {
     resultParts.push('..');

--- a/modules/@angular/compiler/src/output/js_emitter.ts
+++ b/modules/@angular/compiler/src/output/js_emitter.ts
@@ -13,7 +13,7 @@ export class JavaScriptEmitter implements OutputEmitter {
     var converter = new JsEmitterVisitor(moduleUrl);
     var ctx = EmitterVisitorContext.createRoot(exportedVars);
     converter.visitAllStatements(stmts, ctx);
-    var srcParts: any[] /** TODO #9100 */ = [];
+    var srcParts: any[] /* TODO #9100 */ = [];
     converter.importsWithPrefixes.forEach((prefix, importedModuleUrl) => {
       // Note: can't write the real word for import as it screws up system.js auto detection...
       srcParts.push(

--- a/modules/@angular/compiler/src/output/output_ast.ts
+++ b/modules/@angular/compiler/src/output/output_ast.ts
@@ -181,7 +181,7 @@ export enum BuiltinVar {
 }
 
 export class ReadVarExpr extends Expression {
-  public name: any /** TODO #9100 */;
+  public name: any /* TODO #9100 */;
   public builtin: BuiltinVar;
 
   constructor(name: string|BuiltinVar, type: Type = null) {

--- a/modules/@angular/compiler/src/output/output_interpreter.ts
+++ b/modules/@angular/compiler/src/output/output_interpreter.ts
@@ -177,7 +177,7 @@ class StatementInterpreter implements o.StatementVisitor, o.ExpressionVisitor {
   visitInvokeMethodExpr(expr: o.InvokeMethodExpr, ctx: _ExecutionContext): any {
     var receiver = expr.receiver.visitExpression(this, ctx);
     var args = this.visitAllExpressions(expr.args, ctx);
-    var result: any /** TODO #9100 */;
+    var result: any /* TODO #9100 */;
     if (isPresent(expr.builtin)) {
       switch (expr.builtin) {
         case o.BuiltinMethod.ConcatArray:
@@ -329,7 +329,7 @@ class StatementInterpreter implements o.StatementVisitor, o.ExpressionVisitor {
     }
   }
   visitReadPropExpr(ast: o.ReadPropExpr, ctx: _ExecutionContext): any {
-    var result: any /** TODO #9100 */;
+    var result: any /* TODO #9100 */;
     var receiver = ast.receiver.visitExpression(this, ctx);
     if (isDynamicInstance(receiver)) {
       var di = <DynamicInstance>receiver;
@@ -358,7 +358,7 @@ class StatementInterpreter implements o.StatementVisitor, o.ExpressionVisitor {
   visitLiteralMapExpr(ast: o.LiteralMapExpr, ctx: _ExecutionContext): any {
     var result = {};
     ast.entries.forEach(
-        (entry) => (result as any /** TODO #9100 */)[<string>entry[0]] =
+        (entry) => (result as any /* TODO #9100 */)[<string>entry[0]] =
             (<o.Expression>entry[1]).visitExpression(this, ctx));
     return result;
   }
@@ -386,51 +386,51 @@ function _declareFn(
     case 0:
       return () => _executeFunctionStatements(varNames, [], statements, ctx, visitor);
     case 1:
-      return (d0: any /** TODO #9100 */) =>
+      return (d0: any /* TODO #9100 */) =>
                  _executeFunctionStatements(varNames, [d0], statements, ctx, visitor);
     case 2:
-      return (d0: any /** TODO #9100 */, d1: any /** TODO #9100 */) =>
+      return (d0: any /* TODO #9100 */, d1: any /* TODO #9100 */) =>
                  _executeFunctionStatements(varNames, [d0, d1], statements, ctx, visitor);
     case 3:
-      return (d0: any /** TODO #9100 */, d1: any /** TODO #9100 */, d2: any /** TODO #9100 */) =>
+      return (d0: any /* TODO #9100 */, d1: any /* TODO #9100 */, d2: any /* TODO #9100 */) =>
                  _executeFunctionStatements(varNames, [d0, d1, d2], statements, ctx, visitor);
     case 4:
-      return (d0: any /** TODO #9100 */, d1: any /** TODO #9100 */, d2: any /** TODO #9100 */,
-              d3: any /** TODO #9100 */) =>
+      return (d0: any /* TODO #9100 */, d1: any /* TODO #9100 */, d2: any /* TODO #9100 */,
+              d3: any /* TODO #9100 */) =>
                  _executeFunctionStatements(varNames, [d0, d1, d2, d3], statements, ctx, visitor);
     case 5:
-      return (d0: any /** TODO #9100 */, d1: any /** TODO #9100 */, d2: any /** TODO #9100 */,
-              d3: any /** TODO #9100 */, d4: any /** TODO #9100 */) =>
+      return (d0: any /* TODO #9100 */, d1: any /* TODO #9100 */, d2: any /* TODO #9100 */,
+              d3: any /* TODO #9100 */, d4: any /* TODO #9100 */) =>
                  _executeFunctionStatements(
                      varNames, [d0, d1, d2, d3, d4], statements, ctx, visitor);
     case 6:
-      return (d0: any /** TODO #9100 */, d1: any /** TODO #9100 */, d2: any /** TODO #9100 */,
-              d3: any /** TODO #9100 */, d4: any /** TODO #9100 */, d5: any /** TODO #9100 */) =>
+      return (d0: any /* TODO #9100 */, d1: any /* TODO #9100 */, d2: any /* TODO #9100 */,
+              d3: any /* TODO #9100 */, d4: any /* TODO #9100 */, d5: any /* TODO #9100 */) =>
                  _executeFunctionStatements(
                      varNames, [d0, d1, d2, d3, d4, d5], statements, ctx, visitor);
     case 7:
-      return (d0: any /** TODO #9100 */, d1: any /** TODO #9100 */, d2: any /** TODO #9100 */,
-              d3: any /** TODO #9100 */, d4: any /** TODO #9100 */, d5: any /** TODO #9100 */,
-              d6: any /** TODO #9100 */) =>
+      return (d0: any /* TODO #9100 */, d1: any /* TODO #9100 */, d2: any /* TODO #9100 */,
+              d3: any /* TODO #9100 */, d4: any /* TODO #9100 */, d5: any /* TODO #9100 */,
+              d6: any /* TODO #9100 */) =>
                  _executeFunctionStatements(
                      varNames, [d0, d1, d2, d3, d4, d5, d6], statements, ctx, visitor);
     case 8:
-      return (d0: any /** TODO #9100 */, d1: any /** TODO #9100 */, d2: any /** TODO #9100 */,
-              d3: any /** TODO #9100 */, d4: any /** TODO #9100 */, d5: any /** TODO #9100 */,
-              d6: any /** TODO #9100 */, d7: any /** TODO #9100 */) =>
+      return (d0: any /* TODO #9100 */, d1: any /* TODO #9100 */, d2: any /* TODO #9100 */,
+              d3: any /* TODO #9100 */, d4: any /* TODO #9100 */, d5: any /* TODO #9100 */,
+              d6: any /* TODO #9100 */, d7: any /* TODO #9100 */) =>
                  _executeFunctionStatements(
                      varNames, [d0, d1, d2, d3, d4, d5, d6, d7], statements, ctx, visitor);
     case 9:
-      return (d0: any /** TODO #9100 */, d1: any /** TODO #9100 */, d2: any /** TODO #9100 */,
-              d3: any /** TODO #9100 */, d4: any /** TODO #9100 */, d5: any /** TODO #9100 */,
-              d6: any /** TODO #9100 */, d7: any /** TODO #9100 */, d8: any /** TODO #9100 */) =>
+      return (d0: any /* TODO #9100 */, d1: any /* TODO #9100 */, d2: any /* TODO #9100 */,
+              d3: any /* TODO #9100 */, d4: any /* TODO #9100 */, d5: any /* TODO #9100 */,
+              d6: any /* TODO #9100 */, d7: any /* TODO #9100 */, d8: any /* TODO #9100 */) =>
                  _executeFunctionStatements(
                      varNames, [d0, d1, d2, d3, d4, d5, d6, d7, d8], statements, ctx, visitor);
     case 10:
-      return (d0: any /** TODO #9100 */, d1: any /** TODO #9100 */, d2: any /** TODO #9100 */,
-              d3: any /** TODO #9100 */, d4: any /** TODO #9100 */, d5: any /** TODO #9100 */,
-              d6: any /** TODO #9100 */, d7: any /** TODO #9100 */, d8: any /** TODO #9100 */,
-              d9: any /** TODO #9100 */) =>
+      return (d0: any /* TODO #9100 */, d1: any /* TODO #9100 */, d2: any /* TODO #9100 */,
+              d3: any /* TODO #9100 */, d4: any /* TODO #9100 */, d5: any /* TODO #9100 */,
+              d6: any /* TODO #9100 */, d7: any /* TODO #9100 */, d8: any /* TODO #9100 */,
+              d9: any /* TODO #9100 */) =>
                  _executeFunctionStatements(
                      varNames, [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9], statements, ctx, visitor);
     default:

--- a/modules/@angular/compiler/src/output/output_jit.ts
+++ b/modules/@angular/compiler/src/output/output_jit.ts
@@ -19,7 +19,7 @@ class JitEmitterVisitor extends AbstractJsEmitterVisitor {
   getArgs(): {[key: string]: any} {
     var result = {};
     for (var i = 0; i < this._evalArgNames.length; i++) {
-      (result as any /** TODO #9100 */)[this._evalArgNames[i]] = this._evalArgValues[i];
+      (result as any /* TODO #9100 */)[this._evalArgNames[i]] = this._evalArgValues[i];
     }
     return result;
   }

--- a/modules/@angular/compiler/src/output/ts_emitter.ts
+++ b/modules/@angular/compiler/src/output/ts_emitter.ts
@@ -38,7 +38,7 @@ export class TypeScriptEmitter implements OutputEmitter {
     var converter = new _TsEmitterVisitor(moduleUrl);
     var ctx = EmitterVisitorContext.createRoot(exportedVars);
     converter.visitAllStatements(stmts, ctx);
-    var srcParts: any[] /** TODO #9100 */ = [];
+    var srcParts: any[] /* TODO #9100 */ = [];
     converter.importsWithPrefixes.forEach((prefix, importedModuleUrl) => {
       // Note: can't write the real word for import as it screws up system.js auto detection...
       srcParts.push(
@@ -203,7 +203,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
   }
 
   visitBuiltintType(type: o.BuiltinType, ctx: EmitterVisitorContext): any {
-    var typeStr: any /** TODO #9100 */;
+    var typeStr: any /* TODO #9100 */;
     switch (type.name) {
       case o.BuiltinTypeName.Bool:
         typeStr = 'boolean';
@@ -246,7 +246,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
   }
 
   getBuiltinMethodName(method: o.BuiltinMethod): string {
-    var name: any /** TODO #9100 */;
+    var name: any /* TODO #9100 */;
     switch (method) {
       case o.BuiltinMethod.ConcatArray:
         name = 'concat';
@@ -265,7 +265,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
 
 
   private _visitParams(params: o.FnParam[], ctx: EmitterVisitorContext): void {
-    this.visitAllObjects((param: any /** TODO #9100 */) => {
+    this.visitAllObjects((param: any /* TODO #9100 */) => {
       ctx.print(param.name);
       ctx.print(':');
       this.visitType(param.type, ctx);
@@ -289,7 +289,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     if (isPresent(typeParams) && typeParams.length > 0) {
       ctx.print(`<`);
       this.visitAllObjects(
-          (type: any /** TODO #9100 */) => type.visitType(this, ctx), typeParams, ctx, ',');
+          (type: any /* TODO #9100 */) => type.visitType(this, ctx), typeParams, ctx, ',');
       ctx.print(`>`);
     }
   }

--- a/modules/@angular/compiler/src/runtime_compiler.ts
+++ b/modules/@angular/compiler/src/runtime_compiler.ts
@@ -193,8 +193,8 @@ class CompiledTemplate {
   proxyViewFactory: Function;
   constructor() {
     this.proxyViewFactory =
-        (viewUtils: any /** TODO #9100 */, childInjector: any /** TODO #9100 */,
-         contextEl: any /** TODO #9100 */) => this.viewFactory(viewUtils, childInjector, contextEl);
+        (viewUtils: any /* TODO #9100 */, childInjector: any /* TODO #9100 */,
+         contextEl: any /* TODO #9100 */) => this.viewFactory(viewUtils, childInjector, contextEl);
   }
 
   init(viewFactory: Function) { this.viewFactory = viewFactory; }

--- a/modules/@angular/compiler/src/schema/dom_element_schema_registry.ts
+++ b/modules/@angular/compiler/src/schema/dom_element_schema_registry.ts
@@ -241,7 +241,7 @@ export class DomElementSchemaRegistry extends ElementSchemaRegistry {
       var superType = this.schema[typeParts[1]];
       if (isPresent(superType)) {
         StringMapWrapper.forEach(
-            superType, (v: any /** TODO #9100 */, k: any /** TODO #9100 */) => type[k] = v);
+            superType, (v: any /* TODO #9100 */, k: any /* TODO #9100 */) => type[k] = v);
       }
       properties.forEach((property: string) => {
         if (property == '') {

--- a/modules/@angular/compiler/src/shadow_css.ts
+++ b/modules/@angular/compiler/src/shadow_css.ts
@@ -169,7 +169,7 @@ export class ShadowCss {
     // Difference with webcomponents.js: does not handle comments
     return StringWrapper.replaceAllMapped(
         cssText, _cssContentNextSelectorRe,
-        function(m: any /** TODO #9100 */) { return m[1] + '{'; });
+        function(m: any /* TODO #9100 */) { return m[1] + '{'; });
   }
 
   /*
@@ -190,7 +190,7 @@ export class ShadowCss {
   private _insertPolyfillRulesInCssText(cssText: string): string {
     // Difference with webcomponents.js: does not handle comments
     return StringWrapper.replaceAllMapped(
-        cssText, _cssContentRuleRe, function(m: any /** TODO #9100 */) {
+        cssText, _cssContentRuleRe, function(m: any /* TODO #9100 */) {
           var rule = m[0];
           rule = StringWrapper.replace(rule, m[1], '');
           rule = StringWrapper.replace(rule, m[2], '');
@@ -236,7 +236,7 @@ export class ShadowCss {
   **/
   private _extractUnscopedRulesFromCssText(cssText: string): string {
     // Difference with webcomponents.js: does not handle comments
-    var r = '', m: any /** TODO #9100 */;
+    var r = '', m: any /* TODO #9100 */;
     var matcher = RegExpWrapper.matcher(_cssContentUnscopedRuleRe, cssText);
     while (isPresent(m = RegExpMatcherWrapper.next(matcher))) {
       var rule = m[0];
@@ -280,9 +280,9 @@ export class ShadowCss {
 
   private _convertColonRule(cssText: string, regExp: RegExp, partReplacer: Function): string {
     // p1 = :host, p2 = contents of (), p3 rest of rule
-    return StringWrapper.replaceAllMapped(cssText, regExp, function(m: any /** TODO #9100 */) {
+    return StringWrapper.replaceAllMapped(cssText, regExp, function(m: any /* TODO #9100 */) {
       if (isPresent(m[2])) {
-        var parts = m[2].split(','), r: any[] /** TODO #9100 */ = [];
+        var parts = m[2].split(','), r: any[] /* TODO #9100 */ = [];
         for (var i = 0; i < parts.length; i++) {
           var p = parts[i];
           if (isBlank(p)) break;
@@ -336,7 +336,7 @@ export class ShadowCss {
 
   private _scopeSelector(
       selector: string, scopeSelector: string, hostSelector: string, strict: boolean): string {
-    var r: any[] /** TODO #9100 */ = [], parts = selector.split(',');
+    var r: any[] /* TODO #9100 */ = [], parts = selector.split(',');
     for (var i = 0; i < parts.length; i++) {
       var p = parts[i].trim();
       var deepParts = StringWrapper.split(p, _shadowDeepSelectors);
@@ -388,7 +388,7 @@ export class ShadowCss {
   private _applyStrictSelectorScope(selector: string, scopeSelector: string): string {
     var isRe = /\[is=([^\]]*)\]/g;
     scopeSelector =
-        StringWrapper.replaceAllMapped(scopeSelector, isRe, (m: any /** TODO #9100 */) => m[1]);
+        StringWrapper.replaceAllMapped(scopeSelector, isRe, (m: any /* TODO #9100 */) => m[1]);
     var splits = [' ', '>', '+', '~'], scoped = selector, attrName = '[' + scopeSelector + ']';
     for (var i = 0; i < splits.length; i++) {
       var sep = splits[i];
@@ -450,7 +450,7 @@ var _colonHostContextRe = /:host-context/gim;
 var _commentRe = /\/\*[\s\S]*?\*\//g;
 
 function stripComments(input:string):string {
-  return StringWrapper.replaceAllMapped(input, _commentRe, (_: any /** TODO #9100 */) => '');
+  return StringWrapper.replaceAllMapped(input, _commentRe, (_: any /* TODO #9100 */) => '');
 }
 
 var _ruleRe = /(\s*)([^;\{\}]+?)(\s*)((?:{%BLOCK%}?\s*;?)|(?:\s*;))/g;
@@ -466,7 +466,7 @@ export class CssRule {
 export function processRules(input:string, ruleCallback:Function):string {
   var inputWithEscapedBlocks = escapeBlocks(input);
   var nextBlockIndex = 0;
-  return StringWrapper.replaceAllMapped(inputWithEscapedBlocks.escapedString, _ruleRe, function(m: any /** TODO #9100 */) {
+  return StringWrapper.replaceAllMapped(inputWithEscapedBlocks.escapedString, _ruleRe, function(m: any /* TODO #9100 */) {
     var selector = m[2];
     var content = '';
     var suffix = m[4];
@@ -487,10 +487,10 @@ class StringWithEscapedBlocks {
 
 function escapeBlocks(input:string):StringWithEscapedBlocks {
   var inputParts = StringWrapper.split(input, _curlyRe);
-  var resultParts: any[] /** TODO #9100 */ = [];
-  var escapedBlocks: any[] /** TODO #9100 */ = [];
+  var resultParts: any[] /* TODO #9100 */ = [];
+  var escapedBlocks: any[] /* TODO #9100 */ = [];
   var bracketCount = 0;
-  var currentBlockParts: any[] /** TODO #9100 */ = [];
+  var currentBlockParts: any[] /* TODO #9100 */ = [];
   for (var partIndex = 0; partIndex<inputParts.length; partIndex++) {
     var part = inputParts[partIndex];
     if (part == CLOSE_CURLY) {

--- a/modules/@angular/compiler/src/util.ts
+++ b/modules/@angular/compiler/src/util.ts
@@ -54,8 +54,8 @@ export class ValueTransformer implements ValueVisitor {
   }
   visitStringMap(map: {[key: string]: any}, context: any): any {
     var result = {};
-    StringMapWrapper.forEach(map, (value: any /** TODO #9100 */, key: any /** TODO #9100 */) => {
-      (result as any /** TODO #9100 */)[key] = visitValue(value, this, context);
+    StringMapWrapper.forEach(map, (value: any /* TODO #9100 */, key: any /* TODO #9100 */) => {
+      (result as any /* TODO #9100 */)[key] = visitValue(value, this, context);
     });
     return result;
   }

--- a/modules/@angular/compiler/src/view_compiler/compile_element.ts
+++ b/modules/@angular/compiler/src/view_compiler/compile_element.ts
@@ -160,9 +160,9 @@ export class CompileElement extends CompileNode {
           queriesForProvider.map(query => new _QueryWithRead(query, resolvedProvider.token)));
     });
     StringMapWrapper.forEach(
-        this.referenceTokens, (_: any /** TODO #9100 */, varName: any /** TODO #9100 */) => {
+        this.referenceTokens, (_: any /* TODO #9100 */, varName: any /* TODO #9100 */) => {
           var token = this.referenceTokens[varName];
-          var varValue: any /** TODO #9100 */;
+          var varValue: any /* TODO #9100 */;
           if (isPresent(token)) {
             varValue = this._instances.get(token);
           } else {
@@ -277,7 +277,7 @@ export class CompileElement extends CompileNode {
 
   private _getLocalDependency(
       requestingProviderType: ProviderAstType, dep: CompileDiDependencyMetadata): o.Expression {
-    var result: any /** TODO #9100 */ = null;
+    var result: any /* TODO #9100 */ = null;
     // constructor content query
     if (isBlank(result) && isPresent(dep.query)) {
       result = this._addQuery(dep.query, null).queryList;
@@ -314,7 +314,7 @@ export class CompileElement extends CompileNode {
   private _getDependency(requestingProviderType: ProviderAstType, dep: CompileDiDependencyMetadata):
       o.Expression {
     var currElement: CompileElement = this;
-    var result: any /** TODO #9100 */ = null;
+    var result: any /* TODO #9100 */ = null;
     if (dep.isValue) {
       result = o.literal(dep.value);
     }
@@ -341,7 +341,7 @@ export class CompileElement extends CompileNode {
 function createInjectInternalCondition(
     nodeIndex: number, childNodeCount: number, provider: ProviderAst,
     providerExpr: o.Expression): o.Statement {
-  var indexCondition: any /** TODO #9100 */;
+  var indexCondition: any /* TODO #9100 */;
   if (childNodeCount > 0) {
     indexCondition = o.literal(nodeIndex)
                          .lowerEquals(InjectMethodVars.requestNodeIndex)
@@ -359,8 +359,8 @@ function createProviderProperty(
     propName: string, provider: ProviderAst, providerValueExpressions: o.Expression[],
     isMulti: boolean, isEager: boolean, compileElement: CompileElement): o.Expression {
   var view = compileElement.view;
-  var resolvedProviderValueExpr: any /** TODO #9100 */;
-  var type: any /** TODO #9100 */;
+  var resolvedProviderValueExpr: any /* TODO #9100 */;
+  var type: any /* TODO #9100 */;
   if (isMulti) {
     resolvedProviderValueExpr = o.literalArr(providerValueExpressions);
     type = new o.ArrayType(o.DYNAMIC_TYPE);
@@ -405,8 +405,8 @@ class _ValueOutputAstTransformer extends ValueTransformer {
     return o.literalArr(arr.map(value => visitValue(value, this, context)));
   }
   visitStringMap(map: {[key: string]: any}, context: any): o.Expression {
-    var entries: any[] /** TODO #9100 */ = [];
-    StringMapWrapper.forEach(map, (value: any /** TODO #9100 */, key: any /** TODO #9100 */) => {
+    var entries: any[] /* TODO #9100 */ = [];
+    StringMapWrapper.forEach(map, (value: any /* TODO #9100 */, key: any /* TODO #9100 */) => {
       entries.push([key, visitValue(value, this, context)]);
     });
     return o.literalMap(entries);

--- a/modules/@angular/compiler/src/view_compiler/compile_query.ts
+++ b/modules/@angular/compiler/src/view_compiler/compile_query.ts
@@ -56,7 +56,7 @@ export class CompileQuery {
     return !this._values.values.some(value => value instanceof ViewQueryValues);
   }
 
-  afterChildren(targetStaticMethod: any /** TODO #9100 */, targetDynamicMethod: CompileMethod) {
+  afterChildren(targetStaticMethod: any /* TODO #9100 */, targetDynamicMethod: CompileMethod) {
     var values = createQueryValues(this._values);
     var updateStmts = [this.queryList.callMethod('reset', [o.literalArr(values)]).toStmt()];
     if (isPresent(this.ownerDirectiveExpression)) {

--- a/modules/@angular/compiler/src/view_compiler/event_binder.ts
+++ b/modules/@angular/compiler/src/view_compiler/event_binder.ts
@@ -84,7 +84,7 @@ export class CompileEventListener {
   }
 
   listenToRenderer() {
-    var listenExpr: any /** TODO #9100 */;
+    var listenExpr: any /* TODO #9100 */;
     var eventListener = o.THIS_EXPR.callMethod(
         'eventHandler',
         [o.THIS_EXPR.prop(this._methodName).callMethod(o.BuiltinMethod.bind, [o.THIS_EXPR])]);
@@ -144,7 +144,7 @@ export function bindDirectiveOutputs(
     eventListeners: CompileEventListener[]) {
   StringMapWrapper.forEach(
       directiveAst.directive.outputs,
-      (eventName: any /** TODO #9100 */, observablePropName: any /** TODO #9100 */) => {
+      (eventName: any /* TODO #9100 */, observablePropName: any /* TODO #9100 */) => {
         eventListeners.filter(listener => listener.eventName == eventName).forEach((listener) => {
           listener.listenToDirective(directiveInstance, observablePropName);
         });

--- a/modules/@angular/compiler/src/view_compiler/expression_converter.ts
+++ b/modules/@angular/compiler/src/view_compiler/expression_converter.ts
@@ -28,7 +28,7 @@ export function convertCdExpressionToIr(
 export function convertCdStatementToIr(
     nameResolver: NameResolver, implicitReceiver: o.Expression, stmt: cdAst.AST): o.Statement[] {
   var visitor = new _AstToIrVisitor(nameResolver, implicitReceiver, null);
-  var statements: any[] /** TODO #9100 */ = [];
+  var statements: any[] /* TODO #9100 */ = [];
   flattenStatements(stmt.visit(visitor, _Mode.Statement), statements);
   return statements;
 }
@@ -66,7 +66,7 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
       private _valueUnwrapper: o.ReadVarExpr) {}
 
   visitBinary(ast: cdAst.Binary, mode: _Mode): any {
-    var op: any /** TODO #9100 */;
+    var op: any /* TODO #9100 */;
     switch (ast.operation) {
       case '+':
         op = o.BinaryOperator.Plus;
@@ -174,7 +174,7 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
         mode, this._nameResolver.createLiteralArray(this.visitAll(ast.expressions, mode)));
   }
   visitLiteralMap(ast: cdAst.LiteralMap, mode: _Mode): any {
-    var parts: any[] /** TODO #9100 */ = [];
+    var parts: any[] /* TODO #9100 */ = [];
     for (var i = 0; i < ast.keys.length; i++) {
       parts.push([ast.keys[i], ast.values[i].visit(this, _Mode.Expression)]);
     }
@@ -185,7 +185,7 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
   }
   visitMethodCall(ast: cdAst.MethodCall, mode: _Mode): any {
     var args = this.visitAll(ast.args, _Mode.Expression);
-    var result: any /** TODO #9100 */ = null;
+    var result: any /* TODO #9100 */ = null;
     var receiver = ast.receiver.visit(this, _Mode.Expression);
     if (receiver === IMPLICIT_RECEIVER) {
       var varExpr = this._nameResolver.getLocal(ast.name);
@@ -204,7 +204,7 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
     return convertToStatementIfNeeded(mode, o.not(ast.expression.visit(this, _Mode.Expression)));
   }
   visitPropertyRead(ast: cdAst.PropertyRead, mode: _Mode): any {
-    var result: any /** TODO #9100 */ = null;
+    var result: any /* TODO #9100 */ = null;
     var receiver = ast.receiver.visit(this, _Mode.Expression);
     if (receiver === IMPLICIT_RECEIVER) {
       result = this._nameResolver.getLocal(ast.name);

--- a/modules/@angular/compiler/src/view_compiler/property_binder.ts
+++ b/modules/@angular/compiler/src/view_compiler/property_binder.ts
@@ -91,7 +91,7 @@ function bindAndWriteToRenderer(
     var renderMethod: string;
     var oldRenderValue: o.Expression = sanitizedValue(boundProp, fieldExpr);
     var renderValue: o.Expression = sanitizedValue(boundProp, currValExpr);
-    var updateStmts: any[] /** TODO #9100 */ = [];
+    var updateStmts: any[] /* TODO #9100 */ = [];
     switch (boundProp.type) {
       case PropertyBindingType.Property:
         if (view.genConfig.logBindingUpdate) {

--- a/modules/@angular/compiler/src/view_compiler/util.ts
+++ b/modules/@angular/compiler/src/view_compiler/util.ts
@@ -60,7 +60,7 @@ export function createDiTokenExpression(token: CompileTokenMetadata): o.Expressi
 }
 
 export function createFlatArray(expressions: o.Expression[]): o.Expression {
-  var lastNonArrayExpressions: any[] /** TODO #9100 */ = [];
+  var lastNonArrayExpressions: any[] /* TODO #9100 */ = [];
   var result: o.Expression = o.literalArr([]);
   for (var i = 0; i < expressions.length; i++) {
     var expr = expressions[i];

--- a/modules/@angular/compiler/src/view_compiler/view_builder.ts
+++ b/modules/@angular/compiler/src/view_compiler/view_builder.ts
@@ -152,7 +152,7 @@ class ViewBuilderVisitor implements TemplateAstVisitor {
 
   visitElement(ast: ElementAst, parent: CompileElement): any {
     var nodeIndex = this.view.nodes.length;
-    var createRenderNodeExpr: any /** TODO #9100 */;
+    var createRenderNodeExpr: any /* TODO #9100 */;
     var debugContextExpr = this.view.createMethod.resetDebugInfoExpr(nodeIndex, ast);
     if (nodeIndex === 0 && this.view.viewType === ViewType.HOST) {
       createRenderNodeExpr = o.THIS_EXPR.callMethod(
@@ -206,7 +206,7 @@ class ViewBuilderVisitor implements TemplateAstVisitor {
     compileElement.afterChildren(this.view.nodes.length - nodeIndex - 1);
 
     if (isPresent(compViewExpr)) {
-      var codeGenContentNodes: any /** TODO #9100 */;
+      var codeGenContentNodes: any /* TODO #9100 */;
       if (this.view.component.type.isHost) {
         codeGenContentNodes = ViewProperties.projectableNodes;
       } else {
@@ -281,11 +281,10 @@ function _mergeHtmlAndDirectiveAttrs(
   var result: {[key: string]: string} = {};
   StringMapWrapper.forEach(
       declaredHtmlAttrs,
-      (value: any /** TODO #9100 */, key: any /** TODO #9100 */) => { result[key] = value; });
+      (value: any /* TODO #9100 */, key: any /* TODO #9100 */) => { result[key] = value; });
   directives.forEach(directiveMeta => {
     StringMapWrapper.forEach(
-        directiveMeta.hostAttributes,
-        (value: any /** TODO #9100 */, name: any /** TODO #9100 */) => {
+        directiveMeta.hostAttributes, (value: any /* TODO #9100 */, name: any /* TODO #9100 */) => {
           var prevValue = result[name];
           result[name] = isPresent(prevValue) ? mergeAttributeValue(name, prevValue, value) : value;
         });
@@ -308,14 +307,14 @@ function mergeAttributeValue(attrName: string, attrValue1: string, attrValue2: s
 }
 
 function mapToKeyValueArray(data: {[key: string]: string}): string[][] {
-  var entryArray: any[] /** TODO #9100 */ = [];
-  StringMapWrapper.forEach(data, (value: any /** TODO #9100 */, name: any /** TODO #9100 */) => {
+  var entryArray: any[] /* TODO #9100 */ = [];
+  StringMapWrapper.forEach(data, (value: any /* TODO #9100 */, name: any /* TODO #9100 */) => {
     entryArray.push([name, value]);
   });
   // We need to sort to get a defined output order
   // for tests and for caching generated artifacts...
   ListWrapper.sort(entryArray, (entry1, entry2) => StringWrapper.compare(entry1[0], entry2[0]));
-  var keyValueArray: any[] /** TODO #9100 */ = [];
+  var keyValueArray: any[] /* TODO #9100 */ = [];
   entryArray.forEach((entry) => { keyValueArray.push([entry[0], entry[1]]); });
   return keyValueArray;
 }
@@ -351,7 +350,7 @@ function createStaticNodeDebugInfo(node: CompileNode): o.Expression {
   var compileElement = node instanceof CompileElement ? node : null;
   var providerTokens: o.Expression[] = [];
   var componentToken: o.Expression = o.NULL_EXPR;
-  var varTokenEntries: any[] /** TODO #9100 */ = [];
+  var varTokenEntries: any[] /* TODO #9100 */ = [];
   if (isPresent(compileElement)) {
     providerTokens = compileElement.getProviderTokens();
     if (isPresent(compileElement.component)) {
@@ -359,7 +358,7 @@ function createStaticNodeDebugInfo(node: CompileNode): o.Expression {
     }
     StringMapWrapper.forEach(
         compileElement.referenceTokens,
-        (token: any /** TODO #9100 */, varName: any /** TODO #9100 */) => {
+        (token: any /* TODO #9100 */, varName: any /* TODO #9100 */) => {
           varTokenEntries.push(
               [varName, isPresent(token) ? createDiTokenExpression(token) : o.NULL_EXPR]);
         });
@@ -429,8 +428,8 @@ function createViewFactory(
     new o.FnParam(ViewConstructorVars.parentInjector.name, o.importType(Identifiers.Injector)),
     new o.FnParam(ViewConstructorVars.declarationEl.name, o.importType(Identifiers.AppElement))
   ];
-  var initRenderCompTypeStmts: any[] /** TODO #9100 */ = [];
-  var templateUrlInfo: any /** TODO #9100 */;
+  var initRenderCompTypeStmts: any[] /* TODO #9100 */ = [];
+  var templateUrlInfo: any /* TODO #9100 */;
   if (view.component.template.templateUrl == view.component.type.moduleUrl) {
     templateUrlInfo =
         `${view.component.type.moduleUrl} class ${view.component.type.name} - inline template`;
@@ -461,7 +460,7 @@ function createViewFactory(
 
 function generateCreateMethod(view: CompileView): o.Statement[] {
   var parentRenderNodeExpr: o.Expression = o.NULL_EXPR;
-  var parentRenderNodeStmts: any[] /** TODO #9100 */ = [];
+  var parentRenderNodeStmts: any[] /* TODO #9100 */ = [];
   if (view.viewType === ViewType.COMPONENT) {
     parentRenderNodeExpr = ViewProperties.renderer.callMethod(
         'createViewRoot', [o.THIS_EXPR.prop('declarationAppElement').prop('nativeElement')]);
@@ -491,7 +490,7 @@ function generateCreateMethod(view: CompileView): o.Statement[] {
 }
 
 function generateDetectChangesMethod(view: CompileView): o.Statement[] {
-  var stmts: any[] /** TODO #9100 */ = [];
+  var stmts: any[] /* TODO #9100 */ = [];
   if (view.detectChangesInInputsMethod.isEmpty() && view.updateContentQueriesMethod.isEmpty() &&
       view.afterContentLifecycleCallbacksMethod.isEmpty() &&
       view.detectChangesRenderPropertiesMethod.isEmpty() &&
@@ -516,7 +515,7 @@ function generateDetectChangesMethod(view: CompileView): o.Statement[] {
     stmts.push(new o.IfStmt(o.not(DetectChangesVars.throwOnChange), afterViewStmts));
   }
 
-  var varStmts: any[] /** TODO #9100 */ = [];
+  var varStmts: any[] /* TODO #9100 */ = [];
   var readVars = o.findReadVarNames(stmts);
   if (SetWrapper.has(readVars, DetectChangesVars.changed.name)) {
     varStmts.push(DetectChangesVars.changed.set(o.literal(true)).toDeclStmt(o.BOOL_TYPE));

--- a/modules/@angular/compiler/src/view_compiler/view_compiler.ts
+++ b/modules/@angular/compiler/src/view_compiler/view_compiler.ts
@@ -25,9 +25,9 @@ export class ViewCompiler {
   compileComponent(
       component: CompileDirectiveMetadata, template: TemplateAst[], styles: o.Expression,
       pipes: CompilePipeMetadata[]): ViewCompileResult {
-    var dependencies: any[] /** TODO #9100 */ = [];
+    var dependencies: any[] /* TODO #9100 */ = [];
     var compiledAnimations = this._animationCompiler.compileComponent(component);
-    var statements: any[] /** TODO #9100 */ = [];
+    var statements: any[] /* TODO #9100 */ = [];
     compiledAnimations.map(entry => {
       statements.push(entry.statesMapStatement);
       statements.push(entry.fnStatement);

--- a/modules/@angular/compiler/test/animation/animation_compiler_spec.ts
+++ b/modules/@angular/compiler/test/animation/animation_compiler_spec.ts
@@ -7,7 +7,7 @@ import {CompileMetadataResolver} from '../../src/metadata_resolver';
 
 export function main() {
   describe('RuntimeAnimationCompiler', () => {
-    var resolver: any /** TODO #9100 */;
+    var resolver: any /* TODO #9100 */;
     beforeEach(
         inject([CompileMetadataResolver], (res: CompileMetadataResolver) => { resolver = res; }));
 

--- a/modules/@angular/compiler/test/animation/animation_parser_spec.ts
+++ b/modules/@angular/compiler/test/animation/animation_parser_spec.ts
@@ -13,7 +13,7 @@ export function main() {
       var flatStyles: {[key: string]: string | number} = {};
       styles.styles.forEach(
           entry => StringMapWrapper.forEach(
-              entry, (val: any /** TODO #9100 */, prop: any /** TODO #9100 */) => {
+              entry, (val: any /* TODO #9100 */, prop: any /* TODO #9100 */) => {
                 flatStyles[prop] = val;
               }));
       return flatStyles;
@@ -24,7 +24,7 @@ export function main() {
 
     var collectStepStyles = (step: AnimationStepAst): Array<{[key: string]: string | number}> => {
       var keyframes = step.keyframes;
-      var styles: any[] /** TODO #9100 */ = [];
+      var styles: any[] /* TODO #9100 */ = [];
       if (step.startingStyles.styles.length > 0) {
         styles.push(combineStyles(step.startingStyles));
       }
@@ -32,7 +32,7 @@ export function main() {
       return styles;
     };
 
-    var resolver: any /** TODO #9100 */;
+    var resolver: any /* TODO #9100 */;
     beforeEach(
         inject([CompileMetadataResolver], (res: CompileMetadataResolver) => { resolver = res; }));
 

--- a/modules/@angular/compiler/test/css/lexer_spec.ts
+++ b/modules/@angular/compiler/test/css/lexer_spec.ts
@@ -5,12 +5,12 @@ import {isPresent} from '../../src/facade/lang';
 
 export function main() {
   function tokenize(
-      code: any /** TODO #9100 */, trackComments: boolean = false,
+      code: any /* TODO #9100 */, trackComments: boolean = false,
       mode: CssLexerMode = CssLexerMode.ALL): CssToken[] {
     var scanner = new CssLexer().scan(code, trackComments);
     scanner.setMode(mode);
 
-    var tokens: any[] /** TODO #9100 */ = [];
+    var tokens: any[] /* TODO #9100 */ = [];
     var output = scanner.scan();
     while (output != null) {
       var error = output.error;
@@ -268,7 +268,7 @@ export function main() {
       it('should throw an error if a selector is being parsed while in the wrong mode', () => {
         var cssCode = '.class > tag';
 
-        var capturedMessage: any /** TODO #9100 */;
+        var capturedMessage: any /* TODO #9100 */;
         try {
           tokenize(cssCode, false, CssLexerMode.STYLE_BLOCK);
         } catch (e) {
@@ -292,7 +292,7 @@ export function main() {
     describe('Attribute Mode', () => {
       it('should consider attribute selectors as valid input and throw when an invalid modifier is used',
          () => {
-           function tokenizeAttr(modifier: any /** TODO #9100 */) {
+           function tokenizeAttr(modifier: any /* TODO #9100 */) {
              var cssCode = 'value' + modifier + '=\'something\'';
              return tokenize(cssCode, false, CssLexerMode.ATTRIBUTE_SELECTOR);
            }
@@ -310,7 +310,7 @@ export function main() {
 
     describe('Media Query Mode', () => {
       it('should validate media queries with a reduced subset of valid characters', () => {
-        function tokenizeQuery(code: any /** TODO #9100 */) {
+        function tokenizeQuery(code: any /* TODO #9100 */) {
           return tokenize(code, false, CssLexerMode.MEDIA_QUERY);
         }
 
@@ -331,7 +331,7 @@ export function main() {
     describe('Pseudo Selector Mode', () => {
       it('should validate pseudo selector identifiers with a reduced subset of valid characters',
          () => {
-           function tokenizePseudo(code: any /** TODO #9100 */) {
+           function tokenizePseudo(code: any /* TODO #9100 */) {
              return tokenize(code, false, CssLexerMode.PSEUDO_SELECTOR);
            }
 
@@ -348,7 +348,7 @@ export function main() {
     describe('Pseudo Selector Mode', () => {
       it('should validate pseudo selector identifiers with a reduced subset of valid characters',
          () => {
-           function tokenizePseudo(code: any /** TODO #9100 */) {
+           function tokenizePseudo(code: any /* TODO #9100 */) {
              return tokenize(code, false, CssLexerMode.PSEUDO_SELECTOR);
            }
 
@@ -366,7 +366,7 @@ export function main() {
         'Style Block Mode', () => {
           it('should style blocks with a reduced subset of valid characters',
              () => {
-               function tokenizeStyles(code: any /** TODO #9100 */) {
+               function tokenizeStyles(code: any /* TODO #9100 */) {
                  return tokenize(code, false, CssLexerMode.STYLE_BLOCK);
                }
 

--- a/modules/@angular/compiler/test/css/parser_spec.ts
+++ b/modules/@angular/compiler/test/css/parser_spec.ts
@@ -4,7 +4,7 @@ import {afterEach, beforeEach, ddescribe, describe, expect, iit, it, xit} from '
 
 import {BaseException} from '../../src/facade/exceptions';
 
-export function assertTokens(tokens: any /** TODO #9100 */, valuesArr: any /** TODO #9100 */) {
+export function assertTokens(tokens: any /* TODO #9100 */, valuesArr: any /* TODO #9100 */) {
   for (var i = 0; i < tokens.length; i++) {
     expect(tokens[i].strValue == valuesArr[i]);
   }
@@ -12,14 +12,14 @@ export function assertTokens(tokens: any /** TODO #9100 */, valuesArr: any /** T
 
 export function main() {
   describe('CssParser', () => {
-    function parse(css: any /** TODO #9100 */): ParsedCssResult {
+    function parse(css: any /* TODO #9100 */): ParsedCssResult {
       var lexer = new CssLexer();
       var scanner = lexer.scan(css);
       var parser = new CssParser(scanner, 'some-fake-file-name.css');
       return parser.parse();
     }
 
-    function makeAST(css: any /** TODO #9100 */): CssStyleSheetAST {
+    function makeAST(css: any /* TODO #9100 */): CssStyleSheetAST {
       var output = parse(css);
       var errors = output.errors;
       if (errors.length > 0) {

--- a/modules/@angular/compiler/test/css/visitor_spec.ts
+++ b/modules/@angular/compiler/test/css/visitor_spec.ts
@@ -5,7 +5,7 @@ import {afterEach, beforeEach, ddescribe, describe, expect, iit, it, xit} from '
 import {BaseException} from '../../src/facade/exceptions';
 import {NumberWrapper, StringWrapper, isPresent} from '../../src/facade/lang';
 
-function _assertTokens(tokens: any /** TODO #9100 */, valuesArr: any /** TODO #9100 */) {
+function _assertTokens(tokens: any /* TODO #9100 */, valuesArr: any /* TODO #9100 */) {
   for (var i = 0; i < tokens.length; i++) {
     expect(tokens[i].strValue == valuesArr[i]);
   }
@@ -14,19 +14,18 @@ function _assertTokens(tokens: any /** TODO #9100 */, valuesArr: any /** TODO #9
 class MyVisitor implements CssASTVisitor {
   captures: {[key: string]: any[]} = {};
 
-  _capture(
-      method: any /** TODO #9100 */, ast: any /** TODO #9100 */, context: any /** TODO #9100 */) {
+  _capture(method: any /* TODO #9100 */, ast: any /* TODO #9100 */, context: any /* TODO #9100 */) {
     this.captures[method] = isPresent(this.captures[method]) ? this.captures[method] : [];
     this.captures[method].push([ast, context]);
   }
 
   constructor(ast: CssStyleSheetAST, context?: any) { ast.visit(this, context); }
 
-  visitCssValue(ast: any /** TODO #9100 */, context?: any): void {
+  visitCssValue(ast: any /* TODO #9100 */, context?: any): void {
     this._capture('visitCssValue', ast, context);
   }
 
-  visitInlineCssRule(ast: any /** TODO #9100 */, context?: any): void {
+  visitInlineCssRule(ast: any /* TODO #9100 */, context?: any): void {
     this._capture('visitInlineCssRule', ast, context);
   }
 
@@ -89,7 +88,7 @@ export function main() {
   }
 
   describe('CSS parsing and visiting', () => {
-    var ast: any /** TODO #9100 */;
+    var ast: any /* TODO #9100 */;
     var context = {};
 
     beforeEach(() => {

--- a/modules/@angular/compiler/test/directive_lifecycle_spec.ts
+++ b/modules/@angular/compiler/test/directive_lifecycle_spec.ts
@@ -104,7 +104,7 @@ export function main() {
 class DirectiveNoHooks {}
 
 class DirectiveWithOnChangesMethod {
-  ngOnChanges(_: any /** TODO #9100 */) {}
+  ngOnChanges(_: any /* TODO #9100 */) {}
 }
 
 class DirectiveWithOnInitMethod {

--- a/modules/@angular/compiler/test/directive_resolver_spec.ts
+++ b/modules/@angular/compiler/test/directive_resolver_spec.ts
@@ -12,22 +12,22 @@ class SomeChildDirective extends SomeDirective {
 
 @Directive({selector: 'someDirective', inputs: ['c']})
 class SomeDirectiveWithInputs {
-  @Input() a: any /** TODO #9100 */;
-  @Input('renamed') b: any /** TODO #9100 */;
-  c: any /** TODO #9100 */;
+  @Input() a: any /* TODO #9100 */;
+  @Input('renamed') b: any /* TODO #9100 */;
+  c: any /* TODO #9100 */;
 }
 
 @Directive({selector: 'someDirective', outputs: ['c']})
 class SomeDirectiveWithOutputs {
-  @Output() a: any /** TODO #9100 */;
-  @Output('renamed') b: any /** TODO #9100 */;
-  c: any /** TODO #9100 */;
+  @Output() a: any /* TODO #9100 */;
+  @Output('renamed') b: any /* TODO #9100 */;
+  c: any /* TODO #9100 */;
 }
 
 
 @Directive({selector: 'someDirective', outputs: ['a']})
 class SomeDirectiveWithDuplicateOutputs {
-  @Output() a: any /** TODO #9100 */;
+  @Output() a: any /* TODO #9100 */;
 }
 
 @Directive({selector: 'someDirective', properties: ['a']})
@@ -41,20 +41,20 @@ class SomeDirectiveWithEvents {
 @Directive({selector: 'someDirective'})
 class SomeDirectiveWithSetterProps {
   @Input('renamed')
-  set a(value: any /** TODO #9100 */) {}
+  set a(value: any /* TODO #9100 */) {}
 }
 
 @Directive({selector: 'someDirective'})
 class SomeDirectiveWithGetterOutputs {
   @Output('renamed')
-  get a(): any /** TODO #9100 */ { return null; }
+  get a(): any /* TODO #9100 */ { return null; }
 }
 
 @Directive({selector: 'someDirective', host: {'[c]': 'c'}})
 class SomeDirectiveWithHostBindings {
-  @HostBinding() a: any /** TODO #9100 */;
-  @HostBinding('renamed') b: any /** TODO #9100 */;
-  c: any /** TODO #9100 */;
+  @HostBinding() a: any /* TODO #9100 */;
+  @HostBinding('renamed') b: any /* TODO #9100 */;
+  c: any /* TODO #9100 */;
 }
 
 @Directive({selector: 'someDirective', host: {'(c)': 'onC()'}})
@@ -62,31 +62,31 @@ class SomeDirectiveWithHostListeners {
   @HostListener('a')
   onA() {}
   @HostListener('b', ['$event.value'])
-  onB(value: any /** TODO #9100 */) {}
+  onB(value: any /* TODO #9100 */) {}
 }
 
 @Directive({selector: 'someDirective', queries: {'cs': new ContentChildren('c')}})
 class SomeDirectiveWithContentChildren {
   @ContentChildren('a') as: any;
-  c: any /** TODO #9100 */;
+  c: any /* TODO #9100 */;
 }
 
 @Directive({selector: 'someDirective', queries: {'cs': new ViewChildren('c')}})
 class SomeDirectiveWithViewChildren {
   @ViewChildren('a') as: any;
-  c: any /** TODO #9100 */;
+  c: any /* TODO #9100 */;
 }
 
 @Directive({selector: 'someDirective', queries: {'c': new ContentChild('c')}})
 class SomeDirectiveWithContentChild {
   @ContentChild('a') a: any;
-  c: any /** TODO #9100 */;
+  c: any /* TODO #9100 */;
 }
 
 @Directive({selector: 'someDirective', queries: {'c': new ViewChild('c')}})
 class SomeDirectiveWithViewChild {
   @ViewChild('a') a: any;
-  c: any /** TODO #9100 */;
+  c: any /* TODO #9100 */;
 }
 
 class SomeDirectiveWithoutMetadata {}

--- a/modules/@angular/compiler/test/expression_parser/lexer_spec.ts
+++ b/modules/@angular/compiler/test/expression_parser/lexer_spec.ts
@@ -7,47 +7,47 @@ function lex(text: string): any[] {
   return new Lexer().tokenize(text);
 }
 
-function expectToken(token: any /** TODO #9100 */, index: any /** TODO #9100 */) {
+function expectToken(token: any /* TODO #9100 */, index: any /* TODO #9100 */) {
   expect(token instanceof Token).toBe(true);
   expect(token.index).toEqual(index);
 }
 
 function expectCharacterToken(
-    token: any /** TODO #9100 */, index: any /** TODO #9100 */, character: any /** TODO #9100 */) {
+    token: any /* TODO #9100 */, index: any /* TODO #9100 */, character: any /* TODO #9100 */) {
   expect(character.length).toBe(1);
   expectToken(token, index);
   expect(token.isCharacter(StringWrapper.charCodeAt(character, 0))).toBe(true);
 }
 
 function expectOperatorToken(
-    token: any /** TODO #9100 */, index: any /** TODO #9100 */, operator: any /** TODO #9100 */) {
+    token: any /* TODO #9100 */, index: any /* TODO #9100 */, operator: any /* TODO #9100 */) {
   expectToken(token, index);
   expect(token.isOperator(operator)).toBe(true);
 }
 
 function expectNumberToken(
-    token: any /** TODO #9100 */, index: any /** TODO #9100 */, n: any /** TODO #9100 */) {
+    token: any /* TODO #9100 */, index: any /* TODO #9100 */, n: any /* TODO #9100 */) {
   expectToken(token, index);
   expect(token.isNumber()).toBe(true);
   expect(token.toNumber()).toEqual(n);
 }
 
 function expectStringToken(
-    token: any /** TODO #9100 */, index: any /** TODO #9100 */, str: any /** TODO #9100 */) {
+    token: any /* TODO #9100 */, index: any /* TODO #9100 */, str: any /* TODO #9100 */) {
   expectToken(token, index);
   expect(token.isString()).toBe(true);
   expect(token.toString()).toEqual(str);
 }
 
 function expectIdentifierToken(
-    token: any /** TODO #9100 */, index: any /** TODO #9100 */, identifier: any /** TODO #9100 */) {
+    token: any /* TODO #9100 */, index: any /* TODO #9100 */, identifier: any /* TODO #9100 */) {
   expectToken(token, index);
   expect(token.isIdentifier()).toBe(true);
   expect(token.toString()).toEqual(identifier);
 }
 
 function expectKeywordToken(
-    token: any /** TODO #9100 */, index: any /** TODO #9100 */, keyword: any /** TODO #9100 */) {
+    token: any /* TODO #9100 */, index: any /* TODO #9100 */, keyword: any /* TODO #9100 */) {
   expectToken(token, index);
   expect(token.isKeyword()).toBe(true);
   expect(token.toString()).toEqual(keyword);

--- a/modules/@angular/compiler/test/expression_parser/parser_spec.ts
+++ b/modules/@angular/compiler/test/expression_parser/parser_spec.ts
@@ -10,26 +10,26 @@ import {Unparser} from './unparser';
 export function main() {
   function createParser() { return new Parser(new Lexer()); }
 
-  function parseAction(text: any /** TODO #9100 */, location: any /** TODO #9100 */ = null): any {
+  function parseAction(text: any /* TODO #9100 */, location: any /* TODO #9100 */ = null): any {
     return createParser().parseAction(text, location);
   }
 
-  function parseBinding(text: any /** TODO #9100 */, location: any /** TODO #9100 */ = null): any {
+  function parseBinding(text: any /* TODO #9100 */, location: any /* TODO #9100 */ = null): any {
     return createParser().parseBinding(text, location);
   }
 
   function parseTemplateBindings(
-      text: any /** TODO #9100 */, location: any /** TODO #9100 */ = null): any {
+      text: any /* TODO #9100 */, location: any /* TODO #9100 */ = null): any {
     return createParser().parseTemplateBindings(text, location).templateBindings;
   }
 
   function parseInterpolation(
-      text: any /** TODO #9100 */, location: any /** TODO #9100 */ = null): any {
+      text: any /* TODO #9100 */, location: any /* TODO #9100 */ = null): any {
     return createParser().parseInterpolation(text, location);
   }
 
   function parseSimpleBinding(
-      text: any /** TODO #9100 */, location: any /** TODO #9100 */ = null): any {
+      text: any /* TODO #9100 */, location: any /* TODO #9100 */ = null): any {
     return createParser().parseSimpleBinding(text, location);
   }
 
@@ -53,11 +53,9 @@ export function main() {
     expect(unparse(ast)).toEqual(expected);
   }
 
-  function expectActionError(text: any /** TODO #9100 */) {
-    return expect(() => parseAction(text));
-  }
+  function expectActionError(text: any /* TODO #9100 */) { return expect(() => parseAction(text)); }
 
-  function expectBindingError(text: any /** TODO #9100 */) {
+  function expectBindingError(text: any /* TODO #9100 */) {
     return expect(() => parseBinding(text));
   }
 

--- a/modules/@angular/compiler/test/output/output_emitter_spec.ts
+++ b/modules/@angular/compiler/test/output/output_emitter_spec.ts
@@ -14,7 +14,7 @@ import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {browserDetection} from '@angular/platform-browser/testing'
 
 export function main() {
-  var outputDefs: any[] /** TODO #9100 */ = []; outputDefs.push({
+  var outputDefs: any[] /* TODO #9100 */ = []; outputDefs.push({
     'getExpressions': () => interpretStatements(
                           codegenStmts, 'getExpressions', new DynamicClassInstanceFactory()),
     'name': 'interpreted'
@@ -38,7 +38,7 @@ export function main() {
       () => {
         outputDefs.forEach((outputDef) => {
           describe(`${outputDef['name']}`, () => {
-            var expressions: any /** TODO #9100 */;
+            var expressions: any /* TODO #9100 */;
             beforeEach(() => { expressions = outputDef['getExpressions']()(); });
 
             it('should support literals', () => {
@@ -113,8 +113,8 @@ export function main() {
             });
 
             describe('operators', () => {
-              var ops: any /** TODO #9100 */;
-              var aObj: any /** TODO #9100 */, bObj: any /** TODO #9100 */;
+              var ops: any /* TODO #9100 */;
+              var aObj: any /* TODO #9100 */, bObj: any /* TODO #9100 */;
               beforeEach(() => {
                 ops = expressions['operators'];
                 aObj = new Object();

--- a/modules/@angular/compiler/test/output/output_emitter_util.ts
+++ b/modules/@angular/compiler/test/output/output_emitter_util.ts
@@ -10,7 +10,7 @@ import {BaseException} from '../../src/facade/exceptions';
 export class ExternalClass {
   changeable: any;
   constructor(public data: any) { this.changeable = data; }
-  someMethod(a: any /** TODO #9100 */) { return {'param': a, 'data': this.data}; }
+  someMethod(a: any /* TODO #9100 */) { return {'param': a, 'data': this.data}; }
 }
 
 var testDataIdentifier = new CompileIdentifierMetadata({
@@ -262,5 +262,5 @@ class _InterpretiveDynamicClass extends ExternalClass implements DynamicInstance
       public getters: Map<string, Function>, public methods: Map<string, Function>) {
     super(args[0]);
   }
-  childMethod(a: any /** TODO #9100 */) { return this.methods.get('childMethod')(a); }
+  childMethod(a: any /* TODO #9100 */) { return this.methods.get('childMethod')(a); }
 }

--- a/modules/@angular/compiler/test/selector_spec.ts
+++ b/modules/@angular/compiler/test/selector_spec.ts
@@ -6,9 +6,9 @@ import {el} from '@angular/platform-browser/testing';
 
 export function main() {
   describe('SelectorMatcher', () => {
-    var matcher: any /** TODO #9100 */, selectableCollector: any /** TODO #9100 */,
-        s1: any /** TODO #9100 */, s2: any /** TODO #9100 */, s3: any /** TODO #9100 */,
-        s4: any /** TODO #9100 */;
+    var matcher: any /* TODO #9100 */, selectableCollector: any /* TODO #9100 */,
+        s1: any /* TODO #9100 */, s2: any /* TODO #9100 */, s3: any /* TODO #9100 */,
+        s4: any /* TODO #9100 */;
     var matched: any[];
 
     function reset() { matched = []; }
@@ -16,7 +16,7 @@ export function main() {
     beforeEach(() => {
       reset();
       s1 = s2 = s3 = s4 = null;
-      selectableCollector = (selector: any /** TODO #9100 */, context: any /** TODO #9100 */) => {
+      selectableCollector = (selector: any /* TODO #9100 */, context: any /* TODO #9100 */) => {
         matched.push(selector);
         matched.push(context);
       };

--- a/modules/@angular/compiler/test/shadow_css_spec.ts
+++ b/modules/@angular/compiler/test/shadow_css_spec.ts
@@ -180,8 +180,8 @@ export function main() {
   describe('processRules', () => {
     describe('parse rules', () => {
       function captureRules(input: string): CssRule[] {
-        var result: any[] /** TODO #9100 */ = [];
-        processRules(input, (cssRule: any /** TODO #9100 */) => {
+        var result: any[] /* TODO #9100 */ = [];
+        processRules(input, (cssRule: any /* TODO #9100 */) => {
           result.push(cssRule);
           return cssRule;
         });
@@ -212,14 +212,14 @@ export function main() {
     describe('modify rules', () => {
       it('should allow to change the selector while preserving whitespaces', () => {
         expect(processRules(
-                   '@import a; b {c {d}} e {f}', (cssRule: any /** TODO #9100 */) => new CssRule(
+                   '@import a; b {c {d}} e {f}', (cssRule: any /* TODO #9100 */) => new CssRule(
                                                      cssRule.selector + '2', cssRule.content)))
             .toEqual('@import a2; b2 {c {d}} e2 {f}');
       });
 
       it('should allow to change the content', () => {
         expect(processRules(
-                   'a {b}', (cssRule: any /** TODO #9100 */) =>
+                   'a {b}', (cssRule: any /* TODO #9100 */) =>
                                 new CssRule(cssRule.selector, cssRule.content + '2')))
             .toEqual('a {b2}');
       });

--- a/modules/@angular/compiler/test/style_url_resolver_spec.ts
+++ b/modules/@angular/compiler/test/style_url_resolver_spec.ts
@@ -4,7 +4,7 @@ import {beforeEach, ddescribe, describe, expect, iit, it, xit} from '@angular/co
 
 export function main() {
   describe('extractStyleUrls', () => {
-    var urlResolver: any /** TODO #9100 */;
+    var urlResolver: any /* TODO #9100 */;
 
     beforeEach(() => { urlResolver = new UrlResolver(); });
 

--- a/modules/@angular/compiler/test/template_parser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser_spec.ts
@@ -25,7 +25,7 @@ var MOCK_SCHEMA_REGISTRY = [{
 let zeConsole = console;
 
 export function main() {
-  var ngIf: any /** TODO #9100 */;
+  var ngIf: any /* TODO #9100 */;
   var parse:
       (template: string, directives: CompileDirectiveMetadata[], pipes?: CompilePipeMetadata[]) =>
           TemplateAst[];
@@ -441,10 +441,10 @@ export function main() {
       });
 
       describe('providers', () => {
-        var nextProviderId: any /** TODO #9100 */;
+        var nextProviderId: any /* TODO #9100 */;
 
         function createToken(value: string): CompileTokenMetadata {
-          var token: any /** TODO #9100 */;
+          var token: any /* TODO #9100 */;
           if (value.startsWith('type:')) {
             token = new CompileTokenMetadata({
               identifier:
@@ -970,7 +970,7 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
     });
 
     describe('content projection', () => {
-      var compCounter: any /** TODO #9100 */;
+      var compCounter: any /* TODO #9100 */;
       beforeEach(() => { compCounter = 0; });
 
       function createComp(

--- a/modules/@angular/compiler/test/template_preparser_spec.ts
+++ b/modules/@angular/compiler/test/template_preparser_spec.ts
@@ -4,7 +4,7 @@ import {afterEach, beforeEach, beforeEachProviders, ddescribe, describe, expect,
 
 export function main() {
   describe('preparseElement', () => {
-    var htmlParser: any /** TODO #9100 */;
+    var htmlParser: any /* TODO #9100 */;
     beforeEach(inject([HtmlParser], (_htmlParser: HtmlParser) => { htmlParser = _htmlParser; }));
 
     function preparse(html: string): PreparsedElement {

--- a/modules/@angular/compiler/test/xhr_mock_spec.ts
+++ b/modules/@angular/compiler/test/xhr_mock_spec.ts
@@ -12,7 +12,7 @@ export function main() {
 
     function expectResponse(
         request: Promise<string>, url: string, response: string,
-        done: any /** TODO #9100 */ = null) {
+        done: any /* TODO #9100 */ = null) {
       function onResponse(text: string): string {
         if (response === null) {
           throw `Unexpected response ${url} -> ${text}`;
@@ -48,7 +48,7 @@ export function main() {
     it('should return an error from the definitions',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          var url = '/foo';
-         var response: any /** TODO #9100 */ = null;
+         var response: any /* TODO #9100 */ = null;
          xhr.when(url, response);
          expectResponse(xhr.get(url), url, response, () => async.done());
          xhr.flush();
@@ -66,7 +66,7 @@ export function main() {
     it('should return an error from the expectations',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          var url = '/foo';
-         var response: any /** TODO #9100 */ = null;
+         var response: any /* TODO #9100 */ = null;
          xhr.expect(url, response);
          expectResponse(xhr.get(url), url, response, () => async.done());
          xhr.flush();

--- a/modules/@angular/compiler/testing/test_component_builder.ts
+++ b/modules/@angular/compiler/testing/test_component_builder.ts
@@ -60,10 +60,10 @@ export class ComponentFixture<T> {
 
   private _isStable: boolean = true;
   private _completer: PromiseCompleter<any> = null;
-  private _onUnstableSubscription: any /** TODO #9100 */ = null;
-  private _onStableSubscription: any /** TODO #9100 */ = null;
-  private _onMicrotaskEmptySubscription: any /** TODO #9100 */ = null;
-  private _onErrorSubscription: any /** TODO #9100 */ = null;
+  private _onUnstableSubscription: any /* TODO #9100 */ = null;
+  private _onStableSubscription: any /* TODO #9100 */ = null;
+  private _onMicrotaskEmptySubscription: any /* TODO #9100 */ = null;
+  private _onErrorSubscription: any /* TODO #9100 */ = null;
 
   constructor(componentRef: ComponentRef<T>, ngZone: NgZone, autoDetect: boolean) {
     this.changeDetectorRef = componentRef.changeDetectorRef;
@@ -354,8 +354,8 @@ export class TestComponentBuilder {
   }
 
   createFakeAsync(rootComponentType: Type): ComponentFixture<any> {
-    let result: any /** TODO #9100 */;
-    let error: any /** TODO #9100 */;
+    let result: any /* TODO #9100 */;
+    let error: any /* TODO #9100 */;
     PromiseWrapper.then(
         this.createAsync(rootComponentType), (_result) => { result = _result; },
         (_error) => { error = _error; });

--- a/modules/@angular/compiler/testing/view_resolver_mock.ts
+++ b/modules/@angular/compiler/testing/view_resolver_mock.ts
@@ -72,7 +72,7 @@ export class MockViewResolver extends ViewResolver {
       view = super.resolve(component);
     }
 
-    var directives: any[] /** TODO #9100 */ = [];
+    var directives: any[] /* TODO #9100 */ = [];
     if (isPresent(view.directives)) {
       flattenArray(view.directives, directives);
     }

--- a/modules/@angular/compiler/testing/xhr_mock.ts
+++ b/modules/@angular/compiler/testing/xhr_mock.ts
@@ -63,7 +63,7 @@ export class MockXHR extends XHR {
   verifyNoOutstandingExpectations() {
     if (this._expectations.length === 0) return;
 
-    var urls: any[] /** TODO #9100 */ = [];
+    var urls: any[] /* TODO #9100 */ = [];
     for (var i = 0; i < this._expectations.length; i++) {
       var expectation = this._expectations[i];
       urls.push(expectation.url);

--- a/modules/@angular/core/src/animation/active_animation_players_map.ts
+++ b/modules/@angular/core/src/animation/active_animation_players_map.ts
@@ -17,9 +17,9 @@ export class ActiveAnimationPlayersMap {
   }
 
   findAllPlayersByElement(element: any): AnimationPlayer[] {
-    var players: any[] /** TODO #9100 */ = [];
+    var players: any[] /* TODO #9100 */ = [];
     StringMapWrapper.forEach(
-        this._map.get(element), (player: any /** TODO #9100 */) => players.push(player));
+        this._map.get(element), (player: any /* TODO #9100 */) => players.push(player));
     return players;
   }
 

--- a/modules/@angular/core/src/animation/animation_group_player.ts
+++ b/modules/@angular/core/src/animation/animation_group_player.ts
@@ -56,7 +56,7 @@ export class AnimationGroupPlayer implements AnimationPlayer {
 
   reset(): void { this._players.forEach(player => player.reset()); }
 
-  setPosition(p: any /** TODO #9100 */): void {
+  setPosition(p: any /* TODO #9100 */): void {
     this._players.forEach(player => { player.setPosition(p); });
   }
 

--- a/modules/@angular/core/src/animation/animation_player.ts
+++ b/modules/@angular/core/src/animation/animation_player.ts
@@ -9,7 +9,7 @@ export abstract class AnimationPlayer {
   abstract finish(): void;
   abstract destroy(): void;
   abstract reset(): void;
-  abstract setPosition(p: any /** TODO #9100 */): void;
+  abstract setPosition(p: any /* TODO #9100 */): void;
   abstract getPosition(): number;
   get parentPlayer(): AnimationPlayer { throw new BaseException('NOT IMPLEMENTED: Base Class'); }
   set parentPlayer(player: AnimationPlayer) {
@@ -18,7 +18,7 @@ export abstract class AnimationPlayer {
 }
 
 export class NoOpAnimationPlayer implements AnimationPlayer {
-  private _subscriptions: any[] /** TODO #9100 */ = [];
+  private _subscriptions: any[] /* TODO #9100 */ = [];
   public parentPlayer: AnimationPlayer = null;
   constructor() { scheduleMicroTask(() => this._onFinish()); }
   /** @internal */
@@ -33,6 +33,6 @@ export class NoOpAnimationPlayer implements AnimationPlayer {
   finish(): void { this._onFinish(); }
   destroy(): void {}
   reset(): void {}
-  setPosition(p: any /** TODO #9100 */): void {}
+  setPosition(p: any /* TODO #9100 */): void {}
   getPosition(): number { return 0; }
 }

--- a/modules/@angular/core/src/animation/animation_sequence_player.ts
+++ b/modules/@angular/core/src/animation/animation_sequence_player.ts
@@ -71,7 +71,7 @@ export class AnimationSequencePlayer implements AnimationPlayer {
     this._players.forEach(player => player.destroy());
   }
 
-  setPosition(p: any /** TODO #9100 */): void { this._players[0].setPosition(p); }
+  setPosition(p: any /* TODO #9100 */): void { this._players[0].setPosition(p); }
 
   getPosition(): number { return this._players[0].getPosition(); }
 }

--- a/modules/@angular/core/src/animation/metadata.ts
+++ b/modules/@angular/core/src/animation/metadata.ts
@@ -294,7 +294,7 @@ export function style(
       input = [<{[key: string]: string | number}>tokens];
     }
     input.forEach(entry => {
-      var entryOffset = (entry as any /** TODO #9100 */)['offset'];
+      var entryOffset = (entry as any /* TODO #9100 */)['offset'];
       if (isPresent(entryOffset)) {
         offset = offset == null ? NumberWrapper.parseFloat(entryOffset) : offset;
       }

--- a/modules/@angular/core/src/application_ref.ts
+++ b/modules/@angular/core/src/application_ref.ts
@@ -285,8 +285,8 @@ export class ApplicationRef_ extends ApplicationRef {
     zone.run(() => { this._exceptionHandler = _injector.get(ExceptionHandler); });
     this._asyncInitDonePromise = this.run(() => {
       let inits: Function[] = _injector.get(APP_INITIALIZER, null);
-      var asyncInitResults: any[] /** TODO #9100 */ = [];
-      var asyncInitDonePromise: any /** TODO #9100 */;
+      var asyncInitResults: any[] /* TODO #9100 */ = [];
+      var asyncInitDonePromise: any /* TODO #9100 */;
       if (isPresent(inits)) {
         for (var i = 0; i < inits.length; i++) {
           var initResult = inits[i]();
@@ -330,7 +330,7 @@ export class ApplicationRef_ extends ApplicationRef {
 
   run(callback: Function): any {
     var zone = this.injector.get(NgZone);
-    var result: any /** TODO #9100 */;
+    var result: any /* TODO #9100 */;
     // Note: Don't use zone.runGuarded as we want to know about
     // the thrown exception!
     // Note: the completer needs to be created outside

--- a/modules/@angular/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/modules/@angular/core/src/change_detection/differs/default_iterable_differ.ts
@@ -22,7 +22,7 @@ var trackByIdentity = (index: number, item: any) => item;
  */
 export class DefaultIterableDiffer implements IterableDiffer {
   private _length: number = null;
-  private _collection: any /** TODO #9100 */ = null;
+  private _collection: any /* TODO #9100 */ = null;
   // Keeps track of the used records at any point in time (during & across `_check()` calls)
   private _linkedRecords: _DuplicateMap = null;
   // Keeps track of the removed records at any point in time during `_check()` calls.
@@ -112,8 +112,8 @@ export class DefaultIterableDiffer implements IterableDiffer {
     var record: CollectionChangeRecord = this._itHead;
     var mayBeDirty: boolean = false;
     var index: number;
-    var item: any /** TODO #9100 */;
-    var itemTrackBy: any /** TODO #9100 */;
+    var item: any /* TODO #9100 */;
+    var itemTrackBy: any /* TODO #9100 */;
     if (isArray(collection)) {
       var list = collection;
       this._length = collection.length;
@@ -136,7 +136,7 @@ export class DefaultIterableDiffer implements IterableDiffer {
       }
     } else {
       index = 0;
-      iterateListLike(collection, (item: any /** TODO #9100 */) => {
+      iterateListLike(collection, (item: any /* TODO #9100 */) => {
         itemTrackBy = this._trackByFn(index, item);
         if (record === null || !looseIdentical(record.trackById, itemTrackBy)) {
           record = this._mismatch(record, item, itemTrackBy, index);
@@ -503,23 +503,23 @@ export class DefaultIterableDiffer implements IterableDiffer {
 
 
   toString(): string {
-    var list: any[] /** TODO #9100 */ = [];
-    this.forEachItem((record: any /** TODO #9100 */) => list.push(record));
+    var list: any[] /* TODO #9100 */ = [];
+    this.forEachItem((record: any /* TODO #9100 */) => list.push(record));
 
-    var previous: any[] /** TODO #9100 */ = [];
-    this.forEachPreviousItem((record: any /** TODO #9100 */) => previous.push(record));
+    var previous: any[] /* TODO #9100 */ = [];
+    this.forEachPreviousItem((record: any /* TODO #9100 */) => previous.push(record));
 
-    var additions: any[] /** TODO #9100 */ = [];
-    this.forEachAddedItem((record: any /** TODO #9100 */) => additions.push(record));
+    var additions: any[] /* TODO #9100 */ = [];
+    this.forEachAddedItem((record: any /* TODO #9100 */) => additions.push(record));
 
-    var moves: any[] /** TODO #9100 */ = [];
-    this.forEachMovedItem((record: any /** TODO #9100 */) => moves.push(record));
+    var moves: any[] /* TODO #9100 */ = [];
+    this.forEachMovedItem((record: any /* TODO #9100 */) => moves.push(record));
 
-    var removals: any[] /** TODO #9100 */ = [];
-    this.forEachRemovedItem((record: any /** TODO #9100 */) => removals.push(record));
+    var removals: any[] /* TODO #9100 */ = [];
+    this.forEachRemovedItem((record: any /* TODO #9100 */) => removals.push(record));
 
-    var identityChanges: any[] /** TODO #9100 */ = [];
-    this.forEachIdentityChange((record: any /** TODO #9100 */) => identityChanges.push(record));
+    var identityChanges: any[] /* TODO #9100 */ = [];
+    this.forEachIdentityChange((record: any /* TODO #9100 */) => identityChanges.push(record));
 
     return 'collection: ' + list.join(', ') + '\n' +
         'previous: ' + previous.join(', ') + '\n' +

--- a/modules/@angular/core/src/change_detection/differs/default_keyvalue_differ.ts
+++ b/modules/@angular/core/src/change_detection/differs/default_keyvalue_differ.ts
@@ -88,8 +88,8 @@ export class DefaultKeyValueDiffer implements KeyValueDiffer {
     var lastNewSeqRecord: KeyValueChangeRecord = null;
     var seqChanged: boolean = false;
 
-    this._forEach(map, (value: any /** TODO #9100 */, key: any /** TODO #9100 */) => {
-      var newSeqRecord: any /** TODO #9100 */;
+    this._forEach(map, (value: any /* TODO #9100 */, key: any /* TODO #9100 */) => {
+      var newSeqRecord: any /* TODO #9100 */;
       if (oldSeqRecord !== null && key === oldSeqRecord.key) {
         newSeqRecord = oldSeqRecord;
         if (!looseIdentical(value, oldSeqRecord.currentValue)) {
@@ -298,11 +298,11 @@ export class DefaultKeyValueDiffer implements KeyValueDiffer {
   }
 
   toString(): string {
-    var items: any[] /** TODO #9100 */ = [];
-    var previous: any[] /** TODO #9100 */ = [];
-    var changes: any[] /** TODO #9100 */ = [];
-    var additions: any[] /** TODO #9100 */ = [];
-    var removals: any[] /** TODO #9100 */ = [];
+    var items: any[] /* TODO #9100 */ = [];
+    var previous: any[] /* TODO #9100 */ = [];
+    var changes: any[] /* TODO #9100 */ = [];
+    var additions: any[] /* TODO #9100 */ = [];
+    var removals: any[] /* TODO #9100 */ = [];
     var record: KeyValueChangeRecord;
 
     for (record = this._mapHead; record !== null; record = record._next) {
@@ -329,7 +329,7 @@ export class DefaultKeyValueDiffer implements KeyValueDiffer {
   }
 
   /** @internal */
-  _forEach(obj: any /** TODO #9100 */, fn: Function) {
+  _forEach(obj: any /* TODO #9100 */, fn: Function) {
     if (obj instanceof Map) {
       (<Map<any, any>>obj).forEach(<any>fn);
     } else {

--- a/modules/@angular/core/src/change_detection/differs/iterable_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/iterable_differs.ts
@@ -13,7 +13,7 @@ import {ChangeDetectorRef} from '../change_detector_ref';
  */
 export interface IterableDiffer {
   diff(object: any): any;
-  onDestroy(): any /** TODO #9100 */;
+  onDestroy(): any /* TODO #9100 */;
 }
 
 /**

--- a/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
@@ -9,8 +9,8 @@ import {ChangeDetectorRef} from '../change_detector_ref';
  * A differ that tracks changes made to an object over time.
  */
 export interface KeyValueDiffer {
-  diff(object: any): any /** TODO #9100 */;
-  onDestroy(): any /** TODO #9100 */;
+  diff(object: any): any /* TODO #9100 */;
+  onDestroy(): any /* TODO #9100 */;
 }
 
 /**

--- a/modules/@angular/core/src/di/metadata.ts
+++ b/modules/@angular/core/src/di/metadata.ts
@@ -43,7 +43,7 @@ import {stringify} from '../facade/lang';
  * @stable
  */
 export class InjectMetadata {
-  constructor(public token: any /** TODO #9100 */) {}
+  constructor(public token: any /* TODO #9100 */) {}
   toString(): string { return `@Inject(${stringify(this.token)})`; }
 }
 
@@ -81,7 +81,7 @@ export class OptionalMetadata {
  * @stable
  */
 export class DependencyMetadata {
-  get token(): any /** TODO #9100 */ { return null; }
+  get token(): any /* TODO #9100 */ { return null; }
 }
 
 /**

--- a/modules/@angular/core/src/di/provider.ts
+++ b/modules/@angular/core/src/di/provider.ts
@@ -23,7 +23,7 @@ export class Provider {
   /**
    * Token used when retrieving this provider. Usually, it is a type {@link Type}.
    */
-  token: any /** TODO #9100 */;
+  token: any /* TODO #9100 */;
 
   /**
    * Binds a DI token to an implementation class.
@@ -69,7 +69,7 @@ export class Provider {
    * expect(injector.get("message")).toEqual('Hello');
    * ```
    */
-  useValue: any /** TODO #9100 */;
+  useValue: any /* TODO #9100 */;
 
   /**
    * Binds a DI token to an existing token.
@@ -103,7 +103,7 @@ export class Provider {
    * expect(injectorClass.get(Vehicle) instanceof Car).toBe(true);
    * ```
    */
-  useExisting: any /** TODO #9100 */;
+  useExisting: any /* TODO #9100 */;
 
   /**
    * Binds a DI token to a function which computes the value.
@@ -150,7 +150,7 @@ export class Provider {
   _multi: boolean;
 
   constructor(
-      token: any /** TODO #9100 */, {useClass, useValue, useExisting, useFactory, deps, multi}: {
+      token: any /* TODO #9100 */, {useClass, useValue, useExisting, useFactory, deps, multi}: {
         useClass?: Type,
         useValue?: any,
         useExisting?: any,
@@ -207,7 +207,7 @@ export class Provider {
  * @ts2dart_const
  */
 export class Binding extends Provider {
-  constructor(token: any /** TODO #9100 */, {toClass, toValue, toAlias, toFactory, deps, multi}: {
+  constructor(token: any /* TODO #9100 */, {toClass, toValue, toAlias, toFactory, deps, multi}: {
     toClass?: Type,
     toValue?: any,
     toAlias?: any,
@@ -256,7 +256,7 @@ export class Binding extends Provider {
  *
  * @deprecated
  */
-export function bind(token: any /** TODO #9100 */): ProviderBuilder {
+export function bind(token: any /* TODO #9100 */): ProviderBuilder {
   return new ProviderBuilder(token);
 }
 
@@ -265,7 +265,7 @@ export function bind(token: any /** TODO #9100 */): ProviderBuilder {
  * @deprecated
  */
 export class ProviderBuilder {
-  constructor(public token: any /** TODO #9100 */) {}
+  constructor(public token: any /* TODO #9100 */) {}
 
   /**
    * Binds a DI token to a class.
@@ -391,7 +391,7 @@ export class ProviderBuilder {
  * @deprecated
  */
 export function provide(
-    token: any /** TODO #9100 */, {useClass, useValue, useExisting, useFactory, deps, multi}: {
+    token: any /* TODO #9100 */, {useClass, useValue, useExisting, useFactory, deps, multi}: {
       useClass?: Type,
       useValue?: any,
       useExisting?: any,

--- a/modules/@angular/core/src/di/reflective_exceptions.ts
+++ b/modules/@angular/core/src/di/reflective_exceptions.ts
@@ -6,7 +6,7 @@ import {ReflectiveInjector} from './reflective_injector';
 import {ReflectiveKey} from './reflective_key';
 
 function findFirstClosedCycle(keys: any[]): any[] {
-  var res: any[] /** TODO #9100 */ = [];
+  var res: any[] /* TODO #9100 */ = [];
   for (var i = 0; i < keys.length; ++i) {
     if (ListWrapper.contains(res, keys[i])) {
       res.push(keys[i]);
@@ -148,8 +148,8 @@ export class InstantiationError extends WrappedException {
   injectors: ReflectiveInjector[];
 
   constructor(
-      injector: ReflectiveInjector, originalException: any /** TODO #9100 */,
-      originalStack: any /** TODO #9100 */, key: ReflectiveKey) {
+      injector: ReflectiveInjector, originalException: any /* TODO #9100 */,
+      originalStack: any /* TODO #9100 */, key: ReflectiveKey) {
     super('DI Exception', originalException, originalStack, null);
     this.keys = [key];
     this.injectors = [injector];
@@ -182,7 +182,7 @@ export class InstantiationError extends WrappedException {
  * @stable
  */
 export class InvalidProviderError extends BaseException {
-  constructor(provider: any /** TODO #9100 */) {
+  constructor(provider: any /* TODO #9100 */) {
     super(`Invalid provider - only instances of Provider and Type are allowed, got: ${provider}`);
   }
 }
@@ -217,12 +217,12 @@ export class InvalidProviderError extends BaseException {
  * @stable
  */
 export class NoAnnotationError extends BaseException {
-  constructor(typeOrFunc: any /** TODO #9100 */, params: any[][]) {
+  constructor(typeOrFunc: any /* TODO #9100 */, params: any[][]) {
     super(NoAnnotationError._genMessage(typeOrFunc, params));
   }
 
-  private static _genMessage(typeOrFunc: any /** TODO #9100 */, params: any[][]) {
-    var signature: any[] /** TODO #9100 */ = [];
+  private static _genMessage(typeOrFunc: any /* TODO #9100 */, params: any[][]) {
+    var signature: any[] /* TODO #9100 */ = [];
     for (var i = 0, ii = params.length; i < ii; i++) {
       var parameter = params[i];
       if (isBlank(parameter) || parameter.length == 0) {
@@ -253,7 +253,7 @@ export class NoAnnotationError extends BaseException {
  * @stable
  */
 export class OutOfBoundsError extends BaseException {
-  constructor(index: any /** TODO #9100 */) { super(`Index ${index} is out-of-bounds.`); }
+  constructor(index: any /* TODO #9100 */) { super(`Index ${index} is out-of-bounds.`); }
 }
 
 // TODO: add a working example after alpha38 is released
@@ -270,7 +270,7 @@ export class OutOfBoundsError extends BaseException {
  * ```
  */
 export class MixingMultiProvidersWithRegularProvidersError extends BaseException {
-  constructor(provider1: any /** TODO #9100 */, provider2: any /** TODO #9100 */) {
+  constructor(provider1: any /* TODO #9100 */, provider2: any /* TODO #9100 */) {
     super(
         'Cannot mix multi providers and regular providers, got: ' + provider1.toString() + ' ' +
         provider2.toString());

--- a/modules/@angular/core/src/di/reflective_injector.ts
+++ b/modules/@angular/core/src/di/reflective_injector.ts
@@ -729,7 +729,7 @@ export class ReflectiveInjector_ implements ReflectiveInjector {
       throw e;
     }
 
-    var obj: any /** TODO #9100 */;
+    var obj: any /* TODO #9100 */;
     try {
       switch (length) {
         case 0:
@@ -882,7 +882,7 @@ export class ReflectiveInjector_ implements ReflectiveInjector {
 var INJECTOR_KEY = ReflectiveKey.get(Injector);
 
 function _mapProviders(injector: ReflectiveInjector_, fn: Function): any[] {
-  var res: any[] /** TODO #9100 */ = [];
+  var res: any[] /* TODO #9100 */ = [];
   for (var i = 0; i < injector._proto.numberOfProviders; ++i) {
     res.push(fn(injector._proto.getProviderAtIndex(i)));
   }

--- a/modules/@angular/core/src/di/reflective_provider.ts
+++ b/modules/@angular/core/src/di/reflective_provider.ts
@@ -22,7 +22,7 @@ export class ReflectiveDependency {
   }
 }
 
-const _EMPTY_LIST: any[] /** TODO #9100 */ = /*@ts2dart_const*/[];
+const _EMPTY_LIST: any[] /* TODO #9100 */ = /*@ts2dart_const*/[];
 
 /**
  * An internal resolved representation of a {@link Provider} used by the {@link Injector}.
@@ -95,13 +95,13 @@ export class ResolvedReflectiveFactory {
  */
 export function resolveReflectiveFactory(provider: Provider): ResolvedReflectiveFactory {
   var factoryFn: Function;
-  var resolvedDeps: any /** TODO #9100 */;
+  var resolvedDeps: any /* TODO #9100 */;
   if (isPresent(provider.useClass)) {
     var useClass = resolveForwardRef(provider.useClass);
     factoryFn = reflector.factory(useClass);
     resolvedDeps = _dependenciesFor(useClass);
   } else if (isPresent(provider.useExisting)) {
-    factoryFn = (aliasInstance: any /** TODO #9100 */) => aliasInstance;
+    factoryFn = (aliasInstance: any /* TODO #9100 */) => aliasInstance;
     resolvedDeps = [ReflectiveDependency.fromKey(ReflectiveKey.get(provider.useExisting))];
   } else if (isPresent(provider.useFactory)) {
     factoryFn = provider.useFactory;
@@ -159,7 +159,7 @@ export function mergeResolvedReflectiveProviders(
         normalizedProvidersMap.set(provider.key.id, provider);
       }
     } else {
-      var resolvedProvider: any /** TODO #9100 */;
+      var resolvedProvider: any /* TODO #9100 */;
       if (provider.multiProvider) {
         resolvedProvider = new ResolvedReflectiveProvider_(
             provider.key, ListWrapper.clone(provider.resolvedFactories), provider.multiProvider);
@@ -219,10 +219,10 @@ function _dependenciesFor(typeOrFunc: any): ReflectiveDependency[] {
 }
 
 function _extractToken(
-    typeOrFunc: any /** TODO #9100 */, metadata: any /** TODO #9100 */ /*any[] | any*/,
+    typeOrFunc: any /* TODO #9100 */, metadata: any /* TODO #9100 */ /*any[] | any*/,
     params: any[][]): ReflectiveDependency {
-  var depProps: any[] /** TODO #9100 */ = [];
-  var token: any /** TODO #9100 */ = null;
+  var depProps: any[] /* TODO #9100 */ = [];
+  var token: any /* TODO #9100 */ = null;
   var optional = false;
 
   if (!isArray(metadata)) {
@@ -233,8 +233,8 @@ function _extractToken(
     }
   }
 
-  var lowerBoundVisibility: any /** TODO #9100 */ = null;
-  var upperBoundVisibility: any /** TODO #9100 */ = null;
+  var lowerBoundVisibility: any /* TODO #9100 */ = null;
+  var upperBoundVisibility: any /* TODO #9100 */ = null;
 
   for (var i = 0; i < metadata.length; ++i) {
     var paramMetadata = metadata[i];
@@ -275,9 +275,9 @@ function _extractToken(
 }
 
 function _createDependency(
-    token: any /** TODO #9100 */, optional: any /** TODO #9100 */,
-    lowerBoundVisibility: any /** TODO #9100 */, upperBoundVisibility: any /** TODO #9100 */,
-    depProps: any /** TODO #9100 */): ReflectiveDependency {
+    token: any /* TODO #9100 */, optional: any /* TODO #9100 */,
+    lowerBoundVisibility: any /* TODO #9100 */, upperBoundVisibility: any /* TODO #9100 */,
+    depProps: any /* TODO #9100 */): ReflectiveDependency {
   return new ReflectiveDependency(
       ReflectiveKey.get(token), optional, lowerBoundVisibility, upperBoundVisibility, depProps);
 }

--- a/modules/@angular/core/src/linker/debug_context.ts
+++ b/modules/@angular/core/src/linker/debug_context.ts
@@ -62,8 +62,8 @@ export class DebugContext implements RenderDebugInfo {
     if (isPresent(staticNodeInfo)) {
       var refs = staticNodeInfo.refTokens;
       StringMapWrapper.forEach(
-          refs, (refToken: any /** TODO #9100 */, refName: any /** TODO #9100 */) => {
-            var varValue: any /** TODO #9100 */;
+          refs, (refToken: any /* TODO #9100 */, refName: any /* TODO #9100 */) => {
+            var varValue: any /* TODO #9100 */;
             if (isBlank(refToken)) {
               varValue =
                   isPresent(this._view.allNodes) ? this._view.allNodes[this._nodeIndex] : null;

--- a/modules/@angular/core/src/linker/element.ts
+++ b/modules/@angular/core/src/linker/element.ts
@@ -41,7 +41,7 @@ export class AppElement {
   get injector(): Injector { return this.parentView.injector(this.index); }
 
   mapNestedViews(nestedViewClass: any, callback: Function): any[] {
-    var result: any[] /** TODO #9100 */ = [];
+    var result: any[] /* TODO #9100 */ = [];
     if (isPresent(this.nestedViews)) {
       this.nestedViews.forEach((nestedView) => {
         if (nestedView.clazz === nestedViewClass) {
@@ -63,7 +63,7 @@ export class AppElement {
       this.nestedViews = nestedViews;
     }
     ListWrapper.insert(nestedViews, viewIndex, view);
-    var refRenderNode: any /** TODO #9100 */;
+    var refRenderNode: any /* TODO #9100 */;
     if (viewIndex > 0) {
       var prevView = nestedViews[viewIndex - 1];
       refRenderNode = prevView.lastRootNode;

--- a/modules/@angular/core/src/linker/view.ts
+++ b/modules/@angular/core/src/linker/view.ts
@@ -88,7 +88,7 @@ export abstract class AppView<T> {
   create(context: T, givenProjectableNodes: Array<any|any[]>, rootSelectorOrNode: string|any):
       AppElement {
     this.context = context;
-    var projectableNodes: any /** TODO #9100 */;
+    var projectableNodes: any /* TODO #9100 */;
     switch (this.type) {
       case ViewType.COMPONENT:
         projectableNodes = ensureSlotCount(givenProjectableNodes, this.componentType.slotCount);
@@ -130,7 +130,7 @@ export abstract class AppView<T> {
 
   selectOrCreateHostElement(
       elementName: string, rootSelectorOrNode: string|any, debugInfo: RenderDebugInfo): any {
-    var hostElement: any /** TODO #9100 */;
+    var hostElement: any /* TODO #9100 */;
     if (isPresent(rootSelectorOrNode)) {
       hostElement = this.renderer.selectRootElement(rootSelectorOrNode, debugInfo);
     } else {
@@ -395,7 +395,7 @@ export class DebugAppView<T> extends AppView<T> {
 
   eventHandler(cb: Function): Function {
     var superHandler = super.eventHandler(cb);
-    return (event: any /** TODO #9100 */) => {
+    return (event: any /* TODO #9100 */) => {
       this._resetDebug();
       try {
         return superHandler(event);
@@ -408,7 +408,7 @@ export class DebugAppView<T> extends AppView<T> {
 }
 
 function _findLastRenderNode(node: any): any {
-  var lastNode: any /** TODO #9100 */;
+  var lastNode: any /* TODO #9100 */;
   if (node instanceof AppElement) {
     var appEl = <AppElement>node;
     lastNode = appEl.nativeElement;

--- a/modules/@angular/core/src/linker/view_ref.ts
+++ b/modules/@angular/core/src/linker/view_ref.ts
@@ -11,7 +11,7 @@ import {AppView} from './view';
 export abstract class ViewRef {
   get destroyed(): boolean { return <boolean>unimplemented(); }
 
-  abstract onDestroy(callback: Function): any /** TODO #9100 */;
+  abstract onDestroy(callback: Function): any /* TODO #9100 */;
 }
 
 /**
@@ -76,7 +76,7 @@ export abstract class EmbeddedViewRef<C> extends ViewRef {
   /**
    * Destroys the view and all of the data structures associated with it.
    */
-  abstract destroy(): any /** TODO #9100 */;
+  abstract destroy(): any /* TODO #9100 */;
 }
 
 export class ViewRef_<C> implements EmbeddedViewRef<C>, ChangeDetectorRef {

--- a/modules/@angular/core/src/linker/view_utils.ts
+++ b/modules/@angular/core/src/linker/view_utils.ts
@@ -61,10 +61,10 @@ function _flattenNestedViewRenderNodes(nodes: any[], renderNodes: any[]): any[] 
   return renderNodes;
 }
 
-const EMPTY_ARR: any[] /** TODO #9100 */ = /*@ts2dart_const*/[];
+const EMPTY_ARR: any[] /* TODO #9100 */ = /*@ts2dart_const*/[];
 
 export function ensureSlotCount(projectableNodes: any[][], expectedSlotCount: number): any[][] {
-  var res: any /** TODO #9100 */;
+  var res: any /* TODO #9100 */;
   if (isBlank(projectableNodes)) {
     res = EMPTY_ARR;
   } else if (projectableNodes.length < expectedSlotCount) {
@@ -148,7 +148,7 @@ export function mapLooseIdentical<V>(m1: {[key: string]: V}, m2: {[key: string]:
   if (k1.length != k2.length) {
     return false;
   }
-  var key: any /** TODO #9100 */;
+  var key: any /* TODO #9100 */;
   for (var i = 0; i < k1.length; i++) {
     key = k1[i];
     if (!looseIdentical(m1[key], m2[key])) {
@@ -162,12 +162,12 @@ export function castByValue<T>(input: any, value: T): T {
   return <T>input;
 }
 
-export const EMPTY_ARRAY: any[] /** TODO #9100 */ = /*@ts2dart_const*/[];
+export const EMPTY_ARRAY: any[] /* TODO #9100 */ = /*@ts2dart_const*/[];
 export const EMPTY_MAP = /*@ts2dart_const*/ {};
 
 export function pureProxy1<P0, R>(fn: (p0: P0) => R): (p0: P0) => R {
   var result: R;
-  var v0: any /** TODO #9100 */;
+  var v0: any /* TODO #9100 */;
   v0 = uninitialized;
   return (p0) => {
     if (!looseIdentical(v0, p0)) {
@@ -180,7 +180,7 @@ export function pureProxy1<P0, R>(fn: (p0: P0) => R): (p0: P0) => R {
 
 export function pureProxy2<P0, P1, R>(fn: (p0: P0, p1: P1) => R): (p0: P0, p1: P1) => R {
   var result: R;
-  var v0: any /** TODO #9100 */, v1: any /** TODO #9100 */;
+  var v0: any /* TODO #9100 */, v1: any /* TODO #9100 */;
   v0 = v1 = uninitialized;
   return (p0, p1) => {
     if (!looseIdentical(v0, p0) || !looseIdentical(v1, p1)) {
@@ -195,7 +195,7 @@ export function pureProxy2<P0, P1, R>(fn: (p0: P0, p1: P1) => R): (p0: P0, p1: P
 export function pureProxy3<P0, P1, P2, R>(fn: (p0: P0, p1: P1, p2: P2) => R): (
     p0: P0, p1: P1, p2: P2) => R {
   var result: R;
-  var v0: any /** TODO #9100 */, v1: any /** TODO #9100 */, v2: any /** TODO #9100 */;
+  var v0: any /* TODO #9100 */, v1: any /* TODO #9100 */, v2: any /* TODO #9100 */;
   v0 = v1 = v2 = uninitialized;
   return (p0, p1, p2) => {
     if (!looseIdentical(v0, p0) || !looseIdentical(v1, p1) || !looseIdentical(v2, p2)) {
@@ -211,8 +211,8 @@ export function pureProxy3<P0, P1, P2, R>(fn: (p0: P0, p1: P1, p2: P2) => R): (
 export function pureProxy4<P0, P1, P2, P3, R>(fn: (p0: P0, p1: P1, p2: P2, p3: P3) => R): (
     p0: P0, p1: P1, p2: P2, p3: P3) => R {
   var result: R;
-  var v0: any /** TODO #9100 */, v1: any /** TODO #9100 */, v2: any /** TODO #9100 */,
-      v3: any /** TODO #9100 */;
+  var v0: any /* TODO #9100 */, v1: any /* TODO #9100 */, v2: any /* TODO #9100 */,
+      v3: any /* TODO #9100 */;
   v0 = v1 = v2 = v3 = uninitialized;
   return (p0, p1, p2, p3) => {
     if (!looseIdentical(v0, p0) || !looseIdentical(v1, p1) || !looseIdentical(v2, p2) ||
@@ -231,8 +231,8 @@ export function pureProxy5<P0, P1, P2, P3, P4, R>(
     fn: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) => R): (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) =>
     R {
   var result: R;
-  var v0: any /** TODO #9100 */, v1: any /** TODO #9100 */, v2: any /** TODO #9100 */,
-      v3: any /** TODO #9100 */, v4: any /** TODO #9100 */;
+  var v0: any /* TODO #9100 */, v1: any /* TODO #9100 */, v2: any /* TODO #9100 */,
+      v3: any /* TODO #9100 */, v4: any /* TODO #9100 */;
   v0 = v1 = v2 = v3 = v4 = uninitialized;
   return (p0, p1, p2, p3, p4) => {
     if (!looseIdentical(v0, p0) || !looseIdentical(v1, p1) || !looseIdentical(v2, p2) ||
@@ -253,8 +253,8 @@ export function pureProxy6<P0, P1, P2, P3, P4, P5, R>(
     fn: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) =>
         R): (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) => R {
   var result: R;
-  var v0: any /** TODO #9100 */, v1: any /** TODO #9100 */, v2: any /** TODO #9100 */,
-      v3: any /** TODO #9100 */, v4: any /** TODO #9100 */, v5: any /** TODO #9100 */;
+  var v0: any /* TODO #9100 */, v1: any /* TODO #9100 */, v2: any /* TODO #9100 */,
+      v3: any /* TODO #9100 */, v4: any /* TODO #9100 */, v5: any /* TODO #9100 */;
   v0 = v1 = v2 = v3 = v4 = v5 = uninitialized;
   return (p0, p1, p2, p3, p4, p5) => {
     if (!looseIdentical(v0, p0) || !looseIdentical(v1, p1) || !looseIdentical(v2, p2) ||
@@ -275,9 +275,9 @@ export function pureProxy7<P0, P1, P2, P3, P4, P5, P6, R>(
     fn: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) =>
         R): (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) => R {
   var result: R;
-  var v0: any /** TODO #9100 */, v1: any /** TODO #9100 */, v2: any /** TODO #9100 */,
-      v3: any /** TODO #9100 */, v4: any /** TODO #9100 */, v5: any /** TODO #9100 */,
-      v6: any /** TODO #9100 */;
+  var v0: any /* TODO #9100 */, v1: any /* TODO #9100 */, v2: any /* TODO #9100 */,
+      v3: any /* TODO #9100 */, v4: any /* TODO #9100 */, v5: any /* TODO #9100 */,
+      v6: any /* TODO #9100 */;
   v0 = v1 = v2 = v3 = v4 = v5 = v6 = uninitialized;
   return (p0, p1, p2, p3, p4, p5, p6) => {
     if (!looseIdentical(v0, p0) || !looseIdentical(v1, p1) || !looseIdentical(v2, p2) ||
@@ -300,9 +300,9 @@ export function pureProxy8<P0, P1, P2, P3, P4, P5, P6, P7, R>(
     fn: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) =>
         R): (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) => R {
   var result: R;
-  var v0: any /** TODO #9100 */, v1: any /** TODO #9100 */, v2: any /** TODO #9100 */,
-      v3: any /** TODO #9100 */, v4: any /** TODO #9100 */, v5: any /** TODO #9100 */,
-      v6: any /** TODO #9100 */, v7: any /** TODO #9100 */;
+  var v0: any /* TODO #9100 */, v1: any /* TODO #9100 */, v2: any /* TODO #9100 */,
+      v3: any /* TODO #9100 */, v4: any /* TODO #9100 */, v5: any /* TODO #9100 */,
+      v6: any /* TODO #9100 */, v7: any /* TODO #9100 */;
   v0 = v1 = v2 = v3 = v4 = v5 = v6 = v7 = uninitialized;
   return (p0, p1, p2, p3, p4, p5, p6, p7) => {
     if (!looseIdentical(v0, p0) || !looseIdentical(v1, p1) || !looseIdentical(v2, p2) ||
@@ -326,9 +326,9 @@ export function pureProxy9<P0, P1, P2, P3, P4, P5, P6, P7, P8, R>(
     fn: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8) =>
         R): (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8) => R {
   var result: R;
-  var v0: any /** TODO #9100 */, v1: any /** TODO #9100 */, v2: any /** TODO #9100 */,
-      v3: any /** TODO #9100 */, v4: any /** TODO #9100 */, v5: any /** TODO #9100 */,
-      v6: any /** TODO #9100 */, v7: any /** TODO #9100 */, v8: any /** TODO #9100 */;
+  var v0: any /* TODO #9100 */, v1: any /* TODO #9100 */, v2: any /* TODO #9100 */,
+      v3: any /* TODO #9100 */, v4: any /* TODO #9100 */, v5: any /* TODO #9100 */,
+      v6: any /* TODO #9100 */, v7: any /* TODO #9100 */, v8: any /* TODO #9100 */;
   v0 = v1 = v2 = v3 = v4 = v5 = v6 = v7 = v8 = uninitialized;
   return (p0, p1, p2, p3, p4, p5, p6, p7, p8) => {
     if (!looseIdentical(v0, p0) || !looseIdentical(v1, p1) || !looseIdentical(v2, p2) ||
@@ -353,10 +353,10 @@ export function pureProxy10<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, R>(
     fn: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9) =>
         R): (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9) => R {
   var result: R;
-  var v0: any /** TODO #9100 */, v1: any /** TODO #9100 */, v2: any /** TODO #9100 */,
-      v3: any /** TODO #9100 */, v4: any /** TODO #9100 */, v5: any /** TODO #9100 */,
-      v6: any /** TODO #9100 */, v7: any /** TODO #9100 */, v8: any /** TODO #9100 */,
-      v9: any /** TODO #9100 */;
+  var v0: any /* TODO #9100 */, v1: any /* TODO #9100 */, v2: any /* TODO #9100 */,
+      v3: any /* TODO #9100 */, v4: any /* TODO #9100 */, v5: any /* TODO #9100 */,
+      v6: any /* TODO #9100 */, v7: any /* TODO #9100 */, v8: any /* TODO #9100 */,
+      v9: any /* TODO #9100 */;
   v0 = v1 = v2 = v3 = v4 = v5 = v6 = v7 = v8 = v9 = uninitialized;
   return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9) => {
     if (!looseIdentical(v0, p0) || !looseIdentical(v1, p1) || !looseIdentical(v2, p2) ||

--- a/modules/@angular/core/src/metadata/lifecycle_hooks.ts
+++ b/modules/@angular/core/src/metadata/lifecycle_hooks.ts
@@ -79,7 +79,7 @@ export var LIFECYCLE_HOOKS_VALUES = [
  * @stable
  */
 export abstract class OnChanges {
-  abstract ngOnChanges(changes: SimpleChanges): any /** TODO #9100 */;
+  abstract ngOnChanges(changes: SimpleChanges): any /* TODO #9100 */;
 }
 
 /**
@@ -124,7 +124,7 @@ export abstract class OnChanges {
  *  ```
  * @stable
  */
-export abstract class OnInit { abstract ngOnInit(): any /** TODO #9100 */; }
+export abstract class OnInit { abstract ngOnInit(): any /* TODO #9100 */; }
 
 /**
  * Implement this interface to supplement the default change detection algorithm in your directive.
@@ -193,7 +193,7 @@ export abstract class OnInit { abstract ngOnInit(): any /** TODO #9100 */; }
  * ```
  * @stable
  */
-export abstract class DoCheck { abstract ngDoCheck(): any /** TODO #9100 */; }
+export abstract class DoCheck { abstract ngDoCheck(): any /* TODO #9100 */; }
 
 /**
  * Implement this interface to get notified when your directive is destroyed.
@@ -285,7 +285,7 @@ export abstract class DoCheck { abstract ngDoCheck(): any /** TODO #9100 */; }
  *
  * @stable
  */
-export abstract class OnDestroy { abstract ngOnDestroy(): any /** TODO #9100 */; }
+export abstract class OnDestroy { abstract ngOnDestroy(): any /* TODO #9100 */; }
 
 /**
  * Implement this interface to get notified when your directive's content has been fully
@@ -339,7 +339,7 @@ export abstract class OnDestroy { abstract ngOnDestroy(): any /** TODO #9100 */;
  * ```
  * @stable
  */
-export abstract class AfterContentInit { abstract ngAfterContentInit(): any /** TODO #9100 */; }
+export abstract class AfterContentInit { abstract ngAfterContentInit(): any /* TODO #9100 */; }
 
 /**
  * Implement this interface to get notified after every check of your directive's content.
@@ -389,7 +389,7 @@ export abstract class AfterContentInit { abstract ngAfterContentInit(): any /** 
  * @stable
  */
 export abstract class AfterContentChecked {
-  abstract ngAfterContentChecked(): any /** TODO #9100 */;
+  abstract ngAfterContentChecked(): any /* TODO #9100 */;
 }
 
 /**
@@ -438,7 +438,7 @@ export abstract class AfterContentChecked {
  * ```
  * @stable
  */
-export abstract class AfterViewInit { abstract ngAfterViewInit(): any /** TODO #9100 */; }
+export abstract class AfterViewInit { abstract ngAfterViewInit(): any /* TODO #9100 */; }
 
 /**
  * Implement this interface to get notified after every check of your component's view.
@@ -489,4 +489,4 @@ export abstract class AfterViewInit { abstract ngAfterViewInit(): any /** TODO #
  * ```
  * @stable
  */
-export abstract class AfterViewChecked { abstract ngAfterViewChecked(): any /** TODO #9100 */; }
+export abstract class AfterViewChecked { abstract ngAfterViewChecked(): any /* TODO #9100 */; }

--- a/modules/@angular/core/src/profile/wtf_impl.ts
+++ b/modules/@angular/core/src/profile/wtf_impl.ts
@@ -11,9 +11,9 @@ interface WTF {
 
 interface Trace {
   events: Events;
-  leaveScope(scope: Scope, returnValue: any): any /** TODO #9100 */;
+  leaveScope(scope: Scope, returnValue: any): any /* TODO #9100 */;
   beginTimeRange(rangeType: string, action: string): Range;
-  endTimeRange(range: Range): any /** TODO #9100 */;
+  endTimeRange(range: Range): any /* TODO #9100 */;
 }
 
 export interface Range {}
@@ -22,13 +22,13 @@ interface Events {
   createScope(signature: string, flags: any): Scope;
 }
 
-export interface Scope { (...args: any[] /** TODO #9100 */): any; }
+export interface Scope { (...args: any[] /* TODO #9100 */): any; }
 
 var trace: Trace;
 var events: Events;
 
 export function detectWTF(): boolean {
-  var wtf: WTF = (global as any /** TODO #9100 */)['wtf'];
+  var wtf: WTF = (global as any /* TODO #9100 */)['wtf'];
   if (wtf) {
     trace = wtf['trace'];
     if (trace) {

--- a/modules/@angular/core/src/reflection/reflection_capabilities.ts
+++ b/modules/@angular/core/src/reflection/reflection_capabilities.ts
@@ -96,9 +96,9 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
   }
 
   /** @internal */
-  _zipTypesAndAnnotations(
-      paramTypes: any /** TODO #9100 */, paramAnnotations: any /** TODO #9100 */): any[][] {
-    var result: any /** TODO #9100 */;
+  _zipTypesAndAnnotations(paramTypes: any /* TODO #9100 */, paramAnnotations: any /* TODO #9100 */):
+      any[][] {
+    var result: any /* TODO #9100 */;
 
     if (typeof paramTypes === 'undefined') {
       result = new Array(paramAnnotations.length);
@@ -134,9 +134,9 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
     if (isPresent((<any>typeOrFunc).ctorParameters)) {
       let ctorParameters = (<any>typeOrFunc).ctorParameters;
       let paramTypes =
-          ctorParameters.map((ctorParam: any /** TODO #9100 */) => ctorParam && ctorParam.type);
+          ctorParameters.map((ctorParam: any /* TODO #9100 */) => ctorParam && ctorParam.type);
       let paramAnnotations = ctorParameters.map(
-          (ctorParam: any /** TODO #9100 */) =>
+          (ctorParam: any /* TODO #9100 */) =>
               ctorParam && convertTsickleDecoratorIntoMetadata(ctorParam.decorators));
       return this._zipTypesAndAnnotations(paramTypes, paramAnnotations);
     }

--- a/modules/@angular/core/src/render/api.ts
+++ b/modules/@angular/core/src/render/api.ts
@@ -62,15 +62,15 @@ export abstract class Renderer {
       void;
 
   abstract setElementClass(renderElement: any, className: string, isAdd: boolean): any
-      /** TODO #9100 */;
+      /* TODO #9100 */;
 
   abstract setElementStyle(renderElement: any, styleName: string, styleValue: string): any
-      /** TODO #9100 */;
+      /* TODO #9100 */;
 
   abstract invokeElementMethod(renderElement: any, methodName: string, args?: any[]): any
-      /** TODO #9100 */;
+      /* TODO #9100 */;
 
-  abstract setText(renderNode: any, text: string): any /** TODO #9100 */;
+  abstract setText(renderNode: any, text: string): any /* TODO #9100 */;
 
   abstract animate(
       element: any, startingStyles: AnimationStyles, keyframes: AnimationKeyframe[],

--- a/modules/@angular/core/src/util/decorators.ts
+++ b/modules/@angular/core/src/util/decorators.ts
@@ -232,7 +232,7 @@ export function Class(clsDef: ClassDefinition): ConcreteType {
   }
 
   if (!constructor['name']) {
-    (constructor as any /** TODO #9100 */)['overriddenName'] = `class${_nextClassId++}`;
+    (constructor as any /* TODO #9100 */)['overriddenName'] = `class${_nextClassId++}`;
   }
 
   return <ConcreteType>constructor;
@@ -248,9 +248,9 @@ var Reflect = global.Reflect;
 })();
 
 export function makeDecorator(
-    annotationCls: any /** TODO #9100 */,
+    annotationCls: any /* TODO #9100 */,
     chainFn: (fn: Function) => void = null): (...args: any[]) => (cls: any) => any {
-  function DecoratorFactory(objOrType: any /** TODO #9100 */): (cls: any) => any {
+  function DecoratorFactory(objOrType: any /* TODO #9100 */): (cls: any) => any {
     var annotationInstance = new (<any>annotationCls)(objOrType);
     if (this instanceof annotationCls) {
       return annotationInstance;
@@ -259,7 +259,7 @@ export function makeDecorator(
           isFunction(this) && this.annotations instanceof Array ? this.annotations : [];
       chainAnnotation.push(annotationInstance);
       var TypeDecorator: TypeDecorator =
-          <TypeDecorator>function TypeDecorator(cls: any /** TODO #9100 */) {
+          <TypeDecorator>function TypeDecorator(cls: any /* TODO #9100 */) {
             var annotations = Reflect.getOwnMetadata('annotations', cls);
             annotations = annotations || [];
             annotations.push(annotationInstance);
@@ -277,8 +277,8 @@ export function makeDecorator(
   return DecoratorFactory;
 }
 
-export function makeParamDecorator(annotationCls: any /** TODO #9100 */): any {
-  function ParamDecoratorFactory(...args: any[] /** TODO #9100 */): any {
+export function makeParamDecorator(annotationCls: any /* TODO #9100 */): any {
+  function ParamDecoratorFactory(...args: any[] /* TODO #9100 */): any {
     var annotationInstance = Object.create(annotationCls.prototype);
     annotationCls.apply(annotationInstance, args);
     if (this instanceof annotationCls) {
@@ -290,8 +290,8 @@ export function makeParamDecorator(annotationCls: any /** TODO #9100 */): any {
 
 
     function ParamDecorator(
-        cls: any /** TODO #9100 */, unusedKey: any /** TODO #9100 */,
-        index: any /** TODO #9100 */): any {
+        cls: any /* TODO #9100 */, unusedKey: any /* TODO #9100 */,
+        index: any /* TODO #9100 */): any {
       var parameters: any[][] = Reflect.getMetadata('parameters', cls);
       parameters = parameters || [];
 
@@ -314,8 +314,8 @@ export function makeParamDecorator(annotationCls: any /** TODO #9100 */): any {
   return ParamDecoratorFactory;
 }
 
-export function makePropDecorator(annotationCls: any /** TODO #9100 */): any {
-  function PropDecoratorFactory(...args: any[] /** TODO #9100 */): any {
+export function makePropDecorator(annotationCls: any /* TODO #9100 */): any {
+  function PropDecoratorFactory(...args: any[] /* TODO #9100 */): any {
     var decoratorInstance = Object.create(annotationCls.prototype);
     annotationCls.apply(decoratorInstance, args);
 

--- a/modules/@angular/core/src/zone/ng_zone_impl.ts
+++ b/modules/@angular/core/src/zone/ng_zone_impl.ts
@@ -37,11 +37,11 @@ export class NgZoneImpl {
 
     if (Zone) {
       this.outer = this.inner = Zone.current;
-      if ((Zone as any /** TODO #9100 */)['wtfZoneSpec']) {
-        this.inner = this.inner.fork((Zone as any /** TODO #9100 */)['wtfZoneSpec']);
+      if ((Zone as any /* TODO #9100 */)['wtfZoneSpec']) {
+        this.inner = this.inner.fork((Zone as any /* TODO #9100 */)['wtfZoneSpec']);
       }
-      if (trace && (Zone as any /** TODO #9100 */)['longStackTraceZoneSpec']) {
-        this.inner = this.inner.fork((Zone as any /** TODO #9100 */)['longStackTraceZoneSpec']);
+      if (trace && (Zone as any /* TODO #9100 */)['longStackTraceZoneSpec']) {
+        this.inner = this.inner.fork((Zone as any /* TODO #9100 */)['longStackTraceZoneSpec']);
       }
       this.inner = this.inner.fork({
         name: 'angular',

--- a/modules/@angular/core/test/animation/active_animations_players_map_spec.ts
+++ b/modules/@angular/core/test/animation/active_animations_players_map_spec.ts
@@ -9,8 +9,8 @@ import {AsyncTestCompleter, beforeEach, ddescribe, describe, expect, iit, inject
 
 export function main() {
   describe('ActiveAnimationsPlayersMap', function() {
-    var playersMap: any /** TODO #9100 */;
-    var elementNode: any /** TODO #9100 */;
+    var playersMap: any /* TODO #9100 */;
+    var elementNode: any /* TODO #9100 */;
     var animationName = 'animationName';
 
     beforeEach(() => {

--- a/modules/@angular/core/test/animation/animation_group_player_spec.ts
+++ b/modules/@angular/core/test/animation/animation_group_player_spec.ts
@@ -6,7 +6,7 @@ import {AsyncTestCompleter, beforeEach, ddescribe, describe, expect, iit, inject
 
 export function main() {
   describe('AnimationGroupPlayer', function() {
-    var players: any /** TODO #9100 */;
+    var players: any /* TODO #9100 */;
     beforeEach(() => {
       players = [
         new MockAnimationPlayer(),

--- a/modules/@angular/core/test/animation/animation_integration_spec.ts
+++ b/modules/@angular/core/test/animation/animation_integration_spec.ts
@@ -38,7 +38,7 @@ function declareTests() {
     var makeAnimationCmp =
         (tcb: TestComponentBuilder, tpl: string,
          animationEntry: AnimationEntryMetadata | AnimationEntryMetadata[],
-         callback: any /** TODO #9100 */ = null) => {
+         callback: any /* TODO #9100 */ = null) => {
           var entries = isArray(animationEntry) ? <AnimationEntryMetadata[]>animationEntry :
                                                   [<AnimationEntryMetadata>animationEntry];
           tcb = tcb.overrideTemplate(DummyIfCmp, tpl);
@@ -59,7 +59,7 @@ function declareTests() {
                        [transition(
                            'void => *',
                            [style({'opacity': 0}), animate(500, style({'opacity': 1}))])]),
-                   (fixture: any /** TODO #9100 */) => {
+                   (fixture: any /* TODO #9100 */) => {
                      var cmp = fixture.debugElement.componentInstance;
                      cmp.exp = true;
                      fixture.detectChanges();
@@ -85,7 +85,7 @@ function declareTests() {
                        [transition(
                            '* => void',
                            [style({'opacity': 1}), animate(500, style({'opacity': 0}))])]),
-                   (fixture: any /** TODO #9100 */) => {
+                   (fixture: any /* TODO #9100 */) => {
                      var cmp = fixture.debugElement.componentInstance;
                      cmp.exp = true;
                      fixture.detectChanges();
@@ -202,7 +202,7 @@ function declareTests() {
 
       describe('groups/sequences', () => {
         var assertPlaying =
-            (player: MockAnimationDriver, isPlaying: any /** TODO #9100 */) => {
+            (player: MockAnimationDriver, isPlaying: any /* TODO #9100 */) => {
               var method = 'play';
               var lastEntry = player.log.length > 0 ? player.log[player.log.length - 1] : null;
               if (isPresent(lastEntry)) {
@@ -587,7 +587,7 @@ function declareTests() {
                    trigger(
                        'myAnimation',
                        [transition('* => void', [animate(1000, style({'opacity': 0}))])]),
-                   (fixture: any /** TODO #9100 */) => {
+                   (fixture: any /* TODO #9100 */) => {
                      tick();
 
                      var cmp = fixture.debugElement.componentInstance;
@@ -622,7 +622,7 @@ function declareTests() {
                                                 animate(1000, style({'opacity': 0})),
                                                 animate(1000, style({'opacity': 1}))
                                               ])]),
-                   (fixture: any /** TODO #9100 */) => {
+                   (fixture: any /* TODO #9100 */) => {
                      tick();
 
                      var cmp = fixture.debugElement.componentInstance;
@@ -660,7 +660,7 @@ function declareTests() {
                              'state1 => state2',
                              [style({'width': 100}), animate(1000, style({'width': 1000}))])])
                    ],
-                   (fixture: any /** TODO #9100 */) => {
+                   (fixture: any /* TODO #9100 */) => {
                      tick();
 
                      var cmp = fixture.debugElement.componentInstance;
@@ -715,7 +715,7 @@ function declareTests() {
                          state('final', style({'top': '100px'})),
                          transition('* => final', [animate(1000)])
                        ])],
-                   (fixture: any /** TODO #9100 */) => {
+                   (fixture: any /* TODO #9100 */) => {
                      tick();
 
                      var cmp = fixture.debugElement.componentInstance;
@@ -747,7 +747,7 @@ function declareTests() {
                          state('red', style({'background': 'red'})),
                          transition('* => *', [animate(1000)])
                        ])],
-                   (fixture: any /** TODO #9100 */) => {
+                   (fixture: any /* TODO #9100 */) => {
                      tick();
 
                      var cmp = fixture.debugElement.componentInstance;
@@ -802,7 +802,7 @@ function declareTests() {
                          state('void', style({'height': '100px'})),
                          transition('* => *', [animate(1000)])
                        ])],
-                   (fixture: any /** TODO #9100 */) => {
+                   (fixture: any /* TODO #9100 */) => {
                      tick();
 
                      var cmp = fixture.debugElement.componentInstance;
@@ -829,7 +829,7 @@ function declareTests() {
                          state('void', style({'width': '0px'})),
                          state('final', style({'width': '100px'})),
                        ])],
-                   (fixture: any /** TODO #9100 */) => {
+                   (fixture: any /* TODO #9100 */) => {
                      tick();
 
                      var cmp = fixture.debugElement.componentInstance;
@@ -858,7 +858,7 @@ function declareTests() {
                          state('a, c', style({'height': '100px'})),
                          state('b, d', style({'width': '100px'})),
                        ])],
-                   (fixture: any /** TODO #9100 */) => {
+                   (fixture: any /* TODO #9100 */) => {
                      tick();
 
                      var cmp = fixture.debugElement.componentInstance;
@@ -919,7 +919,7 @@ function declareTests() {
                          transition('a => b, b => c', [animate(1000)]),
                          transition('* => *', [animate(300)])
                        ])],
-                   (fixture: any /** TODO #9100 */) => {
+                   (fixture: any /* TODO #9100 */) => {
                      tick();
 
                      var cmp = fixture.debugElement.componentInstance;
@@ -965,7 +965,7 @@ function declareTests() {
                          state('final', style({'height': '333px', 'width': '200px'})),
                          transition('void => final', [animate(1000)])
                        ])],
-                   (fixture: any /** TODO #9100 */) => {
+                   (fixture: any /* TODO #9100 */) => {
                      tick();
 
                      var cmp = fixture.debugElement.componentInstance;

--- a/modules/@angular/core/test/animation/animation_sequence_player_spec.ts
+++ b/modules/@angular/core/test/animation/animation_sequence_player_spec.ts
@@ -6,7 +6,7 @@ import {AsyncTestCompleter, beforeEach, ddescribe, describe, expect, iit, inject
 
 export function main() {
   describe('AnimationSequencePlayer', function() {
-    var players: any /** TODO #9100 */;
+    var players: any /* TODO #9100 */;
     beforeEach(() => {
       players = [
         new MockAnimationPlayer(),

--- a/modules/@angular/core/test/application_ref_spec.ts
+++ b/modules/@angular/core/test/application_ref_spec.ts
@@ -142,6 +142,6 @@ class _MockComponentRef extends ComponentRef_<any> {
 }
 
 class _MockConsole implements Console {
-  log(message: any /** TODO #9100 */) {}
-  warn(message: any /** TODO #9100 */) {}
+  log(message: any /* TODO #9100 */) {}
+  warn(message: any /* TODO #9100 */) {}
 }

--- a/modules/@angular/core/test/change_detection/differs/default_iterable_differ_spec.ts
+++ b/modules/@angular/core/test/change_detection/differs/default_iterable_differ_spec.ts
@@ -22,7 +22,7 @@ class ComplexItem {
 export function main() {
   describe('iterable differ', function() {
     describe('DefaultIterableDiffer', function() {
-      var differ: any /** TODO #9100 */;
+      var differ: any /* TODO #9100 */;
 
       beforeEach(() => { differ = new DefaultIterableDiffer(); });
 
@@ -58,7 +58,7 @@ export function main() {
       });
 
       it('should detect additions', () => {
-        let l: any[] /** TODO #9100 */ = [];
+        let l: any[] /* TODO #9100 */ = [];
         differ.check(l);
         expect(differ.toString()).toEqual(iterableChangesAsString({collection: []}));
 
@@ -138,7 +138,7 @@ export function main() {
       });
 
       it('should detect changes in list', () => {
-        let l: any[] /** TODO #9100 */ = [];
+        let l: any[] /* TODO #9100 */ = [];
         differ.check(l);
 
         l.push('a');
@@ -315,7 +315,7 @@ export function main() {
     });
 
     describe('trackBy function by id', function() {
-      var differ: any /** TODO #9100 */;
+      var differ: any /* TODO #9100 */;
 
       var trackByItemId = (index: number, item: any): any => item.id;
 
@@ -404,7 +404,7 @@ export function main() {
       });
     });
     describe('trackBy function by index', function() {
-      var differ: any /** TODO #9100 */;
+      var differ: any /* TODO #9100 */;
 
       var trackByIndex = (index: number, item: any): number => index;
 

--- a/modules/@angular/core/test/change_detection/differs/default_keyvalue_differ_spec.ts
+++ b/modules/@angular/core/test/change_detection/differs/default_keyvalue_differ_spec.ts
@@ -9,7 +9,7 @@ import {kvChangesAsString} from '../../change_detection/util';
 export function main() {
   describe('keyvalue differ', function() {
     describe('DefaultKeyValueDiffer', function() {
-      var differ: any /** TODO #9100 */;
+      var differ: any /* TODO #9100 */;
       var m: Map<any, any>;
 
       beforeEach(() => {
@@ -50,7 +50,7 @@ export function main() {
       });
 
       it('should expose previous and current value', () => {
-        var previous: any /** TODO #9100 */, current: any /** TODO #9100 */;
+        var previous: any /* TODO #9100 */, current: any /* TODO #9100 */;
 
         m.set(1, 10);
         differ.check(m);
@@ -58,7 +58,7 @@ export function main() {
         m.set(1, 20);
         differ.check(m);
 
-        differ.forEachChangedItem((record: any /** TODO #9100 */) => {
+        differ.forEachChangedItem((record: any /* TODO #9100 */) => {
           previous = record.previousValue;
           current = record.currentValue;
         });
@@ -143,19 +143,19 @@ export function main() {
             let m = {};
             differ.check(m);
 
-            (m as any /** TODO #9100 */)['a'] = 'A';
+            (m as any /* TODO #9100 */)['a'] = 'A';
             differ.check(m);
             expect(differ.toString())
                 .toEqual(kvChangesAsString({map: ['a[null->A]'], additions: ['a[null->A]']}));
 
-            (m as any /** TODO #9100 */)['b'] = 'B';
+            (m as any /* TODO #9100 */)['b'] = 'B';
             differ.check(m);
             expect(differ.toString())
                 .toEqual(kvChangesAsString(
                     {map: ['a', 'b[null->B]'], previous: ['a'], additions: ['b[null->B]']}));
 
-            (m as any /** TODO #9100 */)['b'] = 'BB';
-            (m as any /** TODO #9100 */)['d'] = 'D';
+            (m as any /* TODO #9100 */)['b'] = 'BB';
+            (m as any /* TODO #9100 */)['d'] = 'D';
             differ.check(m);
             expect(differ.toString()).toEqual(kvChangesAsString({
               map: ['a', 'b[B->BB]', 'd[null->D]'],
@@ -165,8 +165,8 @@ export function main() {
             }));
 
             m = {};
-            (m as any /** TODO #9100 */)['a'] = 'A';
-            (m as any /** TODO #9100 */)['d'] = 'D';
+            (m as any /* TODO #9100 */)['a'] = 'A';
+            (m as any /* TODO #9100 */)['d'] = 'D';
             differ.check(m);
             expect(differ.toString()).toEqual(kvChangesAsString({
               map: ['a', 'd'],

--- a/modules/@angular/core/test/change_detection/differs/iterable_differs_spec.ts
+++ b/modules/@angular/core/test/change_detection/differs/iterable_differs_spec.ts
@@ -6,9 +6,9 @@ import {SpyIterableDifferFactory} from '../../spies';
 
 export function main() {
   describe('IterableDiffers', function() {
-    var factory1: any /** TODO #9100 */;
-    var factory2: any /** TODO #9100 */;
-    var factory3: any /** TODO #9100 */;
+    var factory1: any /* TODO #9100 */;
+    var factory2: any /* TODO #9100 */;
+    var factory3: any /* TODO #9100 */;
 
     beforeEach(() => {
       factory1 = new SpyIterableDifferFactory();

--- a/modules/@angular/core/test/di/reflective_injector_spec.ts
+++ b/modules/@angular/core/test/di/reflective_injector_spec.ts
@@ -33,7 +33,7 @@ class Car {
 
 @Injectable()
 class CarWithOptionalEngine {
-  engine: any /** TODO #9100 */;
+  engine: any /* TODO #9100 */;
   constructor(@Optional() engine: Engine) { this.engine = engine; }
 }
 
@@ -65,10 +65,10 @@ class CyclicEngine {
 }
 
 class NoAnnotations {
-  constructor(secretDependency: any /** TODO #9100 */) {}
+  constructor(secretDependency: any /* TODO #9100 */) {}
 }
 
-function factoryFn(a: any /** TODO #9100 */) {}
+function factoryFn(a: any /* TODO #9100 */) {}
 
 export function main() {
   var dynamicProviders = [
@@ -157,7 +157,7 @@ export function main() {
       });
 
       it('should provide to a factory', () => {
-        function sportsCarFactory(e: any /** TODO #9100 */) { return new SportsCar(e); }
+        function sportsCarFactory(e: any /* TODO #9100 */) { return new SportsCar(e); }
 
         var injector =
             createInjector([Engine, {provide: Car, useFactory: sportsCarFactory, deps: [Engine]}]);
@@ -557,7 +557,7 @@ export function main() {
       it('should support overriding factory dependencies with dependency annotations', () => {
         var providers = ReflectiveInjector.resolve([{
           provide: 'token',
-          useFactory: (e: any /** TODO #9100 */) => 'result',
+          useFactory: (e: any /* TODO #9100 */) => 'result',
           deps: [[new InjectMetadata('dep'), new CustomDependencyMetadata()]]
         }]);
 
@@ -572,12 +572,12 @@ export function main() {
       it('should allow declaring dependencies with flat arrays', () => {
         var resolved = ReflectiveInjector.resolve([{
           provide: 'token',
-          useFactory: (e: any /** TODO #9100 */) => e,
+          useFactory: (e: any /* TODO #9100 */) => e,
           deps: [new InjectMetadata('dep')]
         }]);
         var nestedResolved = ReflectiveInjector.resolve([{
           provide: 'token',
-          useFactory: (e: any /** TODO #9100 */) => e,
+          useFactory: (e: any /* TODO #9100 */) => e,
           deps: [[new InjectMetadata('dep')]]
         }]);
         expect(resolved[0].resolvedFactories[0].dependencies[0].key.token)

--- a/modules/@angular/core/test/directive_lifecycle_integration_spec.ts
+++ b/modules/@angular/core/test/directive_lifecycle_integration_spec.ts
@@ -54,10 +54,10 @@ class LifecycleDir implements DoCheck {
 })
 class LifecycleCmp implements OnChanges,
     OnInit, DoCheck, AfterContentInit, AfterContentChecked, AfterViewInit, AfterViewChecked {
-  field: any /** TODO #9100 */;
+  field: any /* TODO #9100 */;
   constructor(private _log: Log) {}
 
-  ngOnChanges(_: any /** TODO #9100 */) { this._log.add('ngOnChanges'); }
+  ngOnChanges(_: any /* TODO #9100 */) { this._log.add('ngOnChanges'); }
 
   ngOnInit() { this._log.add('ngOnInit'); }
 

--- a/modules/@angular/core/test/dom/shim_spec.ts
+++ b/modules/@angular/core/test/dom/shim_spec.ts
@@ -4,8 +4,8 @@ export function main() {
   describe('Shim', () => {
 
     it('should provide correct function.name ', () => {
-      var functionWithoutName = identity(() => function(_: any /** TODO #9100 */) {});
-      function foo(_: any /** TODO #9100 */){};
+      var functionWithoutName = identity(() => function(_: any /* TODO #9100 */) {});
+      function foo(_: any /* TODO #9100 */){};
 
       expect((<any>functionWithoutName).name).toBeFalsy();
       expect((<any>foo).name).toEqual('foo');
@@ -14,6 +14,6 @@ export function main() {
   });
 }
 
-function identity(a: any /** TODO #9100 */) {
+function identity(a: any /* TODO #9100 */) {
   return a;
 }

--- a/modules/@angular/core/test/facade/observable_spec.ts
+++ b/modules/@angular/core/test/facade/observable_spec.ts
@@ -10,7 +10,7 @@ export function main() {
       it('should call next with values',
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
 
-           let o = new Observable((sink: any /** TODO #9100 */) => { sink.next(1); });
+           let o = new Observable((sink: any /* TODO #9100 */) => { sink.next(1); });
 
            o.subscribe(v => {
              expect(v).toEqual(1);
@@ -22,7 +22,7 @@ export function main() {
       it('should call next and then complete',
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
 
-           let o = new Observable((sink: any /** TODO #9100 */) => {
+           let o = new Observable((sink: any /* TODO #9100 */) => {
              sink.next(1);
              sink.complete();
            });
@@ -40,7 +40,7 @@ export function main() {
       it('should call error with errors',
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
 
-           let o = new Observable((sink: any /** TODO #9100 */) => { sink.error('oh noes!'); });
+           let o = new Observable((sink: any /* TODO #9100 */) => { sink.error('oh noes!'); });
 
            o.subscribe(
                v => {

--- a/modules/@angular/core/test/fake_async_spec.ts
+++ b/modules/@angular/core/test/fake_async_spec.ts
@@ -14,19 +14,19 @@ export function main() {
     });
 
     it('should pass arguments to the wrapped function', () => {
-      fakeAsync((foo: any /** TODO #9100 */, bar: any /** TODO #9100 */) => {
+      fakeAsync((foo: any /* TODO #9100 */, bar: any /* TODO #9100 */) => {
         expect(foo).toEqual('foo');
         expect(bar).toEqual('bar');
       })('foo', 'bar');
     });
 
-    it('should work with inject()', fakeAsync(inject([Parser], (parser: any /** TODO #9100 */) => {
+    it('should work with inject()', fakeAsync(inject([Parser], (parser: any /* TODO #9100 */) => {
          expect(parser).toBeAnInstanceOf(Parser);
        })));
 
     it('should throw on nested calls', () => {
       expect(() => {
-        fakeAsync(() => { fakeAsync((): any /** TODO #9100 */ => null)(); })();
+        fakeAsync(() => { fakeAsync((): any /* TODO #9100 */ => null)(); })();
       }).toThrowError('fakeAsync() calls can not be nested');
     });
 
@@ -181,7 +181,7 @@ export function main() {
 
       it('should be able to cancel periodic timers from a callback', fakeAsync(() => {
            var cycles = 0;
-           var id: any /** TODO #9100 */;
+           var id: any /* TODO #9100 */;
 
            id = TimerWrapper.setInterval(() => {
              cycles++;

--- a/modules/@angular/core/test/linker/change_detection_integration_spec.ts
+++ b/modules/@angular/core/test/linker/change_detection_integration_spec.ts
@@ -280,7 +280,7 @@ export function main() {
 
       it('should support function calls', fakeAsync(() => {
            var ctx = _bindSimpleValue('a()(99)', TestData);
-           ctx.componentInstance.a = () => (a: any /** TODO #9100 */) => a;
+           ctx.componentInstance.a = () => (a: any /* TODO #9100 */) => a;
            ctx.detectChanges(false);
            expect(renderLog.log).toEqual(['someProp=99']);
          }));
@@ -1127,13 +1127,13 @@ class DirectiveLog {
 @Pipe({name: 'countingPipe'})
 class CountingPipe implements PipeTransform {
   state: number = 0;
-  transform(value: any /** TODO #9100 */) { return `${value} state:${this.state ++}`; }
+  transform(value: any /* TODO #9100 */) { return `${value} state:${this.state ++}`; }
 }
 
 @Pipe({name: 'countingImpurePipe', pure: false})
 class CountingImpurePipe implements PipeTransform {
   state: number = 0;
-  transform(value: any /** TODO #9100 */) { return `${value} state:${this.state ++}`; }
+  transform(value: any /* TODO #9100 */) { return `${value} state:${this.state ++}`; }
 }
 
 @Pipe({name: 'pipeWithOnDestroy'})
@@ -1142,23 +1142,23 @@ class PipeWithOnDestroy implements PipeTransform, OnDestroy {
 
   ngOnDestroy() { this.directiveLog.add('pipeWithOnDestroy', 'ngOnDestroy'); }
 
-  transform(value: any /** TODO #9100 */): any /** TODO #9100 */ { return null; }
+  transform(value: any /* TODO #9100 */): any /* TODO #9100 */ { return null; }
 }
 
 @Pipe({name: 'identityPipe'})
 class IdentityPipe implements PipeTransform {
-  transform(value: any /** TODO #9100 */) { return value; }
+  transform(value: any /* TODO #9100 */) { return value; }
 }
 
 @Pipe({name: 'wrappedPipe'})
 class WrappedPipe implements PipeTransform {
-  transform(value: any /** TODO #9100 */) { return WrappedValue.wrap(value); }
+  transform(value: any /* TODO #9100 */) { return WrappedValue.wrap(value); }
 }
 
 @Pipe({name: 'multiArgPipe'})
 class MultiArgPipe implements PipeTransform {
   transform(
-      value: any /** TODO #9100 */, arg1: any /** TODO #9100 */, arg2: any /** TODO #9100 */,
+      value: any /* TODO #9100 */, arg1: any /* TODO #9100 */, arg2: any /* TODO #9100 */,
       arg3 = 'default') {
     return `${value} ${arg1} ${arg2} ${arg3}`;
   }
@@ -1214,10 +1214,10 @@ class EmitterDirective {
 @Directive({selector: '[testDirective]', exportAs: 'testDirective'})
 class TestDirective implements OnInit, DoCheck, OnChanges, AfterContentInit, AfterContentChecked,
     AfterViewInit, AfterViewChecked, OnDestroy {
-  @Input() a: any /** TODO #9100 */;
-  @Input() b: any /** TODO #9100 */;
-  changes: any /** TODO #9100 */;
-  event: any /** TODO #9100 */;
+  @Input() a: any /* TODO #9100 */;
+  @Input() b: any /* TODO #9100 */;
+  changes: any /* TODO #9100 */;
+  event: any /* TODO #9100 */;
   eventEmitter: EventEmitter<string> = new EventEmitter<string>();
 
   @Input('testDirective') name: string;
@@ -1226,7 +1226,7 @@ class TestDirective implements OnInit, DoCheck, OnChanges, AfterContentInit, Aft
 
   constructor(public log: DirectiveLog) {}
 
-  onEvent(event: any /** TODO #9100 */) { this.event = event; }
+  onEvent(event: any /* TODO #9100 */) { this.event = event; }
 
   ngDoCheck() { this.log.add(this.name, 'ngDoCheck'); }
 
@@ -1237,12 +1237,12 @@ class TestDirective implements OnInit, DoCheck, OnChanges, AfterContentInit, Aft
     }
   }
 
-  ngOnChanges(changes: any /** TODO #9100 */) {
+  ngOnChanges(changes: any /* TODO #9100 */) {
     this.log.add(this.name, 'ngOnChanges');
     var r = {};
     StringMapWrapper.forEach(
-        changes, (c: any /** TODO #9100 */, key: any /** TODO #9100 */) =>
-                     (r as any /** TODO #9100 */)[key] = c.currentValue);
+        changes, (c: any /* TODO #9100 */, key: any /* TODO #9100 */) =>
+                     (r as any /* TODO #9100 */)[key] = c.currentValue);
     this.changes = r;
     if (this.throwOn == 'ngOnChanges') {
       throw new BaseException('Boom!');
@@ -1346,9 +1346,9 @@ class Person {
     this.address = address;
   }
 
-  sayHi(m: any /** TODO #9100 */) { return `Hi, ${m}`; }
+  sayHi(m: any /* TODO #9100 */) { return `Hi, ${m}`; }
 
-  passThrough(val: any /** TODO #9100 */) { return val; }
+  passThrough(val: any /* TODO #9100 */) { return val; }
 
   toString(): string {
     var address = this.address == null ? '' : ' address=' + this.address.toString();
@@ -1361,7 +1361,7 @@ class Address {
   cityGetterCalls: number = 0;
   zipCodeGetterCalls: number = 0;
 
-  constructor(public _city: string, public _zipcode: any /** TODO #9100 */ = null) {}
+  constructor(public _city: string, public _zipcode: any /* TODO #9100 */ = null) {}
 
   get city() {
     this.cityGetterCalls++;

--- a/modules/@angular/core/test/linker/dynamic_component_loader_spec.ts
+++ b/modules/@angular/core/test/linker/dynamic_component_loader_spec.ts
@@ -143,7 +143,7 @@ export function main() {
       it('should allow to create, update and destroy components',
          inject(
              [AsyncTestCompleter, DynamicComponentLoader, DOCUMENT, Injector],
-             (async: AsyncTestCompleter, loader: DynamicComponentLoader, doc: any /** TODO #9100 */,
+             (async: AsyncTestCompleter, loader: DynamicComponentLoader, doc: any /* TODO #9100 */,
               injector: Injector) => {
                var rootEl = createRootElement(doc, 'child-cmp');
                getDOM().appendChild(doc.body, rootEl);
@@ -173,7 +173,7 @@ export function main() {
       it('should allow to pass projectable nodes',
          inject(
              [AsyncTestCompleter, DynamicComponentLoader, DOCUMENT, Injector],
-             (async: AsyncTestCompleter, loader: DynamicComponentLoader, doc: any /** TODO #9100 */,
+             (async: AsyncTestCompleter, loader: DynamicComponentLoader, doc: any /* TODO #9100 */,
               injector: Injector) => {
                var rootEl = createRootElement(doc, 'dummy');
                getDOM().appendChild(doc.body, rootEl);

--- a/modules/@angular/core/test/linker/integration_spec.ts
+++ b/modules/@angular/core/test/linker/integration_spec.ts
@@ -819,7 +819,7 @@ function declareTests(isJit: boolean) {
 
                var cmpEl = fixture.debugElement.children[0];
                var cmp: PushCmpWithHostEvent = cmpEl.inject(PushCmpWithHostEvent);
-               cmp.ctxCallback = (_: any /** TODO #9100 */) => fixture.destroy();
+               cmp.ctxCallback = (_: any /* TODO #9100 */) => fixture.destroy();
 
                expect(() => cmpEl.triggerEventHandler('click', <Event>{})).not.toThrow();
              })));
@@ -1486,7 +1486,7 @@ function declareTests(isJit: boolean) {
              }));
 
       it('should report a meaningful error when a component is missing view annotation',
-         inject([TestComponentBuilder], (tcb: TestComponentBuilder): any /** TODO #9100 */ => {
+         inject([TestComponentBuilder], (tcb: TestComponentBuilder): any /* TODO #9100 */ => {
            try {
              tcb.createAsync(ComponentWithoutView);
            } catch (e) {
@@ -1615,7 +1615,7 @@ function declareTests(isJit: boolean) {
                [TestComponentBuilder, AsyncTestCompleter],
                (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
 
-                 var undefinedValue: any /** TODO #9100 */;
+                 var undefinedValue: any /* TODO #9100 */;
 
                  tcb = tcb.overrideView(
                      MyComp, new ViewMetadata({directives: [undefinedValue], template: ''}));
@@ -1691,7 +1691,7 @@ function declareTests(isJit: boolean) {
        inject(
            [TestComponentBuilder, AsyncTestCompleter, ANCHOR_ELEMENT],
            (tcb: TestComponentBuilder, async: AsyncTestCompleter,
-            anchorElement: any /** TODO #9100 */) => {
+            anchorElement: any /* TODO #9100 */) => {
              tcb.overrideView(MyComp, new ViewMetadata({
                                 template: '<div><div *someImpvp="ctxBoolProp">hello</div></div>',
                                 directives: [SomeImperativeViewport]
@@ -2028,7 +2028,7 @@ class MyService {
 @Component({selector: 'simple-imp-cmp', template: ''})
 @Injectable()
 class SimpleImperativeViewComponent {
-  done: any /** TODO #9100 */;
+  done: any /* TODO #9100 */;
 
   constructor(self: ElementRef, renderer: Renderer) {
     var hostElement = self.nativeElement;
@@ -2084,7 +2084,7 @@ class EventCmp {
 @Injectable()
 class PushCmp {
   numberOfChecks: number;
-  prop: any /** TODO #9100 */;
+  prop: any /* TODO #9100 */;
 
   constructor() { this.numberOfChecks = 0; }
 
@@ -2106,7 +2106,7 @@ class PushCmp {
 class PushCmpWithRef {
   numberOfChecks: number;
   ref: ChangeDetectorRef;
-  prop: any /** TODO #9100 */;
+  prop: any /* TODO #9100 */;
 
   constructor(ref: ChangeDetectorRef) {
     this.numberOfChecks = 0;
@@ -2128,7 +2128,7 @@ class PushCmpWithRef {
   template: ''
 })
 class PushCmpWithHostEvent {
-  ctxCallback: Function = (_: any /** TODO #9100 */) => {};
+  ctxCallback: Function = (_: any /* TODO #9100 */) => {};
 }
 
 @Component({
@@ -2153,7 +2153,7 @@ class PushCmpWithAsyncPipe {
     return this.promise;
   }
 
-  resolve(value: any /** TODO #9100 */) { this.completer.resolve(value); }
+  resolve(value: any /* TODO #9100 */) { this.completer.resolve(value); }
 }
 
 @Component({selector: 'my-comp', directives: []})
@@ -2246,7 +2246,7 @@ class SomeViewport {
 @Pipe({name: 'double'})
 class DoublePipe implements PipeTransform, OnDestroy {
   ngOnDestroy() {}
-  transform(value: any /** TODO #9100 */) { return `${value}${value}`; }
+  transform(value: any /* TODO #9100 */) { return `${value}${value}`; }
 }
 
 @Directive({selector: '[emitter]', outputs: ['event']})
@@ -2319,13 +2319,13 @@ class DirectiveListeningDomEventOther {
 @Directive({selector: '[listenerprevent]', host: {'(click)': 'onEvent($event)'}})
 @Injectable()
 class DirectiveListeningDomEventPrevent {
-  onEvent(event: any /** TODO #9100 */) { return false; }
+  onEvent(event: any /* TODO #9100 */) { return false; }
 }
 
 @Directive({selector: '[listenernoprevent]', host: {'(click)': 'onEvent($event)'}})
 @Injectable()
 class DirectiveListeningDomEventNoPrevent {
-  onEvent(event: any /** TODO #9100 */) { return true; }
+  onEvent(event: any /* TODO #9100 */) { return true; }
 }
 
 @Directive({selector: '[id]', inputs: ['id']})
@@ -2344,9 +2344,9 @@ class EventDir {
 @Directive({selector: '[static]'})
 @Injectable()
 class NeedsAttribute {
-  typeAttribute: any /** TODO #9100 */;
-  staticAttribute: any /** TODO #9100 */;
-  fooAttribute: any /** TODO #9100 */;
+  typeAttribute: any /* TODO #9100 */;
+  staticAttribute: any /* TODO #9100 */;
+  fooAttribute: any /* TODO #9100 */;
   constructor(
       @Attribute('type') typeAttribute: String, @Attribute('static') staticAttribute: String,
       @Attribute('foo') fooAttribute: String) {
@@ -2418,9 +2418,9 @@ class ToolbarComponent {
 @Injectable()
 class DirectiveWithTwoWayBinding {
   controlChange = new EventEmitter();
-  control: any /** TODO #9100 */ = null;
+  control: any /* TODO #9100 */ = null;
 
-  triggerChange(value: any /** TODO #9100 */) {
+  triggerChange(value: any /* TODO #9100 */) {
     ObservableWrapper.callEmit(this.controlChange, value);
   }
 }
@@ -2479,9 +2479,9 @@ class DirectiveProvidingInjectableInHostAndView {
 @Component({selector: 'directive-consuming-injectable', template: ''})
 @Injectable()
 class DirectiveConsumingInjectable {
-  injectable: any /** TODO #9100 */;
+  injectable: any /* TODO #9100 */;
 
-  constructor(@Host() @Inject(InjectableService) injectable: any /** TODO #9100 */) {
+  constructor(@Host() @Inject(InjectableService) injectable: any /* TODO #9100 */) {
     this.injectable = injectable;
   }
 }
@@ -2491,13 +2491,13 @@ class DirectiveConsumingInjectable {
 @Component({selector: 'directive-containing-directive-consuming-an-injectable'})
 @Injectable()
 class DirectiveContainingDirectiveConsumingAnInjectable {
-  directive: any /** TODO #9100 */;
+  directive: any /* TODO #9100 */;
 }
 
 @Component({selector: 'directive-consuming-injectable-unbounded', template: ''})
 @Injectable()
 class DirectiveConsumingInjectableUnbounded {
-  injectable: any /** TODO #9100 */;
+  injectable: any /* TODO #9100 */;
 
   constructor(
       injectable: InjectableService,
@@ -2531,7 +2531,7 @@ class GrandParentProvidingEventBus {
   constructor(bus: EventBus) { this.bus = bus; }
 }
 
-function createParentBus(peb: any /** TODO #9100 */) {
+function createParentBus(peb: any /* TODO #9100 */) {
   return new EventBus(peb, 'parent');
 }
 
@@ -2564,10 +2564,10 @@ class ChildConsumingEventBus {
 @Injectable()
 class SomeImperativeViewport {
   view: EmbeddedViewRef<Object>;
-  anchor: any /** TODO #9100 */;
+  anchor: any /* TODO #9100 */;
   constructor(
       public vc: ViewContainerRef, public templateRef: TemplateRef<Object>,
-      @Inject(ANCHOR_ELEMENT) anchor: any /** TODO #9100 */) {
+      @Inject(ANCHOR_ELEMENT) anchor: any /* TODO #9100 */) {
     this.view = null;
     this.anchor = anchor;
   }
@@ -2626,16 +2626,16 @@ class ComponentWithTemplate {
 
 @Directive({selector: 'with-prop-decorators'})
 class DirectiveWithPropDecorators {
-  target: any /** TODO #9100 */;
+  target: any /* TODO #9100 */;
 
   @Input('elProp') dirProp: string;
   @Output('elEvent') event = new EventEmitter();
 
   @HostBinding('attr.my-attr') myAttr: string;
   @HostListener('click', ['$event.target'])
-  onClick(target: any /** TODO #9100 */) { this.target = target; }
+  onClick(target: any /* TODO #9100 */) { this.target = target; }
 
-  fireEvent(msg: any /** TODO #9100 */) { ObservableWrapper.callEmit(this.event, msg); }
+  fireEvent(msg: any /* TODO #9100 */) { ObservableWrapper.callEmit(this.event, msg); }
 }
 
 @Component({selector: 'some-cmp'})

--- a/modules/@angular/core/test/linker/projection_integration_spec.ts
+++ b/modules/@angular/core/test/linker/projection_integration_spec.ts
@@ -335,7 +335,7 @@ export function main() {
                               }))
                  .createAsync(MainComp)
                  .then((main) => {
-                   var sourceDirective: any /** TODO #9100 */;
+                   var sourceDirective: any /* TODO #9100 */;
 
                    // We can't use the child nodes to get a hold of this because it's not in the dom
                    // at

--- a/modules/@angular/core/test/linker/query_integration_spec.ts
+++ b/modules/@angular/core/test/linker/query_integration_spec.ts
@@ -838,7 +838,7 @@ class NeedsContentChild implements AfterContentInit, AfterContentChecked {
   }
 
   get child() { return this._child; }
-  logs: any[] /** TODO #9100 */ = [];
+  logs: any[] /* TODO #9100 */ = [];
 
   ngAfterContentInit() { this.logs.push(['init', isPresent(this.child) ? this.child.text : null]); }
 
@@ -867,7 +867,7 @@ class NeedsViewChild implements AfterViewInit,
   }
 
   get child() { return this._child; }
-  logs: any[] /** TODO #9100 */ = [];
+  logs: any[] /* TODO #9100 */ = [];
 
   ngAfterViewInit() { this.logs.push(['init', isPresent(this.child) ? this.child.text : null]); }
 
@@ -1106,7 +1106,7 @@ class NeedsViewContainerWithRead {
 
 @Component({selector: 'has-null-query-condition', template: '<div></div>'})
 class HasNullQueryCondition {
-  @ContentChildren(null) errorTrigger: any /** TODO #9100 */;
+  @ContentChildren(null) errorTrigger: any /* TODO #9100 */;
 }
 
 @Component({
@@ -1146,7 +1146,7 @@ class HasNullQueryCondition {
 @Injectable()
 class MyComp0 {
   shouldShow: boolean;
-  list: any /** TODO #9100 */;
+  list: any /* TODO #9100 */;
   constructor() {
     this.shouldShow = false;
     this.list = ['1d', '2d', '3d'];

--- a/modules/@angular/core/test/linker/query_list_spec.ts
+++ b/modules/@angular/core/test/linker/query_list_spec.ts
@@ -21,7 +21,7 @@ export function main() {
       log = '';
     });
 
-    function logAppend(item: any /** TODO #9100 */) { log += (log.length == 0 ? '' : ', ') + item; }
+    function logAppend(item: any /* TODO #9100 */) { log += (log.length == 0 ? '' : ', ') + item; }
 
     it('should support resetting and iterating over the new objects', () => {
       queryList.reset(['one']);
@@ -50,7 +50,7 @@ export function main() {
     if (!IS_DART) {
       it('should support filter', () => {
         queryList.reset(['one', 'two']);
-        expect((<_JsQueryList>queryList).filter((x: any /** TODO #9100 */) => x == 'one')).toEqual([
+        expect((<_JsQueryList>queryList).filter((x: any /* TODO #9100 */) => x == 'one')).toEqual([
           'one'
         ]);
       });
@@ -58,14 +58,14 @@ export function main() {
       it('should support reduce', () => {
         queryList.reset(['one', 'two']);
         expect((<_JsQueryList>queryList)
-                   .reduce((a: any /** TODO #9100 */, x: any /** TODO #9100 */) => a + x, 'start:'))
+                   .reduce((a: any /* TODO #9100 */, x: any /* TODO #9100 */) => a + x, 'start:'))
             .toEqual('start:onetwo');
       });
 
       it('should support toArray', () => {
         queryList.reset(['one', 'two']);
         expect((<_JsQueryList>queryList)
-                   .reduce((a: any /** TODO #9100 */, x: any /** TODO #9100 */) => a + x, 'start:'))
+                   .reduce((a: any /* TODO #9100 */, x: any /* TODO #9100 */) => a + x, 'start:'))
             .toEqual('start:onetwo');
       });
 
@@ -106,7 +106,7 @@ export function main() {
            }));
 
         it('should provides query list as an argument', fakeAsync(() => {
-             var recorded: any /** TODO #9100 */;
+             var recorded: any /* TODO #9100 */;
              ObservableWrapper.subscribe(queryList.changes, (v: any) => { recorded = v; });
 
              queryList.reset(['one']);

--- a/modules/@angular/core/test/linker/reflector_component_resolver_spec.ts
+++ b/modules/@angular/core/test/linker/reflector_component_resolver_spec.ts
@@ -7,7 +7,7 @@ import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 
 export function main() {
   describe('Compiler', () => {
-    var someCompFactory: any /** TODO #9100 */;
+    var someCompFactory: any /* TODO #9100 */;
 
     beforeEachProviders(() => [{provide: ComponentResolver, useClass: ReflectorComponentResolver}]);
 

--- a/modules/@angular/core/test/linker/view_injector_integration_spec.ts
+++ b/modules/@angular/core/test/linker/view_injector_integration_spec.ts
@@ -103,19 +103,19 @@ class NeedsDirective {
 @Directive({selector: '[needsService]'})
 class NeedsService {
   service: any;
-  constructor(@Inject('service') service: any /** TODO #9100 */) { this.service = service; }
+  constructor(@Inject('service') service: any /* TODO #9100 */) { this.service = service; }
 }
 
 @Directive({selector: '[needsAppService]'})
 class NeedsAppService {
   service: any;
-  constructor(@Inject('appService') service: any /** TODO #9100 */) { this.service = service; }
+  constructor(@Inject('appService') service: any /* TODO #9100 */) { this.service = service; }
 }
 
 @Component({selector: '[needsHostAppService]', template: '', directives: ALL_DIRECTIVES})
 class NeedsHostAppService {
   service: any;
-  constructor(@Host() @Inject('appService') service: any /** TODO #9100 */) {
+  constructor(@Host() @Inject('appService') service: any /* TODO #9100 */) {
     this.service = service;
   }
 }
@@ -123,20 +123,20 @@ class NeedsHostAppService {
 @Component({selector: '[needsServiceComponent]', template: ''})
 class NeedsServiceComponent {
   service: any;
-  constructor(@Inject('service') service: any /** TODO #9100 */) { this.service = service; }
+  constructor(@Inject('service') service: any /* TODO #9100 */) { this.service = service; }
 }
 
 @Directive({selector: '[needsServiceFromHost]'})
 class NeedsServiceFromHost {
   service: any;
-  constructor(@Host() @Inject('service') service: any /** TODO #9100 */) { this.service = service; }
+  constructor(@Host() @Inject('service') service: any /* TODO #9100 */) { this.service = service; }
 }
 
 @Directive({selector: '[needsAttribute]'})
 class NeedsAttribute {
-  typeAttribute: any /** TODO #9100 */;
-  titleAttribute: any /** TODO #9100 */;
-  fooAttribute: any /** TODO #9100 */;
+  typeAttribute: any /* TODO #9100 */;
+  titleAttribute: any /* TODO #9100 */;
+  fooAttribute: any /* TODO #9100 */;
   constructor(
       @Attribute('type') typeAttribute: String, @Attribute('title') titleAttribute: String,
       @Attribute('foo') fooAttribute: String) {
@@ -148,33 +148,33 @@ class NeedsAttribute {
 
 @Directive({selector: '[needsAttributeNoType]'})
 class NeedsAttributeNoType {
-  fooAttribute: any /** TODO #9100 */;
-  constructor(@Attribute('foo') fooAttribute: any /** TODO #9100 */) {
+  fooAttribute: any /* TODO #9100 */;
+  constructor(@Attribute('foo') fooAttribute: any /* TODO #9100 */) {
     this.fooAttribute = fooAttribute;
   }
 }
 
 @Directive({selector: '[needsElementRef]'})
 class NeedsElementRef {
-  elementRef: any /** TODO #9100 */;
+  elementRef: any /* TODO #9100 */;
   constructor(ref: ElementRef) { this.elementRef = ref; }
 }
 
 @Directive({selector: '[needsViewContainerRef]'})
 class NeedsViewContainerRef {
-  viewContainer: any /** TODO #9100 */;
+  viewContainer: any /* TODO #9100 */;
   constructor(vc: ViewContainerRef) { this.viewContainer = vc; }
 }
 
 @Directive({selector: '[needsTemplateRef]'})
 class NeedsTemplateRef {
-  templateRef: any /** TODO #9100 */;
+  templateRef: any /* TODO #9100 */;
   constructor(ref: TemplateRef<Object>) { this.templateRef = ref; }
 }
 
 @Directive({selector: '[optionallyNeedsTemplateRef]'})
 class OptionallyNeedsTemplateRef {
-  templateRef: any /** TODO #9100 */;
+  templateRef: any /* TODO #9100 */;
   constructor(@Optional() ref: TemplateRef<Object>) { this.templateRef = ref; }
 }
 
@@ -215,7 +215,7 @@ class PipeNeedsChangeDetectorRef {
 @Pipe({name: 'pipeNeedsService'})
 export class PipeNeedsService implements PipeTransform {
   service: any;
-  constructor(@Inject('service') service: any /** TODO #9100 */) { this.service = service; }
+  constructor(@Inject('service') service: any /* TODO #9100 */) { this.service = service; }
   transform(value: any): any { return this; }
 }
 
@@ -307,7 +307,7 @@ export function main() {
                    .overrideProviders(SomeOtherDirective, [
                      {provide: 'injectable1', useValue: 'new-injectable1'}, {
                        provide: 'injectable2',
-                       useFactory: (val: any /** TODO #9100 */) => `${val}-injectable2`,
+                       useFactory: (val: any /* TODO #9100 */) => `${val}-injectable2`,
                        deps: [[new InjectMetadata('injectable1'), new SkipSelfMetadata()]]
                      }
                    ]));
@@ -319,7 +319,7 @@ export function main() {
            var providers = [
              {provide: 'injectable1', useValue: 'injectable1'}, {
                provide: 'injectable2',
-               useFactory: (val: any /** TODO #9100 */) => `${val}-injectable2`,
+               useFactory: (val: any /* TODO #9100 */) => `${val}-injectable2`,
                deps: ['injectable1']
              }
            ];
@@ -332,7 +332,7 @@ export function main() {
            var viewProviders = [
              {provide: 'injectable1', useValue: 'injectable1'}, {
                provide: 'injectable2',
-               useFactory: (val: any /** TODO #9100 */) => `${val}-injectable2`,
+               useFactory: (val: any /* TODO #9100 */) => `${val}-injectable2`,
                deps: ['injectable1']
              }
            ];

--- a/modules/@angular/core/test/metadata/decorators_spec.ts
+++ b/modules/@angular/core/test/metadata/decorators_spec.ts
@@ -18,7 +18,7 @@ export function main() {
 
     it('should create type in ES5', () => {
       function MyComponent(){};
-      var as: any /** TODO #9100 */;
+      var as: any /* TODO #9100 */;
       (<any>MyComponent).annotations = as = Component({}).View({});
       expect(reflector.annotations(MyComponent)).toEqual(as.annotations);
     });

--- a/modules/@angular/core/test/reflection/reflector_common.ts
+++ b/modules/@angular/core/test/reflection/reflector_common.ts
@@ -1,26 +1,26 @@
 import {makeDecorator, makeParamDecorator, makePropDecorator} from '@angular/core/src/util/decorators';
 
 export class ClassDecoratorMeta {
-  constructor(public value: any /** TODO #9100 */) {}
+  constructor(public value: any /* TODO #9100 */) {}
 }
 
 export class ParamDecoratorMeta {
-  constructor(public value: any /** TODO #9100 */) {}
+  constructor(public value: any /* TODO #9100 */) {}
 }
 
 export class PropDecoratorMeta {
-  constructor(public value: any /** TODO #9100 */) {}
+  constructor(public value: any /* TODO #9100 */) {}
 }
 
-export function classDecorator(value: any /** TODO #9100 */) {
+export function classDecorator(value: any /* TODO #9100 */) {
   return new ClassDecoratorMeta(value);
 }
 
-export function paramDecorator(value: any /** TODO #9100 */) {
+export function paramDecorator(value: any /* TODO #9100 */) {
   return new ParamDecoratorMeta(value);
 }
 
-export function propDecorator(value: any /** TODO #9100 */) {
+export function propDecorator(value: any /* TODO #9100 */) {
   return new PropDecoratorMeta(value);
 }
 

--- a/modules/@angular/core/test/reflection/reflector_spec.ts
+++ b/modules/@angular/core/test/reflection/reflector_spec.ts
@@ -7,17 +7,17 @@ import {IS_DART} from '../../src/facade/lang';
 import {browserDetection} from '@angular/platform-browser/testing'
 
 class AType {
-  value: any /** TODO #9100 */;
+  value: any /* TODO #9100 */;
 
-  constructor(value: any /** TODO #9100 */) { this.value = value; }
+  constructor(value: any /* TODO #9100 */) { this.value = value; }
 }
 
 @ClassDecorator('class') class ClassWithDecorators {
-  @PropDecorator('p1') @PropDecorator('p2') a: any /** TODO #9100 */;
-  b: any /** TODO #9100 */;
+  @PropDecorator('p1') @PropDecorator('p2') a: any /* TODO #9100 */;
+  b: any /* TODO #9100 */;
 
   @PropDecorator('p3')
-  set c(value: any /** TODO #9100 */) {
+  set c(value: any /* TODO #9100 */) {
   }
 
   constructor(@ParamDecorator('a') a: AType, @ParamDecorator('b') b: AType) {
@@ -27,19 +27,19 @@ class AType {
 }
 
 class ClassWithoutDecorators {
-  constructor(a: any /** TODO #9100 */, b: any /** TODO #9100 */) {}
+  constructor(a: any /* TODO #9100 */, b: any /* TODO #9100 */) {}
 }
 
 class TestObj {
-  a: any /** TODO #9100 */;
-  b: any /** TODO #9100 */;
+  a: any /* TODO #9100 */;
+  b: any /* TODO #9100 */;
 
-  constructor(a: any /** TODO #9100 */, b: any /** TODO #9100 */) {
+  constructor(a: any /* TODO #9100 */, b: any /* TODO #9100 */) {
   this.a = a;
   this.b = b;
   }
 
-  identity(arg: any /** TODO #9100 */) {
+  identity(arg: any /* TODO #9100 */) {
   return arg; }
 }
 
@@ -66,7 +66,7 @@ class SubClassDoesNotDeclareOnInit extends SuperClassImplementingOnInit {}
 
 export function main() {
   describe('Reflector', () => {
-  var reflector: any /** TODO #9100 */;
+  var reflector: any /* TODO #9100 */;
 
   beforeEach(() => { reflector = new Reflector(new ReflectionCapabilities()); });
 
@@ -105,8 +105,8 @@ export function main() {
     // TODO: remove when issue is solved: https://github.com/angular/angular/issues/4756
     if (!browserDetection.isEdge) {
       it('should check args from no to max', () => {
-        var f = (t: any /** TODO #9100 */) => reflector.factory(t);
-        var checkArgs = (obj: any /** TODO #9100 */, args: any /** TODO #9100 */) =>
+        var f = (t: any /* TODO #9100 */) => reflector.factory(t);
+        var checkArgs = (obj: any /* TODO #9100 */, args: any /* TODO #9100 */) =>
             expect(obj.args).toEqual(args);
 
         // clang-format off
@@ -232,7 +232,7 @@ export function main() {
     });
 
     it('should return a registered getter if available', () => {
-      reflector.registerGetters({'abc': (obj: any /** TODO #9100 */) => 'fake'});
+      reflector.registerGetters({'abc': (obj: any /* TODO #9100 */) => 'fake'});
       expect(reflector.getter('abc')('anything')).toEqual('fake');
     });
   });
@@ -246,9 +246,9 @@ export function main() {
     });
 
     it('should return a registered setter if available', () => {
-      var updateMe: any /** TODO #9100 */;
+      var updateMe: any /* TODO #9100 */;
       reflector.registerSetters({
-        'abc': (obj: any /** TODO #9100 */, value: any /** TODO #9100 */) => { updateMe = value; }
+        'abc': (obj: any /* TODO #9100 */, value: any /* TODO #9100 */) => { updateMe = value; }
       });
       reflector.setter('abc')('anything', 'fake');
 
@@ -265,7 +265,7 @@ export function main() {
 
     it('should return a registered method if available', () => {
       reflector.registerMethods(
-          {'abc': (obj: any /** TODO #9100 */, args: any /** TODO #9100 */) => args});
+          {'abc': (obj: any /* TODO #9100 */, args: any /* TODO #9100 */) => args});
       expect(reflector.method('abc')('anything', ['fake'])).toEqual(['fake']);
     });
   });

--- a/modules/@angular/core/test/testing_internal_spec.ts
+++ b/modules/@angular/core/test/testing_internal_spec.ts
@@ -5,10 +5,10 @@ import {RegExpWrapper} from '../../router/src/facade/lang';
 import {beforeEach, containsRegexp, ddescribe, describe, expect, iit, it, tick} from '../testing';
 
 class TestObj {
-  prop: any /** TODO #9100 */;
-  constructor(prop: any /** TODO #9100 */) { this.prop = prop; }
+  prop: any /* TODO #9100 */;
+  constructor(prop: any /* TODO #9100 */) { this.prop = prop; }
   someFunc(): number { return -1; }
-  someComplexFunc(a: any /** TODO #9100 */) { return a; }
+  someComplexFunc(a: any /* TODO #9100 */) { return a; }
 }
 
 class SpyTestObj extends SpyObject {
@@ -69,7 +69,7 @@ export function main() {
     });
 
     describe('spy objects', () => {
-      var spyObj: any /** TODO #9100 */;
+      var spyObj: any /* TODO #9100 */;
 
       beforeEach(() => { spyObj = <any>new SpyTestObj(); });
 
@@ -78,7 +78,7 @@ export function main() {
 
       it('should record function calls', () => {
         spyObj.spy('someFunc')
-            .andCallFake((a: any /** TODO #9100 */, b: any /** TODO #9100 */) => {return a + b});
+            .andCallFake((a: any /* TODO #9100 */, b: any /* TODO #9100 */) => {return a + b});
 
         expect(spyObj.someFunc(1, 2)).toEqual(3);
         expect(spyObj.spy('someFunc')).toHaveBeenCalledWith(1, 2);

--- a/modules/@angular/core/test/util/decorators_spec.ts
+++ b/modules/@angular/core/test/util/decorators_spec.ts
@@ -56,16 +56,16 @@ export function main() {
 
     describe('Class', () => {
       it('should create a class', () => {
-        var i0: any /** TODO #9100 */, i1: any /** TODO #9100 */;
+        var i0: any /* TODO #9100 */, i1: any /* TODO #9100 */;
         var MyClass = (<any>TestDecorator('test-works')).Class(<any>{
           extends: Class(<any>{
             constructor: function() {},
             extendWorks: function() { return 'extend ' + this.arg; }
           }),
-          constructor: [String, function(arg: any /** TODO #9100 */) { this.arg = arg; }],
+          constructor: [String, function(arg: any /* TODO #9100 */) { this.arg = arg; }],
           methodA: [
             i0 = new Inject(String), [i1 = Inject(String), Number],
-            function(a: any /** TODO #9100 */, b: any /** TODO #9100 */) {}
+            function(a: any /* TODO #9100 */, b: any /* TODO #9100 */) {}
           ],
           works: function() { return this.arg; },
           prototype: 'IGNORE'

--- a/modules/@angular/core/testing/animation/mock_animation_driver.ts
+++ b/modules/@angular/core/testing/animation/mock_animation_driver.ts
@@ -6,7 +6,7 @@ import {StringMapWrapper} from '../../src/facade/collection';
 import {MockAnimationPlayer} from '../../testing/animation/mock_animation_player';
 
 export class MockAnimationDriver extends AnimationDriver {
-  log: any[] /** TODO #9100 */ = [];
+  log: any[] /* TODO #9100 */ = [];
   animate(
       element: any, startingStyles: AnimationStyles, keyframes: AnimationKeyframe[],
       duration: number, delay: number, easing: string): AnimationPlayer {
@@ -33,8 +33,8 @@ function _serializeStyles(styles: AnimationStyles): {[key: string]: any} {
   var flatStyles = {};
   styles.styles.forEach(
       entry => StringMapWrapper.forEach(
-          entry, (val: any /** TODO #9100 */, prop: any /** TODO #9100 */) => {
-            (flatStyles as any /** TODO #9100 */)[prop] = val;
+          entry, (val: any /* TODO #9100 */, prop: any /* TODO #9100 */) => {
+            (flatStyles as any /* TODO #9100 */)[prop] = val;
           }));
   return flatStyles;
 }

--- a/modules/@angular/core/testing/animation/mock_animation_player.ts
+++ b/modules/@angular/core/testing/animation/mock_animation_player.ts
@@ -2,12 +2,12 @@ import {AnimationPlayer} from '../../src/animation/animation_player';
 import {isPresent} from '../../src/facade/lang';
 
 export class MockAnimationPlayer implements AnimationPlayer {
-  private _subscriptions: any[] /** TODO #9100 */ = [];
+  private _subscriptions: any[] /* TODO #9100 */ = [];
   private _finished = false;
   private _destroyed = false;
   public parentPlayer: AnimationPlayer = null;
 
-  public log: any[] /** TODO #9100 */ = [];
+  public log: any[] /* TODO #9100 */ = [];
 
   private _onfinish(): void {
     if (!this._finished) {
@@ -42,6 +42,6 @@ export class MockAnimationPlayer implements AnimationPlayer {
     }
   }
 
-  setPosition(p: any /** TODO #9100 */): void {}
+  setPosition(p: any /* TODO #9100 */): void {}
   getPosition(): number { return 0; }
 }

--- a/modules/@angular/core/testing/async.ts
+++ b/modules/@angular/core/testing/async.ts
@@ -15,7 +15,7 @@
  */
 export function async(fn: Function): Function {
   return () => new Promise<void>((finishCallback, failCallback) => {
-           var AsyncTestZoneSpec = (Zone as any /** TODO #9100 */)['AsyncTestZoneSpec'];
+           var AsyncTestZoneSpec = (Zone as any /* TODO #9100 */)['AsyncTestZoneSpec'];
            var testZoneSpec = new AsyncTestZoneSpec(finishCallback, failCallback, 'test');
            var testZone = Zone.current.fork(testZoneSpec);
            return testZone.run(fn);

--- a/modules/@angular/core/testing/fake_async.ts
+++ b/modules/@angular/core/testing/fake_async.ts
@@ -1,7 +1,7 @@
 import {BaseException} from '../index';
 import {getTestInjector} from './test_injector';
 
-let _FakeAsyncTestZoneSpecType = (Zone as any /** TODO #9100 */)['FakeAsyncTestZoneSpec'];
+let _FakeAsyncTestZoneSpecType = (Zone as any /* TODO #9100 */)['FakeAsyncTestZoneSpec'];
 
 /**
  * Wraps a function to be executed in the fakeAsync zone:
@@ -27,7 +27,7 @@ export function fakeAsync(fn: Function): Function {
   let fakeAsyncTestZoneSpec = new _FakeAsyncTestZoneSpecType();
   let fakeAsyncZone = Zone.current.fork(fakeAsyncTestZoneSpec);
 
-  return function(...args: any[] /** TODO #9100 */) {
+  return function(...args: any[] /* TODO #9100 */) {
     let res = fakeAsyncZone.run(() => {
       let res = fn(...args);
       flushMicrotasks();

--- a/modules/@angular/core/testing/lang_utils.ts
+++ b/modules/@angular/core/testing/lang_utils.ts
@@ -1,4 +1,4 @@
-export function getTypeOf(instance: any /** TODO #9100 */) {
+export function getTypeOf(instance: any /* TODO #9100 */) {
   return instance.constructor;
 }
 

--- a/modules/@angular/core/testing/logger.ts
+++ b/modules/@angular/core/testing/logger.ts
@@ -6,9 +6,9 @@ export class Log {
 
   constructor() { this.logItems = []; }
 
-  add(value: any /** TODO #9100 */): void { this.logItems.push(value); }
+  add(value: any /* TODO #9100 */): void { this.logItems.push(value); }
 
-  fn(value: any /** TODO #9100 */) {
+  fn(value: any /* TODO #9100 */) {
     return (a1: any = null, a2: any = null, a3: any = null, a4: any = null, a5: any = null) => {
       this.logItems.push(value);
     };

--- a/modules/@angular/core/testing/regexp.ts
+++ b/modules/@angular/core/testing/regexp.ts
@@ -5,5 +5,5 @@ var _RE_SPECIAL_CHARS =
 var _ESCAPE_RE = RegExpWrapper.create(`[\\${_RE_SPECIAL_CHARS.join('\\')}]`);
 export function containsRegexp(input: string): RegExp {
   return RegExpWrapper.create(StringWrapper.replaceAllMapped(
-      input, _ESCAPE_RE, (match: any /** TODO #9100 */) => `\\${match[0]}`));
+      input, _ESCAPE_RE, (match: any /* TODO #9100 */) => `\\${match[0]}`));
 }

--- a/modules/@angular/core/testing/testing.ts
+++ b/modules/@angular/core/testing/testing.ts
@@ -8,7 +8,7 @@ import {TestInjector, async, getTestInjector, inject, injectAsync} from './test_
 
 export {async, inject, injectAsync} from './test_injector';
 
-declare var global: any /** TODO #9100 */;
+declare var global: any /* TODO #9100 */;
 
 var _global = <any>(typeof window === 'undefined' ? global : window);
 

--- a/modules/@angular/core/testing/testing_internal.ts
+++ b/modules/@angular/core/testing/testing_internal.ts
@@ -11,7 +11,7 @@ export {AsyncTestCompleter} from './async_test_completer';
 export {inject} from './test_injector';
 export {expect} from './testing';
 
-export var proxy: ClassDecorator = (t: any /** TODO #9100 */) => t;
+export var proxy: ClassDecorator = (t: any /* TODO #9100 */) => t;
 
 var _global = <any>(typeof window === 'undefined' ? global : window);
 
@@ -25,7 +25,7 @@ var jsmIt = _global.it;
 var jsmIIt = _global.fit;
 var jsmXIt = _global.xit;
 
-var runnerStack: any[] /** TODO #9100 */ = [];
+var runnerStack: any[] /* TODO #9100 */ = [];
 var inIt = false;
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 3000;
 var globalTimeOut = jasmine.DEFAULT_TIMEOUT_INTERVAL;
@@ -53,7 +53,7 @@ class BeforeEachRunner {
 // Reset the test providers before each test
 jsmBeforeEach(() => { testInjector.reset(); });
 
-function _describe(jsmFn: any /** TODO #9100 */, ...args: any[] /** TODO #9100 */) {
+function _describe(jsmFn: any /* TODO #9100 */, ...args: any[] /* TODO #9100 */) {
   var parentRunner = runnerStack.length === 0 ? null : runnerStack[runnerStack.length - 1];
   var runner = new BeforeEachRunner(parentRunner);
   runnerStack.push(runner);
@@ -62,15 +62,15 @@ function _describe(jsmFn: any /** TODO #9100 */, ...args: any[] /** TODO #9100 *
   return suite;
 }
 
-export function describe(...args: any[] /** TODO #9100 */): void {
+export function describe(...args: any[] /* TODO #9100 */): void {
   return _describe(jsmDescribe, ...args);
 }
 
-export function ddescribe(...args: any[] /** TODO #9100 */): void {
+export function ddescribe(...args: any[] /* TODO #9100 */): void {
   return _describe(jsmDDescribe, ...args);
 }
 
-export function xdescribe(...args: any[] /** TODO #9100 */): void {
+export function xdescribe(...args: any[] /* TODO #9100 */): void {
   return _describe(jsmXDescribe, ...args);
 }
 
@@ -96,7 +96,7 @@ export function beforeEach(fn: Function): void {
  *     {provide: SomeToken, useValue: myValue},
  *   ]);
  */
-export function beforeEachProviders(fn: any /** TODO #9100 */): void {
+export function beforeEachProviders(fn: any /* TODO #9100 */): void {
   jsmBeforeEach(() => {
     var providers = fn();
     if (!providers) return;
@@ -107,7 +107,7 @@ export function beforeEachProviders(fn: any /** TODO #9100 */): void {
 /**
  * @deprecated
  */
-export function beforeEachBindings(fn: any /** TODO #9100 */): void {
+export function beforeEachBindings(fn: any /* TODO #9100 */): void {
   beforeEachProviders(fn);
 }
 
@@ -120,7 +120,7 @@ function _it(jsmFn: Function, name: string, testFn: Function, testTimeOut: numbe
   var runner = runnerStack[runnerStack.length - 1];
   var timeOut = Math.max(globalTimeOut, testTimeOut);
 
-  jsmFn(name, (done: any /** TODO #9100 */) => {
+  jsmFn(name, (done: any /* TODO #9100 */) => {
     var completerProvider = {
       provide: AsyncTestCompleter,
       useFactory: () => {
@@ -151,20 +151,20 @@ function _it(jsmFn: Function, name: string, testFn: Function, testTimeOut: numbe
 }
 
 export function it(
-    name: any /** TODO #9100 */, fn: any /** TODO #9100 */,
-    timeOut: any /** TODO #9100 */ = null): void {
+    name: any /* TODO #9100 */, fn: any /* TODO #9100 */,
+    timeOut: any /* TODO #9100 */ = null): void {
   return _it(jsmIt, name, fn, timeOut);
 }
 
 export function xit(
-    name: any /** TODO #9100 */, fn: any /** TODO #9100 */,
-    timeOut: any /** TODO #9100 */ = null): void {
+    name: any /* TODO #9100 */, fn: any /* TODO #9100 */,
+    timeOut: any /* TODO #9100 */ = null): void {
   return _it(jsmXIt, name, fn, timeOut);
 }
 
 export function iit(
-    name: any /** TODO #9100 */, fn: any /** TODO #9100 */,
-    timeOut: any /** TODO #9100 */ = null): void {
+    name: any /* TODO #9100 */, fn: any /* TODO #9100 */,
+    timeOut: any /* TODO #9100 */ = null): void {
   return _it(jsmIIt, name, fn, timeOut);
 }
 
@@ -176,14 +176,14 @@ export interface GuinessCompatibleSpy extends jasmine.Spy {
    * function. */
   andCallFake(fn: Function): GuinessCompatibleSpy;
   /** removes all recorded calls */
-  reset(): any /** TODO #9100 */;
+  reset(): any /* TODO #9100 */;
 }
 
 export class SpyObject {
-  constructor(type: any /** TODO #9100 */ = null) {
+  constructor(type: any /* TODO #9100 */ = null) {
     if (type) {
       for (var prop in type.prototype) {
-        var m: any /** TODO #9100 */ = null;
+        var m: any /* TODO #9100 */ = null;
         try {
           m = type.prototype[prop];
         } catch (e) {
@@ -199,22 +199,22 @@ export class SpyObject {
     }
   }
   // Noop so that SpyObject has the same interface as in Dart
-  noSuchMethod(args: any /** TODO #9100 */) {}
+  noSuchMethod(args: any /* TODO #9100 */) {}
 
-  spy(name: any /** TODO #9100 */) {
-    if (!(this as any /** TODO #9100 */)[name]) {
-      (this as any /** TODO #9100 */)[name] = this._createGuinnessCompatibleSpy(name);
+  spy(name: any /* TODO #9100 */) {
+    if (!(this as any /* TODO #9100 */)[name]) {
+      (this as any /* TODO #9100 */)[name] = this._createGuinnessCompatibleSpy(name);
     }
-    return (this as any /** TODO #9100 */)[name];
+    return (this as any /* TODO #9100 */)[name];
   }
 
-  prop(name: any /** TODO #9100 */, value: any /** TODO #9100 */) {
-    (this as any /** TODO #9100 */)[name] = value;
+  prop(name: any /* TODO #9100 */, value: any /* TODO #9100 */) {
+    (this as any /* TODO #9100 */)[name] = value;
   }
 
   static stub(
-      object: any /** TODO #9100 */ = null, config: any /** TODO #9100 */ = null,
-      overrides: any /** TODO #9100 */ = null) {
+      object: any /* TODO #9100 */ = null, config: any /* TODO #9100 */ = null,
+      overrides: any /* TODO #9100 */ = null) {
     if (!(object instanceof SpyObject)) {
       overrides = config;
       config = object;
@@ -222,14 +222,14 @@ export class SpyObject {
     }
 
     var m = StringMapWrapper.merge(config, overrides);
-    StringMapWrapper.forEach(m, (value: any /** TODO #9100 */, key: any /** TODO #9100 */) => {
+    StringMapWrapper.forEach(m, (value: any /* TODO #9100 */, key: any /* TODO #9100 */) => {
       object.spy(key).andReturn(value);
     });
     return object;
   }
 
   /** @internal */
-  _createGuinnessCompatibleSpy(name: any /** TODO #9100 */): GuinessCompatibleSpy {
+  _createGuinnessCompatibleSpy(name: any /* TODO #9100 */): GuinessCompatibleSpy {
     var newSpy: GuinessCompatibleSpy = <any>jasmine.createSpy(name);
     newSpy.andCallFake = <any>newSpy.and.callFake;
     newSpy.andReturn = <any>newSpy.and.returnValue;

--- a/modules/@angular/facade/src/async.ts
+++ b/modules/@angular/facade/src/async.ts
@@ -130,14 +130,14 @@ export class EventEmitter<T> extends Subject<T> {
   next(value: any) { super.next(value); }
 
   subscribe(generatorOrNext?: any, error?: any, complete?: any): any {
-    let schedulerFn: any /** TODO #9100 */;
-    let errorFn = (err: any): any /** TODO #9100 */ => null;
-    let completeFn = (): any /** TODO #9100 */ => null;
+    let schedulerFn: any /* TODO #9100 */;
+    let errorFn = (err: any): any /* TODO #9100 */ => null;
+    let completeFn = (): any /* TODO #9100 */ => null;
 
     if (generatorOrNext && typeof generatorOrNext === 'object') {
-      schedulerFn = this.__isAsync ? (value: any /** TODO #9100 */) => {
+      schedulerFn = this.__isAsync ? (value: any /* TODO #9100 */) => {
         setTimeout(() => generatorOrNext.next(value));
-      } : (value: any /** TODO #9100 */) => { generatorOrNext.next(value); };
+      } : (value: any /* TODO #9100 */) => { generatorOrNext.next(value); };
 
       if (generatorOrNext.error) {
         errorFn = this.__isAsync ? (err) => { setTimeout(() => generatorOrNext.error(err)); } :
@@ -149,9 +149,9 @@ export class EventEmitter<T> extends Subject<T> {
                                       () => { generatorOrNext.complete(); };
       }
     } else {
-      schedulerFn = this.__isAsync ? (value: any /** TODO #9100 */) => {
+      schedulerFn = this.__isAsync ? (value: any /* TODO #9100 */) => {
         setTimeout(() => generatorOrNext(value));
-      } : (value: any /** TODO #9100 */) => { generatorOrNext(value); };
+      } : (value: any /* TODO #9100 */) => { generatorOrNext(value); };
 
       if (error) {
         errorFn =

--- a/modules/@angular/facade/src/browser.ts
+++ b/modules/@angular/facade/src/browser.ts
@@ -6,7 +6,7 @@ var win = typeof window !== 'undefined' && window || <any>{};
 export {win as window};
 export var document = win.document;
 export var location = win.location;
-export var gc = win['gc'] ? () => win['gc']() : (): any /** TODO #9100 */ => null;
+export var gc = win['gc'] ? () => win['gc']() : (): any /* TODO #9100 */ => null;
 export var performance = win['performance'] ? win['performance'] : null;
 export const Event = win['Event'];
 export const MouseEvent = win['MouseEvent'];

--- a/modules/@angular/facade/src/exceptions.ts
+++ b/modules/@angular/facade/src/exceptions.ts
@@ -24,8 +24,8 @@ export class WrappedException extends BaseWrappedException {
   private _wrapperStack: any;
 
   constructor(
-      private _wrapperMessage: string, private _originalException: any /** TODO #9100 */,
-      private _originalStack?: any /** TODO #9100 */, private _context?: any /** TODO #9100 */) {
+      private _wrapperMessage: string, private _originalException: any /* TODO #9100 */,
+      private _originalStack?: any /* TODO #9100 */, private _context?: any /* TODO #9100 */) {
     super(_wrapperMessage);
     this._wrapperStack = (<any>new Error(_wrapperMessage)).stack;
   }

--- a/modules/@angular/facade/src/intl.ts
+++ b/modules/@angular/facade/src/intl.ts
@@ -128,12 +128,12 @@ function hour12Modify(
 
 function digitCondition(prop: string, len: number): Intl.DateTimeFormatOptions {
   var result = {};
-  (result as any /** TODO #9100 */)[prop] = len == 2 ? '2-digit' : 'numeric';
+  (result as any /* TODO #9100 */)[prop] = len == 2 ? '2-digit' : 'numeric';
   return result;
 }
 function nameCondition(prop: string, len: number): Intl.DateTimeFormatOptions {
   var result = {};
-  (result as any /** TODO #9100 */)[prop] = len < 4 ? 'short' : 'long';
+  (result as any /* TODO #9100 */)[prop] = len < 4 ? 'short' : 'long';
   return result;
 }
 
@@ -157,11 +157,11 @@ var datePartsFormatterCache: Map<string, string[]> = new Map<string, string[]>()
 
 function dateFormatter(format: string, date: Date, locale: string): string {
   var text = '';
-  var match: any /** TODO #9100 */;
-  var fn: any /** TODO #9100 */;
+  var match: any /* TODO #9100 */;
+  var fn: any /* TODO #9100 */;
   var parts: string[] = [];
-  if ((PATTERN_ALIASES as any /** TODO #9100 */)[format]) {
-    return (PATTERN_ALIASES as any /** TODO #9100 */)[format](date, locale);
+  if ((PATTERN_ALIASES as any /* TODO #9100 */)[format]) {
+    return (PATTERN_ALIASES as any /* TODO #9100 */)[format](date, locale);
   }
 
 
@@ -185,7 +185,7 @@ function dateFormatter(format: string, date: Date, locale: string): string {
   }
 
   parts.forEach(part => {
-    fn = (DATE_FORMATS as any /** TODO #9100 */)[part];
+    fn = (DATE_FORMATS as any /* TODO #9100 */)[part];
     text += fn ? fn(date, locale) :
                  part === '\'\'' ? '\'' : part.replace(/(^'|'$)/g, '').replace(/''/g, '\'');
   });
@@ -195,8 +195,8 @@ function dateFormatter(format: string, date: Date, locale: string): string {
 
 var slice = [].slice;
 function concat(
-    array1: any /** TODO #9100 */, array2: any /** TODO #9100 */,
-    index: any /** TODO #9100 */): string[] {
+    array1: any /* TODO #9100 */, array2: any /* TODO #9100 */,
+    index: any /* TODO #9100 */): string[] {
   return array1.concat(slice.call(array2, index));
 }
 

--- a/modules/@angular/facade/src/lang.ts
+++ b/modules/@angular/facade/src/lang.ts
@@ -21,11 +21,11 @@ export interface BrowserNodeGlobal {
 }
 
 // TODO(jteplitz602): Load WorkerGlobalScope from lib.webworker.d.ts file #3492
-declare var WorkerGlobalScope: any /** TODO #9100 */;
+declare var WorkerGlobalScope: any /* TODO #9100 */;
 // CommonJS / Node have global context exposed as "global" variable.
 // We don't want to include the whole node.d.ts this this compilation unit so we'll just fake
 // the global "global" var for now.
-declare var global: any /** TODO #9100 */;
+declare var global: any /* TODO #9100 */;
 
 var globalScope: BrowserNodeGlobal;
 if (typeof window === 'undefined') {
@@ -64,7 +64,7 @@ export interface Type extends Function {}
 /**
  * Runtime representation of a type that is constructable (non-abstract).
  */
-export interface ConcreteType extends Type { new (...args: any[] /** TODO #9100 */): any; }
+export interface ConcreteType extends Type { new (...args: any[] /* TODO #9100 */): any; }
 
 export function getTypeNameForDebugging(type: Type): string {
   if (type['name']) {

--- a/modules/@angular/facade/test/async_spec.ts
+++ b/modules/@angular/facade/test/async_spec.ts
@@ -54,7 +54,7 @@ export function main() {
     if (!browserDetection.isEdge) {
       it('delivers next and error events synchronously',
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-           let log: any[] /** TODO #9100 */ = [];
+           let log: any[] /* TODO #9100 */ = [];
            ObservableWrapper.subscribe(
                emitter,
                (x) => {
@@ -74,7 +74,7 @@ export function main() {
          }));
 
       it('delivers next and complete events synchronously', () => {
-        let log: any[] /** TODO #9100 */ = [];
+        let log: any[] /* TODO #9100 */ = [];
         ObservableWrapper.subscribe(
             emitter,
             (x) => {
@@ -98,7 +98,7 @@ export function main() {
     it('delivers events asynchronously when forced to async mode',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          var e = new EventEmitter(true);
-         var log: any[] /** TODO #9100 */ = [];
+         var log: any[] /* TODO #9100 */ = [];
          ObservableWrapper.subscribe(e, (x) => {
            log.push(x);
            expect(log).toEqual([1, 3, 2]);

--- a/modules/@angular/facade/test/collection_spec.ts
+++ b/modules/@angular/facade/test/collection_spec.ts
@@ -97,12 +97,12 @@ export function main() {
     });
 
     describe('forEachWithIndex', () => {
-      var l: any /** TODO #9100 */;
+      var l: any /* TODO #9100 */;
 
       beforeEach(() => { l = ['a', 'b']; });
 
       it('should iterate over an array passing values and indices', () => {
-        var record: any[] /** TODO #9100 */ = [];
+        var record: any[] /* TODO #9100 */ = [];
         ListWrapper.forEachWithIndex(l, (value, index) => record.push([value, index]));
         expect(record).toEqual([['a', 0], ['b', 1]]);
       });

--- a/modules/@angular/facade/test/lang_spec.ts
+++ b/modules/@angular/facade/test/lang_spec.ts
@@ -15,8 +15,8 @@ export function main() {
     it('should expose the index for each match', () => {
       var re = /(!)/g;
       var matcher = RegExpWrapper.matcher(re, '0!23!567!!');
-      var indexes: any[] /** TODO #9100 */ = [];
-      var m: any /** TODO #9100 */;
+      var indexes: any[] /* TODO #9100 */ = [];
+      var m: any /* TODO #9100 */;
 
       while (isPresent(m = RegExpMatcherWrapper.next(matcher))) {
         indexes.push(m.index);
@@ -39,7 +39,7 @@ export function main() {
     it('should implement replace all', () => {
       let re = /(\d)+/g;
       let m =
-          RegExpWrapper.replaceAll(re, 'a1b2c', (match: any /** TODO #9100 */) => `!${match[1]}!`);
+          RegExpWrapper.replaceAll(re, 'a1b2c', (match: any /* TODO #9100 */) => `!${match[1]}!`);
       expect(m).toEqual('a!1!b!2!c');
     });
   });
@@ -52,7 +52,7 @@ export function main() {
   });
 
   describe('String', () => {
-    var s: any /** TODO #9100 */;
+    var s: any /* TODO #9100 */;
 
     describe('slice', () => {
       beforeEach(() => { s = 'abcdefghij'; });

--- a/modules/@angular/http/src/backends/xhr_backend.ts
+++ b/modules/@angular/http/src/backends/xhr_backend.ts
@@ -106,7 +106,7 @@ export class XHRConnection implements Connection {
     });
   }
 
-  setDetectedContentType(req: any /** TODO #9100 */, _xhr: any /** TODO #9100 */) {
+  setDetectedContentType(req: any /* TODO #9100 */, _xhr: any /* TODO #9100 */) {
     // Skip if a custom Content-Type header is provided
     if (isPresent(req.headers) && isPresent(req.headers.get('Content-Type'))) {
       return;

--- a/modules/@angular/http/src/headers.ts
+++ b/modules/@angular/http/src/headers.ts
@@ -122,12 +122,12 @@ export class Headers {
   toJSON(): {[key: string]: any} {
     let serializableHeaders = {};
     this._headersMap.forEach((values: string[], name: string) => {
-      let list: any[] /** TODO #9100 */ = [];
+      let list: any[] /* TODO #9100 */ = [];
 
       iterateListLike(
-          values, (val: any /** TODO #9100 */) => list = ListWrapper.concat(list, val.split(',')));
+          values, (val: any /* TODO #9100 */) => list = ListWrapper.concat(list, val.split(',')));
 
-      (serializableHeaders as any /** TODO #9100 */)[name] = list;
+      (serializableHeaders as any /* TODO #9100 */)[name] = list;
     });
     return serializableHeaders;
   }

--- a/modules/@angular/http/src/static_request.ts
+++ b/modules/@angular/http/src/static_request.ts
@@ -170,6 +170,6 @@ export class Request {
 
 const noop = function() {};
 const w = typeof window == 'object' ? window : noop;
-const FormData = (w as any /** TODO #9100 */)['FormData'] || noop;
-const Blob = (w as any /** TODO #9100 */)['Blob'] || noop;
-const ArrayBuffer = (w as any /** TODO #9100 */)['ArrayBuffer'] || noop;
+const FormData = (w as any /* TODO #9100 */)['FormData'] || noop;
+const Blob = (w as any /* TODO #9100 */)['Blob'] || noop;
+const ArrayBuffer = (w as any /* TODO #9100 */)['ArrayBuffer'] || noop;

--- a/modules/@angular/http/test/backends/xhr_backend_spec.ts
+++ b/modules/@angular/http/test/backends/xhr_backend_spec.ts
@@ -268,7 +268,7 @@ export function main() {
                 'Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
       });
 
-      if ((global as any /** TODO #9100 */)['Blob']) {
+      if ((global as any /* TODO #9100 */)['Blob']) {
         it('should use FormData body and detect content type header to the request', () => {
           var body = new FormData();
           body.append('test1', 'val1');

--- a/modules/@angular/http/test/headers_spec.ts
+++ b/modules/@angular/http/test/headers_spec.ts
@@ -57,9 +57,9 @@ export function main() {
 
 
     describe('.toJSON()', () => {
-      let headers: any /** TODO #9100 */ = null;
-      let inputArr: any /** TODO #9100 */ = null;
-      let obj: any /** TODO #9100 */ = null;
+      let headers: any /* TODO #9100 */ = null;
+      let inputArr: any /* TODO #9100 */ = null;
+      let obj: any /* TODO #9100 */ = null;
 
       beforeEach(() => {
         headers = new Headers();

--- a/modules/@angular/platform-browser/src/browser/browser_adapter.ts
+++ b/modules/@angular/platform-browser/src/browser/browser_adapter.ts
@@ -61,7 +61,7 @@ var _chromeNumKeyPadMap = {
 export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   parse(templateHtml: string) { throw new Error('parse not implemented'); }
   static makeCurrent() { setRootDomAdapter(new BrowserDomAdapter()); }
-  hasProperty(element: any /** TODO #9100 */, name: string): boolean { return name in element; }
+  hasProperty(element: any /* TODO #9100 */, name: string): boolean { return name in element; }
   setProperty(el: /*element*/ any, name: string, value: any) { el[name] = value; }
   getProperty(el: /*element*/ any, name: string): any { return el[name]; }
   invoke(el: /*element*/ any, methodName: string, args: any[]): any {
@@ -69,7 +69,7 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   }
 
   // TODO(tbosch): move this into a separate environment class once we have it
-  logError(error: any /** TODO #9100 */) {
+  logError(error: any /* TODO #9100 */) {
     if (window.console.error) {
       window.console.error(error);
     } else {
@@ -77,9 +77,9 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     }
   }
 
-  log(error: any /** TODO #9100 */) { window.console.log(error); }
+  log(error: any /* TODO #9100 */) { window.console.log(error); }
 
-  logGroup(error: any /** TODO #9100 */) {
+  logGroup(error: any /* TODO #9100 */) {
     if (window.console.group) {
       window.console.group(error);
       this.logError(error);
@@ -97,30 +97,29 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   get attrToPropMap(): any { return _attrToPropMap; }
 
   query(selector: string): any { return document.querySelector(selector); }
-  querySelector(el: any /** TODO #9100 */, selector: string): HTMLElement {
+  querySelector(el: any /* TODO #9100 */, selector: string): HTMLElement {
     return el.querySelector(selector);
   }
-  querySelectorAll(el: any /** TODO #9100 */, selector: string): any[] {
+  querySelectorAll(el: any /* TODO #9100 */, selector: string): any[] {
     return el.querySelectorAll(selector);
   }
-  on(el: any /** TODO #9100 */, evt: any /** TODO #9100 */, listener: any /** TODO #9100 */) {
+  on(el: any /* TODO #9100 */, evt: any /* TODO #9100 */, listener: any /* TODO #9100 */) {
     el.addEventListener(evt, listener, false);
   }
-  onAndCancel(
-      el: any /** TODO #9100 */, evt: any /** TODO #9100 */,
-      listener: any /** TODO #9100 */): Function {
+  onAndCancel(el: any /* TODO #9100 */, evt: any /* TODO #9100 */, listener: any /* TODO #9100 */):
+      Function {
     el.addEventListener(evt, listener, false);
     // Needed to follow Dart's subscription semantic, until fix of
     // https://code.google.com/p/dart/issues/detail?id=17406
     return () => { el.removeEventListener(evt, listener, false); };
   }
-  dispatchEvent(el: any /** TODO #9100 */, evt: any /** TODO #9100 */) { el.dispatchEvent(evt); }
+  dispatchEvent(el: any /* TODO #9100 */, evt: any /* TODO #9100 */) { el.dispatchEvent(evt); }
   createMouseEvent(eventType: string): MouseEvent {
     var evt: MouseEvent = document.createEvent('MouseEvent');
     evt.initEvent(eventType, true, true);
     return evt;
   }
-  createEvent(eventType: any /** TODO #9100 */): Event {
+  createEvent(eventType: any /* TODO #9100 */): Event {
     var evt: Event = document.createEvent('Event');
     evt.initEvent(eventType, true, true);
     return evt;
@@ -132,11 +131,11 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   isPrevented(evt: Event): boolean {
     return evt.defaultPrevented || isPresent(evt.returnValue) && !evt.returnValue;
   }
-  getInnerHTML(el: any /** TODO #9100 */): string { return el.innerHTML; }
-  getTemplateContent(el: any /** TODO #9100 */): Node {
+  getInnerHTML(el: any /* TODO #9100 */): string { return el.innerHTML; }
+  getTemplateContent(el: any /* TODO #9100 */): Node {
     return 'content' in el && el instanceof HTMLTemplateElement ? el.content : null;
   }
-  getOuterHTML(el: any /** TODO #9100 */): string { return el.outerHTML; }
+  getOuterHTML(el: any /* TODO #9100 */): string { return el.outerHTML; }
   nodeName(node: Node): string { return node.nodeName; }
   nodeValue(node: Node): string { return node.nodeValue; }
   type(node: HTMLInputElement): string { return node.type; }
@@ -147,11 +146,11 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
       return node;
     }
   }
-  firstChild(el: any /** TODO #9100 */): Node { return el.firstChild; }
-  nextSibling(el: any /** TODO #9100 */): Node { return el.nextSibling; }
-  parentElement(el: any /** TODO #9100 */): Node { return el.parentNode; }
-  childNodes(el: any /** TODO #9100 */): Node[] { return el.childNodes; }
-  childNodesAsList(el: any /** TODO #9100 */): any[] {
+  firstChild(el: any /* TODO #9100 */): Node { return el.firstChild; }
+  nextSibling(el: any /* TODO #9100 */): Node { return el.nextSibling; }
+  parentElement(el: any /* TODO #9100 */): Node { return el.parentNode; }
+  childNodes(el: any /* TODO #9100 */): Node[] { return el.childNodes; }
+  childNodesAsList(el: any /* TODO #9100 */): any[] {
     var childNodes = el.childNodes;
     var res = ListWrapper.createFixedSize(childNodes.length);
     for (var i = 0; i < childNodes.length; i++) {
@@ -159,49 +158,49 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     }
     return res;
   }
-  clearNodes(el: any /** TODO #9100 */) {
+  clearNodes(el: any /* TODO #9100 */) {
     while (el.firstChild) {
       el.removeChild(el.firstChild);
     }
   }
-  appendChild(el: any /** TODO #9100 */, node: any /** TODO #9100 */) { el.appendChild(node); }
-  removeChild(el: any /** TODO #9100 */, node: any /** TODO #9100 */) { el.removeChild(node); }
-  replaceChild(el: Node, newChild: any /** TODO #9100 */, oldChild: any /** TODO #9100 */) {
+  appendChild(el: any /* TODO #9100 */, node: any /* TODO #9100 */) { el.appendChild(node); }
+  removeChild(el: any /* TODO #9100 */, node: any /* TODO #9100 */) { el.removeChild(node); }
+  replaceChild(el: Node, newChild: any /* TODO #9100 */, oldChild: any /* TODO #9100 */) {
     el.replaceChild(newChild, oldChild);
   }
-  remove(node: any /** TODO #9100 */): Node {
+  remove(node: any /* TODO #9100 */): Node {
     if (node.parentNode) {
       node.parentNode.removeChild(node);
     }
     return node;
   }
-  insertBefore(el: any /** TODO #9100 */, node: any /** TODO #9100 */) {
+  insertBefore(el: any /* TODO #9100 */, node: any /* TODO #9100 */) {
     el.parentNode.insertBefore(node, el);
   }
-  insertAllBefore(el: any /** TODO #9100 */, nodes: any /** TODO #9100 */) {
-    nodes.forEach((n: any /** TODO #9100 */) => el.parentNode.insertBefore(n, el));
+  insertAllBefore(el: any /* TODO #9100 */, nodes: any /* TODO #9100 */) {
+    nodes.forEach((n: any /* TODO #9100 */) => el.parentNode.insertBefore(n, el));
   }
-  insertAfter(el: any /** TODO #9100 */, node: any /** TODO #9100 */) {
+  insertAfter(el: any /* TODO #9100 */, node: any /* TODO #9100 */) {
     el.parentNode.insertBefore(node, el.nextSibling);
   }
-  setInnerHTML(el: any /** TODO #9100 */, value: any /** TODO #9100 */) { el.innerHTML = value; }
-  getText(el: any /** TODO #9100 */): string { return el.textContent; }
+  setInnerHTML(el: any /* TODO #9100 */, value: any /* TODO #9100 */) { el.innerHTML = value; }
+  getText(el: any /* TODO #9100 */): string { return el.textContent; }
   // TODO(vicb): removed Element type because it does not support StyleElement
-  setText(el: any /** TODO #9100 */, value: string) { el.textContent = value; }
-  getValue(el: any /** TODO #9100 */): string { return el.value; }
-  setValue(el: any /** TODO #9100 */, value: string) { el.value = value; }
-  getChecked(el: any /** TODO #9100 */): boolean { return el.checked; }
-  setChecked(el: any /** TODO #9100 */, value: boolean) { el.checked = value; }
+  setText(el: any /* TODO #9100 */, value: string) { el.textContent = value; }
+  getValue(el: any /* TODO #9100 */): string { return el.value; }
+  setValue(el: any /* TODO #9100 */, value: string) { el.value = value; }
+  getChecked(el: any /* TODO #9100 */): boolean { return el.checked; }
+  setChecked(el: any /* TODO #9100 */, value: boolean) { el.checked = value; }
   createComment(text: string): Comment { return document.createComment(text); }
-  createTemplate(html: any /** TODO #9100 */): HTMLElement {
+  createTemplate(html: any /* TODO #9100 */): HTMLElement {
     var t = document.createElement('template');
     t.innerHTML = html;
     return t;
   }
-  createElement(tagName: any /** TODO #9100 */, doc = document): HTMLElement {
+  createElement(tagName: any /* TODO #9100 */, doc = document): HTMLElement {
     return doc.createElement(tagName);
   }
-  createElementNS(ns: any /** TODO #9100 */, tagName: any /** TODO #9100 */, doc = document):
+  createElementNS(ns: any /* TODO #9100 */, tagName: any /* TODO #9100 */, doc = document):
       Element {
     return doc.createElementNS(ns, tagName);
   }
@@ -220,37 +219,35 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   getShadowRoot(el: HTMLElement): DocumentFragment { return (<any>el).shadowRoot; }
   getHost(el: HTMLElement): HTMLElement { return (<any>el).host; }
   clone(node: Node): Node { return node.cloneNode(true); }
-  getElementsByClassName(element: any /** TODO #9100 */, name: string): HTMLElement[] {
+  getElementsByClassName(element: any /* TODO #9100 */, name: string): HTMLElement[] {
     return element.getElementsByClassName(name);
   }
-  getElementsByTagName(element: any /** TODO #9100 */, name: string): HTMLElement[] {
+  getElementsByTagName(element: any /* TODO #9100 */, name: string): HTMLElement[] {
     return element.getElementsByTagName(name);
   }
-  classList(element: any /** TODO #9100 */): any[] {
+  classList(element: any /* TODO #9100 */): any[] {
     return <any[]>Array.prototype.slice.call(element.classList, 0);
   }
-  addClass(element: any /** TODO #9100 */, className: string) { element.classList.add(className); }
-  removeClass(element: any /** TODO #9100 */, className: string) {
+  addClass(element: any /* TODO #9100 */, className: string) { element.classList.add(className); }
+  removeClass(element: any /* TODO #9100 */, className: string) {
     element.classList.remove(className);
   }
-  hasClass(element: any /** TODO #9100 */, className: string): boolean {
+  hasClass(element: any /* TODO #9100 */, className: string): boolean {
     return element.classList.contains(className);
   }
-  setStyle(element: any /** TODO #9100 */, styleName: string, styleValue: string) {
+  setStyle(element: any /* TODO #9100 */, styleName: string, styleValue: string) {
     element.style[styleName] = styleValue;
   }
-  removeStyle(element: any /** TODO #9100 */, stylename: string) {
-    element.style[stylename] = null;
-  }
-  getStyle(element: any /** TODO #9100 */, stylename: string): string {
+  removeStyle(element: any /* TODO #9100 */, stylename: string) { element.style[stylename] = null; }
+  getStyle(element: any /* TODO #9100 */, stylename: string): string {
     return element.style[stylename];
   }
-  hasStyle(element: any /** TODO #9100 */, styleName: string, styleValue: string = null): boolean {
+  hasStyle(element: any /* TODO #9100 */, styleName: string, styleValue: string = null): boolean {
     var value = this.getStyle(element, styleName) || '';
     return styleValue ? value == styleValue : value.length > 0;
   }
-  tagName(element: any /** TODO #9100 */): string { return element.tagName; }
-  attributeMap(element: any /** TODO #9100 */): Map<string, string> {
+  tagName(element: any /* TODO #9100 */): string { return element.tagName; }
+  attributeMap(element: any /* TODO #9100 */): Map<string, string> {
     var res = new Map<string, string>();
     var elAttrs = element.attributes;
     for (var i = 0; i < elAttrs.length; i++) {
@@ -259,38 +256,38 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     }
     return res;
   }
-  hasAttribute(element: any /** TODO #9100 */, attribute: string): boolean {
+  hasAttribute(element: any /* TODO #9100 */, attribute: string): boolean {
     return element.hasAttribute(attribute);
   }
-  hasAttributeNS(element: any /** TODO #9100 */, ns: string, attribute: string): boolean {
+  hasAttributeNS(element: any /* TODO #9100 */, ns: string, attribute: string): boolean {
     return element.hasAttributeNS(ns, attribute);
   }
-  getAttribute(element: any /** TODO #9100 */, attribute: string): string {
+  getAttribute(element: any /* TODO #9100 */, attribute: string): string {
     return element.getAttribute(attribute);
   }
-  getAttributeNS(element: any /** TODO #9100 */, ns: string, name: string): string {
+  getAttributeNS(element: any /* TODO #9100 */, ns: string, name: string): string {
     return element.getAttributeNS(ns, name);
   }
-  setAttribute(element: any /** TODO #9100 */, name: string, value: string) {
+  setAttribute(element: any /* TODO #9100 */, name: string, value: string) {
     element.setAttribute(name, value);
   }
-  setAttributeNS(element: any /** TODO #9100 */, ns: string, name: string, value: string) {
+  setAttributeNS(element: any /* TODO #9100 */, ns: string, name: string, value: string) {
     element.setAttributeNS(ns, name, value);
   }
-  removeAttribute(element: any /** TODO #9100 */, attribute: string) {
+  removeAttribute(element: any /* TODO #9100 */, attribute: string) {
     element.removeAttribute(attribute);
   }
-  removeAttributeNS(element: any /** TODO #9100 */, ns: string, name: string) {
+  removeAttributeNS(element: any /* TODO #9100 */, ns: string, name: string) {
     element.removeAttributeNS(ns, name);
   }
-  templateAwareRoot(el: any /** TODO #9100 */): any {
+  templateAwareRoot(el: any /* TODO #9100 */): any {
     return this.isTemplateElement(el) ? this.content(el) : el;
   }
   createHtmlDocument(): HTMLDocument {
     return document.implementation.createHTMLDocument('fakeTitle');
   }
   defaultDoc(): HTMLDocument { return document; }
-  getBoundingClientRect(el: any /** TODO #9100 */): any {
+  getBoundingClientRect(el: any /* TODO #9100 */): any {
     try {
       return el.getBoundingClientRect();
     } catch (e) {
@@ -299,7 +296,7 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   }
   getTitle(): string { return document.title; }
   setTitle(newTitle: string) { document.title = newTitle || ''; }
-  elementMatches(n: any /** TODO #9100 */, selector: string): boolean {
+  elementMatches(n: any /* TODO #9100 */, selector: string): boolean {
     var matches = false;
     if (n instanceof HTMLElement) {
       if (n.matches) {
@@ -318,10 +315,10 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   isTextNode(node: Node): boolean { return node.nodeType === Node.TEXT_NODE; }
   isCommentNode(node: Node): boolean { return node.nodeType === Node.COMMENT_NODE; }
   isElementNode(node: Node): boolean { return node.nodeType === Node.ELEMENT_NODE; }
-  hasShadowRoot(node: any /** TODO #9100 */): boolean {
+  hasShadowRoot(node: any /* TODO #9100 */): boolean {
     return node instanceof HTMLElement && isPresent(node.shadowRoot);
   }
-  isShadowRoot(node: any /** TODO #9100 */): boolean { return node instanceof DocumentFragment; }
+  isShadowRoot(node: any /* TODO #9100 */): boolean { return node instanceof DocumentFragment; }
   importIntoDoc(node: Node): any {
     var toImport = node;
     if (this.isTemplateElement(node)) {
@@ -331,7 +328,7 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   }
   adoptNode(node: Node): any { return document.adoptNode(node); }
   getHref(el: Element): string { return (<any>el).href; }
-  getEventKey(event: any /** TODO #9100 */): string {
+  getEventKey(event: any /* TODO #9100 */): string {
     var key = event.key;
     if (isBlank(key)) {
       key = event.keyIdentifier;
@@ -348,12 +345,12 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
           // There is a bug in Chrome for numeric keypad keys:
           // https://code.google.com/p/chromium/issues/detail?id=155654
           // 1, 2, 3 ... are reported as A, B, C ...
-          key = (_chromeNumKeyPadMap as any /** TODO #9100 */)[key];
+          key = (_chromeNumKeyPadMap as any /* TODO #9100 */)[key];
         }
       }
     }
     if (_keyMap.hasOwnProperty(key)) {
-      key = (_keyMap as any /** TODO #9100 */)[key];
+      key = (_keyMap as any /* TODO #9100 */)[key];
     }
     return key;
   }
@@ -377,21 +374,21 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   }
   resetBaseElement(): void { baseElement = null; }
   getUserAgent(): string { return window.navigator.userAgent; }
-  setData(element: any /** TODO #9100 */, name: string, value: string) {
+  setData(element: any /* TODO #9100 */, name: string, value: string) {
     this.setAttribute(element, 'data-' + name, value);
   }
-  getData(element: any /** TODO #9100 */, name: string): string {
+  getData(element: any /* TODO #9100 */, name: string): string {
     return this.getAttribute(element, 'data-' + name);
   }
-  getComputedStyle(element: any /** TODO #9100 */): any { return getComputedStyle(element); }
+  getComputedStyle(element: any /* TODO #9100 */): any { return getComputedStyle(element); }
   // TODO(tbosch): move this into a separate environment class once we have it
   setGlobalVar(path: string, value: any) { setValueOnPath(global, path, value); }
-  requestAnimationFrame(callback: any /** TODO #9100 */): number {
+  requestAnimationFrame(callback: any /* TODO #9100 */): number {
     return window.requestAnimationFrame(callback);
   }
   cancelAnimationFrame(id: number) { window.cancelAnimationFrame(id); }
   supportsWebAnimation(): boolean {
-    return isFunction((document as any /** TODO #9100 */).body['animate']);
+    return isFunction((document as any /* TODO #9100 */).body['animate']);
   }
   performanceNow(): number {
     // performance.now() is not available in all browsers, see
@@ -415,7 +412,7 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
 }
 
 
-var baseElement: any /** TODO #9100 */ = null;
+var baseElement: any /* TODO #9100 */ = null;
 function getBaseElementHref(): string {
   if (isBlank(baseElement)) {
     baseElement = document.querySelector('base');
@@ -427,8 +424,8 @@ function getBaseElementHref(): string {
 }
 
 // based on urlUtils.js in AngularJS 1
-var urlParsingNode: any /** TODO #9100 */ = null;
-function relativePath(url: any /** TODO #9100 */): string {
+var urlParsingNode: any /* TODO #9100 */ = null;
+function relativePath(url: any /* TODO #9100 */): string {
   if (isBlank(urlParsingNode)) {
     urlParsingNode = document.createElement('a');
   }

--- a/modules/@angular/platform-browser/src/browser/testability.ts
+++ b/modules/@angular/platform-browser/src/browser/testability.ts
@@ -44,18 +44,18 @@ export class BrowserGetTestability implements GetTestability {
 
     global.getAllAngularRootElements = () => registry.getAllRootElements();
 
-    var whenAllStable = (callback: any /** TODO #9100 */) => {
+    var whenAllStable = (callback: any /* TODO #9100 */) => {
       var testabilities = global.getAllAngularTestabilities();
       var count = testabilities.length;
       var didWork = false;
-      var decrement = function(didWork_: any /** TODO #9100 */) {
+      var decrement = function(didWork_: any /* TODO #9100 */) {
         didWork = didWork || didWork_;
         count--;
         if (count == 0) {
           callback(didWork);
         }
       };
-      testabilities.forEach(function(testability: any /** TODO #9100 */) {
+      testabilities.forEach(function(testability: any /* TODO #9100 */) {
         testability.whenStable(decrement);
       });
     };

--- a/modules/@angular/platform-browser/src/dom/debug/ng_probe.ts
+++ b/modules/@angular/platform-browser/src/dom/debug/ng_probe.ts
@@ -19,18 +19,18 @@ const CORE_TOKENS_GLOBAL_NAME = 'ng.coreTokens';
  * null if the given native element does not have an Angular view associated
  * with it.
  */
-export function inspectNativeElement(element: any /** TODO #9100 */): DebugNode {
+export function inspectNativeElement(element: any /* TODO #9100 */): DebugNode {
   return getDebugNode(element);
 }
 
-function _createConditionalRootRenderer(rootRenderer: any /** TODO #9100 */) {
+function _createConditionalRootRenderer(rootRenderer: any /* TODO #9100 */) {
   if (assertionsEnabled()) {
     return _createRootRenderer(rootRenderer);
   }
   return rootRenderer;
 }
 
-function _createRootRenderer(rootRenderer: any /** TODO #9100 */) {
+function _createRootRenderer(rootRenderer: any /* TODO #9100 */) {
   getDOM().setGlobalVar(INSPECT_GLOBAL_NAME, inspectNativeElement);
   getDOM().setGlobalVar(CORE_TOKENS_GLOBAL_NAME, CORE_TOKENS);
   return new DebugDomRootRenderer(rootRenderer);

--- a/modules/@angular/platform-browser/src/dom/dom_adapter.ts
+++ b/modules/@angular/platform-browser/src/dom/dom_adapter.ts
@@ -22,15 +22,15 @@ export function setRootDomAdapter(adapter: DomAdapter) {
  */
 export abstract class DomAdapter {
   public xhrType: Type = null;
-  abstract hasProperty(element: any /** TODO #9100 */, name: string): boolean;
-  abstract setProperty(el: Element, name: string, value: any): any /** TODO #9100 */;
+  abstract hasProperty(element: any /* TODO #9100 */, name: string): boolean;
+  abstract setProperty(el: Element, name: string, value: any): any /* TODO #9100 */;
   abstract getProperty(el: Element, name: string): any;
   abstract invoke(el: Element, methodName: string, args: any[]): any;
 
-  abstract logError(error: any /** TODO #9100 */): any /** TODO #9100 */;
-  abstract log(error: any /** TODO #9100 */): any /** TODO #9100 */;
-  abstract logGroup(error: any /** TODO #9100 */): any /** TODO #9100 */;
-  abstract logGroupEnd(): any /** TODO #9100 */;
+  abstract logError(error: any /* TODO #9100 */): any /* TODO #9100 */;
+  abstract log(error: any /* TODO #9100 */): any /* TODO #9100 */;
+  abstract logGroup(error: any /* TODO #9100 */): any /* TODO #9100 */;
+  abstract logGroupEnd(): any /* TODO #9100 */;
 
   /** @deprecated */
   getXHR(): Type { return this.xhrType; }
@@ -44,116 +44,115 @@ export abstract class DomAdapter {
   /** @internal */
   _attrToPropMap: {[key: string]: string};
 
-  abstract parse(templateHtml: string): any /** TODO #9100 */;
+  abstract parse(templateHtml: string): any /* TODO #9100 */;
   abstract query(selector: string): any;
-  abstract querySelector(el: any /** TODO #9100 */, selector: string): HTMLElement;
-  abstract querySelectorAll(el: any /** TODO #9100 */, selector: string): any[];
-  abstract on(
-      el: any /** TODO #9100 */, evt: any /** TODO #9100 */, listener: any /** TODO #9100 */): any
-      /** TODO #9100 */;
+  abstract querySelector(el: any /* TODO #9100 */, selector: string): HTMLElement;
+  abstract querySelectorAll(el: any /* TODO #9100 */, selector: string): any[];
+  abstract on(el: any /* TODO #9100 */, evt: any /* TODO #9100 */, listener: any /* TODO #9100 */):
+      any
+      /* TODO #9100 */;
   abstract onAndCancel(
-      el: any /** TODO #9100 */, evt: any /** TODO #9100 */,
-      listener: any /** TODO #9100 */): Function;
-  abstract dispatchEvent(el: any /** TODO #9100 */, evt: any /** TODO #9100 */): any
-      /** TODO #9100 */;
-  abstract createMouseEvent(eventType: any /** TODO #9100 */): any;
+      el: any /* TODO #9100 */, evt: any /* TODO #9100 */,
+      listener: any /* TODO #9100 */): Function;
+  abstract dispatchEvent(el: any /* TODO #9100 */, evt: any /* TODO #9100 */): any
+      /* TODO #9100 */;
+  abstract createMouseEvent(eventType: any /* TODO #9100 */): any;
   abstract createEvent(eventType: string): any;
-  abstract preventDefault(evt: any /** TODO #9100 */): any /** TODO #9100 */;
-  abstract isPrevented(evt: any /** TODO #9100 */): boolean;
-  abstract getInnerHTML(el: any /** TODO #9100 */): string;
+  abstract preventDefault(evt: any /* TODO #9100 */): any /* TODO #9100 */;
+  abstract isPrevented(evt: any /* TODO #9100 */): boolean;
+  abstract getInnerHTML(el: any /* TODO #9100 */): string;
   /** Returns content if el is a <template> element, null otherwise. */
-  abstract getTemplateContent(el: any /** TODO #9100 */): any;
-  abstract getOuterHTML(el: any /** TODO #9100 */): string;
-  abstract nodeName(node: any /** TODO #9100 */): string;
-  abstract nodeValue(node: any /** TODO #9100 */): string;
-  abstract type(node: any /** TODO #9100 */): string;
-  abstract content(node: any /** TODO #9100 */): any;
-  abstract firstChild(el: any /** TODO #9100 */): Node;
-  abstract nextSibling(el: any /** TODO #9100 */): Node;
-  abstract parentElement(el: any /** TODO #9100 */): Node;
-  abstract childNodes(el: any /** TODO #9100 */): Node[];
-  abstract childNodesAsList(el: any /** TODO #9100 */): Node[];
-  abstract clearNodes(el: any /** TODO #9100 */): any /** TODO #9100 */;
-  abstract appendChild(el: any /** TODO #9100 */, node: any /** TODO #9100 */): any
-      /** TODO #9100 */;
-  abstract removeChild(el: any /** TODO #9100 */, node: any /** TODO #9100 */): any
-      /** TODO #9100 */;
+  abstract getTemplateContent(el: any /* TODO #9100 */): any;
+  abstract getOuterHTML(el: any /* TODO #9100 */): string;
+  abstract nodeName(node: any /* TODO #9100 */): string;
+  abstract nodeValue(node: any /* TODO #9100 */): string;
+  abstract type(node: any /* TODO #9100 */): string;
+  abstract content(node: any /* TODO #9100 */): any;
+  abstract firstChild(el: any /* TODO #9100 */): Node;
+  abstract nextSibling(el: any /* TODO #9100 */): Node;
+  abstract parentElement(el: any /* TODO #9100 */): Node;
+  abstract childNodes(el: any /* TODO #9100 */): Node[];
+  abstract childNodesAsList(el: any /* TODO #9100 */): Node[];
+  abstract clearNodes(el: any /* TODO #9100 */): any /* TODO #9100 */;
+  abstract appendChild(el: any /* TODO #9100 */, node: any /* TODO #9100 */): any
+      /* TODO #9100 */;
+  abstract removeChild(el: any /* TODO #9100 */, node: any /* TODO #9100 */): any
+      /* TODO #9100 */;
   abstract replaceChild(
-      el: any /** TODO #9100 */, newNode: any /** TODO #9100 */,
-      oldNode: any /** TODO #9100 */): any /** TODO #9100 */;
-  abstract remove(el: any /** TODO #9100 */): Node;
-  abstract insertBefore(el: any /** TODO #9100 */, node: any /** TODO #9100 */): any
-      /** TODO #9100 */;
-  abstract insertAllBefore(el: any /** TODO #9100 */, nodes: any /** TODO #9100 */): any
-      /** TODO #9100 */;
-  abstract insertAfter(el: any /** TODO #9100 */, node: any /** TODO #9100 */): any
-      /** TODO #9100 */;
-  abstract setInnerHTML(el: any /** TODO #9100 */, value: any /** TODO #9100 */): any
-      /** TODO #9100 */;
-  abstract getText(el: any /** TODO #9100 */): string;
-  abstract setText(el: any /** TODO #9100 */, value: string): any /** TODO #9100 */;
-  abstract getValue(el: any /** TODO #9100 */): string;
-  abstract setValue(el: any /** TODO #9100 */, value: string): any /** TODO #9100 */;
-  abstract getChecked(el: any /** TODO #9100 */): boolean;
-  abstract setChecked(el: any /** TODO #9100 */, value: boolean): any /** TODO #9100 */;
+      el: any /* TODO #9100 */, newNode: any /* TODO #9100 */, oldNode: any /* TODO #9100 */): any
+      /* TODO #9100 */;
+  abstract remove(el: any /* TODO #9100 */): Node;
+  abstract insertBefore(el: any /* TODO #9100 */, node: any /* TODO #9100 */): any
+      /* TODO #9100 */;
+  abstract insertAllBefore(el: any /* TODO #9100 */, nodes: any /* TODO #9100 */): any
+      /* TODO #9100 */;
+  abstract insertAfter(el: any /* TODO #9100 */, node: any /* TODO #9100 */): any
+      /* TODO #9100 */;
+  abstract setInnerHTML(el: any /* TODO #9100 */, value: any /* TODO #9100 */): any
+      /* TODO #9100 */;
+  abstract getText(el: any /* TODO #9100 */): string;
+  abstract setText(el: any /* TODO #9100 */, value: string): any /* TODO #9100 */;
+  abstract getValue(el: any /* TODO #9100 */): string;
+  abstract setValue(el: any /* TODO #9100 */, value: string): any /* TODO #9100 */;
+  abstract getChecked(el: any /* TODO #9100 */): boolean;
+  abstract setChecked(el: any /* TODO #9100 */, value: boolean): any /* TODO #9100 */;
   abstract createComment(text: string): any;
-  abstract createTemplate(html: any /** TODO #9100 */): HTMLElement;
-  abstract createElement(tagName: any /** TODO #9100 */, doc?: any /** TODO #9100 */): HTMLElement;
-  abstract createElementNS(ns: string, tagName: string, doc?: any /** TODO #9100 */): Element;
-  abstract createTextNode(text: string, doc?: any /** TODO #9100 */): Text;
-  abstract createScriptTag(attrName: string, attrValue: string, doc?: any /** TODO #9100 */):
+  abstract createTemplate(html: any /* TODO #9100 */): HTMLElement;
+  abstract createElement(tagName: any /* TODO #9100 */, doc?: any /* TODO #9100 */): HTMLElement;
+  abstract createElementNS(ns: string, tagName: string, doc?: any /* TODO #9100 */): Element;
+  abstract createTextNode(text: string, doc?: any /* TODO #9100 */): Text;
+  abstract createScriptTag(attrName: string, attrValue: string, doc?: any /* TODO #9100 */):
       HTMLElement;
-  abstract createStyleElement(css: string, doc?: any /** TODO #9100 */): HTMLStyleElement;
-  abstract createShadowRoot(el: any /** TODO #9100 */): any;
-  abstract getShadowRoot(el: any /** TODO #9100 */): any;
-  abstract getHost(el: any /** TODO #9100 */): any;
-  abstract getDistributedNodes(el: any /** TODO #9100 */): Node[];
+  abstract createStyleElement(css: string, doc?: any /* TODO #9100 */): HTMLStyleElement;
+  abstract createShadowRoot(el: any /* TODO #9100 */): any;
+  abstract getShadowRoot(el: any /* TODO #9100 */): any;
+  abstract getHost(el: any /* TODO #9100 */): any;
+  abstract getDistributedNodes(el: any /* TODO #9100 */): Node[];
   abstract clone /*<T extends Node>*/ (node: Node /*T*/): Node /*T*/;
-  abstract getElementsByClassName(element: any /** TODO #9100 */, name: string): HTMLElement[];
-  abstract getElementsByTagName(element: any /** TODO #9100 */, name: string): HTMLElement[];
-  abstract classList(element: any /** TODO #9100 */): any[];
-  abstract addClass(element: any /** TODO #9100 */, className: string): any /** TODO #9100 */;
-  abstract removeClass(element: any /** TODO #9100 */, className: string): any /** TODO #9100 */;
-  abstract hasClass(element: any /** TODO #9100 */, className: string): boolean;
-  abstract setStyle(element: any /** TODO #9100 */, styleName: string, styleValue: string): any
-      /** TODO #9100 */;
-  abstract removeStyle(element: any /** TODO #9100 */, styleName: string): any /** TODO #9100 */;
-  abstract getStyle(element: any /** TODO #9100 */, styleName: string): string;
-  abstract hasStyle(element: any /** TODO #9100 */, styleName: string, styleValue?: string):
-      boolean;
-  abstract tagName(element: any /** TODO #9100 */): string;
-  abstract attributeMap(element: any /** TODO #9100 */): Map<string, string>;
-  abstract hasAttribute(element: any /** TODO #9100 */, attribute: string): boolean;
-  abstract hasAttributeNS(element: any /** TODO #9100 */, ns: string, attribute: string): boolean;
-  abstract getAttribute(element: any /** TODO #9100 */, attribute: string): string;
-  abstract getAttributeNS(element: any /** TODO #9100 */, ns: string, attribute: string): string;
-  abstract setAttribute(element: any /** TODO #9100 */, name: string, value: string): any
-      /** TODO #9100 */;
-  abstract setAttributeNS(element: any /** TODO #9100 */, ns: string, name: string, value: string):
-      any /** TODO #9100 */;
-  abstract removeAttribute(element: any /** TODO #9100 */, attribute: string): any
-      /** TODO #9100 */;
-  abstract removeAttributeNS(element: any /** TODO #9100 */, ns: string, attribute: string): any
-      /** TODO #9100 */;
-  abstract templateAwareRoot(el: any /** TODO #9100 */): any /** TODO #9100 */;
+  abstract getElementsByClassName(element: any /* TODO #9100 */, name: string): HTMLElement[];
+  abstract getElementsByTagName(element: any /* TODO #9100 */, name: string): HTMLElement[];
+  abstract classList(element: any /* TODO #9100 */): any[];
+  abstract addClass(element: any /* TODO #9100 */, className: string): any /* TODO #9100 */;
+  abstract removeClass(element: any /* TODO #9100 */, className: string): any /* TODO #9100 */;
+  abstract hasClass(element: any /* TODO #9100 */, className: string): boolean;
+  abstract setStyle(element: any /* TODO #9100 */, styleName: string, styleValue: string): any
+      /* TODO #9100 */;
+  abstract removeStyle(element: any /* TODO #9100 */, styleName: string): any /* TODO #9100 */;
+  abstract getStyle(element: any /* TODO #9100 */, styleName: string): string;
+  abstract hasStyle(element: any /* TODO #9100 */, styleName: string, styleValue?: string): boolean;
+  abstract tagName(element: any /* TODO #9100 */): string;
+  abstract attributeMap(element: any /* TODO #9100 */): Map<string, string>;
+  abstract hasAttribute(element: any /* TODO #9100 */, attribute: string): boolean;
+  abstract hasAttributeNS(element: any /* TODO #9100 */, ns: string, attribute: string): boolean;
+  abstract getAttribute(element: any /* TODO #9100 */, attribute: string): string;
+  abstract getAttributeNS(element: any /* TODO #9100 */, ns: string, attribute: string): string;
+  abstract setAttribute(element: any /* TODO #9100 */, name: string, value: string): any
+      /* TODO #9100 */;
+  abstract setAttributeNS(element: any /* TODO #9100 */, ns: string, name: string, value: string):
+      any /* TODO #9100 */;
+  abstract removeAttribute(element: any /* TODO #9100 */, attribute: string): any
+      /* TODO #9100 */;
+  abstract removeAttributeNS(element: any /* TODO #9100 */, ns: string, attribute: string): any
+      /* TODO #9100 */;
+  abstract templateAwareRoot(el: any /* TODO #9100 */): any /* TODO #9100 */;
   abstract createHtmlDocument(): HTMLDocument;
   abstract defaultDoc(): HTMLDocument;
-  abstract getBoundingClientRect(el: any /** TODO #9100 */): any /** TODO #9100 */;
+  abstract getBoundingClientRect(el: any /* TODO #9100 */): any /* TODO #9100 */;
   abstract getTitle(): string;
-  abstract setTitle(newTitle: string): any /** TODO #9100 */;
-  abstract elementMatches(n: any /** TODO #9100 */, selector: string): boolean;
+  abstract setTitle(newTitle: string): any /* TODO #9100 */;
+  abstract elementMatches(n: any /* TODO #9100 */, selector: string): boolean;
   abstract isTemplateElement(el: any): boolean;
-  abstract isTextNode(node: any /** TODO #9100 */): boolean;
-  abstract isCommentNode(node: any /** TODO #9100 */): boolean;
-  abstract isElementNode(node: any /** TODO #9100 */): boolean;
-  abstract hasShadowRoot(node: any /** TODO #9100 */): boolean;
-  abstract isShadowRoot(node: any /** TODO #9100 */): boolean;
+  abstract isTextNode(node: any /* TODO #9100 */): boolean;
+  abstract isCommentNode(node: any /* TODO #9100 */): boolean;
+  abstract isElementNode(node: any /* TODO #9100 */): boolean;
+  abstract hasShadowRoot(node: any /* TODO #9100 */): boolean;
+  abstract isShadowRoot(node: any /* TODO #9100 */): boolean;
   abstract importIntoDoc /*<T extends Node>*/ (node: Node /*T*/): Node /*T*/;
   abstract adoptNode /*<T extends Node>*/ (node: Node /*T*/): Node /*T*/;
-  abstract getHref(element: any /** TODO #9100 */): string;
-  abstract getEventKey(event: any /** TODO #9100 */): string;
-  abstract resolveAndSetHref(element: any /** TODO #9100 */, baseUrl: string, href: string): any
-      /** TODO #9100 */;
+  abstract getHref(element: any /* TODO #9100 */): string;
+  abstract getEventKey(event: any /* TODO #9100 */): string;
+  abstract resolveAndSetHref(element: any /* TODO #9100 */, baseUrl: string, href: string): any
+      /* TODO #9100 */;
   abstract supportsDOMEvents(): boolean;
   abstract supportsNativeShadowDOM(): boolean;
   abstract getGlobalEventTarget(target: string): any;
@@ -162,13 +161,13 @@ export abstract class DomAdapter {
   abstract getBaseHref(): string;
   abstract resetBaseElement(): void;
   abstract getUserAgent(): string;
-  abstract setData(element: any /** TODO #9100 */, name: string, value: string): any
-      /** TODO #9100 */;
-  abstract getComputedStyle(element: any /** TODO #9100 */): any;
-  abstract getData(element: any /** TODO #9100 */, name: string): string;
-  abstract setGlobalVar(name: string, value: any): any /** TODO #9100 */;
-  abstract requestAnimationFrame(callback: any /** TODO #9100 */): number;
-  abstract cancelAnimationFrame(id: any /** TODO #9100 */): any /** TODO #9100 */;
+  abstract setData(element: any /* TODO #9100 */, name: string, value: string): any
+      /* TODO #9100 */;
+  abstract getComputedStyle(element: any /* TODO #9100 */): any;
+  abstract getData(element: any /* TODO #9100 */, name: string): string;
+  abstract setGlobalVar(name: string, value: any): any /* TODO #9100 */;
+  abstract requestAnimationFrame(callback: any /* TODO #9100 */): number;
+  abstract cancelAnimationFrame(id: any /* TODO #9100 */): any /* TODO #9100 */;
   abstract supportsWebAnimation(): boolean;
   abstract performanceNow(): number;
   abstract getAnimationPrefix(): string;
@@ -177,5 +176,5 @@ export abstract class DomAdapter {
 
   abstract supportsCookies(): boolean;
   abstract getCookie(name: string): string;
-  abstract setCookie(name: string, value: string): any /** TODO #9100 */;
+  abstract setCookie(name: string, value: string): any /* TODO #9100 */;
 }

--- a/modules/@angular/platform-browser/src/dom/dom_renderer.ts
+++ b/modules/@angular/platform-browser/src/dom/dom_renderer.ts
@@ -68,7 +68,7 @@ export class DomRenderer implements Renderer {
   }
 
   selectRootElement(selectorOrNode: string|any, debugInfo: RenderDebugInfo): Element {
-    var el: any /** TODO #9100 */;
+    var el: any /* TODO #9100 */;
     if (isString(selectorOrNode)) {
       el = getDOM().querySelector(this._rootRenderer.document, selectorOrNode);
       if (isBlank(el)) {
@@ -85,7 +85,7 @@ export class DomRenderer implements Renderer {
     var nsAndName = splitNamespace(name);
     var el = isPresent(nsAndName[0]) ?
         getDOM().createElementNS(
-            (NAMESPACE_URIS as any /** TODO #9100 */)[nsAndName[0]], nsAndName[1]) :
+            (NAMESPACE_URIS as any /* TODO #9100 */)[nsAndName[0]], nsAndName[1]) :
         getDOM().createElement(nsAndName[1]);
     if (isPresent(this._contentAttr)) {
       getDOM().setAttribute(el, this._contentAttr, '');
@@ -97,7 +97,7 @@ export class DomRenderer implements Renderer {
   }
 
   createViewRoot(hostElement: any): any {
-    var nodesParent: any /** TODO #9100 */;
+    var nodesParent: any /* TODO #9100 */;
     if (this.componentProto.encapsulation === ViewEncapsulation.Native) {
       nodesParent = getDOM().createShadowRoot(hostElement);
       this._rootRenderer.sharedStylesHost.addHost(nodesParent);
@@ -163,11 +163,11 @@ export class DomRenderer implements Renderer {
   }
 
   setElementAttribute(renderElement: any, attributeName: string, attributeValue: string): void {
-    var attrNs: any /** TODO #9100 */;
+    var attrNs: any /* TODO #9100 */;
     var nsAndName = splitNamespace(attributeName);
     if (isPresent(nsAndName[0])) {
       attributeName = nsAndName[0] + ':' + nsAndName[1];
-      attrNs = (NAMESPACE_URIS as any /** TODO #9100 */)[nsAndName[0]];
+      attrNs = (NAMESPACE_URIS as any /* TODO #9100 */)[nsAndName[0]];
     }
     if (isPresent(attributeValue)) {
       if (isPresent(attrNs)) {
@@ -191,7 +191,7 @@ export class DomRenderer implements Renderer {
           TEMPLATE_BINDINGS_EXP,
           StringWrapper.replaceAll(getDOM().getText(renderElement), /\n/g, ''));
       var parsedBindings = Json.parse(existingBindings[1]);
-      (parsedBindings as any /** TODO #9100 */)[dashCasedPropertyName] = propertyValue;
+      (parsedBindings as any /* TODO #9100 */)[dashCasedPropertyName] = propertyValue;
       getDOM().setText(
           renderElement,
           StringWrapper.replace(TEMPLATE_COMMENT_TEXT, '{}', Json.stringify(parsedBindings)));
@@ -230,7 +230,7 @@ export class DomRenderer implements Renderer {
   }
 }
 
-function moveNodesAfterSibling(sibling: any /** TODO #9100 */, nodes: any /** TODO #9100 */) {
+function moveNodesAfterSibling(sibling: any /* TODO #9100 */, nodes: any /* TODO #9100 */) {
   var parent = getDOM().parentElement(sibling);
   if (nodes.length > 0 && isPresent(parent)) {
     var nextSibling = getDOM().nextSibling(sibling);
@@ -246,14 +246,14 @@ function moveNodesAfterSibling(sibling: any /** TODO #9100 */, nodes: any /** TO
   }
 }
 
-function appendNodes(parent: any /** TODO #9100 */, nodes: any /** TODO #9100 */) {
+function appendNodes(parent: any /* TODO #9100 */, nodes: any /* TODO #9100 */) {
   for (var i = 0; i < nodes.length; i++) {
     getDOM().appendChild(parent, nodes[i]);
   }
 }
 
 function decoratePreventDefault(eventHandler: Function): Function {
-  return (event: any /** TODO #9100 */) => {
+  return (event: any /* TODO #9100 */) => {
     var allowDefaultBehavior = eventHandler(event);
     if (allowDefaultBehavior === false) {
       // TODO(tbosch): move preventDefault into event plugins...

--- a/modules/@angular/platform-browser/src/dom/events/dom_events.ts
+++ b/modules/@angular/platform-browser/src/dom/events/dom_events.ts
@@ -11,7 +11,7 @@ export class DomEventsPlugin extends EventManagerPlugin {
 
   addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
     var zone = this.manager.getZone();
-    var outsideHandler = (event: any /** TODO #9100 */) => zone.runGuarded(() => handler(event));
+    var outsideHandler = (event: any /* TODO #9100 */) => zone.runGuarded(() => handler(event));
     return this.manager.getZone().runOutsideAngular(
         () => getDOM().onAndCancel(element, eventName, outsideHandler));
   }
@@ -19,7 +19,7 @@ export class DomEventsPlugin extends EventManagerPlugin {
   addGlobalEventListener(target: string, eventName: string, handler: Function): Function {
     var element = getDOM().getGlobalEventTarget(target);
     var zone = this.manager.getZone();
-    var outsideHandler = (event: any /** TODO #9100 */) => zone.runGuarded(() => handler(event));
+    var outsideHandler = (event: any /* TODO #9100 */) => zone.runGuarded(() => handler(event));
     return this.manager.getZone().runOutsideAngular(
         () => getDOM().onAndCancel(element, eventName, outsideHandler));
   }

--- a/modules/@angular/platform-browser/src/dom/events/key_events.ts
+++ b/modules/@angular/platform-browser/src/dom/events/key_events.ts
@@ -89,7 +89,7 @@ export class KeyEventsPlugin extends EventManagerPlugin {
 
   static eventCallback(element: HTMLElement, fullKey: any, handler: Function, zone: NgZone):
       Function {
-    return (event: any /** TODO #9100 */) => {
+    return (event: any /* TODO #9100 */) => {
       if (StringWrapper.equals(KeyEventsPlugin.getEventFullKey(event), fullKey)) {
         zone.runGuarded(() => handler(event));
       }

--- a/modules/@angular/platform-browser/src/dom/shared_styles_host.ts
+++ b/modules/@angular/platform-browser/src/dom/shared_styles_host.ts
@@ -14,7 +14,7 @@ export class SharedStylesHost {
   constructor() {}
 
   addStyles(styles: string[]) {
-    var additions: any[] /** TODO #9100 */ = [];
+    var additions: any[] /* TODO #9100 */ = [];
     styles.forEach(style => {
       if (!SetWrapper.has(this._stylesSet, style)) {
         this._stylesSet.add(style);

--- a/modules/@angular/platform-browser/src/dom/util.ts
+++ b/modules/@angular/platform-browser/src/dom/util.ts
@@ -6,10 +6,10 @@ var DASH_CASE_REGEXP = /-([a-z])/g;
 
 export function camelCaseToDashCase(input: string): string {
   return StringWrapper.replaceAllMapped(
-      input, CAMEL_CASE_REGEXP, (m: any /** TODO #9100 */) => { return '-' + m[1].toLowerCase(); });
+      input, CAMEL_CASE_REGEXP, (m: any /* TODO #9100 */) => { return '-' + m[1].toLowerCase(); });
 }
 
 export function dashCaseToCamelCase(input: string): string {
   return StringWrapper.replaceAllMapped(
-      input, DASH_CASE_REGEXP, (m: any /** TODO #9100 */) => { return m[1].toUpperCase(); });
+      input, DASH_CASE_REGEXP, (m: any /* TODO #9100 */) => { return m[1].toUpperCase(); });
 }

--- a/modules/@angular/platform-browser/src/dom/web_animations_player.ts
+++ b/modules/@angular/platform-browser/src/dom/web_animations_player.ts
@@ -48,7 +48,7 @@ export class WebAnimationsPlayer implements AnimationPlayer {
     this._onFinish();
   }
 
-  setPosition(p: any /** TODO #9100 */): void { this._player.currentTime = p * this.totalTime; }
+  setPosition(p: any /* TODO #9100 */): void { this._player.currentTime = p * this.totalTime; }
 
   getPosition(): number { return this._player.currentTime / this.totalTime; }
 }

--- a/modules/@angular/platform-browser/src/security/html_sanitizer.ts
+++ b/modules/@angular/platform-browser/src/security/html_sanitizer.ts
@@ -168,7 +168,7 @@ class SanitizingHtmlSerializer {
     }
   }
 
-  private chars(chars: any /** TODO #9100 */) { this.buf.push(encodeEntities(chars)); }
+  private chars(chars: any /* TODO #9100 */) { this.buf.push(encodeEntities(chars)); }
 }
 
 // Regular Expressions for parsing tags and attributes
@@ -183,18 +183,18 @@ const NON_ALPHANUMERIC_REGEXP = /([^\#-~ |!])/g;
  * @param value
  * @returns {string} escaped text
  */
-function encodeEntities(value: any /** TODO #9100 */) {
+function encodeEntities(value: any /* TODO #9100 */) {
   return value.replace(/&/g, '&amp;')
       .replace(
           SURROGATE_PAIR_REGEXP,
-          function(match: any /** TODO #9100 */) {
+          function(match: any /* TODO #9100 */) {
             let hi = match.charCodeAt(0);
             let low = match.charCodeAt(1);
             return '&#' + (((hi - 0xD800) * 0x400) + (low - 0xDC00) + 0x10000) + ';';
           })
       .replace(
           NON_ALPHANUMERIC_REGEXP,
-          function(match: any /** TODO #9100 */) { return '&#' + match.charCodeAt(0) + ';'; })
+          function(match: any /* TODO #9100 */) { return '&#' + match.charCodeAt(0) + ';'; })
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;');
 }

--- a/modules/@angular/platform-browser/src/web_workers/shared/client_message_broker.ts
+++ b/modules/@angular/platform-browser/src/web_workers/shared/client_message_broker.ts
@@ -43,7 +43,7 @@ export class ClientMessageBroker_ extends ClientMessageBroker {
   public _serializer: Serializer;
 
   constructor(
-      messageBus: MessageBus, _serializer: Serializer, public channel: any /** TODO #9100 */) {
+      messageBus: MessageBus, _serializer: Serializer, public channel: any /* TODO #9100 */) {
     super();
     this._sink = messageBus.to(channel);
     this._serializer = _serializer;
@@ -56,7 +56,7 @@ export class ClientMessageBroker_ extends ClientMessageBroker {
     var time: string = stringify(DateWrapper.toMillis(DateWrapper.now()));
     var iteration: number = 0;
     var id: string = name + time + stringify(iteration);
-    while (isPresent((this as any /** TODO #9100 */)._pending[id])) {
+    while (isPresent((this as any /* TODO #9100 */)._pending[id])) {
       id = `${name}${time}${iteration}`;
       iteration++;
     }
@@ -64,7 +64,7 @@ export class ClientMessageBroker_ extends ClientMessageBroker {
   }
 
   runOnService(args: UiArguments, returnType: Type): Promise<any> {
-    var fnArgs: any[] /** TODO #9100 */ = [];
+    var fnArgs: any[] /* TODO #9100 */ = [];
     if (isPresent(args.args)) {
       args.args.forEach(argument => {
         if (argument.type != null) {
@@ -100,7 +100,7 @@ export class ClientMessageBroker_ extends ClientMessageBroker {
     // TODO(jteplitz602): Create a class for these messages so we don't keep using StringMap #3685
     var message = {'method': args.method, 'args': fnArgs};
     if (id != null) {
-      (message as any /** TODO #9100 */)['id'] = id;
+      (message as any /* TODO #9100 */)['id'] = id;
     }
     ObservableWrapper.callEmit(this._sink, message);
 
@@ -149,7 +149,7 @@ class MessageData {
 }
 
 export class FnArg {
-  constructor(public value: any /** TODO #9100 */, public type: Type) {}
+  constructor(public value: any /* TODO #9100 */, public type: Type) {}
 }
 
 export class UiArguments {

--- a/modules/@angular/platform-browser/src/web_workers/shared/service_message_broker.ts
+++ b/modules/@angular/platform-browser/src/web_workers/shared/service_message_broker.ts
@@ -46,7 +46,7 @@ export class ServiceMessageBroker_ extends ServiceMessageBroker {
 
   constructor(
       messageBus: MessageBus, private _serializer: Serializer,
-      public channel: any /** TODO #9100 */) {
+      public channel: any /* TODO #9100 */) {
     super();
     this._sink = messageBus.to(channel);
     var source = messageBus.from(channel);

--- a/modules/@angular/platform-browser/src/web_workers/ui/event_dispatcher.ts
+++ b/modules/@angular/platform-browser/src/web_workers/ui/event_dispatcher.ts
@@ -8,7 +8,7 @@ export class EventDispatcher {
   constructor(private _sink: EventEmitter<any>, private _serializer: Serializer) {}
 
   dispatchRenderEvent(element: any, eventTarget: string, eventName: string, event: any): boolean {
-    var serializedEvent: any /** TODO #9100 */;
+    var serializedEvent: any /* TODO #9100 */;
     // TODO (jteplitz602): support custom events #3350
     switch (event.type) {
       case 'click':

--- a/modules/@angular/platform-browser/src/web_workers/ui/event_serializer.ts
+++ b/modules/@angular/platform-browser/src/web_workers/ui/event_serializer.ts
@@ -59,7 +59,7 @@ function serializeEvent(e: any, properties: string[]): {[key: string]: any} {
   var serialized = {};
   for (var i = 0; i < properties.length; i++) {
     var prop = properties[i];
-    (serialized as any /** TODO #9100 */)[prop] = e[prop];
+    (serialized as any /* TODO #9100 */)[prop] = e[prop];
   }
   return serialized;
 }

--- a/modules/@angular/platform-browser/src/web_workers/ui/renderer.ts
+++ b/modules/@angular/platform-browser/src/web_workers/ui/renderer.ts
@@ -169,7 +169,7 @@ export class MessageBasedRenderer {
   private _listen(renderer: Renderer, renderElement: any, eventName: string, unlistenId: number) {
     var unregisterCallback = renderer.listen(
         renderElement, eventName,
-        (event: any /** TODO #9100 */) =>
+        (event: any /* TODO #9100 */) =>
             this._eventDispatcher.dispatchRenderEvent(renderElement, null, eventName, event));
     this._renderStore.store(unregisterCallback, unlistenId);
   }
@@ -178,7 +178,7 @@ export class MessageBasedRenderer {
       renderer: Renderer, eventTarget: string, eventName: string, unlistenId: number) {
     var unregisterCallback = renderer.listenGlobal(
         eventTarget, eventName,
-        (event: any /** TODO #9100 */) =>
+        (event: any /* TODO #9100 */) =>
             this._eventDispatcher.dispatchRenderEvent(null, eventTarget, eventName, event));
     this._renderStore.store(unregisterCallback, unlistenId);
   }

--- a/modules/@angular/platform-browser/src/web_workers/worker/renderer.ts
+++ b/modules/@angular/platform-browser/src/web_workers/worker/renderer.ts
@@ -14,7 +14,7 @@ import {deserializeGenericEvent} from './event_deserializer';
 
 @Injectable()
 export class WebWorkerRootRenderer implements RootRenderer {
-  private _messageBroker: any /** TODO #9100 */;
+  private _messageBroker: any /* TODO #9100 */;
   public globalEvents: NamedEventEmitter = new NamedEventEmitter();
   private _componentRenderers: Map<string, WebWorkerRenderer> =
       new Map<string, WebWorkerRenderer>();

--- a/modules/@angular/platform-browser/src/web_workers/worker/worker_adapter.ts
+++ b/modules/@angular/platform-browser/src/web_workers/worker/worker_adapter.ts
@@ -10,7 +10,7 @@ import {Type} from '../../facade/lang';
 export class WorkerDomAdapter extends DomAdapter {
   static makeCurrent() { setRootDomAdapter(new WorkerDomAdapter()); }
 
-  logError(error: any /** TODO #9100 */) {
+  logError(error: any /* TODO #9100 */) {
     if (console.error) {
       console.error(error);
     } else {
@@ -18,9 +18,9 @@ export class WorkerDomAdapter extends DomAdapter {
     }
   }
 
-  log(error: any /** TODO #9100 */) { console.log(error); }
+  log(error: any /* TODO #9100 */) { console.log(error); }
 
-  logGroup(error: any /** TODO #9100 */) {
+  logGroup(error: any /* TODO #9100 */) {
     if (console.group) {
       console.group(error);
       this.logError(error);
@@ -35,7 +35,7 @@ export class WorkerDomAdapter extends DomAdapter {
     }
   }
 
-  hasProperty(element: any /** TODO #9100 */, name: string): boolean { throw 'not implemented'; }
+  hasProperty(element: any /* TODO #9100 */, name: string): boolean { throw 'not implemented'; }
   setProperty(el: Element, name: string, value: any) { throw 'not implemented'; }
   getProperty(el: Element, name: string): any { throw 'not implemented'; }
   invoke(el: Element, methodName: string, args: any[]): any { throw 'not implemented'; }
@@ -47,135 +47,134 @@ export class WorkerDomAdapter extends DomAdapter {
 
   parse(templateHtml: string) { throw 'not implemented'; }
   query(selector: string): any { throw 'not implemented'; }
-  querySelector(el: any /** TODO #9100 */, selector: string): HTMLElement {
+  querySelector(el: any /* TODO #9100 */, selector: string): HTMLElement {
     throw 'not implemented';
   }
-  querySelectorAll(el: any /** TODO #9100 */, selector: string): any[] { throw 'not implemented'; }
-  on(el: any /** TODO #9100 */, evt: any /** TODO #9100 */, listener: any /** TODO #9100 */) {
+  querySelectorAll(el: any /* TODO #9100 */, selector: string): any[] { throw 'not implemented'; }
+  on(el: any /* TODO #9100 */, evt: any /* TODO #9100 */, listener: any /* TODO #9100 */) {
     throw 'not implemented';
   }
-  onAndCancel(
-      el: any /** TODO #9100 */, evt: any /** TODO #9100 */,
-      listener: any /** TODO #9100 */): Function {
+  onAndCancel(el: any /* TODO #9100 */, evt: any /* TODO #9100 */, listener: any /* TODO #9100 */):
+      Function {
     throw 'not implemented';
   }
-  dispatchEvent(el: any /** TODO #9100 */, evt: any /** TODO #9100 */) { throw 'not implemented'; }
-  createMouseEvent(eventType: any /** TODO #9100 */): any { throw 'not implemented'; }
+  dispatchEvent(el: any /* TODO #9100 */, evt: any /* TODO #9100 */) { throw 'not implemented'; }
+  createMouseEvent(eventType: any /* TODO #9100 */): any { throw 'not implemented'; }
   createEvent(eventType: string): any { throw 'not implemented'; }
-  preventDefault(evt: any /** TODO #9100 */) { throw 'not implemented'; }
-  isPrevented(evt: any /** TODO #9100 */): boolean { throw 'not implemented'; }
-  getInnerHTML(el: any /** TODO #9100 */): string { throw 'not implemented'; }
-  getTemplateContent(el: any /** TODO #9100 */): any { throw 'not implemented'; }
-  getOuterHTML(el: any /** TODO #9100 */): string { throw 'not implemented'; }
-  nodeName(node: any /** TODO #9100 */): string { throw 'not implemented'; }
-  nodeValue(node: any /** TODO #9100 */): string { throw 'not implemented'; }
-  type(node: any /** TODO #9100 */): string { throw 'not implemented'; }
-  content(node: any /** TODO #9100 */): any { throw 'not implemented'; }
-  firstChild(el: any /** TODO #9100 */): Node { throw 'not implemented'; }
-  nextSibling(el: any /** TODO #9100 */): Node { throw 'not implemented'; }
-  parentElement(el: any /** TODO #9100 */): Node { throw 'not implemented'; }
-  childNodes(el: any /** TODO #9100 */): Node[] { throw 'not implemented'; }
-  childNodesAsList(el: any /** TODO #9100 */): Node[] { throw 'not implemented'; }
-  clearNodes(el: any /** TODO #9100 */) { throw 'not implemented'; }
-  appendChild(el: any /** TODO #9100 */, node: any /** TODO #9100 */) { throw 'not implemented'; }
-  removeChild(el: any /** TODO #9100 */, node: any /** TODO #9100 */) { throw 'not implemented'; }
+  preventDefault(evt: any /* TODO #9100 */) { throw 'not implemented'; }
+  isPrevented(evt: any /* TODO #9100 */): boolean { throw 'not implemented'; }
+  getInnerHTML(el: any /* TODO #9100 */): string { throw 'not implemented'; }
+  getTemplateContent(el: any /* TODO #9100 */): any { throw 'not implemented'; }
+  getOuterHTML(el: any /* TODO #9100 */): string { throw 'not implemented'; }
+  nodeName(node: any /* TODO #9100 */): string { throw 'not implemented'; }
+  nodeValue(node: any /* TODO #9100 */): string { throw 'not implemented'; }
+  type(node: any /* TODO #9100 */): string { throw 'not implemented'; }
+  content(node: any /* TODO #9100 */): any { throw 'not implemented'; }
+  firstChild(el: any /* TODO #9100 */): Node { throw 'not implemented'; }
+  nextSibling(el: any /* TODO #9100 */): Node { throw 'not implemented'; }
+  parentElement(el: any /* TODO #9100 */): Node { throw 'not implemented'; }
+  childNodes(el: any /* TODO #9100 */): Node[] { throw 'not implemented'; }
+  childNodesAsList(el: any /* TODO #9100 */): Node[] { throw 'not implemented'; }
+  clearNodes(el: any /* TODO #9100 */) { throw 'not implemented'; }
+  appendChild(el: any /* TODO #9100 */, node: any /* TODO #9100 */) { throw 'not implemented'; }
+  removeChild(el: any /* TODO #9100 */, node: any /* TODO #9100 */) { throw 'not implemented'; }
   replaceChild(
-      el: any /** TODO #9100 */, newNode: any /** TODO #9100 */, oldNode: any /** TODO #9100 */) {
+      el: any /* TODO #9100 */, newNode: any /* TODO #9100 */, oldNode: any /* TODO #9100 */) {
     throw 'not implemented';
   }
-  remove(el: any /** TODO #9100 */): Node { throw 'not implemented'; }
-  insertBefore(el: any /** TODO #9100 */, node: any /** TODO #9100 */) { throw 'not implemented'; }
-  insertAllBefore(el: any /** TODO #9100 */, nodes: any /** TODO #9100 */) {
+  remove(el: any /* TODO #9100 */): Node { throw 'not implemented'; }
+  insertBefore(el: any /* TODO #9100 */, node: any /* TODO #9100 */) { throw 'not implemented'; }
+  insertAllBefore(el: any /* TODO #9100 */, nodes: any /* TODO #9100 */) {
     throw 'not implemented';
   }
-  insertAfter(el: any /** TODO #9100 */, node: any /** TODO #9100 */) { throw 'not implemented'; }
-  setInnerHTML(el: any /** TODO #9100 */, value: any /** TODO #9100 */) { throw 'not implemented'; }
-  getText(el: any /** TODO #9100 */): string { throw 'not implemented'; }
-  setText(el: any /** TODO #9100 */, value: string) { throw 'not implemented'; }
-  getValue(el: any /** TODO #9100 */): string { throw 'not implemented'; }
-  setValue(el: any /** TODO #9100 */, value: string) { throw 'not implemented'; }
-  getChecked(el: any /** TODO #9100 */): boolean { throw 'not implemented'; }
-  setChecked(el: any /** TODO #9100 */, value: boolean) { throw 'not implemented'; }
+  insertAfter(el: any /* TODO #9100 */, node: any /* TODO #9100 */) { throw 'not implemented'; }
+  setInnerHTML(el: any /* TODO #9100 */, value: any /* TODO #9100 */) { throw 'not implemented'; }
+  getText(el: any /* TODO #9100 */): string { throw 'not implemented'; }
+  setText(el: any /* TODO #9100 */, value: string) { throw 'not implemented'; }
+  getValue(el: any /* TODO #9100 */): string { throw 'not implemented'; }
+  setValue(el: any /* TODO #9100 */, value: string) { throw 'not implemented'; }
+  getChecked(el: any /* TODO #9100 */): boolean { throw 'not implemented'; }
+  setChecked(el: any /* TODO #9100 */, value: boolean) { throw 'not implemented'; }
   createComment(text: string): any { throw 'not implemented'; }
-  createTemplate(html: any /** TODO #9100 */): HTMLElement { throw 'not implemented'; }
-  createElement(tagName: any /** TODO #9100 */, doc?: any /** TODO #9100 */): HTMLElement {
+  createTemplate(html: any /* TODO #9100 */): HTMLElement { throw 'not implemented'; }
+  createElement(tagName: any /* TODO #9100 */, doc?: any /* TODO #9100 */): HTMLElement {
     throw 'not implemented';
   }
-  createElementNS(ns: string, tagName: string, doc?: any /** TODO #9100 */): Element {
+  createElementNS(ns: string, tagName: string, doc?: any /* TODO #9100 */): Element {
     throw 'not implemented';
   }
-  createTextNode(text: string, doc?: any /** TODO #9100 */): Text { throw 'not implemented'; }
-  createScriptTag(attrName: string, attrValue: string, doc?: any /** TODO #9100 */): HTMLElement {
+  createTextNode(text: string, doc?: any /* TODO #9100 */): Text { throw 'not implemented'; }
+  createScriptTag(attrName: string, attrValue: string, doc?: any /* TODO #9100 */): HTMLElement {
     throw 'not implemented';
   }
-  createStyleElement(css: string, doc?: any /** TODO #9100 */): HTMLStyleElement {
+  createStyleElement(css: string, doc?: any /* TODO #9100 */): HTMLStyleElement {
     throw 'not implemented';
   }
-  createShadowRoot(el: any /** TODO #9100 */): any { throw 'not implemented'; }
-  getShadowRoot(el: any /** TODO #9100 */): any { throw 'not implemented'; }
-  getHost(el: any /** TODO #9100 */): any { throw 'not implemented'; }
-  getDistributedNodes(el: any /** TODO #9100 */): Node[] { throw 'not implemented'; }
+  createShadowRoot(el: any /* TODO #9100 */): any { throw 'not implemented'; }
+  getShadowRoot(el: any /* TODO #9100 */): any { throw 'not implemented'; }
+  getHost(el: any /* TODO #9100 */): any { throw 'not implemented'; }
+  getDistributedNodes(el: any /* TODO #9100 */): Node[] { throw 'not implemented'; }
   clone(node: Node): Node { throw 'not implemented'; }
-  getElementsByClassName(element: any /** TODO #9100 */, name: string): HTMLElement[] {
+  getElementsByClassName(element: any /* TODO #9100 */, name: string): HTMLElement[] {
     throw 'not implemented';
   }
-  getElementsByTagName(element: any /** TODO #9100 */, name: string): HTMLElement[] {
+  getElementsByTagName(element: any /* TODO #9100 */, name: string): HTMLElement[] {
     throw 'not implemented';
   }
-  classList(element: any /** TODO #9100 */): any[] { throw 'not implemented'; }
-  addClass(element: any /** TODO #9100 */, className: string) { throw 'not implemented'; }
-  removeClass(element: any /** TODO #9100 */, className: string) { throw 'not implemented'; }
-  hasClass(element: any /** TODO #9100 */, className: string): boolean { throw 'not implemented'; }
-  setStyle(element: any /** TODO #9100 */, styleName: string, styleValue: string) {
+  classList(element: any /* TODO #9100 */): any[] { throw 'not implemented'; }
+  addClass(element: any /* TODO #9100 */, className: string) { throw 'not implemented'; }
+  removeClass(element: any /* TODO #9100 */, className: string) { throw 'not implemented'; }
+  hasClass(element: any /* TODO #9100 */, className: string): boolean { throw 'not implemented'; }
+  setStyle(element: any /* TODO #9100 */, styleName: string, styleValue: string) {
     throw 'not implemented';
   }
-  removeStyle(element: any /** TODO #9100 */, styleName: string) { throw 'not implemented'; }
-  getStyle(element: any /** TODO #9100 */, styleName: string): string { throw 'not implemented'; }
-  hasStyle(element: any /** TODO #9100 */, styleName: string, styleValue?: string): boolean {
+  removeStyle(element: any /* TODO #9100 */, styleName: string) { throw 'not implemented'; }
+  getStyle(element: any /* TODO #9100 */, styleName: string): string { throw 'not implemented'; }
+  hasStyle(element: any /* TODO #9100 */, styleName: string, styleValue?: string): boolean {
     throw 'not implemented';
   }
-  tagName(element: any /** TODO #9100 */): string { throw 'not implemented'; }
-  attributeMap(element: any /** TODO #9100 */): Map<string, string> { throw 'not implemented'; }
-  hasAttribute(element: any /** TODO #9100 */, attribute: string): boolean {
+  tagName(element: any /* TODO #9100 */): string { throw 'not implemented'; }
+  attributeMap(element: any /* TODO #9100 */): Map<string, string> { throw 'not implemented'; }
+  hasAttribute(element: any /* TODO #9100 */, attribute: string): boolean {
     throw 'not implemented';
   }
-  hasAttributeNS(element: any /** TODO #9100 */, ns: string, attribute: string): boolean {
+  hasAttributeNS(element: any /* TODO #9100 */, ns: string, attribute: string): boolean {
     throw 'not implemented';
   }
-  getAttribute(element: any /** TODO #9100 */, attribute: string): string {
+  getAttribute(element: any /* TODO #9100 */, attribute: string): string {
     throw 'not implemented';
   }
-  getAttributeNS(element: any /** TODO #9100 */, ns: string, attribute: string): string {
+  getAttributeNS(element: any /* TODO #9100 */, ns: string, attribute: string): string {
     throw 'not implemented';
   }
-  setAttribute(element: any /** TODO #9100 */, name: string, value: string) {
+  setAttribute(element: any /* TODO #9100 */, name: string, value: string) {
     throw 'not implemented';
   }
-  setAttributeNS(element: any /** TODO #9100 */, ns: string, name: string, value: string) {
+  setAttributeNS(element: any /* TODO #9100 */, ns: string, name: string, value: string) {
     throw 'not implemented';
   }
-  removeAttribute(element: any /** TODO #9100 */, attribute: string) { throw 'not implemented'; }
-  removeAttributeNS(element: any /** TODO #9100 */, ns: string, attribute: string) {
+  removeAttribute(element: any /* TODO #9100 */, attribute: string) { throw 'not implemented'; }
+  removeAttributeNS(element: any /* TODO #9100 */, ns: string, attribute: string) {
     throw 'not implemented';
   }
-  templateAwareRoot(el: any /** TODO #9100 */) { throw 'not implemented'; }
+  templateAwareRoot(el: any /* TODO #9100 */) { throw 'not implemented'; }
   createHtmlDocument(): HTMLDocument { throw 'not implemented'; }
   defaultDoc(): HTMLDocument { throw 'not implemented'; }
-  getBoundingClientRect(el: any /** TODO #9100 */) { throw 'not implemented'; }
+  getBoundingClientRect(el: any /* TODO #9100 */) { throw 'not implemented'; }
   getTitle(): string { throw 'not implemented'; }
   setTitle(newTitle: string) { throw 'not implemented'; }
-  elementMatches(n: any /** TODO #9100 */, selector: string): boolean { throw 'not implemented'; }
+  elementMatches(n: any /* TODO #9100 */, selector: string): boolean { throw 'not implemented'; }
   isTemplateElement(el: any): boolean { throw 'not implemented'; }
-  isTextNode(node: any /** TODO #9100 */): boolean { throw 'not implemented'; }
-  isCommentNode(node: any /** TODO #9100 */): boolean { throw 'not implemented'; }
-  isElementNode(node: any /** TODO #9100 */): boolean { throw 'not implemented'; }
-  hasShadowRoot(node: any /** TODO #9100 */): boolean { throw 'not implemented'; }
-  isShadowRoot(node: any /** TODO #9100 */): boolean { throw 'not implemented'; }
+  isTextNode(node: any /* TODO #9100 */): boolean { throw 'not implemented'; }
+  isCommentNode(node: any /* TODO #9100 */): boolean { throw 'not implemented'; }
+  isElementNode(node: any /* TODO #9100 */): boolean { throw 'not implemented'; }
+  hasShadowRoot(node: any /* TODO #9100 */): boolean { throw 'not implemented'; }
+  isShadowRoot(node: any /* TODO #9100 */): boolean { throw 'not implemented'; }
   importIntoDoc(node: Node): Node { throw 'not implemented'; }
   adoptNode(node: Node): Node { throw 'not implemented'; }
-  getHref(element: any /** TODO #9100 */): string { throw 'not implemented'; }
-  getEventKey(event: any /** TODO #9100 */): string { throw 'not implemented'; }
-  resolveAndSetHref(element: any /** TODO #9100 */, baseUrl: string, href: string) {
+  getHref(element: any /* TODO #9100 */): string { throw 'not implemented'; }
+  getEventKey(event: any /* TODO #9100 */): string { throw 'not implemented'; }
+  resolveAndSetHref(element: any /* TODO #9100 */, baseUrl: string, href: string) {
     throw 'not implemented';
   }
   supportsDOMEvents(): boolean { throw 'not implemented'; }
@@ -186,12 +185,12 @@ export class WorkerDomAdapter extends DomAdapter {
   getBaseHref(): string { throw 'not implemented'; }
   resetBaseElement(): void { throw 'not implemented'; }
   getUserAgent(): string { throw 'not implemented'; }
-  setData(element: any /** TODO #9100 */, name: string, value: string) { throw 'not implemented'; }
-  getComputedStyle(element: any /** TODO #9100 */): any { throw 'not implemented'; }
-  getData(element: any /** TODO #9100 */, name: string): string { throw 'not implemented'; }
+  setData(element: any /* TODO #9100 */, name: string, value: string) { throw 'not implemented'; }
+  getComputedStyle(element: any /* TODO #9100 */): any { throw 'not implemented'; }
+  getData(element: any /* TODO #9100 */, name: string): string { throw 'not implemented'; }
   setGlobalVar(name: string, value: any) { throw 'not implemented'; }
-  requestAnimationFrame(callback: any /** TODO #9100 */): number { throw 'not implemented'; }
-  cancelAnimationFrame(id: any /** TODO #9100 */) { throw 'not implemented'; }
+  requestAnimationFrame(callback: any /* TODO #9100 */): number { throw 'not implemented'; }
+  cancelAnimationFrame(id: any /* TODO #9100 */) { throw 'not implemented'; }
   performanceNow(): number { throw 'not implemented'; }
   getAnimationPrefix(): string { throw 'not implemented'; }
   getTransitionEnd(): string { throw 'not implemented'; }

--- a/modules/@angular/platform-browser/src/worker_render.ts
+++ b/modules/@angular/platform-browser/src/worker_render.ts
@@ -100,7 +100,7 @@ export function initializeGenericWorkerRenderer(injector: Injector) {
 
   // initialize message services after the bus has been created
   let services = injector.get(WORKER_RENDER_STARTABLE_MESSAGING_SERVICE);
-  zone.runGuarded(() => { services.forEach((svc: any /** TODO #9100 */) => { svc.start(); }); });
+  zone.runGuarded(() => { services.forEach((svc: any /* TODO #9100 */) => { svc.start(); }); });
 }
 
 export function bootstrapRender(

--- a/modules/@angular/platform-browser/test/browser/bootstrap_spec.ts
+++ b/modules/@angular/platform-browser/test/browser/bootstrap_spec.ts
@@ -31,16 +31,16 @@ class HelloRootCmp2 {
 
 @Component({selector: 'hello-app', template: ''})
 class HelloRootCmp3 {
-  appBinding: any /** TODO #9100 */;
+  appBinding: any /* TODO #9100 */;
 
-  constructor(@Inject('appBinding') appBinding: any /** TODO #9100 */) {
+  constructor(@Inject('appBinding') appBinding: any /* TODO #9100 */) {
     this.appBinding = appBinding;
   }
 }
 
 @Component({selector: 'hello-app', template: ''})
 class HelloRootCmp4 {
-  appRef: any /** TODO #9100 */;
+  appRef: any /* TODO #9100 */;
 
   constructor(@Inject(ApplicationRef) appRef: ApplicationRef) { this.appRef = appRef; }
 }
@@ -71,13 +71,13 @@ class _ArrayLogger {
 
 
 class DummyConsole implements Console {
-  log(message: any /** TODO #9100 */) {}
-  warn(message: any /** TODO #9100 */) {}
+  log(message: any /* TODO #9100 */) {}
+  warn(message: any /* TODO #9100 */) {}
 }
 
 export function main() {
-  var fakeDoc: any /** TODO #9100 */, el: any /** TODO #9100 */, el2: any /** TODO #9100 */,
-      testProviders: any /** TODO #9100 */, lightDom: any /** TODO #9100 */;
+  var fakeDoc: any /* TODO #9100 */, el: any /* TODO #9100 */, el2: any /* TODO #9100 */,
+      testProviders: any /* TODO #9100 */, lightDom: any /* TODO #9100 */;
 
   describe('bootstrap factory method', () => {
     beforeEach(() => {

--- a/modules/@angular/platform-browser/test/browser/rectangle_mock.ts
+++ b/modules/@angular/platform-browser/test/browser/rectangle_mock.ts
@@ -1,5 +1,5 @@
 export function createRectangle(
-    left: any /** TODO #9100 */, top: any /** TODO #9100 */, width: any /** TODO #9100 */,
-    height: any /** TODO #9100 */) {
+    left: any /* TODO #9100 */, top: any /* TODO #9100 */, width: any /* TODO #9100 */,
+    height: any /* TODO #9100 */) {
   return {left, top, width, height};
 }

--- a/modules/@angular/platform-browser/test/browser/tools/spies.ts
+++ b/modules/@angular/platform-browser/test/browser/tools/spies.ts
@@ -9,7 +9,7 @@ export class SpyApplicationRef extends SpyObject {
 }
 
 export class SpyComponentRef extends SpyObject {
-  injector: any /** TODO #9100 */;
+  injector: any /* TODO #9100 */;
   constructor() {
     super();
     this.injector = ReflectiveInjector.resolveAndCreate(
@@ -17,6 +17,6 @@ export class SpyComponentRef extends SpyObject {
   }
 }
 
-export function callNgProfilerTimeChangeDetection(config?: any /** TODO #9100 */): void {
+export function callNgProfilerTimeChangeDetection(config?: any /* TODO #9100 */): void {
   (<any>global).ng.profiler.timeChangeDetection(config);
 }

--- a/modules/@angular/platform-browser/test/dom/events/event_manager_spec.ts
+++ b/modules/@angular/platform-browser/test/dom/events/event_manager_spec.ts
@@ -7,7 +7,7 @@ import {EventManager, EventManagerPlugin} from '@angular/platform-browser/src/do
 import {el} from '../../../testing/browser_util';
 
 export function main() {
-  var domEventPlugin: any /** TODO #9100 */;
+  var domEventPlugin: any /* TODO #9100 */;
 
   describe('EventManager', () => {
 
@@ -16,7 +16,7 @@ export function main() {
     it('should delegate event bindings to plugins that are passed in from the most generic one to the most specific one',
        () => {
          var element = el('<div></div>');
-         var handler = (e: any /** TODO #9100 */) => e;
+         var handler = (e: any /* TODO #9100 */) => e;
          var plugin = new FakeEventManagerPlugin(['click']);
          var manager = new EventManager([domEventPlugin, plugin], new FakeNgZone());
          manager.addEventListener(element, 'click', handler);
@@ -25,8 +25,8 @@ export function main() {
 
     it('should delegate event bindings to the first plugin supporting the event', () => {
       var element = el('<div></div>');
-      var clickHandler = (e: any /** TODO #9100 */) => e;
-      var dblClickHandler = (e: any /** TODO #9100 */) => e;
+      var clickHandler = (e: any /* TODO #9100 */) => e;
+      var dblClickHandler = (e: any /* TODO #9100 */) => e;
       var plugin1 = new FakeEventManagerPlugin(['dblclick']);
       var plugin2 = new FakeEventManagerPlugin(['click', 'dblclick']);
       var manager = new EventManager([plugin2, plugin1], new FakeNgZone());
@@ -53,8 +53,8 @@ export function main() {
 
       var child = getDOM().firstChild(element);
       var dispatchedEvent = getDOM().createMouseEvent('click');
-      var receivedEvent: any /** TODO #9100 */ = null;
-      var handler = (e: any /** TODO #9100 */) => { receivedEvent = e; };
+      var receivedEvent: any /* TODO #9100 */ = null;
+      var handler = (e: any /* TODO #9100 */) => { receivedEvent = e; };
       var manager = new EventManager([domEventPlugin], new FakeNgZone());
       manager.addEventListener(element, 'click', handler);
       getDOM().dispatchEvent(child, dispatchedEvent);
@@ -66,8 +66,8 @@ export function main() {
       var element = el('<div><div></div></div>');
       getDOM().appendChild(getDOM().defaultDoc().body, element);
       var dispatchedEvent = getDOM().createMouseEvent('click');
-      var receivedEvent: any /** TODO #9100 */ = null;
-      var handler = (e: any /** TODO #9100 */) => { receivedEvent = e; };
+      var receivedEvent: any /* TODO #9100 */ = null;
+      var handler = (e: any /* TODO #9100 */) => { receivedEvent = e; };
       var manager = new EventManager([domEventPlugin], new FakeNgZone());
 
       var remover = manager.addGlobalEventListener('document', 'click', handler);
@@ -88,7 +88,7 @@ class FakeEventManagerPlugin extends EventManagerPlugin {
 
   supports(eventName: string): boolean { return ListWrapper.contains(this._supports, eventName); }
 
-  addEventListener(element: any /** TODO #9100 */, eventName: string, handler: Function) {
+  addEventListener(element: any /* TODO #9100 */, eventName: string, handler: Function) {
     this._eventHandler.set(eventName, handler);
     return () => { this._eventHandler.delete(eventName); };
   }
@@ -96,7 +96,7 @@ class FakeEventManagerPlugin extends EventManagerPlugin {
 
 class FakeNgZone extends NgZone {
   constructor() { super({enableLongStackTrace: false}); }
-  run(fn: any /** TODO #9100 */) { fn(); }
+  run(fn: any /* TODO #9100 */) { fn(); }
 
-  runOutsideAngular(fn: any /** TODO #9100 */) { return fn(); }
+  runOutsideAngular(fn: any /* TODO #9100 */) { return fn(); }
 }

--- a/modules/@angular/platform-browser/test/dom/shared_styles_host_spec.ts
+++ b/modules/@angular/platform-browser/test/dom/shared_styles_host_spec.ts
@@ -4,7 +4,7 @@ import {DomSharedStylesHost} from '@angular/platform-browser/src/dom/shared_styl
 
 export function main() {
   describe('DomSharedStylesHost', () => {
-    var doc: any /** TODO #9100 */;
+    var doc: any /* TODO #9100 */;
     var ssh: DomSharedStylesHost;
     var someHost: Element;
     beforeEach(() => {

--- a/modules/@angular/platform-browser/test/dom/web_animations_player_spec.ts
+++ b/modules/@angular/platform-browser/test/dom/web_animations_player_spec.ts
@@ -12,7 +12,7 @@ export function main() {
   }
 
   describe('WebAnimationsPlayer', () => {
-    var player: any /** TODO #9100 */, captures: any /** TODO #9100 */;
+    var player: any /* TODO #9100 */, captures: any /* TODO #9100 */;
     beforeEach(() => {
       var newPlayer = makePlayer();
       captures = <{[key: string]: any}>newPlayer['captures'];

--- a/modules/@angular/platform-browser/test/testing_public_browser_spec.ts
+++ b/modules/@angular/platform-browser/test/testing_public_browser_spec.ts
@@ -110,9 +110,9 @@ export function main() {
            inject([XHR], (xhr: XHR) => { expect(xhr).toBeAnInstanceOf(XHRImpl); }));
 
         it('should allow the use of fakeAsync',
-           fakeAsync(inject([FancyService], (service: any /** TODO #9100 */) => {
-             var value: any /** TODO #9100 */;
-             service.getAsyncValue().then(function(val: any /** TODO #9100 */) { value = val; });
+           fakeAsync(inject([FancyService], (service: any /* TODO #9100 */) => {
+             var value: any /* TODO #9100 */;
+             service.getAsyncValue().then(function(val: any /* TODO #9100 */) { value = val; });
              tick();
              expect(value).toEqual('async value');
            })));
@@ -125,9 +125,9 @@ export function main() {
       var patchJasmineIt = () => {
         var deferred = PromiseWrapper.completer();
         originalJasmineIt = jasmine.getEnv().it;
-        jasmine.getEnv().it = (description: string, fn: any /** TODO #9100 */) => {
+        jasmine.getEnv().it = (description: string, fn: any /* TODO #9100 */) => {
           var done = () => { deferred.resolve() };
-          (<any>done).fail = (err: any /** TODO #9100 */) => { deferred.reject(err) };
+          (<any>done).fail = (err: any /* TODO #9100 */) => { deferred.reject(err) };
           fn(done);
           return null;
         };
@@ -136,7 +136,7 @@ export function main() {
 
       var restoreJasmineIt = () => { jasmine.getEnv().it = originalJasmineIt; };
 
-      it('should fail when an XHR fails', (done: any /** TODO #9100 */) => {
+      it('should fail when an XHR fails', (done: any /* TODO #9100 */) => {
         var itPromise = patchJasmineIt();
 
         it('should fail with an error from a promise',

--- a/modules/@angular/platform-browser/test/testing_public_spec.ts
+++ b/modules/@angular/platform-browser/test/testing_public_spec.ts
@@ -101,7 +101,7 @@ export function main() {
 
     it('should run normal tests', () => { actuallyDone = true; });
 
-    it('should run normal async tests', (done: any /** TODO #9100 */) => {
+    it('should run normal async tests', (done: any /* TODO #9100 */) => {
       setTimeout(() => {
         actuallyDone = true;
         done();
@@ -121,28 +121,28 @@ export function main() {
     describe('setting up Providers', () => {
       beforeEachProviders(() => [{provide: FancyService, useValue: new FancyService()}]);
 
-      it('should use set up providers', inject([FancyService], (service: any /** TODO #9100 */) => {
+      it('should use set up providers', inject([FancyService], (service: any /* TODO #9100 */) => {
            expect(service.value).toEqual('real value');
          }));
 
       it('should wait until returned promises',
-         async(inject([FancyService], (service: any /** TODO #9100 */) => {
+         async(inject([FancyService], (service: any /* TODO #9100 */) => {
            service.getAsyncValue().then(
-               (value: any /** TODO #9100 */) => { expect(value).toEqual('async value'); });
+               (value: any /* TODO #9100 */) => { expect(value).toEqual('async value'); });
            service.getTimeoutValue().then(
-               (value: any /** TODO #9100 */) => { expect(value).toEqual('timeout value'); });
+               (value: any /* TODO #9100 */) => { expect(value).toEqual('timeout value'); });
          })));
 
       it('should allow the use of fakeAsync',
-         fakeAsync(inject([FancyService], (service: any /** TODO #9100 */) => {
-           var value: any /** TODO #9100 */;
-           service.getAsyncValue().then(function(val: any /** TODO #9100 */) { value = val; });
+         fakeAsync(inject([FancyService], (service: any /* TODO #9100 */) => {
+           var value: any /* TODO #9100 */;
+           service.getAsyncValue().then(function(val: any /* TODO #9100 */) { value = val; });
            tick();
            expect(value).toEqual('async value');
          })));
 
-      it('should allow use of "done"', (done: any /** TODO #9100 */) => {
-        inject([FancyService], (service: any /** TODO #9100 */) => {
+      it('should allow use of "done"', (done: any /* TODO #9100 */) => {
+        inject([FancyService], (service: any /* TODO #9100 */) => {
           let count = 0;
           let id = setInterval(() => {
             count++;
@@ -155,24 +155,23 @@ export function main() {
       });
 
       describe('using beforeEach', () => {
-        beforeEach(inject([FancyService], (service: any /** TODO #9100 */) => {
+        beforeEach(inject([FancyService], (service: any /* TODO #9100 */) => {
           service.value = 'value modified in beforeEach';
         }));
 
         it('should use modified providers',
-           inject([FancyService], (service: any /** TODO #9100 */) => {
+           inject([FancyService], (service: any /* TODO #9100 */) => {
              expect(service.value).toEqual('value modified in beforeEach');
            }));
       });
 
       describe('using async beforeEach', () => {
-        beforeEach(async(inject([FancyService], (service: any /** TODO #9100 */) => {
-          service.getAsyncValue().then(
-              (value: any /** TODO #9100 */) => { service.value = value; });
+        beforeEach(async(inject([FancyService], (service: any /* TODO #9100 */) => {
+          service.getAsyncValue().then((value: any /* TODO #9100 */) => { service.value = value; });
         })));
 
         it('should use asynchronously modified value',
-           inject([FancyService], (service: any /** TODO #9100 */) => {
+           inject([FancyService], (service: any /* TODO #9100 */) => {
              expect(service.value).toEqual('async value');
            }));
       });
@@ -181,13 +180,13 @@ export function main() {
     describe('per test providers', () => {
       it('should allow per test providers',
          withProviders(() => [{provide: FancyService, useValue: new FancyService()}])
-             .inject([FancyService], (service: any /** TODO #9100 */) => {
+             .inject([FancyService], (service: any /* TODO #9100 */) => {
                expect(service.value).toEqual('real value');
              }));
 
       it('should return value from inject', () => {
         let retval = withProviders(() => [{provide: FancyService, useValue: new FancyService()}])
-                         .inject([FancyService], (service: any /** TODO #9100 */) => {
+                         .inject([FancyService], (service: any /* TODO #9100 */) => {
                            expect(service.value).toEqual('real value');
                            return 10;
                          })();
@@ -203,9 +202,9 @@ export function main() {
     var patchJasmineIt = () => {
       var deferred = PromiseWrapper.completer();
       originalJasmineIt = jasmine.getEnv().it;
-      jasmine.getEnv().it = (description: string, fn: any /** TODO #9100 */) => {
+      jasmine.getEnv().it = (description: string, fn: any /* TODO #9100 */) => {
         var done = () => { deferred.resolve() };
-        (<any>done).fail = (err: any /** TODO #9100 */) => { deferred.reject(err) };
+        (<any>done).fail = (err: any /* TODO #9100 */) => { deferred.reject(err) };
         fn(done);
         return null;
       };
@@ -219,7 +218,7 @@ export function main() {
       originalJasmineBeforeEach = jasmine.getEnv().beforeEach;
       jasmine.getEnv().beforeEach = (fn: any) => {
         var done = () => { deferred.resolve() };
-        (<any>done).fail = (err: any /** TODO #9100 */) => { deferred.reject(err) };
+        (<any>done).fail = (err: any /* TODO #9100 */) => { deferred.reject(err) };
         fn(done);
         return null;
       };
@@ -229,7 +228,7 @@ export function main() {
     var restoreJasmineBeforeEach =
         () => { jasmine.getEnv().beforeEach = originalJasmineBeforeEach; };
 
-    it('should fail when an asynchronous error is thrown', (done: any /** TODO #9100 */) => {
+    it('should fail when an asynchronous error is thrown', (done: any /* TODO #9100 */) => {
       var itPromise = patchJasmineIt();
 
       it('throws an async error',
@@ -244,7 +243,7 @@ export function main() {
       restoreJasmineIt();
     });
 
-    it('should fail when a returned promise is rejected', (done: any /** TODO #9100 */) => {
+    it('should fail when a returned promise is rejected', (done: any /* TODO #9100 */) => {
       var itPromise = patchJasmineIt();
 
       it('should fail with an error from a promise', async(inject([], () => {
@@ -267,7 +266,7 @@ export function main() {
     describe('using beforeEachProviders', () => {
       beforeEachProviders(() => [{provide: FancyService, useValue: new FancyService()}]);
 
-      beforeEach(inject([FancyService], (service: any /** TODO #9100 */) => {
+      beforeEach(inject([FancyService], (service: any /* TODO #9100 */) => {
         expect(service.value).toEqual('real value');
       }));
 

--- a/modules/@angular/platform-browser/test/web_workers/shared/service_message_broker_spec.ts
+++ b/modules/@angular/platform-browser/test/web_workers/shared/service_message_broker_spec.ts
@@ -19,7 +19,7 @@ export function main() {
   beforeEachProviders(() => [Serializer, {provide: ON_WEB_WORKER, useValue: true}, RenderStore]);
 
   describe('UIMessageBroker', () => {
-    var messageBuses: any /** TODO #9100 */;
+    var messageBuses: any /* TODO #9100 */;
 
     beforeEach(() => {
       messageBuses = createPairedMessageBuses();

--- a/modules/@angular/platform-browser/test/web_workers/shared/web_worker_test_util.ts
+++ b/modules/@angular/platform-browser/test/web_workers/shared/web_worker_test_util.ts
@@ -47,7 +47,7 @@ export function expectBrokerCall(
       expect(args.args.length).toEqual(vals.length);
       ListWrapper.forEachWithIndex(vals, (v, i) => {expect(v).toEqual(args.args[i].value)});
     }
-    var promise: any /** TODO #9100 */ = null;
+    var promise: any /* TODO #9100 */ = null;
     if (isPresent(handler)) {
       let givenValues = args.args.map((arg) => {arg.value});
       if (givenValues.length > 0) {

--- a/modules/@angular/platform-browser/test/web_workers/worker/renderer_integration_spec.ts
+++ b/modules/@angular/platform-browser/test/web_workers/worker/renderer_integration_spec.ts
@@ -119,7 +119,7 @@ export function main() {
                  .createAsync(MyComp2)
                  .then((fixture) => {
                    var checkSetters =
-                       (componentRef: any /** TODO #9100 */, workerEl: any /** TODO #9100 */) => {
+                       (componentRef: any /* TODO #9100 */, workerEl: any /* TODO #9100 */) => {
                          var renderer = getRenderer(componentRef);
                          var el = getRenderElement(workerEl);
                          renderer.setElementProperty(workerEl, 'tabIndex', 1);
@@ -236,7 +236,7 @@ export function main() {
 @Injectable()
 class MyComp2 {
   ctxProp: string;
-  ctxNumProp: any /** TODO #9100 */;
+  ctxNumProp: any /* TODO #9100 */;
   ctxBoolProp: boolean;
   constructor() {
     this.ctxProp = 'initial value';

--- a/modules/@angular/platform-browser/test/xhr/xhr_cache_setter.ts
+++ b/modules/@angular/platform-browser/test/xhr/xhr_cache_setter.ts
@@ -1,3 +1,3 @@
-export function setTemplateCache(cache: any /** TODO #9100 */): void {
+export function setTemplateCache(cache: any /* TODO #9100 */): void {
   (<any>window).$templateCache = cache;
 }

--- a/modules/@angular/platform-browser/testing/benchmark_util.ts
+++ b/modules/@angular/platform-browser/testing/benchmark_util.ts
@@ -11,8 +11,8 @@ export function getIntParameter(name: string) {
 
 export function getStringParameter(name: string) {
   var els = DOM.querySelectorAll(document, `input[name="${name}"]`);
-  var value: any /** TODO #9100 */;
-  var el: any /** TODO #9100 */;
+  var value: any /* TODO #9100 */;
+  var el: any /* TODO #9100 */;
 
   for (var i = 0; i < els.length; i++) {
     el = els[i];
@@ -32,12 +32,12 @@ export function getStringParameter(name: string) {
 
 export function bindAction(selector: string, callback: Function) {
   var el = DOM.querySelector(document, selector);
-  DOM.on(el, 'click', function(_: any /** TODO #9100 */) { callback(); });
+  DOM.on(el, 'click', function(_: any /* TODO #9100 */) { callback(); });
 }
 
 export function microBenchmark(
-    name: any /** TODO #9100 */, iterationCount: any /** TODO #9100 */,
-    callback: any /** TODO #9100 */) {
+    name: any /* TODO #9100 */, iterationCount: any /* TODO #9100 */,
+    callback: any /* TODO #9100 */) {
   var durationName = `${name}/${iterationCount}`;
   window.console.time(durationName);
   callback();

--- a/modules/@angular/platform-browser/testing/browser_util.ts
+++ b/modules/@angular/platform-browser/testing/browser_util.ts
@@ -53,7 +53,7 @@ export class BrowserDetection {
 BrowserDetection.setup();
 
 export function dispatchEvent(
-    element: any /** TODO #9100 */, eventType: any /** TODO #9100 */): void {
+    element: any /* TODO #9100 */, eventType: any /* TODO #9100 */): void {
   getDOM().dispatchEvent(element, getDOM().createEvent(eventType));
 }
 
@@ -68,14 +68,14 @@ export function normalizeCSS(css: string): string {
   css = StringWrapper.replaceAll(css, / }/g, '}');
   css = StringWrapper.replaceAllMapped(
       css, /url\((\"|\s)(.+)(\"|\s)\)(\s*)/g,
-      (match: any /** TODO #9100 */) => `url("${match[2]}")`);
+      (match: any /* TODO #9100 */) => `url("${match[2]}")`);
   css = StringWrapper.replaceAllMapped(
-      css, /\[(.+)=([^"\]]+)\]/g, (match: any /** TODO #9100 */) => `[${match[1]}="${match[2]}"]`);
+      css, /\[(.+)=([^"\]]+)\]/g, (match: any /* TODO #9100 */) => `[${match[1]}="${match[2]}"]`);
   return css;
 }
 
 var _singleTagWhitelist = ['br', 'hr', 'input'];
-export function stringifyElement(el: any /** TODO #9100 */): string {
+export function stringifyElement(el: any /* TODO #9100 */): string {
   var result = '';
   if (getDOM().isElementNode(el)) {
     var tagName = getDOM().tagName(el).toLowerCase();
@@ -85,7 +85,7 @@ export function stringifyElement(el: any /** TODO #9100 */): string {
 
     // Attributes in an ordered way
     var attributeMap = getDOM().attributeMap(el);
-    var keys: any[] /** TODO #9100 */ = [];
+    var keys: any[] /* TODO #9100 */ = [];
     attributeMap.forEach((v, k) => keys.push(k));
     ListWrapper.sort(keys);
     for (let i = 0; i < keys.length; i++) {

--- a/modules/@angular/platform-browser/testing/dom_test_component_renderer.ts
+++ b/modules/@angular/platform-browser/testing/dom_test_component_renderer.ts
@@ -12,7 +12,7 @@ import {el} from './browser_util';
  */
 @Injectable()
 export class DOMTestComponentRenderer extends TestComponentRenderer {
-  constructor(@Inject(DOCUMENT) private _doc: any /** TODO #9100 */) { super(); }
+  constructor(@Inject(DOCUMENT) private _doc: any /* TODO #9100 */) { super(); }
 
   insertRootElement(rootElId: string) {
     let rootEl = el(`<div id="${rootElId}"></div>`);

--- a/modules/@angular/platform-browser/testing/e2e_util.ts
+++ b/modules/@angular/platform-browser/testing/e2e_util.ts
@@ -1,12 +1,12 @@
 import * as webdriver from 'selenium-webdriver';
 
-declare var global: any /** TODO #9100 */;
+declare var global: any /* TODO #9100 */;
 declare var expect: Function;
 export var browser: protractor.IBrowser = global['browser'];
 export var $: cssSelectorHelper = global['$'];
 
-export function clickAll(buttonSelectors: any /** TODO #9100 */) {
-  buttonSelectors.forEach(function(selector: any /** TODO #9100 */) { $(selector).click(); });
+export function clickAll(buttonSelectors: any /* TODO #9100 */) {
+  buttonSelectors.forEach(function(selector: any /* TODO #9100 */) { $(selector).click(); });
 }
 
 export function verifyNoBrowserErrors() {

--- a/modules/@angular/platform-browser/testing/perf_util.ts
+++ b/modules/@angular/platform-browser/testing/perf_util.ts
@@ -1,34 +1,34 @@
 export {verifyNoBrowserErrors} from './e2e_util';
 
-var benchpress = (global as any /** TODO #9100 */)['benchpress'];
+var benchpress = (global as any /* TODO #9100 */)['benchpress'];
 var bind = benchpress.bind;
 var Options = benchpress.Options;
 
-export function runClickBenchmark(config: any /** TODO #9100 */) {
+export function runClickBenchmark(config: any /* TODO #9100 */) {
   browser.ignoreSynchronization = !config.waitForAngular2;
   var buttons =
-      config.buttons.map(function(selector: any /** TODO #9100 */) { return $(selector); });
+      config.buttons.map(function(selector: any /* TODO #9100 */) { return $(selector); });
   config.work = function() {
-    buttons.forEach(function(button: any /** TODO #9100 */) { button.click(); });
+    buttons.forEach(function(button: any /* TODO #9100 */) { button.click(); });
   };
   return runBenchmark(config);
 }
 
-export function runBenchmark(config: any /** TODO #9100 */) {
+export function runBenchmark(config: any /* TODO #9100 */) {
   return getScaleFactor(browser.params.benchmark.scaling).then(function(scaleFactor) {
     var description = {};
-    var urlParams: any[] /** TODO #9100 */ = [];
+    var urlParams: any[] /* TODO #9100 */ = [];
     if (config.params) {
-      config.params.forEach(function(param: any /** TODO #9100 */) {
+      config.params.forEach(function(param: any /* TODO #9100 */) {
         var name = param.name;
         var value = applyScaleFactor(param.value, scaleFactor, param.scale);
         urlParams.push(name + '=' + value);
-        (description as any /** TODO #9100 */)[name] = value;
+        (description as any /* TODO #9100 */)[name] = value;
       });
     }
     var url = encodeURI(config.url + '?' + urlParams.join('&'));
     return browser.get(url).then(function() {
-      return (global as any /** TODO #9100 */)['benchpressRunner'].sample({
+      return (global as any /* TODO #9100 */)['benchpressRunner'].sample({
         id: config.id,
         execute: config.work,
         prepare: config.prepare,
@@ -39,10 +39,10 @@ export function runBenchmark(config: any /** TODO #9100 */) {
   });
 }
 
-function getScaleFactor(possibleScalings: any /** TODO #9100 */) {
+function getScaleFactor(possibleScalings: any /* TODO #9100 */) {
   return browser.executeScript('return navigator.userAgent').then(function(userAgent: string) {
     var scaleFactor = 1;
-    possibleScalings.forEach(function(entry: any /** TODO #9100 */) {
+    possibleScalings.forEach(function(entry: any /* TODO #9100 */) {
       if (userAgent.match(entry.userAgent)) {
         scaleFactor = entry.value;
       }
@@ -52,8 +52,7 @@ function getScaleFactor(possibleScalings: any /** TODO #9100 */) {
 }
 
 function applyScaleFactor(
-    value: any /** TODO #9100 */, scaleFactor: any /** TODO #9100 */,
-    method: any /** TODO #9100 */) {
+    value: any /* TODO #9100 */, scaleFactor: any /* TODO #9100 */, method: any /* TODO #9100 */) {
   if (method === 'log2') {
     return value + Math.log(scaleFactor) / Math.LN2;
   } else if (method === 'sqrt') {

--- a/modules/@angular/platform-server/src/parse5_adapter.ts
+++ b/modules/@angular/platform-server/src/parse5_adapter.ts
@@ -7,9 +7,9 @@ import {BaseException} from '../src/facade/exceptions';
 import {SelectorMatcher, CssSelector} from '../compiler_private';
 import {XHR} from '@angular/compiler';
 
-var parser: any /** TODO #9100 */ = null;
-var serializer: any /** TODO #9100 */ = null;
-var treeAdapter: any /** TODO #9100 */ = null;
+var parser: any /* TODO #9100 */ = null;
+var serializer: any /* TODO #9100 */ = null;
+var treeAdapter: any /* TODO #9100 */ = null;
 
 var _attrToPropMap: {[key: string]: string} = {
   'class': 'className',
@@ -17,11 +17,11 @@ var _attrToPropMap: {[key: string]: string} = {
   'readonly': 'readOnly',
   'tabindex': 'tabIndex',
 };
-var defDoc: any /** TODO #9100 */ = null;
+var defDoc: any /* TODO #9100 */ = null;
 
 var mapProps = ['attribs', 'x-attribsNamespace', 'x-attribsPrefix'];
 
-function _notImplemented(methodName: any /** TODO #9100 */) {
+function _notImplemented(methodName: any /* TODO #9100 */) {
   return new BaseException('This method is not implemented in Parse5DomAdapter: ' + methodName);
 }
 
@@ -34,7 +34,7 @@ export class Parse5DomAdapter extends DomAdapter {
     setRootDomAdapter(new Parse5DomAdapter());
   }
 
-  hasProperty(element: any /** TODO #9100 */, name: string): boolean {
+  hasProperty(element: any /* TODO #9100 */, name: string): boolean {
     return _HTMLElementPropertyList.indexOf(name) > -1;
   }
   // TODO(tbosch): don't even call this method when we run the tests on server side
@@ -52,11 +52,11 @@ export class Parse5DomAdapter extends DomAdapter {
   // by not using the DomRenderer in tests. Keeping this for now to make tests happy...
   getProperty(el: /*element*/ any, name: string): any { return el[name]; }
 
-  logError(error: any /** TODO #9100 */) { console.error(error); }
+  logError(error: any /* TODO #9100 */) { console.error(error); }
 
-  log(error: any /** TODO #9100 */) { console.log(error); }
+  log(error: any /* TODO #9100 */) { console.log(error); }
 
-  logGroup(error: any /** TODO #9100 */) { console.error(error); }
+  logGroup(error: any /* TODO #9100 */) { console.error(error); }
 
   logGroupEnd() {}
 
@@ -64,15 +64,15 @@ export class Parse5DomAdapter extends DomAdapter {
 
   get attrToPropMap() { return _attrToPropMap; }
 
-  query(selector: any /** TODO #9100 */) { throw _notImplemented('query'); }
-  querySelector(el: any /** TODO #9100 */, selector: string): any {
+  query(selector: any /* TODO #9100 */) { throw _notImplemented('query'); }
+  querySelector(el: any /* TODO #9100 */, selector: string): any {
     return this.querySelectorAll(el, selector)[0];
   }
-  querySelectorAll(el: any /** TODO #9100 */, selector: string): any[] {
-    var res: any[] /** TODO #9100 */ = [];
+  querySelectorAll(el: any /* TODO #9100 */, selector: string): any[] {
+    var res: any[] /* TODO #9100 */ = [];
     var _recursive =
-        (result: any /** TODO #9100 */, node: any /** TODO #9100 */,
-         selector: any /** TODO #9100 */, matcher: any /** TODO #9100 */) => {
+        (result: any /* TODO #9100 */, node: any /* TODO #9100 */, selector: any /* TODO #9100 */,
+         matcher: any /* TODO #9100 */) => {
           var cNodes = node.childNodes;
           if (cNodes && cNodes.length > 0) {
             for (var i = 0; i < cNodes.length; i++) {
@@ -90,8 +90,7 @@ export class Parse5DomAdapter extends DomAdapter {
     return res;
   }
   elementMatches(
-      node: any /** TODO #9100 */, selector: string,
-      matcher: any /** TODO #9100 */ = null): boolean {
+      node: any /* TODO #9100 */, selector: string, matcher: any /* TODO #9100 */ = null): boolean {
     if (this.isElementNode(node) && selector === '*') {
       return true;
     }
@@ -119,11 +118,11 @@ export class Parse5DomAdapter extends DomAdapter {
 
       matcher.match(
           cssSelector,
-          function(selector: any /** TODO #9100 */, cb: any /** TODO #9100 */) { result = true; });
+          function(selector: any /* TODO #9100 */, cb: any /* TODO #9100 */) { result = true; });
     }
     return result;
   }
-  on(el: any /** TODO #9100 */, evt: any /** TODO #9100 */, listener: any /** TODO #9100 */) {
+  on(el: any /* TODO #9100 */, evt: any /* TODO #9100 */, listener: any /* TODO #9100 */) {
     var listenersMap: {[k: /*any*/ string]: any} = el._eventListenersMap;
     if (isBlank(listenersMap)) {
       var listenersMap: {[k: /*any*/ string]: any} = StringMapWrapper.create();
@@ -136,15 +135,14 @@ export class Parse5DomAdapter extends DomAdapter {
     listeners.push(listener);
     StringMapWrapper.set(listenersMap, evt, listeners);
   }
-  onAndCancel(
-      el: any /** TODO #9100 */, evt: any /** TODO #9100 */,
-      listener: any /** TODO #9100 */): Function {
+  onAndCancel(el: any /* TODO #9100 */, evt: any /* TODO #9100 */, listener: any /* TODO #9100 */):
+      Function {
     this.on(el, evt, listener);
     return () => {
       ListWrapper.remove(StringMapWrapper.get<any[]>(el._eventListenersMap, evt), listener);
     };
   }
-  dispatchEvent(el: any /** TODO #9100 */, evt: any /** TODO #9100 */) {
+  dispatchEvent(el: any /* TODO #9100 */, evt: any /* TODO #9100 */) {
     if (isBlank(evt.target)) {
       evt.target = el;
     }
@@ -163,7 +161,7 @@ export class Parse5DomAdapter extends DomAdapter {
       this.dispatchEvent(el._window, evt);
     }
   }
-  createMouseEvent(eventType: any /** TODO #9100 */): Event { return this.createEvent(eventType); }
+  createMouseEvent(eventType: any /* TODO #9100 */): Event { return this.createEvent(eventType); }
   createEvent(eventType: string): Event {
     var evt = <Event>{
       type: eventType,
@@ -172,30 +170,30 @@ export class Parse5DomAdapter extends DomAdapter {
     };
     return evt;
   }
-  preventDefault(evt: any /** TODO #9100 */) { evt.returnValue = false; }
-  isPrevented(evt: any /** TODO #9100 */): boolean {
+  preventDefault(evt: any /* TODO #9100 */) { evt.returnValue = false; }
+  isPrevented(evt: any /* TODO #9100 */): boolean {
     return isPresent(evt.returnValue) && !evt.returnValue;
   }
-  getInnerHTML(el: any /** TODO #9100 */): string {
+  getInnerHTML(el: any /* TODO #9100 */): string {
     return serializer.serialize(this.templateAwareRoot(el));
   }
-  getTemplateContent(el: any /** TODO #9100 */): Node {
+  getTemplateContent(el: any /* TODO #9100 */): Node {
     return null;  // no <template> support in parse5.
   }
-  getOuterHTML(el: any /** TODO #9100 */): string {
+  getOuterHTML(el: any /* TODO #9100 */): string {
     serializer.html = '';
     serializer._serializeElement(el);
     return serializer.html;
   }
-  nodeName(node: any /** TODO #9100 */): string { return node.tagName; }
-  nodeValue(node: any /** TODO #9100 */): string { return node.nodeValue; }
+  nodeName(node: any /* TODO #9100 */): string { return node.tagName; }
+  nodeValue(node: any /* TODO #9100 */): string { return node.nodeValue; }
   type(node: any): string { throw _notImplemented('type'); }
-  content(node: any /** TODO #9100 */): string { return node.childNodes[0]; }
-  firstChild(el: any /** TODO #9100 */): Node { return el.firstChild; }
-  nextSibling(el: any /** TODO #9100 */): Node { return el.nextSibling; }
-  parentElement(el: any /** TODO #9100 */): Node { return el.parent; }
-  childNodes(el: any /** TODO #9100 */): Node[] { return el.childNodes; }
-  childNodesAsList(el: any /** TODO #9100 */): any[] {
+  content(node: any /* TODO #9100 */): string { return node.childNodes[0]; }
+  firstChild(el: any /* TODO #9100 */): Node { return el.firstChild; }
+  nextSibling(el: any /* TODO #9100 */): Node { return el.nextSibling; }
+  parentElement(el: any /* TODO #9100 */): Node { return el.parent; }
+  childNodes(el: any /* TODO #9100 */): Node[] { return el.childNodes; }
+  childNodesAsList(el: any /* TODO #9100 */): any[] {
     var childNodes = el.childNodes;
     var res = ListWrapper.createFixedSize(childNodes.length);
     for (var i = 0; i < childNodes.length; i++) {
@@ -203,21 +201,21 @@ export class Parse5DomAdapter extends DomAdapter {
     }
     return res;
   }
-  clearNodes(el: any /** TODO #9100 */) {
+  clearNodes(el: any /* TODO #9100 */) {
     while (el.childNodes.length > 0) {
       this.remove(el.childNodes[0]);
     }
   }
-  appendChild(el: any /** TODO #9100 */, node: any /** TODO #9100 */) {
+  appendChild(el: any /* TODO #9100 */, node: any /* TODO #9100 */) {
     this.remove(node);
     treeAdapter.appendChild(this.templateAwareRoot(el), node);
   }
-  removeChild(el: any /** TODO #9100 */, node: any /** TODO #9100 */) {
+  removeChild(el: any /* TODO #9100 */, node: any /* TODO #9100 */) {
     if (ListWrapper.contains(el.childNodes, node)) {
       this.remove(node);
     }
   }
-  remove(el: any /** TODO #9100 */): HTMLElement {
+  remove(el: any /* TODO #9100 */): HTMLElement {
     var parent = el.parent;
     if (parent) {
       var index = parent.childNodes.indexOf(el);
@@ -236,28 +234,28 @@ export class Parse5DomAdapter extends DomAdapter {
     el.parent = null;
     return el;
   }
-  insertBefore(el: any /** TODO #9100 */, node: any /** TODO #9100 */) {
+  insertBefore(el: any /* TODO #9100 */, node: any /* TODO #9100 */) {
     this.remove(node);
     treeAdapter.insertBefore(el.parent, node, el);
   }
-  insertAllBefore(el: any /** TODO #9100 */, nodes: any /** TODO #9100 */) {
-    nodes.forEach((n: any /** TODO #9100 */) => this.insertBefore(el, n));
+  insertAllBefore(el: any /* TODO #9100 */, nodes: any /* TODO #9100 */) {
+    nodes.forEach((n: any /* TODO #9100 */) => this.insertBefore(el, n));
   }
-  insertAfter(el: any /** TODO #9100 */, node: any /** TODO #9100 */) {
+  insertAfter(el: any /* TODO #9100 */, node: any /* TODO #9100 */) {
     if (el.nextSibling) {
       this.insertBefore(el.nextSibling, node);
     } else {
       this.appendChild(el.parent, node);
     }
   }
-  setInnerHTML(el: any /** TODO #9100 */, value: any /** TODO #9100 */) {
+  setInnerHTML(el: any /* TODO #9100 */, value: any /* TODO #9100 */) {
     this.clearNodes(el);
     var content = parser.parseFragment(value);
     for (var i = 0; i < content.childNodes.length; i++) {
       treeAdapter.appendChild(el, content.childNodes[i]);
     }
   }
-  getText(el: any /** TODO #9100 */, isRecursive?: boolean): string {
+  getText(el: any /* TODO #9100 */, isRecursive?: boolean): string {
     if (this.isTextNode(el)) {
       return el.data;
     } else if (this.isCommentNode(el)) {
@@ -274,7 +272,7 @@ export class Parse5DomAdapter extends DomAdapter {
       return textContent;
     }
   }
-  setText(el: any /** TODO #9100 */, value: string) {
+  setText(el: any /* TODO #9100 */, value: string) {
     if (this.isTextNode(el) || this.isCommentNode(el)) {
       el.data = value;
     } else {
@@ -282,21 +280,21 @@ export class Parse5DomAdapter extends DomAdapter {
       if (value !== '') treeAdapter.insertText(el, value);
     }
   }
-  getValue(el: any /** TODO #9100 */): string { return el.value; }
-  setValue(el: any /** TODO #9100 */, value: string) { el.value = value; }
-  getChecked(el: any /** TODO #9100 */): boolean { return el.checked; }
-  setChecked(el: any /** TODO #9100 */, value: boolean) { el.checked = value; }
+  getValue(el: any /* TODO #9100 */): string { return el.value; }
+  setValue(el: any /* TODO #9100 */, value: string) { el.value = value; }
+  getChecked(el: any /* TODO #9100 */): boolean { return el.checked; }
+  setChecked(el: any /* TODO #9100 */, value: boolean) { el.checked = value; }
   createComment(text: string): Comment { return treeAdapter.createCommentNode(text); }
-  createTemplate(html: any /** TODO #9100 */): HTMLElement {
+  createTemplate(html: any /* TODO #9100 */): HTMLElement {
     var template = treeAdapter.createElement('template', 'http://www.w3.org/1999/xhtml', []);
     var content = parser.parseFragment(html);
     treeAdapter.appendChild(template, content);
     return template;
   }
-  createElement(tagName: any /** TODO #9100 */): HTMLElement {
+  createElement(tagName: any /* TODO #9100 */): HTMLElement {
     return treeAdapter.createElement(tagName, 'http://www.w3.org/1999/xhtml', []);
   }
-  createElementNS(ns: any /** TODO #9100 */, tagName: any /** TODO #9100 */): HTMLElement {
+  createElementNS(ns: any /* TODO #9100 */, tagName: any /* TODO #9100 */): HTMLElement {
     return treeAdapter.createElement(tagName, ns, []);
   }
   createTextNode(text: string): Text {
@@ -313,16 +311,16 @@ export class Parse5DomAdapter extends DomAdapter {
     this.setText(style, css);
     return <HTMLStyleElement>style;
   }
-  createShadowRoot(el: any /** TODO #9100 */): HTMLElement {
+  createShadowRoot(el: any /* TODO #9100 */): HTMLElement {
     el.shadowRoot = treeAdapter.createDocumentFragment();
     el.shadowRoot.parent = el;
     return el.shadowRoot;
   }
-  getShadowRoot(el: any /** TODO #9100 */): Element { return el.shadowRoot; }
-  getHost(el: any /** TODO #9100 */): string { return el.host; }
+  getShadowRoot(el: any /* TODO #9100 */): Element { return el.shadowRoot; }
+  getHost(el: any /* TODO #9100 */): string { return el.host; }
   getDistributedNodes(el: any): Node[] { throw _notImplemented('getDistributedNodes'); }
   clone(node: Node): Node {
-    var _recursive = (node: any /** TODO #9100 */) => {
+    var _recursive = (node: any /* TODO #9100 */) => {
       var nodeClone = Object.create(Object.getPrototypeOf(node));
       for (var prop in node) {
         var desc = Object.getOwnPropertyDescriptor(node, prop);
@@ -362,21 +360,21 @@ export class Parse5DomAdapter extends DomAdapter {
     };
     return _recursive(node);
   }
-  getElementsByClassName(element: any /** TODO #9100 */, name: string): HTMLElement[] {
+  getElementsByClassName(element: any /* TODO #9100 */, name: string): HTMLElement[] {
     return this.querySelectorAll(element, '.' + name);
   }
   getElementsByTagName(element: any, name: string): HTMLElement[] {
     throw _notImplemented('getElementsByTagName');
   }
-  classList(element: any /** TODO #9100 */): string[] {
-    var classAttrValue: any /** TODO #9100 */ = null;
+  classList(element: any /* TODO #9100 */): string[] {
+    var classAttrValue: any /* TODO #9100 */ = null;
     var attributes = element.attribs;
     if (attributes && attributes.hasOwnProperty('class')) {
       classAttrValue = attributes['class'];
     }
     return classAttrValue ? classAttrValue.trim().split(/\s+/g) : [];
   }
-  addClass(element: any /** TODO #9100 */, className: string) {
+  addClass(element: any /* TODO #9100 */, className: string) {
     var classList = this.classList(element);
     var index = classList.indexOf(className);
     if (index == -1) {
@@ -384,7 +382,7 @@ export class Parse5DomAdapter extends DomAdapter {
       element.attribs['class'] = element.className = classList.join(' ');
     }
   }
-  removeClass(element: any /** TODO #9100 */, className: string) {
+  removeClass(element: any /* TODO #9100 */, className: string) {
     var classList = this.classList(element);
     var index = classList.indexOf(className);
     if (index > -1) {
@@ -392,15 +390,15 @@ export class Parse5DomAdapter extends DomAdapter {
       element.attribs['class'] = element.className = classList.join(' ');
     }
   }
-  hasClass(element: any /** TODO #9100 */, className: string): boolean {
+  hasClass(element: any /* TODO #9100 */, className: string): boolean {
     return ListWrapper.contains(this.classList(element), className);
   }
-  hasStyle(element: any /** TODO #9100 */, styleName: string, styleValue: string = null): boolean {
+  hasStyle(element: any /* TODO #9100 */, styleName: string, styleValue: string = null): boolean {
     var value = this.getStyle(element, styleName) || '';
     return styleValue ? value == styleValue : value.length > 0;
   }
   /** @internal */
-  _readStyleAttribute(element: any /** TODO #9100 */) {
+  _readStyleAttribute(element: any /* TODO #9100 */) {
     var styleMap = {};
     var attributes = element.attribs;
     if (attributes && attributes.hasOwnProperty('style')) {
@@ -409,14 +407,14 @@ export class Parse5DomAdapter extends DomAdapter {
       for (var i = 0; i < styleList.length; i++) {
         if (styleList[i].length > 0) {
           var elems = styleList[i].split(/:+/g);
-          (styleMap as any /** TODO #9100 */)[elems[0].trim()] = elems[1].trim();
+          (styleMap as any /* TODO #9100 */)[elems[0].trim()] = elems[1].trim();
         }
       }
     }
     return styleMap;
   }
   /** @internal */
-  _writeStyleAttribute(element: any /** TODO #9100 */, styleMap: any /** TODO #9100 */) {
+  _writeStyleAttribute(element: any /* TODO #9100 */, styleMap: any /* TODO #9100 */) {
     var styleAttrValue = '';
     for (var key in styleMap) {
       var newValue = styleMap[key];
@@ -426,22 +424,22 @@ export class Parse5DomAdapter extends DomAdapter {
     }
     element.attribs['style'] = styleAttrValue;
   }
-  setStyle(element: any /** TODO #9100 */, styleName: string, styleValue: string) {
+  setStyle(element: any /* TODO #9100 */, styleName: string, styleValue: string) {
     var styleMap = this._readStyleAttribute(element);
-    (styleMap as any /** TODO #9100 */)[styleName] = styleValue;
+    (styleMap as any /* TODO #9100 */)[styleName] = styleValue;
     this._writeStyleAttribute(element, styleMap);
   }
-  removeStyle(element: any /** TODO #9100 */, styleName: string) {
+  removeStyle(element: any /* TODO #9100 */, styleName: string) {
     this.setStyle(element, styleName, null);
   }
-  getStyle(element: any /** TODO #9100 */, styleName: string): string {
+  getStyle(element: any /* TODO #9100 */, styleName: string): string {
     var styleMap = this._readStyleAttribute(element);
-    return styleMap.hasOwnProperty(styleName) ? (styleMap as any /** TODO #9100 */)[styleName] : '';
+    return styleMap.hasOwnProperty(styleName) ? (styleMap as any /* TODO #9100 */)[styleName] : '';
   }
-  tagName(element: any /** TODO #9100 */): string {
+  tagName(element: any /* TODO #9100 */): string {
     return element.tagName == 'style' ? 'STYLE' : element.tagName;
   }
-  attributeMap(element: any /** TODO #9100 */): Map<string, string> {
+  attributeMap(element: any /* TODO #9100 */): Map<string, string> {
     var res = new Map<string, string>();
     var elAttrs = treeAdapter.getAttrList(element);
     for (var i = 0; i < elAttrs.length; i++) {
@@ -450,21 +448,21 @@ export class Parse5DomAdapter extends DomAdapter {
     }
     return res;
   }
-  hasAttribute(element: any /** TODO #9100 */, attribute: string): boolean {
+  hasAttribute(element: any /* TODO #9100 */, attribute: string): boolean {
     return element.attribs && element.attribs.hasOwnProperty(attribute);
   }
-  hasAttributeNS(element: any /** TODO #9100 */, ns: string, attribute: string): boolean {
+  hasAttributeNS(element: any /* TODO #9100 */, ns: string, attribute: string): boolean {
     throw 'not implemented';
   }
-  getAttribute(element: any /** TODO #9100 */, attribute: string): string {
+  getAttribute(element: any /* TODO #9100 */, attribute: string): string {
     return element.attribs && element.attribs.hasOwnProperty(attribute) ?
         element.attribs[attribute] :
         null;
   }
-  getAttributeNS(element: any /** TODO #9100 */, ns: string, attribute: string): string {
+  getAttributeNS(element: any /* TODO #9100 */, ns: string, attribute: string): string {
     throw 'not implemented';
   }
-  setAttribute(element: any /** TODO #9100 */, attribute: string, value: string) {
+  setAttribute(element: any /* TODO #9100 */, attribute: string, value: string) {
     if (attribute) {
       element.attribs[attribute] = value;
       if (attribute === 'class') {
@@ -472,18 +470,18 @@ export class Parse5DomAdapter extends DomAdapter {
       }
     }
   }
-  setAttributeNS(element: any /** TODO #9100 */, ns: string, attribute: string, value: string) {
+  setAttributeNS(element: any /* TODO #9100 */, ns: string, attribute: string, value: string) {
     throw 'not implemented';
   }
-  removeAttribute(element: any /** TODO #9100 */, attribute: string) {
+  removeAttribute(element: any /* TODO #9100 */, attribute: string) {
     if (attribute) {
       StringMapWrapper.delete(element.attribs, attribute);
     }
   }
-  removeAttributeNS(element: any /** TODO #9100 */, ns: string, name: string) {
+  removeAttributeNS(element: any /* TODO #9100 */, ns: string, name: string) {
     throw 'not implemented';
   }
-  templateAwareRoot(el: any /** TODO #9100 */): any {
+  templateAwareRoot(el: any /* TODO #9100 */): any {
     return this.isTemplateElement(el) ? this.content(el) : el;
   }
   createHtmlDocument(): Document {
@@ -504,7 +502,7 @@ export class Parse5DomAdapter extends DomAdapter {
     }
     return defDoc;
   }
-  getBoundingClientRect(el: any /** TODO #9100 */): any {
+  getBoundingClientRect(el: any /* TODO #9100 */): any {
     return {left: 0, top: 0, width: 0, height: 0};
   }
   getTitle(): string { return this.defaultDoc().title || ''; }
@@ -512,17 +510,17 @@ export class Parse5DomAdapter extends DomAdapter {
   isTemplateElement(el: any): boolean {
     return this.isElementNode(el) && this.tagName(el) === 'template';
   }
-  isTextNode(node: any /** TODO #9100 */): boolean { return treeAdapter.isTextNode(node); }
-  isCommentNode(node: any /** TODO #9100 */): boolean { return treeAdapter.isCommentNode(node); }
-  isElementNode(node: any /** TODO #9100 */): boolean {
+  isTextNode(node: any /* TODO #9100 */): boolean { return treeAdapter.isTextNode(node); }
+  isCommentNode(node: any /* TODO #9100 */): boolean { return treeAdapter.isCommentNode(node); }
+  isElementNode(node: any /* TODO #9100 */): boolean {
     return node ? treeAdapter.isElementNode(node) : false;
   }
-  hasShadowRoot(node: any /** TODO #9100 */): boolean { return isPresent(node.shadowRoot); }
-  isShadowRoot(node: any /** TODO #9100 */): boolean { return this.getShadowRoot(node) == node; }
-  importIntoDoc(node: any /** TODO #9100 */): any { return this.clone(node); }
-  adoptNode(node: any /** TODO #9100 */): any { return node; }
-  getHref(el: any /** TODO #9100 */): string { return el.href; }
-  resolveAndSetHref(el: any /** TODO #9100 */, baseUrl: string, href: string) {
+  hasShadowRoot(node: any /* TODO #9100 */): boolean { return isPresent(node.shadowRoot); }
+  isShadowRoot(node: any /* TODO #9100 */): boolean { return this.getShadowRoot(node) == node; }
+  importIntoDoc(node: any /* TODO #9100 */): any { return this.clone(node); }
+  adoptNode(node: any /* TODO #9100 */): any { return node; }
+  getHref(el: any /* TODO #9100 */): string { return el.href; }
+  resolveAndSetHref(el: any /* TODO #9100 */, baseUrl: string, href: string) {
     if (href == null) {
       el.href = baseUrl;
     } else {
@@ -530,8 +528,8 @@ export class Parse5DomAdapter extends DomAdapter {
     }
   }
   /** @internal */
-  _buildRules(parsedRules: any /** TODO #9100 */, css?: any /** TODO #9100 */) {
-    var rules: any[] /** TODO #9100 */ = [];
+  _buildRules(parsedRules: any /* TODO #9100 */, css?: any /* TODO #9100 */) {
+    var rules: any[] /* TODO #9100 */ = [];
     for (var i = 0; i < parsedRules.length; i++) {
       var parsedRule = parsedRules[i];
       var rule: {[key: string]: any} = StringMapWrapper.create();
@@ -583,16 +581,16 @@ export class Parse5DomAdapter extends DomAdapter {
   getHistory(): History { throw 'not implemented'; }
   getLocation(): Location { throw 'not implemented'; }
   getUserAgent(): string { return 'Fake user agent'; }
-  getData(el: any /** TODO #9100 */, name: string): string {
+  getData(el: any /* TODO #9100 */, name: string): string {
     return this.getAttribute(el, 'data-' + name);
   }
-  getComputedStyle(el: any /** TODO #9100 */): any { throw 'not implemented'; }
-  setData(el: any /** TODO #9100 */, name: string, value: string) {
+  getComputedStyle(el: any /* TODO #9100 */): any { throw 'not implemented'; }
+  setData(el: any /* TODO #9100 */, name: string, value: string) {
     this.setAttribute(el, 'data-' + name, value);
   }
   // TODO(tbosch): move this into a separate environment class once we have it
   setGlobalVar(path: string, value: any) { setValueOnPath(global, path, value); }
-  requestAnimationFrame(callback: any /** TODO #9100 */): number { return setTimeout(callback, 0); }
+  requestAnimationFrame(callback: any /* TODO #9100 */): number { return setTimeout(callback, 0); }
   cancelAnimationFrame(id: number) { clearTimeout(id); }
   supportsWebAnimation(): boolean { return false; }
   performanceNow(): number { return DateWrapper.toMillis(DateWrapper.now()); }
@@ -601,12 +599,12 @@ export class Parse5DomAdapter extends DomAdapter {
   supportsAnimation(): boolean { return true; }
 
   replaceChild(
-      el: any /** TODO #9100 */, newNode: any /** TODO #9100 */, oldNode: any /** TODO #9100 */) {
+      el: any /* TODO #9100 */, newNode: any /* TODO #9100 */, oldNode: any /* TODO #9100 */) {
     throw new Error('not implemented');
   }
   parse(templateHtml: string) { throw new Error('not implemented'); }
   invoke(el: Element, methodName: string, args: any[]): any { throw new Error('not implemented'); }
-  getEventKey(event: any /** TODO #9100 */): string { throw new Error('not implemented'); }
+  getEventKey(event: any /* TODO #9100 */): string { throw new Error('not implemented'); }
 
   supportsCookies(): boolean { return false; }
   getCookie(name: string): string { throw new Error('not implemented'); }

--- a/modules/@angular/router-deprecated/src/directives/router_outlet.ts
+++ b/modules/@angular/router-deprecated/src/directives/router_outlet.ts
@@ -147,7 +147,7 @@ export class RouterOutlet implements OnDestroy {
    * or resolves to true if the hook is not present.
    */
   routerCanReuse(nextInstruction: ComponentInstruction): Promise<boolean> {
-    var result: any /** TODO #9100 */;
+    var result: any /* TODO #9100 */;
 
     if (isBlank(this._currentInstruction) ||
         this._currentInstruction.componentType != nextInstruction.componentType) {

--- a/modules/@angular/router-deprecated/src/instruction.ts
+++ b/modules/@angular/router-deprecated/src/instruction.ts
@@ -199,7 +199,7 @@ export abstract class Instruction {
 
   /** @internal */
   _stringifyAux(): string {
-    var routes: any[] /** TODO #9100 */ = [];
+    var routes: any[] /* TODO #9100 */ = [];
     StringMapWrapper.forEach(this.auxInstruction, (auxInstruction: Instruction, _: string) => {
       routes.push(auxInstruction._stringifyPathMatrixAux());
     });
@@ -316,7 +316,7 @@ export class ComponentInstruction {
    */
   constructor(
       public urlPath: string, public urlParams: string[], data: RouteData,
-      public componentType: any /** TODO #9100 */, public terminal: boolean,
+      public componentType: any /* TODO #9100 */, public terminal: boolean,
       public specificity: string, public params: {[key: string]: string} = null,
       public routeName: string) {
     this.routeData = isPresent(data) ? data : BLANK_ROUTE_DATA;

--- a/modules/@angular/router-deprecated/src/lifecycle/route_lifecycle_reflector.ts
+++ b/modules/@angular/router-deprecated/src/lifecycle/route_lifecycle_reflector.ts
@@ -4,12 +4,12 @@ import {reflector} from '../../core_private';
 
 import {CanActivate, RouteLifecycleHook} from './lifecycle_annotations_impl';
 
-export function hasLifecycleHook(e: RouteLifecycleHook, type: any /** TODO #9100 */): boolean {
+export function hasLifecycleHook(e: RouteLifecycleHook, type: any /* TODO #9100 */): boolean {
   if (!(type instanceof Type)) return false;
   return e.name in (<any>type).prototype;
 }
 
-export function getCanActivateHook(type: any /** TODO #9100 */): Function {
+export function getCanActivateHook(type: any /* TODO #9100 */): Function {
   var annotations = reflector.annotations(type);
   for (let i = 0; i < annotations.length; i += 1) {
     let annotation = annotations[i];

--- a/modules/@angular/router-deprecated/src/route_config/route_config_normalizer.ts
+++ b/modules/@angular/router-deprecated/src/route_config/route_config_normalizer.ts
@@ -92,7 +92,7 @@ export function normalizeRouteConfig(
 function wrapLoaderToReconfigureRegistry(loader: Function, registry: RouteRegistry): () =>
     Promise<Type> {
   return () => {
-    return loader().then((componentType: any /** TODO #9100 */) => {
+    return loader().then((componentType: any /* TODO #9100 */) => {
       registry.configFromComponent(componentType);
       return componentType;
     });

--- a/modules/@angular/router-deprecated/src/route_registry.ts
+++ b/modules/@angular/router-deprecated/src/route_registry.ts
@@ -221,7 +221,7 @@ export class RouteRegistry {
    */
   generate(linkParams: any[], ancestorInstructions: Instruction[], _aux = false): Instruction {
     var params = splitAndFlattenLinkParams(linkParams);
-    var prevInstruction: any /** TODO #9100 */;
+    var prevInstruction: any /* TODO #9100 */;
 
     // The first segment should be either '.' (generate from parent) or '' (generate from root).
     // When we normalize above, we strip all the slashes, './' becomes '.' and '/' becomes ''.
@@ -249,7 +249,7 @@ export class RouteRegistry {
         // we must only peak at the link param, and not consume it
         let routeName = ListWrapper.first(params);
         let parentComponentType = this._rootComponent;
-        let grandparentComponentType: any /** TODO #9100 */ = null;
+        let grandparentComponentType: any /* TODO #9100 */ = null;
 
         if (ancestorInstructions.length > 1) {
           let parentComponentInstruction = ancestorInstructions[ancestorInstructions.length - 1];
@@ -319,7 +319,7 @@ export class RouteRegistry {
       linkParams: any[], ancestorInstructions: Instruction[], prevInstruction: Instruction,
       _aux = false, _originalLink: any[]): Instruction {
     let parentComponentType = this._rootComponent;
-    let componentInstruction: any /** TODO #9100 */ = null;
+    let componentInstruction: any /* TODO #9100 */ = null;
     let auxInstructions: {[key: string]: Instruction} = {};
 
     let parentInstruction: Instruction = ListWrapper.last(ancestorInstructions);
@@ -442,7 +442,7 @@ export class RouteRegistry {
       return null;
     }
 
-    var defaultChild: any /** TODO #9100 */ = null;
+    var defaultChild: any /* TODO #9100 */ = null;
     if (isPresent(rules.defaultRule.handler.componentType)) {
       var componentInstruction = rules.defaultRule.generate({});
       if (!rules.defaultRule.terminal) {
@@ -463,7 +463,7 @@ export class RouteRegistry {
  * Returns: ['', 'a', 'b', {c: 2}]
  */
 function splitAndFlattenLinkParams(linkParams: any[]): any[] {
-  var accumulation: any[] /** TODO #9100 */ = [];
+  var accumulation: any[] /* TODO #9100 */ = [];
   linkParams.forEach(function(item: any) {
     if (isString(item)) {
       var strItem: string = <string>item;
@@ -515,7 +515,7 @@ function compareSpecificityStrings(a: string, b: string): number {
   return a.length - b.length;
 }
 
-function assertTerminalComponent(component: any /** TODO #9100 */, path: any /** TODO #9100 */) {
+function assertTerminalComponent(component: any /* TODO #9100 */, path: any /* TODO #9100 */) {
   if (!isType(component)) {
     return;
   }

--- a/modules/@angular/router-deprecated/src/router.ts
+++ b/modules/@angular/router-deprecated/src/router.ts
@@ -119,7 +119,7 @@ export class Router {
     this._auxRouters.set(outletName, router);
     router._outlet = outlet;
 
-    var auxInstruction: any /** TODO #9100 */;
+    var auxInstruction: any /* TODO #9100 */;
     if (isPresent(this.currentInstruction) &&
         isPresent(auxInstruction = this.currentInstruction.auxInstruction[outletName])) {
       return router.commit(auxInstruction);
@@ -157,7 +157,7 @@ export class Router {
       if (isPresent(instruction.component.params)) {
         StringMapWrapper.forEach(
             instruction.component.params,
-            (value: any /** TODO #9100 */, key: any /** TODO #9100 */) => {
+            (value: any /* TODO #9100 */, key: any /* TODO #9100 */) => {
               if (currentInstruction.component.params[key] !== value) {
                 reason = false;
               }
@@ -260,7 +260,7 @@ export class Router {
       }
 
       StringMapWrapper.forEach(
-          instruction.auxInstruction, (instruction: Instruction, _: any /** TODO #9100 */) => {
+          instruction.auxInstruction, (instruction: Instruction, _: any /* TODO #9100 */) => {
             unsettledInstructions.push(this._settleInstruction(instruction));
           });
       return PromiseWrapper.all(unsettledInstructions);
@@ -549,7 +549,7 @@ export class RootRouter extends Router {
 }
 
 class ChildRouter extends Router {
-  constructor(parent: Router, hostComponent: any /** TODO #9100 */) {
+  constructor(parent: Router, hostComponent: any /* TODO #9100 */) {
     super(parent.registry, parent, hostComponent, parent.root);
     this.parent = parent;
   }

--- a/modules/@angular/router-deprecated/src/rules/route_paths/param_route_path.ts
+++ b/modules/@angular/router-deprecated/src/rules/route_paths/param_route_path.ts
@@ -121,7 +121,7 @@ export class ParamRoutePath implements RoutePath {
       if (isPresent(currentUrlSegment)) {
         // the star segment consumes all of the remaining URL, including matrix params
         if (pathSegment instanceof StarPathSegment) {
-          (positionalParams as any /** TODO #9100 */)[pathSegment.name] =
+          (positionalParams as any /* TODO #9100 */)[pathSegment.name] =
               currentUrlSegment.toString();
           captured.push(currentUrlSegment.toString());
           nextUrlSegment = null;
@@ -131,7 +131,7 @@ export class ParamRoutePath implements RoutePath {
         captured.push(currentUrlSegment.path);
 
         if (pathSegment instanceof DynamicPathSegment) {
-          (positionalParams as any /** TODO #9100 */)[pathSegment.name] =
+          (positionalParams as any /* TODO #9100 */)[pathSegment.name] =
               decodeDynamicSegment(currentUrlSegment.path);
         } else if (!pathSegment.match(currentUrlSegment.path)) {
           return null;
@@ -149,8 +149,8 @@ export class ParamRoutePath implements RoutePath {
 
     var urlPath = captured.join('/');
 
-    var auxiliary: any[] /** TODO #9100 */ = [];
-    var urlParams: any[] /** TODO #9100 */ = [];
+    var auxiliary: any[] /* TODO #9100 */ = [];
+    var urlParams: any[] /* TODO #9100 */ = [];
     var allParams = positionalParams;
     if (isPresent(currentUrlSegment)) {
       // If this is the root component, read query params. Otherwise, read matrix params.
@@ -172,7 +172,7 @@ export class ParamRoutePath implements RoutePath {
   generateUrl(params: {[key: string]: any}): GeneratedUrl {
     var paramTokens = new TouchMap(params);
 
-    var path: any[] /** TODO #9100 */ = [];
+    var path: any[] /* TODO #9100 */ = [];
 
     for (var i = 0; i < this._segments.length; i++) {
       let segment = this._segments[i];
@@ -203,7 +203,7 @@ export class ParamRoutePath implements RoutePath {
 
     var limit = segmentStrings.length - 1;
     for (var i = 0; i <= limit; i++) {
-      var segment = segmentStrings[i], match: any /** TODO #9100 */;
+      var segment = segmentStrings[i], match: any /* TODO #9100 */;
 
       if (isPresent(match = RegExpWrapper.firstMatch(DynamicPathSegment.paramMatcher, segment))) {
         this._segments.push(new DynamicPathSegment(match[1]));
@@ -234,8 +234,7 @@ export class ParamRoutePath implements RoutePath {
     // The code below uses place values to combine the different types of segments into a single
     // string that we can sort later. Each static segment is marked as a specificity of "2," each
     // dynamic segment is worth "1" specificity, and stars are worth "0" specificity.
-    var i: any /** TODO #9100 */, length = this._segments.length,
-                                  specificity: any /** TODO #9100 */;
+    var i: any /* TODO #9100 */, length = this._segments.length, specificity: any /* TODO #9100 */;
     if (length == 0) {
       // a single slash (or "empty segment" is as specific as a static segment
       specificity += '2';
@@ -251,8 +250,8 @@ export class ParamRoutePath implements RoutePath {
   private _calculateHash(): string {
     // this function is used to determine whether a route config path like `/foo/:id` collides with
     // `/foo/:name`
-    var i: any /** TODO #9100 */, length = this._segments.length;
-    var hashParts: any[] /** TODO #9100 */ = [];
+    var i: any /* TODO #9100 */, length = this._segments.length;
+    var hashParts: any[] /* TODO #9100 */ = [];
     for (i = 0; i < length; i++) {
       hashParts.push(this._segments[i].hash);
     }

--- a/modules/@angular/router-deprecated/src/rules/rule_set.ts
+++ b/modules/@angular/router-deprecated/src/rules/rule_set.ts
@@ -40,7 +40,7 @@ export class RuleSet {
    * @returns {boolean} true if the config is terminal
    */
   config(config: RouteDefinition): boolean {
-    let handler: any /** TODO #9100 */;
+    let handler: any /* TODO #9100 */;
 
     if (isPresent(config.name) && config.name[0].toUpperCase() != config.name[0]) {
       let suggestedName = config.name[0].toUpperCase() + config.name.substring(1);
@@ -100,7 +100,7 @@ export class RuleSet {
    * Given a URL, returns a list of `RouteMatch`es, which are partial recognitions for some route.
    */
   recognize(urlParse: Url): Promise<RouteMatch>[] {
-    var solutions: any[] /** TODO #9100 */ = [];
+    var solutions: any[] /* TODO #9100 */ = [];
 
     this.rules.forEach((routeRecognizer: AbstractRule) => {
       var pathMatch = routeRecognizer.recognize(urlParse);
@@ -153,7 +153,7 @@ export class RuleSet {
     return rule.generate(params);
   }
 
-  private _assertNoHashCollision(hash: string, path: any /** TODO #9100 */) {
+  private _assertNoHashCollision(hash: string, path: any /* TODO #9100 */) {
     this.rules.forEach((rule) => {
       if (hash == rule.hash) {
         throw new BaseException(

--- a/modules/@angular/router-deprecated/src/rules/rules.ts
+++ b/modules/@angular/router-deprecated/src/rules/rules.ts
@@ -21,7 +21,7 @@ export class PathMatch extends RouteMatch {
 }
 
 export class RedirectMatch extends RouteMatch {
-  constructor(public redirectTo: any[], public specificity: any /** TODO #9100 */) { super(); }
+  constructor(public redirectTo: any[], public specificity: any /* TODO #9100 */) { super(); }
 }
 
 // Rules are responsible for recognizing URL segments and generating instructions
@@ -46,7 +46,7 @@ export class RedirectRule implements AbstractRule {
    * Returns `null` or a `ParsedUrl` representing the new path to match
    */
   recognize(beginningSegment: Url): Promise<RouteMatch> {
-    var match: any /** TODO #9100 */ = null;
+    var match: any /* TODO #9100 */ = null;
     if (isPresent(this._pathRecognizer.matchUrl(beginningSegment))) {
       match = new RedirectMatch(this.redirectTo, this._pathRecognizer.specificity);
     }

--- a/modules/@angular/router-deprecated/src/url_parser.ts
+++ b/modules/@angular/router-deprecated/src/url_parser.ts
@@ -3,14 +3,13 @@ import {BaseException} from '../src/facade/exceptions';
 import {RegExpWrapper, isBlank, isPresent} from '../src/facade/lang';
 
 export function convertUrlParamsToArray(urlParams: {[key: string]: any}): string[] {
-  var paramsArray: any[] /** TODO #9100 */ = [];
+  var paramsArray: any[] /* TODO #9100 */ = [];
   if (isBlank(urlParams)) {
     return [];
   }
-  StringMapWrapper.forEach(
-      urlParams, (value: any /** TODO #9100 */, key: any /** TODO #9100 */) => {
-        paramsArray.push((value === true) ? key : key + '=' + value);
-      });
+  StringMapWrapper.forEach(urlParams, (value: any /* TODO #9100 */, key: any /* TODO #9100 */) => {
+    paramsArray.push((value === true) ? key : key + '=' + value);
+  });
   return paramsArray;
 }
 
@@ -129,7 +128,7 @@ export class UrlParser {
       // TODO: should these params just be dropped?
       this.parseMatrixParams();
     }
-    var child: any /** TODO #9100 */ = null;
+    var child: any /* TODO #9100 */ = null;
     if (this.peekStartsWith('/') && !this.peekStartsWith('//')) {
       this.capture('/');
       child = this.parseSegment();

--- a/modules/@angular/router-deprecated/src/utils.ts
+++ b/modules/@angular/router-deprecated/src/utils.ts
@@ -7,7 +7,7 @@ export class TouchMap {
 
   constructor(map: {[key: string]: any}) {
     if (isPresent(map)) {
-      StringMapWrapper.forEach(map, (value: any /** TODO #9100 */, key: any /** TODO #9100 */) => {
+      StringMapWrapper.forEach(map, (value: any /* TODO #9100 */, key: any /* TODO #9100 */) => {
         this.map[key] = isPresent(value) ? value.toString() : null;
         this.keys[key] = true;
       });

--- a/modules/@angular/router-deprecated/test/directives/router_link_spec.ts
+++ b/modules/@angular/router-deprecated/test/directives/router_link_spec.ts
@@ -23,7 +23,7 @@ export function main() {
                         }]);
 
     beforeEach(
-        inject([TestComponentBuilder], (tcBuilder: any /** TODO #9100 */) => { tcb = tcBuilder; }));
+        inject([TestComponentBuilder], (tcBuilder: any /* TODO #9100 */) => { tcb = tcBuilder; }));
 
     it('should update a[href] attribute',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
@@ -41,7 +41,7 @@ export function main() {
     it('should call router.navigate when a link is clicked',
        inject(
            [AsyncTestCompleter, Router],
-           (async: AsyncTestCompleter, router: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, router: any /* TODO #9100 */) => {
 
              tcb.createAsync(TestComponent).then((testComponent) => {
                testComponent.detectChanges();
@@ -56,7 +56,7 @@ export function main() {
     it('should call router.navigate when a link is clicked if target is _self',
        inject(
            [AsyncTestCompleter, Router],
-           (async: AsyncTestCompleter, router: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, router: any /* TODO #9100 */) => {
 
              tcb.createAsync(TestComponent).then((testComponent) => {
                testComponent.detectChanges();
@@ -70,7 +70,7 @@ export function main() {
     it('should NOT call router.navigate when a link is clicked if target is set to other than _self',
        inject(
            [AsyncTestCompleter, Router],
-           (async: AsyncTestCompleter, router: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, router: any /* TODO #9100 */) => {
 
              tcb.createAsync(TestComponent).then((testComponent) => {
                testComponent.detectChanges();
@@ -115,14 +115,14 @@ class TestComponent {
 
 function makeDummyLocation() {
   var dl = new SpyLocation();
-  dl.spy('prepareExternalUrl').andCallFake((url: any /** TODO #9100 */) => url);
+  dl.spy('prepareExternalUrl').andCallFake((url: any /* TODO #9100 */) => url);
   return dl;
 }
 
 function makeDummyRouter() {
   var dr = new SpyRouter();
-  dr.spy('generate').andCallFake((routeParams: any /** TODO #9100 */) => dummyInstruction);
-  dr.spy('isRouteActive').andCallFake((_: any /** TODO #9100 */) => false);
+  dr.spy('generate').andCallFake((routeParams: any /* TODO #9100 */) => dummyInstruction);
+  dr.spy('isRouteActive').andCallFake((_: any /* TODO #9100 */) => false);
   dr.spy('navigateInstruction');
   return dr;
 }

--- a/modules/@angular/router-deprecated/test/integration/bootstrap_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/bootstrap_spec.ts
@@ -20,8 +20,8 @@ import {MockApplicationRef} from '@angular/core/testing';
 
 // noinspection JSAnnotator
 class DummyConsole implements Console {
-  log(message: any /** TODO #9100 */) {}
-  warn(message: any /** TODO #9100 */) {}
+  log(message: any /* TODO #9100 */) {}
+  warn(message: any /* TODO #9100 */) {}
 }
 
 export function main() {
@@ -46,7 +46,7 @@ export function main() {
            {provide: DOCUMENT, useValue: fakeDoc}, {provide: Console, useClass: DummyConsole}
          ]).then((applicationRef) => {
            var router = applicationRef.instance.router;
-           router.subscribe((_: any /** TODO #9100 */) => {
+           router.subscribe((_: any /* TODO #9100 */) => {
              expect(el).toHaveText('outer { hello }');
              expect(applicationRef.instance.location.path()).toEqual('');
              async.done();
@@ -89,7 +89,7 @@ export function main() {
                    ['/parent/child', 'root { parent { hello } }', false]
                  ];
 
-                 router.subscribe((_: any /** TODO #9100 */) => {
+                 router.subscribe((_: any /* TODO #9100 */) => {
                    var location = fixture.debugElement.componentInstance.location;
                    var element = fixture.debugElement.nativeElement;
                    var path = location.path();
@@ -134,7 +134,7 @@ export function main() {
 
                tcb.createAsync(HierarchyAppCmp).then((fixture) => {
                  var router = fixture.debugElement.componentInstance.router;
-                 router.subscribe((_: any /** TODO #9100 */) => {
+                 router.subscribe((_: any /* TODO #9100 */) => {
                    expect(fixture.debugElement.nativeElement)
                        .toHaveText('root { parent { hello } }');
                    expect(fixture.debugElement.componentInstance.location.path())
@@ -155,7 +155,7 @@ export function main() {
 
                  tcb.createAsync(HierarchyAppCmp).then((fixture) => {
                    var router = fixture.debugElement.componentInstance.router;
-                   router.subscribe((_: any /** TODO #9100 */) => {
+                   router.subscribe((_: any /* TODO #9100 */) => {
                      expect(fixture.debugElement.nativeElement)
                          .toHaveText('root { parent { hello } }');
                      expect(fixture.debugElement.componentInstance.location.path())
@@ -179,7 +179,7 @@ export function main() {
              (async: AsyncTestCompleter, tcb: TestComponentBuilder) => {
                tcb.createAsync(QueryStringAppCmp).then((fixture) => {
                  var router = fixture.debugElement.componentInstance.router;
-                 router.subscribe((_: any /** TODO #9100 */) => {
+                 router.subscribe((_: any /* TODO #9100 */) => {
                    fixture.detectChanges();
 
                    expect(fixture.debugElement.nativeElement)
@@ -200,7 +200,7 @@ export function main() {
 
       beforeEachProviders(() => [{provide: ROUTER_PRIMARY_COMPONENT, useValue: AppCmp}]);
 
-      beforeEach(inject([TestComponentBuilder], (testComponentBuilder: any /** TODO #9100 */) => {
+      beforeEach(inject([TestComponentBuilder], (testComponentBuilder: any /* TODO #9100 */) => {
         tcb = testComponentBuilder;
       }));
 
@@ -210,7 +210,7 @@ export function main() {
              let appInstance = fixture.debugElement.componentInstance;
              let router = appInstance.router;
 
-             router.subscribe((_: any /** TODO #9100 */) => {
+             router.subscribe((_: any /* TODO #9100 */) => {
                fixture.detectChanges();
 
                expect(appInstance.helloCmp).toBeAnInstanceOf(HelloCmp);

--- a/modules/@angular/router-deprecated/test/integration/impl/async_route_spec_impl.ts
+++ b/modules/@angular/router-deprecated/test/integration/impl/async_route_spec_impl.ts
@@ -16,15 +16,15 @@ function getLinkElement(rtc: ComponentFixture<any>) {
 }
 
 function asyncRoutesWithoutChildrenWithRouteData() {
-  var fixture: any /** TODO #9100 */;
-  var tcb: any /** TODO #9100 */;
-  var rtr: any /** TODO #9100 */;
+  var fixture: any /* TODO #9100 */;
+  var tcb: any /* TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -59,15 +59,15 @@ function asyncRoutesWithoutChildrenWithRouteData() {
 }
 
 function asyncRoutesWithoutChildrenWithoutParams() {
-  var fixture: any /** TODO #9100 */;
-  var tcb: any /** TODO #9100 */;
-  var rtr: any /** TODO #9100 */;
+  var fixture: any /* TODO #9100 */;
+  var tcb: any /* TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -113,7 +113,7 @@ function asyncRoutesWithoutChildrenWithoutParams() {
   it('should navigate from a link click',
      inject(
          [AsyncTestCompleter, Location],
-         (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+         (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
            compile(
                tcb, `<a [routerLink]="['Hello']">go to hello</a> | <router-outlet></router-outlet>`)
                .then((rtc) => {fixture = rtc})
@@ -123,7 +123,7 @@ function asyncRoutesWithoutChildrenWithoutParams() {
                  fixture.detectChanges();
                  expect(fixture.debugElement.nativeElement).toHaveText('go to hello | ');
 
-                 rtr.subscribe((_: any /** TODO #9100 */) => {
+                 rtr.subscribe((_: any /* TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement).toHaveText('go to hello | hello');
                    expect(location.urlChanges).toEqual(['/test']);
@@ -137,15 +137,15 @@ function asyncRoutesWithoutChildrenWithoutParams() {
 
 
 function asyncRoutesWithoutChildrenWithParams() {
-  var fixture: any /** TODO #9100 */;
-  var tcb: any /** TODO #9100 */;
-  var rtr: any /** TODO #9100 */;
+  var fixture: any /* TODO #9100 */;
+  var tcb: any /* TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -194,7 +194,7 @@ function asyncRoutesWithoutChildrenWithParams() {
   it('should navigate from a link click',
      inject(
          [AsyncTestCompleter, Location],
-         (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+         (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
            compile(
                tcb,
                `<a [routerLink]="['User', {name: 'naomi'}]">greet naomi</a> | <router-outlet></router-outlet>`)
@@ -205,7 +205,7 @@ function asyncRoutesWithoutChildrenWithParams() {
                  fixture.detectChanges();
                  expect(fixture.debugElement.nativeElement).toHaveText('greet naomi | ');
 
-                 rtr.subscribe((_: any /** TODO #9100 */) => {
+                 rtr.subscribe((_: any /* TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
                        .toHaveText('greet naomi | hello naomi');
@@ -239,15 +239,15 @@ function asyncRoutesWithoutChildrenWithParams() {
 
 
 function asyncRoutesWithSyncChildrenWithoutDefaultRoutes() {
-  var fixture: any /** TODO #9100 */;
-  var tcb: any /** TODO #9100 */;
-  var rtr: any /** TODO #9100 */;
+  var fixture: any /* TODO #9100 */;
+  var tcb: any /* TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -295,7 +295,7 @@ function asyncRoutesWithSyncChildrenWithoutDefaultRoutes() {
   it('should navigate from a link click',
      inject(
          [AsyncTestCompleter, Location],
-         (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+         (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
            compile(
                tcb,
                `<a [routerLink]="['Parent', 'Child']">nav to child</a> | outer { <router-outlet></router-outlet> }`)
@@ -306,7 +306,7 @@ function asyncRoutesWithSyncChildrenWithoutDefaultRoutes() {
                  fixture.detectChanges();
                  expect(fixture.debugElement.nativeElement).toHaveText('nav to child | outer {  }');
 
-                 rtr.subscribe((_: any /** TODO #9100 */) => {
+                 rtr.subscribe((_: any /* TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
                        .toHaveText('nav to child | outer { inner { hello } }');
@@ -321,15 +321,15 @@ function asyncRoutesWithSyncChildrenWithoutDefaultRoutes() {
 
 
 function asyncRoutesWithSyncChildrenWithDefaultRoutes() {
-  var fixture: any /** TODO #9100 */;
-  var tcb: any /** TODO #9100 */;
-  var rtr: any /** TODO #9100 */;
+  var fixture: any /* TODO #9100 */;
+  var tcb: any /* TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -377,7 +377,7 @@ function asyncRoutesWithSyncChildrenWithDefaultRoutes() {
   it('should navigate from a link click',
      inject(
          [AsyncTestCompleter, Location],
-         (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+         (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
            compile(
                tcb,
                `<a [routerLink]="['/Parent']">link to inner</a> | outer { <router-outlet></router-outlet> }`)
@@ -389,7 +389,7 @@ function asyncRoutesWithSyncChildrenWithDefaultRoutes() {
                  expect(fixture.debugElement.nativeElement)
                      .toHaveText('link to inner | outer {  }');
 
-                 rtr.subscribe((_: any /** TODO #9100 */) => {
+                 rtr.subscribe((_: any /* TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
                        .toHaveText('link to inner | outer { inner { hello } }');
@@ -404,15 +404,15 @@ function asyncRoutesWithSyncChildrenWithDefaultRoutes() {
 
 
 function asyncRoutesWithAsyncChildrenWithoutParamsWithoutDefaultRoutes() {
-  var rootTC: any /** TODO #9100 */;
-  var tcb: any /** TODO #9100 */;
-  var rtr: any /** TODO #9100 */;
+  var rootTC: any /* TODO #9100 */;
+  var tcb: any /* TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -460,7 +460,7 @@ function asyncRoutesWithAsyncChildrenWithoutParamsWithoutDefaultRoutes() {
   it('should navigate from a link click',
      inject(
          [AsyncTestCompleter, Location],
-         (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+         (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
            compile(
                tcb,
                `<a [routerLink]="['Parent', 'Child']">nav to child</a> | outer { <router-outlet></router-outlet> }`)
@@ -471,7 +471,7 @@ function asyncRoutesWithAsyncChildrenWithoutParamsWithoutDefaultRoutes() {
                  rootTC.detectChanges();
                  expect(rootTC.debugElement.nativeElement).toHaveText('nav to child | outer {  }');
 
-                 rtr.subscribe((_: any /** TODO #9100 */) => {
+                 rtr.subscribe((_: any /* TODO #9100 */) => {
                    rootTC.detectChanges();
                    expect(rootTC.debugElement.nativeElement)
                        .toHaveText('nav to child | outer { inner { hello } }');
@@ -486,15 +486,15 @@ function asyncRoutesWithAsyncChildrenWithoutParamsWithoutDefaultRoutes() {
 
 
 function asyncRoutesWithAsyncChildrenWithoutParamsWithDefaultRoutes() {
-  var rootTC: any /** TODO #9100 */;
-  var tcb: any /** TODO #9100 */;
-  var rtr: any /** TODO #9100 */;
+  var rootTC: any /* TODO #9100 */;
+  var tcb: any /* TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -542,7 +542,7 @@ function asyncRoutesWithAsyncChildrenWithoutParamsWithDefaultRoutes() {
   it('should navigate from a link click',
      inject(
          [AsyncTestCompleter, Location],
-         (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+         (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
            compile(
                tcb,
                `<a [routerLink]="['Parent']">nav to child</a> | outer { <router-outlet></router-outlet> }`)
@@ -553,7 +553,7 @@ function asyncRoutesWithAsyncChildrenWithoutParamsWithDefaultRoutes() {
                  rootTC.detectChanges();
                  expect(rootTC.debugElement.nativeElement).toHaveText('nav to child | outer {  }');
 
-                 rtr.subscribe((_: any /** TODO #9100 */) => {
+                 rtr.subscribe((_: any /* TODO #9100 */) => {
                    rootTC.detectChanges();
                    expect(rootTC.debugElement.nativeElement)
                        .toHaveText('nav to child | outer { inner { hello } }');
@@ -568,15 +568,15 @@ function asyncRoutesWithAsyncChildrenWithoutParamsWithDefaultRoutes() {
 
 
 function asyncRoutesWithAsyncChildrenWithParamsWithoutDefaultRoutes() {
-  var fixture: any /** TODO #9100 */;
-  var tcb: any /** TODO #9100 */;
-  var rtr: any /** TODO #9100 */;
+  var fixture: any /* TODO #9100 */;
+  var tcb: any /* TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -626,7 +626,7 @@ function asyncRoutesWithAsyncChildrenWithParamsWithoutDefaultRoutes() {
   it('should navigate from a link click',
      inject(
          [AsyncTestCompleter, Location],
-         (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+         (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
            compile(
                tcb,
                `<a [routerLink]="['/Team', {id: 'angular'}, 'User', {name: 'matias'}]">nav to matias</a> { <router-outlet></router-outlet> }`)
@@ -637,7 +637,7 @@ function asyncRoutesWithAsyncChildrenWithParamsWithoutDefaultRoutes() {
                  fixture.detectChanges();
                  expect(fixture.debugElement.nativeElement).toHaveText('nav to matias {  }');
 
-                 rtr.subscribe((_: any /** TODO #9100 */) => {
+                 rtr.subscribe((_: any /* TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
                        .toHaveText('nav to matias { team angular | user { hello matias } }');
@@ -651,21 +651,20 @@ function asyncRoutesWithAsyncChildrenWithParamsWithoutDefaultRoutes() {
 }
 
 export function registerSpecs() {
-  (specs as any /** TODO #9100 */)['asyncRoutesWithoutChildrenWithRouteData'] =
+  (specs as any /* TODO #9100 */)['asyncRoutesWithoutChildrenWithRouteData'] =
       asyncRoutesWithoutChildrenWithRouteData;
-  (specs as any /** TODO #9100 */)['asyncRoutesWithoutChildrenWithoutParams'] =
+  (specs as any /* TODO #9100 */)['asyncRoutesWithoutChildrenWithoutParams'] =
       asyncRoutesWithoutChildrenWithoutParams;
-  (specs as any /** TODO #9100 */)['asyncRoutesWithoutChildrenWithParams'] =
+  (specs as any /* TODO #9100 */)['asyncRoutesWithoutChildrenWithParams'] =
       asyncRoutesWithoutChildrenWithParams;
-  (specs as any /** TODO #9100 */)['asyncRoutesWithSyncChildrenWithoutDefaultRoutes'] =
+  (specs as any /* TODO #9100 */)['asyncRoutesWithSyncChildrenWithoutDefaultRoutes'] =
       asyncRoutesWithSyncChildrenWithoutDefaultRoutes;
-  (specs as any /** TODO #9100 */)['asyncRoutesWithSyncChildrenWithDefaultRoutes'] =
+  (specs as any /* TODO #9100 */)['asyncRoutesWithSyncChildrenWithDefaultRoutes'] =
       asyncRoutesWithSyncChildrenWithDefaultRoutes;
-  (specs as
-       any /** TODO #9100 */)['asyncRoutesWithAsyncChildrenWithoutParamsWithoutDefaultRoutes'] =
+  (specs as any /* TODO #9100 */)['asyncRoutesWithAsyncChildrenWithoutParamsWithoutDefaultRoutes'] =
       asyncRoutesWithAsyncChildrenWithoutParamsWithoutDefaultRoutes;
-  (specs as any /** TODO #9100 */)['asyncRoutesWithAsyncChildrenWithoutParamsWithDefaultRoutes'] =
+  (specs as any /* TODO #9100 */)['asyncRoutesWithAsyncChildrenWithoutParamsWithDefaultRoutes'] =
       asyncRoutesWithAsyncChildrenWithoutParamsWithDefaultRoutes;
-  (specs as any /** TODO #9100 */)['asyncRoutesWithAsyncChildrenWithParamsWithoutDefaultRoutes'] =
+  (specs as any /* TODO #9100 */)['asyncRoutesWithAsyncChildrenWithParamsWithoutDefaultRoutes'] =
       asyncRoutesWithAsyncChildrenWithParamsWithoutDefaultRoutes;
 }

--- a/modules/@angular/router-deprecated/test/integration/impl/aux_route_spec_impl.ts
+++ b/modules/@angular/router-deprecated/test/integration/impl/aux_route_spec_impl.ts
@@ -16,11 +16,11 @@ function getLinkElement(rtc: ComponentFixture<any>, linkIndex: number = 0) {
 function auxRoutes() {
   var tcb: TestComponentBuilder;
   var fixture: ComponentFixture<any>;
-  var rtr: any /** TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -80,7 +80,7 @@ function auxRoutes() {
   it('should navigate from a link click',
      inject(
          [AsyncTestCompleter, Location],
-         (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+         (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
            compile(
                tcb,
                `<a [routerLink]="['/', ['Modal']]">open modal</a> | <a [routerLink]="['/Hello']">hello</a> | main {<router-outlet></router-outlet>} | aux {<router-outlet name="modal"></router-outlet>}`)
@@ -96,7 +96,7 @@ function auxRoutes() {
 
                  var navCount = 0;
 
-                 rtr.subscribe((_: any /** TODO #9100 */) => {
+                 rtr.subscribe((_: any /* TODO #9100 */) => {
                    navCount += 1;
                    fixture.detectChanges();
                    if (navCount == 1) {
@@ -129,11 +129,11 @@ function auxRoutes() {
 function auxRoutesWithAPrimaryRoute() {
   var tcb: TestComponentBuilder;
   var fixture: ComponentFixture<any>;
-  var rtr: any /** TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -193,7 +193,7 @@ function auxRoutesWithAPrimaryRoute() {
   it('should navigate from a link click',
      inject(
          [AsyncTestCompleter, Location],
-         (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+         (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
            compile(
                tcb,
                `<a [routerLink]="['/Hello', ['Modal']]">open modal</a> | main {<router-outlet></router-outlet>} | aux {<router-outlet name="modal"></router-outlet>}`)
@@ -207,7 +207,7 @@ function auxRoutesWithAPrimaryRoute() {
                  expect(fixture.debugElement.nativeElement)
                      .toHaveText('open modal | main {} | aux {}');
 
-                 rtr.subscribe((_: any /** TODO #9100 */) => {
+                 rtr.subscribe((_: any /* TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
                        .toHaveText('open modal | main {hello} | aux {modal}');
@@ -221,8 +221,8 @@ function auxRoutesWithAPrimaryRoute() {
 }
 
 export function registerSpecs() {
-  (specs as any /** TODO #9100 */)['auxRoutes'] = auxRoutes;
-  (specs as any /** TODO #9100 */)['auxRoutesWithAPrimaryRoute'] = auxRoutesWithAPrimaryRoute;
+  (specs as any /* TODO #9100 */)['auxRoutes'] = auxRoutes;
+  (specs as any /* TODO #9100 */)['auxRoutesWithAPrimaryRoute'] = auxRoutesWithAPrimaryRoute;
 }
 
 

--- a/modules/@angular/router-deprecated/test/integration/impl/sync_route_spec_impl.ts
+++ b/modules/@angular/router-deprecated/test/integration/impl/sync_route_spec_impl.ts
@@ -15,15 +15,15 @@ function getLinkElement(rtc: ComponentFixture<any>) {
 }
 
 function syncRoutesWithoutChildrenWithoutParams() {
-  var fixture: any /** TODO #9100 */;
-  var tcb: any /** TODO #9100 */;
-  var rtr: any /** TODO #9100 */;
+  var fixture: any /* TODO #9100 */;
+  var tcb: any /* TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -69,7 +69,7 @@ function syncRoutesWithoutChildrenWithoutParams() {
   it('should navigate from a link click',
      inject(
          [AsyncTestCompleter, Location],
-         (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+         (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
            compile(
                tcb, `<a [routerLink]="['Hello']">go to hello</a> | <router-outlet></router-outlet>`)
                .then((rtc) => {fixture = rtc})
@@ -80,7 +80,7 @@ function syncRoutesWithoutChildrenWithoutParams() {
                  fixture.detectChanges();
                  expect(fixture.debugElement.nativeElement).toHaveText('go to hello | ');
 
-                 rtr.subscribe((_: any /** TODO #9100 */) => {
+                 rtr.subscribe((_: any /* TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement).toHaveText('go to hello | hello');
                    expect(location.urlChanges).toEqual(['/test']);
@@ -94,15 +94,15 @@ function syncRoutesWithoutChildrenWithoutParams() {
 
 
 function syncRoutesWithoutChildrenWithParams() {
-  var fixture: any /** TODO #9100 */;
-  var tcb: any /** TODO #9100 */;
-  var rtr: any /** TODO #9100 */;
+  var fixture: any /* TODO #9100 */;
+  var tcb: any /* TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -153,7 +153,7 @@ function syncRoutesWithoutChildrenWithParams() {
   it('should navigate from a link click',
      inject(
          [AsyncTestCompleter, Location],
-         (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+         (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
            compile(
                tcb,
                `<a [routerLink]="['User', {name: 'naomi'}]">greet naomi</a> | <router-outlet></router-outlet>`)
@@ -164,7 +164,7 @@ function syncRoutesWithoutChildrenWithParams() {
                  fixture.detectChanges();
                  expect(fixture.debugElement.nativeElement).toHaveText('greet naomi | ');
 
-                 rtr.subscribe((_: any /** TODO #9100 */) => {
+                 rtr.subscribe((_: any /* TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
                        .toHaveText('greet naomi | hello naomi');
@@ -199,15 +199,15 @@ function syncRoutesWithoutChildrenWithParams() {
 
 
 function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithoutParams() {
-  var fixture: any /** TODO #9100 */;
-  var tcb: any /** TODO #9100 */;
-  var rtr: any /** TODO #9100 */;
+  var fixture: any /* TODO #9100 */;
+  var tcb: any /* TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -258,7 +258,7 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithoutParams() {
   it('should navigate from a link click',
      inject(
          [AsyncTestCompleter, Location],
-         (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+         (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
            compile(
                tcb,
                `<a [routerLink]="['Parent', 'Child']">nav to child</a> | outer { <router-outlet></router-outlet> }`)
@@ -269,7 +269,7 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithoutParams() {
                  fixture.detectChanges();
                  expect(fixture.debugElement.nativeElement).toHaveText('nav to child | outer {  }');
 
-                 rtr.subscribe((_: any /** TODO #9100 */) => {
+                 rtr.subscribe((_: any /* TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
                        .toHaveText('nav to child | outer { inner { hello } }');
@@ -284,15 +284,15 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithoutParams() {
 
 
 function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithParams() {
-  var fixture: any /** TODO #9100 */;
-  var tcb: any /** TODO #9100 */;
-  var rtr: any /** TODO #9100 */;
+  var fixture: any /* TODO #9100 */;
+  var tcb: any /* TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -342,7 +342,7 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithParams() {
   it('should navigate from a link click',
      inject(
          [AsyncTestCompleter, Location],
-         (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+         (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
            compile(
                tcb,
                `<a [routerLink]="['/Team', {id: 'angular'}, 'User', {name: 'matias'}]">nav to matias</a> { <router-outlet></router-outlet> }`)
@@ -353,7 +353,7 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithParams() {
                  fixture.detectChanges();
                  expect(fixture.debugElement.nativeElement).toHaveText('nav to matias {  }');
 
-                 rtr.subscribe((_: any /** TODO #9100 */) => {
+                 rtr.subscribe((_: any /* TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
                        .toHaveText('nav to matias { team angular | user { hello matias } }');
@@ -368,15 +368,15 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithParams() {
 
 
 function syncRoutesWithSyncChildrenWithDefaultRoutesWithoutParams() {
-  var fixture: any /** TODO #9100 */;
-  var tcb: any /** TODO #9100 */;
-  var rtr: any /** TODO #9100 */;
+  var fixture: any /* TODO #9100 */;
+  var tcb: any /* TODO #9100 */;
+  var rtr: any /* TODO #9100 */;
 
   beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -424,7 +424,7 @@ function syncRoutesWithSyncChildrenWithDefaultRoutesWithoutParams() {
   it('should navigate from a link click',
      inject(
          [AsyncTestCompleter, Location],
-         (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+         (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
            compile(
                tcb,
                `<a [routerLink]="['/Parent']">link to inner</a> | outer { <router-outlet></router-outlet> }`)
@@ -436,7 +436,7 @@ function syncRoutesWithSyncChildrenWithDefaultRoutesWithoutParams() {
                  expect(fixture.debugElement.nativeElement)
                      .toHaveText('link to inner | outer {  }');
 
-                 rtr.subscribe((_: any /** TODO #9100 */) => {
+                 rtr.subscribe((_: any /* TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
                        .toHaveText('link to inner | outer { inner { hello } }');
@@ -458,7 +458,7 @@ function syncRoutesWithDynamicComponents() {
 
   beforeEach(inject(
       [TestComponentBuilder, Router],
-      (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+      (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
         tcb = tcBuilder;
         rtr = router;
       }));
@@ -503,16 +503,16 @@ function syncRoutesWithDynamicComponents() {
 
 
 export function registerSpecs() {
-  (specs as any /** TODO #9100 */)['syncRoutesWithoutChildrenWithoutParams'] =
+  (specs as any /* TODO #9100 */)['syncRoutesWithoutChildrenWithoutParams'] =
       syncRoutesWithoutChildrenWithoutParams;
-  (specs as any /** TODO #9100 */)['syncRoutesWithoutChildrenWithParams'] =
+  (specs as any /* TODO #9100 */)['syncRoutesWithoutChildrenWithParams'] =
       syncRoutesWithoutChildrenWithParams;
-  (specs as any /** TODO #9100 */)['syncRoutesWithSyncChildrenWithoutDefaultRoutesWithoutParams'] =
+  (specs as any /* TODO #9100 */)['syncRoutesWithSyncChildrenWithoutDefaultRoutesWithoutParams'] =
       syncRoutesWithSyncChildrenWithoutDefaultRoutesWithoutParams;
-  (specs as any /** TODO #9100 */)['syncRoutesWithSyncChildrenWithoutDefaultRoutesWithParams'] =
+  (specs as any /* TODO #9100 */)['syncRoutesWithSyncChildrenWithoutDefaultRoutesWithParams'] =
       syncRoutesWithSyncChildrenWithoutDefaultRoutesWithParams;
-  (specs as any /** TODO #9100 */)['syncRoutesWithSyncChildrenWithDefaultRoutesWithoutParams'] =
+  (specs as any /* TODO #9100 */)['syncRoutesWithSyncChildrenWithDefaultRoutesWithoutParams'] =
       syncRoutesWithSyncChildrenWithDefaultRoutesWithoutParams;
-  (specs as any /** TODO #9100 */)['syncRoutesWithDynamicComponents'] =
+  (specs as any /* TODO #9100 */)['syncRoutesWithDynamicComponents'] =
       syncRoutesWithDynamicComponents;
 }

--- a/modules/@angular/router-deprecated/test/integration/lifecycle_hook_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/lifecycle_hook_spec.ts
@@ -13,7 +13,7 @@ import {AsyncRoute, AuxRoute, Redirect, Route, RouteConfig} from '../../src/rout
 
 import {RootCmp, TEST_ROUTER_PROVIDERS, compile} from './util';
 
-var cmpInstanceCount: any /** TODO #9100 */;
+var cmpInstanceCount: any /* TODO #9100 */;
 var log: string[];
 var eventBus: EventEmitter<any>;
 var completer: PromiseCompleter<any>;

--- a/modules/@angular/router-deprecated/test/integration/navigation_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/navigation_spec.ts
@@ -10,21 +10,21 @@ import {AsyncRoute, AuxRoute, Redirect, Route, RouteConfig} from '../../src/rout
 
 import {RootCmp, TEST_ROUTER_PROVIDERS, compile} from './util';
 
-var cmpInstanceCount: any /** TODO #9100 */;
-var childCmpInstanceCount: any /** TODO #9100 */;
+var cmpInstanceCount: any /* TODO #9100 */;
+var childCmpInstanceCount: any /* TODO #9100 */;
 
 export function main() {
   describe('navigation', () => {
 
     var tcb: TestComponentBuilder;
     var fixture: ComponentFixture<any>;
-    var rtr: any /** TODO #9100 */;
+    var rtr: any /* TODO #9100 */;
 
     beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
     beforeEach(inject(
         [TestComponentBuilder, Router],
-        (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+        (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
           tcb = tcBuilder;
           rtr = router;
           childCmpInstanceCount = 0;
@@ -92,7 +92,7 @@ export function main() {
     it('should navigate to child routes when the root component has an empty path',
        inject(
            [AsyncTestCompleter, Location],
-           (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
              compile(tcb, 'outer { <router-outlet></router-outlet> }')
                  .then((rtc) => {fixture = rtc})
                  .then((_) => rtr.config([new Route({path: '/...', component: ParentCmp})]))
@@ -123,7 +123,7 @@ export function main() {
     it('should replace state when normalized paths are equal',
        inject(
            [AsyncTestCompleter, Location],
-           (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
              compile(tcb)
                  .then((rtc) => {fixture = rtc})
                  .then((_) => location.setInitialPath('/test/'))

--- a/modules/@angular/router-deprecated/test/integration/redirect_route_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/redirect_route_spec.ts
@@ -9,21 +9,21 @@ import {AsyncRoute, AuxRoute, Redirect, Route, RouteConfig} from '../../src/rout
 import {GoodbyeCmp, HelloCmp, RedirectToParentCmp} from './impl/fixture_components';
 import {RootCmp, TEST_ROUTER_PROVIDERS, compile} from './util';
 
-var cmpInstanceCount: any /** TODO #9100 */;
-var childCmpInstanceCount: any /** TODO #9100 */;
+var cmpInstanceCount: any /* TODO #9100 */;
+var childCmpInstanceCount: any /* TODO #9100 */;
 
 export function main() {
   describe('redirects', () => {
 
     var tcb: TestComponentBuilder;
     var rootTC: ComponentFixture<any>;
-    var rtr: any /** TODO #9100 */;
+    var rtr: any /* TODO #9100 */;
 
     beforeEachProviders(() => TEST_ROUTER_PROVIDERS);
 
     beforeEach(inject(
         [TestComponentBuilder, Router],
-        (tcBuilder: any /** TODO #9100 */, router: any /** TODO #9100 */) => {
+        (tcBuilder: any /* TODO #9100 */, router: any /* TODO #9100 */) => {
           tcb = tcBuilder;
           rtr = router;
           childCmpInstanceCount = 0;
@@ -34,7 +34,7 @@ export function main() {
     it('should apply when navigating by URL',
        inject(
            [AsyncTestCompleter, Location],
-           (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
              compile(tcb)
                  .then((rtc) => {rootTC = rtc})
                  .then((_) => rtr.config([
@@ -54,7 +54,7 @@ export function main() {
     it('should recognize and apply absolute redirects',
        inject(
            [AsyncTestCompleter, Location],
-           (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
              compile(tcb)
                  .then((rtc) => {rootTC = rtc})
                  .then((_) => rtr.config([
@@ -74,7 +74,7 @@ export function main() {
     it('should recognize and apply relative child redirects',
        inject(
            [AsyncTestCompleter, Location],
-           (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
              compile(tcb)
                  .then((rtc) => {rootTC = rtc})
                  .then((_) => rtr.config([
@@ -94,7 +94,7 @@ export function main() {
     it('should recognize and apply relative parent redirects',
        inject(
            [AsyncTestCompleter, Location],
-           (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
              compile(tcb)
                  .then((rtc) => {rootTC = rtc})
                  .then((_) => rtr.config([
@@ -114,7 +114,7 @@ export function main() {
     it('should not redirect when redirect is less specific than other matching routes',
        inject(
            [AsyncTestCompleter, Location],
-           (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, location: any /* TODO #9100 */) => {
              compile(tcb)
                  .then((rtc) => {rootTC = rtc})
                  .then((_) => rtr.config([

--- a/modules/@angular/router-deprecated/test/integration/router_link_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/router_link_spec.ts
@@ -32,7 +32,7 @@ export function main() {
 
     beforeEach(inject(
         [TestComponentBuilder, Router, Location],
-        (tcBuilder: any /** TODO #9100 */, rtr: Router, loc: Location) => {
+        (tcBuilder: any /* TODO #9100 */, rtr: Router, loc: Location) => {
           tcb = tcBuilder;
           router = rtr;
           location = loc;
@@ -325,7 +325,7 @@ export function main() {
 
     describe('when clicked', () => {
 
-      var clickOnElement = function(view: any /** TODO #9100 */) {
+      var clickOnElement = function(view: any /* TODO #9100 */) {
         var anchorEl = fixture.debugElement.query(By.css('a')).nativeElement;
         var dispatchedEvent = getDOM().createMouseEvent('click');
         getDOM().dispatchEvent(anchorEl, dispatchedEvent);
@@ -383,7 +383,7 @@ function getHref(tc: ComponentFixture<any>) {
 
 @Component({selector: 'my-comp', template: '', directives: [ROUTER_DIRECTIVES]})
 class MyComp7 {
-  name: any /** TODO #9100 */;
+  name: any /* TODO #9100 */;
 }
 
 @Component({selector: 'user-cmp', template: 'hello {{user}}'})

--- a/modules/@angular/router-deprecated/test/integration/util.ts
+++ b/modules/@angular/router-deprecated/test/integration/util.ts
@@ -37,13 +37,13 @@ export var TEST_ROUTER_PROVIDERS: any[] = [
   {provide: ROUTER_PRIMARY_COMPONENT, useValue: RootCmp}, {provide: Router, useClass: RootRouter}
 ];
 
-export function clickOnElement(anchorEl: any /** TODO #9100 */) {
+export function clickOnElement(anchorEl: any /* TODO #9100 */) {
   var dispatchedEvent = getDOM().createMouseEvent('click');
   getDOM().dispatchEvent(anchorEl, dispatchedEvent);
   return dispatchedEvent;
 }
 
-export function getHref(elt: any /** TODO #9100 */) {
+export function getHref(elt: any /* TODO #9100 */) {
   return getDOM().getAttribute(elt, 'href');
 }
 
@@ -52,7 +52,7 @@ export function getHref(elt: any /** TODO #9100 */) {
  * Router integration suite DSL
  */
 
-var specNameBuilder: any[] /** TODO #9100 */ = [];
+var specNameBuilder: any[] /* TODO #9100 */ = [];
 
 // we add the specs themselves onto this map
 export var specs = {};
@@ -100,7 +100,7 @@ function descriptionToSpecName(description: string): string {
 export function itShouldRoute() {
   var specSuiteName = spaceCaseToCamelCase(specNameBuilder.join(' '));
 
-  var spec = (specs as any /** TODO #9100 */)[specSuiteName];
+  var spec = (specs as any /* TODO #9100 */)[specSuiteName];
   if (isBlank(spec)) {
     throw new BaseException(`Router integration spec suite "${specSuiteName}" was not found.`);
   } else {

--- a/modules/@angular/router-deprecated/test/location/hash_location_strategy_spec.ts
+++ b/modules/@angular/router-deprecated/test/location/hash_location_strategy_spec.ts
@@ -16,7 +16,7 @@ export function main() {
     describe('without APP_BASE_HREF', () => {
       beforeEach(inject(
           [PlatformLocation, HashLocationStrategy],
-          (pl: any /** TODO #9100 */, ls: any /** TODO #9100 */) => {
+          (pl: any /* TODO #9100 */, ls: any /* TODO #9100 */) => {
             platformLocation = pl;
             locationStrategy = ls;
             platformLocation.spy('pushState');
@@ -58,7 +58,7 @@ export function main() {
 
       beforeEach(inject(
           [PlatformLocation, HashLocationStrategy],
-          (pl: any /** TODO #9100 */, ls: any /** TODO #9100 */) => {
+          (pl: any /* TODO #9100 */, ls: any /* TODO #9100 */) => {
             platformLocation = pl;
             locationStrategy = ls;
             platformLocation.spy('pushState');
@@ -93,7 +93,7 @@ export function main() {
 
       beforeEach(inject(
           [PlatformLocation, HashLocationStrategy],
-          (pl: any /** TODO #9100 */, ls: any /** TODO #9100 */) => {
+          (pl: any /* TODO #9100 */, ls: any /* TODO #9100 */) => {
             platformLocation = pl;
             locationStrategy = ls;
             platformLocation.spy('pushState');
@@ -128,7 +128,7 @@ export function main() {
 
       beforeEach(inject(
           [PlatformLocation, HashLocationStrategy],
-          (pl: any /** TODO #9100 */, ls: any /** TODO #9100 */) => {
+          (pl: any /* TODO #9100 */, ls: any /* TODO #9100 */) => {
             platformLocation = pl;
             locationStrategy = ls;
             platformLocation.spy('pushState');
@@ -161,7 +161,7 @@ export function main() {
     describe('hashLocationStrategy bugs', () => {
       beforeEach(inject(
           [PlatformLocation, HashLocationStrategy],
-          (pl: any /** TODO #9100 */, ls: any /** TODO #9100 */) => {
+          (pl: any /* TODO #9100 */, ls: any /* TODO #9100 */) => {
             platformLocation = pl;
             locationStrategy = ls;
             platformLocation.spy('pushState');

--- a/modules/@angular/router-deprecated/test/location/location_spec.ts
+++ b/modules/@angular/router-deprecated/test/location/location_spec.ts
@@ -8,7 +8,7 @@ import {MockLocationStrategy} from '@angular/common/testing';
 export function main() {
   describe('Location', () => {
 
-    var locationStrategy: any /** TODO #9100 */, location: any /** TODO #9100 */;
+    var locationStrategy: any /* TODO #9100 */, location: any /* TODO #9100 */;
 
     function makeLocation(
         baseHref: string = '/my/app', provider: any = /*@ts2dart_const*/[]): Location {
@@ -37,7 +37,7 @@ export function main() {
     it('should normalize urls on popstate',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
 
-         location.subscribe((ev: any /** TODO #9100 */) => {
+         location.subscribe((ev: any /* TODO #9100 */) => {
            expect(ev['url']).toEqual('/user/btford');
            async.done();
          });
@@ -48,7 +48,7 @@ export function main() {
       var locationStrategy = new MockLocationStrategy();
       var location = new Location(locationStrategy);
 
-      function assertUrl(path: any /** TODO #9100 */) { expect(location.path()).toEqual(path); }
+      function assertUrl(path: any /* TODO #9100 */) { expect(location.path()).toEqual(path); }
 
       location.go('/ready');
       assertUrl('/ready');

--- a/modules/@angular/router-deprecated/test/location/path_location_strategy_spec.ts
+++ b/modules/@angular/router-deprecated/test/location/path_location_strategy_spec.ts
@@ -6,7 +6,7 @@ import {SpyPlatformLocation} from '../spies';
 
 export function main() {
   describe('PathLocationStrategy', () => {
-    var platformLocation: any /** TODO #9100 */, locationStrategy: any /** TODO #9100 */;
+    var platformLocation: any /* TODO #9100 */, locationStrategy: any /* TODO #9100 */;
 
     beforeEachProviders(() => [PathLocationStrategy, {
                           provide: PlatformLocation,
@@ -26,7 +26,7 @@ export function main() {
     describe('without APP_BASE_HREF', () => {
       beforeEach(inject(
           [PlatformLocation, PathLocationStrategy],
-          (pl: any /** TODO #9100 */, ls: any /** TODO #9100 */) => {
+          (pl: any /* TODO #9100 */, ls: any /* TODO #9100 */) => {
             platformLocation = pl;
             locationStrategy = ls;
           }));
@@ -59,7 +59,7 @@ export function main() {
 
       beforeEach(inject(
           [PlatformLocation, PathLocationStrategy],
-          (pl: any /** TODO #9100 */, ls: any /** TODO #9100 */) => {
+          (pl: any /* TODO #9100 */, ls: any /* TODO #9100 */) => {
             platformLocation = pl;
             locationStrategy = ls;
             platformLocation.spy('pushState');
@@ -94,7 +94,7 @@ export function main() {
 
       beforeEach(inject(
           [PlatformLocation, PathLocationStrategy],
-          (pl: any /** TODO #9100 */, ls: any /** TODO #9100 */) => {
+          (pl: any /* TODO #9100 */, ls: any /* TODO #9100 */) => {
             platformLocation = pl;
             locationStrategy = ls;
             platformLocation.spy('pushState');
@@ -129,7 +129,7 @@ export function main() {
 
       beforeEach(inject(
           [PlatformLocation, PathLocationStrategy],
-          (pl: any /** TODO #9100 */, ls: any /** TODO #9100 */) => {
+          (pl: any /* TODO #9100 */, ls: any /* TODO #9100 */) => {
             platformLocation = pl;
             locationStrategy = ls;
             platformLocation.spy('pushState');

--- a/modules/@angular/router-deprecated/test/route_config/route_config_spec.ts
+++ b/modules/@angular/router-deprecated/test/route_config/route_config_spec.ts
@@ -21,14 +21,13 @@ class _ArrayLogger {
 }
 
 class DummyConsole implements Console {
-  log(message: any /** TODO #9100 */) {}
-  warn(message: any /** TODO #9100 */) {}
+  log(message: any /* TODO #9100 */) {}
+  warn(message: any /* TODO #9100 */) {}
 }
 
 export function main() {
   describe('RouteConfig with POJO arguments', () => {
-    var fakeDoc: any /** TODO #9100 */, el: any /** TODO #9100 */,
-        testBindings: any /** TODO #9100 */;
+    var fakeDoc: any /* TODO #9100 */, el: any /* TODO #9100 */, testBindings: any /* TODO #9100 */;
     beforeEach(() => {
       fakeDoc = getDOM().createHtmlDocument();
       el = getDOM().createElement('app-cmp', fakeDoc);
@@ -47,7 +46,7 @@ export function main() {
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          bootstrap(HierarchyAppCmp, testBindings).then((applicationRef) => {
            var router = applicationRef.instance.router;
-           router.subscribe((_: any /** TODO #9100 */) => {
+           router.subscribe((_: any /* TODO #9100 */) => {
              expect(el).toHaveText('root { parent { hello } }');
              expect(applicationRef.instance.location.path()).toEqual('/parent/child');
              async.done();
@@ -61,7 +60,7 @@ export function main() {
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          bootstrap(RedirectAppCmp, testBindings).then((applicationRef) => {
            var router = applicationRef.instance.router;
-           router.subscribe((_: any /** TODO #9100 */) => {
+           router.subscribe((_: any /* TODO #9100 */) => {
              expect(el).toHaveText('root { hello }');
              expect(applicationRef.instance.location.path()).toEqual('/after');
              async.done();
@@ -75,7 +74,7 @@ export function main() {
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          bootstrap(AsyncAppCmp, testBindings).then((applicationRef) => {
            var router = applicationRef.instance.router;
-           router.subscribe((_: any /** TODO #9100 */) => {
+           router.subscribe((_: any /* TODO #9100 */) => {
              expect(el).toHaveText('root { hello }');
              expect(applicationRef.instance.location.path()).toEqual('/hello');
              async.done();
@@ -89,7 +88,7 @@ export function main() {
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          bootstrap(AuxAppCmp, testBindings).then((applicationRef) => {
            var router = applicationRef.instance.router;
-           router.subscribe((_: any /** TODO #9100 */) => {
+           router.subscribe((_: any /* TODO #9100 */) => {
              expect(el).toHaveText('root { hello } aside { hello }');
              expect(applicationRef.instance.location.path()).toEqual('/hello(aside)');
              async.done();
@@ -103,7 +102,7 @@ export function main() {
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          bootstrap(ConciseAsyncAppCmp, testBindings).then((applicationRef) => {
            var router = applicationRef.instance.router;
-           router.subscribe((_: any /** TODO #9100 */) => {
+           router.subscribe((_: any /* TODO #9100 */) => {
              expect(el).toHaveText('root { hello }');
              expect(applicationRef.instance.location.path()).toEqual('/hello');
              async.done();
@@ -117,7 +116,7 @@ export function main() {
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          bootstrap(ExplicitConstructorAppCmp, testBindings).then((applicationRef) => {
            var router = applicationRef.instance.router;
-           router.subscribe((_: any /** TODO #9100 */) => {
+           router.subscribe((_: any /* TODO #9100 */) => {
              expect(el).toHaveText('root { hello }');
              expect(applicationRef.instance.location.path()).toEqual('/hello');
              async.done();

--- a/modules/@angular/router-deprecated/test/route_registry_spec.ts
+++ b/modules/@angular/router-deprecated/test/route_registry_spec.ts
@@ -313,7 +313,7 @@ export function main() {
   });
 }
 
-function stringifyInstruction(instruction: any /** TODO #9100 */): string {
+function stringifyInstruction(instruction: any /* TODO #9100 */): string {
   return instruction.toRootUrl();
 }
 

--- a/modules/@angular/router-deprecated/test/router_spec.ts
+++ b/modules/@angular/router-deprecated/test/router_spec.ts
@@ -314,7 +314,7 @@ export function main() {
 }
 
 
-function stringifyInstruction(instruction: any /** TODO #9100 */): string {
+function stringifyInstruction(instruction: any /* TODO #9100 */): string {
   return instruction.toRootUrl();
 }
 
@@ -330,12 +330,11 @@ class DummyParentComp {
 
 function makeDummyOutlet(): RouterOutlet {
   var ref = new SpyRouterOutlet();
-  ref.spy('canActivate').andCallFake((_: any /** TODO #9100 */) => PromiseWrapper.resolve(true));
-  ref.spy('routerCanReuse')
-      .andCallFake((_: any /** TODO #9100 */) => PromiseWrapper.resolve(false));
+  ref.spy('canActivate').andCallFake((_: any /* TODO #9100 */) => PromiseWrapper.resolve(true));
+  ref.spy('routerCanReuse').andCallFake((_: any /* TODO #9100 */) => PromiseWrapper.resolve(false));
   ref.spy('routerCanDeactivate')
-      .andCallFake((_: any /** TODO #9100 */) => PromiseWrapper.resolve(true));
-  ref.spy('activate').andCallFake((_: any /** TODO #9100 */) => PromiseWrapper.resolve(true));
+      .andCallFake((_: any /* TODO #9100 */) => PromiseWrapper.resolve(true));
+  ref.spy('activate').andCallFake((_: any /* TODO #9100 */) => PromiseWrapper.resolve(true));
   return <any>ref;
 }
 

--- a/modules/@angular/router-deprecated/test/rules/route_paths/regex_route_param_spec.ts
+++ b/modules/@angular/router-deprecated/test/rules/route_paths/regex_route_param_spec.ts
@@ -4,7 +4,7 @@ import {GeneratedUrl} from '../../../src/rules/route_paths/route_path';
 import {RegexRoutePath} from '../../../src/rules/route_paths/regex_route_path';
 import {parser, Url} from '../../../src/url_parser';
 
-function emptySerializer(params: any /** TODO #9100 */) {
+function emptySerializer(params: any /* TODO #9100 */) {
   return new GeneratedUrl('', {});
 }
 
@@ -29,7 +29,7 @@ export function main() {
     });
 
     it('should generate a url by calling the provided serializer', () => {
-      function serializer(params: any /** TODO #9100 */) {
+      function serializer(params: any /* TODO #9100 */) {
         return new GeneratedUrl(`/a/${params['a']}/b/${params['b']}`, {});
       }
       var rec = new RegexRoutePath('/a/(.+)/b/(.+)$', serializer);

--- a/modules/@angular/router-deprecated/test/rules/rule_set_spec.ts
+++ b/modules/@angular/router-deprecated/test/rules/rule_set_spec.ts
@@ -61,7 +61,7 @@ export function main() {
        }));
 
     it('should recognize a regex', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-         function emptySerializer(params: any /** TODO #9100 */): GeneratedUrl {
+         function emptySerializer(params: any /* TODO #9100 */): GeneratedUrl {
            return new GeneratedUrl('', {});
          }
 
@@ -78,7 +78,7 @@ export function main() {
 
     it('should recognize a regex with named_groups',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-         function emptySerializer(params: any /** TODO #9100 */): GeneratedUrl {
+         function emptySerializer(params: any /* TODO #9100 */): GeneratedUrl {
            return new GeneratedUrl('', {});
          }
 
@@ -151,7 +151,7 @@ export function main() {
 
 
     it('should generate using a serializer', () => {
-      function simpleSerializer(params: any /** TODO #9100 */): GeneratedUrl {
+      function simpleSerializer(params: any /* TODO #9100 */): GeneratedUrl {
         var extra = {c: params['c']};
         return new GeneratedUrl(`/${params['a']}/${params['b']}`, extra);
       }

--- a/modules/@angular/router-deprecated/testing.ts
+++ b/modules/@angular/router-deprecated/testing.ts
@@ -1,2 +1,2 @@
 // future location of testing for router.
-export var __nothing__: any /** TODO #9100 */;
+export var __nothing__: any /* TODO #9100 */;

--- a/modules/@angular/router/src/link.ts
+++ b/modules/@angular/router/src/link.ts
@@ -38,7 +38,7 @@ function _normalizeCommands(commands: any[]): _NormalizedNavigationCommands {
 
   let numberOfDoubleDots = 0;
   let isAbsolute = false;
-  let res: any[] /** TODO #9100 */ = [];
+  let res: any[] /* TODO #9100 */ = [];
 
   for (let i = 0; i < commands.length; ++i) {
     let c = commands[i];
@@ -170,8 +170,8 @@ function _update(node: TreeNode<UrlSegment>, commands: any[]): TreeNode<UrlSegme
 function _stringify(params: {[key: string]: any}): {[key: string]: string} {
   let res = {};
   StringMapWrapper.forEach(
-      params, (v: any /** TODO #9100 */, k: any /** TODO #9100 */) =>
-                  (res as any /** TODO #9100 */)[k] = v.toString());
+      params, (v: any /* TODO #9100 */, k: any /* TODO #9100 */) =>
+                  (res as any /* TODO #9100 */)[k] = v.toString());
   return res;
 }
 

--- a/modules/@angular/router/src/recognize.ts
+++ b/modules/@angular/router/src/recognize.ts
@@ -25,7 +25,7 @@ function _recognize(
         `Component '${stringify(parentComponent)}' does not have route configuration`);
   }
 
-  let match: any /** TODO #9100 */;
+  let match: any /* TODO #9100 */;
   try {
     match = _match(metadata, url);
   } catch (e) {
@@ -138,7 +138,7 @@ function _matchWithParts(route: RouteMetadata, url: TreeNode<UrlSegment>): _Matc
 
   let parts = path.split('/');
   let positionalParams = {};
-  let consumedUrlSegments: any[] /** TODO #9100 */ = [];
+  let consumedUrlSegments: any[] /* TODO #9100 */ = [];
 
   let lastParent: TreeNode<UrlSegment> = null;
   let lastSegment: TreeNode<UrlSegment> = null;
@@ -161,7 +161,7 @@ function _matchWithParts(route: RouteMetadata, url: TreeNode<UrlSegment>): _Matc
     }
 
     if (isPosParam) {
-      (positionalParams as any /** TODO #9100 */)[p.substring(1)] = current.value.segment;
+      (positionalParams as any /* TODO #9100 */)[p.substring(1)] = current.value.segment;
     }
 
     consumedUrlSegments.push(current.value);
@@ -180,13 +180,13 @@ function _matchWithParts(route: RouteMetadata, url: TreeNode<UrlSegment>): _Matc
 function _checkOutletNameUniqueness(nodes: TreeNode<RouteSegment>[]): TreeNode<RouteSegment>[] {
   let names = {};
   nodes.forEach(n => {
-    let segmentWithSameOutletName = (names as any /** TODO #9100 */)[n.value.outlet];
+    let segmentWithSameOutletName = (names as any /* TODO #9100 */)[n.value.outlet];
     if (isPresent(segmentWithSameOutletName)) {
       let p = segmentWithSameOutletName.stringifiedUrlSegments;
       let c = n.value.stringifiedUrlSegments;
       throw new BaseException(`Two segments cannot have the same outlet name: '${p}' and '${c}'.`);
     }
-    (names as any /** TODO #9100 */)[n.value.outlet] = n.value;
+    (names as any /* TODO #9100 */)[n.value.outlet] = n.value;
   });
   return nodes;
 }

--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -208,18 +208,18 @@ class _ActivateSegments {
       currNode: TreeNode<RouteSegment>, prevNode: TreeNode<RouteSegment>,
       outletMap: RouterOutletMap, components: Object[]): void {
     let prevChildren = isPresent(prevNode) ? prevNode.children.reduce((m, c) => {
-      (m as any /** TODO #9100 */)[c.value.outlet] = c;
+      (m as any /* TODO #9100 */)[c.value.outlet] = c;
       return m;
     }, {}) : {};
 
     currNode.children.forEach(c => {
       this.activateSegments(
-          c, (prevChildren as any /** TODO #9100 */)[c.value.outlet], outletMap, components);
+          c, (prevChildren as any /* TODO #9100 */)[c.value.outlet], outletMap, components);
       StringMapWrapper.delete(prevChildren, c.value.outlet);
     });
 
     StringMapWrapper.forEach(
-        prevChildren, (v: any /** TODO #9100 */, k: any /** TODO #9100 */) =>
+        prevChildren, (v: any /* TODO #9100 */, k: any /* TODO #9100 */) =>
                           this.deactivateOutlet(outletMap._outlets[k], components));
   }
 
@@ -270,7 +270,7 @@ class _ActivateSegments {
   private deactivateOutlet(outlet: RouterOutlet, components: Object[]): void {
     if (isPresent(outlet) && outlet.isActivated) {
       StringMapWrapper.forEach(
-          outlet.outletMap._outlets, (v: any /** TODO #9100 */, k: any /** TODO #9100 */) =>
+          outlet.outletMap._outlets, (v: any /* TODO #9100 */, k: any /* TODO #9100 */) =>
                                          this.deactivateOutlet(v, components));
       if (this.performMutation) {
         outlet.deactivate();

--- a/modules/@angular/router/src/router_url_serializer.ts
+++ b/modules/@angular/router/src/router_url_serializer.ts
@@ -110,7 +110,7 @@ class _UrlParser {
       matrixParams = this.parseMatrixParams();
     }
 
-    var aux: any[] /** TODO #9100 */ = [];
+    var aux: any[] /* TODO #9100 */ = [];
     if (this.peekStartsWith('(')) {
       aux = this.parseAuxiliaryRoutes();
     }
@@ -185,7 +185,7 @@ class _UrlParser {
   }
 
   parseAuxiliaryRoutes(): TreeNode<UrlSegment>[] {
-    var segments: any[] /** TODO #9100 */ = [];
+    var segments: any[] /* TODO #9100 */ = [];
     this.capture('(');
 
     while (!this.peekStartsWith(')') && this._remaining.length > 0) {

--- a/modules/@angular/router/src/segments.ts
+++ b/modules/@angular/router/src/segments.ts
@@ -94,7 +94,7 @@ export class UrlSegment {
 function _serializeParams(params: {[key: string]: string}): string {
   let res = '';
   StringMapWrapper.forEach(
-      params, (v: any /** TODO #9100 */, k: any /** TODO #9100 */) => res += `;${k}=${v}`);
+      params, (v: any /* TODO #9100 */, k: any /* TODO #9100 */) => res += `;${k}=${v}`);
   return res;
 }
 

--- a/modules/@angular/router/test/integration_spec.ts
+++ b/modules/@angular/router/test/integration_spec.ts
@@ -16,14 +16,14 @@ export function main() {
             [{provide: RouterUrlSerializer, useClass: DefaultRouterUrlSerializer}, RouterOutletMap,
              {provide: Location, useClass: SpyLocation}, {
                provide: RouteSegment,
-               useFactory: (r: any /** TODO #9100 */) => r.routeTree.root,
+               useFactory: (r: any /* TODO #9100 */) => r.routeTree.root,
                deps: [Router]
              },
              {
                provide: Router,
                useFactory:
-                   (resolver: any /** TODO #9100 */, urlParser: any /** TODO #9100 */,
-                    outletMap: any /** TODO #9100 */, location: any /** TODO #9100 */) =>
+                   (resolver: any /* TODO #9100 */, urlParser: any /* TODO #9100 */,
+                    outletMap: any /* TODO #9100 */, location: any /* TODO #9100 */) =>
                        new Router(
                            'RootComponent', RootCmp, resolver, urlParser, outletMap, location),
                deps: [ComponentResolver, RouterUrlSerializer, RouterOutletMap, Location]
@@ -32,8 +32,8 @@ export function main() {
     it('should update location when navigating',
        fakeAsync(inject(
            [Router, TestComponentBuilder, Location],
-           (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */,
-            location: any /** TODO #9100 */) => {
+           (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */,
+            location: any /* TODO #9100 */) => {
              let fixture = tcb.createFakeAsync(RootCmp);
 
              router.navigateByUrl('/team/22/user/victor');
@@ -49,8 +49,8 @@ export function main() {
     it('should navigate back and forward',
        fakeAsync(inject(
            [Router, TestComponentBuilder, Location],
-           (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */,
-            location: any /** TODO #9100 */) => {
+           (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */,
+            location: any /* TODO #9100 */) => {
              let fixture = tcb.createFakeAsync(RootCmp);
 
              router.navigateByUrl('/team/33/simple');
@@ -71,8 +71,8 @@ export function main() {
     it('should navigate when locations changes',
        fakeAsync(inject(
            [Router, TestComponentBuilder, Location],
-           (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */,
-            location: any /** TODO #9100 */) => {
+           (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */,
+            location: any /* TODO #9100 */) => {
              let fixture = tcb.createFakeAsync(RootCmp);
 
              router.navigateByUrl('/team/22/user/victor');
@@ -88,7 +88,7 @@ export function main() {
     it('should support nested routes',
        fakeAsync(inject(
            [Router, TestComponentBuilder],
-           (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */) => {
+           (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */) => {
              let fixture = tcb.createFakeAsync(RootCmp);
 
              router.navigateByUrl('/team/22/user/victor');
@@ -101,7 +101,7 @@ export function main() {
     it('should support aux routes',
        fakeAsync(inject(
            [Router, TestComponentBuilder],
-           (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */) => {
+           (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */) => {
              let fixture = tcb.createFakeAsync(RootCmp);
 
              router.navigateByUrl('/team/22/user/victor(/simple)');
@@ -114,7 +114,7 @@ export function main() {
     it('should deactivate outlets',
        fakeAsync(inject(
            [Router, TestComponentBuilder],
-           (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */) => {
+           (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */) => {
              let fixture = tcb.createFakeAsync(RootCmp);
 
              router.navigateByUrl('/team/22/user/victor(/simple)');
@@ -130,7 +130,7 @@ export function main() {
     it('should deactivate nested outlets',
        fakeAsync(inject(
            [Router, TestComponentBuilder],
-           (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */) => {
+           (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */) => {
              let fixture = tcb.createFakeAsync(RootCmp);
 
              router.navigateByUrl('/team/22/user/victor(/simple)');
@@ -145,7 +145,7 @@ export function main() {
     it('should update nested routes when url changes',
        fakeAsync(inject(
            [Router, TestComponentBuilder],
-           (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */) => {
+           (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */) => {
              let fixture = tcb.createFakeAsync(RootCmp);
 
              router.navigateByUrl('/team/22/user/victor');
@@ -164,8 +164,8 @@ export function main() {
     it('should not deactivate the route if can deactivate returns false',
        fakeAsync(inject(
            [Router, TestComponentBuilder, Location],
-           (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */,
-            location: any /** TODO #9100 */) => {
+           (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */,
+            location: any /* TODO #9100 */) => {
              let fixture = tcb.createFakeAsync(RootCmp);
 
              router.navigateByUrl('/team/22/cannotDeactivate');
@@ -184,7 +184,7 @@ export function main() {
       it('should support absolute router links',
          fakeAsync(inject(
              [Router, TestComponentBuilder],
-             (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */) => {
+             (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */) => {
                let fixture = tcb.createFakeAsync(RootCmp);
                advance(fixture);
 
@@ -203,7 +203,7 @@ export function main() {
       it('should support relative router links',
          fakeAsync(inject(
              [Router, TestComponentBuilder],
-             (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */) => {
+             (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */) => {
                let fixture = tcb.createFakeAsync(RootCmp);
                advance(fixture);
 
@@ -225,7 +225,7 @@ export function main() {
       it('should set the router-link-active class',
          fakeAsync(inject(
              [Router, TestComponentBuilder],
-             (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */) => {
+             (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */) => {
                let fixture = tcb.createFakeAsync(RootCmp);
                advance(fixture);
 
@@ -245,7 +245,7 @@ export function main() {
       it('should update router links when router changes',
          fakeAsync(inject(
              [Router, TestComponentBuilder],
-             (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */) => {
+             (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */) => {
                let fixture = tcb.createFakeAsync(RootCmp);
                advance(fixture);
 
@@ -267,7 +267,7 @@ export function main() {
       it('should support top-level link',
          fakeAsync(inject(
              [Router, TestComponentBuilder],
-             (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */) => {
+             (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */) => {
                let fixture = tcb.createFakeAsync(LinkCmp);
                advance(fixture);
                expect(fixture.debugElement.nativeElement).toHaveText('link');
@@ -276,8 +276,8 @@ export function main() {
       it('should replace state when path is equal to current path',
          fakeAsync(inject(
              [Router, TestComponentBuilder, Location],
-             (router: any /** TODO #9100 */, tcb: any /** TODO #9100 */,
-              location: any /** TODO #9100 */) => {
+             (router: any /* TODO #9100 */, tcb: any /* TODO #9100 */,
+              location: any /* TODO #9100 */) => {
                let fixture = tcb.createFakeAsync(RootCmp);
 
                router.navigateByUrl('/team/33/simple');
@@ -310,15 +310,15 @@ function compileRoot(tcb: TestComponentBuilder): Promise<ComponentFixture<any>> 
 class UserCmp implements OnActivate {
   user: string;
   routerOnActivate(
-      s: RouteSegment, a?: any /** TODO #9100 */, b?: any /** TODO #9100 */,
-      c?: any /** TODO #9100 */) {
+      s: RouteSegment, a?: any /* TODO #9100 */, b?: any /* TODO #9100 */,
+      c?: any /* TODO #9100 */) {
     this.user = s.getParam('name');
   }
 }
 
 @Component({selector: 'cannot-deactivate', template: `cannotDeactivate`})
 class CanDeactivateCmp implements CanDeactivate {
-  routerCanDeactivate(a?: any /** TODO #9100 */, b?: any /** TODO #9100 */): Promise<boolean> {
+  routerCanDeactivate(a?: any /* TODO #9100 */, b?: any /* TODO #9100 */): Promise<boolean> {
     return PromiseWrapper.resolve(false);
   }
 }
@@ -365,8 +365,8 @@ class RelativeLinkCmp {
 class TeamCmp implements OnActivate {
   id: string;
   routerOnActivate(
-      s: RouteSegment, a?: any /** TODO #9100 */, b?: any /** TODO #9100 */,
-      c?: any /** TODO #9100 */) {
+      s: RouteSegment, a?: any /* TODO #9100 */, b?: any /* TODO #9100 */,
+      c?: any /* TODO #9100 */) {
     this.id = s.getParam('id');
   }
 }

--- a/modules/@angular/router/test/recognize_spec.ts
+++ b/modules/@angular/router/test/recognize_spec.ts
@@ -14,7 +14,7 @@ export function main() {
     it('should handle position args',
        inject(
            [AsyncTestCompleter, ComponentResolver],
-           (async: AsyncTestCompleter, resolver: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, resolver: any /* TODO #9100 */) => {
              recognize(resolver, ComponentA, tree('b/paramB/c/paramC/d'), emptyRouteTree)
                  .then(r => {
                    let a = r.root;
@@ -40,7 +40,7 @@ export function main() {
     it('should support empty routes',
        inject(
            [AsyncTestCompleter, ComponentResolver],
-           (async: AsyncTestCompleter, resolver: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, resolver: any /* TODO #9100 */) => {
              recognize(resolver, ComponentA, tree('f'), emptyRouteTree).then(r => {
                let a = r.root;
                expect(stringifyUrl(a.urlSegments)).toEqual(['']);
@@ -61,7 +61,7 @@ export function main() {
     it('should handle aux routes',
        inject(
            [AsyncTestCompleter, ComponentResolver],
-           (async: AsyncTestCompleter, resolver: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, resolver: any /* TODO #9100 */) => {
              recognize(resolver, ComponentA, tree('b/paramB(/d//right:d)'), emptyRouteTree)
                  .then(r => {
                    let c = r.children(r.root);
@@ -84,7 +84,7 @@ export function main() {
     it('should error when two segments with the same outlet name',
        inject(
            [AsyncTestCompleter, ComponentResolver],
-           (async: AsyncTestCompleter, resolver: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, resolver: any /* TODO #9100 */) => {
              recognize(resolver, ComponentA, tree('b/paramB(right:d//right:e)'), emptyRouteTree)
                  .catch(e => {
                    expect(e.message).toEqual(
@@ -96,7 +96,7 @@ export function main() {
     it('should handle nested aux routes',
        inject(
            [AsyncTestCompleter, ComponentResolver],
-           (async: AsyncTestCompleter, resolver: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, resolver: any /* TODO #9100 */) => {
              recognize(resolver, ComponentA, tree('b/paramB(/d(right:e))'), emptyRouteTree)
                  .then(r => {
                    let c = r.children(r.root);
@@ -119,7 +119,7 @@ export function main() {
     it('should handle non top-level aux routes',
        inject(
            [AsyncTestCompleter, ComponentResolver],
-           (async: AsyncTestCompleter, resolver: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, resolver: any /* TODO #9100 */) => {
              recognize(resolver, ComponentA, tree('b/paramB/d(e)'), emptyRouteTree).then(r => {
                let c = r.children(r.firstChild(r.root));
                expect(stringifyUrl(c[0].urlSegments)).toEqual(['d']);
@@ -137,7 +137,7 @@ export function main() {
     it('should handle matrix parameters',
        inject(
            [AsyncTestCompleter, ComponentResolver],
-           (async: AsyncTestCompleter, resolver: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, resolver: any /* TODO #9100 */) => {
              recognize(
                  resolver, ComponentA, tree('b/paramB;b1=1;b2=2(/d;d1=1;d2=2)'), emptyRouteTree)
                  .then(r => {
@@ -152,7 +152,7 @@ export function main() {
     it('should match a wildcard',
        inject(
            [AsyncTestCompleter, ComponentResolver],
-           (async: AsyncTestCompleter, resolver: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, resolver: any /* TODO #9100 */) => {
              recognize(resolver, ComponentG, tree('a;aa=1/b;bb=2'), emptyRouteTree).then(r => {
                let c = r.children(r.root);
                expect(c.length).toEqual(1);
@@ -166,7 +166,7 @@ export function main() {
     it('should error when no matching routes',
        inject(
            [AsyncTestCompleter, ComponentResolver],
-           (async: AsyncTestCompleter, resolver: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, resolver: any /* TODO #9100 */) => {
              recognize(resolver, ComponentA, tree('invalid'), emptyRouteTree).catch(e => {
                expect(e.message).toContain('Cannot match any routes');
                async.done();
@@ -176,7 +176,7 @@ export function main() {
     it('should handle no matching routes (too short)',
        inject(
            [AsyncTestCompleter, ComponentResolver],
-           (async: AsyncTestCompleter, resolver: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, resolver: any /* TODO #9100 */) => {
              recognize(resolver, ComponentA, tree('b'), emptyRouteTree).catch(e => {
                expect(e.message).toContain('Cannot match any routes');
                async.done();
@@ -186,7 +186,7 @@ export function main() {
     it('should error when a component doesn\'t have @Routes',
        inject(
            [AsyncTestCompleter, ComponentResolver],
-           (async: AsyncTestCompleter, resolver: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, resolver: any /* TODO #9100 */) => {
              recognize(resolver, ComponentA, tree('d/invalid'), emptyRouteTree).catch(e => {
                expect(e.message).toEqual(
                    'Component \'ComponentD\' does not have route configuration');
@@ -197,7 +197,7 @@ export function main() {
     it('should reuse existing segments',
        inject(
            [AsyncTestCompleter, ComponentResolver],
-           (async: AsyncTestCompleter, resolver: any /** TODO #9100 */) => {
+           (async: AsyncTestCompleter, resolver: any /* TODO #9100 */) => {
              recognize(resolver, ComponentA, tree('/b/1/d'), emptyRouteTree).then(t1 => {
                recognize(resolver, ComponentA, tree('/b/1/e'), t1).then(t2 => {
                  expect(t1.root).toBe(t2.root);

--- a/modules/@angular/router/test/router_link_spec.ts
+++ b/modules/@angular/router/test/router_link_spec.ts
@@ -15,8 +15,8 @@ export function main() {
              {provide: LocationStrategy, useClass: MockLocationStrategy}, {
                provide: Router,
                useFactory:
-                   (resolver: any /** TODO #9100 */, urlParser: any /** TODO #9100 */,
-                    outletMap: any /** TODO #9100 */, location: any /** TODO #9100 */) =>
+                   (resolver: any /* TODO #9100 */, urlParser: any /* TODO #9100 */,
+                    outletMap: any /* TODO #9100 */, location: any /* TODO #9100 */) =>
                        new Router(
                            'RootComponent', RootCmp, resolver, urlParser, outletMap, location),
                deps: [ComponentResolver, RouterUrlSerializer, RouterOutletMap, Location]
@@ -26,7 +26,7 @@ export function main() {
       it('should accept an array of commands',
          inject(
              [Router, LocationStrategy],
-             (router: any /** TODO #9100 */, locationStrategy: any /** TODO #9100 */) => {
+             (router: any /* TODO #9100 */, locationStrategy: any /* TODO #9100 */) => {
                let link = new RouterLink(null, router, locationStrategy);
                link.routerLink = ['/one', 11];
                expect(link.href).toEqual('/one/11');
@@ -35,7 +35,7 @@ export function main() {
       it('should accept a single command',
          inject(
              [Router, LocationStrategy],
-             (router: any /** TODO #9100 */, locationStrategy: any /** TODO #9100 */) => {
+             (router: any /* TODO #9100 */, locationStrategy: any /* TODO #9100 */) => {
                let link = new RouterLink(null, router, locationStrategy);
                link.routerLink = '/one/11';
                expect(link.href).toEqual('/one/11');

--- a/modules/@angular/router/testing/router_testing_providers.ts
+++ b/modules/@angular/router/testing/router_testing_providers.ts
@@ -29,7 +29,7 @@ export const ROUTER_FAKE_PROVIDERS: any[] = /*@ts2dart_const*/[
   },
   /*@ts2dart_Provider*/ {
     provide: RouteSegment,
-    useFactory: (r: any /** TODO #9100 */) => r.routeTree.root,
+    useFactory: (r: any /* TODO #9100 */) => r.routeTree.root,
     deps: [Router]
   }
 ];

--- a/modules/@angular/upgrade/src/downgrade_ng2_adapter.ts
+++ b/modules/@angular/upgrade/src/downgrade_ng2_adapter.ts
@@ -44,11 +44,11 @@ export class DowngradeNg2ComponentAdapter {
     var inputs = this.info.inputs;
     for (var i = 0; i < inputs.length; i++) {
       var input = inputs[i];
-      var expr: any /** TODO #9100 */ = null;
+      var expr: any /* TODO #9100 */ = null;
       if (attrs.hasOwnProperty(input.attr)) {
-        var observeFn = ((prop: any /** TODO #9100 */) => {
+        var observeFn = ((prop: any /* TODO #9100 */) => {
           var prevValue = INITIAL_VALUE;
-          return (value: any /** TODO #9100 */) => {
+          return (value: any /* TODO #9100 */) => {
             if (this.inputChanges !== null) {
               this.inputChangeCount++;
               this.inputChanges[prop] =
@@ -60,18 +60,18 @@ export class DowngradeNg2ComponentAdapter {
         })(input.prop);
         attrs.$observe(input.attr, observeFn);
       } else if (attrs.hasOwnProperty(input.bindAttr)) {
-        expr = (attrs as any /** TODO #9100 */)[input.bindAttr];
+        expr = (attrs as any /* TODO #9100 */)[input.bindAttr];
       } else if (attrs.hasOwnProperty(input.bracketAttr)) {
-        expr = (attrs as any /** TODO #9100 */)[input.bracketAttr];
+        expr = (attrs as any /* TODO #9100 */)[input.bracketAttr];
       } else if (attrs.hasOwnProperty(input.bindonAttr)) {
-        expr = (attrs as any /** TODO #9100 */)[input.bindonAttr];
+        expr = (attrs as any /* TODO #9100 */)[input.bindonAttr];
       } else if (attrs.hasOwnProperty(input.bracketParenAttr)) {
-        expr = (attrs as any /** TODO #9100 */)[input.bracketParenAttr];
+        expr = (attrs as any /* TODO #9100 */)[input.bracketParenAttr];
       }
       if (expr != null) {
         var watchFn =
-            ((prop: any /** TODO #9100 */) =>
-                 (value: any /** TODO #9100 */, prevValue: any /** TODO #9100 */) => {
+            ((prop: any /* TODO #9100 */) =>
+                 (value: any /* TODO #9100 */, prevValue: any /* TODO #9100 */) => {
                    if (this.inputChanges != null) {
                      this.inputChangeCount++;
                      this.inputChanges[prop] = new Ng1Change(prevValue, value);
@@ -110,7 +110,7 @@ export class DowngradeNg2ComponentAdapter {
     var outputs = this.info.outputs;
     for (var j = 0; j < outputs.length; j++) {
       var output = outputs[j];
-      var expr: any /** TODO #9100 */ = null;
+      var expr: any /* TODO #9100 */ = null;
       var assignExpr = false;
 
       var bindonAttr =
@@ -120,14 +120,14 @@ export class DowngradeNg2ComponentAdapter {
           null;
 
       if (attrs.hasOwnProperty(output.onAttr)) {
-        expr = (attrs as any /** TODO #9100 */)[output.onAttr];
+        expr = (attrs as any /* TODO #9100 */)[output.onAttr];
       } else if (attrs.hasOwnProperty(output.parenAttr)) {
-        expr = (attrs as any /** TODO #9100 */)[output.parenAttr];
+        expr = (attrs as any /* TODO #9100 */)[output.parenAttr];
       } else if (attrs.hasOwnProperty(bindonAttr)) {
-        expr = (attrs as any /** TODO #9100 */)[bindonAttr];
+        expr = (attrs as any /* TODO #9100 */)[bindonAttr];
         assignExpr = true;
       } else if (attrs.hasOwnProperty(bracketParenAttr)) {
-        expr = (attrs as any /** TODO #9100 */)[bracketParenAttr];
+        expr = (attrs as any /* TODO #9100 */)[bracketParenAttr];
         assignExpr = true;
       }
 
@@ -141,8 +141,8 @@ export class DowngradeNg2ComponentAdapter {
         if (emitter) {
           emitter.subscribe({
             next: assignExpr ?
-                ((setter: any) => (v: any /** TODO #9100 */) => setter(this.scope, v))(setter) :
-                ((getter: any) => (v: any /** TODO #9100 */) =>
+                ((setter: any) => (v: any /* TODO #9100 */) => setter(this.scope, v))(setter) :
+                ((getter: any) => (v: any /* TODO #9100 */) =>
                      getter(this.scope, {$event: v}))(getter)
           });
         } else {

--- a/modules/@angular/upgrade/src/metadata.ts
+++ b/modules/@angular/upgrade/src/metadata.ts
@@ -30,7 +30,7 @@ export function getComponentInfo(type: Type): ComponentInfo {
     throw new Error('Only selectors matching element names are supported, got: ' + selector);
   }
   var selector = selector.replace(
-      SKEWER_CASE, (all: any /** TODO #9100 */, letter: string) => letter.toUpperCase());
+      SKEWER_CASE, (all: any /* TODO #9100 */, letter: string) => letter.toUpperCase());
   return {
     type: type,
     selector: selector,

--- a/modules/@angular/upgrade/src/upgrade_ng1_adapter.ts
+++ b/modules/@angular/upgrade/src/upgrade_ng1_adapter.ts
@@ -26,7 +26,7 @@ export class UpgradeNg1ComponentAdapterBuilder {
 
   constructor(public name: string) {
     var selector = name.replace(
-        CAMEL_CASE, (all: any /** TODO #9100 */, next: string) => '-' + next.toLowerCase());
+        CAMEL_CASE, (all: any /* TODO #9100 */, next: string) => '-' + next.toLowerCase());
     var self = this;
     this.type =
         Directive({selector: selector, inputs: this.inputsRename, outputs: this.outputsRename})
@@ -130,8 +130,7 @@ export class UpgradeNg1ComponentAdapterBuilder {
       } else {
         return new Promise((resolve, err) => {
           httpBackend(
-              'GET', url, null,
-              (status: any /** TODO #9100 */, response: any /** TODO #9100 */) => {
+              'GET', url, null, (status: any /* TODO #9100 */, response: any /* TODO #9100 */) => {
                 if (status == 200) {
                   resolve(this.linkFn = compileHtml(templateCache.put(url, response)));
                 } else {
@@ -144,7 +143,7 @@ export class UpgradeNg1ComponentAdapterBuilder {
       throw new Error(`Directive '${this.name}' is not a component, it is missing template.`);
     }
     return null;
-    function compileHtml(html: any /** TODO #9100 */): angular.ILinkFn {
+    function compileHtml(html: any /* TODO #9100 */): angular.ILinkFn {
       var div = document.createElement('div');
       div.innerHTML = html;
       return compile(div.childNodes);
@@ -154,7 +153,7 @@ export class UpgradeNg1ComponentAdapterBuilder {
   static resolve(
       exportedComponents: {[name: string]: UpgradeNg1ComponentAdapterBuilder},
       injector: angular.IInjectorService): Promise<any> {
-    var promises: any[] /** TODO #9100 */ = [];
+    var promises: any[] /* TODO #9100 */ = [];
     var compile: angular.ICompileService = injector.get(NG1_COMPILE);
     var templateCache: angular.ITemplateCacheService = injector.get(NG1_TEMPLATE_CACHE);
     var httpBackend: angular.IHttpBackendService = injector.get(NG1_HTTP_BACKEND);
@@ -196,16 +195,16 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
     }
 
     for (var i = 0; i < inputs.length; i++) {
-      (this as any /** TODO #9100 */)[inputs[i]] = null;
+      (this as any /* TODO #9100 */)[inputs[i]] = null;
     }
     for (var j = 0; j < outputs.length; j++) {
-      var emitter = (this as any /** TODO #9100 */)[outputs[j]] = new EventEmitter();
+      var emitter = (this as any /* TODO #9100 */)[outputs[j]] = new EventEmitter();
       this.setComponentProperty(
-          outputs[j], ((emitter: any /** TODO #9100 */) => (value: any /** TODO #9100 */) =>
+          outputs[j], ((emitter: any /* TODO #9100 */) => (value: any /* TODO #9100 */) =>
                            emitter.emit(value))(emitter));
     }
     for (var k = 0; k < propOuts.length; k++) {
-      (this as any /** TODO #9100 */)[propOuts[k]] = new EventEmitter();
+      (this as any /* TODO #9100 */)[propOuts[k]] = new EventEmitter();
       this.checkLastValues.push(INITIAL_VALUE);
     }
   }
@@ -225,7 +224,7 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
     }
 
     var childNodes: Node[] = [];
-    var childNode: any /** TODO #9100 */;
+    var childNode: any /* TODO #9100 */;
     while (childNode = this.element.firstChild) {
       this.element.removeChild(childNode);
       childNodes.push(childNode);
@@ -235,8 +234,9 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
         this.element.appendChild(clonedElement[i]);
       }
     }, {
-      parentBoundTranscludeFn: (scope: any /** TODO #9100 */,
-                                cloneAttach: any /** TODO #9100 */) => { cloneAttach(childNodes); }
+      parentBoundTranscludeFn: (scope: any /* TODO #9100 */, cloneAttach: any /* TODO #9100 */) => {
+        cloneAttach(childNodes);
+      }
     });
     if (this.destinationObj.$onInit) {
       this.destinationObj.$onInit();
@@ -264,7 +264,7 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
         if (typeof value == 'number' && isNaN(value) && typeof last == 'number' && isNaN(last)) {
           // ignore because NaN != NaN
         } else {
-          var eventEmitter: EventEmitter<any> = (this as any /** TODO #9100 */)[this.propOuts[i]];
+          var eventEmitter: EventEmitter<any> = (this as any /* TODO #9100 */)[this.propOuts[i]];
           eventEmitter.emit(lastValues[i] = value);
         }
       }
@@ -276,7 +276,7 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
     this.destinationObj[this.propertyMap[name]] = value;
   }
 
-  private buildController(controllerType: any /** TODO #9100 */) {
+  private buildController(controllerType: any /* TODO #9100 */) {
     var locals = {$scope: this.componentScope, $element: this.$element};
     var controller: any =
         this.$controller(controllerType, locals, null, this.directive.controllerAs);
@@ -314,7 +314,7 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
       }
       return dep;
     } else if (require instanceof Array) {
-      var deps: any[] /** TODO #9100 */ = [];
+      var deps: any[] /* TODO #9100 */ = [];
       for (var i = 0; i < require.length; i++) {
         deps.push(this.resolveRequired($element, require[i]));
       }

--- a/modules/@angular/upgrade/test/upgrade_spec.ts
+++ b/modules/@angular/upgrade/test/upgrade_spec.ts
@@ -54,8 +54,8 @@ export function main() {
       it('should interleave scope and component expressions',
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
            var ng1Module = angular.module('ng1', []);
-           var log: any[] /** TODO #9100 */ = [];
-           var l = function(value: any /** TODO #9100 */) {
+           var log: any[] /* TODO #9100 */ = [];
+           var l = function(value: any /* TODO #9100 */) {
              log.push(value);
              return value + ';';
            };
@@ -63,7 +63,7 @@ export function main() {
 
            ng1Module.directive('ng1a', () => { return {template: '{{ l(\'ng1a\') }}'}; });
            ng1Module.directive('ng1b', () => { return {template: '{{ l(\'ng1b\') }}'}; });
-           ng1Module.run(($rootScope: any /** TODO #9100 */) => {
+           ng1Module.run(($rootScope: any /* TODO #9100 */) => {
              $rootScope.l = l;
              $rootScope.reset = () => log.length = 0;
            });
@@ -96,7 +96,7 @@ export function main() {
            var adapter: UpgradeAdapter = new UpgradeAdapter();
            var ng1Module = angular.module('ng1', []);
 
-           ng1Module.run(($rootScope: any /** TODO #9100 */) => {
+           ng1Module.run(($rootScope: any /* TODO #9100 */) => {
              $rootScope.dataA = 'A';
              $rootScope.dataB = 'B';
              $rootScope.modelA = 'initModelA';
@@ -131,14 +131,14 @@ export function main() {
                this.twoWayAEmitter = new EventEmitter();
                this.twoWayBEmitter = new EventEmitter();
              },
-             ngOnChanges: function(changes: any /** TODO #9100 */) {
-               var assert = (prop: any /** TODO #9100 */, value: any /** TODO #9100 */) => {
+             ngOnChanges: function(changes: any /* TODO #9100 */) {
+               var assert = (prop: any /* TODO #9100 */, value: any /* TODO #9100 */) => {
                  if (this[prop] != value) {
                    throw new Error(`Expected: '${prop}' to be '${value}' but was '${this[prop]}'`);
                  }
                };
 
-               var assertChange = (prop: any /** TODO #9100 */, value: any /** TODO #9100 */) => {
+               var assertChange = (prop: any /* TODO #9100 */, value: any /* TODO #9100 */) => {
                  assert(prop, value);
                  if (!changes[prop]) {
                    throw new Error(`Changes record for '${prop}' not found.`);
@@ -207,7 +207,7 @@ export function main() {
              return {
                template: '<div ng-if="!destroyIt"><ng2></ng2></div>',
                controller: function(
-                   $rootScope: any /** TODO #9100 */, $timeout: any /** TODO #9100 */) {
+                   $rootScope: any /* TODO #9100 */, $timeout: any /* TODO #9100 */) {
                  $timeout(function() { $rootScope.destroyIt = true; });
                }
              };
@@ -233,11 +233,11 @@ export function main() {
 
            ng1Module.directive('ng1', [
              '$compile',
-             ($compile: any /** TODO #9100 */) => {
+             ($compile: any /* TODO #9100 */) => {
                return {
                  link: function(
-                     $scope: any /** TODO #9100 */, $element: any /** TODO #9100 */,
-                     $attrs: any /** TODO #9100 */) {
+                     $scope: any /* TODO #9100 */, $element: any /* TODO #9100 */,
+                     $attrs: any /* TODO #9100 */) {
                    var compiled = $compile('<ng2></ng2>');
                    var template = compiled($scope);
                    $element.append(template);
@@ -268,8 +268,8 @@ export function main() {
              return {
                template: 'Hello {{fullName}}; A: {{dataA}}; B: {{dataB}}; | ',
                scope: {fullName: '@', modelA: '=dataA', modelB: '=dataB', event: '&'},
-               link: function(scope: any /** TODO #9100 */) {
-                 scope.$watch('dataB', (v: any /** TODO #9100 */) => {
+               link: function(scope: any /* TODO #9100 */) {
+                 scope.$watch('dataB', (v: any /* TODO #9100 */) => {
                    if (v == 'Savkin') {
                      scope.dataB = 'SAVKIN';
                      scope.event('WORKS');
@@ -323,7 +323,7 @@ export function main() {
                restrict: 'E',
                template: '{{someText}} - Length: {{data.length}}',
                scope: {data: '='},
-               controller: function($scope: any /** TODO #9100 */) {
+               controller: function($scope: any /* TODO #9100 */) {
                  $scope.someText = 'ng1 - Data: ' + $scope.data;
                }
              };
@@ -367,7 +367,7 @@ export function main() {
                restrict: 'E',
                template: '{{someText}} - Length: {{data.length}}',
                scope: {data: '='},
-               link: function($scope: any /** TODO #9100 */) {
+               link: function($scope: any /* TODO #9100 */) {
                  $scope.someText = 'ng1 - Data: ' + $scope.data;
                }
              };
@@ -406,9 +406,9 @@ export function main() {
            var adapter = new UpgradeAdapter();
            var ng1Module = angular.module('ng1', []);
            ng1Module.value(
-               '$httpBackend', (method: any /** TODO #9100 */, url: any /** TODO #9100 */,
-                                post: any /** TODO #9100 */,
-                                cbFn: any /** TODO #9100 */) => { cbFn(200, `${method}:${url}`); });
+               '$httpBackend',
+               (method: any /* TODO #9100 */, url: any /* TODO #9100 */, post: any /* TODO #9100 */,
+                cbFn: any /* TODO #9100 */) => { cbFn(200, `${method}:${url}`); });
 
            var ng1 = function() { return {templateUrl: 'url.html'}; };
            ng1Module.directive('ng1', ng1);
@@ -431,9 +431,9 @@ export function main() {
            var adapter = new UpgradeAdapter();
            var ng1Module = angular.module('ng1', []);
            ng1Module.value(
-               '$httpBackend', (method: any /** TODO #9100 */, url: any /** TODO #9100 */,
-                                post: any /** TODO #9100 */,
-                                cbFn: any /** TODO #9100 */) => { cbFn(200, `${method}:${url}`); });
+               '$httpBackend',
+               (method: any /* TODO #9100 */, url: any /* TODO #9100 */, post: any /* TODO #9100 */,
+                cbFn: any /* TODO #9100 */) => { cbFn(200, `${method}:${url}`); });
 
            var ng1 = function() { return {templateUrl() { return 'url.html' }}; };
            ng1Module.directive('ng1', ng1);
@@ -498,7 +498,7 @@ export function main() {
            var adapter = new UpgradeAdapter();
            var ng1Module = angular.module('ng1', []);
            ng1Module.run(
-               ($templateCache: any /** TODO #9100 */) => $templateCache.put('url.html', 'WORKS'));
+               ($templateCache: any /* TODO #9100 */) => $templateCache.put('url.html', 'WORKS'));
 
            var ng1 = function() { return {templateUrl: 'url.html'}; };
            ng1Module.directive('ng1', ng1);
@@ -529,7 +529,7 @@ export function main() {
                controllerAs: 'ctl',
                controller: Class({
                  constructor: function(
-                     $scope: any /** TODO #9100 */, $element: any /** TODO #9100 */) {
+                     $scope: any /* TODO #9100 */, $element: any /* TODO #9100 */) {
                    (<any>this).verifyIAmAClass();
                    this.scope = $scope.$parent.$parent == $scope.$root ? 'scope' : 'wrong-scope';
                    this.hasElement = $element[0].nodeName;
@@ -620,7 +620,7 @@ export function main() {
            var adapter = new UpgradeAdapter();
            var ng1Module = angular.module('ng1', []);
 
-           var ng1 = function($rootScope: any /** TODO #9100 */) {
+           var ng1 = function($rootScope: any /* TODO #9100 */) {
              return {
                scope: {title: '@'},
                bindToController: true,
@@ -629,8 +629,8 @@ export function main() {
                controllerAs: 'ctrl',
                controller: Class({constructor: function() { this.status = 'WORKS'; }}),
                link: function(
-                   scope: any /** TODO #9100 */, element: any /** TODO #9100 */,
-                   attrs: any /** TODO #9100 */, linkController: any /** TODO #9100 */) {
+                   scope: any /* TODO #9100 */, element: any /* TODO #9100 */,
+                   attrs: any /* TODO #9100 */, linkController: any /* TODO #9100 */) {
                  expect(scope.$root).toEqual($rootScope);
                  expect(element[0].nodeName).toEqual('NG1');
                  expect(linkController.status).toEqual('WORKS');
@@ -670,8 +670,8 @@ export function main() {
                controllerAs: 'ctrl',
                controller: Class({constructor: function() { this.status = 'WORKS'; }}),
                link: function(
-                   scope: any /** TODO #9100 */, element: any /** TODO #9100 */,
-                   attrs: any /** TODO #9100 */, linkControllers: any /** TODO #9100 */) {
+                   scope: any /* TODO #9100 */, element: any /* TODO #9100 */,
+                   attrs: any /* TODO #9100 */, linkControllers: any /* TODO #9100 */) {
                  expect(linkControllers[0].status).toEqual('WORKS');
                  expect(linkControllers[1].parent).toEqual('PARENT');
                  expect(linkControllers[2]).toBe(undefined);

--- a/modules/playground/e2e_test/alt_routing/routing_spec.ts
+++ b/modules/playground/e2e_test/alt_routing/routing_spec.ts
@@ -1,6 +1,6 @@
 import {verifyNoBrowserErrors} from '@angular/platform-browser/testing_e2e';
 
-function waitForElement(selector: any /** TODO #9100 */) {
+function waitForElement(selector: any /* TODO #9100 */) {
   var EC = (<any>protractor).ExpectedConditions;
   // Waits for the element with id 'abc' to be present on the dom.
   browser.wait(EC.presenceOf($(selector)), 20000);

--- a/modules/playground/e2e_test/hash_routing/hash_location_spec.ts
+++ b/modules/playground/e2e_test/hash_routing/hash_location_spec.ts
@@ -1,6 +1,6 @@
 import {verifyNoBrowserErrors} from '@angular/platform-browser/testing_e2e';
 
-function waitForElement(selector: any /** TODO #9100 */) {
+function waitForElement(selector: any /* TODO #9100 */) {
   var EC = (<any>protractor).ExpectedConditions;
   // Waits for the element with id 'abc' to be present on the dom.
   browser.wait(EC.presenceOf($(selector)), 20000);

--- a/modules/playground/e2e_test/hello_world/hello_world_spec.ts
+++ b/modules/playground/e2e_test/hello_world/hello_world_spec.ts
@@ -23,12 +23,12 @@ describe('hello world', function() {
 
 });
 
-function getComponentText(selector: any /** TODO #9100 */, innerSelector: any /** TODO #9100 */) {
+function getComponentText(selector: any /* TODO #9100 */, innerSelector: any /* TODO #9100 */) {
   return browser.executeScript('return document.querySelector("' + selector + '").querySelector("' +
                                innerSelector + '").textContent');
 }
 
-function clickComponentButton(selector: any /** TODO #9100 */, innerSelector: any /** TODO #9100 */) {
+function clickComponentButton(selector: any /* TODO #9100 */, innerSelector: any /* TODO #9100 */) {
   return browser.executeScript('return document.querySelector("' + selector + '").querySelector("' +
                                innerSelector + '").click()');
 }

--- a/modules/playground/e2e_test/http/http_spec.ts
+++ b/modules/playground/e2e_test/http/http_spec.ts
@@ -14,7 +14,7 @@ describe('http', function() {
   });
 });
 
-function getComponentText(selector: any /** TODO #9100 */, innerSelector: any /** TODO #9100 */) {
+function getComponentText(selector: any /* TODO #9100 */, innerSelector: any /* TODO #9100 */) {
   return browser.executeScript('return document.querySelector("' + selector + '").querySelector("' +
                                innerSelector + '").textContent.trim()');
 }

--- a/modules/playground/e2e_test/jsonp/jsonp_spec.ts
+++ b/modules/playground/e2e_test/jsonp/jsonp_spec.ts
@@ -14,7 +14,7 @@ describe('jsonp', function() {
   });
 });
 
-function getComponentText(selector: any /** TODO #9100 */, innerSelector: any /** TODO #9100 */) {
+function getComponentText(selector: any /* TODO #9100 */, innerSelector: any /* TODO #9100 */) {
   return browser.executeScript('return document.querySelector("' + selector + '").querySelector("' +
                                innerSelector + '").textContent.trim()');
 }

--- a/modules/playground/e2e_test/relative_assets/assets_spec.ts
+++ b/modules/playground/e2e_test/relative_assets/assets_spec.ts
@@ -1,6 +1,6 @@
 import {verifyNoBrowserErrors} from '@angular/platform-browser/testing_e2e';
 
-function waitForElement(selector: any /** TODO #9100 */) {
+function waitForElement(selector: any /* TODO #9100 */) {
   var EC = (<any>protractor).ExpectedConditions;
   // Waits for the element with id 'abc' to be present on the dom.
   browser.wait(EC.presenceOf($(selector)), 20000);
@@ -24,7 +24,7 @@ describe('relative assets relative-app', () => {
 
     waitForElement('my-cmp .inner-container');
     var elem = element(by.css('my-cmp .inner-container'));
-    var width = browser.executeScript(function(e: any /** TODO #9100 */) {
+    var width = browser.executeScript(function(e: any /* TODO #9100 */) {
       return parseInt(window.getComputedStyle(e).width);
     }, elem.getWebElement());
 

--- a/modules/playground/e2e_test/routing/routing_spec.ts
+++ b/modules/playground/e2e_test/routing/routing_spec.ts
@@ -1,6 +1,6 @@
 import {verifyNoBrowserErrors} from '@angular/platform-browser/testing_e2e';
 
-function waitForElement(selector: any /** TODO #9100 */) {
+function waitForElement(selector: any /* TODO #9100 */) {
   var EC = (<any>protractor).ExpectedConditions;
   // Waits for the element with id 'abc' to be present on the dom.
   browser.wait(EC.presenceOf($(selector)), 20000);

--- a/modules/playground/e2e_test/sourcemap/sourcemap_spec.ts
+++ b/modules/playground/e2e_test/sourcemap/sourcemap_spec.ts
@@ -15,8 +15,8 @@ describe('sourcemaps', function() {
     // so that the browser logs can be read out!
     browser.executeScript('1+1');
     browser.manage().logs().get('browser').then(function(logs) {
-      var errorLine: any /** TODO #9100 */ = null;
-      var errorColumn: any /** TODO #9100 */ = null;
+      var errorLine: any /* TODO #9100 */ = null;
+      var errorColumn: any /* TODO #9100 */ = null;
       logs.forEach(function(log) {
         var match = /\.createError\s+\(.+:(\d+):(\d+)/m.exec(log.message);
         if (match) {

--- a/modules/playground/e2e_test/web_workers/router/router_spec.ts
+++ b/modules/playground/e2e_test/web_workers/router/router_spec.ts
@@ -64,7 +64,7 @@ describe("WebWorker Router", () => {
     }, 5000);
   }
 
-  function waitForUrl(regex: any /** TODO #9100 */): void {
+  function waitForUrl(regex: any /* TODO #9100 */): void {
     browser.wait(() => {
       let deferred = protractor.promise.defer();
       browser.getCurrentUrl().then(

--- a/modules/playground/src/alt_routing/app/inbox-app.ts
+++ b/modules/playground/src/alt_routing/app/inbox-app.ts
@@ -53,8 +53,8 @@ class InboxRecord {
     this.subject = record['subject'];
     this.content = record['content'];
     this.email = record['email'];
-    this.firstName = (record as any /** TODO #9100 */)['first-name'];
-    this.lastName = (record as any /** TODO #9100 */)['last-name'];
+    this.firstName = (record as any /* TODO #9100 */)['first-name'];
+    this.lastName = (record as any /* TODO #9100 */)['last-name'];
     this.date = record['date'];
     this.draft = record['draft'] == true;
   }
@@ -79,7 +79,7 @@ class DbService {
                                    data.filter(record => !isPresent(record['draft'])));
   }
 
-  email(id: any /** TODO #9100 */): Promise<any> {
+  email(id: any /* TODO #9100 */): Promise<any> {
     return PromiseWrapper.then(this.getData(), (data: any[]) => {
       for (var i = 0; i < data.length; i++) {
         var entry = data[i];

--- a/modules/playground/src/animate/app/animate-app.ts
+++ b/modules/playground/src/animate/app/animate-app.ts
@@ -60,8 +60,8 @@ import {
   ]
 })
 export class AnimateApp {
-  public items: any[] /** TODO #9100 */ = [];
-  public _state: any /** TODO #9100 */;
+  public items: any[] /* TODO #9100 */ = [];
+  public _state: any /* TODO #9100 */;
 
   public bgStatus = 'focus';
 

--- a/modules/playground/src/async/index.ts
+++ b/modules/playground/src/async/index.ts
@@ -33,9 +33,9 @@ class AsyncApplication {
   val2: number = 0;
   val3: number = 0;
   val4: number = 0;
-  timeoutId: any /** TODO #9100 */ = null;
-  multiTimeoutId: any /** TODO #9100 */ = null;
-  intervalId: any /** TODO #9100 */ = null;
+  timeoutId: any /* TODO #9100 */ = null;
+  multiTimeoutId: any /* TODO #9100 */ = null;
+  intervalId: any /* TODO #9100 */ = null;
 
   increment(): void { this.val1++; };
 
@@ -51,7 +51,7 @@ class AsyncApplication {
     this.cancelMultiDelayedIncrements();
 
     var self = this;
-    function helper(_i: any /** TODO #9100 */) {
+    function helper(_i: any /* TODO #9100 */) {
       if (_i <= 0) {
         self.multiTimeoutId = null;
         return;

--- a/modules/playground/src/bootstrap.ts
+++ b/modules/playground/src/bootstrap.ts
@@ -1,7 +1,7 @@
 declare var System: any;
 
 
-(function(global: any /** TODO #9100 */) {
+(function(global: any /* TODO #9100 */) {
 
   writeScriptTag('/all/playground/vendor/es6-shim.js');
   writeScriptTag('/all/playground/vendor/zone.js');
@@ -59,11 +59,13 @@ declare var System: any;
 
 
     // BOOTSTRAP the app!
-    System.import('index').then(function(m: any /** TODO #9100 */) { m.main(); }, console.error.bind(console));
+    System.import('index').then(function(m: any /* TODO #9100 */) {
+      m.main();
+    }, console.error.bind(console));
   }
 
 
-  function writeScriptTag(scriptUrl: any /** TODO #9100 */, onload?: any /** TODO #9100 */) {
+  function writeScriptTag(scriptUrl: any /* TODO #9100 */, onload?: any /* TODO #9100 */) {
     document.write(`<script src="${scriptUrl}" onload="${onload}"></script>`);
   }
 }(window));

--- a/modules/playground/src/gestures/index.ts
+++ b/modules/playground/src/gestures/index.ts
@@ -7,11 +7,13 @@ class GesturesCmp {
   pinchScale: number = 1;
   rotateAngle: number = 0;
 
-  onSwipe(event: any /** TODO #9100 */): void { this.swipeDirection = event.deltaX > 0 ? 'right' : 'left'; }
+  onSwipe(event: any /* TODO #9100 */): void {
+    this.swipeDirection = event.deltaX > 0 ? 'right' : 'left';
+  }
 
-  onPinch(event: any /** TODO #9100 */): void { this.pinchScale = event.scale; }
+  onPinch(event: any /* TODO #9100 */): void { this.pinchScale = event.scale; }
 
-  onRotate(event: any /** TODO #9100 */): void { this.rotateAngle = event.rotation; }
+  onRotate(event: any /* TODO #9100 */): void { this.rotateAngle = event.rotation; }
 }
 
 export function main() {

--- a/modules/playground/src/key_events/index.ts
+++ b/modules/playground/src/key_events/index.ts
@@ -18,12 +18,12 @@ class KeyEventsApp {
   lastKey: string = '(none)';
   shiftEnter: boolean = false;
 
-  onKeyDown(event: any /** TODO #9100 */): void {
+  onKeyDown(event: any /* TODO #9100 */): void {
     this.lastKey = KeyEventsPlugin.getEventFullKey(event);
     event.preventDefault();
   }
 
-  onShiftEnter(event: any /** TODO #9100 */): void {
+  onShiftEnter(event: any /* TODO #9100 */): void {
     this.shiftEnter = true;
     event.preventDefault();
   }

--- a/modules/playground/src/model_driven_forms/index.ts
+++ b/modules/playground/src/model_driven_forms/index.ts
@@ -48,7 +48,7 @@ function creditCardValidator(c: AbstractControl): {[key: string]: boolean} {
   directives: [NgIf]
 })
 class ShowError {
-  formDir: any /** TODO #9100 */;
+  formDir: any /* TODO #9100 */;
   controlPath: string;
   errorTypes: string[];
 
@@ -69,7 +69,7 @@ class ShowError {
 
   _errorMessage(code: string): string {
     var config = {'required': 'is required', 'invalidCreditCard': 'is invalid credit card number'};
-    return (config as any /** TODO #9100 */)[code];
+    return (config as any /* TODO #9100 */)[code];
   }
 }
 
@@ -135,7 +135,7 @@ class ShowError {
   directives: [FORM_DIRECTIVES, NgFor, ShowError]
 })
 class ModelDrivenForms {
-  form: any /** TODO #9100 */;
+  form: any /* TODO #9100 */;
   countries = ['US', 'Canada'];
 
   constructor(fb: FormBuilder) {

--- a/modules/playground/src/routing/app/inbox-app.ts
+++ b/modules/playground/src/routing/app/inbox-app.ts
@@ -49,8 +49,8 @@ class InboxRecord {
     this.subject = record['subject'];
     this.content = record['content'];
     this.email = record['email'];
-    this.firstName = (record as any /** TODO #9100 */)['first-name'];
-    this.lastName = (record as any /** TODO #9100 */)['last-name'];
+    this.firstName = (record as any /* TODO #9100 */)['first-name'];
+    this.lastName = (record as any /* TODO #9100 */)['last-name'];
     this.date = record['date'];
     this.draft = record['draft'] == true;
   }
@@ -75,7 +75,7 @@ class DbService {
                                    data.filter(record => !isPresent(record['draft'])));
   }
 
-  email(id: any /** TODO #9100 */): Promise<any> {
+  email(id: any /* TODO #9100 */): Promise<any> {
     return PromiseWrapper.then(this.getData(), (data: any[]) => {
       for (var i = 0; i < data.length; i++) {
         var entry = data[i];

--- a/modules/playground/src/template_driven_forms/index.ts
+++ b/modules/playground/src/template_driven_forms/index.ts
@@ -31,7 +31,7 @@ class CheckoutModel {
 /**
  * Custom validator.
  */
-function creditCardValidator(c: any /** TODO #9100 */): {[key: string]: boolean} {
+function creditCardValidator(c: any /* TODO #9100 */): {[key: string]: boolean} {
   if (isPresent(c.value) && RegExpWrapper.test(/^\d{16}$/g, c.value)) {
     return null;
   } else {
@@ -73,7 +73,7 @@ class CreditCardValidator {
   directives: [NgIf]
 })
 class ShowError {
-  formDir: any /** TODO #9100 */;
+  formDir: any /* TODO #9100 */;
   controlPath: string;
   errorTypes: string[];
 
@@ -94,7 +94,7 @@ class ShowError {
 
   _errorMessage(code: string): string {
     var config = {'required': 'is required', 'invalidCreditCard': 'is invalid credit card number'};
-    return (config as any /** TODO #9100 */)[code];
+    return (config as any /* TODO #9100 */)[code];
   }
 }
 

--- a/modules/playground/src/todo/index.ts
+++ b/modules/playground/src/todo/index.ts
@@ -14,14 +14,14 @@ class TodoApp {
 
   constructor(public todoStore: Store<Todo>, public factory: TodoFactory) {}
 
-  enterTodo(inputElement: any /** TODO #9100 */): void {
+  enterTodo(inputElement: any /* TODO #9100 */): void {
     this.addTodo(inputElement.value);
     inputElement.value = '';
   }
 
   editTodo(todo: Todo): void { this.todoEdit = todo; }
 
-  doneEditing($event: any /** TODO #9100 */, todo: Todo): void {
+  doneEditing($event: any /* TODO #9100 */, todo: Todo): void {
     var which = $event.which;
     var target = $event.target;
     if (which === 13) {
@@ -39,7 +39,7 @@ class TodoApp {
 
   deleteMe(todo: Todo): void { this.todoStore.remove(todo); }
 
-  toggleAll($event: any /** TODO #9100 */): void {
+  toggleAll($event: any /* TODO #9100 */): void {
     var isComplete = $event.target.checked;
     this.todoStore.list.forEach((todo: Todo) => { todo.completed = isComplete; });
   }

--- a/modules/playground/src/upgrade/index.ts
+++ b/modules/playground/src/upgrade/index.ts
@@ -22,7 +22,7 @@ var adapter: UpgradeAdapter = new UpgradeAdapter();
 
 var ng1module = angular.module('myExample', []);
 
-ng1module.controller('Index', function($scope: any /** TODO #9100 */) { $scope.name = 'World'; });
+ng1module.controller('Index', function($scope: any /* TODO #9100 */) { $scope.name = 'World'; });
 
 ng1module.directive('user', function() {
   return {

--- a/modules/playground/src/web_workers/images/index_common.ts
+++ b/modules/playground/src/web_workers/images/index_common.ts
@@ -7,12 +7,12 @@ import {FileReader, Uint8ArrayWrapper} from './file_api';
 
 @Component({selector: 'image-demo', viewProviders: [BitmapService], templateUrl: 'image_demo.html'})
 export class ImageDemo {
-  images: any[] /** TODO #9100 */ = [];
+  images: any[] /* TODO #9100 */ = [];
   fileInput: String;
 
   constructor(private _bitmapService: BitmapService) {}
 
-  uploadFiles(files: any /** TODO #9100 */) {
+  uploadFiles(files: any /* TODO #9100 */) {
     for (var i = 0; i < files.length; i++) {
       var reader = new FileReader();
       reader.addEventListener("load", this.handleReaderLoad(reader));

--- a/modules/playground/src/web_workers/images/services/bitmap.ts
+++ b/modules/playground/src/web_workers/images/services/bitmap.ts
@@ -1,6 +1,6 @@
 /// <reference path="../bitmap.d.ts" /> /// <reference path="../b64.d.ts" />
 import {Injectable} from '@angular/core';
-declare var base64js: any /** TODO #9100 */;
+declare var base64js: any /* TODO #9100 */;
 
 // Temporary fix for Typescript issue #4220 (https://github.com/Microsoft/TypeScript/issues/4220)
 // var _ImageData: (width: number, height: number) => void = <any>postMessage;
@@ -151,7 +151,7 @@ export class BitmapService {
   // Based on example from
   // http://www.worldwidewhat.net/2012/07/how-to-draw-bitmaps-using-javascript/
   private _getLittleEndianHex(value: number): string {
-    var result: any[] /** TODO #9100 */ = [];
+    var result: any[] /* TODO #9100 */ = [];
 
     for (var bytes = 4; bytes > 0; bytes--) {
       result.push(String.fromCharCode(value & 255));

--- a/modules/playground/src/web_workers/input/index_common.ts
+++ b/modules/playground/src/web_workers/input/index_common.ts
@@ -18,7 +18,7 @@ export class InputCmp {
   inputVal = "";
   textareaVal = "";
 
-  inputChanged(e: any /** TODO #9100 */) { this.inputVal = e.target.value; }
+  inputChanged(e: any /* TODO #9100 */) { this.inputVal = e.target.value; }
 
-  textAreaChanged(e: any /** TODO #9100 */) { this.textareaVal = e.target.value; }
+  textAreaChanged(e: any /* TODO #9100 */) { this.textareaVal = e.target.value; }
 }

--- a/modules/playground/src/web_workers/kitchen_sink/index_common.ts
+++ b/modules/playground/src/web_workers/kitchen_sink/index_common.ts
@@ -52,5 +52,7 @@ export class HelloCmp {
 
   changeGreeting(): void { this.greeting = 'howdy'; }
 
-  onKeyDown(event: any /** TODO #9100 */): void { this.lastKey = StringWrapper.fromCharCode(event.keyCode); }
+  onKeyDown(event: any /* TODO #9100 */): void {
+    this.lastKey = StringWrapper.fromCharCode(event.keyCode);
+  }
 }

--- a/modules/playground/src/web_workers/todo/index_common.ts
+++ b/modules/playground/src/web_workers/todo/index_common.ts
@@ -22,7 +22,7 @@ export class TodoApp {
     this.inputValue = "";
   }
 
-  doneEditing($event: any /** TODO #9100 */, todo: Todo): void {
+  doneEditing($event: any /* TODO #9100 */, todo: Todo): void {
     var which = $event.keyCode;
     if (which === 13) {
       todo.title = todo.editTitle;
@@ -56,7 +56,7 @@ export class TodoApp {
 
   deleteMe(todo: Todo): void { this.todoStore.remove(todo); }
 
-  toggleAll($event: any /** TODO #9100 */): void {
+  toggleAll($event: any /* TODO #9100 */): void {
     this.isComplete = !this.isComplete;
     this.todoStore.list.forEach((todo: Todo) => { todo.completed = this.isComplete; });
   }


### PR DESCRIPTION
Double asterisk comments are parsed as JSDoc comments, which causes
problems with the closure compiler. This commit changes them all to single asterisks.
