### PR TITLE
feat(DomRenderer): Adding support for document fragments in SVG foreign objects

### DIFF
--- a/modules/@angular/core/test/linker/integration_spec.ts
+++ b/modules/@angular/core/test/linker/integration_spec.ts
@@ -1994,6 +1994,31 @@ function declareTests({useJit}: {useJit: boolean}) {
                      });
                }));
 
+        it('should support foreignObjects with document fragments',
+           inject(
+               [TestComponentBuilder, AsyncTestCompleter],
+               (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
+                 tcb.overrideView(
+                        MyComp, new ViewMetadata({
+                          template:
+                              '<svg><foreignObject><xhtml:div><p>Test</p></xhtml:div></foreignObject></svg>'
+                        }))
+                     .createAsync(MyComp)
+                     .then((fixture) => {
+                       var el = fixture.debugElement.nativeElement;
+                       var svg = getDOM().childNodes(el)[0];
+                       var foreignObject = getDOM().childNodes(svg)[0];
+                       var p = getDOM().childNodes(foreignObject)[0];
+                       expect(getDOM().getProperty(<Element>svg, 'namespaceURI'))
+                           .toEqual('http://www.w3.org/2000/svg');
+                       expect(getDOM().getProperty(<Element>foreignObject, 'namespaceURI'))
+                           .toEqual('http://www.w3.org/2000/svg');
+                       expect(getDOM().getProperty(<Element>p, 'namespaceURI'))
+                           .toEqual('http://www.w3.org/1999/xhtml');
+
+                       async.done();
+                     });
+               }));
       });
 
       describe('attributes', () => {

--- a/modules/@angular/platform-browser/src/dom/dom_renderer.ts
+++ b/modules/@angular/platform-browser/src/dom/dom_renderer.ts
@@ -15,7 +15,8 @@ import {camelCaseToDashCase} from './util';
 
 const NAMESPACE_URIS = {
   'xlink': 'http://www.w3.org/1999/xlink',
-  'svg': 'http://www.w3.org/2000/svg'
+  'svg': 'http://www.w3.org/2000/svg',
+  'xhtml': 'http://www.w3.org/1999/xhtml'
 };
 const TEMPLATE_COMMENT_TEXT = 'template bindings={}';
 var TEMPLATE_BINDINGS_EXP = /^template bindings=(.*)$/g;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
This PR solves the issue described by: #6190
Document fragments within SVG foreign objects can't be created since the renderer continues to use SVG namespace for contained elements.

```
<svg><foreignObject><div><p>Test</p></div></foreignObject></svg>
```

This does currently not work because the renderer would try to render the content of the `foreignObject` element using the SVG namespace.

**What is the new behavior?**

By added the xhtml namespace explicitly to `NAMESPACE_URIS` one can now write a document fragment within a `foreignObject` element by defining the namespace prefix:

```
<svg><foreignObject><xhtml:div><p>Test</p></xhtml:div></foreignObject></svg>
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

…gn objects
