### PR TITLE
Fix `enableDebugTools` import path

### DIFF
--- a/TOOLS_JS.md
+++ b/TOOLS_JS.md
@@ -14,7 +14,7 @@ Ctrl + Shift + j.
 By default the debug tools are disabled. You can enable debug tools as follows:
 
 ```typescript
-import {enableDebugTools} from 'angular2/platform/browser';
+import {enableDebugTools} from '@angular/platform-browser';
 
 bootstrap(Application).then((appRef) => {
   enableDebugTools(appRef);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```

Currently the JS tools example imports `enableDebugTools` from `angular2/platform/browser`. However, the package name has been changed, so  `enableDebugTools` needs to be imported from `@angular/platform-browser`. I checked the new import path with `2.0.0-rc2` and can provide a Plunk if required.

There are no breaking changes as this is a doc-only fix.
