### PR TITLE
fix(platform-browser-dynamic): Add @Injectable() annotation to XHRImpl.

### DIFF
--- a/modules/@angular/platform-browser-dynamic/src/xhr/xhr_impl.ts
+++ b/modules/@angular/platform-browser-dynamic/src/xhr/xhr_impl.ts
@@ -5,12 +5,13 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
 import {XHR} from '@angular/compiler';
+import {Injectable} from '@angular/core';
 
 import {isPresent} from '../facade/lang';
 import {PromiseCompleter, PromiseWrapper} from '../facade/promise';
 
+@Injectable()
 export class XHRImpl extends XHR {
   get(url: string): Promise<string> {
     var completer: PromiseCompleter<string> = PromiseWrapper.completer();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format

**What kind of change does this PR introduce?** (check one with "x")

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Angular App fails to start when compiled with closure

**What is the new behavior?**
It works.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```

**Other information**:
Needed to unblock Google3.

Otherwise Closure compiled code will complain that the class is missing the annotation.
