### PR TITLE
fix(forms): export AbstractFormGroupDirective

### DIFF
--- a/modules/@angular/forms/src/directives/abstract_form_group_directive.ts
+++ b/modules/@angular/forms/src/directives/abstract_form_group_directive.ts
@@ -15,10 +15,13 @@ import {Form} from './form_interface';
 import {composeAsyncValidators, composeValidators, controlPath} from './shared';
 import {AsyncValidatorFn, ValidatorFn} from './validators';
 
-/**
-  This is a base class for code shared between {@link NgModelGroup} and {@link FormGroupName}.
- */
 
+
+/**
+ * This is a base class for code shared between {@link NgModelGroup} and {@link FormGroupName}.
+ *
+ * @experimental
+ */
 export class AbstractFormGroupDirective extends ControlContainer implements OnInit, OnDestroy {
   /** @internal */
   _parent: ControlContainer;

--- a/modules/@angular/forms/src/forms.ts
+++ b/modules/@angular/forms/src/forms.ts
@@ -23,6 +23,7 @@
 
 export {FORM_DIRECTIVES, REACTIVE_FORM_DIRECTIVES} from './directives';
 export {AbstractControlDirective} from './directives/abstract_control_directive';
+export {AbstractFormGroupDirective} from './directives/abstract_form_group_directive';
 export {CheckboxControlValueAccessor} from './directives/checkbox_value_accessor';
 export {ControlContainer} from './directives/control_container';
 export {ControlValueAccessor, NG_VALUE_ACCESSOR} from './directives/control_value_accessor';

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -63,6 +63,17 @@ export declare abstract class AbstractControlDirective {
 }
 
 /** @experimental */
+export declare class AbstractFormGroupDirective extends ControlContainer implements OnInit, OnDestroy {
+    asyncValidator: AsyncValidatorFn;
+    control: FormGroup;
+    formDirective: Form;
+    path: string[];
+    validator: ValidatorFn;
+    ngOnDestroy(): void;
+    ngOnInit(): void;
+}
+
+/** @experimental */
 export interface AsyncValidatorFn {
     (c: AbstractControl): any;
 }


### PR DESCRIPTION
**Current behavior**

Because
- `Form` is **exported** -- see line 30/31 of `modules/@angular/forms/src/forms.ts`: i.e., <br>`export {Form} from './directives/form_interface'`; and
- Methods of `Form`, which are public, have an `AbstractFormGroupDirective` parameter; e.g.,<br>`Form.getFormGroup(dir: AbstractFormGroupDirective): FormGroup`.
- But `AbstractFormGroupDirective` isn't exported.

Then it makes sense for `AbstractFormGroupDirective` to be public/exported too. In any case, if it isn't exported then the **API docs for `Form` don't get generated properly;** i.e., we get 404 links for method signatures containing the `AbstractFormGroupDirective` type because **there is no API page for `AbstractFormGroupDirective`**. (There can be no such page because it is not exported.)

**Expected behavior**

One should be able to navigate to the API page of any type exported via a public interface. Hence, there should be an API page for `AbstractFormGroupDirective`.
