### PR TITLE
fix(http): add search param escaping for keys

### DIFF
--- a/modules/@angular/http/src/url_search_params.ts
+++ b/modules/@angular/http/src/url_search_params.ts
@@ -122,8 +122,9 @@ export class URLSearchParams {
 
   toString(): string {
     var paramsList: string[] = [];
-    this.paramsMap.forEach(
-        (values, k) => { values.forEach(v => paramsList.push(k + '=' + encodeURIComponent(v))); });
+    this.paramsMap.forEach((values, k) => {
+      values.forEach(v => paramsList.push(encodeURIComponent(k) + '=' + encodeURIComponent(v)));
+    });
     return paramsList.join('&');
   }
 

--- a/modules/@angular/http/test/url_search_params_spec.ts
+++ b/modules/@angular/http/test/url_search_params_spec.ts
@@ -26,6 +26,15 @@ export function main() {
     });
 
 
+    it('should encode special characters in params', () => {
+      var searchParams = new URLSearchParams();
+      searchParams.append('a', '1+1');
+      searchParams.append('b c', '2');
+      searchParams.append('d%', '3$');
+      expect(searchParams.toString()).toEqual('a=1%2B1&b%20c=2&d%25=3%24');
+    });
+
+
     it('should support map-like merging operation via setAll()', () => {
       var mapA = new URLSearchParams('a=1&a=2&a=3&c=8');
       var mapB = new URLSearchParams('a=4&a=5&a=6&b=7');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

``` javascript
import Http from '@angular2/http';

export class Test {
  constructor(private http: Http) {}

  public search() {
    let params: URLSearchParams = new URLSearchParams();
    params.set('a+b', 'c');

    return this.http.get("http://www.google.com/",  { search: params });
  }
}
```

Makes a call: https://www.google.com/?a+b=c

**What is the new behavior?**

Call: https://www.google.com/?a%2Bb=c with correctly encoded key ('+' turns into '%2B') 

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

The same implementation as in Chromium for URLSearchParams:
https://codereview.chromium.org/143313002/patch/1240001/1250021

``` c++
String DOMURLSearchParams::toString() const
{
    StringBuilder result;
    for (unsigned i = 0; i < m_params.size(); ++i) {
        if (i)
            result.append('&');
        result.append(encodeString(m_params[i].first));
        result.append('=');
        result.append(encodeString(m_params[i].second));
    }
    return result.toString();
}
```
