### PR TITLE
fix(core/testing): move ComponentFixture to core 

### DIFF
--- a/modules/@angular/common/test/directives/ng_class_spec.ts
+++ b/modules/@angular/common/test/directives/ng_class_spec.ts
@@ -6,12 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {beforeEach, beforeEachProviders, ddescribe, xdescribe, describe, expect, iit, inject, it, xit,} from '@angular/core/testing/testing_internal';
-import {ComponentFixture, TestComponentBuilder} from '@angular/compiler/testing';
-import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
-import {ListWrapper, StringMapWrapper, SetWrapper} from '../../src/facade/collection';
+import {NgClass, NgFor} from '@angular/common';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 import {Component, provide} from '@angular/core';
-import {NgFor, NgClass} from '@angular/common';
+import {ComponentFixture} from '@angular/core/testing';
+import {beforeEach, beforeEachProviders, ddescribe, describe, expect, iit, inject, it, xdescribe, xit} from '@angular/core/testing/testing_internal';
+import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
+
+import {ListWrapper, SetWrapper, StringMapWrapper} from '../../src/facade/collection';
 
 function detectChangesAndCheck(fixture: ComponentFixture<any>, classes: string) {
   fixture.detectChanges();

--- a/modules/@angular/common/test/directives/ng_for_spec.ts
+++ b/modules/@angular/common/test/directives/ng_for_spec.ts
@@ -8,7 +8,7 @@
 
 import {beforeEach, beforeEachProviders, ddescribe, describe, iit, inject, it, xit,} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 
 import {ListWrapper} from '../../src/facade/collection';
 import {IS_DART} from '../../src/facade/lang';

--- a/modules/@angular/common/test/directives/ng_style_spec.ts
+++ b/modules/@angular/common/test/directives/ng_style_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {beforeEach, beforeEachProviders, ddescribe, xdescribe, describe, expect, iit, inject, it, xit,} from '@angular/core/testing/testing_internal';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 
 import {StringMapWrapper} from '../../src/facade/collection';

--- a/modules/@angular/common/test/directives/ng_switch_spec.ts
+++ b/modules/@angular/common/test/directives/ng_switch_spec.ts
@@ -9,7 +9,7 @@
 import {beforeEach, ddescribe, describe, expect, iit, inject, it, xit,} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 import {Component} from '@angular/core';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 
 import {NgSwitch, NgSwitchCase, NgSwitchDefault} from '@angular/common';
 

--- a/modules/@angular/common/test/directives/ng_template_outlet_spec.ts
+++ b/modules/@angular/common/test/directives/ng_template_outlet_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {beforeEach, ddescribe, describe, expect, iit, inject, it, xit,} from '@angular/core/testing/testing_internal';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 import {Component, Directive, TemplateRef, ContentChildren, QueryList} from '@angular/core';
 import {NgTemplateOutlet} from '@angular/common';

--- a/modules/@angular/common/test/directives/non_bindable_spec.ts
+++ b/modules/@angular/common/test/directives/non_bindable_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {beforeEach, ddescribe, describe, expect, iit, inject, it, xit,} from '@angular/core/testing/testing_internal';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {Component, Directive} from '@angular/core';
 import {ElementRef} from '@angular/core/src/linker/element_ref';

--- a/modules/@angular/common/test/forms-deprecated/integration_spec.ts
+++ b/modules/@angular/common/test/forms-deprecated/integration_spec.ts
@@ -9,10 +9,9 @@
 import {NgFor, NgIf} from '@angular/common';
 import {Control, ControlGroup, ControlValueAccessor, FORM_DIRECTIVES, FORM_PROVIDERS, NG_ASYNC_VALIDATORS, NG_VALIDATORS, NgControl, NgForm, RadioButtonState, Validator, Validators} from '@angular/common/src/forms-deprecated';
 import {TestComponentBuilder} from '@angular/compiler/testing';
-import {ComponentFixture} from '@angular/compiler/testing';
 import {Component, Directive, EventEmitter, Output} from '@angular/core';
 import {Input, Provider, forwardRef} from '@angular/core';
-import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {afterEach, beforeEach, ddescribe, describe, expect, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 import {By} from '@angular/platform-browser/src/dom/debug/by';

--- a/modules/@angular/common/test/pipes/slice_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/slice_pipe_spec.ts
@@ -7,10 +7,9 @@
  */
 
 import {ddescribe, describe, it, iit, xit, expect, beforeEach, afterEach, inject,} from '@angular/core/testing/testing_internal';
-import {} from '@angular/core/testing/testing_internal';
-import {browserDetection} from '@angular/platform-browser/testing/browser_util';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
+import {browserDetection} from '@angular/platform-browser/testing/browser_util';
 
 import {Component} from '@angular/core';
 import {SlicePipe} from '@angular/common';

--- a/modules/@angular/compiler/testing/test_component_builder.ts
+++ b/modules/@angular/compiler/testing/test_component_builder.ts
@@ -7,7 +7,7 @@
  */
 
 import {AnimationEntryMetadata, ChangeDetectorRef, ComponentFactory, ComponentRef, ComponentResolver, DebugElement, ElementRef, Injectable, Injector, NgZone, NgZoneError, OpaqueToken, ViewMetadata, getDebugNode} from '@angular/core';
-import {tick} from '@angular/core/testing';
+import {ComponentFixture, tick} from '@angular/core/testing';
 
 import {DirectiveResolver, ViewResolver} from '../index';
 import {ObservableWrapper, PromiseCompleter, PromiseWrapper} from '../src/facade/async';
@@ -15,6 +15,11 @@ import {ListWrapper, MapWrapper} from '../src/facade/collection';
 import {BaseException} from '../src/facade/exceptions';
 import {IS_DART, Type, isBlank, isPresent, scheduleMicroTask} from '../src/facade/lang';
 
+/**
+ *  @deprecated
+ *  Import ComponentFixture from @angular/core/testing instead.
+ */
+export {ComponentFixture} from '@angular/core/testing';
 /**
  * An abstract class for inserting the root test component element in a platform independent way.
  */
@@ -24,180 +29,6 @@ export class TestComponentRenderer {
 
 export var ComponentFixtureAutoDetect = new OpaqueToken('ComponentFixtureAutoDetect');
 export var ComponentFixtureNoNgZone = new OpaqueToken('ComponentFixtureNoNgZone');
-
-/**
- * Fixture for debugging and testing a component.
- */
-export class ComponentFixture<T> {
-  /**
-   * The DebugElement associated with the root element of this component.
-   */
-  debugElement: DebugElement;
-
-  /**
-   * The instance of the root component class.
-   */
-  componentInstance: any;
-
-  /**
-   * The native element at the root of the component.
-   */
-  nativeElement: any;
-
-  /**
-   * The ElementRef for the element at the root of the component.
-   */
-  elementRef: ElementRef;
-
-  /**
-   * The ComponentRef for the component
-   */
-  componentRef: ComponentRef<T>;
-
-  /**
-   * The ChangeDetectorRef for the component
-   */
-  changeDetectorRef: ChangeDetectorRef;
-
-  /**
-   * The NgZone in which this component was instantiated.
-   */
-  ngZone: NgZone;
-
-  private _autoDetect: boolean;
-
-  private _isStable: boolean = true;
-  private _completer: PromiseCompleter<any> = null;
-  private _onUnstableSubscription: any /** TODO #9100 */ = null;
-  private _onStableSubscription: any /** TODO #9100 */ = null;
-  private _onMicrotaskEmptySubscription: any /** TODO #9100 */ = null;
-  private _onErrorSubscription: any /** TODO #9100 */ = null;
-
-  constructor(componentRef: ComponentRef<T>, ngZone: NgZone, autoDetect: boolean) {
-    this.changeDetectorRef = componentRef.changeDetectorRef;
-    this.elementRef = componentRef.location;
-    this.debugElement = <DebugElement>getDebugNode(this.elementRef.nativeElement);
-    this.componentInstance = componentRef.instance;
-    this.nativeElement = this.elementRef.nativeElement;
-    this.componentRef = componentRef;
-    this.ngZone = ngZone;
-    this._autoDetect = autoDetect;
-
-    if (ngZone != null) {
-      this._onUnstableSubscription =
-          ObservableWrapper.subscribe(ngZone.onUnstable, (_) => { this._isStable = false; });
-      this._onMicrotaskEmptySubscription =
-          ObservableWrapper.subscribe(ngZone.onMicrotaskEmpty, (_) => {
-            if (this._autoDetect) {
-              // Do a change detection run with checkNoChanges set to true to check
-              // there are no changes on the second run.
-              this.detectChanges(true);
-            }
-          });
-      this._onStableSubscription = ObservableWrapper.subscribe(ngZone.onStable, (_) => {
-        this._isStable = true;
-        // Check whether there are no pending macrotasks in a microtask so that ngZone gets a chance
-        // to update the state of pending macrotasks.
-        scheduleMicroTask(() => {
-          if (!this.ngZone.hasPendingMacrotasks) {
-            if (this._completer != null) {
-              this._completer.resolve(true);
-              this._completer = null;
-            }
-          }
-        });
-      });
-
-      this._onErrorSubscription = ObservableWrapper.subscribe(
-          ngZone.onError, (error: NgZoneError) => { throw error.error; });
-    }
-  }
-
-  private _tick(checkNoChanges: boolean) {
-    this.changeDetectorRef.detectChanges();
-    if (checkNoChanges) {
-      this.checkNoChanges();
-    }
-  }
-
-  /**
-   * Trigger a change detection cycle for the component.
-   */
-  detectChanges(checkNoChanges: boolean = true): void {
-    if (this.ngZone != null) {
-      // Run the change detection inside the NgZone so that any async tasks as part of the change
-      // detection are captured by the zone and can be waited for in isStable.
-      this.ngZone.run(() => { this._tick(checkNoChanges); });
-    } else {
-      // Running without zone. Just do the change detection.
-      this._tick(checkNoChanges);
-    }
-  }
-
-  /**
-   * Do a change detection run to make sure there were no changes.
-   */
-  checkNoChanges(): void { this.changeDetectorRef.checkNoChanges(); }
-
-  /**
-   * Set whether the fixture should autodetect changes.
-   *
-   * Also runs detectChanges once so that any existing change is detected.
-   */
-  autoDetectChanges(autoDetect: boolean = true) {
-    if (this.ngZone == null) {
-      throw new BaseException('Cannot call autoDetectChanges when ComponentFixtureNoNgZone is set');
-    }
-    this._autoDetect = autoDetect;
-    this.detectChanges();
-  }
-
-  /**
-   * Return whether the fixture is currently stable or has async tasks that have not been completed
-   * yet.
-   */
-  isStable(): boolean { return this._isStable && !this.ngZone.hasPendingMacrotasks; }
-
-  /**
-   * Get a promise that resolves when the fixture is stable.
-   *
-   * This can be used to resume testing after events have triggered asynchronous activity or
-   * asynchronous change detection.
-   */
-  whenStable(): Promise<any> {
-    if (this.isStable()) {
-      return PromiseWrapper.resolve(false);
-    } else if (this._completer !== null) {
-      return this._completer.promise;
-    } else {
-      this._completer = new PromiseCompleter<any>();
-      return this._completer.promise;
-    }
-  }
-
-  /**
-   * Trigger component destruction.
-   */
-  destroy(): void {
-    this.componentRef.destroy();
-    if (this._onUnstableSubscription != null) {
-      ObservableWrapper.dispose(this._onUnstableSubscription);
-      this._onUnstableSubscription = null;
-    }
-    if (this._onStableSubscription != null) {
-      ObservableWrapper.dispose(this._onStableSubscription);
-      this._onStableSubscription = null;
-    }
-    if (this._onMicrotaskEmptySubscription != null) {
-      ObservableWrapper.dispose(this._onMicrotaskEmptySubscription);
-      this._onMicrotaskEmptySubscription = null;
-    }
-    if (this._onErrorSubscription != null) {
-      ObservableWrapper.dispose(this._onErrorSubscription);
-      this._onErrorSubscription = null;
-    }
-  }
-}
 
 var _nextRootElementId = 0;
 

--- a/modules/@angular/core/test/linker/change_detection_integration_spec.ts
+++ b/modules/@angular/core/test/linker/change_detection_integration_spec.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {TestComponentBuilder} from '@angular/compiler/testing';
+import {ComponentFixture, fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {afterEach, beforeEach, beforeEachProviders, ddescribe, describe, expect, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
-
-import {fakeAsync, flushMicrotasks, tick,} from '@angular/core/testing';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
 
 import {isBlank, NumberWrapper,} from '../../src/facade/lang';
 import {BaseException} from '../../src/facade/exceptions';

--- a/modules/@angular/core/test/linker/dynamic_component_loader_spec.ts
+++ b/modules/@angular/core/test/linker/dynamic_component_loader_spec.ts
@@ -8,7 +8,8 @@
 
 import {beforeEach, ddescribe, xdescribe, describe, expect, iit, inject, beforeEachProviders, it, xit,} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {ComponentFixture} from '@angular/core/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 import {Predicate} from '../../src/facade/collection';
 import {Injector, OnDestroy, DebugElement, Type, ViewContainerRef, ViewChild} from '@angular/core';
 import {Component, ViewMetadata} from '@angular/core/src/metadata';

--- a/modules/@angular/core/test/linker/integration_spec.ts
+++ b/modules/@angular/core/test/linker/integration_spec.ts
@@ -7,8 +7,8 @@
  */
 
 import {beforeEach, ddescribe, xdescribe, describe, expect, iit, inject, beforeEachProviders, it, xit,} from '@angular/core/testing/testing_internal';
-import {fakeAsync, tick} from '@angular/core/testing';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {fakeAsync, tick, ComponentFixture} from '@angular/core/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {isPresent, stringify, isBlank,} from '../../src/facade/lang';

--- a/modules/@angular/core/test/linker/projection_integration_spec.ts
+++ b/modules/@angular/core/test/linker/projection_integration_spec.ts
@@ -8,7 +8,8 @@
 
 import {beforeEach, ddescribe, xdescribe, describe, expect, iit, inject, beforeEachProviders, it, xit,} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {ComponentFixture} from '@angular/core/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 

--- a/modules/@angular/core/test/linker/view_injector_integration_spec.ts
+++ b/modules/@angular/core/test/linker/view_injector_integration_spec.ts
@@ -7,8 +7,8 @@
  */
 
 import {describe, ddescribe, it, iit, xit, xdescribe, expect, beforeEach, beforeEachProviders, inject,} from '@angular/core/testing/testing_internal';
-import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {fakeAsync, flushMicrotasks, tick, ComponentFixture} from '@angular/core/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 import {isBlank} from '../../src/facade/lang';
 import {Type, ViewContainerRef, TemplateRef, ElementRef, ChangeDetectorRef, ChangeDetectionStrategy, Directive, Component, DebugElement, forwardRef, Input, PipeTransform, Attribute, ViewMetadata, provide, Optional, Inject, Self, InjectMetadata, Pipe, Host, SkipSelfMetadata} from '@angular/core';
 import {NgIf, NgFor} from '@angular/common';

--- a/modules/@angular/core/testing.ts
+++ b/modules/@angular/core/testing.ts
@@ -7,6 +7,7 @@
  */
 
 export * from './testing/async';
+export * from './testing/component_fixture';
 export * from './testing/fake_async';
 export * from './testing/test_injector';
 export * from './testing/testing';

--- a/modules/@angular/core/testing/component_fixture.ts
+++ b/modules/@angular/core/testing/component_fixture.ts
@@ -1,0 +1,189 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {AnimationEntryMetadata, ChangeDetectorRef, ComponentFactory, ComponentRef, ComponentResolver, DebugElement, ElementRef, Injectable, Injector, NgZone, NgZoneError, OpaqueToken, ViewMetadata, getDebugNode} from '../index';
+import {ObservableWrapper, PromiseCompleter, PromiseWrapper} from '../src/facade/async';
+import {BaseException} from '../src/facade/exceptions';
+import {scheduleMicroTask} from '../src/facade/lang';
+
+import {tick} from './fake_async';
+
+
+/**
+ * Fixture for debugging and testing a component.
+ */
+export class ComponentFixture<T> {
+  /**
+   * The DebugElement associated with the root element of this component.
+   */
+  debugElement: DebugElement;
+
+  /**
+   * The instance of the root component class.
+   */
+  componentInstance: any;
+
+  /**
+   * The native element at the root of the component.
+   */
+  nativeElement: any;
+
+  /**
+   * The ElementRef for the element at the root of the component.
+   */
+  elementRef: ElementRef;
+
+  /**
+   * The ComponentRef for the component
+   */
+  componentRef: ComponentRef<T>;
+
+  /**
+   * The ChangeDetectorRef for the component
+   */
+  changeDetectorRef: ChangeDetectorRef;
+
+  /**
+   * The NgZone in which this component was instantiated.
+   */
+  ngZone: NgZone;
+
+  private _autoDetect: boolean;
+
+  private _isStable: boolean = true;
+  private _completer: PromiseCompleter<any> = null;
+  private _onUnstableSubscription: any /** TODO #9100 */ = null;
+  private _onStableSubscription: any /** TODO #9100 */ = null;
+  private _onMicrotaskEmptySubscription: any /** TODO #9100 */ = null;
+  private _onErrorSubscription: any /** TODO #9100 */ = null;
+
+  constructor(componentRef: ComponentRef<T>, ngZone: NgZone, autoDetect: boolean) {
+    this.changeDetectorRef = componentRef.changeDetectorRef;
+    this.elementRef = componentRef.location;
+    this.debugElement = <DebugElement>getDebugNode(this.elementRef.nativeElement);
+    this.componentInstance = componentRef.instance;
+    this.nativeElement = this.elementRef.nativeElement;
+    this.componentRef = componentRef;
+    this.ngZone = ngZone;
+    this._autoDetect = autoDetect;
+
+    if (ngZone != null) {
+      this._onUnstableSubscription =
+          ObservableWrapper.subscribe(ngZone.onUnstable, (_) => { this._isStable = false; });
+      this._onMicrotaskEmptySubscription =
+          ObservableWrapper.subscribe(ngZone.onMicrotaskEmpty, (_) => {
+            if (this._autoDetect) {
+              // Do a change detection run with checkNoChanges set to true to check
+              // there are no changes on the second run.
+              this.detectChanges(true);
+            }
+          });
+      this._onStableSubscription = ObservableWrapper.subscribe(ngZone.onStable, (_) => {
+        this._isStable = true;
+        // Check whether there are no pending macrotasks in a microtask so that ngZone gets a chance
+        // to update the state of pending macrotasks.
+        scheduleMicroTask(() => {
+          if (!this.ngZone.hasPendingMacrotasks) {
+            if (this._completer != null) {
+              this._completer.resolve(true);
+              this._completer = null;
+            }
+          }
+        });
+      });
+
+      this._onErrorSubscription = ObservableWrapper.subscribe(
+          ngZone.onError, (error: NgZoneError) => { throw error.error; });
+    }
+  }
+
+  private _tick(checkNoChanges: boolean) {
+    this.changeDetectorRef.detectChanges();
+    if (checkNoChanges) {
+      this.checkNoChanges();
+    }
+  }
+
+  /**
+   * Trigger a change detection cycle for the component.
+   */
+  detectChanges(checkNoChanges: boolean = true): void {
+    if (this.ngZone != null) {
+      // Run the change detection inside the NgZone so that any async tasks as part of the change
+      // detection are captured by the zone and can be waited for in isStable.
+      this.ngZone.run(() => { this._tick(checkNoChanges); });
+    } else {
+      // Running without zone. Just do the change detection.
+      this._tick(checkNoChanges);
+    }
+  }
+
+  /**
+   * Do a change detection run to make sure there were no changes.
+   */
+  checkNoChanges(): void { this.changeDetectorRef.checkNoChanges(); }
+
+  /**
+   * Set whether the fixture should autodetect changes.
+   *
+   * Also runs detectChanges once so that any existing change is detected.
+   */
+  autoDetectChanges(autoDetect: boolean = true) {
+    if (this.ngZone == null) {
+      throw new BaseException('Cannot call autoDetectChanges when ComponentFixtureNoNgZone is set');
+    }
+    this._autoDetect = autoDetect;
+    this.detectChanges();
+  }
+
+  /**
+   * Return whether the fixture is currently stable or has async tasks that have not been completed
+   * yet.
+   */
+  isStable(): boolean { return this._isStable && !this.ngZone.hasPendingMacrotasks; }
+
+  /**
+   * Get a promise that resolves when the fixture is stable.
+   *
+   * This can be used to resume testing after events have triggered asynchronous activity or
+   * asynchronous change detection.
+   */
+  whenStable(): Promise<any> {
+    if (this.isStable()) {
+      return PromiseWrapper.resolve(false);
+    } else if (this._completer !== null) {
+      return this._completer.promise;
+    } else {
+      this._completer = new PromiseCompleter<any>();
+      return this._completer.promise;
+    }
+  }
+
+  /**
+   * Trigger component destruction.
+   */
+  destroy(): void {
+    this.componentRef.destroy();
+    if (this._onUnstableSubscription != null) {
+      ObservableWrapper.dispose(this._onUnstableSubscription);
+      this._onUnstableSubscription = null;
+    }
+    if (this._onStableSubscription != null) {
+      ObservableWrapper.dispose(this._onStableSubscription);
+      this._onStableSubscription = null;
+    }
+    if (this._onMicrotaskEmptySubscription != null) {
+      ObservableWrapper.dispose(this._onMicrotaskEmptySubscription);
+      this._onMicrotaskEmptySubscription = null;
+    }
+    if (this._onErrorSubscription != null) {
+      ObservableWrapper.dispose(this._onErrorSubscription);
+      this._onErrorSubscription = null;
+    }
+  }
+}

--- a/modules/@angular/forms/test/integration_spec.ts
+++ b/modules/@angular/forms/test/integration_spec.ts
@@ -8,9 +8,9 @@
 
 import {NgFor, NgIf} from '@angular/common';
 import {TestComponentBuilder} from '@angular/compiler/testing';
-import {ComponentFixture} from '@angular/compiler/testing';
 import {Component, Directive, EventEmitter, Output} from '@angular/core';
 import {Input, Provider, forwardRef} from '@angular/core';
+import {ComponentFixture} from '@angular/core/testing';
 import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {afterEach, beforeEach, ddescribe, describe, expect, iit, inject, it, xdescribe, xit} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';

--- a/modules/@angular/platform-browser-dynamic/test/xhr/xhr_cache_spec.ts
+++ b/modules/@angular/platform-browser-dynamic/test/xhr/xhr_cache_spec.ts
@@ -12,7 +12,7 @@ import {beforeEach, beforeEachProviders, ddescribe, describe, iit, inject, it, x
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 
 import {fakeAsync, flushMicrotasks, tick,} from '@angular/core/testing';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 import {expect} from '@angular/platform-browser/testing/matchers';
 import {BaseException} from '../../src/facade/exceptions';
 import {CachedXHR} from '../../src/xhr/xhr_cache';

--- a/modules/@angular/router-deprecated/test/integration/impl/async_route_spec_impl.ts
+++ b/modules/@angular/router-deprecated/test/integration/impl/async_route_spec_impl.ts
@@ -7,7 +7,8 @@
  */
 
 import {beforeEach, beforeEachProviders, expect, iit, inject, it, xit,} from '@angular/core/testing/testing_internal';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
+import {ComponentFixture} from '@angular/core/testing';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 
 import {Location} from '@angular/common';

--- a/modules/@angular/router-deprecated/test/integration/impl/aux_route_spec_impl.ts
+++ b/modules/@angular/router-deprecated/test/integration/impl/aux_route_spec_impl.ts
@@ -7,8 +7,9 @@
  */
 
 import {Location} from '@angular/common';
-import {ComponentFixture, TestComponentBuilder} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 import {Component} from '@angular/core';
+import {ComponentFixture} from '@angular/core/testing';
 import {beforeEach, beforeEachProviders, ddescribe, describe, expect, iit, inject, it, xdescribe, xit} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 import {By} from '@angular/platform-browser/src/dom/debug/by';

--- a/modules/@angular/router-deprecated/test/integration/impl/sync_route_spec_impl.ts
+++ b/modules/@angular/router-deprecated/test/integration/impl/sync_route_spec_impl.ts
@@ -8,7 +8,8 @@
 
 import {beforeEach, beforeEachProviders, expect, iit, inject, it, xit,} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
+import {ComponentFixture} from '@angular/core/testing';
 
 import {specs, compile, TEST_ROUTER_PROVIDERS, clickOnElement, getHref} from '../util';
 import {Location} from '@angular/common';

--- a/modules/@angular/router-deprecated/test/integration/lifecycle_hook_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/lifecycle_hook_spec.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentFixture, TestComponentBuilder} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 import {Component, Inject, Injector, provide} from '@angular/core';
+import {ComponentFixture} from '@angular/core/testing';
 import {beforeEach, beforeEachProviders, ddescribe, describe, expect, iit, inject, it, xdescribe, xit} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 import {RouteParams, Router, RouterLink, RouterOutlet} from '@angular/router-deprecated';

--- a/modules/@angular/router-deprecated/test/integration/navigation_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/navigation_spec.ts
@@ -7,8 +7,9 @@
  */
 
 import {Location} from '@angular/common';
-import {ComponentFixture, TestComponentBuilder} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 import {Component, Inject, Injector, provide} from '@angular/core';
+import {ComponentFixture} from '@angular/core/testing';
 import {beforeEach, beforeEachProviders, ddescribe, describe, expect, iit, inject, it, xdescribe, xit} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 import {RouteData, RouteParams, Router, RouterLink, RouterOutlet} from '@angular/router-deprecated';

--- a/modules/@angular/router-deprecated/test/integration/redirect_route_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/redirect_route_spec.ts
@@ -7,7 +7,8 @@
  */
 
 import {Location} from '@angular/common';
-import {ComponentFixture, TestComponentBuilder} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
+import {ComponentFixture} from '@angular/core/testing';
 import {beforeEach, beforeEachProviders, ddescribe, describe, expect, iit, inject, it, xdescribe, xit} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 import {RouteData, RouteParams, Router, RouterLink, RouterOutlet} from '@angular/router-deprecated';

--- a/modules/@angular/router-deprecated/test/integration/router_link_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/router_link_spec.ts
@@ -8,7 +8,8 @@
 
 import {beforeEach, ddescribe, xdescribe, describe, expect, iit, inject, beforeEachProviders, it, xit,} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
-import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
+import {ComponentFixture} from '@angular/core/testing';
 import {Location} from '@angular/common';
 import {NumberWrapper, escapeRegExp} from '../../src/facade/lang';
 import {PromiseWrapper} from '../../src/facade/async';

--- a/modules/@angular/router-deprecated/test/integration/util.ts
+++ b/modules/@angular/router-deprecated/test/integration/util.ts
@@ -8,8 +8,9 @@
 
 import {Location} from '@angular/common';
 import {SpyLocation} from '@angular/common/testing';
-import {ComponentFixture, TestComponentBuilder} from '@angular/compiler/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
 import {Component, provide} from '@angular/core';
+import {ComponentFixture} from '@angular/core/testing';
 import {beforeEach, beforeEachProviders, ddescribe, describe, inject, it, xdescribe, xit} from '@angular/core/testing/testing_internal';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {ROUTER_DIRECTIVES, ROUTER_PRIMARY_COMPONENT, Router} from '@angular/router-deprecated';

--- a/tools/public_api_guard/compiler/testing.d.ts
+++ b/tools/public_api_guard/compiler/testing.d.ts
@@ -1,20 +1,3 @@
-export declare class ComponentFixture<T> {
-    changeDetectorRef: ChangeDetectorRef;
-    componentInstance: any;
-    componentRef: ComponentRef<T>;
-    debugElement: DebugElement;
-    elementRef: ElementRef;
-    nativeElement: any;
-    ngZone: NgZone;
-    constructor(componentRef: ComponentRef<T>, ngZone: NgZone, autoDetect: boolean);
-    autoDetectChanges(autoDetect?: boolean): void;
-    checkNoChanges(): void;
-    destroy(): void;
-    detectChanges(checkNoChanges?: boolean): void;
-    isStable(): boolean;
-    whenStable(): Promise<any>;
-}
-
 export declare var ComponentFixtureAutoDetect: OpaqueToken;
 
 export declare var ComponentFixtureNoNgZone: OpaqueToken;

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -6,6 +6,23 @@ export declare function beforeEach(fn: Function): void;
 
 export declare function beforeEachProviders(fn: () => Array<any>): void;
 
+export declare class ComponentFixture<T> {
+    changeDetectorRef: ChangeDetectorRef;
+    componentInstance: any;
+    componentRef: ComponentRef<T>;
+    debugElement: DebugElement;
+    elementRef: ElementRef;
+    nativeElement: any;
+    ngZone: NgZone;
+    constructor(componentRef: ComponentRef<T>, ngZone: NgZone, autoDetect: boolean);
+    autoDetectChanges(autoDetect?: boolean): void;
+    checkNoChanges(): void;
+    destroy(): void;
+    detectChanges(checkNoChanges?: boolean): void;
+    isStable(): boolean;
+    whenStable(): Promise<any>;
+}
+
 export declare var ddescribe: Function;
 
 export declare var describe: Function;


### PR DESCRIPTION
```
BREAKING CHANGE:

`ComponentFixture` will be moving out of `@angular/compiler/testing` to `@angular/core/testing` in
the next release.
```
