### PR TITLE
fix(http): fix URLSearchParams clone method to include subclassed Que…

### DIFF
--- a/modules/@angular/http/src/url_search_params.ts
+++ b/modules/@angular/http/src/url_search_params.ts
@@ -89,7 +89,7 @@ export class URLSearchParams {
   }
 
   clone(): URLSearchParams {
-    var clone = new URLSearchParams();
+    var clone = new URLSearchParams('', this.queryEncoder);
     clone.appendAll(this);
     return clone;
   }

--- a/modules/@angular/http/test/url_search_params_spec.ts
+++ b/modules/@angular/http/test/url_search_params_spec.ts
@@ -127,5 +127,27 @@ export function main() {
       expect(mapA.getAll('c')).toEqual(['8']);
       expect(mapA.toString()).toEqual('a=4&a=5&a=6&c=8&b=7');
     });
+
+    it('should support a clone operation via clone()', () => {
+      var fooQueryEncoder = {
+        encodeKey(k: string) { return encodeURIComponent(k); },
+        encodeValue(v: string) { return encodeURIComponent(v); }
+      };
+      var paramsA = new URLSearchParams('', fooQueryEncoder);
+      paramsA.set('a', '2');
+      paramsA.set('q', '4+');
+      paramsA.set('c', '8');
+      var paramsB = new URLSearchParams();
+      paramsB.set('a', '2');
+      paramsB.set('q', '4+');
+      paramsB.set('c', '8');
+      expect(paramsB.toString()).toEqual('a=2&q=4+&c=8');
+      var paramsC = paramsA.clone();
+      expect(paramsC.has('a')).toBe(true);
+      expect(paramsC.has('b')).toBe(false);
+      expect(paramsC.has('c')).toBe(true);
+      expect(paramsC.toString()).toEqual('a=2&q=4%2B&c=8');
+    });
+
   });
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The URLSearchParams clone method will not properly preserve a subclassed QueryEncoder.  This prevents any HTTP method from using a subclassed QueryEncoder via RequestOptionsArgs.

**What is the new behavior?**
The URLSearchParams clone method will properly preserve subclassed QueryEncoders.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

…ryEncoder
