### PR TITLE
fix(compiler): Missing metadata files should result in undefined

### DIFF
--- a/modules/@angular/compiler-cli/src/reflector_host.ts
+++ b/modules/@angular/compiler-cli/src/reflector_host.ts
@@ -184,14 +184,13 @@ export class ReflectorHost implements StaticReflectorHost, ImportGenerator {
       if (this.context.exists(metadataPath)) {
         return this.readMetadata(metadataPath);
       }
+    } else {
+      const sf = this.program.getSourceFile(filePath);
+      if (!sf) {
+        throw new Error(`Source file ${filePath} not present in program.`);
+      }
+      return this.metadataCollector.getMetadata(sf);
     }
-
-    let sf = this.program.getSourceFile(filePath);
-    if (!sf) {
-      throw new Error(`Source file ${filePath} not present in program.`);
-    }
-    const metadata = this.metadataCollector.getMetadata(sf);
-    return metadata;
   }
 
   readMetadata(filePath: string) {

--- a/modules/@angular/compiler-cli/test/reflector_host_spec.ts
+++ b/modules/@angular/compiler-cli/test/reflector_host_spec.ts
@@ -92,6 +92,10 @@ describe('reflector_host', () => {
      () => {
          expect(reflectorHost.getMetadataFor('node_modules/@angular/core.d.ts'))
              .toEqual({__symbolic: 'module', version: 1, metadata: {foo: {__symbolic: 'class'}}})});
+
+  it('should be able to read metadata from an otherwise unused .d.ts file ', () => {
+    expect(reflectorHost.getMetadataFor('node_modules/@angular/unused.d.ts')).toBeUndefined();
+  });
 });
 
 const dummyModule = 'export let foo: any[];'
@@ -115,8 +119,8 @@ const FILES: Entry = {
           'core.d.ts': dummyModule,
           'core.metadata.json':
               `{"__symbolic":"module", "version": 1, "metadata": {"foo": {"__symbolic": "class"}}}`,
-          'router-deprecated':
-              {'index.d.ts': dummyModule, 'src': {'providers.d.ts': dummyModule}}
+          'router-deprecated': {'index.d.ts': dummyModule, 'src': {'providers.d.ts': dummyModule}},
+          'unused.d.ts': dummyModule
         }
       }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

`ngc` throws an exception complaining about the file not being `in the program` when a module is referenced in metadata but the collector did not produce metadata for it. This error is misleading and unnecessary as it doesn't need to find `.d.ts`.

**What is the new behavior?**

The ReflectorHost now produces `undefined` in these cases allowing the `StaticReflector` to produce a more meaningful error message or ignore it (as in should have in #9678).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

RelectorHost threw an exception when metadata was requested for a
.d.ts file that didn't have a .metadata.json file.  Changed it to
return undefined.

Fixes #9678
