### PR TITLE
chore(api): clean up compiler/testing api

### DIFF
--- a/modules/@angular/compiler/test/directive_normalizer_spec.ts
+++ b/modules/@angular/compiler/test/directive_normalizer_spec.ts
@@ -10,7 +10,7 @@ import {CompileTemplateMetadata, CompileTypeMetadata} from '@angular/compiler/sr
 import {CompilerConfig} from '@angular/compiler/src/config';
 import {DirectiveNormalizer} from '@angular/compiler/src/directive_normalizer';
 import {XHR} from '@angular/compiler/src/xhr';
-import {MockXHR} from '@angular/compiler/testing';
+import {MockXHR} from '@angular/compiler/testing/xhr_mock';
 import {ViewEncapsulation} from '@angular/core/src/metadata/view';
 import {beforeEach, beforeEachProviders, ddescribe, describe, expect, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';

--- a/modules/@angular/compiler/test/test_bindings.ts
+++ b/modules/@angular/compiler/test/test_bindings.ts
@@ -8,7 +8,8 @@
 
 import {ElementSchemaRegistry, UrlResolver, XHR} from '@angular/compiler';
 import {createUrlResolverWithoutPackagePrefix} from '@angular/compiler/src/url_resolver';
-import {MockSchemaRegistry, MockXHR} from '@angular/compiler/testing';
+import {MockSchemaRegistry} from '@angular/compiler/testing';
+import {MockXHR} from '@angular/compiler/testing/xhr_mock';
 
 export var TEST_PROVIDERS: any[] = [
   {provide: ElementSchemaRegistry, useValue: new MockSchemaRegistry({}, {})},

--- a/modules/@angular/compiler/test/xhr_mock_spec.ts
+++ b/modules/@angular/compiler/test/xhr_mock_spec.ts
@@ -8,7 +8,7 @@
 
 import {beforeEach, ddescribe, describe, expect, iit, inject, it,} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
-import {MockXHR} from '@angular/compiler/testing';
+import {MockXHR} from '@angular/compiler/testing/xhr_mock';
 import {PromiseWrapper} from '../src/facade/async';
 import {isPresent} from '../src/facade/lang';
 

--- a/modules/@angular/compiler/testing.ts
+++ b/modules/@angular/compiler/testing.ts
@@ -8,6 +8,5 @@
 
 export * from './testing/schema_registry_mock';
 export * from './testing/view_resolver_mock';
-export * from './testing/xhr_mock';
 export * from './testing/test_component_builder';
 export * from './testing/directive_resolver_mock';

--- a/tools/public_api_guard/compiler/testing.d.ts
+++ b/tools/public_api_guard/compiler/testing.d.ts
@@ -51,14 +51,6 @@ export declare class MockViewResolver extends ViewResolver {
     resolve(component: Type): ViewMetadata;
 }
 
-export declare class MockXHR extends XHR {
-    get(url: string): Promise<string>;
-    expect(url: string, response: string): void;
-    when(url: string, response: string): void;
-    flush(): void;
-    verifyNoOutstandingExpectations(): void;
-}
-
 export declare class TestComponentBuilder {
     constructor(_injector: Injector);
     overrideTemplate(componentType: Type, template: string): TestComponentBuilder;


### PR DESCRIPTION
Do not export MockXHR, which is a private helper.
