### PR TITLE
fix(upgrade): allow e2e tests to run against ngUpgrade applications

### DIFF
--- a/modules/@angular/upgrade/src/upgrade_adapter.ts
+++ b/modules/@angular/upgrade/src/upgrade_adapter.ts
@@ -372,11 +372,8 @@ export class UpgradeAdapter {
       }
     });
 
-    Promise
-        .all([
-          this.compileNg2Components(compiler, componentFactoryRefMap), ng1BootstrapPromise,
-          ng1compilePromise
-        ])
+    Promise.all([ng1BootstrapPromise, ng1compilePromise])
+        .then(() => { this.compileNg2Components(compiler, componentFactoryRefMap); })
         .then(() => {
           ngZone.run(() => {
             if (rootScopePrototype) {

--- a/modules/playground/e2e_test/upgrade/upgrade_spec.ts
+++ b/modules/playground/e2e_test/upgrade/upgrade_spec.ts
@@ -1,13 +1,17 @@
 import {verifyNoBrowserErrors} from "@angular/platform-browser/testing_e2e";
 
-// TODO(i): reenable once we fix issue with exposing testability to protractor when using ngUpgrade
-// https://github.com/angular/angular/issues/9407
-xdescribe('ngUpgrade', function() {
+describe('ngUpgrade', function() {
   var URL = 'all/playground/src/upgrade/index.html';
 
-  beforeEach(function() { browser.get(URL); });
+  beforeEach(function() {
+    browser.rootEl = 'body';
+    browser.get(URL);
+  });
 
-  afterEach(verifyNoBrowserErrors);
+  afterEach(function() {
+    (<any>browser).useAllAngular2AppRoots();
+    verifyNoBrowserErrors();
+  });
 
   it('should bootstrap Angular 1 and Angular 2 apps together', function() {
     var ng1NameInput = element(by.css('input[ng-model]=name'));


### PR DESCRIPTION
Previously, ngUpgrade apps would fail in Protractor e2e tests if
an upgraded ng1 compnent used a property binding.

Closes #9407
