### PR TITLE
feat(core): allow injection of ElementRef and ViewContainerRef into services

### DIFF
--- a/modules/@angular/compiler/src/provider_parser.ts
+++ b/modules/@angular/compiler/src/provider_parser.ts
@@ -197,14 +197,16 @@ export class ProviderElementContext {
       if ((requestingProviderType === ProviderAstType.Directive ||
            requestingProviderType === ProviderAstType.Component)) {
         if (dep.token.equalsTo(identifierToken(Identifiers.Renderer)) ||
-            dep.token.equalsTo(identifierToken(Identifiers.ElementRef)) ||
             dep.token.equalsTo(identifierToken(Identifiers.ChangeDetectorRef)) ||
             dep.token.equalsTo(identifierToken(Identifiers.TemplateRef))) {
           return dep;
         }
-        if (dep.token.equalsTo(identifierToken(Identifiers.ViewContainerRef))) {
-          this._hasViewContainer = true;
-        }
+      }
+      if (dep.token.equalsTo(identifierToken(Identifiers.ElementRef))) {
+        return dep;
+      }
+      if (dep.token.equalsTo(identifierToken(Identifiers.ViewContainerRef))) {
+        this._hasViewContainer = true;
       }
       // access the injector
       if (dep.token.equalsTo(identifierToken(Identifiers.Injector))) {


### PR DESCRIPTION
@tbosch if I'm not mistaken this is the change we've discussed yesterday. I wasn't sure what the semantic should be for `TemplateRef`, `Renderer` and `ChangeDetectorRef` so for now exposed just bare minimum.

Now, there is one thing that bothers me here - from my testing it looks like it was already possible to inject `ElementRef` into services, even without my change. Was it the root ElementRef? If so this PR would be a breaking change, no?

It would be great if we could get this one into RC.3 as some of my work depends on it.

cc: @jelbourn 
