### PR TITLE
Add repository metadata

### DIFF
--- a/modules/@angular/platform-browser-dynamic/package.json
+++ b/modules/@angular/platform-browser-dynamic/package.json
@@ -12,5 +12,9 @@
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular.git"
   }
 }


### PR DESCRIPTION
The `repository` property in the `package.json` is highly recommended.
