### PR TITLE
fix(core): run ngOnDestroy hook before output events are detached

### DIFF
--- a/modules/@angular/core/test/linker/change_detection_integration_spec.ts
+++ b/modules/@angular/core/test/linker/change_detection_integration_spec.ts
@@ -84,6 +84,7 @@ export function main() {
           CompWithRef,
           EmitterDirective,
           PushComp,
+          OnDestroyDirective,
           OrderCheckDirective2,
           OrderCheckDirective0,
           OrderCheckDirective1,
@@ -1040,7 +1041,16 @@ export function main() {
              ]);
            }));
 
-        it('should call ngOnDestory on pipes', fakeAsync(() => {
+        it('should deliver synchronous events to parent', fakeAsync(() => {
+             var ctx = createCompFixture('<div (destroy)="a=$event" onDestroyDirective></div>');
+
+             ctx.detectChanges(false);
+             ctx.destroy();
+
+             expect(ctx.componentInstance.a).toEqual('destroyed');
+           }));
+
+        it('should call ngOnDestroy on pipes', fakeAsync(() => {
              var ctx = createCompFixture('{{true | pipeWithOnDestroy }}');
 
              ctx.detectChanges(false);
@@ -1440,6 +1450,13 @@ class InjectableWithLifecycle {
   constructor(public log: DirectiveLog) {}
 
   ngOnDestroy() { this.log.add(this.name, 'ngOnDestroy'); }
+}
+
+@Directive({selector: '[onDestroyDirective]'})
+class OnDestroyDirective implements OnDestroy {
+  @Output('destroy') emitter = new EventEmitter<string>(false);
+
+  ngOnDestroy() { this.emitter.emit('destroyed'); }
 }
 
 @Directive({selector: '[orderCheck0]'})


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
#6984

**What is the new behavior?**

ngOnDestroy hook runs before output events are detached

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Make possible to emit synchronous events at the moment the component is destroyed, and process these events on parents.
Previously, parent components never received such events because outputs were disconnected before ngOnDestroy ran.

While this is a simple change, I'll add any required tests once I can get angular to build on my machine (I need npm v2 because of my projects).
