### PR TITLE
feat(forms): add support for standalone ngModel dirs inside forms

### DIFF
--- a/modules/@angular/forms/src/directives/form_interface.ts
+++ b/modules/@angular/forms/src/directives/form_interface.ts
@@ -24,7 +24,7 @@ export interface Form {
   /**
    * Add a control to this form.
    */
-  addControl(dir: NgControl): FormControl;
+  addControl(dir: NgControl): void;
 
   /**
    * Remove a control from this form.

--- a/modules/@angular/forms/src/directives/ng_form.ts
+++ b/modules/@angular/forms/src/directives/ng_form.ts
@@ -116,16 +116,13 @@ export class NgForm extends ControlContainer implements Form {
 
   get controls(): {[key: string]: AbstractControl} { return this.form.controls; }
 
-  addControl(dir: NgModel): FormControl {
-    const ctrl = new FormControl();
+  addControl(dir: NgModel): void {
     PromiseWrapper.scheduleMicrotask(() => {
       const container = this._findContainer(dir.path);
-      dir._control = <FormControl>container.registerControl(dir.name, ctrl);
+      dir._control = <FormControl>container.registerControl(dir.name, dir.control);
       setUpControl(dir.control, dir);
       dir.control.updateValueAndValidity({emitEvent: false});
     });
-
-    return ctrl;
   }
 
   getControl(dir: NgModel): FormControl { return <FormControl>this.form.find(dir.path); }

--- a/modules/@angular/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/modules/@angular/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -144,12 +144,11 @@ export class FormGroupDirective extends ControlContainer implements Form,
 
   get path(): string[] { return []; }
 
-  addControl(dir: NgControl): FormControl {
+  addControl(dir: NgControl): void {
     const ctrl: any = this.form.find(dir.path);
     setUpControl(ctrl, dir);
     ctrl.updateValueAndValidity({emitEvent: false});
     this.directives.push(dir);
-    return ctrl;
   }
 
   getControl(dir: NgControl): FormControl { return <FormControl>this.form.find(dir.path); }

--- a/modules/@angular/forms/test/directives_spec.ts
+++ b/modules/@angular/forms/test/directives_spec.ts
@@ -281,7 +281,7 @@ export function main() {
         personControlGroupDir = new NgModelGroup(form, [], []);
         personControlGroupDir.name = 'person';
 
-        loginControlDir = new FormControlName(personControlGroupDir, null, null, [defaultAccessor]);
+        loginControlDir = new NgModel(personControlGroupDir, null, null, [defaultAccessor]);
         loginControlDir.name = 'login';
         loginControlDir.valueAccessor = new DummyControlValueAccessor();
       });


### PR DESCRIPTION
This PR allows the use of ngModels within forms without necessarily requiring the registration of their form controls with the parent form.

r: @vsavkin 
cc: @StephenFluin:  can you look at the new error message?

**Before**
If you wanted to include an ngModel within a form tag, it had to have a `name` attribute so that the ngModel could be registered with the parent form properly (for aggregate form validation and value).  

``` html
<form>
    <input [(ngModel)]="person.name" name="first">
    <input [(ngModel)]="person.food">      //  always throws error because name is not set
</form>
```

However, in some rare cases, it might be desirable to have an ngModel within a form tag, but not registered with the form.   This setup was not supported and would throw an error.

**After**

``` html
<form #f="ngForm">
    <input [(ngModel)]="person.name" name="first">
    <input [(ngModel)]="person.food" [ngModelOptions]="{standalone: true}"> 
</form>

{{ f.value | json }}       // {first: ""}
```

Now, if for some reason you need to have a standalone ngModel within a form tag, it's still usable without registering it with the parent form by setting the `standalone` property in `ngModelOptions`.  This way, you can explicitly dictate that you don't want the form registration, but users who may forget the name attribute will still get a helpful error.

It's worth noting that ngModels can still, as always, be used outside of a form tag without a name attribute or an ngModelOptions property.  
