### PR TITLE
feat(radio): support radio button sharing a control

### DIFF
--- a/modules/@angular/forms/src/directives.ts
+++ b/modules/@angular/forms/src/directives.ts
@@ -25,7 +25,7 @@ export {NgForm} from './directives/ng_form';
 export {NgModel} from './directives/ng_model';
 export {NgModelGroup} from './directives/ng_model_group';
 export {NumberValueAccessor} from './directives/number_value_accessor';
-export {RadioButtonState, RadioControlValueAccessor} from './directives/radio_control_value_accessor';
+export {RadioControlValueAccessor} from './directives/radio_control_value_accessor';
 export {FormControlDirective} from './directives/reactive_directives/form_control_directive';
 export {FormControlName} from './directives/reactive_directives/form_control_name';
 export {FormGroupDirective} from './directives/reactive_directives/form_group_directive';

--- a/modules/@angular/forms/src/directives/ng_form.ts
+++ b/modules/@angular/forms/src/directives/ng_form.ts
@@ -9,6 +9,7 @@ import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
 import {ControlContainer} from './control_container';
 import {Form} from './form_interface';
 import {NgControl} from './ng_control';
+import {NgModel} from './ng_model';
 import {NgModelGroup} from './ng_model_group';
 import {composeAsyncValidators, composeValidators, setUpControl, setUpFormGroup} from './shared';
 
@@ -107,20 +108,21 @@ export class NgForm extends ControlContainer implements Form {
 
   get controls(): {[key: string]: AbstractControl} { return this.form.controls; }
 
-  addControl(dir: NgControl): FormControl {
+  addControl(dir: NgModel): FormControl {
     const ctrl = new FormControl();
     PromiseWrapper.scheduleMicrotask(() => {
       const container = this._findContainer(dir.path);
-      setUpControl(ctrl, dir);
-      container.registerControl(dir.name, ctrl);
-      ctrl.updateValueAndValidity({emitEvent: false});
+      dir._control = <FormControl>container.registerControl(dir.name, ctrl);
+      setUpControl(dir.control, dir);
+      dir.control.updateValueAndValidity({emitEvent: false});
     });
+
     return ctrl;
   }
 
-  getControl(dir: NgControl): FormControl { return <FormControl>this.form.find(dir.path); }
+  getControl(dir: NgModel): FormControl { return <FormControl>this.form.find(dir.path); }
 
-  removeControl(dir: NgControl): void {
+  removeControl(dir: NgModel): void {
     PromiseWrapper.scheduleMicrotask(() => {
       var container = this._findContainer(dir.path);
       if (isPresent(container)) {

--- a/modules/@angular/forms/src/forms.ts
+++ b/modules/@angular/forms/src/forms.ts
@@ -13,7 +13,7 @@
  */
 
 
-export {FORM_DIRECTIVES, REACTIVE_FORM_DIRECTIVES, RadioButtonState} from './directives';
+export {FORM_DIRECTIVES, REACTIVE_FORM_DIRECTIVES} from './directives';
 export {AbstractControlDirective} from './directives/abstract_control_directive';
 export {CheckboxControlValueAccessor} from './directives/checkbox_value_accessor';
 export {ControlContainer} from './directives/control_container';

--- a/modules/@angular/forms/src/model.ts
+++ b/modules/@angular/forms/src/model.ts
@@ -282,7 +282,7 @@ export abstract class AbstractControl {
  */
 export class FormControl extends AbstractControl {
   /** @internal */
-  _onChange: Function;
+  _onChange: Function[] = [];
 
   constructor(
       value: any = null, validator: ValidatorFn|ValidatorFn[] = null,
@@ -312,7 +312,9 @@ export class FormControl extends AbstractControl {
   } = {}): void {
     emitModelToViewChange = isPresent(emitModelToViewChange) ? emitModelToViewChange : true;
     this._value = value;
-    if (isPresent(this._onChange) && emitModelToViewChange) this._onChange(this._value);
+    if (this._onChange.length && emitModelToViewChange) {
+      this._onChange.forEach((changeFn) => changeFn(this._value));
+    }
     this.updateValueAndValidity({onlySelf: onlySelf, emitEvent: emitEvent});
   }
 
@@ -329,7 +331,7 @@ export class FormControl extends AbstractControl {
   /**
    * Register a listener for change events.
    */
-  registerOnChange(fn: Function): void { this._onChange = fn; }
+  registerOnChange(fn: Function): void { this._onChange.push(fn); }
 }
 
 /**
@@ -364,9 +366,11 @@ export class FormGroup extends AbstractControl {
   /**
    * Register a control with the group's list of controls.
    */
-  registerControl(name: string, control: AbstractControl): void {
+  registerControl(name: string, control: AbstractControl): AbstractControl {
+    if (this.controls[name]) return this.controls[name];
     this.controls[name] = control;
     control.setParent(this);
+    return control;
   }
 
   /**


### PR DESCRIPTION
This PR adds the ability for radio buttons to share a `FormControl` instance.  This means you no longer need to create a RadioButtonState to manage radio buttons.  

**Before**:

``` html
<form #f="ngForm">
   <input type="radio" name="food" [(ngModel)]="foodChicken">
   <input type="radio" name="food" [(ngModel)]="foodFish">
</form>

{{ f. value | json }}      // { foodChicken: {value: 'chicken', checked: false}, foodFish: {value: 'fish', checked: true} }
```

``` ts
class MyComp {
   foodChicken = new RadioButtonState(false, 'chicken');
   foodFish = new RadioButtonState(true, 'fish');
}
```

**After**:

``` html
<form #f="ngForm">
   <input type="radio" name="food" [(ngModel)]="food" value="chicken">
   <input type="radio" name="food" [(ngModel)]="food" value="fish">
</form>

{{ f. value | json }}      // { food: 'fish' }
```

``` ts
class MyComp {
   food = 'fish';
}
```

Note: this change will land probably in RC.3, not RC.2.
