### PR TITLE
build(gulp): Fix paths for public-api tasks on Windows

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,7 @@ const entrypoints = [
   'dist/packages-dist/forms/index.d.ts',
   'dist/packages-dist/router/index.d.ts'
 ];
-const publicApiDir = 'tools/public_api_guard';
+const publicApiDir = path.normalize('tools/public_api_guard');
 const publicApiArgs = [
   '--rootDir', 'dist/packages-dist',
   '--stripExportPattern', '^__',
@@ -64,7 +64,7 @@ gulp.task('public-api:enforce', (done) => {
   const child_process = require('child_process');
   child_process
       .spawn(
-          `${__dirname}/node_modules/.bin/ts-api-guardian`,
+          path.join(__dirname, `/node_modules/.bin/ts-api-guardian${/^win/.test(os.platform()) ? '.cmd' : ''}`),
           ['--verifyDir', publicApiDir].concat(publicApiArgs), {stdio: 'inherit'})
       .on('close', (errorCode) => {
         if (errorCode !== 0) {
@@ -80,7 +80,7 @@ gulp.task('public-api:update', (done) => {
   const child_process = require('child_process');
   child_process
       .spawn(
-          `${__dirname}/node_modules/.bin/ts-api-guardian`,
+          path.join(__dirname, `/node_modules/.bin/ts-api-guardian${/^win/.test(os.platform()) ? '.cmd' : ''}`),
           ['--outDir', publicApiDir].concat(publicApiArgs), {stdio: 'inherit'})
       .on('close', (errorCode) => done(errorCode));
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

`gulp public-api:update` and `gulp public-api:enforce` did not work on Windows due to wrong paths.

**What is the new behavior?**

These tasks now work properly on Windows.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
