### PR TITLE
docs(api): fix broken links to examples and docs

### DIFF
--- a/modules/@angular/core/src/metadata.ts
+++ b/modules/@angular/core/src/metadata.ts
@@ -528,8 +528,9 @@ export interface AppModuleMetadataFactory {
  *
  * ## Lifecycle hooks
  *
- * When the component class implements some {@link ../../guide/lifecycle-hooks.html} the callbacks
- * are called by the change detection at defined points in time during the life of the component.
+ * When the component class implements some {@link ../../../guide/lifecycle-hooks.html} the
+ * callbacks are called by the change detection at defined points in time during the life of the
+ * component.
  *
  * ### Example
  *
@@ -859,8 +860,9 @@ export var Component: ComponentMetadataFactory =
  *
  * ## Lifecycle hooks
  *
- * When the directive class implements some {@link ../../guide/lifecycle-hooks.html} the callbacks
- * are called by the change detection at defined points in time during the life of the directive.
+ * When the directive class implements some {@link ../../../guide/lifecycle-hooks.html} the
+ * callbacks are called by the change detection at defined points in time during the life of the
+ * directive.
  *
  * ### Example
  *

--- a/modules/@angular/core/src/metadata/directives.ts
+++ b/modules/@angular/core/src/metadata/directives.ts
@@ -332,8 +332,9 @@ import {ViewEncapsulation} from './view';
  *
  * ## Lifecycle hooks
  *
- * When the directive class implements some {@link ../../guide/lifecycle-hooks.html} the callbacks
- * are called by the change detection at defined points in time during the life of the directive.
+ * When the directive class implements some {@link ../../../guide/lifecycle-hooks.html} the
+ * callbacks are called by the change detection at defined points in time during the life of the
+ * directive.
  *
  * ### Example
  *
@@ -790,8 +791,9 @@ export class DirectiveMetadata extends InjectableMetadata {
  *
  * ## Lifecycle hooks
  *
- * When the component class implements some {@link ../../guide/lifecycle-hooks.html} the callbacks
- * are called by the change detection at defined points in time during the life of the component.
+ * When the component class implements some {@link ../../../guide/lifecycle-hooks.html} the
+ * callbacks are called by the change detection at defined points in time during the life of the
+ * component.
  *
  * ### Example
  *

--- a/modules/@angular/platform-browser/src/dom/debug/by.ts
+++ b/modules/@angular/platform-browser/src/dom/debug/by.ts
@@ -25,7 +25,7 @@ export class By {
    *
    * ## Example
    *
-   * {@example platform/dom/debug/ts/by/by.ts region='by_all'}
+   * {@example platform-browser/dom/debug/ts/by/by.ts region='by_all'}
    */
   static all(): Predicate<DebugElement> { return (debugElement) => true; }
 
@@ -34,7 +34,7 @@ export class By {
    *
    * ## Example
    *
-   * {@example platform/dom/debug/ts/by/by.ts region='by_css'}
+   * {@example platform-browser/dom/debug/ts/by/by.ts region='by_css'}
    */
   static css(selector: string): Predicate<DebugElement> {
     return (debugElement) => {
@@ -49,7 +49,7 @@ export class By {
    *
    * ## Example
    *
-   * {@example platform/dom/debug/ts/by/by.ts region='by_directive'}
+   * {@example platform-browser/dom/debug/ts/by/by.ts region='by_directive'}
    */
   static directive(type: Type): Predicate<DebugElement> {
     return (debugElement) => { return debugElement.providerTokens.indexOf(type) !== -1; };

--- a/modules/@angular/router-deprecated/src/interfaces.ts
+++ b/modules/@angular/router-deprecated/src/interfaces.ts
@@ -33,7 +33,7 @@ var __make_dart_analyzer_happy: Promise<any> = null;
  * instantiate and activate child components.
  *
  * ### Example
- * {@example router/ts/on_activate/on_activate_example.ts region='routerOnActivate'}
+ * {@example router_deprecated/ts/on_activate/on_activate_example.ts region='routerOnActivate'}
  */
 export interface OnActivate {
   routerOnActivate(nextInstruction: ComponentInstruction, prevInstruction: ComponentInstruction):
@@ -53,7 +53,7 @@ export interface OnActivate {
  * previous route or `null`.
  *
  * ### Example
- * {@example router/ts/reuse/reuse_example.ts region='reuseCmp'}
+ * {@example router_deprecated/ts/reuse/reuse_example.ts region='reuseCmp'}
  */
 export interface OnReuse {
   routerOnReuse(nextInstruction: ComponentInstruction, prevInstruction: ComponentInstruction): any
@@ -73,7 +73,8 @@ export interface OnReuse {
  * If `routerOnDeactivate` returns a promise, the route change will wait until the promise settles.
  *
  * ### Example
- * {@example router/ts/on_deactivate/on_deactivate_example.ts region='routerOnDeactivate'}
+ * {@example router_deprecated/ts/on_deactivate/on_deactivate_example.ts
+ * region='routerOnDeactivate'}
  */
 export interface OnDeactivate {
   routerOnDeactivate(nextInstruction: ComponentInstruction, prevInstruction: ComponentInstruction):
@@ -98,7 +99,7 @@ export interface OnDeactivate {
  * If `routerCanReuse` throws or rejects, the navigation will be cancelled.
  *
  * ### Example
- * {@example router/ts/reuse/reuse_example.ts region='reuseCmp'}
+ * {@example router_deprecated/ts/reuse/reuse_example.ts region='reuseCmp'}
  */
 export interface CanReuse {
   routerCanReuse(nextInstruction: ComponentInstruction, prevInstruction: ComponentInstruction):
@@ -122,7 +123,8 @@ export interface CanReuse {
  * If `routerCanDeactivate` throws or rejects, the navigation is also cancelled.
  *
  * ### Example
- * {@example router/ts/can_deactivate/can_deactivate_example.ts region='routerCanDeactivate'}
+ * {@example router_deprecated/ts/can_deactivate/can_deactivate_example.ts
+ * region='routerCanDeactivate'}
  */
 export interface CanDeactivate {
   routerCanDeactivate(nextInstruction: ComponentInstruction, prevInstruction: ComponentInstruction):

--- a/modules/@angular/router-deprecated/src/lifecycle/lifecycle_annotations.ts
+++ b/modules/@angular/router-deprecated/src/lifecycle/lifecycle_annotations.ts
@@ -43,7 +43,7 @@ export {routerCanDeactivate, routerCanReuse, routerOnActivate, routerOnDeactivat
  *
  * ### Example
  *
- * {@example router/ts/can_activate/can_activate_example.ts region='canActivate' }
+ * {@example router_deprecated/ts/can_activate/can_activate_example.ts region='canActivate' }
  * @Annotation
  */
 export var CanActivate:


### PR DESCRIPTION
Done as part of the angular.io API docs cleanup.
