### PR TITLE
docs: update cheatsheet import lines

### DIFF
--- a/modules/@angular/docs/cheatsheet/bootstrapping.md
+++ b/modules/@angular/docs/cheatsheet/bootstrapping.md
@@ -2,7 +2,7 @@
 Bootstrapping
 @cheatsheetIndex 0
 @description
-{@target ts}`import {bootstrap} from 'angular2/platform/browser';`{@endtarget}
+{@target ts}`import { bootstrap } from '@angular/platform-browser-dynamic';`{@endtarget}
 {@target js}Available from the `ng.platform.browser` namespace{@endtarget}
 {@target dart}`import 'package:angular2/platform/browser.dart';`{@endtarget}
 

--- a/modules/@angular/docs/cheatsheet/built-in-directives.md
+++ b/modules/@angular/docs/cheatsheet/built-in-directives.md
@@ -2,7 +2,7 @@
 Built-in directives
 @cheatsheetIndex 2
 @description
-{@target ts}`import {NgIf, ...} from 'angular2/common';`{@endtarget}
+{@target ts}`import {NgIf, ...} from '@angular/common';`{@endtarget}
 {@target js}Available from the `ng.common` namespace{@endtarget}
 {@target dart}Available using `platform_directives` in pubspec{@endtarget}
 

--- a/modules/@angular/docs/cheatsheet/class-decorators.md
+++ b/modules/@angular/docs/cheatsheet/class-decorators.md
@@ -2,7 +2,7 @@
 Class decorators
 @cheatsheetIndex 4
 @description
-{@target ts}`import {Directive, ...} from 'angular2/core';`{@endtarget}
+{@target ts}`import {Directive, ...} from '@angular/core';`{@endtarget}
 {@target js}Available from the `ng.core` namespace{@endtarget}
 {@target dart}`import 'package:angular2/core.dart';`{@endtarget}
 

--- a/modules/@angular/docs/cheatsheet/dependency-injection.md
+++ b/modules/@angular/docs/cheatsheet/dependency-injection.md
@@ -2,8 +2,6 @@
 Dependency injection configuration
 @cheatsheetIndex 9
 @description
-{@target ts}`import {provide} from 'angular2/core';`{@endtarget}
-{@target js}Available from the `ng.core` namespace{@endtarget}
 {@target dart}`import 'package:angular2/core.dart';`{@endtarget}
 
 @cheatsheetItem

--- a/modules/@angular/docs/cheatsheet/directive-and-component-decorators.md
+++ b/modules/@angular/docs/cheatsheet/directive-and-component-decorators.md
@@ -2,7 +2,7 @@
 Class field decorators for directives and components
 @cheatsheetIndex 7
 @description
-{@target ts}`import {Input, ...} from 'angular2/core';`{@endtarget}
+{@target ts}`import {Input, ...} from '@angular/core';`{@endtarget}
 {@target js}Available from the `ng.core` namespace{@endtarget}
 {@target dart}`import 'package:angular2/core.dart';`{@endtarget}
 

--- a/modules/@angular/docs/cheatsheet/forms.md
+++ b/modules/@angular/docs/cheatsheet/forms.md
@@ -2,7 +2,7 @@
 Forms
 @cheatsheetIndex 3
 @description
-{@target ts}`import {FORM_DIRECTIVES} from 'angular2/common';`{@endtarget}
+{@target ts}`import {FORM_DIRECTIVES} from '@angular/common';`{@endtarget}
 {@target js}Available from `ng.common.FORM_DIRECTIVES`{@endtarget}
 {@target dart}Available using `platform_directives` in pubspec{@endtarget}
 

--- a/modules/@angular/docs/cheatsheet/routing.md
+++ b/modules/@angular/docs/cheatsheet/routing.md
@@ -2,7 +2,7 @@
 Routing and navigation
 @cheatsheetIndex 10
 @description
-{@target ts}`import {RouteConfig, ROUTER_DIRECTIVES, ROUTER_PROVIDERS, ...} from 'angular2/router';`{@endtarget}
+{@target ts}`import {provideRouter, RouteConfig, ROUTER_DIRECTIVES, ...} from '@angular/router';`{@endtarget}
 {@target js}Available from the `ng.router` namespace{@endtarget}
 {@target dart}`import 'package:angular2/router.dart';`{@endtarget}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

This updates the cheatsheet import lines to use the scoped packages.

Notes:

We have a `{@target ts}`import {NgIf, ...} from '@angular/common';`{@endtarget}`. Do we really need that line? I don't think anyone is importing `NgIf` by hand anymore.

Same with: `{@target ts}`import {FORM_DIRECTIVES} from '@angular/common';`{@endtarget}`.

The Dart part is not modified (that will be fixed on a PR will all the dart needed changes).

Also the Router cheatsheet needs a massive update but I will delegate that work to our router expert.
