### PR TITLE
feat(forms): updateValue for form groups and form arrays

### DIFF
--- a/modules/@angular/forms/src/directives/ng_form.ts
+++ b/modules/@angular/forms/src/directives/ng_form.ts
@@ -164,6 +164,8 @@ export class NgForm extends ControlContainer implements Form {
     });
   }
 
+  updateValue(value: {[key: string]: any}): void { this.control.updateValue(value); }
+
   onSubmit(): boolean {
     this._submitted = true;
     ObservableWrapper.callEmit(this.ngSubmit, null);

--- a/modules/@angular/forms/test/model_spec.ts
+++ b/modules/@angular/forms/test/model_spec.ts
@@ -551,6 +551,89 @@ export function main() {
         });
       });
 
+      describe('updateValue', () => {
+        let c: FormControl, c2: FormControl, g: FormGroup;
+
+        beforeEach(() => {
+          c = new FormControl('');
+          c2 = new FormControl('');
+          g = new FormGroup({'one': c, 'two': c2});
+        });
+
+        it('should update its own value', () => {
+          g.updateValue({'one': 'one', 'two': 'two'});
+          expect(g.value).toEqual({'one': 'one', 'two': 'two'});
+        });
+
+        it('should update child values', () => {
+          g.updateValue({'one': 'one', 'two': 'two'});
+          expect(c.value).toEqual('one');
+          expect(c2.value).toEqual('two');
+        });
+
+        it('should update parent values', () => {
+          const form = new FormGroup({'parent': g});
+          g.updateValue({'one': 'one', 'two': 'two'});
+          expect(form.value).toEqual({'parent': {'one': 'one', 'two': 'two'}});
+        });
+
+        it('should ignore fields that are missing from supplied value', () => {
+          g.updateValue({'one': 'one'});
+          expect(g.value).toEqual({'one': 'one', 'two': ''});
+        });
+
+        it('should not ignore fields that are null', () => {
+          g.updateValue({'one': null});
+          expect(g.value).toEqual({'one': null, 'two': ''});
+        });
+
+        it('should throw if a value is provided for a missing control', () => {
+          expect(() => g.updateValue({
+            'three': 'three'
+          })).toThrowError(new RegExp(`Cannot find form control with name: three`));
+        });
+
+        describe('updateValue() events', () => {
+          let form: FormGroup;
+          let logger: any[];
+
+          beforeEach(() => {
+            form = new FormGroup({'parent': g});
+            logger = [];
+          });
+
+          it('should emit one valueChange event per control', () => {
+            form.valueChanges.subscribe(() => logger.push('form'));
+            g.valueChanges.subscribe(() => logger.push('group'));
+            c.valueChanges.subscribe(() => logger.push('control1'));
+            c2.valueChanges.subscribe(() => logger.push('control2'));
+
+            g.updateValue({'one': 'one', 'two': 'two'});
+            expect(logger).toEqual(['control1', 'control2', 'group', 'form']);
+          });
+
+          it('should not emit valueChange events for skipped controls', () => {
+            form.valueChanges.subscribe(() => logger.push('form'));
+            g.valueChanges.subscribe(() => logger.push('group'));
+            c.valueChanges.subscribe(() => logger.push('control1'));
+            c2.valueChanges.subscribe(() => logger.push('control2'));
+
+            g.updateValue({'one': 'one'});
+            expect(logger).toEqual(['control1', 'group', 'form']);
+          });
+
+          it('should emit one statusChange event per control', () => {
+            form.statusChanges.subscribe(() => logger.push('form'));
+            g.statusChanges.subscribe(() => logger.push('group'));
+            c.statusChanges.subscribe(() => logger.push('control1'));
+            c2.statusChanges.subscribe(() => logger.push('control2'));
+
+            g.updateValue({'one': 'one', 'two': 'two'});
+            expect(logger).toEqual(['control1', 'control2', 'group', 'form']);
+          });
+        });
+      });
+
       describe('optional components', () => {
         describe('contains', () => {
           var group: any /** TODO #9100 */;
@@ -813,6 +896,89 @@ export function main() {
         it('should be an empty array when there are no child controls', () => {
           var a = new FormArray([]);
           expect(a.value).toEqual([]);
+        });
+      });
+
+      describe('updateValue', () => {
+        let c: FormControl, c2: FormControl, a: FormArray;
+
+        beforeEach(() => {
+          c = new FormControl('');
+          c2 = new FormControl('');
+          a = new FormArray([c, c2]);
+        });
+
+        it('should update its own value', () => {
+          a.updateValue(['one', 'two']);
+          expect(a.value).toEqual(['one', 'two']);
+        });
+
+        it('should update child values', () => {
+          a.updateValue(['one', 'two']);
+          expect(c.value).toEqual('one');
+          expect(c2.value).toEqual('two');
+        });
+
+        it('should update parent values', () => {
+          const form = new FormGroup({'parent': a});
+          a.updateValue(['one', 'two']);
+          expect(form.value).toEqual({'parent': ['one', 'two']});
+        });
+
+        it('should ignore fields that are missing from supplied value', () => {
+          a.updateValue([, 'two']);
+          expect(a.value).toEqual(['', 'two']);
+        });
+
+        it('should not ignore fields that are null', () => {
+          a.updateValue([null]);
+          expect(a.value).toEqual([null, '']);
+        });
+
+        it('should throw if a value is provided for a missing control', () => {
+          expect(() => a.updateValue([
+            , , 'three'
+          ])).toThrowError(new RegExp(`Cannot find form control at index 2`));
+        });
+
+        describe('updateValue() events', () => {
+          let form: FormGroup;
+          let logger: any[];
+
+          beforeEach(() => {
+            form = new FormGroup({'parent': a});
+            logger = [];
+          });
+
+          it('should emit one valueChange event per control', () => {
+            form.valueChanges.subscribe(() => logger.push('form'));
+            a.valueChanges.subscribe(() => logger.push('array'));
+            c.valueChanges.subscribe(() => logger.push('control1'));
+            c2.valueChanges.subscribe(() => logger.push('control2'));
+
+            a.updateValue(['one', 'two']);
+            expect(logger).toEqual(['control1', 'control2', 'array', 'form']);
+          });
+
+          it('should not emit valueChange events for skipped controls', () => {
+            form.valueChanges.subscribe(() => logger.push('form'));
+            a.valueChanges.subscribe(() => logger.push('array'));
+            c.valueChanges.subscribe(() => logger.push('control1'));
+            c2.valueChanges.subscribe(() => logger.push('control2'));
+
+            a.updateValue(['one']);
+            expect(logger).toEqual(['control1', 'array', 'form']);
+          });
+
+          it('should emit one statusChange event per control', () => {
+            form.statusChanges.subscribe(() => logger.push('form'));
+            a.statusChanges.subscribe(() => logger.push('array'));
+            c.statusChanges.subscribe(() => logger.push('control1'));
+            c2.statusChanges.subscribe(() => logger.push('control2'));
+
+            a.updateValue(['one', 'two']);
+            expect(logger).toEqual(['control1', 'control2', 'array', 'form']);
+          });
         });
       });
 

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -39,6 +39,7 @@ export declare abstract class AbstractControl {
     }): void;
     setParent(parent: FormGroup | FormArray): void;
     setValidators(newValidator: ValidatorFn | ValidatorFn[]): void;
+    abstract updateValue(value: any, options?: Object): void;
     updateValueAndValidity({onlySelf, emitEvent}?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
@@ -127,6 +128,9 @@ export declare class FormArray extends AbstractControl {
     insert(index: number, control: AbstractControl): void;
     push(control: AbstractControl): void;
     removeAt(index: number): void;
+    updateValue(value: any[], {onlySelf}?: {
+        onlySelf?: boolean;
+    }): void;
 }
 
 /** @experimental */
@@ -211,6 +215,11 @@ export declare class FormGroup extends AbstractControl {
     include(controlName: string): void;
     registerControl(name: string, control: AbstractControl): AbstractControl;
     removeControl(name: string): void;
+    updateValue(value: {
+        [key: string]: any;
+    }, {onlySelf}?: {
+        onlySelf?: boolean;
+    }): void;
 }
 
 /** @experimental */
@@ -312,6 +321,9 @@ export declare class NgForm extends ControlContainer implements Form {
     removeControl(dir: NgModel): void;
     removeFormGroup(dir: NgModelGroup): void;
     updateModel(dir: NgControl, value: any): void;
+    updateValue(value: {
+        [key: string]: any;
+    }): void;
 }
 
 /** @experimental */


### PR DESCRIPTION
This PR adds support for `updateValue()` on `FormGroup` and `FormArray` instances.   Previously, you had to call `updateValue()` on each child form control individually.   Now you can pass an object to `updateValue()` at the top level, where key names match the structure of the form.  Missing fields from the passed in value will be ignored.

**Before**

``` ts
class MyComp {
  firstCtrl = new FormControl();
  lastCtrl = new FormControl();
  foodCtrl = new FormControl();

  form = new FormGroup({
    name: new FormGroup({
      first: this.firstCtrl,
      last: this.lastCtrl
    }),
    food: this.foodCtrl
  });

  update() {
     this.firstCtrl.updateValue('Nancy');
     this.lastCtrl.updateValue('Drew');
     this.foodCtrl.updateValue('chicken');
  }
}
```

**After**

``` ts
class MyComp {
  constructor(fb: FormBuilder) {
     this.form = fb.group({
        name: fb.group({ first: [''], last: [''] }),
        food: ['']
      });
   }

  update() {
     this.form.updateValue({
        name: {first: 'Nancy', last: 'Drew'},
        food: 'chicken'
     });
  }
}
```

This comes in very handy when you are loading data into your form asynchronously:

``` ts
class MyComp implements OnInit {
  constructor(fb: FormBuilder, private _http: Http) {
     this.form = fb.group({
        name: fb.group({ first: [''], last: [''] }),
        food: ['']
      });
   }

  ngOnInit() {
    this._http.get(someUrl)
              .map(this.extractData)
              .subscribe(person => this.form.updateValue(person));
  }
}
```

Closes https://github.com/angular/angular/issues/9553
