### PR TITLE
build: fix some issues on Windows platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 
 # JS files must always use LF for tools to work
 *.js eol=lf
+
+# Must keep Windows line ending to be parsed correctly
+scripts/windows/packages.txt eol=crlf

--- a/build.sh
+++ b/build.sh
@@ -73,12 +73,12 @@ do
 
   echo "======      TSC 1.8 d.ts compat for ${DESTDIR}   ====="
   # safely strips 'readonly' specifier from d.ts files to make them compatible with tsc 1.8
-  if [[ ${TRAVIS} ]]; then
-    find ${DESTDIR} -type f -name '*.d.ts' -print0 | xargs -0 sed -i    -e 's/\(^ *(static |private )*\)*readonly  */\1/g'
-    find ${DESTDIR} -type f -name '*.d.ts' -print0 | xargs -0 sed -i    -E 's/^( +)abstract ([[:alnum:]]+\:)/\1\2/g'
+  if [ "$(uname)" == "Darwin" ]; then
+    find ${DESTDIR} -type f -name '*.d.ts' -print0 | xargs -0 sed -i ''    -e 's/\(^ *(static |private )*\)*readonly  */\1/g'
+    find ${DESTDIR} -type f -name '*.d.ts' -print0 | xargs -0 sed -i ''    -E 's/^( +)abstract ([[:alnum:]]+\:)/\1\2/g'
   else
-    find ${DESTDIR} -type f -name '*.d.ts' -print0 | xargs -0 sed -i '' -e 's/\(^ *(static |private )*\)*readonly  */\1/g'
-    find ${DESTDIR} -type f -name '*.d.ts' -print0 | xargs -0 sed -i '' -E 's/^( +)abstract ([[:alnum:]]+\:)/\1\2/g'
+    find ${DESTDIR} -type f -name '*.d.ts' -print0 | xargs -0 sed -i -e 's/\(^ *(static |private )*\)*readonly  */\1/g'
+    find ${DESTDIR} -type f -name '*.d.ts' -print0 | xargs -0 sed -i -E 's/^( +)abstract ([[:alnum:]]+\:)/\1\2/g'
   fi
 
   if [[ ${PACKAGE} != compiler-cli ]]; then

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ require('./tools/check-environment')(
 
 const gulp = require('gulp');
 const path = require('path');
+const os = require('os');
 
 const srcsToFmt = ['tools/**/*.ts', 'modules/@angular/**/*.ts'];
 
@@ -61,7 +62,8 @@ function tsc(projectPath, done) {
 
   child_process
       .spawn(
-          `${__dirname}/node_modules/.bin/tsc`, ['-p', path.join(__dirname, projectPath)],
+          path.normalize(`${__dirname}/node_modules/.bin/tsc`) + (/^win/.test(os.platform()) ? '.cmd' : ''),
+          ['-p', path.join(__dirname, projectPath)],
           {stdio: 'inherit'})
       .on('close', (errorCode) => done(errorCode));
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/angular/angular.git"
   },
   "scripts": {
-    "postinstall": "node tools/npm/copy-npm-shrinkwrap; webdriver-manager update"
+    "postinstall": "node tools/npm/copy-npm-shrinkwrap && webdriver-manager update"
   },
   "dependencies": {
     "es6-shim": "^0.35.0",

--- a/scripts/windows/create-symlinks.sh
+++ b/scripts/windows/create-symlinks.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+cd `dirname $0`
+
+while read PACKAGE
+do
+  DESTDIR=./../../modules/\@angular/${PACKAGE}/src
+  mv ${DESTDIR}/facade ${DESTDIR}/facade.old
+  cmd <<< "mklink \"..\\..\\modules\\\@angular\\"${PACKAGE}"\\src\\facade\" \"..\\..\\facade\\src\\\""
+done < packages.txt

--- a/scripts/windows/packages.txt
+++ b/scripts/windows/packages.txt
@@ -1,0 +1,9 @@
+common
+compiler
+core
+forms
+http
+platform-browser
+platform-browser-dynamic
+platform-server
+router-deprecated

--- a/scripts/windows/remove-symlinks.sh
+++ b/scripts/windows/remove-symlinks.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+cd `dirname $0`
+
+while read PACKAGE
+do
+  DESTDIR=./../../modules/\@angular/${PACKAGE}/src
+  rm ${DESTDIR}/facade
+  mv ${DESTDIR}/facade.old ${DESTDIR}/facade
+done < packages.txt

--- a/tools/tsc-watch/tsc_watch.ts
+++ b/tools/tsc-watch/tsc_watch.ts
@@ -1,4 +1,6 @@
 import {spawn} from 'child_process';
+import {platform} from 'os';
+import {normalize} from 'path';
 import {resolve} from 'url';
 
 enum State {
@@ -7,7 +9,7 @@ enum State {
   error
 }
 
-export const TSC = 'node_modules/typescript/bin/tsc';
+export const TSC = normalize('node_modules/.bin/tsc') + (/^win/.test(platform()) ? '.cmd' : '');
 export type Command = (stdIn: any, stdErr: any) => Promise<number>;
 
 export class TscWatch {


### PR DESCRIPTION
All scripts are currently broken on Windows platforms, this PR makes some of them work.
It has been tested on Win7 64bits with Node 5.11.1. and GitBash.

Most of the changes are adaptation to the platform.
The only special case are the committed symlinks which obviously don't work on Windows. To solve, I've added two scripts to create and remove them on Windows. They should be created before running other scripts, and removed before submitting PRs.

With these changes, the following commands are now working:
- `npm install`
- `./build.sh`
- `./presubmit.sh` (but some issues with clang)
- `./test.sh browser`
- `./test.sh tools`

Known remaining issues:
- `./test.sh node` is broken (during codegen processing, modules starting with `@angular` can't be found)
- clang is not up-to-date on Windows, so it raises errors, cc @mprobst 
- IDEs are lost with symlinks (Webstorm, VS code) and @angular package(VS code)

@vicb it should solve #9356 also
