### PR TITLE
chore(gulp): add `public-api` target

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,13 @@ gulp.task('public-api:enforce', (done) => {
     });
 });
 
-gulp.task('public-api:update', ['build.sh'], (done) => {
+gulp.task('public-api', ['build.sh'], (done) => {
+    gulp.start('public-api:no-build');
+});
+
+gulp.task('public-api:no-build', ['public-api:update', 'format:enforce']);
+
+gulp.task('public-api:update', (done) => {
   const childProcess = require('child_process');
 
   childProcess


### PR DESCRIPTION
This is a followup to additions recently made by @vicb.
- Add `public-api` as a target; it does a build.sh, and then an update and enforces format.<br>This new target **gives API docs builders a single target** to run when working on API docs.
- Remove `build.sh` as a dependency for `public-api:update` since it is a dependency for `public-api`.
