### PR TITLE
feat(security): fail more detectably when using a safe value in interpolation

### DIFF
--- a/modules/@angular/platform-browser/src/security/dom_sanitization_service.ts
+++ b/modules/@angular/platform-browser/src/security/dom_sanitization_service.ts
@@ -9,7 +9,9 @@ import {sanitizeUrl} from './url_sanitizer';
 export {SecurityContext};
 
 
-/** Marker interface for a value that's safe to use in a particular context. */
+/**
+ * Marker interface for a value that's safe to use in a particular context.
+ */
 export interface SafeValue {}
 /** Marker interface for a value that's safe to use as HTML. */
 export interface SafeHtml extends SafeValue {}
@@ -151,7 +153,12 @@ abstract class SafeValueImpl implements SafeValue {
   constructor(public changingThisBreaksApplicationSecurity: string) {
     // empty
   }
+
   abstract getTypeName(): string;
+
+  toString() {
+    return `SafeValue must use [property]=binding: ${this.changingThisBreaksApplicationSecurity}`;
+  }
 }
 
 class SafeHtmlImpl extends SafeValueImpl implements SafeHtml {


### PR DESCRIPTION
If a user ends up with a safe value in an interpolation context, that's probably
a bug. Returning `"SafeValue must use [property]= binding"` will make it easier
to detect and correct the situation. Detecting the situation and throwing an
error for it could cause performance issues, so we're not doing this at this
point (but might revisit later).

Part of #8511 and #9253.
