### PR TITLE
fix(compiler): throw for hierarchical component selectors

### DIFF
--- a/modules/@angular/compiler/test/selector_spec.ts
+++ b/modules/@angular/compiler/test/selector_spec.ts
@@ -243,6 +243,8 @@ export function main() {
   });
 
   describe('CssSelector.parse', () => {
+    const HIERARCHICAL_SELECTOR_ERR_MSG = /Hierarchical selectors are not supported/;
+
     it('should detect element names', () => {
       var cssSelector = CssSelector.parse('sometag')[0];
       expect(cssSelector.element).toEqual('sometag');
@@ -323,6 +325,49 @@ export function main() {
       }).toThrowError('Multiple selectors in :not are not supported');
     });
 
+    it('should throw for child selectors', () => {
+      expect(() => {
+        var cssSelectors = CssSelector.parse('parent > child');
+        console.log(cssSelectors);
+      }).toThrowError(HIERARCHICAL_SELECTOR_ERR_MSG);
+
+      expect(() => {
+        var cssSelectors = CssSelector.parse('parent>child');
+        console.log(cssSelectors);
+      }).toThrowError(HIERARCHICAL_SELECTOR_ERR_MSG);
+
+      expect(() => {
+        var cssSelectors = CssSelector.parse('parent    >  child');
+        console.log(cssSelectors);
+      }).toThrowError(HIERARCHICAL_SELECTOR_ERR_MSG);
+    });
+
+    it('should throw for descendent selectors', () => {
+      expect(() => {
+        var cssSelectors = CssSelector.parse('parent child');
+        console.log(cssSelectors);
+      }).toThrowError(HIERARCHICAL_SELECTOR_ERR_MSG);
+
+      expect(() => {
+        var cssSelectors = CssSelector.parse('parent     child');
+        console.log(cssSelectors);
+      }).toThrowError(HIERARCHICAL_SELECTOR_ERR_MSG);
+    });
+
+    it('should throw for adjacent sibling selectors', () => {
+      expect(() => {
+        var cssSelectors = CssSelector.parse('parent + child');
+        console.log(cssSelectors);
+      }).toThrowError(HIERARCHICAL_SELECTOR_ERR_MSG);
+    });
+
+    it('should throw for general sibling selectors', () => {
+      expect(() => {
+        var cssSelectors = CssSelector.parse('parent ~ child');
+        console.log(cssSelectors);
+      }).toThrowError(HIERARCHICAL_SELECTOR_ERR_MSG);
+    });
+
     it('should detect lists of selectors', () => {
       var cssSelectors = CssSelector.parse('.someclass,[attrname=attrvalue], sometag');
       expect(cssSelectors.length).toEqual(3);
@@ -330,6 +375,14 @@ export function main() {
       expect(cssSelectors[0].classNames).toEqual(['someclass']);
       expect(cssSelectors[1].attrs).toEqual(['attrname', 'attrvalue']);
       expect(cssSelectors[2].element).toEqual('sometag');
+    });
+
+    it('should detect lists of element selectors', () => {
+      var cssSelectors = CssSelector.parse('sometag,someothertag');
+      expect(cssSelectors.length).toEqual(2);
+
+      expect(cssSelectors[0].element).toEqual('sometag');
+      expect(cssSelectors[1].element).toEqual('someothertag');
     });
 
     it('should detect lists of selectors with :not', () => {


### PR DESCRIPTION
Fixes #6600
Fixes #2589

It is potentially a breaking change since previously hierarchical component selectors (ex. `taga tagb`) would match `tagb` (regardless of a parent) and some people might, accidentally have their app working. Let me know if this one should be marked as a BC. 
