### PR TITLE
fix(i18n): do not extract message when there is not child nodes

### DIFF
--- a/modules/@angular/compiler/src/i18n/message_extractor.ts
+++ b/modules/@angular/compiler/src/i18n/message_extractor.ts
@@ -1,6 +1,6 @@
 import {Parser} from '../expression_parser/parser';
 import {StringMapWrapper} from '../facade/collection';
-import {isPresent} from '../facade/lang';
+import {isPresent, isArray} from '../facade/lang';
 import {HtmlAst, HtmlElementAst} from '../html_ast';
 import {HtmlParser} from '../html_parser';
 import {ParseError} from '../parse_util';
@@ -112,7 +112,7 @@ export class MessageExtractor {
   }
 
   private _extractMessagesFromPart(p: Part): void {
-    if (p.hasI18n) {
+    if (p.hasI18n && isPresent(p.children) && isArray(p.children) && p.children.length > 0) {
       this.messages.push(p.createMessage(this._parser));
       this._recurseToExtractMessagesFromAttributes(p.children);
     } else {

--- a/modules/@angular/compiler/test/i18n/message_extractor_spec.ts
+++ b/modules/@angular/compiler/test/i18n/message_extractor_spec.ts
@@ -66,6 +66,22 @@ export function main() {
       expect(res.messages).toEqual([new Message('message1', 'meaning1', 'desc1')]);
     });
 
+    it('should not create a new message when there is not child nodes', () => {
+      let res = extractor.extract(
+          '<div i18n></div>',
+          'someUrl');
+
+      expect(res.messages).toEqual([]);
+    });
+
+    it('should not create a new message when there is not child nodes (comment)', () => {
+      let res = extractor.extract(
+          '<!-- i18n--><!-- /i18n -->',
+          'someUrl');
+
+      expect(res.messages).toEqual([]);
+    });
+
     it('should replace interpolation with placeholders (text nodes)', () => {
       let res = extractor.extract('<div i18n>Hi {{one}} and {{two}}</div>', 'someurl');
       expect(res.messages).toEqual([new Message(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
see https://github.com/angular/angular/issues/8802 and https://github.com/angular/angular/issues/9104

**What is the new behavior?**
messages are not extracted when there is not child nodes

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
