### PR TITLE
chore(api): clean up unused exports from e2e testing helpers

### DIFF
--- a/modules/@angular/examples/router_deprecated/ts/can_activate/can_activate_spec.ts
+++ b/modules/@angular/examples/router_deprecated/ts/can_activate/can_activate_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@angular/core/testing';
-import {browser, verifyNoBrowserErrors} from '@angular/platform-browser/testing_e2e';
+import {verifyNoBrowserErrors} from '@angular/platform-browser/testing_e2e';
 
 function waitForElement(selector: string) {
   var EC = (<any>protractor).ExpectedConditions;

--- a/modules/@angular/examples/router_deprecated/ts/can_deactivate/can_deactivate_spec.ts
+++ b/modules/@angular/examples/router_deprecated/ts/can_deactivate/can_deactivate_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@angular/core/testing';
-import {browser, verifyNoBrowserErrors} from '@angular/platform-browser/testing_e2e';
+import {verifyNoBrowserErrors} from '@angular/platform-browser/testing_e2e';
 
 function waitForElement(selector: string) {
   var EC = (<any>protractor).ExpectedConditions;

--- a/modules/@angular/examples/router_deprecated/ts/on_deactivate/on_deactivate_spec.ts
+++ b/modules/@angular/examples/router_deprecated/ts/on_deactivate/on_deactivate_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@angular/core/testing';
-import {browser, verifyNoBrowserErrors} from '@angular/platform-browser/testing_e2e';
+import {verifyNoBrowserErrors} from '@angular/platform-browser/testing_e2e';
 
 function waitForElement(selector: string) {
   var EC = (<any>protractor).ExpectedConditions;

--- a/modules/@angular/examples/router_deprecated/ts/reuse/reuse_spec.ts
+++ b/modules/@angular/examples/router_deprecated/ts/reuse/reuse_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {expect} from '@angular/core/testing';
-import {browser, verifyNoBrowserErrors} from '@angular/platform-browser/testing_e2e';
+import {verifyNoBrowserErrors} from '@angular/platform-browser/testing_e2e';
 
 function waitForElement(selector: string) {
   var EC = (<any>protractor).ExpectedConditions;

--- a/modules/@angular/platform-browser/testing/e2e_util.ts
+++ b/modules/@angular/platform-browser/testing/e2e_util.ts
@@ -8,21 +8,16 @@
 
 import * as webdriver from 'selenium-webdriver';
 
-declare var global: any /** TODO #9100 */;
-declare var expect: Function;
-export var browser: protractor.IBrowser = global['browser'];
-export var $: cssSelectorHelper = global['$'];
 
-export function clickAll(buttonSelectors: any /** TODO #9100 */) {
-  buttonSelectors.forEach(function(selector: any /** TODO #9100 */) { $(selector).click(); });
-}
+declare var browser: any;
+declare var expect: any;
 
 export function verifyNoBrowserErrors() {
   // TODO(tbosch): Bug in ChromeDriver: Need to execute at least one command
   // so that the browser logs can be read out!
   browser.executeScript('1+1');
-  browser.manage().logs().get('browser').then(function(browserLog) {
-    var filteredLog = browserLog.filter(function(logEntry) {
+  browser.manage().logs().get('browser').then(function(browserLog: any) {
+    var filteredLog = browserLog.filter(function(logEntry: any) {
       if (logEntry.level.value >= webdriver.logging.Level.INFO.value) {
         console.log('>> ' + logEntry.message);
       }

--- a/tools/public_api_guard/platform-browser/testing_e2e.d.ts
+++ b/tools/public_api_guard/platform-browser/testing_e2e.d.ts
@@ -1,7 +1,1 @@
-export declare var $: cssSelectorHelper;
-
-export declare var browser: protractor.IBrowser;
-
-export declare function clickAll(buttonSelectors: any): void;
-
 export declare function verifyNoBrowserErrors(): void;


### PR DESCRIPTION
This is round one of the browser-platform/testing API cleanup. The testing e2e used to export protractor globals as any and they were mostly unused and unnecessary. Removing.

As a further note, we should probably follow-up later and move `@angular/browser-platform/testing/e2e_util` and `perf_util` to a separate bundle - they are not related to any of the other code in browser-platform, and are actually to be run in node.js environments. @IgorMinar any ideas on how this should work in bundling? I'm not convinced that anything in either of those should be exported publicly.
