### PR TITLE
feat(forms): compose validator fns automatically if arrays

### DIFF
--- a/modules/@angular/common/src/forms/form_builder.ts
+++ b/modules/@angular/common/src/forms/form_builder.ts
@@ -69,8 +69,9 @@ export class FormBuilder {
   /**
    * Construct a new {@link FormControl} with the given `value`,`validator`, and `asyncValidator`.
    */
-  control(value: Object, validator: ValidatorFn = null, asyncValidator: AsyncValidatorFn = null):
-      modelModule.FormControl {
+  control(
+      value: Object, validator: ValidatorFn|ValidatorFn[] = null,
+      asyncValidator: AsyncValidatorFn|AsyncValidatorFn[] = null): modelModule.FormControl {
     return new modelModule.FormControl(value, validator, asyncValidator);
   }
 

--- a/modules/@angular/common/src/forms/model.ts
+++ b/modules/@angular/common/src/forms/model.ts
@@ -3,7 +3,9 @@ import {ListWrapper, StringMapWrapper} from '../facade/collection';
 import {isBlank, isPresent, normalizeBool} from '../facade/lang';
 import {PromiseWrapper} from '../facade/promise';
 
+import {composeAsyncValidators, composeValidators} from './directives/shared';
 import {AsyncValidatorFn, ValidatorFn} from './directives/validators';
+
 
 
 /**
@@ -48,6 +50,15 @@ function _find(control: AbstractControl, path: Array<string|number>| string) {
 
 function toObservable(r: any): Observable<any> {
   return PromiseWrapper.isPromise(r) ? ObservableWrapper.fromPromise(r) : r;
+}
+
+function coerceToValidator(validator: ValidatorFn | ValidatorFn[]): ValidatorFn {
+  return Array.isArray(validator) ? composeValidators(validator) : validator;
+}
+
+function coerceToAsyncValidator(asyncValidator: AsyncValidatorFn | AsyncValidatorFn[]):
+    AsyncValidatorFn {
+  return Array.isArray(asyncValidator) ? composeAsyncValidators(asyncValidator) : asyncValidator;
 }
 
 /**
@@ -275,8 +286,9 @@ export class FormControl extends AbstractControl {
   _onChange: Function;
 
   constructor(
-      value: any = null, validator: ValidatorFn = null, asyncValidator: AsyncValidatorFn = null) {
-    super(validator, asyncValidator);
+      value: any = null, validator: ValidatorFn|ValidatorFn[] = null,
+      asyncValidator: AsyncValidatorFn|AsyncValidatorFn[] = null) {
+    super(coerceToValidator(validator), coerceToAsyncValidator(asyncValidator));
     this._value = value;
     this.updateValueAndValidity({onlySelf: true, emitEvent: false});
     this._initObservables();

--- a/modules/@angular/common/test/forms/model_spec.ts
+++ b/modules/@angular/common/test/forms/model_spec.ts
@@ -31,6 +31,8 @@ export function main() {
     return e;
   }
 
+  function otherAsyncValidator() { return PromiseWrapper.resolve({'other': true}); }
+
   describe('Form Model', () => {
     describe('FormControl', () => {
       it('should default the value to null', () => {
@@ -48,6 +50,15 @@ export function main() {
           var c = new FormControl('value', Validators.required);
           c.updateValue(null);
           expect(c.valid).toEqual(false);
+        });
+
+        it('should support arrays of validator functions if passed', () => {
+          const c = new FormControl('value', [Validators.required, Validators.minLength(3)]);
+          c.updateValue('a');
+          expect(c.valid).toEqual(false);
+
+          c.updateValue('aaa');
+          expect(c.valid).toEqual(true);
         });
 
         it('should return errors', () => {
@@ -115,6 +126,14 @@ export function main() {
              tick(300);
 
              expect(c.valid).toEqual(true);
+           }));
+
+        it('should support arrays of async validator functions if passed', fakeAsync(() => {
+             const c =
+                 new FormControl('value', null, [asyncValidator('expected'), otherAsyncValidator]);
+             tick();
+
+             expect(c.errors).toEqual({'async': true, 'other': true});
            }));
       });
 


### PR DESCRIPTION
This PR allows validator functions and async validator functions to optionally be passed in as an array.

Previously, if you wanted to pass multiple validators into a form control on instantiation, you had to compose them yourself:

``` ts
class MyComp {
   myForm = new FormGroup({
      firstName: new FormControl('Nancy', Validators.required),
      lastName: new FormControl('Drew', Validators.compose([
         Validators.required, Validators.minLength(3)
      ]))
   })
}
```

Now you can pass in an array of validator or async validator functions directly and they will be composed for you internally.  Or you can pass in a single validator function on its own, as you did before:

``` ts
class MyComp {
   myForm = new FormGroup({
      firstName: new FormControl('Nancy', Validators.required),
      lastName: new FormControl('Drew', [Validators.required, Validators.minLength(3)])
   })
}
```

This change only applies to the new forms module (not the one currently linked in @angular/common's index.ts). 
