### PR TITLE
feat(core): use the CSS parser to shim Shadow DOM CSS code

### DIFF
--- a/modules/@angular/compiler/src/css/lexer.ts
+++ b/modules/@angular/compiler/src/css/lexer.ts
@@ -1,9 +1,9 @@
-import {$$, $0, $9, $A, $AMPERSAND, $AT, $BACKSLASH, $BANG, $CARET, $COLON, $COMMA, $CR, $DQ, $EOF, $EQ, $FF, $GT, $HASH, $LBRACE, $LBRACKET, $LF, $LPAREN, $MINUS, $PERCENT, $PERIOD, $PIPE, $PLUS, $QUESTION, $RBRACE, $RBRACKET, $RPAREN, $SEMICOLON, $SLASH, $SQ, $STAR, $TILDA, $VTAB, $Z, $_, $a, $z, isWhitespace} from '@angular/compiler/src/chars';
+import {$$, $0, $9, $A, $AMPERSAND, $AT, $BACKSLASH, $BANG, $CARET, $COLON, $COMMA, $CR, $DQ, $EOF, $EQ, $FF, $GT, $HASH, $LBRACE, $LBRACKET, $LF, $LPAREN, $MINUS, $PERCENT, $PERIOD, $PIPE, $PLUS, $QUESTION, $RBRACE, $RBRACKET, $RPAREN, $SEMICOLON, $SLASH, $SQ, $STAR, $TILDA, $VTAB, $Z, $_, $a, $z, isWhitespace} from '../chars';
 
 import {BaseException} from '../facade/exceptions';
-import {NumberWrapper, StringWrapper, isPresent, resolveEnumToken} from '../facade/lang';
+import {StringWrapper, isPresent, resolveEnumToken} from '../facade/lang';
 
-export {$AT, $COLON, $COMMA, $EOF, $LBRACE, $LBRACKET, $LPAREN, $RBRACE, $RBRACKET, $RPAREN, $SEMICOLON, isWhitespace} from '@angular/compiler/src/chars';
+export {$AT, $COLON, $COMMA, $EOF, $GT, $LBRACE, $LBRACKET, $LPAREN, $PLUS, $RBRACE, $RBRACKET, $RPAREN, $SEMICOLON, $SLASH, $SPACE, $TAB, $TILDA, isWhitespace} from '../chars';
 
 export enum CssTokenType {
   EOF,
@@ -23,6 +23,7 @@ export enum CssLexerMode {
   ALL_TRACK_WS,
   SELECTOR,
   PSEUDO_SELECTOR,
+  PSEUDO_SELECTOR_WITH_ARGUMENTS,
   ATTRIBUTE_SELECTOR,
   AT_RULE_QUERY,
   MEDIA_QUERY,
@@ -94,6 +95,7 @@ export class CssScannerError extends BaseException {
 function _trackWhitespace(mode: CssLexerMode) {
   switch (mode) {
     case CssLexerMode.SELECTOR:
+    case CssLexerMode.PSEUDO_SELECTOR:
     case CssLexerMode.ALL_TRACK_WS:
     case CssLexerMode.STYLE_VALUE:
       return true;
@@ -126,7 +128,7 @@ export class CssScanner {
 
   setMode(mode: CssLexerMode) {
     if (this._currentMode != mode) {
-      if (_trackWhitespace(this._currentMode)) {
+      if (_trackWhitespace(this._currentMode) && !_trackWhitespace(mode)) {
         this.consumeWhitespace();
       }
       this._currentMode = mode;
@@ -178,21 +180,30 @@ export class CssScanner {
 
   consume(type: CssTokenType, value: string = null): LexedCssResult {
     var mode = this._currentMode;
-    this.setMode(CssLexerMode.ALL);
+
+    var tempMode = CssLexerMode.ALL;
+    if (_trackWhitespace(mode)) {
+      tempMode = CssLexerMode.ALL_TRACK_WS;
+    }
+
+    this.setMode(tempMode);
 
     var previousIndex = this.index;
     var previousLine = this.line;
     var previousColumn = this.column;
 
+    var next: CssToken;
     var output = this.scan();
+    if (isPresent(output)) {
+      // just incase the inner scan method returned an error
+      if (isPresent(output.error)) {
+        this.setMode(mode);
+        return output;
+      }
 
-    // just incase the inner scan method returned an error
-    if (isPresent(output.error)) {
-      this.setMode(mode);
-      return output;
+      next = output.token;
     }
 
-    var next = output.token;
     if (!isPresent(next)) {
       next = new CssToken(0, 0, 0, CssTokenType.EOF, 'end of file');
     }
@@ -563,6 +574,8 @@ function isValidSelectorCharacter(code: number): boolean {
     case $COLON:
     case $PIPE:
     case $COMMA:
+    case $LBRACKET:
+    case $RBRACKET:
       return true;
     default:
       return false;
@@ -658,7 +671,7 @@ function isValidCssCharacter(code: number, mode: CssLexerMode): boolean {
     case CssLexerMode.SELECTOR:
       return isValidSelectorCharacter(code);
 
-    case CssLexerMode.PSEUDO_SELECTOR:
+    case CssLexerMode.PSEUDO_SELECTOR_WITH_ARGUMENTS:
       return isValidPseudoSelectorCharacter(code);
 
     case CssLexerMode.ATTRIBUTE_SELECTOR:

--- a/modules/@angular/compiler/test/css/lexer_spec.ts
+++ b/modules/@angular/compiler/test/css/lexer_spec.ts
@@ -331,34 +331,19 @@ export function main() {
     describe('Pseudo Selector Mode', () => {
       it('should validate pseudo selector identifiers with a reduced subset of valid characters',
          () => {
-           function tokenizePseudo(code: any /** TODO #9100 */) {
-             return tokenize(code, false, CssLexerMode.PSEUDO_SELECTOR);
+           function tokenizePseudo(code: string, withArgs = false): CssToken[] {
+             var mode = withArgs ? CssLexerMode.PSEUDO_SELECTOR_WITH_ARGUMENTS :
+                                   CssLexerMode.PSEUDO_SELECTOR;
+             return tokenize(code, false, mode);
            }
 
-           expect(tokenizePseudo('lang(en-us)').length).toEqual(4);
            expect(tokenizePseudo('hover').length).toEqual(1);
            expect(tokenizePseudo('focus').length).toEqual(1);
+           expect(tokenizePseudo('lang(en-us)', true).length).toEqual(4);
 
-           expect(() => { tokenizePseudo('lang(something:broken)'); }).toThrow();
+           expect(() => { tokenizePseudo('lang(something:broken)', true); }).toThrow();
 
-           expect(() => { tokenizePseudo('not(.selector)'); }).toThrow();
-         });
-    });
-
-    describe('Pseudo Selector Mode', () => {
-      it('should validate pseudo selector identifiers with a reduced subset of valid characters',
-         () => {
-           function tokenizePseudo(code: any /** TODO #9100 */) {
-             return tokenize(code, false, CssLexerMode.PSEUDO_SELECTOR);
-           }
-
-           expect(tokenizePseudo('lang(en-us)').length).toEqual(4);
-           expect(tokenizePseudo('hover').length).toEqual(1);
-           expect(tokenizePseudo('focus').length).toEqual(1);
-
-           expect(() => { tokenizePseudo('lang(something:broken)'); }).toThrow();
-
-           expect(() => { tokenizePseudo('not(.selector)'); }).toThrow();
+           expect(() => { tokenizePseudo('not(.selector)', true); }).toThrow();
          });
     });
 

--- a/modules/@angular/compiler/test/css/parser_spec.ts
+++ b/modules/@angular/compiler/test/css/parser_spec.ts
@@ -52,7 +52,7 @@ export function main() {
       expect(value.tokens[0].strValue).toEqual('value123');
     });
 
-    it('should parse mutliple CSS selectors sharing the same set of styles', () => {
+    it('should parse multiple CSS selectors sharing the same set of styles', () => {
       var styles = `
         .class, #id, tag, [attr], key + value, * value, :-moz-any-link {
           prop: value123;
@@ -65,13 +65,26 @@ export function main() {
       var rule = <CssSelectorRuleAST>ast.rules[0];
       expect(rule.selectors.length).toBe(7);
 
-      assertTokens(rule.selectors[0].tokens, ['.', 'class']);
-      assertTokens(rule.selectors[1].tokens, ['#', 'id']);
-      assertTokens(rule.selectors[2].tokens, ['tag']);
-      assertTokens(rule.selectors[3].tokens, ['[', 'attr', ']']);
-      assertTokens(rule.selectors[4].tokens, ['key', ' ', '+', ' ', 'value']);
-      assertTokens(rule.selectors[5].tokens, ['*', ' ', 'value']);
-      assertTokens(rule.selectors[6].tokens, [':', '-moz-any-link']);
+      var classRule = rule.selectors[0];
+      var idRule = rule.selectors[1];
+      var tagRule = rule.selectors[2];
+      var attrRule = rule.selectors[3];
+      var plusOpRule = rule.selectors[4];
+      var starOpRule = rule.selectors[5];
+      var mozRule = rule.selectors[6];
+
+      assertTokens(classRule.selectorParts[0].tokens, ['.', 'class']);
+      assertTokens(idRule.selectorParts[0].tokens, ['.', 'class']);
+      assertTokens(attrRule.selectorParts[0].tokens, ['[', 'attr', ']']);
+
+      assertTokens(plusOpRule.selectorParts[0].tokens, ['key']);
+      expect(plusOpRule.selectorParts[0].operator.strValue).toEqual('+');
+      assertTokens(plusOpRule.selectorParts[1].tokens, ['value']);
+
+      assertTokens(starOpRule.selectorParts[0].tokens, ['*']);
+      assertTokens(starOpRule.selectorParts[1].tokens, ['value']);
+
+      assertTokens(mozRule.selectorParts[0].pseudoSelectors[0].tokens, [':', '-moz-any-link']);
 
       var style1 = <CssDefinitionAST>rule.block.entries[0];
       expect(style1.property.strValue).toEqual('prop');
@@ -324,11 +337,13 @@ export function main() {
       var rules = ast.rules;
 
       var pageRule1 = <CssBlockDefinitionRuleAST>rules[0];
-      expect(pageRule1.strValue).toEqual('one');
+      expect(pageRule1.query.strValue).toEqual('@page one');
+      expect(pageRule1.query.tokens[0].strValue).toEqual('one');
       expect(pageRule1.type).toEqual(BlockType.Page);
 
       var pageRule2 = <CssBlockDefinitionRuleAST>rules[1];
-      expect(pageRule2.strValue).toEqual('two');
+      expect(pageRule2.query.strValue).toEqual('@page two');
+      expect(pageRule2.query.tokens[0].strValue).toEqual('two');
       expect(pageRule2.type).toEqual(BlockType.Page);
 
       var selectorOne = <CssSelectorRuleAST>pageRule1.block.entries[0];
@@ -424,7 +439,8 @@ export function main() {
       var errors = output.errors;
 
       expect(errors[0].msg)
-          .toMatchPattern(/Unbalanced pseudo selector function value at column 0:10/g);
+          .toMatchPattern(
+              /Character does not match expected Character value \("{" should match "\)"\)/);
     });
 
     it('should raise an error when a semi colon is missing from a CSS style/pair that isn\'t the last entry',
@@ -458,8 +474,12 @@ export function main() {
       var rule1 = <CssSelectorRuleAST>ast.rules[0];
       expect(rule1.selectors.length).toEqual(1);
 
-      var selector = rule1.selectors[0];
-      assertTokens(selector.tokens, ['div', ':', 'not', '(', '.', 'ignore-this-div', ')']);
+      var simpleSelector = rule1.selectors[0].selectorParts[0];
+      assertTokens(simpleSelector.tokens, ['div']);
+
+      var pseudoSelector = simpleSelector.pseudoSelectors[0];
+      expect(pseudoSelector.name).toEqual('not');
+      assertTokens(pseudoSelector.tokens, ['.', 'ignore-this-div']);
     });
 
     it('should raise parse errors when CSS key/value pairs are invalid', () => {

--- a/modules/@angular/facade/src/lang.ts
+++ b/modules/@angular/facade/src/lang.ts
@@ -497,6 +497,10 @@ export function bitWiseAnd(values: number[]): number {
   return values.reduce((a, b) => { return a & b; });
 }
 
+export function bitWiseNot(value: number): number {
+  return ~value;
+}
+
 export function escape(s: string): string {
   return _global.encodeURI(s);
 }


### PR DESCRIPTION
Closes #9154

---

@vicb there is a mix of variables/classes with `AST` and `Ast`. Once this PR goes in then I'll make a new PR that converts everything to `Ast` ... Same thing with `Css`.
