### PR TITLE
feat(compiler): Expression span information and error correction

### DIFF
--- a/modules/@angular/compiler/test/expression_parser/lexer_spec.ts
+++ b/modules/@angular/compiler/test/expression_parser/lexer_spec.ts
@@ -15,50 +15,50 @@ function lex(text: string): any[] {
   return new Lexer().tokenize(text);
 }
 
-function expectToken(token: any /** TODO #9100 */, index: any /** TODO #9100 */) {
+function expectToken(token: any, index: any) {
   expect(token instanceof Token).toBe(true);
   expect(token.index).toEqual(index);
 }
 
-function expectCharacterToken(
-    token: any /** TODO #9100 */, index: any /** TODO #9100 */, character: any /** TODO #9100 */) {
+function expectCharacterToken(token: any, index: any, character: any) {
   expect(character.length).toBe(1);
   expectToken(token, index);
   expect(token.isCharacter(StringWrapper.charCodeAt(character, 0))).toBe(true);
 }
 
-function expectOperatorToken(
-    token: any /** TODO #9100 */, index: any /** TODO #9100 */, operator: any /** TODO #9100 */) {
+function expectOperatorToken(token: any, index: any, operator: any) {
   expectToken(token, index);
   expect(token.isOperator(operator)).toBe(true);
 }
 
-function expectNumberToken(
-    token: any /** TODO #9100 */, index: any /** TODO #9100 */, n: any /** TODO #9100 */) {
+function expectNumberToken(token: any, index: any, n: any) {
   expectToken(token, index);
   expect(token.isNumber()).toBe(true);
   expect(token.toNumber()).toEqual(n);
 }
 
-function expectStringToken(
-    token: any /** TODO #9100 */, index: any /** TODO #9100 */, str: any /** TODO #9100 */) {
+function expectStringToken(token: any, index: any, str: any) {
   expectToken(token, index);
   expect(token.isString()).toBe(true);
   expect(token.toString()).toEqual(str);
 }
 
-function expectIdentifierToken(
-    token: any /** TODO #9100 */, index: any /** TODO #9100 */, identifier: any /** TODO #9100 */) {
+function expectIdentifierToken(token: any, index: any, identifier: any) {
   expectToken(token, index);
   expect(token.isIdentifier()).toBe(true);
   expect(token.toString()).toEqual(identifier);
 }
 
-function expectKeywordToken(
-    token: any /** TODO #9100 */, index: any /** TODO #9100 */, keyword: any /** TODO #9100 */) {
+function expectKeywordToken(token: any, index: any, keyword: any) {
   expectToken(token, index);
   expect(token.isKeyword()).toBe(true);
   expect(token.toString()).toEqual(keyword);
+}
+
+function expectErrorToken(token: Token, index: any, message: string) {
+  expectToken(token, index);
+  expect(token.isError()).toBe(true);
+  expect(token.toString()).toEqual(message);
 }
 
 export function main() {
@@ -228,14 +228,13 @@ export function main() {
         expectNumberToken(tokens[0], 0, 0.5E+10);
       });
 
-      it('should throws exception for invalid exponent', function() {
-        expect(() => {
-          lex('0.5E-');
-        }).toThrowError('Lexer Error: Invalid exponent at column 4 in expression [0.5E-]');
+      it('should return exception for invalid exponent', function() {
+        expectErrorToken(
+            lex('0.5E-')[0], 4, 'Lexer Error: Invalid exponent at column 4 in expression [0.5E-]');
 
-        expect(() => {
-          lex('0.5E-A');
-        }).toThrowError('Lexer Error: Invalid exponent at column 4 in expression [0.5E-A]');
+        expectErrorToken(
+            lex('0.5E-A')[0], 4,
+            'Lexer Error: Invalid exponent at column 4 in expression [0.5E-A]');
       });
 
       it('should tokenize number starting with a dot', function() {
@@ -244,9 +243,9 @@ export function main() {
       });
 
       it('should throw error on invalid unicode', function() {
-        expect(() => { lex('\'\\u1\'\'bla\''); })
-            .toThrowError(
-                'Lexer Error: Invalid unicode escape [\\u1\'\'b] at column 2 in expression [\'\\u1\'\'bla\']');
+        expectErrorToken(
+            lex('\'\\u1\'\'bla\'')[0], 2,
+            'Lexer Error: Invalid unicode escape [\\u1\'\'b] at column 2 in expression [\'\\u1\'\'bla\']');
       });
 
       it('should tokenize hash as operator', function() {

--- a/modules/@angular/compiler/test/expression_parser/unparser.ts
+++ b/modules/@angular/compiler/test/expression_parser/unparser.ts
@@ -10,12 +10,12 @@ import {AST, AstVisitor, Binary, BindingPipe, Chain, Conditional, EmptyExpr, Fun
 import {StringWrapper, isPresent, isString} from '../../src/facade/lang';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../src/interpolation_config';
 
-export class Unparser implements AstVisitor {
+class Unparser implements AstVisitor {
   private static _quoteRegExp = /"/g;
   private _expression: string;
   private _interpolationConfig: InterpolationConfig;
 
-  unparse(ast: AST, interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG) {
+  unparse(ast: AST, interpolationConfig: InterpolationConfig) {
     this._expression = '';
     this._interpolationConfig = interpolationConfig;
     this._visit(ast);
@@ -179,4 +179,11 @@ export class Unparser implements AstVisitor {
   }
 
   private _visit(ast: AST) { ast.visit(this); }
+}
+
+const sharedUnparser = new Unparser();
+
+export function unparse(
+    ast: AST, interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG): string {
+  return sharedUnparser.unparse(ast, interpolationConfig);
 }

--- a/modules/@angular/compiler/test/expression_parser/validator.ts
+++ b/modules/@angular/compiler/test/expression_parser/validator.ts
@@ -1,0 +1,110 @@
+import {AST, Binary, BindingPipe, Chain, Conditional, EmptyExpr, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeMethodCall, SafePropertyRead} from '../../src/expression_parser/ast';
+
+import {unparse} from './unparser';
+
+class ASTValidator extends RecursiveAstVisitor {
+  private parentSpan: ParseSpan|undefined;
+
+  visit(ast: AST) {
+    this.parentSpan = undefined;
+    ast.visit(this);
+  }
+
+  validate(ast: AST, cb: () => void): void {
+    if (!inSpan(ast.span, this.parentSpan)) {
+      throw Error(
+          `Invalid AST span [expected (${ast.span.start}, ${ast.span.end}) to be in (${this.parentSpan.start},  ${this.parentSpan.end}) for ${unparse(ast)}`);
+    }
+    const oldParent = this.parentSpan;
+    this.parentSpan = ast.span;
+    cb();
+    this.parentSpan = oldParent;
+  }
+
+  visitBinary(ast: Binary, context: any): any {
+    this.validate(ast, () => super.visitBinary(ast, context));
+  }
+
+  visitChain(ast: Chain, context: any): any {
+    this.validate(ast, () => super.visitChain(ast, context));
+  }
+
+  visitConditional(ast: Conditional, context: any): any {
+    this.validate(ast, () => super.visitConditional(ast, context));
+  }
+
+  visitFunctionCall(ast: FunctionCall, context: any): any {
+    this.validate(ast, () => super.visitFunctionCall(ast, context));
+  }
+
+  visitImplicitReceiver(ast: ImplicitReceiver, context: any): any {
+    this.validate(ast, () => super.visitImplicitReceiver(ast, context));
+  }
+
+  visitInterpolation(ast: Interpolation, context: any): any {
+    this.validate(ast, () => super.visitInterpolation(ast, context));
+  }
+
+  visitKeyedRead(ast: KeyedRead, context: any): any {
+    this.validate(ast, () => super.visitKeyedRead(ast, context));
+  }
+
+  visitKeyedWrite(ast: KeyedWrite, context: any): any {
+    this.validate(ast, () => super.visitKeyedWrite(ast, context));
+  }
+
+  visitLiteralArray(ast: LiteralArray, context: any): any {
+    this.validate(ast, () => super.visitLiteralArray(ast, context));
+  }
+
+  visitLiteralMap(ast: LiteralMap, context: any): any {
+    this.validate(ast, () => super.visitLiteralMap(ast, context));
+  }
+
+  visitLiteralPrimitive(ast: LiteralPrimitive, context: any): any {
+    this.validate(ast, () => super.visitLiteralPrimitive(ast, context));
+  }
+
+  visitMethodCall(ast: MethodCall, context: any): any {
+    this.validate(ast, () => super.visitMethodCall(ast, context));
+  }
+
+  visitPipe(ast: BindingPipe, context: any): any {
+    this.validate(ast, () => super.visitPipe(ast, context));
+  }
+
+  visitPrefixNot(ast: PrefixNot, context: any): any {
+    this.validate(ast, () => super.visitPrefixNot(ast, context));
+  }
+
+  visitPropertyRead(ast: PropertyRead, context: any): any {
+    this.validate(ast, () => super.visitPropertyRead(ast, context));
+  }
+
+  visitPropertyWrite(ast: PropertyWrite, context: any): any {
+    this.validate(ast, () => super.visitPropertyWrite(ast, context));
+  }
+
+  visitQuote(ast: Quote, context: any): any {
+    this.validate(ast, () => super.visitQuote(ast, context));
+  }
+
+  visitSafeMethodCall(ast: SafeMethodCall, context: any): any {
+    this.validate(ast, () => super.visitSafeMethodCall(ast, context));
+  }
+
+  visitSafePropertyRead(ast: SafePropertyRead, context: any): any {
+    this.validate(ast, () => super.visitSafePropertyRead(ast, context));
+  }
+}
+
+function inSpan(span: ParseSpan, parentSpan: ParseSpan | undefined): parentSpan is ParseSpan {
+  return !parentSpan || (span.start >= parentSpan.start && span.end <= parentSpan.end);
+}
+
+const sharedValidator = new ASTValidator();
+
+export function validate<T extends AST>(ast: T): T {
+  sharedValidator.visit(ast);
+  return ast;
+}

--- a/modules/@angular/compiler/test/template_parser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser_spec.ts
@@ -19,10 +19,8 @@ import {afterEach, beforeEach, beforeEachProviders, ddescribe, describe, expect,
 import {Identifiers, identifierToken} from '../src/identifiers';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../src/interpolation_config';
 
-import {Unparser} from './expression_parser/unparser';
+import {unparse} from './expression_parser/unparser';
 import {TEST_PROVIDERS} from './test_bindings';
-
-var expressionUnparser = new Unparser();
 
 var someModuleUrl = 'package:someModule';
 
@@ -809,7 +807,7 @@ There is no directive with "exportAs" set to "dirA" ("<div [ERROR ->]#a="dirA"><
             expect(() => parse('<div #a></div><div #a></div>', []))  .toThrowError(
               `Template parse errors:
 Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>"): TestComp@0:19`);
-           
+
         });
 
             it(
@@ -817,7 +815,7 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
             () => {
                 expect(() => parse('<div #a><template #a><span>OK</span></template></div>', []))
                   .not.toThrowError();
-               
+
             });
 
         it('should assign references with empty value to components', () => {
@@ -1504,17 +1502,14 @@ class TemplateHumanizer implements TemplateAstVisitor {
     return null;
   }
   visitEvent(ast: BoundEventAst, context: any): any {
-    var res = [
-      BoundEventAst, ast.name, ast.target,
-      expressionUnparser.unparse(ast.handler, this.interpolationConfig)
-    ];
+    var res = [BoundEventAst, ast.name, ast.target, unparse(ast.handler, this.interpolationConfig)];
     this.result.push(this._appendContext(ast, res));
     return null;
   }
   visitElementProperty(ast: BoundElementPropertyAst, context: any): any {
     var res = [
-      BoundElementPropertyAst, ast.type, ast.name,
-      expressionUnparser.unparse(ast.value, this.interpolationConfig), ast.unit
+      BoundElementPropertyAst, ast.type, ast.name, unparse(ast.value, this.interpolationConfig),
+      ast.unit
     ];
     this.result.push(this._appendContext(ast, res));
     return null;
@@ -1525,7 +1520,7 @@ class TemplateHumanizer implements TemplateAstVisitor {
     return null;
   }
   visitBoundText(ast: BoundTextAst, context: any): any {
-    var res = [BoundTextAst, expressionUnparser.unparse(ast.value, this.interpolationConfig)];
+    var res = [BoundTextAst, unparse(ast.value, this.interpolationConfig)];
     this.result.push(this._appendContext(ast, res));
     return null;
   }
@@ -1544,8 +1539,7 @@ class TemplateHumanizer implements TemplateAstVisitor {
   }
   visitDirectiveProperty(ast: BoundDirectivePropertyAst, context: any): any {
     var res = [
-      BoundDirectivePropertyAst, ast.directiveName,
-      expressionUnparser.unparse(ast.value, this.interpolationConfig)
+      BoundDirectivePropertyAst, ast.directiveName, unparse(ast.value, this.interpolationConfig)
     ];
     this.result.push(this._appendContext(ast, res));
     return null;
@@ -1590,7 +1584,7 @@ class TemplateContentProjectionHumanizer implements TemplateAstVisitor {
   visitElementProperty(ast: BoundElementPropertyAst, context: any): any { return null; }
   visitAttr(ast: AttrAst, context: any): any { return null; }
   visitBoundText(ast: BoundTextAst, context: any): any {
-    this.result.push([`#text(${expressionUnparser.unparse(ast.value)})`, ast.ngContentIndex]);
+    this.result.push([`#text(${unparse(ast.value)})`, ast.ngContentIndex]);
     return null;
   }
   visitText(ast: TextAst, context: any): any {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The expression parser throws to report an error and the partially built AST is thrown away. Also, the AST doesn't contain location information so it is there is no way to map location to AST nodes. Both of these are required for the language service to use the AST.

**What is the new behavior?**

The parser now always returns an AST even when it encounters an error. It now recovers from errors to be able to continue building an AST after an error is encountered.

The expression AST now contains location span (relative to the source string passed into the parser) allowing mapping locations to AST nodes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

Added error correction so the parser always returns an AST
Added span information to the expression parser
Refactored the test to account for the difference in error reporting
Added tests for error corretion
Modified tests to validate the span information
