### PR TITLE
fix(animations): ensure void => * animations are triggered when an expression is omitted

### DIFF
--- a/modules/@angular/compiler/src/template_parser.ts
+++ b/modules/@angular/compiler/src/template_parser.ts
@@ -562,6 +562,12 @@ class TemplateParseVisitor implements HtmlAstVisitor {
   private _parseAnimation(
       name: string, expression: string, sourceSpan: ParseSourceSpan,
       targetMatchableAttrs: string[][], targetAnimationProps: BoundElementPropertyAst[]) {
+    // This will occur when a @trigger is not paired with an expression.
+    // For animations it is valid to not have an expression since */void
+    // states will be applied by angular when the element is attached/detached
+    if (!isPresent(expression) || expression.length == 0) {
+      expression = 'null';
+    }
     var ast = this._parseBinding(expression, sourceSpan);
     targetMatchableAttrs.push([name, ast.source]);
     targetAnimationProps.push(new BoundElementPropertyAst(


### PR DESCRIPTION
Closes #9327
