### PR TITLE
feat(forms): easier updating of validators on existing controls

### DIFF
--- a/modules/@angular/forms/src/model.ts
+++ b/modules/@angular/forms/src/model.ts
@@ -100,6 +100,18 @@ export abstract class AbstractControl {
 
   get pending(): boolean { return this._status == PENDING; }
 
+  setAsyncValidators(newValidator: AsyncValidatorFn|AsyncValidatorFn[]): void {
+    this.asyncValidator = coerceToAsyncValidator(newValidator);
+  }
+
+  clearAsyncValidators(): void { this.asyncValidator = null; }
+
+  setValidators(newValidator: ValidatorFn|ValidatorFn[]): void {
+    this.validator = coerceToValidator(newValidator);
+  }
+
+  clearValidators(): void { this.validator = null; }
+
   markAsTouched(): void { this._touched = true; }
 
   markAsDirty({onlySelf}: {onlySelf?: boolean} = {}): void {

--- a/modules/@angular/forms/test/model_spec.ts
+++ b/modules/@angular/forms/test/model_spec.ts
@@ -65,6 +65,57 @@ export function main() {
           var c = new FormControl(null, Validators.required);
           expect(c.errors).toEqual({'required': true});
         });
+
+        it('should set single validator', () => {
+          var c = new FormControl(null);
+          expect(c.valid).toEqual(true);
+
+          c.setValidators(Validators.required);
+
+          c.updateValue(null);
+          expect(c.valid).toEqual(false);
+
+          c.updateValue('abc');
+          expect(c.valid).toEqual(true);
+        });
+
+        it('should set multiple validators from array', () => {
+          var c = new FormControl('');
+          expect(c.valid).toEqual(true);
+
+          c.setValidators([Validators.minLength(5), Validators.required]);
+
+          c.updateValue('');
+          expect(c.valid).toEqual(false);
+
+          c.updateValue('abc');
+          expect(c.valid).toEqual(false);
+
+          c.updateValue('abcde');
+          expect(c.valid).toEqual(true);
+        });
+
+        it('should clear validators', () => {
+          var c = new FormControl('', Validators.required);
+          expect(c.valid).toEqual(false);
+
+          c.clearValidators();
+          expect(c.validator).toEqual(null);
+
+          c.updateValue('');
+          expect(c.valid).toEqual(true);
+        });
+
+        it('should add after clearing', () => {
+          var c = new FormControl('', Validators.required);
+          expect(c.valid).toEqual(false);
+
+          c.clearValidators();
+          expect(c.validator).toEqual(null);
+
+          c.setValidators([Validators.required]);
+          expect(c.validator).not.toBe(null);
+        });
       });
 
       describe('asyncValidator', () => {
@@ -134,6 +185,38 @@ export function main() {
              tick();
 
              expect(c.errors).toEqual({'async': true, 'other': true});
+           }));
+
+        it('should add single async validator', fakeAsync(() => {
+             var c = new FormControl('value', null);
+
+             c.setAsyncValidators(asyncValidator('expected'));
+             expect(c.asyncValidator).not.toEqual(null);
+
+             c.updateValue('expected');
+             tick();
+
+             expect(c.valid).toEqual(true);
+           }));
+
+        it('should add async validator from array', fakeAsync(() => {
+             var c = new FormControl('value', null);
+
+             c.setAsyncValidators([asyncValidator('expected')]);
+             expect(c.asyncValidator).not.toEqual(null);
+
+             c.updateValue('expected');
+             tick();
+
+             expect(c.valid).toEqual(true);
+           }));
+
+        it('should clear async validators', fakeAsync(() => {
+             var c = new FormControl('value', [asyncValidator('expected'), otherAsyncValidator]);
+
+             c.clearValidators();
+
+             expect(c.asyncValidator).toEqual(null);
            }));
       });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

This will add support for setting and clearing validators on exiting controls. It's already possible to do this by manipulating the `.validator` property on the control, but I am proposing this as an enhancement of the existing API.

The use case is dynamic forms where user actions in the form might require validation rules on any given control to change dynamically. The goal is to make the validator updates easier. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
