### PR TITLE
feat(animations): namespace pseudo states with a leading colon

### DIFF
--- a/modules/@angular/compiler-cli/integrationtest/src/animate.ts
+++ b/modules/@angular/compiler-cli/integrationtest/src/animate.ts
@@ -14,7 +14,7 @@ import {AUTO_STYLE, Component, animate, state, style, transition, trigger} from 
       'openClose',
       [
         state('*', style({height: AUTO_STYLE, color: 'black', borderColor: 'black'})),
-        state('closed, void', style({height: '0px', color: 'maroon', borderColor: 'maroon'})),
+        state('closed, :void', style({height: '0px', color: 'maroon', borderColor: 'maroon'})),
         state('open', style({height: AUTO_STYLE, borderColor: 'green', color: 'green'})),
         transition('* => *', animate(500))
       ])],

--- a/modules/@angular/compiler/core_private.ts
+++ b/modules/@angular/compiler/core_private.ts
@@ -88,6 +88,8 @@ export var prepareFinalAnimationStyles: typeof t.prepareFinalAnimationStyles =
     r.prepareFinalAnimationStyles;
 export var balanceAnimationKeyframes: typeof t.balanceAnimationKeyframes =
     r.balanceAnimationKeyframes;
+export var assertValidAnimationState: typeof t.assertValidAnimationState =
+    r.assertValidAnimationState;
 export var flattenStyles: typeof t.flattenStyles = r.flattenStyles;
 export var clearStyles: typeof t.clearStyles = r.clearStyles;
 export var collectAndResolveStyles: typeof r.collectAndResolveStyles = r.collectAndResolveStyles;

--- a/modules/@angular/compiler/src/animation/animation_parser.ts
+++ b/modules/@angular/compiler/src/animation/animation_parser.ts
@@ -101,7 +101,7 @@ function _parseAnimationStateTransition(
 function _parseAnimationTransitionExpr(
     eventStr: string, errors: AnimationParseError[]): AnimationStateTransitionExpression[] {
   var expressions: any[] /** TODO #9100 */ = [];
-  var match = eventStr.match(/^(\*|[-\w]+)\s*(<?[=-]>)\s*(\*|[-\w]+)$/);
+  var match = eventStr.match(/^(\*|:?[-\w]+)\s*(<?[=-]>)\s*(\*|:?[-\w]+)$/);
   if (!isPresent(match) || match.length < 4) {
     errors.push(new AnimationParseError(`the provided ${eventStr} is not of a supported format`));
     return expressions;

--- a/modules/@angular/compiler/src/identifiers.ts
+++ b/modules/@angular/compiler/src/identifiers.ts
@@ -8,7 +8,7 @@
 
 import {ANALYZE_FOR_PRECOMPILE, AppModuleFactory, ChangeDetectionStrategy, ChangeDetectorRef, ComponentFactory, ComponentFactoryResolver, ElementRef, Injector, QueryList, RenderComponentType, Renderer, SecurityContext, SimpleChange, TemplateRef, ViewContainerRef, ViewEncapsulation} from '@angular/core';
 
-import {AnimationGroupPlayer as AnimationGroupPlayer_, AnimationKeyframe as AnimationKeyframe_, AnimationSequencePlayer as AnimationSequencePlayer_, AnimationStyles as AnimationStyles_, AppElement, AppModuleInjector, AppView, ChangeDetectorStatus, CodegenComponentFactoryResolver, DebugAppView, DebugContext, EMPTY_ARRAY, EMPTY_MAP, NoOpAnimationPlayer as NoOpAnimationPlayer_, StaticNodeDebugInfo, TemplateRef_, UNINITIALIZED, ValueUnwrapper, ViewType, ViewUtils, balanceAnimationKeyframes as impBalanceAnimationKeyframes, castByValue, checkBinding, clearStyles as impClearStyles, collectAndResolveStyles as impCollectAndResolveStyles, devModeEqual, flattenNestedViewRenderNodes, interpolate, prepareFinalAnimationStyles as impBalanceAnimationStyles, pureProxy1, pureProxy10, pureProxy2, pureProxy3, pureProxy4, pureProxy5, pureProxy6, pureProxy7, pureProxy8, pureProxy9, renderStyles as impRenderStyles} from '../core_private';
+import {AnimationGroupPlayer as AnimationGroupPlayer_, AnimationKeyframe as AnimationKeyframe_, AnimationSequencePlayer as AnimationSequencePlayer_, AnimationStyles as AnimationStyles_, AppElement, AppModuleInjector, AppView, ChangeDetectorStatus, CodegenComponentFactoryResolver, DebugAppView, DebugContext, EMPTY_ARRAY, EMPTY_MAP, NoOpAnimationPlayer as NoOpAnimationPlayer_, StaticNodeDebugInfo, TemplateRef_, UNINITIALIZED, ValueUnwrapper, ViewType, ViewUtils, assertValidAnimationState as impAssertValidAnimationState, balanceAnimationKeyframes as impBalanceAnimationKeyframes, castByValue, checkBinding, clearStyles as impClearStyles, collectAndResolveStyles as impCollectAndResolveStyles, devModeEqual, flattenNestedViewRenderNodes, interpolate, prepareFinalAnimationStyles as impBalanceAnimationStyles, pureProxy1, pureProxy10, pureProxy2, pureProxy3, pureProxy4, pureProxy5, pureProxy6, pureProxy7, pureProxy8, pureProxy9, renderStyles as impRenderStyles} from '../core_private';
 
 import {CompileIdentifierMetadata, CompileTokenMetadata} from './compile_metadata';
 import {assetUrl} from './util';
@@ -242,6 +242,11 @@ export class Identifiers {
     name: 'balanceAnimationKeyframes',
     moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL,
     runtime: impBalanceAnimationKeyframes
+  });
+  static assertValidAnimationState = new CompileIdentifierMetadata({
+    name: 'assertValidAnimationState',
+    moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL,
+    runtime: impAssertValidAnimationState
   });
   static clearStyles = new CompileIdentifierMetadata(
       {name: 'clearStyles', moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL, runtime: impClearStyles});

--- a/modules/@angular/compiler/src/view_compiler/property_binder.ts
+++ b/modules/@angular/compiler/src/view_compiler/property_binder.ts
@@ -157,7 +157,10 @@ function bindAndWriteToRenderer(
         updateStmts.push(newRenderVar.set(renderValue).toDeclStmt());
         updateStmts.push(new o.IfStmt(
             newRenderVar.equals(o.importExpr(Identifiers.UNINITIALIZED)),
-            [newRenderVar.set(emptyStateValue).toStmt()]));
+            [newRenderVar.set(emptyStateValue).toStmt()],
+            [o.importExpr(Identifiers.assertValidAnimationState)
+                 .callFn([newRenderVar, o.literal(animationName)])
+                 .toStmt()]));
 
         updateStmts.push(
             animation.fnVariable.callFn([o.THIS_EXPR, renderNode, oldRenderVar, newRenderVar])

--- a/modules/@angular/core/private_export.ts
+++ b/modules/@angular/core/private_export.ts
@@ -116,6 +116,7 @@ export declare namespace __core_private_types__ {
   export var AnimationKeyframe: typeof AnimationKeyframe_;
   export var prepareFinalAnimationStyles: typeof animationUtils.prepareFinalAnimationStyles;
   export var balanceAnimationKeyframes: typeof animationUtils.balanceAnimationKeyframes;
+  export var assertValidAnimationState: typeof animationUtils.assertValidAnimationState;
   export var flattenStyles: typeof animationUtils.flattenStyles;
   export var clearStyles: typeof animationUtils.clearStyles;
   export var renderStyles: typeof animationUtils.renderStyles;
@@ -185,6 +186,7 @@ export var __core_private__ = {
   AnimationKeyframe: AnimationKeyframe_,
   prepareFinalAnimationStyles: animationUtils.prepareFinalAnimationStyles,
   balanceAnimationKeyframes: animationUtils.balanceAnimationKeyframes,
+  assertValidAnimationState: animationUtils.assertValidAnimationState,
   flattenStyles: animationUtils.flattenStyles,
   clearStyles: animationUtils.clearStyles,
   renderStyles: animationUtils.renderStyles,

--- a/modules/@angular/core/src/animation/animation_constants.ts
+++ b/modules/@angular/core/src/animation/animation_constants.ts
@@ -9,4 +9,4 @@
 export const FILL_STYLE_FLAG = 'true';  // TODO (matsko): change to boolean
 export const ANY_STATE = '*';
 export const DEFAULT_STATE = '*';
-export const EMPTY_STATE = 'void';
+export const EMPTY_STATE = ':void';

--- a/modules/@angular/core/src/animation/animation_style_util.ts
+++ b/modules/@angular/core/src/animation/animation_style_util.ts
@@ -7,6 +7,7 @@
  */
 
 import {ListWrapper, StringMapWrapper} from '../facade/collection';
+import {BaseException} from '../facade/exceptions';
 import {isArray, isPresent} from '../facade/lang';
 
 import {FILL_STYLE_FLAG} from './animation_constants';
@@ -122,4 +123,11 @@ export function flattenStyles(styles: {[key: string]: string | number}[]): {[key
         entry, (value: string, prop: string) => { finalStyles[prop] = value; });
   });
   return finalStyles;
+}
+
+export function assertValidAnimationState(stateValue: string, triggerName: string): void {
+  if (isPresent(stateValue) && stateValue[0] == ':') {
+    throw new BaseException(
+        `The provided value "${stateValue}" for the animation trigger "${triggerName}" is invalid because it is prefixed with a colon`);
+  }
 }

--- a/modules/@angular/core/test/animation/animation_integration_spec.ts
+++ b/modules/@angular/core/test/animation/animation_integration_spec.ts
@@ -54,7 +54,7 @@ function declareTests({useJit}: {useJit: boolean}) {
         };
 
     describe('animation triggers', () => {
-      it('should trigger a state change animation from void => state',
+      it('should trigger a state change animation from :void => state',
          inject(
              [TestComponentBuilder, AnimationDriver],
              fakeAsync((tcb: TestComponentBuilder, driver: MockAnimationDriver) => {
@@ -63,7 +63,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                    trigger(
                        'myAnimation',
                        [transition(
-                           'void => *',
+                           ':void => *',
                            [style({'opacity': 0}), animate(500, style({'opacity': 1}))])]),
                    (fixture: any /** TODO #9100 */) => {
                      var cmp = fixture.debugElement.componentInstance;
@@ -80,7 +80,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                    });
              })));
 
-      it('should trigger a state change animation from state => void',
+      it('should trigger a state change animation from state => :void',
          inject(
              [TestComponentBuilder, AnimationDriver],
              fakeAsync((tcb: TestComponentBuilder, driver: MockAnimationDriver) => {
@@ -89,7 +89,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                    trigger(
                        'myAnimation',
                        [transition(
-                           '* => void',
+                           '* => :void',
                            [style({'opacity': 1}), animate(500, style({'opacity': 0}))])]),
                    (fixture: any /** TODO #9100 */) => {
                      var cmp = fixture.debugElement.componentInstance;
@@ -107,6 +107,29 @@ function declareTests({useJit}: {useJit: boolean}) {
                      expect(keyframes2.length).toEqual(2);
                      expect(keyframes2[0]).toEqual([0, {'opacity': 1}]);
                      expect(keyframes2[1]).toEqual([1, {'opacity': 0}]);
+                   });
+             })));
+
+      it('should throw an error if a state value contains a leading colon value',
+         inject(
+             [TestComponentBuilder, AnimationDriver],
+             fakeAsync((tcb: TestComponentBuilder, driver: MockAnimationDriver) => {
+               makeAnimationCmp(
+                   tcb, '<div *ngIf="exp" [@myAnimation]="exp"></div>',
+                   trigger(
+                       'myAnimation',
+                       [transition(
+                           '* => :void',
+                           [style({'opacity': 1}), animate(500, style({'opacity': 0}))])]),
+                   (fixture: any /** TODO #9100 */) => {
+                     var cmp = fixture.debugElement.componentInstance;
+                     expect(() => {
+                       cmp.exp = ':boo';
+                       fixture.detectChanges();
+                       flushMicrotasks();
+                     })
+                         .toThrowError(
+                             /The provided value ":boo" for the animation trigger "myAnimation" is invalid because it is prefixed with a colon/);
                    });
              })));
 
@@ -161,7 +184,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                                                       'myAnimation',
                                                       [
                                                         state('*', style({'opacity': '1'})),
-                                                        state('void', style({'opacity': '0'})),
+                                                        state(':void', style({'opacity': '0'})),
                                                         transition('* => *', [animate('500ms')])
                                                       ])])
                    .createAsync(DummyIfCmp)
@@ -199,7 +222,7 @@ function declareTests({useJit}: {useJit: boolean}) {
              fakeAsync((tcb: TestComponentBuilder, driver: MockAnimationDriver) => {
                tcb.overrideAnimations(DummyIfCmp, [
                        trigger('myAnimation', [
-                         transition('void => *', [
+                         transition(':void => *', [
                             style({'background': 'red'}),
                             style({'width': '100px'}),
                             style({'background': 'gold'}),
@@ -270,7 +293,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                  tcb.overrideAnimations(
                         DummyIfCmp,
                         [trigger('myAnimation', [transition(
-                                                    'void => *',
+                                                    ':void => *',
                                                     [
                                                       style({'opacity': '0'}),
                                                       animate(1000, style({'opacity': '0.5'})),
@@ -324,7 +347,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                fakeAsync((tcb: TestComponentBuilder, driver: MockAnimationDriver) => {
                  tcb.overrideAnimations(DummyIfCmp, [
                    trigger('myAnimation', [
-                     transition('void => *', [
+                     transition(':void => *', [
                             style({'width': 0, 'height': 0}),
                             group([animate(1000, style({'width': 100})), animate(5000, style({'height': 500}))]),
                             group([animate(1000, style({'width': 0})), animate(5000, style({'height': 0}))])
@@ -384,69 +407,68 @@ function declareTests({useJit}: {useJit: boolean}) {
       });
 
       describe('keyframes', () => {
-        it(
-            'should create an animation step with multiple keyframes',
-            inject(
-                [TestComponentBuilder, AnimationDriver], fakeAsync(
-                                                             (tcb: TestComponentBuilder,
-                                                              driver: MockAnimationDriver) => {
-                                                               tcb.overrideAnimations(
-                                                                      DummyIfCmp,
-                                                                      [trigger(
-                                                                          'myAnimation',
-                                                                          [transition(
-                                                                              'void => *',
-                                                                              [animate(
-                                                                                  1000, keyframes([
-                                                                                    style([{
-                                                                                      'width': 0,
-                                                                                      offset: 0
-                                                                                    }]),
-                                                                                    style([{
-                                                                                      'width': 100,
-                                                                                      offset: 0.25
-                                                                                    }]),
-                                                                                    style([{
-                                                                                      'width': 200,
-                                                                                      offset: 0.75
-                                                                                    }]),
-                                                                                    style([{
-                                                                                      'width': 300,
-                                                                                      offset: 1
-                                                                                    }])
-                                                                                  ]))])])])
-                                                                   .createAsync(DummyIfCmp)
-                                                                   .then((fixture) => {
+        it('should create an animation step with multiple keyframes',
+           inject(
+               [TestComponentBuilder, AnimationDriver], fakeAsync(
+                                                            (tcb: TestComponentBuilder,
+                                                             driver: MockAnimationDriver) => {
+                                                              tcb.overrideAnimations(
+                                                                     DummyIfCmp,
+                                                                     [trigger(
+                                                                         'myAnimation',
+                                                                         [transition(
+                                                                             ':void => *',
+                                                                             [animate(
+                                                                                 1000, keyframes([
+                                                                                   style([{
+                                                                                     'width': 0,
+                                                                                     offset: 0
+                                                                                   }]),
+                                                                                   style([{
+                                                                                     'width': 100,
+                                                                                     offset: 0.25
+                                                                                   }]),
+                                                                                   style([{
+                                                                                     'width': 200,
+                                                                                     offset: 0.75
+                                                                                   }]),
+                                                                                   style([{
+                                                                                     'width': 300,
+                                                                                     offset: 1
+                                                                                   }])
+                                                                                 ]))])])])
+                                                                  .createAsync(DummyIfCmp)
+                                                                  .then((fixture) => {
 
-                                                                     tick();
+                                                                    tick();
 
-                                                                     var cmp =
-                                                                         fixture.debugElement
-                                                                             .componentInstance;
-                                                                     cmp.exp = true;
-                                                                     fixture.detectChanges();
-                                                                     flushMicrotasks();
+                                                                    var cmp =
+                                                                        fixture.debugElement
+                                                                            .componentInstance;
+                                                                    cmp.exp = true;
+                                                                    fixture.detectChanges();
+                                                                    flushMicrotasks();
 
-                                                                     var keyframes =
-                                                                         driver
-                                                                             .log[0]
-                                                                                 ['keyframeLookup'];
-                                                                     expect(keyframes.length)
-                                                                         .toEqual(4);
-                                                                     expect(keyframes[0]).toEqual([
-                                                                       0, {'width': 0}
-                                                                     ]);
-                                                                     expect(keyframes[1]).toEqual([
-                                                                       0.25, {'width': 100}
-                                                                     ]);
-                                                                     expect(keyframes[2]).toEqual([
-                                                                       0.75, {'width': 200}
-                                                                     ]);
-                                                                     expect(keyframes[3]).toEqual([
-                                                                       1, {'width': 300}
-                                                                     ]);
-                                                                   });
-                                                             })));
+                                                                    var keyframes =
+                                                                        driver
+                                                                            .log[0]
+                                                                                ['keyframeLookup'];
+                                                                    expect(keyframes.length)
+                                                                        .toEqual(4);
+                                                                    expect(keyframes[0]).toEqual([
+                                                                      0, {'width': 0}
+                                                                    ]);
+                                                                    expect(keyframes[1]).toEqual([
+                                                                      0.25, {'width': 100}
+                                                                    ]);
+                                                                    expect(keyframes[2]).toEqual([
+                                                                      0.75, {'width': 200}
+                                                                    ]);
+                                                                    expect(keyframes[3]).toEqual([
+                                                                      1, {'width': 300}
+                                                                    ]);
+                                                                  });
+                                                            })));
 
         it('should fetch any keyframe styles that are not defined in the first keyframe from the previous entries or getCompuedStyle',
            inject(
@@ -454,7 +476,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                fakeAsync((tcb: TestComponentBuilder, driver: MockAnimationDriver) => {
                  tcb.overrideAnimations(DummyIfCmp, [
                    trigger('myAnimation', [
-                     transition('void => *', [
+                     transition(':void => *', [
                        style({ 'color': 'white' }),
                        animate(1000, style({ 'color': 'silver' })),
                        animate(1000, keyframes([
@@ -529,7 +551,7 @@ function declareTests({useJit}: {useJit: boolean}) {
              fakeAsync((tcb: TestComponentBuilder, driver: MockAnimationDriver) => {
                tcb.overrideAnimations(DummyIfCmp, [
                         trigger('myAnimation', [
-                          transition('void => *', [
+                          transition(':void => *', [
                                                  style({'background': 'red', 'opacity': 0.5}),
                                                  animate(500, style({'background': 'black'})),
                                                  group([
@@ -635,7 +657,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                    tcb, '<div class="my-if" *ngIf="exp" [@myAnimation]></div>',
                    trigger(
                        'myAnimation',
-                       [transition('* => void', [animate(1000, style({'opacity': 0}))])]),
+                       [transition('* => :void', [animate(1000, style({'opacity': 0}))])]),
                    (fixture: any /** TODO #9100 */) => {
                      tick();
 
@@ -855,7 +877,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                makeAnimationCmp(
                    tcb, `<div *ngIf="exp" @trigger><div class="inner"></div></div>`,
                    [
-                     trigger('trigger', [transition('* => void', [animate(1000)])]),
+                     trigger('trigger', [transition('* => :void', [animate(1000)])]),
                    ],
                    (fixture: any /** TODO #9100 */) => {
                      var cmp = fixture.debugElement.componentInstance;
@@ -974,7 +996,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                    [trigger(
                        'status',
                        [
-                         state('void', style({'height': '100px'})),
+                         state(':void', style({'height': '100px'})),
                          transition('* => *', [animate(1000)])
                        ])],
                    (fixture: any /** TODO #9100 */) => {
@@ -1001,7 +1023,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                    [trigger(
                        'status',
                        [
-                         state('void', style({'width': '0px'})),
+                         state(':void', style({'width': '0px'})),
                          state('final', style({'width': '100px'})),
                        ])],
                    (fixture: any /** TODO #9100 */) => {
@@ -1136,9 +1158,9 @@ function declareTests({useJit}: {useJit: boolean}) {
                    [trigger(
                        'status',
                        [
-                         state('void', style({'height': '100px', 'opacity': 0})),
+                         state(':void', style({'height': '100px', 'opacity': 0})),
                          state('final', style({'height': '333px', 'width': '200px'})),
-                         transition('void => final', [animate(1000)])
+                         transition(':void => final', [animate(1000)])
                        ])],
                    (fixture: any /** TODO #9100 */) => {
                      tick();

--- a/modules/playground/src/animate/app/animate-app.ts
+++ b/modules/playground/src/animate/app/animate-app.ts
@@ -26,7 +26,7 @@ import {
       <button (click)="state='start'">Start State</button>
       <button (click)="state='active'">Active State</button>
       |
-      <button (click)="state='void'">Void State</button>
+      <button (click)="state='gone'">Void State</button>
       <button (click)="state='default'">Unhandled (default) State</button>
       <button style="float:right" (click)="bgStatus='blur'">Blur Page</button>
       <hr />
@@ -48,7 +48,7 @@ import {
     ]),
     trigger("boxAnimation", [
       state("*", style({ "height": "*", "background-color": "#dddddd", "color":"black" })),
-      state("void, hidden", style({ "height": 0, "opacity": 0 })),
+      state(":void, hidden", style({ "height": 0, "opacity": 0 })),
       state("start", style({ "background-color": "red", "height": "*" })),
       state("active", style({ "background-color": "orange", "color": "white", "font-size":"100px" })),
 
@@ -79,7 +79,7 @@ export class AnimateApp {
   get state() { return this._state; }
   set state(s) {
     this._state = s;
-    if (s == 'void') {
+    if (s == 'gone') {
       this.items = [];
     } else {
       this.items = [


### PR DESCRIPTION
BREAKING CHANGE
- Animation states are not allowed to to contain a starting
  colon value.
- The `void` state is now `:void`
