### PR TITLE
feat(upgrade): additional ng2 features for downgraded ng2 components

### DIFF
--- a/modules/@angular/compiler/src/template_parser/template_parser.ts
+++ b/modules/@angular/compiler/src/template_parser/template_parser.ts
@@ -810,7 +810,8 @@ class ElementContext {
   }
 }
 
-function createElementCssSelector(elementName: string, matchableAttrs: string[][]): CssSelector {
+export function createElementCssSelector(
+    elementName: string, matchableAttrs: string[][]): CssSelector {
   const cssSelector = new CssSelector();
   const elNameNoNs = splitNsName(elementName)[1];
 

--- a/modules/@angular/upgrade/src/angular_js.ts
+++ b/modules/@angular/upgrade/src/angular_js.ts
@@ -40,6 +40,7 @@ export interface IRootScopeService {
   $parent: IScope;
   $root: IScope;
   $watch(expr: any, fn?: (a1?: any, a2?: any) => void): Function;
+  $on(event: string, fn?: (event?: any, ...args: any[]) => void): Function;
   $destroy(): any;
   $apply(): any;
   $apply(exp: string): any;

--- a/modules/@angular/upgrade/src/compiler-capture.ts
+++ b/modules/@angular/upgrade/src/compiler-capture.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as compiler from '@angular/compiler';
+import {COMPILER_OPTIONS, Compiler, CompilerOptions, Inject, Injectable} from '@angular/core';
+
+import {NG2_CAPTURED_CONTENT_SELECTORS} from './constants';
+import {isPresent} from './util';
+
+@Injectable()
+export class RuntimeCompilerCapturingFactory extends compiler.RuntimeCompilerFactory {
+  constructor(
+      @Inject(COMPILER_OPTIONS) defaultOptions: CompilerOptions[],
+      @Inject(NG2_CAPTURED_CONTENT_SELECTORS) private _captured: CapturedContentSelectors) {
+    super(defaultOptions);
+  }
+  createCompiler(options: CompilerOptions[] = []): Compiler {
+    // Very ugly hack to get access to the compiler's internal objects.
+    // Better here than in the compiler module itself, though.
+    let runtimeCompiler: any = <any>super.createCompiler(options);
+    let spy = this._captured;
+    let originalCompileTemplate = runtimeCompiler._compileTemplate;
+    runtimeCompiler._compileTemplate = function(template: any) {
+      if (!template.isCompiled && !template.isHost) {
+        const metadata = template.normalizedCompMeta;
+        if (isPresent(metadata.template) && isPresent(metadata.template.ngContentSelectors)) {
+          spy.ngContentSelectors[metadata.selector] = metadata.template.ngContentSelectors;
+        }
+      }
+      return originalCompileTemplate.call(this, template);
+    };
+    return runtimeCompiler;
+  }
+}
+
+@Injectable()
+export class CapturedContentSelectors {
+  ngContentSelectors: {[componentSelector: string]: string[]} = {};
+}

--- a/modules/@angular/upgrade/src/constants.ts
+++ b/modules/@angular/upgrade/src/constants.ts
@@ -7,9 +7,11 @@
  */
 
 export const NG2_COMPILER = 'ng2.Compiler';
+export const NG2_CAPTURED_CONTENT_SELECTORS = 'ng2.CapturedContentSelectors';
 export const NG2_INJECTOR = 'ng2.Injector';
 export const NG2_COMPONENT_FACTORY_REF_MAP = 'ng2.ComponentFactoryRefMap';
 export const NG2_ZONE = 'ng2.NgZone';
+export const NG2_INIT_PROMISE_COMPLETER = 'ng2.InitPromiseCompleter';
 
 export const NG1_PROVIDE = '$provide';
 export const NG1_CONTROLLER = '$controller';
@@ -21,4 +23,4 @@ export const NG1_INJECTOR = '$injector';
 export const NG1_PARSE = '$parse';
 export const NG1_TEMPLATE_CACHE = '$templateCache';
 export const NG1_TESTABILITY = '$$testability';
-export const REQUIRE_INJECTOR = '?^' + NG2_INJECTOR;
+export const REQUIRE_INJECTOR = '?^^' + NG2_INJECTOR;

--- a/modules/@angular/upgrade/src/downgrade_ng2_adapter.ts
+++ b/modules/@angular/upgrade/src/downgrade_ng2_adapter.ts
@@ -23,26 +23,23 @@ export class DowngradeNg2ComponentAdapter {
   componentRef: ComponentRef<any> = null;
   changeDetector: ChangeDetectorRef = null;
   componentScope: angular.IScope;
-  childNodes: Node[];
-  contentInsertionPoint: Node = null;
+  elementInjector: Injector;
 
   constructor(
-      private id: string, private info: ComponentInfo, private element: angular.IAugmentedJQuery,
+      private info: ComponentInfo, private element: angular.IAugmentedJQuery,
       private attrs: angular.IAttributes, private scope: angular.IScope,
       private parentInjector: Injector, private parse: angular.IParseService,
       private componentFactory: ComponentFactory<any>) {
-    (<any>this.element[0]).id = id;
     this.componentScope = scope.$new();
-    this.childNodes = <Node[]><any>element.contents();
   }
 
-  bootstrapNg2() {
+  bootstrapNg2(projectableNodes: Node[][]) {
     var childInjector = ReflectiveInjector.resolveAndCreate(
         [{provide: NG1_SCOPE, useValue: this.componentScope}], this.parentInjector);
-    this.contentInsertionPoint = document.createComment('ng1 insertion point');
 
-    this.componentRef = this.componentFactory.create(
-        childInjector, [[this.contentInsertionPoint]], this.element[0]);
+    this.componentRef =
+        this.componentFactory.create(childInjector, projectableNodes, this.element[0]);
+    this.elementInjector = this.componentRef.injector;
     this.changeDetector = this.componentRef.changeDetectorRef;
     this.component = this.componentRef.instance;
   }
@@ -101,16 +98,6 @@ export class DowngradeNg2ComponentAdapter {
       });
     }
     this.componentScope.$watch(() => this.changeDetector && this.changeDetector.detectChanges());
-  }
-
-  projectContent() {
-    var childNodes = this.childNodes;
-    var parent = this.contentInsertionPoint.parentNode;
-    if (parent) {
-      for (var i = 0, ii = childNodes.length; i < ii; i++) {
-        parent.insertBefore(childNodes[i], this.contentInsertionPoint);
-      }
-    }
   }
 
   setupOutputs() {

--- a/modules/@angular/upgrade/src/platform-upgrade.ts
+++ b/modules/@angular/upgrade/src/platform-upgrade.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CompilerFactory, PlatformRef, Provider, createPlatformFactory} from '@angular/core';
+import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+
+import {CapturedContentSelectors, RuntimeCompilerCapturingFactory} from './compiler-capture';
+import {NG2_CAPTURED_CONTENT_SELECTORS} from './constants';
+
+const INTERNAL_UPGRADE_PLATFORM_PROVIDERS: Provider[] = [
+  {provide: NG2_CAPTURED_CONTENT_SELECTORS, useClass: CapturedContentSelectors},
+  {provide: CompilerFactory, useClass: RuntimeCompilerCapturingFactory}
+];
+
+/**
+ * Platform extending platformBrowserDynamic for applications running both Angular 1 and Angular 2.
+ *
+ * This platform is used by the JiT UpgradeAdapter, but is made public for testing purposes,
+ * should you need access to the platform itself.
+ *
+ * @experimental
+ */
+export const platformUpgrade =
+    createPlatformFactory(platformBrowserDynamic, 'upgrade', INTERNAL_UPGRADE_PLATFORM_PROVIDERS);

--- a/modules/@angular/upgrade/src/upgrade.ts
+++ b/modules/@angular/upgrade/src/upgrade.ts
@@ -11,4 +11,5 @@
  * @description
  * Adapter allowing AngularJS v1 and Angular v2 to run side by side in the same application.
  */
+export {platformUpgrade} from './platform-upgrade';
 export {UpgradeAdapter, UpgradeAdapterRef} from './upgrade_adapter';

--- a/modules/@angular/upgrade/src/util.ts
+++ b/modules/@angular/upgrade/src/util.ts
@@ -5,7 +5,11 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import * as compiler from '@angular/compiler';
 
+export function isPresent(obj: any): boolean {
+  return obj !== undefined && obj !== null;
+}
 
 export function stringify(obj: any): string {
   if (typeof obj == 'function') return obj.name || obj.toString();
@@ -21,4 +25,60 @@ export function onError(e: any) {
 
 export function controllerKey(name: string): string {
   return '$' + name + 'Controller';
+}
+
+function getAttributesAsArray(node: Node): string[][] {
+  var attributes = node.attributes;
+  var asArray: string[][];
+  if (isPresent(attributes)) {
+    let attrLen = attributes.length;
+    asArray = new Array(attrLen);
+    for (var i = 0; i < attrLen; i++) {
+      asArray[i] = [attributes[i].nodeName, attributes[i].nodeValue];
+    }
+  }
+  return asArray || [];
+}
+
+export function sortProjectableNodes(ngContentSelectors: string[], childNodes: Node[]): Node[][] {
+  let projectableNodes: Node[][] = [];
+  let matcher = new compiler.SelectorMatcher();
+  let wildcardNgContentIndex: number;
+  for (let i = 0, ii = ngContentSelectors.length; i < ii; i++) {
+    projectableNodes[i] = [];
+    if (ngContentSelectors[i] === '*') {
+      wildcardNgContentIndex = i;
+    } else {
+      matcher.addSelectables(compiler.CssSelector.parse(ngContentSelectors[i]), i);
+    }
+  }
+  for (let node of childNodes) {
+    let ngContentIndices: number[] = [];
+    let selector =
+        compiler.createElementCssSelector(node.nodeName.toLowerCase(), getAttributesAsArray(node));
+    matcher.match(
+        selector, (selector, ngContentIndex) => { ngContentIndices.push(ngContentIndex); });
+    ngContentIndices.sort();
+    if (isPresent(wildcardNgContentIndex)) {
+      ngContentIndices.push(wildcardNgContentIndex);
+    }
+    if (ngContentIndices.length > 0) {
+      projectableNodes[ngContentIndices[0]].push(node);
+    }
+  }
+  return projectableNodes;
+}
+
+
+export class PromiseCompleter<R> {
+  promise: Promise<R>;
+  resolve: (value?: R|PromiseLike<R>) => void;
+  reject: (error?: any, stackTrace?: string) => void;
+
+  constructor() {
+    this.promise = new Promise((res, rej) => {
+      this.resolve = res;
+      this.reject = rej;
+    });
+  }
 }

--- a/tools/public_api_guard/upgrade/index.d.ts
+++ b/tools/public_api_guard/upgrade/index.d.ts
@@ -1,9 +1,14 @@
+/** @experimental */
+export declare const platformUpgrade: (extraProviders?: Provider[]) => PlatformRef;
+
 /** @stable */
 export declare class UpgradeAdapter {
     constructor(ng2AppModule: Type<any>, compilerOptions?: CompilerOptions);
     bootstrap(element: Element, modules?: any[], config?: angular.IAngularBootstrapConfig): UpgradeAdapterRef;
+    declareNg1Module(modules?: any[]): void;
     downgradeNg2Component(type: Type<any>): Function;
     downgradeNg2Provider(token: any): Function;
+    initForNg1Tests(): UpgradeAdapterRef;
     upgradeNg1Component(name: string): Type<any>;
     upgradeNg1Provider(name: string, options?: {
         asToken: any;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Note: Documentation doesn't mention the absence of support for the added features, the user is lead to believe they are implicitly supported. So no changes on the [upgrade tutorial](https://angular.io/docs/ts/latest/guide/upgrade.html) is needed.

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Angular 2 components downgraded with the UpgradeAdapter are missing several critical features, like multi-slot projection and parent component/providers injection.

**What is the new behavior?**
These features are &now supported by the UpgradeAdapter.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:
- Full use of core Angular 2 projection for downgraded Angular 2
  components. In particular, this enables multi-slot projection and
  other features on &lt;ng-content&gt;.
- Hierarchical injectors for downgraded Angular 2 components: downgraded
  components inherit the injector of the first other downgraded Angular
  2 component they find up the DOM tree.
- declareNg1Module() and initForNg1Tests() methods on the UpgradeAdapter
  to allow testing hybrid applications through Angular 1 without having
  to redeclare the adapter module and recompile every downgraded component
  for every test.

Closes #6629, #7727, #8729, #5462
