### PR TITLE
fix(http): don't encode values that are allowed in query

### DIFF
--- a/modules/@angular/http/http.ts
+++ b/modules/@angular/http/http.ts
@@ -34,7 +34,8 @@ export {Http, Jsonp} from './src/http';
 export {Connection, ConnectionBackend, RequestOptionsArgs, ResponseOptionsArgs, XSRFStrategy} from './src/interfaces';
 export {Request} from './src/static_request';
 export {Response} from './src/static_response';
-export {URLSearchParams} from './src/url_search_params';
+export {QueryEncoder, URLSearchParams} from './src/url_search_params';
+
 
 
 /**

--- a/tools/public_api_guard/http/index.d.ts
+++ b/tools/public_api_guard/http/index.d.ts
@@ -101,6 +101,12 @@ export declare abstract class JSONPConnection implements Connection {
 }
 
 /** @experimental */
+export declare class QueryEncoder {
+    encodeKey(k: string): string;
+    encodeValue(v: string): string;
+}
+
+/** @experimental */
 export declare enum ReadyState {
     Unsent = 0,
     Open = 1,
@@ -209,7 +215,7 @@ export declare enum ResponseType {
 export declare class URLSearchParams {
     paramsMap: Map<string, string[]>;
     rawParams: string;
-    constructor(rawParams?: string);
+    constructor(rawParams?: string, queryEncoder?: QueryEncoder);
     append(param: string, val: string): void;
     appendAll(searchParams: URLSearchParams): void;
     clone(): URLSearchParams;


### PR DESCRIPTION
@vicb still some work to do on this PR, but I hope you can give an initial review and give your thoughts on the approach.

TODO: 
- [ ] Actually inject the QueryEncoder so it can be changed with DI
- [ ] Make the encode a RequestOption property so it can be passed in at runtime (to support multiple encoders for different backends)
- [ ] Add decoding as well, to symmetrically parse query params.
- [ ] Add docs showing how to override encoder

This implements a new class, QueryEncoder, that provides
methods for encoding keys and values of query parameter.
The encoder encodes with encodeURIComponent, and then
decodes a whitelist of allowed characters back to their
unencoded form. QueryEncoder is intended to be provided
to http via Dependency Injection so the default encoding
mechanism can be overridden.

BREAKING CHANGE:

The changes to Http's URLSearchParams serialization now 
prevent encoding of these characters inside query parameters
which were previously converted to percent-encoded values:

@ : $ , ; + ; ? /

Fixes #9348
