### PR TITLE
refactor(router-deprecated): avoid export of private name CanActivate

### DIFF
--- a/modules/@angular/router-deprecated/src/lifecycle/lifecycle_annotations.ts
+++ b/modules/@angular/router-deprecated/src/lifecycle/lifecycle_annotations.ts
@@ -14,7 +14,7 @@
 import {makeDecorator} from '../../core_private';
 import {ComponentInstruction} from '../instruction';
 
-import {CanActivate as CanActivateAnnotation} from './lifecycle_annotations_impl';
+import {CanActivateAnnotation} from './lifecycle_annotations_impl';
 
 export {routerCanDeactivate, routerCanReuse, routerOnActivate, routerOnDeactivate, routerOnReuse} from './lifecycle_annotations_impl';
 

--- a/modules/@angular/router-deprecated/src/lifecycle/lifecycle_annotations_impl.ts
+++ b/modules/@angular/router-deprecated/src/lifecycle/lifecycle_annotations_impl.ts
@@ -13,7 +13,7 @@ export class RouteLifecycleHook {
 }
 
 /* @ts2dart_const */
-export class CanActivate {
+export class CanActivateAnnotation {
   constructor(public fn: Function) {}
 }
 

--- a/modules/@angular/router-deprecated/src/lifecycle/route_lifecycle_reflector.ts
+++ b/modules/@angular/router-deprecated/src/lifecycle/route_lifecycle_reflector.ts
@@ -10,7 +10,7 @@ import {Type} from '@angular/core';
 
 import {reflector} from '../../core_private';
 
-import {CanActivate, RouteLifecycleHook} from './lifecycle_annotations_impl';
+import {CanActivateAnnotation, RouteLifecycleHook} from './lifecycle_annotations_impl';
 
 export function hasLifecycleHook(e: RouteLifecycleHook, type: any /** TODO #9100 */): boolean {
   if (!(type instanceof Type)) return false;
@@ -21,7 +21,7 @@ export function getCanActivateHook(type: any /** TODO #9100 */): Function {
   var annotations = reflector.annotations(type);
   for (let i = 0; i < annotations.length; i += 1) {
     let annotation = annotations[i];
-    if (annotation instanceof CanActivate) {
+    if (annotation instanceof CanActivateAnnotation) {
       return annotation.fn;
     }
   }


### PR DESCRIPTION
`router-deprecated/src/lifecycle/lifecycle_annotations.ts` imports `CanActivate` under an alias and then re-exports something new under the **same name**. This **breaks the API doc generation**. The simple refactoring of this PR renames the private `CanActivate` to `CanActivateAnnotation`.

---

**What is the current behavior?**

API doc generation is broken; see [the API entry for `CanActivate`](https://angular.io/docs/ts/latest/api/router-deprecated/index/CanActivate-decorator.html):

```
export CanActivate(options : CanActivateAnnotation) : (hook: (next: ComponentInstruction, prev: ComponentInstruction) => Promise<boolean>| boolean) =>
ClassDecorator
```

Note the extra `(options : CanActivateAnnotation)`.

**What is the new behavior?**

On the API doc page signature for `CanActivate` should be:

```
export CanActivate: (hook: (next: ComponentInstruction, prev: ComponentInstruction) => Promise<boolean>| boolean) =>
ClassDecorator
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
