### PR TITLE
fix(router): add extra validation for when route was passed as Array.

### DIFF
--- a/modules/@angular/router/src/config.ts
+++ b/modules/@angular/router/src/config.ts
@@ -503,6 +503,9 @@ export function validateConfig(config: Routes): void {
 }
 
 function validateNode(route: Route): void {
+  if (Array.isArray(route)) {
+    throw new Error(`Invalid route configuration: Array cannot be specified`);
+  }
   if (!!route.redirectTo && !!route.children) {
     throw new Error(
         `Invalid configuration of route '${route.path}': redirectTo and children cannot be used together`);

--- a/modules/@angular/router/test/config.spec.ts
+++ b/modules/@angular/router/test/config.spec.ts
@@ -6,6 +6,15 @@ describe('config', () => {
       validateConfig([{path: 'a', redirectTo: 'b'}, {path: 'b', component: ComponentA}]);
     });
 
+    it('should throw when Array is passed', () => {
+      expect(() => {
+        validateConfig([
+          {path: 'a', component: ComponentA},
+          [{path: 'b', component: ComponentB}, {path: 'c', component: ComponentC}]
+        ]);
+      }).toThrowError(`Invalid route configuration: Array cannot be specified`);
+    });
+
     it('should throw when redirectTo and children are used together', () => {
       expect(() => {
         validateConfig(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When route are given as Array, Angular throws error with `Invalid route configuration: routes must have path specified` which does not really express what's wrong.

**What is the new behavior?**
Throw error with new message `Invalid route configuration: Array cannot be specified`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
I'm certain that there are some people who think route can be given as array and it should be eventually flattened.
I hope this will them to figure out the problem they are having.
(Current error message confused me a little bit, and took sometime to resolve it.)
