### PR TITLE
fix(core/testing compiler/testing): move TestComponentBuilder to core…

### DIFF
--- a/modules/@angular/core/testing.ts
+++ b/modules/@angular/core/testing.ts
@@ -9,5 +9,6 @@
 export * from './testing/async';
 export * from './testing/component_fixture';
 export * from './testing/fake_async';
+export * from './testing/test_component_builder';
 export * from './testing/test_injector';
 export * from './testing/testing';

--- a/modules/@angular/core/testing/test_component_builder.ts
+++ b/modules/@angular/core/testing/test_component_builder.ts
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {AnimationEntryMetadata, ComponentFactory, ComponentResolver, Injectable, Injector, NgZone, OpaqueToken, ViewMetadata} from '../index';
+import {PromiseWrapper} from '../src/facade/async';
+import {IS_DART, Type, isPresent} from '../src/facade/lang';
+
+import {ComponentFixture} from './component_fixture';
+import {tick} from './fake_async';
+
+
+/**
+ * An abstract class for inserting the root test component element in a platform independent way.
+ */
+export class TestComponentRenderer {
+  insertRootElement(rootElementId: string) {}
+}
+
+export var ComponentFixtureAutoDetect = new OpaqueToken('ComponentFixtureAutoDetect');
+export var ComponentFixtureNoNgZone = new OpaqueToken('ComponentFixtureNoNgZone');
+
+var _nextRootElementId = 0;
+
+/**
+ * Builds a ComponentFixture for use in component level tests.
+ */
+@Injectable()
+export class TestComponentBuilder {
+  constructor(protected _injector: Injector) {}
+
+  /**
+   * Overrides only the html of a {@link ComponentMetadata}.
+   * All the other properties of the component's {@link ViewMetadata} are preserved.
+   */
+  overrideTemplate(componentType: Type, template: string): TestComponentBuilder {
+    throw new Error(
+        'overrideTemplate is not supported in this implementation of TestComponentBuilder.');
+  }
+
+  /**
+   * Overrides a component's {@link ViewMetadata}.
+   */
+  overrideView(componentType: Type, view: ViewMetadata): TestComponentBuilder {
+    throw new Error(
+        'overrideView is not supported in this implementation of TestComponentBuilder.');
+  }
+
+  /**
+   * Overrides the directives from the component {@link ViewMetadata}.
+   */
+  overrideDirective(componentType: Type, from: Type, to: Type): TestComponentBuilder {
+    throw new Error(
+        'overrideDirective is not supported in this implementation of TestComponentBuilder.');
+  }
+
+  /**
+   * Overrides one or more injectables configured via `providers` metadata property of a directive
+   * or
+   * component.
+   * Very useful when certain providers need to be mocked out.
+   *
+   * The providers specified via this method are appended to the existing `providers` causing the
+   * duplicated providers to
+   * be overridden.
+   */
+  overrideProviders(type: Type, providers: any[]): TestComponentBuilder {
+    throw new Error(
+        'overrideProviders is not supported in this implementation of TestComponentBuilder.');
+  }
+
+  /**
+   * Overrides one or more injectables configured via `providers` metadata property of a directive
+   * or
+   * component.
+   * Very useful when certain providers need to be mocked out.
+   *
+   * The providers specified via this method are appended to the existing `providers` causing the
+   * duplicated providers to
+   * be overridden.
+   */
+  overrideViewProviders(type: Type, providers: any[]): TestComponentBuilder {
+    throw new Error(
+        'overrideViewProviders is not supported in this implementation of TestComponentBuilder.');
+  }
+
+  overrideAnimations(componentType: Type, animations: AnimationEntryMetadata[]):
+      TestComponentBuilder {
+    throw new Error(
+        'overrideAnimations is not supported in this implementation of TestComponentBuilder.');
+  }
+
+  protected createFromFactory<C>(ngZone: NgZone, componentFactory: ComponentFactory<C>):
+      ComponentFixture<C> {
+    let rootElId = `root${_nextRootElementId++}`;
+    var testComponentRenderer: TestComponentRenderer = this._injector.get(TestComponentRenderer);
+    testComponentRenderer.insertRootElement(rootElId);
+
+    var componentRef = componentFactory.create(this._injector, [], `#${rootElId}`);
+    let autoDetect: boolean = this._injector.get(ComponentFixtureAutoDetect, false);
+    return new ComponentFixture<any /*C*/>(componentRef, ngZone, autoDetect);
+  }
+
+  /**
+   * Builds and returns a ComponentFixture.
+   */
+  createAsync(rootComponentType: Type): Promise<ComponentFixture<any>> {
+    let noNgZone = IS_DART || this._injector.get(ComponentFixtureNoNgZone, false);
+    let ngZone: NgZone = noNgZone ? null : this._injector.get(NgZone, null);
+
+    let initComponent = () => {
+      let promise: Promise<ComponentFactory<any>> =
+          this._injector.get(ComponentResolver).resolveComponent(rootComponentType);
+      return promise.then(componentFactory => this.createFromFactory(ngZone, componentFactory));
+    };
+
+    return ngZone == null ? initComponent() : ngZone.run(initComponent);
+  }
+
+  createFakeAsync(rootComponentType: Type): ComponentFixture<any> {
+    let result: any /** TODO #9100 */;
+    let error: any /** TODO #9100 */;
+    PromiseWrapper.then(
+        this.createAsync(rootComponentType), (_result) => { result = _result; },
+        (_error) => { error = _error; });
+    tick();
+    if (isPresent(error)) {
+      throw error;
+    }
+    return result;
+  }
+
+  /**
+   * @deprecated createSync will be replaced with the ability to precompile components from within
+   * the test.
+   */
+  createSync<C>(componentFactory: ComponentFactory<C>): ComponentFixture<C> {
+    let noNgZone = IS_DART || this._injector.get(ComponentFixtureNoNgZone, false);
+    let ngZone: NgZone = noNgZone ? null : this._injector.get(NgZone, null);
+
+    let initComponent = () => this.createFromFactory(ngZone, componentFactory);
+    return ngZone == null ? initComponent() : ngZone.run(initComponent);
+  }
+}

--- a/modules/@angular/platform-browser-dynamic/testing.ts
+++ b/modules/@angular/platform-browser-dynamic/testing.ts
@@ -7,7 +7,8 @@
  */
 
 import {DirectiveResolver, ViewResolver} from '@angular/compiler';
-import {MockDirectiveResolver, MockViewResolver, TestComponentBuilder, TestComponentRenderer} from '@angular/compiler/testing';
+import {MockDirectiveResolver, MockViewResolver, OverridingTestComponentBuilder} from '@angular/compiler/testing';
+import {TestComponentBuilder, TestComponentRenderer} from '@angular/core/testing';
 import {TEST_BROWSER_APPLICATION_PROVIDERS, TEST_BROWSER_PLATFORM_PROVIDERS} from '@angular/platform-browser/testing';
 
 import {BROWSER_APP_COMPILER_PROVIDERS} from './index';
@@ -27,9 +28,9 @@ export const TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS: Array<any /*Type | Provide
 export const TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS: Array<any /*Type | Provider | any[]*/> = [
   TEST_BROWSER_APPLICATION_PROVIDERS, BROWSER_APP_COMPILER_PROVIDERS,
   [
+    {provide: TestComponentBuilder, useClass: OverridingTestComponentBuilder},
     {provide: DirectiveResolver, useClass: MockDirectiveResolver},
     {provide: ViewResolver, useClass: MockViewResolver},
-    TestComponentBuilder,
     {provide: TestComponentRenderer, useClass: DOMTestComponentRenderer},
   ]
 ];

--- a/modules/@angular/platform-server/testing/server.ts
+++ b/modules/@angular/platform-server/testing/server.ts
@@ -7,8 +7,9 @@
  */
 
 import {COMPILER_PROVIDERS, DirectiveResolver, ViewResolver, XHR} from '@angular/compiler';
-import {MockDirectiveResolver, MockViewResolver, TestComponentBuilder, TestComponentRenderer} from '@angular/compiler/testing';
+import {MockDirectiveResolver, MockViewResolver, OverridingTestComponentBuilder} from '@angular/compiler/testing';
 import {APPLICATION_COMMON_PROVIDERS, APP_ID, NgZone, PLATFORM_COMMON_PROVIDERS, PLATFORM_INITIALIZER, RootRenderer} from '@angular/core';
+import {TestComponentBuilder, TestComponentRenderer} from '@angular/core/testing';
 
 import {AnimationDriver, NoOpAnimationDriver} from '../core_private';
 import {DOMTestComponentRenderer} from '../platform_browser_dynamic_testing_private';
@@ -71,9 +72,9 @@ export const TEST_SERVER_APPLICATION_PROVIDERS: Array<any /*Type | Provider | an
       /* @ts2dart_Provider */ {provide: APP_ID, useValue: 'a'},
       /* @ts2dart_Provider */ {provide: SharedStylesHost, useExisting: DomSharedStylesHost},
       DomSharedStylesHost, ELEMENT_PROBE_PROVIDERS,
+      {provide: TestComponentBuilder, useClass: OverridingTestComponentBuilder},
       /* @ts2dart_Provider */ {provide: DirectiveResolver, useClass: MockDirectiveResolver},
       /* @ts2dart_Provider */ {provide: ViewResolver, useClass: MockViewResolver},
       /* @ts2dart_Provider */ {provide: TestComponentRenderer, useClass: DOMTestComponentRenderer},
-      TestComponentBuilder,
       /* @ts2dart_Provider */ {provide: NgZone, useFactory: createNgZone}
     ];

--- a/tools/public_api_guard/compiler/testing.d.ts
+++ b/tools/public_api_guard/compiler/testing.d.ts
@@ -1,7 +1,3 @@
-export declare var ComponentFixtureAutoDetect: OpaqueToken;
-
-export declare var ComponentFixtureNoNgZone: OpaqueToken;
-
 export declare class MockDirectiveResolver extends DirectiveResolver {
     resolve(type: Type): DirectiveMetadata;
     setProvidersOverride(type: Type, providers: any[]): void;
@@ -34,21 +30,13 @@ export declare class MockViewResolver extends ViewResolver {
     setView(component: Type, view: ViewMetadata): void;
 }
 
-export declare class TestComponentBuilder {
-    constructor(_injector: Injector);
+export declare class OverridingTestComponentBuilder extends TestComponentBuilder {
+    constructor(injector: Injector);
     createAsync(rootComponentType: Type): Promise<ComponentFixture<any>>;
-    createFakeAsync(rootComponentType: Type): ComponentFixture<any>;
-    createSync<C>(componentFactory: ComponentFactory<C>): ComponentFixture<C>;
     overrideAnimations(componentType: Type, animations: AnimationEntryMetadata[]): TestComponentBuilder;
-    overrideBindings(type: Type, providers: any[]): TestComponentBuilder;
-    overrideDirective(componentType: Type, from: Type, to: Type): TestComponentBuilder;
-    overrideProviders(type: Type, providers: any[]): TestComponentBuilder;
-    overrideTemplate(componentType: Type, template: string): TestComponentBuilder;
-    overrideView(componentType: Type, view: ViewMetadata): TestComponentBuilder;
-    overrideViewBindings(type: Type, providers: any[]): TestComponentBuilder;
-    overrideViewProviders(type: Type, providers: any[]): TestComponentBuilder;
-}
-
-export declare class TestComponentRenderer {
-    insertRootElement(rootElementId: string): void;
+    overrideDirective(componentType: Type, from: Type, to: Type): OverridingTestComponentBuilder;
+    overrideProviders(type: Type, providers: any[]): OverridingTestComponentBuilder;
+    overrideTemplate(componentType: Type, template: string): OverridingTestComponentBuilder;
+    overrideView(componentType: Type, view: ViewMetadata): OverridingTestComponentBuilder;
+    overrideViewProviders(type: Type, providers: any[]): OverridingTestComponentBuilder;
 }

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -23,6 +23,10 @@ export declare class ComponentFixture<T> {
     whenStable(): Promise<any>;
 }
 
+export declare var ComponentFixtureAutoDetect: OpaqueToken;
+
+export declare var ComponentFixtureNoNgZone: OpaqueToken;
+
 export declare var ddescribe: Function;
 
 export declare var describe: Function;
@@ -55,6 +59,25 @@ export declare function it(name: string, fn: Function, timeOut?: number): void;
 export declare function resetBaseTestProviders(): void;
 
 export declare function setBaseTestProviders(platformProviders: Array<Type | Provider | any[]>, applicationProviders: Array<Type | Provider | any[]>): void;
+
+export declare class TestComponentBuilder {
+    protected _injector: Injector;
+    constructor(_injector: Injector);
+    createAsync(rootComponentType: Type): Promise<ComponentFixture<any>>;
+    createFakeAsync(rootComponentType: Type): ComponentFixture<any>;
+    protected createFromFactory<C>(ngZone: NgZone, componentFactory: ComponentFactory<C>): ComponentFixture<C>;
+    createSync<C>(componentFactory: ComponentFactory<C>): ComponentFixture<C>;
+    overrideAnimations(componentType: Type, animations: AnimationEntryMetadata[]): TestComponentBuilder;
+    overrideDirective(componentType: Type, from: Type, to: Type): TestComponentBuilder;
+    overrideProviders(type: Type, providers: any[]): TestComponentBuilder;
+    overrideTemplate(componentType: Type, template: string): TestComponentBuilder;
+    overrideView(componentType: Type, view: ViewMetadata): TestComponentBuilder;
+    overrideViewProviders(type: Type, providers: any[]): TestComponentBuilder;
+}
+
+export declare class TestComponentRenderer {
+    insertRootElement(rootElementId: string): void;
+}
 
 export declare class TestInjector {
     applicationProviders: Array<Type | Provider | any[] | any>;


### PR DESCRIPTION
TestComponentBuilder now lives in core/testing. compiler/testing contains a private
OverridingTestComponentBuilder implementation which handles the private behavior
we need to override templates. This is part of the effort to simplify the testing
imports and hide compiler APIs.

Closes #9585

BREAKING CHANGE:

`TestComponentBuilder` is now imported from `@angular/core/testing`. Imports
from `@angular/compiler/testing` are deprecated.

Before:

```
import {TestComponentBuilder, TestComponentRenderer, ComponentFixtureAutoDetect} from '@angular/compiler/testing';
```

After:

```
import {TestComponentBuilder, TestComponentRenderer, ComponentFixtureAutoDetect} from '@angular/core/testing';
```
