### PR TITLE
feat(forms): add ability to reset forms

### DIFF
--- a/modules/@angular/forms/src/directives/abstract_control_directive.ts
+++ b/modules/@angular/forms/src/directives/abstract_control_directive.ts
@@ -48,4 +48,8 @@ export abstract class AbstractControlDirective {
   }
 
   get path(): string[] { return null; }
+
+  reset(value: any = undefined): void {
+    if (isPresent(this.control)) this.control.reset(value);
+  }
 }

--- a/modules/@angular/forms/src/directives/ng_form.ts
+++ b/modules/@angular/forms/src/directives/ng_form.ts
@@ -86,9 +86,7 @@ export const formDirectiveProvider: any =
 @Directive({
   selector: 'form:not([ngNoForm]):not([formGroup]),ngForm,[ngForm]',
   providers: [formDirectiveProvider],
-  host: {
-    '(submit)': 'onSubmit()',
-  },
+  host: {'(submit)': 'onSubmit()', '(reset)': 'onReset()'},
   outputs: ['ngSubmit'],
   exportAs: 'ngForm'
 })
@@ -171,6 +169,8 @@ export class NgForm extends ControlContainer implements Form {
     ObservableWrapper.callEmit(this.ngSubmit, null);
     return false;
   }
+
+  onReset(): void { this.form.reset(); }
 
   /** @internal */
   _findContainer(path: string[]): FormGroup {

--- a/modules/@angular/forms/src/directives/ng_model.ts
+++ b/modules/@angular/forms/src/directives/ng_model.ts
@@ -135,6 +135,7 @@ export class NgModel extends NgControl implements OnChanges,
               }
 
               private _updateValue(value: any): void {
-                PromiseWrapper.scheduleMicrotask(() => { this.control.updateValue(value); });
+                PromiseWrapper.scheduleMicrotask(
+                    () => { this.control.updateValue(value, {emitViewToModelChange: false}); });
               }
 }

--- a/modules/@angular/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/modules/@angular/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -105,7 +105,7 @@ export const formDirectiveProvider: any =
 @Directive({
   selector: '[formGroup]',
   providers: [formDirectiveProvider],
-  host: {'(submit)': 'onSubmit()'},
+  host: {'(submit)': 'onSubmit()', '(reset)': 'onReset()'},
   exportAs: 'ngForm'
 })
 export class FormGroupDirective extends ControlContainer implements Form,
@@ -186,6 +186,8 @@ export class FormGroupDirective extends ControlContainer implements Form,
     ObservableWrapper.callEmit(this.ngSubmit, null);
     return false;
   }
+
+  onReset(): void { this.form.reset(); }
 
   /** @internal */
   _updateDomValue() {

--- a/modules/@angular/forms/src/directives/shared.ts
+++ b/modules/@angular/forms/src/directives/shared.ts
@@ -49,8 +49,13 @@ export function setUpControl(control: FormControl, dir: NgControl): void {
     control.markAsDirty();
   });
 
-  // model -> view
-  control.registerOnChange((newValue: any) => dir.valueAccessor.writeValue(newValue));
+  control.registerOnChange((newValue: any, emitModelEvent: boolean) => {
+    // control -> view
+    dir.valueAccessor.writeValue(newValue);
+
+    // control -> ngModel
+    if (emitModelEvent) dir.viewToModelUpdate(newValue);
+  });
 
   // touched
   dir.valueAccessor.registerOnTouched(() => control.markAsTouched());

--- a/modules/@angular/forms/test/integration_spec.ts
+++ b/modules/@angular/forms/test/integration_spec.ts
@@ -279,6 +279,59 @@ export function main() {
              });
            }));
 
+    it('should clear value in UI when form resets programmatically',
+       inject(
+           [TestComponentBuilder, AsyncTestCompleter],
+           (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
+             const login = new FormControl('oldValue');
+             const form = new FormGroup({'login': login});
+
+             const t = `<div [formGroup]="form">
+                <input type="text" formControlName="login">
+               </div>`;
+
+             tcb.overrideTemplate(MyComp8, t).createAsync(MyComp8).then((fixture) => {
+               fixture.debugElement.componentInstance.form = form;
+               fixture.detectChanges();
+
+               login.updateValue('new value');
+
+               const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+               expect(loginEl.value).toBe('new value');
+
+               form.reset();
+               expect(loginEl.value).toBe('');
+               async.done();
+             });
+           }));
+
+    it('should set value in UI when form resets to that value programmatically',
+       inject(
+           [TestComponentBuilder, AsyncTestCompleter],
+           (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
+             const login = new FormControl('oldValue');
+             const form = new FormGroup({'login': login});
+
+             const t = `<div [formGroup]="form">
+                <input type="text" formControlName="login">
+               </div>`;
+
+             tcb.overrideTemplate(MyComp8, t).createAsync(MyComp8).then((fixture) => {
+               fixture.debugElement.componentInstance.form = form;
+               fixture.detectChanges();
+
+               login.updateValue('new value');
+
+               const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+               expect(loginEl.value).toBe('new value');
+
+               form.reset({'login': 'oldValue'});
+
+               expect(loginEl.value).toBe('oldValue');
+               async.done();
+             });
+           }));
+
     it('should support form arrays',
        fakeAsync(inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {
          const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
@@ -1283,6 +1336,32 @@ export function main() {
 
            expect(fixture.debugElement.componentInstance.name).toEqual('updated');
          })));
+
+      it('should reset the form to empty when reset button is clicked',
+         fakeAsync(inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {
+           const t = `
+            <form>
+              <input name="name" [(ngModel)]="name">
+            </form>
+           `;
+
+           const fixture = tcb.overrideTemplate(MyComp8, t).createFakeAsync(MyComp8);
+           tick();
+           fixture.debugElement.componentInstance.name = 'should be cleared';
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           const formEl = fixture.debugElement.query(By.css('form'));
+
+           dispatchEvent(formEl.nativeElement, 'reset');
+           fixture.detectChanges();
+           tick();
+
+           expect(fixture.debugElement.componentInstance.name).toBe(null);
+           expect(form.value.name).toEqual(null);
+         })));
+
 
       it('should emit valueChanges and statusChanges on init',
          fakeAsync(inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -28,9 +28,16 @@ export declare abstract class AbstractControl {
     markAsPending({onlySelf}?: {
         onlySelf?: boolean;
     }): void;
+    markAsPristine({onlySelf}?: {
+        onlySelf?: boolean;
+    }): void;
     markAsTouched({onlySelf}?: {
         onlySelf?: boolean;
     }): void;
+    markAsUntouched({onlySelf}?: {
+        onlySelf?: boolean;
+    }): void;
+    abstract reset(value?: any, options?: Object): void;
     setAsyncValidators(newValidator: AsyncValidatorFn | AsyncValidatorFn[]): void;
     setErrors(errors: {
         [key: string]: any;
@@ -61,6 +68,7 @@ export declare abstract class AbstractControlDirective {
     valid: boolean;
     value: any;
     valueChanges: Observable<any>;
+    reset(value?: any): void;
 }
 
 /** @experimental */
@@ -128,6 +136,9 @@ export declare class FormArray extends AbstractControl {
     insert(index: number, control: AbstractControl): void;
     push(control: AbstractControl): void;
     removeAt(index: number): void;
+    reset(value?: any, {onlySelf}?: {
+        onlySelf?: boolean;
+    }): void;
     updateValue(value: any[], {onlySelf}?: {
         onlySelf?: boolean;
     }): void;
@@ -161,10 +172,14 @@ export declare class FormBuilder {
 export declare class FormControl extends AbstractControl {
     constructor(value?: any, validator?: ValidatorFn | ValidatorFn[], asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[]);
     registerOnChange(fn: Function): void;
-    updateValue(value: any, {onlySelf, emitEvent, emitModelToViewChange}?: {
+    reset(value?: any, {onlySelf}?: {
+        onlySelf?: boolean;
+    }): void;
+    updateValue(value: any, {onlySelf, emitEvent, emitModelToViewChange, emitViewToModelChange}?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
         emitModelToViewChange?: boolean;
+        emitViewToModelChange?: boolean;
     }): void;
 }
 
@@ -215,6 +230,9 @@ export declare class FormGroup extends AbstractControl {
     include(controlName: string): void;
     registerControl(name: string, control: AbstractControl): AbstractControl;
     removeControl(name: string): void;
+    reset(value?: any, {onlySelf}?: {
+        onlySelf?: boolean;
+    }): void;
     updateValue(value: {
         [key: string]: any;
     }, {onlySelf}?: {
@@ -239,6 +257,7 @@ export declare class FormGroupDirective extends ControlContainer implements Form
     getFormArray(dir: FormArrayName): FormArray;
     getFormGroup(dir: FormGroupName): FormGroup;
     ngOnChanges(changes: SimpleChanges): void;
+    onReset(): void;
     onSubmit(): boolean;
     removeControl(dir: NgControl): void;
     removeFormArray(dir: FormArrayName): void;
@@ -317,6 +336,7 @@ export declare class NgForm extends ControlContainer implements Form {
     addFormGroup(dir: NgModelGroup): void;
     getControl(dir: NgModel): FormControl;
     getFormGroup(dir: NgModelGroup): FormGroup;
+    onReset(): void;
     onSubmit(): boolean;
     removeControl(dir: NgModel): void;
     removeFormGroup(dir: NgModelGroup): void;


### PR DESCRIPTION
This PR adds the ability to reset forms programmatically.  Calling `reset()` at any level will:
- Mark the control and any child controls as pristine
- Mark the control and any child controls as untouched
- Set the value of control and child controls to custom value (if provided) or null
- Update value/validity/errors of affected parties

**Usage**

``` ts
@Component({
   selector: 'my-comp',
   template: '
      <div [formGroup]="form">
         <input formControlName="first">
         <input formControlName="last">
      </div>
   '
})
class MyComp {
   form = new FormGroup({
      first: new FormControl('Nancy'),
      last: new FormControl('Drew')
   });
}

   reset() {
      this.form.reset();  // will reset to null
     // this.form.reset({first: 'Nancy', last: 'Drew'});   -- will reset to value specified
   }
```

You can also call `markAsPristine()` or `markAsUntouched()` individually at any level if you'd like more fine-tuned control. 

This PR also ensures that native reset buttons reset the form automatically.  In other words, clicking the following button will reset all your form fields to null in both the UI and in your model:

``` html
<button type="reset">RESET</button>
```
