### PR TITLE
fix(testing): reintroduce and deprecate setBaseTestProviders

### DIFF
--- a/modules/@angular/core/testing/test_injector.ts
+++ b/modules/@angular/core/testing/test_injector.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AppModule, AppModuleFactory, AppModuleMetadata, AppModuleRef, Compiler, CompilerFactory, ComponentStillLoadingError, Injector, PlatformRef, Provider, Type} from '../index';
+import {AppModule, AppModuleFactory, AppModuleMetadata, AppModuleRef, Compiler, CompilerFactory, ComponentStillLoadingError, Injector, PlatformRef, Provider, ReflectiveInjector, Type, assertPlatform, createPlatform, getPlatform} from '../index';
 import {ListWrapper} from '../src/facade/collection';
 import {BaseException} from '../src/facade/exceptions';
 import {FunctionWrapper, isPresent, stringify} from '../src/facade/lang';
@@ -173,6 +173,33 @@ export function getTestInjector() {
  *
  * This may only be called once, to set up the common providers for the current test
  * suite on the current platform. If you absolutely need to change the providers,
+ * first use `resetBaseTestProviders`.
+ *
+ * Test modules and platforms for individual platforms are available from
+ * 'angular2/platform/testing/<platform_name>'.
+ *
+ * @deprecated Use initTestEnvironment instead
+ */
+export function setBaseTestProviders(
+    platformProviders: Array<Type|Provider|any[]>,
+    applicationProviders: Array<Type|Provider|any[]>) {
+  // Create a platform based on the Platform Providers.
+  var platformRef = createPlatform(ReflectiveInjector.resolveAndCreate(platformProviders));
+
+  // Create an AppModule based on the application providers.
+  @AppModule({providers: applicationProviders})
+  class TestAppModule {
+  }
+
+  initTestEnvironment(TestAppModule, platformRef);
+}
+
+/**
+ * Initialize the environment for testing with a compiler factory, a PlatformRef, and an
+ * application module. These are common to every test in the suite.
+ *
+ * This may only be called once, to set up the common providers for the current test
+ * suite on the current platform. If you absolutely need to change the providers,
  * first use `resetTestEnvironment`.
  *
  * Test modules and platforms for individual platforms are available from
@@ -187,6 +214,15 @@ export function initTestEnvironment(appModule: Type, platform: PlatformRef) {
   }
   testInjector.platform = platform;
   testInjector.appModule = appModule;
+}
+
+/**
+ * Reset the providers for the test injector.
+ *
+ * @deprecated Use resetTestEnvironment instead.
+ */
+export function resetBaseTestProviders() {
+  resetTestEnvironment();
 }
 
 /**

--- a/modules/@angular/platform-browser-dynamic/testing.ts
+++ b/modules/@angular/platform-browser-dynamic/testing.ts
@@ -10,7 +10,7 @@ import {CompilerConfig, DirectiveResolver, ViewResolver} from '@angular/compiler
 import {MockDirectiveResolver, MockViewResolver, OverridingTestComponentBuilder} from '@angular/compiler/testing';
 import {AppModule, Compiler, CompilerFactory, PlatformRef, Provider, ReflectiveInjector, Type, createPlatformFactory} from '@angular/core';
 import {TestComponentBuilder, TestComponentRenderer} from '@angular/core/testing';
-import {BrowserTestModule, TEST_BROWSER_PLATFORM_PROVIDERS} from '@angular/platform-browser/testing';
+import {BrowserTestModule, TEST_BROWSER_APPLICATION_PROVIDERS, TEST_BROWSER_PLATFORM_PROVIDERS} from '@angular/platform-browser/testing';
 
 import {BROWSER_APP_COMPILER_PROVIDERS, BROWSER_DYNAMIC_COMPILER_FACTORY, BROWSER_DYNAMIC_PLATFORM_PROVIDERS} from './index';
 import {DOMTestComponentRenderer} from './testing/dom_test_component_renderer';
@@ -61,3 +61,19 @@ export const browserDynamicTestPlatform =
 })
 export class BrowserDynamicTestModule {
 }
+
+/**
+ * @deprecated Use initTestEnvironment with browserDynamicTestPlatform instead.
+ */
+export const TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
+    BROWSER_DYNAMIC_TEST_PLATFORM_PROVIDERS;
+
+
+/**
+ * @deprecated Use initTestEnvironment with BrowserDynamicTestModule instead.
+ */
+export const TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS: Array<any /*Type | Provider | any[]*/> = [
+  TEST_BROWSER_APPLICATION_PROVIDERS,
+  {provide: TestComponentBuilder, useClass: OverridingTestComponentBuilder},
+  {provide: TestComponentRenderer, useClass: DOMTestComponentRenderer},
+];

--- a/modules/@angular/platform-browser/testing/browser.ts
+++ b/modules/@angular/platform-browser/testing/browser.ts
@@ -36,6 +36,15 @@ export const TEST_BROWSER_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[
 ];
 
 /**
+ * @deprecated Use initTestEnvironment with BrowserTestModule instead.
+ */
+export const TEST_BROWSER_APPLICATION_PROVIDERS: Array<any /*Type | Provider | any[]*/> = [
+  BROWSER_APP_PROVIDERS, {provide: APP_ID, useValue: 'a'}, ELEMENT_PROBE_PROVIDERS,
+  {provide: NgZone, useFactory: createNgZone},
+  {provide: AnimationDriver, useValue: AnimationDriver.NOOP}
+];
+
+/**
  * Platform for testing
  *
  * @experimental API related to bootstrapping are still under review.

--- a/modules/@angular/platform-server/testing/server.ts
+++ b/modules/@angular/platform-server/testing/server.ts
@@ -7,7 +7,7 @@
  */
 
 import {AppModule, CompilerFactory, OpaqueToken, PLATFORM_COMMON_PROVIDERS, PLATFORM_INITIALIZER, PlatformRef, ReflectiveInjector, assertPlatform, createPlatform, createPlatformFactory, getPlatform} from '@angular/core';
-import {BROWSER_DYNAMIC_TEST_COMPILER_FACTORY, BrowserDynamicTestModule} from '@angular/platform-browser-dynamic/testing';
+import {BROWSER_DYNAMIC_TEST_COMPILER_FACTORY, BrowserDynamicTestModule, TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS} from '@angular/platform-browser-dynamic/testing';
 
 import {Parse5DomAdapter} from '../src/parse5_adapter';
 
@@ -15,7 +15,10 @@ function initServerTests() {
   Parse5DomAdapter.makeCurrent();
 }
 
-const TEST_SERVER_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
+/**
+ * @deprecated Use initTestEnvironment with serverTestPlatform instead.
+ */
+export const TEST_SERVER_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
     /*@ts2dart_const*/[
       PLATFORM_COMMON_PROVIDERS,
       /*@ts2dart_Provider*/ {provide: PLATFORM_INITIALIZER, useValue: initServerTests, multi: true},
@@ -38,3 +41,9 @@ export const serverTestPlatform =
 @AppModule({modules: [BrowserDynamicTestModule]})
 export class ServerTestModule {
 }
+
+/**
+ * @deprecated Use initTestEnvironment with ServerTestModule instead.
+ */
+export const TEST_SERVER_APPLICATION_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
+    TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS;

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -103,8 +103,14 @@ export declare class InjectSetupWrapper {
 /** @deprecated */
 export declare var it: any;
 
+/** @deprecated */
+export declare function resetBaseTestProviders(): void;
+
 /** @experimental */
 export declare function resetTestEnvironment(): void;
+
+/** @deprecated */
+export declare function setBaseTestProviders(platformProviders: Array<Type | Provider | any[]>, applicationProviders: Array<Type | Provider | any[]>): void;
 
 /** @stable */
 export declare class TestComponentBuilder {

--- a/tools/public_api_guard/platform-browser-dynamic/testing.d.ts
+++ b/tools/public_api_guard/platform-browser-dynamic/testing.d.ts
@@ -7,3 +7,9 @@ export declare class BrowserDynamicTestModule {
 
 /** @experimental */
 export declare const browserDynamicTestPlatform: () => PlatformRef;
+
+/** @deprecated */
+export declare const TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS: Array<any>;
+
+/** @deprecated */
+export declare const TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS: Array<any>;

--- a/tools/public_api_guard/platform-browser/testing.d.ts
+++ b/tools/public_api_guard/platform-browser/testing.d.ts
@@ -5,5 +5,8 @@ export declare class BrowserTestModule {
 /** @experimental */
 export declare const browserTestPlatform: () => PlatformRef;
 
+/** @deprecated */
+export declare const TEST_BROWSER_APPLICATION_PROVIDERS: Array<any>;
+
 /** @experimental */
 export declare const TEST_BROWSER_PLATFORM_PROVIDERS: Array<any>;

--- a/tools/public_api_guard/platform-server/testing.d.ts
+++ b/tools/public_api_guard/platform-server/testing.d.ts
@@ -4,3 +4,9 @@ export declare class ServerTestModule {
 
 /** @experimental */
 export declare const serverTestPlatform: () => PlatformRef;
+
+/** @deprecated */
+export declare const TEST_SERVER_APPLICATION_PROVIDERS: Array<any>;
+
+/** @deprecated */
+export declare const TEST_SERVER_PLATFORM_PROVIDERS: Array<any>;


### PR DESCRIPTION
This change reverts the removal of setBaseTestProviders that was
introduced in 8d746e3f6795c8840116f4649a37a1efb4243eb9.

Instead, setBaseTestProviders and the providers provided from
`@angular/platform-browser-dynamic/testing` and `@angular/server/testing`
will still work for the next release, but are deprecated.

See 8d746e3f6795c8840116f4649a37a1efb4243eb9 for how to upgrade.
