### PR TITLE
fix(common/testing): remove internal MockLocationStrategy from common…

### DIFF
--- a/modules/@angular/common/testing.ts
+++ b/modules/@angular/common/testing.ts
@@ -7,4 +7,3 @@
  */
 
 export {SpyLocation} from './testing/location_mock';
-export {MockLocationStrategy} from './testing/mock_location_strategy';

--- a/modules/@angular/platform-browser/testing/browser.ts
+++ b/modules/@angular/platform-browser/testing/browser.ts
@@ -7,7 +7,6 @@
  */
 
 import {LocationStrategy} from '@angular/common';
-import {MockLocationStrategy} from '@angular/common/testing';
 import {APP_ID, NgZone, PLATFORM_COMMON_PROVIDERS, PLATFORM_INITIALIZER} from '@angular/core';
 
 import {AnimationDriver, NoOpAnimationDriver} from '../core_private';
@@ -29,7 +28,6 @@ const TEST_BROWSER_STATIC_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[
 const ADDITIONAL_TEST_BROWSER_STATIC_PROVIDERS: Array<any /*Type | Provider | any[]*/> = [
   {provide: APP_ID, useValue: 'a'}, ELEMENT_PROBE_PROVIDERS,
   {provide: NgZone, useFactory: createNgZone},
-  {provide: LocationStrategy, useClass: MockLocationStrategy},
   {provide: AnimationDriver, useClass: NoOpAnimationDriver}
 ];
 

--- a/modules/@angular/platform-server/testing/server.ts
+++ b/modules/@angular/platform-server/testing/server.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {MockLocationStrategy} from '@angular/common/testing';
 import {COMPILER_PROVIDERS, DirectiveResolver, ViewResolver, XHR} from '@angular/compiler';
 import {MockDirectiveResolver, MockViewResolver, TestComponentBuilder, TestComponentRenderer} from '@angular/compiler/testing';
 import {APPLICATION_COMMON_PROVIDERS, APP_ID, NgZone, PLATFORM_COMMON_PROVIDERS, PLATFORM_INITIALIZER, RootRenderer} from '@angular/core';
@@ -76,6 +75,5 @@ export const TEST_SERVER_APPLICATION_PROVIDERS: Array<any /*Type | Provider | an
       /* @ts2dart_Provider */ {provide: ViewResolver, useClass: MockViewResolver},
       /* @ts2dart_Provider */ {provide: TestComponentRenderer, useClass: DOMTestComponentRenderer},
       TestComponentBuilder,
-      /* @ts2dart_Provider */ {provide: NgZone, useFactory: createNgZone},
-      /* @ts2dart_Provider */ {provide: LocationStrategy, useClass: MockLocationStrategy}
+      /* @ts2dart_Provider */ {provide: NgZone, useFactory: createNgZone}
     ];

--- a/modules/@angular/router-deprecated/test/integration/bootstrap_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/bootstrap_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {APP_BASE_HREF, LocationStrategy} from '@angular/common';
-import {MockLocationStrategy} from '@angular/common/testing';
+import {MockLocationStrategy} from '@angular/common/testing/mock_location_strategy';
 import {TestComponentBuilder} from '@angular/compiler/testing';
 import {ApplicationRef} from '@angular/core/src/application_ref';
 import {Console} from '@angular/core/src/console';

--- a/modules/@angular/router-deprecated/test/location/location_spec.ts
+++ b/modules/@angular/router-deprecated/test/location/location_spec.ts
@@ -11,7 +11,7 @@ import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 
 import {Injector, provide, ReflectiveInjector} from '@angular/core';
 import {Location, LocationStrategy, APP_BASE_HREF} from '@angular/common';
-import {MockLocationStrategy} from '@angular/common/testing';
+import {MockLocationStrategy} from '@angular/common/testing/mock_location_strategy';
 
 export function main() {
   describe('Location', () => {

--- a/modules/@angular/router-deprecated/test/route_config/route_config_spec.ts
+++ b/modules/@angular/router-deprecated/test/route_config/route_config_spec.ts
@@ -18,7 +18,7 @@ import {DOCUMENT} from '@angular/platform-browser/src/dom/dom_tokens';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
 import {ROUTER_PROVIDERS, Router, RouteConfig, ROUTER_DIRECTIVES} from '@angular/router-deprecated';
 import {ExceptionHandler} from '@angular/core';
-import {MockLocationStrategy} from '@angular/common/testing';
+import {MockLocationStrategy} from '@angular/common/testing/mock_location_strategy';
 
 class _ArrayLogger {
   res: any[] = [];

--- a/modules/@angular/router/test/router.spec.ts
+++ b/modules/@angular/router/test/router.spec.ts
@@ -1,7 +1,8 @@
 import 'rxjs/add/operator/map';
 
-import {Location} from '@angular/common';
+import {Location, LocationStrategy} from '@angular/common';
 import {SpyLocation} from '@angular/common/testing';
+import {MockLocationStrategy} from '@angular/common/testing/mock_location_strategy';
 import {ComponentFixture, TestComponentBuilder} from '@angular/compiler/testing';
 import {Component, Injector} from '@angular/core';
 import {ComponentResolver} from '@angular/core';
@@ -22,6 +23,7 @@ describe('Integration', () => {
       RouterOutletMap,
       {provide: UrlSerializer, useClass: DefaultUrlSerializer},
       {provide: Location, useClass: SpyLocation},
+      {provide: LocationStrategy, useClass: MockLocationStrategy},
       {
         provide: Router,
         useFactory: (resolver: ComponentResolver, urlSerializer: UrlSerializer,

--- a/tools/public_api_guard/common/testing.d.ts
+++ b/tools/public_api_guard/common/testing.d.ts
@@ -1,20 +1,3 @@
-export declare class MockLocationStrategy extends LocationStrategy {
-    internalBaseHref: string;
-    internalPath: string;
-    internalTitle: string;
-    urlChanges: string[];
-    constructor();
-    back(): void;
-    forward(): void;
-    getBaseHref(): string;
-    onPopState(fn: (value: any) => void): void;
-    path(): string;
-    prepareExternalUrl(internal: string): string;
-    pushState(ctx: any, title: string, path: string, query: string): void;
-    replaceState(ctx: any, title: string, path: string, query: string): void;
-    simulatePopState(url: string): void;
-}
-
 export declare class SpyLocation implements Location {
     urlChanges: string[];
     back(): void;


### PR DESCRIPTION
BREAKING CHANGE:

MockLocationStrategy was intended to be internal only and is now removed
from the `@angular/common/testing` public api
