### PR TITLE
bug(datePipe): date format pipe's 2-digit interpretation of minutes and seconds

### DIFF
--- a/modules/@angular/common/test/pipes/date_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/date_pipe_spec.ts
@@ -11,7 +11,7 @@ export function main() {
     var pipe: DatePipe;
 
     beforeEach(() => {
-      date = DateWrapper.create(2015, 6, 15, 21, 43, 11);
+      date = DateWrapper.create(2015, 6, 15, 21, 3, 1);
       pipe = new DatePipe();
     });
 
@@ -50,8 +50,10 @@ export function main() {
           expect(pipe.transform(date, 'EEEE')).toEqual('Monday');
           expect(pipe.transform(date, 'H')).toEqual('21');
           expect(pipe.transform(date, 'j')).toEqual('9 PM');
-          expect(pipe.transform(date, 'm')).toEqual('43');
-          expect(pipe.transform(date, 's')).toEqual('11');
+          expect(pipe.transform(date, 'm')).toEqual('3');
+          expect(pipe.transform(date, 's')).toEqual('1');
+          expect(pipe.transform(date, 'mm')).toEqual('03');
+          expect(pipe.transform(date, 'ss')).toEqual('01');
         });
 
         it('should format common multi component patterns', () => {
@@ -64,22 +66,22 @@ export function main() {
           expect(pipe.transform(date, 'MEd')).toEqual('6Mon15');
           expect(pipe.transform(date, 'MMMd')).toEqual('Jun15');
           expect(pipe.transform(date, 'yMMMMEEEEd')).toEqual('Monday, June 15, 2015');
-          expect(pipe.transform(date, 'jms')).toEqual('9:43:11 PM');
-          expect(pipe.transform(date, 'ms')).toEqual('4311');
-          expect(pipe.transform(date, 'jm')).toEqual('9:43 PM');
+          expect(pipe.transform(date, 'jms')).toEqual('9:03:01 PM');
+          expect(pipe.transform(date, 'ms')).toEqual('31');
+          expect(pipe.transform(date, 'jm')).toEqual('9:03 PM');
         });
 
         it('should format with pattern aliases', () => {
-          expect(pipe.transform(date, 'medium')).toEqual('Jun 15, 2015, 9:43:11 PM');
-          expect(pipe.transform(date, 'short')).toEqual('6/15/2015, 9:43 PM');
+          expect(pipe.transform(date, 'medium')).toEqual('Jun 15, 2015, 9:03:01 PM');
+          expect(pipe.transform(date, 'short')).toEqual('6/15/2015, 9:03 PM');
           expect(pipe.transform(date, 'dd/MM/yyyy')).toEqual('15/06/2015');
           expect(pipe.transform(date, 'MM/dd/yyyy')).toEqual('06/15/2015');
           expect(pipe.transform(date, 'fullDate')).toEqual('Monday, June 15, 2015');
           expect(pipe.transform(date, 'longDate')).toEqual('June 15, 2015');
           expect(pipe.transform(date, 'mediumDate')).toEqual('Jun 15, 2015');
           expect(pipe.transform(date, 'shortDate')).toEqual('6/15/2015');
-          expect(pipe.transform(date, 'mediumTime')).toEqual('9:43:11 PM');
-          expect(pipe.transform(date, 'shortTime')).toEqual('9:43 PM');
+          expect(pipe.transform(date, 'mediumTime')).toEqual('9:03:01 PM');
+          expect(pipe.transform(date, 'shortTime')).toEqual('9:03 PM');
         });
       });
     }

--- a/modules/@angular/facade/src/intl.ts
+++ b/modules/@angular/facade/src/intl.ts
@@ -76,9 +76,9 @@ var DATE_FORMATS = {
   h: hourExtracter(datePartGetterFactory(hour12Modify(digitCondition('hour', 1), true))),
   jj: datePartGetterFactory(digitCondition('hour', 2)),
   j: datePartGetterFactory(digitCondition('hour', 1)),
-  mm: datePartGetterFactory(digitCondition('minute', 2)),
+  mm: digitModifier(datePartGetterFactory(digitCondition('minute', 2))),
   m: datePartGetterFactory(digitCondition('minute', 1)),
-  ss: datePartGetterFactory(digitCondition('second', 2)),
+  ss: digitModifier(datePartGetterFactory(digitCondition('second', 2))),
   s: datePartGetterFactory(digitCondition('second', 1)),
   // while ISO 8601 requires fractions to be prefixed with `.` or `,`
   // we can be just safely rely on using `sss` since we currently don't support single or two digit
@@ -101,6 +101,15 @@ var DATE_FORMATS = {
   GGGG: datePartGetterFactory(nameCondition('era', 4))
 };
 
+
+function digitModifier(inner: (date: Date, locale: string) => string): (
+    date: Date, locale: string) => string {
+  return function(date: Date, locale: string): string {
+    var result = inner(date, locale);
+
+    return result.length == 1 ? '0' + result : result;
+  };
+}
 
 function hourClockExtracter(inner: (date: Date, locale: string) => string): (
     date: Date, locale: string) => string {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Show minutes and second show only as number

**What is the new behavior?**

Minutes and second show as correct 2-digits

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Closes #9333 
