### PR TITLE
chore(compiler-cli): update dependencies to remove mismatch with tsc-wrapped

### DIFF
--- a/modules/@angular/compiler-cli/package.json
+++ b/modules/@angular/compiler-cli/package.json
@@ -9,9 +9,10 @@
     "ng-xi18n": "./src/extract_i18n.js"
   },
   "dependencies": {
-    "@angular/tsc-wrapped": "^0.1.0",
+    "@angular/tsc-wrapped": "^0.2.0",
     "reflect-metadata": "^0.1.2",
-    "parse5": "1.3.2"
+    "parse5": "1.3.2",
+    "minimist": "^1.2.0"
   },
   "peerDependencies": {
     "typescript": "^1.9.0-dev",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
There is signature mismatch between tsc-wrapped (v0.1.0) collector.js#getMetadata and compiler-cli reflector_host.js#getMetadataFor that caused an error anytime ngc was executed. The error received was as follows.

`TypeError: Cannot read property 'getSymbolsInScope' of undefined`

After forcing NPM to install @angular/tsc-wrapped@latest the error was resolved.

**What is the new behavior?**
The new version updates resolve the error from occurring.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
