### PR TITLE
fix(forms): re-enable form provider functions for easier migration

### DIFF
--- a/modules/@angular/forms/src/form_providers.ts
+++ b/modules/@angular/forms/src/form_providers.ts
@@ -6,10 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AppModule, Type} from '@angular/core';
+import {AppModule, PLATFORM_DIRECTIVES, Type} from '@angular/core';
+
 import {FORM_DIRECTIVES, REACTIVE_FORM_DIRECTIVES} from './directives';
 import {RadioControlRegistry} from './directives/radio_control_value_accessor';
 import {FormBuilder} from './form_builder';
+
 
 
 /**
@@ -39,4 +41,20 @@ export class FormsModule {
  */
 @AppModule({providers: [REACTIVE_FORM_PROVIDERS], directives: REACTIVE_FORM_DIRECTIVES, pipes: []})
 export class ReactiveFormsModule {
+}
+
+/**
+ * @deprecated
+ */
+export function disableDeprecatedForms(): any[] {
+  return [];
+}
+
+/**
+ * @deprecated
+ */
+export function provideForms(): any[] {
+  return [
+    {provide: PLATFORM_DIRECTIVES, useValue: FORM_DIRECTIVES, multi: true}, REACTIVE_FORM_PROVIDERS
+  ];
 }

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -102,6 +102,9 @@ export declare class DefaultValueAccessor implements ControlValueAccessor {
     writeValue(value: any): void;
 }
 
+/** @deprecated */
+export declare function disableDeprecatedForms(): any[];
+
 /** @experimental */
 export interface Form {
     addControl(dir: NgControl): void;
@@ -369,6 +372,9 @@ export declare class PatternValidator implements Validator {
         [key: string]: any;
     };
 }
+
+/** @deprecated */
+export declare function provideForms(): any[];
 
 /** @experimental */
 export declare const REACTIVE_FORM_DIRECTIVES: Type[][];


### PR DESCRIPTION
This PR re-adds the form provider functions from the last RC so users don't have to update to AppModules in RC.5 if they don't want to.  These functions are deprecated, but they'll stick around for one more RC before they are retired in favor of the AppModule syntax described [here](https://github.com/angular/angular/pull/9859).

So in RC.5, you can either:

(deprecated, but will still work in RC.5)

``` ts
import {disableDeprecatedForms, provideForms} from '@angular/forms';

bootstrap(App, [
   disableDeprecatedForms(),
   provideForms()
]);
```

-- OR --

``` ts
import {DeprecatedFormsModule} from '@angular/common';

bootstrap(App, {modules: [DeprecatedFormsModule] });
```

-OR-

``` ts
import {FormsModule} from '@angular/forms';

bootstrap(App, {modules: [FormsModule] });
```

-OR-

``` ts
import {ReactiveFormsModule} from '@angular/forms';

bootstrap(App, {modules: [ReactiveFormsModule] });
```

cc: @StephenFluin 
r: @vsavkin 
