### PR TITLE
chore(api): clean up the core testing public API

### DIFF
--- a/modules/@angular/common/test/forms-deprecated/directives_spec.ts
+++ b/modules/@angular/common/test/forms-deprecated/directives_spec.ts
@@ -8,7 +8,7 @@
 
 import {afterEach, beforeEach, ddescribe, describe, expect, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
 
-import {fakeAsync, flushMicrotasks, Log, tick,} from '@angular/core/testing';
+import {fakeAsync, flushMicrotasks, tick,} from '@angular/core/testing';
 
 import {SpyNgControl, SpyValueAccessor} from '../spies';
 

--- a/modules/@angular/common/test/forms-deprecated/model_spec.ts
+++ b/modules/@angular/common/test/forms-deprecated/model_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ddescribe, describe, it, iit, xit, expect, beforeEach, afterEach, inject,} from '@angular/core/testing/testing_internal';
-import {fakeAsync, flushMicrotasks, Log, tick} from '@angular/core/testing';
+import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 import {ControlGroup, Control, ControlArray, Validators} from '@angular/common/src/forms-deprecated';
 import {IS_DART, isPresent} from '../../src/facade/lang';

--- a/modules/@angular/common/test/forms-deprecated/validators_spec.ts
+++ b/modules/@angular/common/test/forms-deprecated/validators_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {AbstractControl, Control, ControlArray, ControlGroup, Validators} from '@angular/common/src/forms-deprecated';
-import {Log, fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
+import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {afterEach, beforeEach, ddescribe, describe, expect, iit, it, xit} from '@angular/core/testing/testing_internal';
 
 import {EventEmitter, ObservableWrapper, TimerWrapper} from '../../src/facade/async';

--- a/modules/@angular/core/test/directive_lifecycle_integration_spec.ts
+++ b/modules/@angular/core/test/directive_lifecycle_integration_spec.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {beforeEach, ddescribe, describe, expect, iit, inject, it, xdescribe, xit,} from '@angular/core/testing/testing_internal';
-import {Log} from '@angular/core/testing';
-import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 import {TestComponentBuilder} from '@angular/compiler/testing';
-
-import {OnChanges, OnInit, DoCheck, AfterContentInit, AfterContentChecked, AfterViewInit, AfterViewChecked} from '@angular/core';
-import {Directive, Component, ViewMetadata} from '@angular/core/src/metadata';
+import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, DoCheck, OnChanges, OnInit} from '@angular/core';
+import {Component, Directive, ViewMetadata} from '@angular/core/src/metadata';
+import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
+import {Log, beforeEach, beforeEachProviders, ddescribe, describe, expect, iit, inject, it, xdescribe, xit} from '@angular/core/testing/testing_internal';
 
 export function main() {
   describe('directive lifecycle integration spec', () => {
+
+    beforeEachProviders(() => { return [Log]; });
 
     it('should invoke lifecycle methods ngOnChanges > ngOnInit > ngDoCheck > ngAfterContentChecked',
        inject(

--- a/modules/@angular/core/test/fake_async_spec.ts
+++ b/modules/@angular/core/test/fake_async_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {beforeEach, ddescribe, describe, expect, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
-import {fakeAsync, flushMicrotasks, Log, tick, discardPeriodicTasks,} from '@angular/core/testing';
+import {Log, beforeEach, ddescribe, describe, expect, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
+import {fakeAsync, flushMicrotasks, tick, discardPeriodicTasks,} from '@angular/core/testing';
 import {TimerWrapper, PromiseWrapper} from '../../router-deprecated/src/facade/async';
 import {BaseException} from '../../router-deprecated/src/facade/exceptions';
 import {Parser} from '../../compiler/src/expression_parser/parser';

--- a/modules/@angular/core/test/linker/change_detection_integration_spec.ts
+++ b/modules/@angular/core/test/linker/change_detection_integration_spec.ts
@@ -8,7 +8,7 @@
 
 import {afterEach, beforeEach, beforeEachProviders, ddescribe, describe, expect, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
 
-import {fakeAsync, flushMicrotasks, Log, tick,} from '@angular/core/testing';
+import {fakeAsync, flushMicrotasks, tick,} from '@angular/core/testing';
 import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
 
 import {isBlank, NumberWrapper,} from '../../src/facade/lang';

--- a/modules/@angular/core/test/linker/integration_spec.ts
+++ b/modules/@angular/core/test/linker/integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {beforeEach, ddescribe, xdescribe, describe, expect, iit, inject, beforeEachProviders, it, xit,} from '@angular/core/testing/testing_internal';
-import {fakeAsync, tick, clearPendingTimers} from '@angular/core/testing';
+import {fakeAsync, tick} from '@angular/core/testing';
 import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
@@ -1630,8 +1630,6 @@ function declareTests({useJit}: {useJit: boolean}) {
              try {
                tc.injector.get(DirectiveEmittingEvent).fireEvent('boom');
              } catch (e) {
-               clearPendingTimers();
-
                var c = e.context;
                expect(getDOM().nodeName(c.renderNode).toUpperCase()).toEqual('SPAN');
                expect(getDOM().nodeName(c.componentRenderElement).toUpperCase()).toEqual('DIV');

--- a/modules/@angular/core/test/linker/view_injector_integration_spec.ts
+++ b/modules/@angular/core/test/linker/view_injector_integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {describe, ddescribe, it, iit, xit, xdescribe, expect, beforeEach, beforeEachProviders, inject,} from '@angular/core/testing/testing_internal';
-import {fakeAsync, flushMicrotasks, Log, tick} from '@angular/core/testing';
+import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
 import {isBlank} from '../../src/facade/lang';
 import {Type, ViewContainerRef, TemplateRef, ElementRef, ChangeDetectorRef, ChangeDetectionStrategy, Directive, Component, DebugElement, forwardRef, Input, PipeTransform, Attribute, ViewMetadata, provide, Optional, Inject, Self, InjectMetadata, Pipe, Host, SkipSelfMetadata} from '@angular/core';

--- a/modules/@angular/core/test/zone/ng_zone_spec.ts
+++ b/modules/@angular/core/test/zone/ng_zone_spec.ts
@@ -6,15 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {beforeEach, ddescribe, describe, expect, iit, inject, it, xdescribe, xit,} from '@angular/core/testing/testing_internal';
-import {Log} from '@angular/core/testing';
+import {Log, beforeEach, ddescribe, describe, expect, iit, inject, it, xdescribe, xit,} from '@angular/core/testing/testing_internal';
 
-import {PromiseCompleter, PromiseWrapper, TimerWrapper, ObservableWrapper} from '../../src/facade/async';
-import {BaseException} from '../../src/facade/exceptions';
-import {IS_DART, scheduleMicroTask, isPresent} from '../../src/facade/lang';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 import {NgZone, NgZoneError} from '@angular/core/src/zone/ng_zone';
 import {browserDetection} from '@angular/platform-browser/testing';
+
+import {ObservableWrapper, PromiseCompleter, PromiseWrapper, TimerWrapper} from '../../src/facade/async';
+import {BaseException} from '../../src/facade/exceptions';
+import {IS_DART, isPresent, scheduleMicroTask} from '../../src/facade/lang';
 
 var needsLongerTimers = browserDetection.isSlow || browserDetection.isEdge;
 var resultTimer = 1000;

--- a/modules/@angular/core/testing.ts
+++ b/modules/@angular/core/testing.ts
@@ -6,10 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+export * from './testing/async';
 export * from './testing/fake_async';
-export * from './testing/lang_utils';
-export * from './testing/logger';
-export * from './testing/ng_zone_mock';
 export * from './testing/test_injector';
 export * from './testing/testing';
-export * from './testing/mock_application_ref';

--- a/modules/@angular/core/testing/async.ts
+++ b/modules/@angular/core/testing/async.ts
@@ -24,6 +24,11 @@
 export function async(fn: Function): Function {
   return () => new Promise<void>((finishCallback, failCallback) => {
            var AsyncTestZoneSpec = (Zone as any /** TODO #9100 */)['AsyncTestZoneSpec'];
+           if (AsyncTestZoneSpec === undefined) {
+             throw new Error(
+                 'AsyncTestZoneSpec is needed for the async() test helper but could not be found. ' +
+                 'Please make sure that your environment includes zone.js/dist/async-test.js');
+           }
            var testZoneSpec = new AsyncTestZoneSpec(finishCallback, failCallback, 'test');
            var testZone = Zone.current.fork(testZoneSpec);
            return testZone.run(fn);

--- a/modules/@angular/core/testing/fake_async.ts
+++ b/modules/@angular/core/testing/fake_async.ts
@@ -7,7 +7,6 @@
  */
 
 import {BaseException} from '../index';
-import {getTestInjector} from './test_injector';
 
 let _FakeAsyncTestZoneSpecType = (Zone as any /** TODO #9100 */)['FakeAsyncTestZoneSpec'];
 
@@ -62,16 +61,6 @@ function _getFakeAsyncZoneSpec(): any {
     throw new Error('The code should be running in the fakeAsync zone to call this function');
   }
   return zoneSpec;
-}
-
-/**
- * Clear the queue of pending timers and microtasks.
- * Tests no longer need to call this explicitly.
- *
- * @deprecated
- */
-export function clearPendingTimers(): void {
-  // Do nothing.
 }
 
 /**

--- a/modules/@angular/core/testing/test_injector.ts
+++ b/modules/@angular/core/testing/test_injector.ts
@@ -11,11 +11,7 @@ import {lockRunMode} from '../src/application_ref';
 import {ListWrapper} from '../src/facade/collection';
 import {BaseException} from '../src/facade/exceptions';
 import {FunctionWrapper, isPresent} from '../src/facade/lang';
-
-import {async} from './async';
 import {AsyncTestCompleter} from './async_test_completer';
-
-export {async} from './async';
 
 export class TestInjector {
   private _instantiated: boolean = false;
@@ -168,42 +164,12 @@ export class InjectSetupWrapper {
       return inject_impl(tokens, fn)();
     };
   }
-
-  /** @deprecated {use async(withProviders().inject())} */
-  injectAsync(tokens: any[], fn: Function): Function {
-    return () => {
-      this._addProviders();
-      return injectAsync_impl(tokens, fn)();
-    };
-  }
 }
 
 export function withProviders(providers: () => any) {
   return new InjectSetupWrapper(providers);
 }
 
-/**
- * @deprecated {use async(inject())}
- *
- * Allows injecting dependencies in `beforeEach()` and `it()`. The test must return
- * a promise which will resolve when all asynchronous activity is complete.
- *
- * Example:
- *
- * ```
- * it('...', injectAsync([AClass], (object) => {
- *   return object.doSomething().then(() => {
- *     expect(...);
- *   });
- * })
- * ```
- *
- */
-export function injectAsync(tokens: any[], fn: Function): Function {
-  return async(inject(tokens, fn));
-}
-
 // This is to ensure inject(Async) within InjectSetupWrapper doesn't call itself
 // when transpiled to Dart.
 var inject_impl = inject;
-var injectAsync_impl = injectAsync;

--- a/modules/@angular/core/testing/testing.ts
+++ b/modules/@angular/core/testing/testing.ts
@@ -12,9 +12,7 @@
  */
 import {isPromise, isString} from '../src/facade/lang';
 
-import {TestInjector, async, getTestInjector, inject, injectAsync} from './test_injector';
-
-export {async, inject, injectAsync} from './test_injector';
+import {TestInjector, getTestInjector} from './test_injector';
 
 declare var global: any;
 
@@ -78,6 +76,8 @@ var jsmBeforeEach = _global.beforeEach;
 var jsmIt = _global.it;
 var jsmIIt = _global.fit;
 var jsmXIt = _global.xit;
+
+// TODO(juliemr): override the globals and make them throw with a useful message.
 
 var testInjector: TestInjector = getTestInjector();
 

--- a/modules/@angular/core/testing/testing_internal.ts
+++ b/modules/@angular/core/testing/testing_internal.ts
@@ -18,6 +18,9 @@ export {MockAnimationPlayer} from './animation/mock_animation_player';
 export {AsyncTestCompleter} from './async_test_completer';
 export {inject} from './test_injector';
 export {expect} from './testing';
+export * from './logger';
+export * from './ng_zone_mock';
+export * from './mock_application_ref';
 
 export var proxy: ClassDecorator = (t: any /** TODO #9100 */) => t;
 

--- a/modules/@angular/examples/testing/ts/fake_async.ts
+++ b/modules/@angular/examples/testing/ts/fake_async.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {clearPendingTimers, describe, expect, fakeAsync, it, tick} from '@angular/core/testing';
+import {describe, discardPeriodicTasks, expect, fakeAsync, it, tick} from '@angular/core/testing';
 
 
 // #docregion basic
@@ -25,14 +25,14 @@ describe('this test', () => {
 
 // #docregion pending
 describe('this test', () => {
-  it('aborts a timer', <any>fakeAsync((): void => {
+  it('aborts a periodic timer', <any>fakeAsync((): void => {
        // This timer is scheduled but doesn't need to complete for the
        // test to pass (maybe it's a timeout for some operation).
        // Leaving it will cause the test to fail...
-       setTimeout(() => {}, 100);
+       setInterval(() => {}, 100);
 
        // Unless we clean it up first.
-       clearPendingTimers();
+       discardPeriodicTasks();
      }));
 });
 // #enddocregion

--- a/modules/@angular/forms/test/directives_spec.ts
+++ b/modules/@angular/forms/test/directives_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {afterEach, beforeEach, ddescribe, describe, expect, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
+import {Log, afterEach, beforeEach, ddescribe, describe, expect, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
 
-import {fakeAsync, flushMicrotasks, Log, tick,} from '@angular/core/testing';
+import {fakeAsync, flushMicrotasks, tick,} from '@angular/core/testing';
 
 import {SpyNgControl, SpyValueAccessor} from './spies';
 

--- a/modules/@angular/forms/test/model_spec.ts
+++ b/modules/@angular/forms/test/model_spec.ts
@@ -6,13 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ddescribe, describe, it, iit, xit, expect, beforeEach, afterEach, inject,} from '@angular/core/testing/testing_internal';
-import {fakeAsync, flushMicrotasks, Log, tick} from '@angular/core/testing';
+import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
+import {afterEach, beforeEach, ddescribe, describe, expect, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
-import {FormGroup, FormControl, FormArray, Validators} from '@angular/forms';
+import {FormArray, FormControl, FormGroup, Validators} from '@angular/forms';
+
+import {EventEmitter, ObservableWrapper, TimerWrapper} from '../src/facade/async';
 import {IS_DART, isPresent} from '../src/facade/lang';
 import {PromiseWrapper} from '../src/facade/promise';
-import {TimerWrapper, ObservableWrapper, EventEmitter} from '../src/facade/async';
 
 export function main() {
   function asyncValidator(expected: any /** TODO #9100 */, timeouts = /*@ts2dart_const*/ {}) {

--- a/modules/@angular/forms/test/validators_spec.ts
+++ b/modules/@angular/forms/test/validators_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Log, fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
+import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {afterEach, beforeEach, ddescribe, describe, expect, iit, it, xit} from '@angular/core/testing/testing_internal';
 import {AbstractControl, FormControl, Validators} from '@angular/forms';
 

--- a/modules/@angular/platform-browser-dynamic/test/testing_public_browser_spec.ts
+++ b/modules/@angular/platform-browser-dynamic/test/testing_public_browser_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {it, iit, xit, describe, ddescribe, xdescribe, expect, beforeEach, beforeEachProviders, inject,} from '@angular/core/testing';
-import {async, fakeAsync, flushMicrotasks, Log, tick,} from '@angular/core/testing';
+import {async, fakeAsync, flushMicrotasks, tick,} from '@angular/core/testing';
 
 import {ROUTER_DIRECTIVES, Route} from '@angular/router-deprecated';
 

--- a/modules/@angular/platform-browser-dynamic/test/xhr/xhr_cache_spec.ts
+++ b/modules/@angular/platform-browser-dynamic/test/xhr/xhr_cache_spec.ts
@@ -12,7 +12,7 @@ import {beforeEach, beforeEachProviders, ddescribe, describe, iit, inject, it, x
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 import {expect} from '@angular/platform-browser/testing';
 
-import {fakeAsync, flushMicrotasks, Log, tick,} from '@angular/core/testing';
+import {fakeAsync, flushMicrotasks, tick,} from '@angular/core/testing';
 import {TestComponentBuilder, ComponentFixture} from '@angular/compiler/testing';
 import {BaseException} from '../../src/facade/exceptions';
 import {CachedXHR} from '../../src/xhr/xhr_cache';

--- a/modules/@angular/platform-browser/test/browser/bootstrap_spec.ts
+++ b/modules/@angular/platform-browser/test/browser/bootstrap_spec.ts
@@ -11,8 +11,7 @@ import {ApplicationRef, disposePlatform} from '@angular/core/src/application_ref
 import {Console} from '@angular/core/src/console';
 import {ComponentRef} from '@angular/core/src/linker/component_factory';
 import {Testability, TestabilityRegistry} from '@angular/core/src/testability/testability';
-import {Log} from '@angular/core/testing';
-import {AsyncTestCompleter, afterEach, beforeEach, describe, expect, inject, it} from '@angular/core/testing/testing_internal';
+import {AsyncTestCompleter, Log, afterEach, beforeEach, beforeEachProviders, describe, expect, inject, it} from '@angular/core/testing/testing_internal';
 import {BROWSER_APP_PROVIDERS, BROWSER_PLATFORM_PROVIDERS} from '@angular/platform-browser';
 import {BROWSER_APP_COMPILER_PROVIDERS, bootstrap} from '@angular/platform-browser-dynamic';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
@@ -89,6 +88,8 @@ export function main() {
       testProviders: any /** TODO #9100 */, lightDom: any /** TODO #9100 */;
 
   describe('bootstrap factory method', () => {
+    beforeEachProviders(() => { return [Log]; });
+
     beforeEach(() => {
       disposePlatform();
 

--- a/modules/@angular/platform-browser/test/web_workers/shared/message_bus_spec.ts
+++ b/modules/@angular/platform-browser/test/web_workers/shared/message_bus_spec.ts
@@ -6,14 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {inject, describe, it, expect, beforeEach, beforeEachProviders,} from '@angular/core/testing/testing_internal';
-import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
-import {ObservableWrapper, TimerWrapper} from '../../../src/facade/async';
-import {MessageBus} from '@angular/platform-browser/src/web_workers/shared/message_bus';
-import {createConnectedMessageBus} from './message_bus_util';
-import {MockNgZone} from '@angular/core/testing';
-import {provide, NgZone} from '@angular/core';
+import {NgZone, provide} from '@angular/core';
 import {withProviders} from '@angular/core/testing/test_injector';
+import {MockNgZone, beforeEach, beforeEachProviders, describe, expect, inject, it} from '@angular/core/testing/testing_internal';
+import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
+import {MessageBus} from '@angular/platform-browser/src/web_workers/shared/message_bus';
+
+import {ObservableWrapper, TimerWrapper} from '../../../src/facade/async';
+
+import {createConnectedMessageBus} from './message_bus_util';
 
 export function main() {
   /**

--- a/modules/@angular/platform-browser/testing/browser.ts
+++ b/modules/@angular/platform-browser/testing/browser.ts
@@ -9,7 +9,6 @@
 import {LocationStrategy} from '@angular/common';
 import {MockLocationStrategy} from '@angular/common/testing';
 import {APP_ID, NgZone, PLATFORM_COMMON_PROVIDERS, PLATFORM_INITIALIZER} from '@angular/core';
-import {Log} from '@angular/core/testing';
 
 import {AnimationDriver, NoOpAnimationDriver} from '../core_private';
 import {BROWSER_APP_PROVIDERS} from '../src/browser';
@@ -28,7 +27,7 @@ const TEST_BROWSER_STATIC_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[
 ];
 
 const ADDITIONAL_TEST_BROWSER_STATIC_PROVIDERS: Array<any /*Type | Provider | any[]*/> = [
-  {provide: APP_ID, useValue: 'a'}, ELEMENT_PROBE_PROVIDERS, Log,
+  {provide: APP_ID, useValue: 'a'}, ELEMENT_PROBE_PROVIDERS,
   {provide: NgZone, useFactory: createNgZone},
   {provide: LocationStrategy, useClass: MockLocationStrategy},
   {provide: AnimationDriver, useClass: NoOpAnimationDriver}

--- a/modules/@angular/platform-server/testing/server.ts
+++ b/modules/@angular/platform-server/testing/server.ts
@@ -19,7 +19,6 @@ import {Parse5DomAdapter} from '../src/parse5_adapter';
 import {DOCUMENT, BROWSER_SANITIZATION_PROVIDERS, EventManager, EVENT_MANAGER_PLUGINS, ELEMENT_PROBE_PROVIDERS, DomEventsPlugin,} from '@angular/platform-browser';
 import {getDOM, DomRootRenderer, DomRootRenderer_, DomSharedStylesHost, SharedStylesHost} from '../platform_browser_private';
 import {LocationStrategy} from '@angular/common';
-import {Log} from '@angular/core/testing';
 
 function initServerTests() {
   Parse5DomAdapter.makeCurrent();
@@ -76,7 +75,7 @@ export const TEST_SERVER_APPLICATION_PROVIDERS: Array<any /*Type | Provider | an
       /* @ts2dart_Provider */ {provide: SharedStylesHost, useExisting: DomSharedStylesHost},
       DomSharedStylesHost, ELEMENT_PROBE_PROVIDERS,
       /* @ts2dart_Provider */ {provide: DirectiveResolver, useClass: MockDirectiveResolver},
-      /* @ts2dart_Provider */ {provide: ViewResolver, useClass: MockViewResolver}, Log,
+      /* @ts2dart_Provider */ {provide: ViewResolver, useClass: MockViewResolver},
       /* @ts2dart_Provider */ {provide: TestComponentRenderer, useClass: DOMTestComponentRenderer},
       TestComponentBuilder,
       /* @ts2dart_Provider */ {provide: NgZone, useFactory: createNgZone},

--- a/modules/@angular/router-deprecated/test/integration/bootstrap_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/bootstrap_spec.ts
@@ -6,24 +6,24 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {beforeEach, beforeEachProviders, ddescribe, describe, expect, iit, inject, it, xdescribe, xit,} from '@angular/core/testing/testing_internal';
-import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
-import {TestComponentBuilder} from '@angular/compiler/testing';
-
-import {bootstrap} from '@angular/platform-browser-dynamic';
 import {APP_BASE_HREF, LocationStrategy} from '@angular/common';
-import {Component} from '@angular/core/src/metadata';
-import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
+import {MockLocationStrategy} from '@angular/common/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
+import {ApplicationRef} from '@angular/core/src/application_ref';
 import {Console} from '@angular/core/src/console';
+import {Component} from '@angular/core/src/metadata';
+import {MockApplicationRef, beforeEach, beforeEachProviders, ddescribe, describe, expect, iit, inject, it, xdescribe, xit} from '@angular/core/testing/testing_internal';
+import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
+import {bootstrap} from '@angular/platform-browser-dynamic';
+import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {DOCUMENT} from '@angular/platform-browser/src/dom/dom_tokens';
-import {RouteConfig, Route, AuxRoute} from '../../src/route_config/route_config_decorator';
+import {ROUTER_DIRECTIVES, ROUTER_PRIMARY_COMPONENT, ROUTER_PROVIDERS, RouteParams, Router} from '@angular/router-deprecated';
+
 import {PromiseWrapper} from '../../src/facade/async';
 import {BaseException} from '../../src/facade/exceptions';
-import {ROUTER_PROVIDERS, ROUTER_PRIMARY_COMPONENT, RouteParams, Router, ROUTER_DIRECTIVES} from '@angular/router-deprecated';
+import {AuxRoute, Route, RouteConfig} from '../../src/route_config/route_config_decorator';
 
-import {MockLocationStrategy} from '@angular/common/testing';
-import {ApplicationRef} from '@angular/core/src/application_ref';
-import {MockApplicationRef} from '@angular/core/testing';
+
 
 // noinspection JSAnnotator
 class DummyConsole implements Console {

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -6,8 +6,6 @@ export declare function beforeEach(fn: Function): void;
 
 export declare function beforeEachProviders(fn: () => Array<any>): void;
 
-export declare function clearPendingTimers(): void;
-
 export declare var ddescribe: Function;
 
 export declare var describe: Function;
@@ -26,53 +24,16 @@ export declare function flushMicrotasks(): void;
 
 export declare function getTestInjector(): TestInjector;
 
-export declare function getTypeOf(instance: any): any;
-
 export declare function iit(name: string, fn: Function, timeOut?: number): void;
 
 export declare function inject(tokens: any[], fn: Function): Function;
 
-export declare function injectAsync(tokens: any[], fn: Function): Function;
-
 export declare class InjectSetupWrapper {
     constructor(_providers: () => any);
     inject(tokens: any[], fn: Function): Function;
-    injectAsync(tokens: any[], fn: Function): Function;
 }
-
-export declare function instantiateType(type: Function, params?: any[]): any;
 
 export declare function it(name: string, fn: Function, timeOut?: number): void;
-
-export declare class Log {
-    logItems: any[];
-    constructor();
-    add(value: any): void;
-    fn(value: any): (a1?: any, a2?: any, a3?: any, a4?: any, a5?: any) => void;
-    clear(): void;
-    result(): string;
-}
-
-export declare class MockApplicationRef extends ApplicationRef {
-    registerBootstrapListener(listener: (ref: ComponentRef<any>) => void): void;
-    registerDisposeListener(dispose: () => void): void;
-    bootstrap<C>(componentFactory: ComponentFactory<C>): ComponentRef<C>;
-    injector: Injector;
-    zone: NgZone;
-    run(callback: Function): any;
-    waitForAsyncInitializers(): Promise<any>;
-    dispose(): void;
-    tick(): void;
-    componentTypes: Type[];
-}
-
-export declare class MockNgZone extends NgZone {
-    constructor();
-    onStable: EventEmitter<any>;
-    run(fn: Function): any;
-    runOutsideAngular(fn: Function): any;
-    simulateZoneExit(): void;
-}
 
 export declare function resetBaseTestProviders(): void;
 


### PR DESCRIPTION
Previously, we were exporting internal mocks and helpers. Move these
to core/testing/testing_internal or remove them if they were
never used.

Remove deprecated items - injectAsync, clearPendingTimers.
