### PR TITLE
fix(router): Added config validation for empty path redirect

### DIFF
--- a/modules/@angular/router/src/config.ts
+++ b/modules/@angular/router/src/config.ts
@@ -43,6 +43,10 @@ function validateNode(route: Route): void {
   }
   if (route.path.startsWith('/')) {
     throw new Error(
-        `Invalid route configuration of route '${route.path}': path cannot start with a slash`);
+        `Invalid configuration of route '${route.path}': path cannot start with a slash`);
+  }
+  if (route.path === '' && !!route.redirectTo && !route.terminal) {
+    throw new Error(
+        `Invalid configuration of route '${route.path}': terminal: true is required with an empty path and redirectTo`);
   }
 }

--- a/modules/@angular/router/test/config.spec.ts
+++ b/modules/@angular/router/test/config.spec.ts
@@ -36,7 +36,13 @@ describe('config', () => {
     it('should throw when path starts with a slash', () => {
       expect(() => {
         validateConfig([<any>{path: '/a', componenta: '', redirectTo: 'b'}]);
-      }).toThrowError(`Invalid route configuration of route '/a': path cannot start with a slash`);
+      }).toThrowError(`Invalid configuration of route '/a': path cannot start with a slash`);
+    });
+
+    it('should throw when an empty path and redirectTo are used without terminal: true', () => {
+      expect(() => {
+        validateConfig([<any>{path: '', redirectTo: 'a'}]);
+      }).toThrowError(`Invalid configuration of route '': terminal: true is required with an empty path and redirectTo`));
     });
   });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Adding a route with the following doesn't error without `terminal: true`

``` js
  { path: '', redirectTo: '/somewhere' }
```

The route should be

``` js
  { path: '', redirectTo: '/somewhere', terminal: true }
```

**What is the new behavior?**

An error will be thrown if `terminal: true` is not included in the route

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

cc: @vsavkin 
