### PR TITLE
chore(docs): Fixed pre-commit command for clang-format

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -256,7 +256,7 @@ to some whitespace difference.
   commit a change. In the angular repo, run
 
 ```
-    $ echo -e '#!/bin/sh\nexec git clang-format' > .git/hooks/pre-commit
+    $ echo -e '#!/bin/sh\nexec git clang-format --style file' > .git/hooks/pre-commit
     $ chmod u+x !$
 ```
 


### PR DESCRIPTION
git-clang-format needs the --style argument to use the .clang-format file.
