### PR TITLE
feat(Control): Add ng-empty-value detection

### DIFF
--- a/modules/@angular/facade/src/lang.ts
+++ b/modules/@angular/facade/src/lang.ts
@@ -102,6 +102,29 @@ export function isBlank(obj: any): boolean {
   return obj === undefined || obj === null;
 }
 
+export function isEmptyValue(val: any): boolean {
+  if (val === undefined) {
+    return true;
+  }
+  if (val === null) {
+    return true;
+  }
+  if (val === '') {
+    return true;
+  }
+  if (typeof val === 'string') {
+    if (String.prototype.trim) {
+      val = val.trim();
+    } else {
+      val = val.replace(/^\s+|\s+$/g, '');
+    }
+  }
+  if (val.length !== undefined) {
+    return val.length === 0;
+  }
+  return false;
+};
+
 export function isBoolean(obj: any): boolean {
   return typeof obj === 'boolean';
 }

--- a/modules/@angular/forms/src/directives/abstract_control_directive.ts
+++ b/modules/@angular/forms/src/directives/abstract_control_directive.ts
@@ -38,4 +38,6 @@ export abstract class AbstractControlDirective {
   get untouched(): boolean { return isPresent(this.control) ? this.control.untouched : null; }
 
   get path(): string[] { return null; }
+
+  get empty(): boolean { return isPresent(this.control) ? this.control.empty : null; }
 }

--- a/modules/@angular/forms/src/directives/ng_control_status.ts
+++ b/modules/@angular/forms/src/directives/ng_control_status.ts
@@ -27,7 +27,8 @@ import {NgControl} from './ng_control';
     '[class.ng-pristine]': 'ngClassPristine',
     '[class.ng-dirty]': 'ngClassDirty',
     '[class.ng-valid]': 'ngClassValid',
-    '[class.ng-invalid]': 'ngClassInvalid'
+    '[class.ng-invalid]': 'ngClassInvalid',
+    '[class.ng-empty-value]': 'ngClassEmptyValue'
   }
 })
 export class NgControlStatus {
@@ -52,5 +53,8 @@ export class NgControlStatus {
   }
   get ngClassInvalid(): boolean {
     return isPresent(this._cd.control) ? !this._cd.control.valid : false;
+  }
+  get ngClassEmptyValue(): boolean {
+    return isPresent(this._cd.control) ? this._cd.control.empty : true;
   }
 }

--- a/modules/@angular/forms/src/model.ts
+++ b/modules/@angular/forms/src/model.ts
@@ -10,7 +10,8 @@ import {composeAsyncValidators, composeValidators} from './directives/shared';
 import {AsyncValidatorFn, ValidatorFn} from './directives/validators';
 import {EventEmitter, Observable, ObservableWrapper} from './facade/async';
 import {ListWrapper, StringMapWrapper} from './facade/collection';
-import {isBlank, isPresent, isPromise, normalizeBool} from './facade/lang';
+import {isBlank, isEmptyValue, isPresent, isPromise, normalizeBool} from './facade/lang';
+
 
 /**
  * Indicates that a FormControl is valid, i.e. that no errors exist in the input value.
@@ -76,6 +77,7 @@ export abstract class AbstractControl {
   private _statusChanges: EventEmitter<any>;
   private _status: string;
   private _errors: {[key: string]: any};
+  private _empty: boolean = true;
   private _pristine: boolean = true;
   private _touched: boolean = false;
   private _parent: FormGroup|FormArray;
@@ -93,6 +95,8 @@ export abstract class AbstractControl {
    * Returns the errors of this control.
    */
   get errors(): {[key: string]: any} { return this._errors; }
+
+  get empty(): boolean { return this._empty; }
 
   get pristine(): boolean { return this._pristine; }
 
@@ -151,6 +155,7 @@ export abstract class AbstractControl {
 
     this._errors = this._runValidator();
     this._status = this._calculateStatus();
+    this._empty = isEmptyValue(this._value);
 
     if (this._status == VALID || this._status == PENDING) {
       this._runAsyncValidator(emitEvent);

--- a/modules/@angular/forms/test/directives_spec.ts
+++ b/modules/@angular/forms/test/directives_spec.ts
@@ -382,6 +382,7 @@ export function main() {
         expect(controlDir.dirty).toBe(control.dirty);
         expect(controlDir.touched).toBe(control.touched);
         expect(controlDir.untouched).toBe(control.untouched);
+        expect(controlDir.empty).toBe(control.empty);
       };
 
       beforeEach(() => {
@@ -431,6 +432,7 @@ export function main() {
         expect(ngModel.dirty).toBe(control.dirty);
         expect(ngModel.touched).toBe(control.touched);
         expect(ngModel.untouched).toBe(control.untouched);
+        expect(ngModel.empty).toBe(control.empty);
       });
 
       it('should set up validator', fakeAsync(() => {

--- a/modules/@angular/forms/test/integration_spec.ts
+++ b/modules/@angular/forms/test/integration_spec.ts
@@ -1531,14 +1531,14 @@ export function main() {
 
                      var input = fixture.debugElement.query(By.css('input')).nativeElement;
                      expect(sortedClassList(input)).toEqual([
-                       'ng-invalid', 'ng-pristine', 'ng-untouched'
+                       'ng-empty-value', 'ng-invalid', 'ng-pristine', 'ng-untouched'
                      ]);
 
                      dispatchEvent(input, 'blur');
                      fixture.detectChanges();
 
                      expect(sortedClassList(input)).toEqual([
-                       'ng-invalid', 'ng-pristine', 'ng-touched'
+                       'ng-empty-value', 'ng-invalid', 'ng-pristine', 'ng-touched'
                      ]);
 
                      input.value = 'updatedValue';
@@ -1568,14 +1568,14 @@ export function main() {
 
                      var input = fixture.debugElement.query(By.css('input')).nativeElement;
                      expect(sortedClassList(input)).toEqual([
-                       'ng-invalid', 'ng-pristine', 'ng-untouched'
+                       'ng-empty-value', 'ng-invalid', 'ng-pristine', 'ng-untouched'
                      ]);
 
                      dispatchEvent(input, 'blur');
                      fixture.detectChanges();
 
                      expect(sortedClassList(input)).toEqual([
-                       'ng-invalid', 'ng-pristine', 'ng-touched'
+                       'ng-empty-value', 'ng-invalid', 'ng-pristine', 'ng-touched'
                      ]);
 
                      input.value = 'updatedValue';
@@ -1602,14 +1602,14 @@ export function main() {
 
                      var input = fixture.debugElement.query(By.css('input')).nativeElement;
                      expect(sortedClassList(input)).toEqual([
-                       'ng-invalid', 'ng-pristine', 'ng-untouched'
+                       'ng-empty-value', 'ng-invalid', 'ng-pristine', 'ng-untouched'
                      ]);
 
                      dispatchEvent(input, 'blur');
                      fixture.detectChanges();
 
                      expect(sortedClassList(input)).toEqual([
-                       'ng-invalid', 'ng-pristine', 'ng-touched'
+                       'ng-empty-value', 'ng-invalid', 'ng-pristine', 'ng-touched'
                      ]);
 
                      input.value = 'updatedValue';

--- a/modules/@angular/forms/test/model_spec.ts
+++ b/modules/@angular/forms/test/model_spec.ts
@@ -242,6 +242,30 @@ export function main() {
         });
       });
 
+      describe('empty', () => {
+        it('should be false after creating a control with value', () => {
+          var c = new FormControl('value');
+          expect(c.empty).toEqual(false);
+        });
+
+        it('should be true after create a control without value', () => {
+          var c = new FormControl('');
+          expect(c.empty).toEqual(true);
+        });
+
+        it('should be false after updating a control to have value', () => {
+          var c = new FormControl('');
+          c.updateValue('value');
+          expect(c.empty).toEqual(false);
+        });
+
+        it('should be true after updating a control to have no value', () => {
+          var c = new FormControl('value');
+          c.updateValue('');
+          expect(c.empty).toEqual(true);
+        });
+      });
+
       describe('updateValue', () => {
         var g: any /** TODO #9100 */, c: any /** TODO #9100 */;
         beforeEach(() => {


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Feature addition for controls.  Makes up for the short-comings of the CSS :empty selector.  Valuable for textareas and input fields that can be empty.  Useful for people who need styling for when a field is empty but not invalid.
- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  No
- **Other Notes**
  `isEmptyValue` is from [Aurelia's Validation module](https://github.com/aurelia/validation/blob/0a7a57fed00452202ca8e8634b993d4712337619/dist/amd/utilities.js#L26)

This was previously opened as #8221, I have since rebased to the latest version of angular for the pull-request.  My apologies for letting the PR go stale.
