### PR TITLE
feat(forms): support setting control name in ngModelOptions

### DIFF
--- a/modules/@angular/common/src/forms/directives/ng_model.ts
+++ b/modules/@angular/common/src/forms/directives/ng_model.ts
@@ -26,11 +26,10 @@ export const formControlBinding: any =
  * two-way binding, use `[(ngModel)]` to ensure the model updates in
  * both directions.
  *
- * ### Example ([live demo](http://plnkr.co/edit/R3UX5qDaUqFO2VYR0UzH?p=preview))
  *  ```typescript
  * @Component({
  *      selector: "search-comp",
- *      directives: [FORM_DIRECTIVES],
+ *      directives: [],
  *      template: `<input type='text' [(ngModel)]="searchQuery">`
  *      })
  * class SearchComp {
@@ -55,7 +54,7 @@ export class NgModel extends NgControl implements OnChanges,
 
   @Input('ngModel') model: any;
   @Input() name: string;
-
+  @Input('ngModelOptions') options: {name?: string};
   @Output('ngModelChange') update = new EventEmitter();
 
   constructor(@Optional() @Host() private _parent: ControlContainer,
@@ -112,6 +111,8 @@ export class NgModel extends NgControl implements OnChanges,
               }
 
               private _checkName() {
+                if (this.options && this.options.name) this.name = this.options.name;
+
                 if (this._parent && !this.name) {
                   throw new BaseException(
                       `Name attribute must be set if ngModel is used within a form.

--- a/modules/@angular/common/test/forms/integration_spec.ts
+++ b/modules/@angular/common/test/forms/integration_spec.ts
@@ -16,6 +16,7 @@ import {ListWrapper} from '../../src/facade/collection';
 import {PromiseWrapper} from '../../src/facade/promise';
 
 export function main() {
+  // TODO(kara): Turn these tests on in CI when we flip the switch on new forms module
   xdescribe('integration tests', () => {
 
     it('should initialize DOM elements with the given form object',
@@ -1261,6 +1262,23 @@ export function main() {
                });
              }));
 
+      it('should override name attribute with ngModelOptions name if provided',
+         fakeAsync(inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {
+           const t = `
+            <form>
+              <input name="one" [(ngModel)]="data" [ngModelOptions]="{name: 'two'}">
+            </form>
+            `;
+
+           const fixture = tcb.overrideTemplate(MyComp8, t).createFakeAsync(MyComp8);
+           tick();
+           fixture.debugElement.componentInstance.data = 'some data';
+           fixture.detectChanges();
+           const form = fixture.debugElement.children[0].inject(NgForm);
+
+           tick();
+           expect(form.value).toEqual({two: 'some data'});
+         })));
 
       // TODO(kara): Fix when re-doing radio buttons
       xit('should support <type=radio>',


### PR DESCRIPTION
This PR only applies to the unreleased forms module, _not_ the default one linked in @angular/common's `index.ts`.

Normally, one can set a form control's name in template-driven forms through the `name` attribute (here the name is `person`):

``` html
<form #f="ngForm">
   <input name="person" [(ngModel)]="myPerson">
</form>
{{ f.value | json }}        // { person: {height: '', city: ''} }
```

``` ts
class MyComp {
   myPerson = {height: '', city: ''};
}
```

This PR adds the option to set the form control name through `ngModelOptions` instead of the `name` attribute.  This can be handy if, for example, you've created a custom form control that is already using `name` as an input for its own use.  

Let's say you have a `person-input` custom component that accepts a name input.  You wouldn't want the value of that unrelated name input to appear on your form.  In this case, the custom component can still use `name` for its own purpose, and you can set the form control name separately in `ngModelOptions`.

``` html
<form #f="ngForm">
   <person-input name="Nancy" [(ngModel)]="myPerson" [ngModelOptions]="{name: 'person'}">
</form>
{{ f.value | json }}        // { person: {height: '', city: ''} }

```

``` ts
class MyComp {
   myPerson = {height: '', city: ''};
}
```
