### PR TITLE
chore(typings): restrict Angular to es5+collections+promise

### DIFF
--- a/modules/@angular/router/src/apply_redirects.ts
+++ b/modules/@angular/router/src/apply_redirects.ts
@@ -214,14 +214,15 @@ function findPosParam(
 }
 
 function findOrCreatePath(part: string, paths: UrlPathWithParams[]): UrlPathWithParams {
-  const matchingIndex = paths.findIndex(s => s.path === part);
-  if (matchingIndex > -1) {
-    const r = paths[matchingIndex];
-    paths.splice(matchingIndex);
-    return r;
-  } else {
-    return new UrlPathWithParams(part, {});
+  let idx = 0;
+  for (const s of paths) {
+    if (s.path === part) {
+      paths.splice(idx);
+      return s;
+    }
+    idx++;
   }
+  return new UrlPathWithParams(part, {});
 }
 
 

--- a/modules/@angular/router/src/create_router_state.ts
+++ b/modules/@angular/router/src/create_router_state.ts
@@ -37,13 +37,12 @@ function createNode(curr: TreeNode<ActivatedRouteSnapshot>, prevState?: TreeNode
 function createOrReuseChildren(
     curr: TreeNode<ActivatedRouteSnapshot>, prevState: TreeNode<ActivatedRoute>) {
   return curr.children.map(child => {
-    const index =
-        prevState.children.findIndex(p => equalRouteSnapshots(p.value.snapshot, child.value));
-    if (index >= 0) {
-      return createNode(child, prevState.children[index]);
-    } else {
-      return createNode(child);
+    for (const p of prevState.children) {
+      if (equalRouteSnapshots(p.value.snapshot, child.value)) {
+        return createNode(child, p);
+      }
     }
+    return createNode(child);
   });
 }
 

--- a/modules/es6-subset.d.ts
+++ b/modules/es6-subset.d.ts
@@ -1,0 +1,65 @@
+
+/**
+ * Subset of lib.es2015.core.d.ts typings.
+ * Angular should not require use of ES6 runtime but some API usages are already present.
+ * See https://github.com/angular/angular/issues/5242
+ * TODO(alexeagle): remove methods below which may not be present in targeted browser
+ */
+
+interface String {
+  /**
+   * Returns true if the sequence of elements of searchString converted to a String is the
+   * same as the corresponding elements of this object (converted to a String) starting at
+   * position. Otherwise returns false.
+   */
+  startsWith(searchString: string, position?: number): boolean;
+
+  /**
+   * Returns true if the sequence of elements of searchString converted to a String is the
+   * same as the corresponding elements of this object (converted to a String) starting at
+   * endPosition – length(this). Otherwise returns false.
+   */
+  endsWith(searchString: string, endPosition?: number): boolean;
+}
+
+interface Array<T> {
+  /**
+   * Returns the value of the first element in the array where predicate is true, and undefined
+   * otherwise.
+   * @param predicate find calls predicate once for each element of the array, in ascending
+   * order, until it finds one where predicate returns true. If such an element is found, find
+   * immediately returns that element value. Otherwise, find returns undefined.
+   * @param thisArg If provided, it will be used as the this value for each invocation of
+   * predicate. If it is not provided, undefined is used instead.
+   */
+  find(predicate: (value: T, index: number, obj: Array<T>) => boolean, thisArg?: any): T;
+  /**
+   * Returns the this object after filling the section identified by start and end with value
+   * @param value value to fill array section with
+   * @param start index to start filling the array at. If start is negative, it is treated as
+   * length+start where length is the length of the array.
+   * @param end index to stop filling the array at. If end is negative, it is treated as
+   * length+end.
+   */
+  fill(value: T, start?: number, end?: number): T[];
+}
+
+interface NumberConstructor {
+  /**
+   * Returns true if the value passed is an integer, false otherwise.
+   * @param number A numeric value.
+   */
+  isInteger(number: number): boolean;
+}
+
+// Workaround https://github.com/Microsoft/TypeScript/issues/9193
+interface PromiseConstructor {
+  all<T>(values: (T | PromiseLike<T>)[]): Promise<T[]>;
+}
+
+interface Function {
+    /**
+      * Returns the name of the function. Function names are read-only and can not be changed.
+      */
+    readonly name: string;
+}

--- a/modules/tsconfig.json
+++ b/modules/tsconfig.json
@@ -16,7 +16,8 @@
     },
     "rootDir": ".",
     "inlineSourceMap": true,
-    "lib": ["es6", "dom"],
+    "lib": ["es5", "dom", "es2015.promise", "es2015.collection", "es2015.iterable"],
+    "skipDefaultLibCheck": true,
     "target": "es5"
   },
   "exclude": [

--- a/modules/types.d.ts
+++ b/modules/types.d.ts
@@ -14,3 +14,4 @@
 /// <reference path="../node_modules/@types/node/index.d.ts" />
 /// <reference path="../node_modules/@types/protractor/index.d.ts" />
 /// <reference path="../node_modules/@types/selenium-webdriver/index.d.ts" />
+/// <reference path="./es6-subset.d.ts" />


### PR DESCRIPTION
Currently Angular can use any part of ES6. This seems to have changed along with the new world repackaging, but I don't think we ever forced users to switch from individual shims (es6-collections + es6-promise) to a full ES6 shim.
Also in google3 this causes compile errors, where we use --lib es5,dom,es2015.iterable
cc @vikerman

Note: still need to make it green
