### PR TITLE
fix(security): no warning when sanitizing escaped html (#9392)

### DIFF
--- a/modules/@angular/platform-browser/src/security/html_sanitizer.ts
+++ b/modules/@angular/platform-browser/src/security/html_sanitizer.ts
@@ -223,11 +223,11 @@ function stripCustomNsAttrs(el: any) {
  * Sanitizes the given unsafe, untrusted HTML fragment, and returns HTML text that is safe to add to
  * the DOM in a browser environment.
  */
-export function sanitizeHtml(unsafeHtml: string): string {
+export function sanitizeHtml(unsafeHtmlInput: string): string {
   try {
-    let containerEl = getInertElement();
+    const containerEl = getInertElement();
     // Make sure unsafeHtml is actually a string (TypeScript types are not enforced at runtime).
-    unsafeHtml = unsafeHtml ? String(unsafeHtml) : '';
+    let unsafeHtml = unsafeHtmlInput ? String(unsafeHtmlInput) : '';
 
     // mXSS protection. Repeatedly parse the document to make sure it stabilizes, so that a browser
     // trying to auto-correct incorrect HTML cannot cause formerly inert HTML to become dangerous.
@@ -258,7 +258,7 @@ export function sanitizeHtml(unsafeHtml: string): string {
       DOM.removeChild(parent, child);
     }
 
-    if (isDevMode() && safeHtml !== unsafeHtml) {
+    if (isDevMode() && safeHtml !== unsafeHtmlInput) {
       DOM.log('WARNING: sanitizing HTML stripped some content.');
     }
 

--- a/modules/@angular/platform-browser/test/security/html_sanitizer_spec.ts
+++ b/modules/@angular/platform-browser/test/security/html_sanitizer_spec.ts
@@ -43,6 +43,10 @@ export function main() {
       t.expect(sanitizeHtml('<?pi nodes?>no.')).toEqual('no.');
       t.expect(logMsgs.join('\n')).toMatch(/sanitizing HTML stripped some content/);
     });
+    t.it('supports sanitizing escaped entities', () => {
+      t.expect(sanitizeHtml('&#128640;')).toEqual('&#128640;');
+      t.expect(logMsgs).toEqual([]);
+    });
     t.it('escapes entities', () => {
       t.expect(sanitizeHtml('<p>Hello &lt; World</p>')).toEqual('<p>Hello &lt; World</p>');
       t.expect(sanitizeHtml('<p>Hello < World</p>')).toEqual('<p>Hello &lt; World</p>');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/angular/angular/issues/9392

**What is the new behavior?**
No warning when properly escaped html is passed to `sanitize`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
