### PR TITLE
fix(router): make RouterLinkActive work on non-anchor tags

### DIFF
--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -130,7 +130,7 @@ export declare const ROUTER_DIRECTIVES: (typeof RouterOutlet | typeof RouterLink
 export declare type RouterConfig = Route[];
 
 /** @stable */
-export declare class RouterLink {
+export declare class RouterLink implements OnChanges, OnDestroy {
     fragment: string;
     queryParams: {
         [k: string]: any;
@@ -138,6 +138,8 @@ export declare class RouterLink {
     routerLink: any[] | string;
     urlTree: UrlTree;
     constructor(router: Router, route: ActivatedRoute, locationStrategy: LocationStrategy);
+    ngOnChanges(changes: {}): any;
+    ngOnDestroy(): any;
     onClick(button: number, ctrlKey: boolean, metaKey: boolean): boolean;
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

https://github.com/angular/angular/issues/9755

**What is the new behavior?**

The `RouterLink` directive now follows the behavior of `RouterLinkWithHref`. The `RouterLinkActive` directive can now work with non-anchor tags.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Maybe the commit message should be something else ? It does not directly concern the `RouterLinkActive` directive. 
