### PR TITLE
fix(testbed): rename TestInjector to TestBed

### DIFF
--- a/modules/@angular/core/testing/test_injector.ts
+++ b/modules/@angular/core/testing/test_injector.ts
@@ -16,7 +16,7 @@ import {AsyncTestCompleter} from './async_test_completer';
 /**
  * @experimental
  */
-export class TestInjector {
+export class TestBed {
   private _instantiated: boolean = false;
 
   private _injector: ReflectiveInjector = null;
@@ -65,16 +65,23 @@ export class TestInjector {
   }
 }
 
-var _testInjector: TestInjector = null;
+var _testBed: TestBed = null;
 
 /**
  * @experimental
  */
-export function getTestInjector() {
-  if (_testInjector == null) {
-    _testInjector = new TestInjector();
+export function getTestBed() {
+  if (_testBed == null) {
+    _testBed = new TestBed();
   }
-  return _testInjector;
+  return _testBed;
+}
+
+/**
+ * @deprecated Use getTestBed().
+ */
+export function getTestInjector() {
+  return getTestBed();
 }
 
 /**
@@ -93,7 +100,7 @@ export function getTestInjector() {
 export function setBaseTestProviders(
     platformProviders: Array<Type|Provider|any[]>,
     applicationProviders: Array<Type|Provider|any[]>) {
-  var testInjector = getTestInjector();
+  var testInjector = getTestBed();
   if (testInjector.platformProviders.length > 0 || testInjector.applicationProviders.length > 0) {
     throw new BaseException('Cannot set base providers because it has already been called');
   }
@@ -113,7 +120,7 @@ export function setBaseTestProviders(
  * @experimental
  */
 export function resetBaseTestProviders() {
-  var testInjector = getTestInjector();
+  var testInjector = getTestBed();
   testInjector.platformProviders = [];
   testInjector.applicationProviders = [];
   testInjector.reset();
@@ -144,7 +151,7 @@ export function resetBaseTestProviders() {
  * @stable
  */
 export function inject(tokens: any[], fn: Function): () => any {
-  let testInjector = getTestInjector();
+  let testInjector = getTestBed();
   if (tokens.indexOf(AsyncTestCompleter) >= 0) {
     // Return an async test method that returns a Promise if AsyncTestCompleter is one of the
     // injected tokens.
@@ -155,7 +162,7 @@ export function inject(tokens: any[], fn: Function): () => any {
     };
   } else {
     // Return a synchronous test method with the injected tokens.
-    return () => { return getTestInjector().execute(tokens, fn); };
+    return () => { return getTestBed().execute(tokens, fn); };
   }
 }
 
@@ -168,7 +175,7 @@ export class InjectSetupWrapper {
   private _addProviders() {
     var additionalProviders = this._providers();
     if (additionalProviders.length > 0) {
-      getTestInjector().addProviders(additionalProviders);
+      getTestBed().addProviders(additionalProviders);
     }
   }
 

--- a/modules/@angular/core/testing/testing.ts
+++ b/modules/@angular/core/testing/testing.ts
@@ -12,7 +12,7 @@
  * allows tests to be asynchronous by either returning a promise or using a 'done' parameter.
  */
 
-import {TestInjector, getTestInjector} from './test_injector';
+import {TestBed, getTestBed} from './test_injector';
 
 declare var global: any;
 
@@ -107,11 +107,11 @@ export var iit = _global.fit;
 export var xit = _global.xit;
 
 
-var testInjector: TestInjector = getTestInjector();
+var testBed: TestBed = getTestBed();
 
 // Reset the test providers before each test.
 if (_global.beforeEach) {
-  beforeEach(() => { testInjector.reset(); });
+  beforeEach(() => { testBed.reset(); });
 }
 
 /**
@@ -123,7 +123,7 @@ if (_global.beforeEach) {
 export function addProviders(providers: Array<any>): void {
   if (!providers) return;
   try {
-    testInjector.addProviders(providers);
+    testBed.addProviders(providers);
   } catch (e) {
     throw new Error(
         'addProviders can\'t be called after the injector has been already created for this test. ' +

--- a/modules/@angular/core/testing/testing_internal.ts
+++ b/modules/@angular/core/testing/testing_internal.ts
@@ -11,7 +11,7 @@ import {StringMapWrapper} from '../src/facade/collection';
 import {Math, global, isFunction, isPromise} from '../src/facade/lang';
 
 import {AsyncTestCompleter} from './async_test_completer';
-import {getTestInjector, inject} from './test_injector';
+import {getTestBed, inject} from './test_injector';
 
 export {MockAnimationDriver} from './animation/mock_animation_driver';
 export {MockAnimationPlayer} from './animation/mock_animation_player';
@@ -41,7 +41,7 @@ var inIt = false;
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 3000;
 var globalTimeOut = jasmine.DEFAULT_TIMEOUT_INTERVAL;
 
-var testInjector = getTestInjector();
+var testBed = getTestBed();
 
 /**
  * Mechanism to run `beforeEach()` functions of Angular tests.
@@ -62,7 +62,7 @@ class BeforeEachRunner {
 }
 
 // Reset the test providers before each test
-jsmBeforeEach(() => { testInjector.reset(); });
+jsmBeforeEach(() => { testBed.reset(); });
 
 function _describe(jsmFn: any /** TODO #9100 */, ...args: any[] /** TODO #9100 */) {
   var parentRunner = runnerStack.length === 0 ? null : runnerStack[runnerStack.length - 1];
@@ -111,7 +111,7 @@ export function beforeEachProviders(fn: any /** TODO #9100 */): void {
   jsmBeforeEach(() => {
     var providers = fn();
     if (!providers) return;
-    testInjector.addProviders(providers);
+    testBed.addProviders(providers);
   });
 }
 
@@ -140,7 +140,7 @@ function _it(jsmFn: Function, name: string, testFn: Function, testTimeOut: numbe
         return new AsyncTestCompleter();
       }
     };
-    testInjector.addProviders([completerProvider]);
+    testBed.addProviders([completerProvider]);
     runner.run();
 
     inIt = true;

--- a/modules/@angular/platform-browser/test/web_workers/worker/renderer_integration_spec.ts
+++ b/modules/@angular/platform-browser/test/web_workers/worker/renderer_integration_spec.ts
@@ -8,7 +8,7 @@
 
 import {inject, ddescribe, describe, it, iit, expect, beforeEach, beforeEachProviders,} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter} from '@angular/core/testing/testing_internal';
-import {TestInjector} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {TestComponentBuilder} from '@angular/compiler/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {provide, Injector, ViewMetadata, Component, Injectable, ComponentRef} from '@angular/core';
@@ -65,15 +65,15 @@ export function main() {
 
     beforeEachProviders(() => {
       uiRenderStore = new RenderStore();
-      var testUiInjector = new TestInjector();
-      testUiInjector.platformProviders = TEST_BROWSER_PLATFORM_PROVIDERS;
-      testUiInjector.applicationProviders = TEST_BROWSER_APPLICATION_PROVIDERS;
-      testUiInjector.addProviders([
+      var uiTestBed = new TestBed();
+      uiTestBed.platformProviders = TEST_BROWSER_PLATFORM_PROVIDERS;
+      uiTestBed.applicationProviders = TEST_BROWSER_APPLICATION_PROVIDERS;
+      uiTestBed.addProviders([
         Serializer, {provide: RenderStore, useValue: uiRenderStore},
         {provide: DomRootRenderer, useClass: DomRootRenderer_},
         {provide: RootRenderer, useExisting: DomRootRenderer}
       ]);
-      uiInjector = testUiInjector.createInjector();
+      uiInjector = uiTestBed.createInjector();
       var uiSerializer = uiInjector.get(Serializer);
       var domRootRenderer = uiInjector.get(DomRootRenderer);
       workerRenderStore = new RenderStore();

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -62,7 +62,10 @@ export declare var fit: any;
 export declare function flushMicrotasks(): void;
 
 /** @experimental */
-export declare function getTestInjector(): TestInjector;
+export declare function getTestBed(): TestBed;
+
+/** @deprecated */
+export declare function getTestInjector(): TestBed;
 
 /** @deprecated */
 export declare var iit: any;
@@ -85,6 +88,17 @@ export declare function resetBaseTestProviders(): void;
 /** @experimental */
 export declare function setBaseTestProviders(platformProviders: Array<Type | Provider | any[]>, applicationProviders: Array<Type | Provider | any[]>): void;
 
+/** @experimental */
+export declare class TestBed {
+    applicationProviders: Array<Type | Provider | any[] | any>;
+    platformProviders: Array<Type | Provider | any[] | any>;
+    addProviders(providers: Array<Type | Provider | any[] | any>): void;
+    createInjector(): ReflectiveInjector;
+    execute(tokens: any[], fn: Function): any;
+    get(token: any): any;
+    reset(): void;
+}
+
 /** @stable */
 export declare class TestComponentBuilder {
     protected _injector: Injector;
@@ -104,17 +118,6 @@ export declare class TestComponentBuilder {
 /** @experimental */
 export declare class TestComponentRenderer {
     insertRootElement(rootElementId: string): void;
-}
-
-/** @experimental */
-export declare class TestInjector {
-    applicationProviders: Array<Type | Provider | any[] | any>;
-    platformProviders: Array<Type | Provider | any[] | any>;
-    addProviders(providers: Array<Type | Provider | any[] | any>): void;
-    createInjector(): ReflectiveInjector;
-    execute(tokens: any[], fn: Function): any;
-    get(token: any): any;
-    reset(): void;
 }
 
 /** @experimental */


### PR DESCRIPTION
The TestBed contains an injector, but does not extend it - changing
the name to better reflect the actual class.

BREAKING CHANGE:

Before:

```
import {TestInjector, getTestInjector} from '@angular/core/testing';
```

After:

```
import {TestBed, getTestBed} from '@angular/core/testing';
```
