### PR TITLE
chore(public api): run build.sh before generating the api doc

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,30 +59,38 @@ const publicApiArgs = [
   '--onStabilityMissing', 'error'
 ].concat(entrypoints);
 
-// Note that these two commands work on built d.ts files instead of the source
-gulp.task('public-api:enforce', (done) => {
-  const child_process = require('child_process');
-  child_process
-      .spawn(
-          path.join(__dirname, `/node_modules/.bin/ts-api-guardian${/^win/.test(os.platform()) ? '.cmd' : ''}`),
-          ['--verifyDir', publicApiDir].concat(publicApiArgs), {stdio: 'inherit'})
-      .on('close', (errorCode) => {
-        if (errorCode !== 0) {
-          done(new Error(
-              'Public API differs from golden file. Please run `gulp public-api:update`.'));
-        } else {
-          done();
-        }
-      });
+gulp.task('build.sh', (done) => {
+  const childProcess = require('child_process');
+
+  childProcess.exec(path.join(__dirname, 'build.sh'), error => done(error));
 });
 
-gulp.task('public-api:update', (done) => {
-  const child_process = require('child_process');
-  child_process
-      .spawn(
-          path.join(__dirname, `/node_modules/.bin/ts-api-guardian${/^win/.test(os.platform()) ? '.cmd' : ''}`),
-          ['--outDir', publicApiDir].concat(publicApiArgs), {stdio: 'inherit'})
-      .on('close', (errorCode) => done(errorCode));
+// Note that these two commands work on built d.ts files instead of the source
+gulp.task('public-api:enforce', (done) => {
+  const childProcess = require('child_process');
+
+  childProcess
+    .spawn(
+      path.join(__dirname, `/node_modules/.bin/ts-api-guardian${/^win/.test(os.platform()) ? '.cmd' : ''}`),
+      ['--verifyDir', publicApiDir].concat(publicApiArgs), {stdio: 'inherit'})
+    .on('close', (errorCode) => {
+      if (errorCode !== 0) {
+        done(new Error(
+          'Public API differs from golden file. Please run `gulp public-api:update`.'));
+      } else {
+        done();
+      }
+    });
+});
+
+gulp.task('public-api:update', ['build.sh'], (done) => {
+  const childProcess = require('child_process');
+
+  childProcess
+    .spawn(
+      path.join(__dirname, `/node_modules/.bin/ts-api-guardian${/^win/.test(os.platform()) ? '.cmd' : ''}`),
+      ['--outDir', publicApiDir].concat(publicApiArgs), {stdio: 'inherit'})
+    .on('close', (errorCode) => done(errorCode));
 });
 
 gulp.task('lint', ['format:enforce', 'tools:build'], () => {
@@ -102,7 +110,7 @@ gulp.task('lint', ['format:enforce', 'tools:build'], () => {
 gulp.task('tools:build', (done) => { tsc('tools/', done); });
 
 gulp.task('check-cycle', (done) => {
-  var madge = require('madge');
+  const madge = require('madge');
 
   var dependencyObject = madge(['dist/all/'], {
     format: 'cjs',
@@ -149,9 +157,9 @@ gulp.task('changelog', () => {
 });
 
 function tsc(projectPath, done) {
-  let child_process = require('child_process');
+  const childProcess = require('child_process');
 
-  child_process
+  childProcess
       .spawn(
           path.normalize(`${__dirname}/node_modules/.bin/tsc`) + (/^win/.test(os.platform()) ? '.cmd' : ''),
           ['-p', path.join(__dirname, projectPath)],


### PR DESCRIPTION
`build.sh` must be executed before updating the golden files anyway so adding it to gulp to save my time.

`public-api:enforce` does not trigger `build.sh` as it is most probably only run on the CI where `build.sh` must have been executed before.

@jasonchoimtt could you please review >
