### PR TITLE
[i18n]: misc changes

### DIFF
--- a/modules/@angular/compiler-cli/src/codegen.ts
+++ b/modules/@angular/compiler-cli/src/codegen.ts
@@ -126,8 +126,7 @@ export class CodeGenerator {
     const reflectorHost = new ReflectorHost(program, compilerHost, options, reflectorHostContext);
     const staticReflector = new StaticReflector(reflectorHost);
     StaticAndDynamicReflectionCapabilities.install(staticReflector);
-    const expressionParser = new Parser(new Lexer());
-    const htmlParser = new HtmlParser(expressionParser);
+    const htmlParser = new HtmlParser();
     const config = new compiler.CompilerConfig({
       genDebugInfo: options.debug === true,
       defaultEncapsulation: ViewEncapsulation.Emulated,
@@ -135,6 +134,7 @@ export class CodeGenerator {
       useJit: false
     });
     const normalizer = new DirectiveNormalizer(xhr, urlResolver, htmlParser, config);
+    const expressionParser = new Parser(new Lexer());
     const tmplParser = new TemplateParser(
         expressionParser, new DomElementSchemaRegistry(), htmlParser,
         /*console*/ null, []);

--- a/modules/@angular/compiler-cli/src/codegen.ts
+++ b/modules/@angular/compiler-cli/src/codegen.ts
@@ -126,7 +126,8 @@ export class CodeGenerator {
     const reflectorHost = new ReflectorHost(program, compilerHost, options, reflectorHostContext);
     const staticReflector = new StaticReflector(reflectorHost);
     StaticAndDynamicReflectionCapabilities.install(staticReflector);
-    const htmlParser = new HtmlParser();
+    const expressionParser = new Parser(new Lexer());
+    const htmlParser = new HtmlParser(expressionParser);
     const config = new compiler.CompilerConfig({
       genDebugInfo: options.debug === true,
       defaultEncapsulation: ViewEncapsulation.Emulated,
@@ -134,9 +135,8 @@ export class CodeGenerator {
       useJit: false
     });
     const normalizer = new DirectiveNormalizer(xhr, urlResolver, htmlParser, config);
-    const parser = new Parser(new Lexer());
     const tmplParser = new TemplateParser(
-        parser, new DomElementSchemaRegistry(), htmlParser,
+        expressionParser, new DomElementSchemaRegistry(), htmlParser,
         /*console*/ null, []);
     const resolver = new CompileMetadataResolver(
         new compiler.DirectiveResolver(staticReflector), new compiler.PipeResolver(staticReflector),

--- a/modules/@angular/compiler-cli/src/extract_i18n.ts
+++ b/modules/@angular/compiler-cli/src/extract_i18n.ts
@@ -137,8 +137,7 @@ class Extractor {
     const reflectorHost = new ReflectorHost(program, compilerHost, options);
     const staticReflector = new StaticReflector(reflectorHost);
     StaticAndDynamicReflectionCapabilities.install(staticReflector);
-    const expressionParser = new Parser(new Lexer());
-    const htmlParser = new HtmlParser(expressionParser);
+    const htmlParser = new HtmlParser();
     const config = new compiler.CompilerConfig({
       genDebugInfo: true,
       defaultEncapsulation: ViewEncapsulation.Emulated,
@@ -146,6 +145,7 @@ class Extractor {
       useJit: false
     });
     const normalizer = new DirectiveNormalizer(xhr, urlResolver, htmlParser, config);
+    const expressionParser = new Parser(new Lexer());
     const resolver = new CompileMetadataResolver(
         new compiler.DirectiveResolver(staticReflector), new compiler.PipeResolver(staticReflector),
         new compiler.ViewResolver(staticReflector), config, staticReflector);

--- a/modules/@angular/compiler-cli/src/extract_i18n.ts
+++ b/modules/@angular/compiler-cli/src/extract_i18n.ts
@@ -137,7 +137,8 @@ class Extractor {
     const reflectorHost = new ReflectorHost(program, compilerHost, options);
     const staticReflector = new StaticReflector(reflectorHost);
     StaticAndDynamicReflectionCapabilities.install(staticReflector);
-    const htmlParser = new HtmlParser();
+    const expressionParser = new Parser(new Lexer());
+    const htmlParser = new HtmlParser(expressionParser);
     const config = new compiler.CompilerConfig({
       genDebugInfo: true,
       defaultEncapsulation: ViewEncapsulation.Emulated,
@@ -145,13 +146,12 @@ class Extractor {
       useJit: false
     });
     const normalizer = new DirectiveNormalizer(xhr, urlResolver, htmlParser, config);
-    const parser = new Parser(new Lexer());
     const resolver = new CompileMetadataResolver(
         new compiler.DirectiveResolver(staticReflector), new compiler.PipeResolver(staticReflector),
         new compiler.ViewResolver(staticReflector), config, staticReflector);
 
     // TODO(vicb): handle implicit
-    const extractor = new MessageExtractor(htmlParser, parser, [], {});
+    const extractor = new MessageExtractor(htmlParser, expressionParser, [], {});
 
     return new Extractor(
         options, program, compilerHost, staticReflector, resolver, normalizer, reflectorHost,

--- a/modules/@angular/compiler/src/assertions.ts
+++ b/modules/@angular/compiler/src/assertions.ts
@@ -8,19 +8,18 @@
 
 import {isDevMode} from '@angular/core';
 
-import {BaseException} from '../src/facade/exceptions';
-import {isArray, isBlank, isString} from '../src/facade/lang';
+import {isArray, isBlank, isPresent, isString} from '../src/facade/lang';
 
 export function assertArrayOfStrings(identifier: string, value: any) {
   if (!isDevMode() || isBlank(value)) {
     return;
   }
   if (!isArray(value)) {
-    throw new BaseException(`Expected '${identifier}' to be an array of strings.`);
+    throw new Error(`Expected '${identifier}' to be an array of strings.`);
   }
   for (var i = 0; i < value.length; i += 1) {
     if (!isString(value[i])) {
-      throw new BaseException(`Expected '${identifier}' to be an array of strings.`);
+      throw new Error(`Expected '${identifier}' to be an array of strings.`);
     }
   }
 }
@@ -33,15 +32,15 @@ const INTERPOLATION_BLACKLIST_REGEXPS = [
 ];
 
 export function assertInterpolationSymbols(identifier: string, value: any): void {
-  if (isDevMode() && !isBlank(value) && (!isArray(value) || value.length != 2)) {
-    throw new BaseException(`Expected '${identifier}' to be an array, [start, end].`);
+  if (isPresent(value) && !(isArray(value) && value.length == 2)) {
+    throw new Error(`Expected '${identifier}' to be an array, [start, end].`);
   } else if (isDevMode() && !isBlank(value)) {
     const start = value[0] as string;
     const end = value[1] as string;
     // black list checking
     INTERPOLATION_BLACKLIST_REGEXPS.forEach(regexp => {
       if (regexp.test(start) || regexp.test(end)) {
-        throw new BaseException(`['${start}', '${end}'] contains unusable interpolation symbol.`);
+        throw new Error(`['${start}', '${end}'] contains unusable interpolation symbol.`);
       }
     });
   }

--- a/modules/@angular/compiler/src/assertions.ts
+++ b/modules/@angular/compiler/src/assertions.ts
@@ -28,7 +28,8 @@ const INTERPOLATION_BLACKLIST_REGEXPS = [
   /^\s*$/,        // empty
   /[<>]/,         // html tag
   /^[{}]$/,       // i18n expansion
-  /&(#|[a-z])/i,  // character reference
+  /&(#|[a-z])/i,  // character reference,
+  /^\/\//,        // comment
 ];
 
 export function assertInterpolationSymbols(identifier: string, value: any): void {

--- a/modules/@angular/compiler/src/compile_metadata.ts
+++ b/modules/@angular/compiler/src/compile_metadata.ts
@@ -768,23 +768,17 @@ export class CompileDirectiveMetadata implements CompileMetadataWithType {
     }
 
     return new CompileDirectiveMetadata({
-      type: type,
-      isComponent: normalizeBool(isComponent),
-      selector: selector,
-      exportAs: exportAs,
-      changeDetection: changeDetection,
+      type,
+      isComponent: normalizeBool(isComponent), selector, exportAs, changeDetection,
       inputs: inputsMap,
-      outputs: outputsMap,
-      hostListeners: hostListeners,
-      hostProperties: hostProperties,
-      hostAttributes: hostAttributes,
+      outputs: outputsMap, hostListeners, hostProperties, hostAttributes,
       lifecycleHooks: isPresent(lifecycleHooks) ? lifecycleHooks : [],
-      providers: providers,
-      viewProviders: viewProviders,
-      queries: queries,
-      viewQueries: viewQueries,
-      precompile: precompile,
-      template: template
+      providers,
+      viewProviders,
+      queries,
+      viewQueries,
+      precompile,
+      template,
     });
   }
   type: CompileTypeMetadata;
@@ -803,8 +797,8 @@ export class CompileDirectiveMetadata implements CompileMetadataWithType {
   queries: CompileQueryMetadata[];
   viewQueries: CompileQueryMetadata[];
   precompile: CompileTypeMetadata[];
-
   template: CompileTemplateMetadata;
+
   constructor(
       {type, isComponent, selector, exportAs, changeDetection, inputs, outputs, hostListeners,
        hostProperties, hostAttributes, lifecycleHooks, providers, viewProviders, queries,
@@ -827,7 +821,7 @@ export class CompileDirectiveMetadata implements CompileMetadataWithType {
         queries?: CompileQueryMetadata[],
         viewQueries?: CompileQueryMetadata[],
         precompile?: CompileTypeMetadata[],
-        template?: CompileTemplateMetadata
+        template?: CompileTemplateMetadata,
       } = {}) {
     this.type = type;
     this.isComponent = isComponent;

--- a/modules/@angular/compiler/src/directive_normalizer.ts
+++ b/modules/@angular/compiler/src/directive_normalizer.ts
@@ -14,6 +14,7 @@ import {CompileDirectiveMetadata, CompileStylesheetMetadata, CompileTemplateMeta
 import {CompilerConfig} from './config';
 import {HtmlAstVisitor, HtmlAttrAst, HtmlCommentAst, HtmlElementAst, HtmlExpansionAst, HtmlExpansionCaseAst, HtmlTextAst, htmlVisitAll} from './html_ast';
 import {HtmlParser} from './html_parser';
+import {InterpolationConfig} from './interpolation_config';
 import {extractStyleUrls, isStyleUrlResolvable} from './style_url_resolver';
 import {PreparsedElementType, preparseElement} from './template_preparser';
 import {UrlResolver} from './url_resolver';

--- a/modules/@angular/compiler/src/directive_normalizer.ts
+++ b/modules/@angular/compiler/src/directive_normalizer.ts
@@ -20,7 +20,6 @@ import {PreparsedElementType, preparseElement} from './template_preparser';
 import {UrlResolver} from './url_resolver';
 import {SyncAsyncResult} from './util';
 import {XHR} from './xhr';
-import {InterpolationConfig} from './interpolation_config';
 
 @Injectable()
 export class DirectiveNormalizer {

--- a/modules/@angular/compiler/src/expression_parser/lexer.ts
+++ b/modules/@angular/compiler/src/expression_parser/lexer.ts
@@ -8,7 +8,6 @@
 
 import {Injectable} from '@angular/core';
 import * as chars from '../chars';
-import {SetWrapper} from '../facade/collection';
 import {BaseException} from '../facade/exceptions';
 import {NumberWrapper, StringJoiner, StringWrapper, isPresent} from '../facade/lang';
 

--- a/modules/@angular/compiler/src/expression_parser/lexer.ts
+++ b/modules/@angular/compiler/src/expression_parser/lexer.ts
@@ -25,10 +25,10 @@ const KEYWORDS = ['var', 'let', 'null', 'undefined', 'true', 'false', 'if', 'els
 
 @Injectable()
 export class Lexer {
-  tokenize(text: string): any[] {
-    var scanner = new _Scanner(text);
-    var tokens: Token[] = [];
-    var token = scanner.scanToken();
+  tokenize(text: string): Token[] {
+    const scanner = new _Scanner(text);
+    const tokens: Token[] = [];
+    let token = scanner.scanToken();
     while (token != null) {
       tokens.push(token);
       token = scanner.scanToken();
@@ -43,43 +43,40 @@ export class Token {
       public strValue: string) {}
 
   isCharacter(code: number): boolean {
-    return (this.type == TokenType.Character && this.numValue == code);
+    return this.type == TokenType.Character && this.numValue == code;
   }
 
-  isNumber(): boolean { return (this.type == TokenType.Number); }
+  isNumber(): boolean { return this.type == TokenType.Number; }
 
-  isString(): boolean { return (this.type == TokenType.String); }
+  isString(): boolean { return this.type == TokenType.String; }
 
   isOperator(operater: string): boolean {
-    return (this.type == TokenType.Operator && this.strValue == operater);
+    return this.type == TokenType.Operator && this.strValue == operater;
   }
 
-  isIdentifier(): boolean { return (this.type == TokenType.Identifier); }
+  isIdentifier(): boolean { return this.type == TokenType.Identifier; }
 
-  isKeyword(): boolean { return (this.type == TokenType.Keyword); }
+  isKeyword(): boolean { return this.type == TokenType.Keyword; }
 
   isKeywordDeprecatedVar(): boolean {
-    return (this.type == TokenType.Keyword && this.strValue == 'var');
+    return this.type == TokenType.Keyword && this.strValue == 'var';
   }
 
-  isKeywordLet(): boolean { return (this.type == TokenType.Keyword && this.strValue == 'let'); }
+  isKeywordLet(): boolean { return this.type == TokenType.Keyword && this.strValue == 'let'; }
 
-  isKeywordNull(): boolean { return (this.type == TokenType.Keyword && this.strValue == 'null'); }
+  isKeywordNull(): boolean { return this.type == TokenType.Keyword && this.strValue == 'null'; }
 
   isKeywordUndefined(): boolean {
-    return (this.type == TokenType.Keyword && this.strValue == 'undefined');
+    return this.type == TokenType.Keyword && this.strValue == 'undefined';
   }
 
-  isKeywordTrue(): boolean { return (this.type == TokenType.Keyword && this.strValue == 'true'); }
+  isKeywordTrue(): boolean { return this.type == TokenType.Keyword && this.strValue == 'true'; }
 
-  isKeywordFalse(): boolean { return (this.type == TokenType.Keyword && this.strValue == 'false'); }
+  isKeywordFalse(): boolean { return this.type == TokenType.Keyword && this.strValue == 'false'; }
 
   isError(): boolean { return this.type == TokenType.Error; }
 
-  toNumber(): number {
-    // -1 instead of NULL ok?
-    return (this.type == TokenType.Number) ? this.numValue : -1;
-  }
+  toNumber(): number { return this.type == TokenType.Number ? this.numValue : -1; }
 
   toString(): string {
     switch (this.type) {

--- a/modules/@angular/compiler/src/expression_parser/parser.ts
+++ b/modules/@angular/compiler/src/expression_parser/parser.ts
@@ -37,8 +37,7 @@ function _createInterpolateRegExp(config: InterpolationConfig): RegExp {
 export class Parser {
   private errors: ParserError[] = [];
 
-  constructor(/** @internal */
-              public _lexer: Lexer) {}
+  constructor(private _lexer: Lexer) {}
 
   parseAction(
       input: string, location: any,

--- a/modules/@angular/compiler/src/html_parser.ts
+++ b/modules/@angular/compiler/src/html_parser.ts
@@ -30,14 +30,12 @@ export class HtmlParseTreeResult {
 
 @Injectable()
 export class HtmlParser {
-  constructor(public _expressionParser: ExpressionParser) {}
-
   parse(
       sourceContent: string, sourceUrl: string, parseExpansionForms: boolean = false,
       interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG):
       HtmlParseTreeResult {
-    var tokensAndErrors = tokenizeHtml(
-        sourceContent, sourceUrl, this._expressionParser, parseExpansionForms, interpolationConfig);
+    var tokensAndErrors =
+        tokenizeHtml(sourceContent, sourceUrl, parseExpansionForms, interpolationConfig);
     var treeAndErrors = new TreeBuilder(tokensAndErrors.tokens).build();
     return new HtmlParseTreeResult(
         treeAndErrors.rootNodes,

--- a/modules/@angular/compiler/src/html_parser.ts
+++ b/modules/@angular/compiler/src/html_parser.ts
@@ -13,6 +13,8 @@ import {HtmlAst, HtmlAttrAst, HtmlTextAst, HtmlCommentAst, HtmlElementAst, HtmlE
 import {HtmlToken, HtmlTokenType, tokenizeHtml} from './html_lexer';
 import {ParseError, ParseSourceSpan} from './parse_util';
 import {getHtmlTagDefinition, getNsPrefix, mergeNsAndName} from './html_tags';
+import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from './interpolation_config';
+import {Parser as ExpressionParser} from './expression_parser/parser';
 
 export class HtmlTreeError extends ParseError {
   static create(elementName: string, span: ParseSourceSpan, msg: string): HtmlTreeError {
@@ -28,9 +30,14 @@ export class HtmlParseTreeResult {
 
 @Injectable()
 export class HtmlParser {
-  parse(sourceContent: string, sourceUrl: string, parseExpansionForms: boolean = false):
+  constructor(public _expressionParser: ExpressionParser) {}
+
+  parse(
+      sourceContent: string, sourceUrl: string, parseExpansionForms: boolean = false,
+      interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG):
       HtmlParseTreeResult {
-    var tokensAndErrors = tokenizeHtml(sourceContent, sourceUrl, parseExpansionForms);
+    var tokensAndErrors = tokenizeHtml(
+        sourceContent, sourceUrl, this._expressionParser, parseExpansionForms, interpolationConfig);
     var treeAndErrors = new TreeBuilder(tokensAndErrors.tokens).build();
     return new HtmlParseTreeResult(
         treeAndErrors.rootNodes,

--- a/modules/@angular/compiler/src/i18n/i18n_html_parser.ts
+++ b/modules/@angular/compiler/src/i18n/i18n_html_parser.ts
@@ -17,7 +17,7 @@ import {ParseError, ParseSourceSpan} from '../parse_util';
 
 import {expandNodes} from './expander';
 import {Message, id} from './message';
-import {I18N_ATTR, I18N_ATTR_PREFIX, I18nError, Part, dedupePhName, getPhNameFromBinding, messageFromAttribute, messageFromI18nAttribute, partition} from './shared';
+import {I18N_ATTR, I18N_ATTR_PREFIX, I18nError, Part, dedupePhName, extractPhNameFromInterpolation, messageFromAttribute, messageFromI18nAttribute, partition} from './shared';
 
 const _PLACEHOLDER_ELEMENT = 'ph';
 const _NAME_ATTR = 'name';
@@ -289,7 +289,7 @@ export class I18nHtmlParser implements HtmlParser {
     let usedNames = new Map<string, number>();
 
     for (var i = 0; i < exps.length; i++) {
-      let phName = getPhNameFromBinding(exps[i], i);
+      let phName = extractPhNameFromInterpolation(exps[i], i);
       expMap.set(dedupePhName(usedNames, phName), exps[i]);
     }
     return expMap;

--- a/modules/@angular/compiler/src/i18n/i18n_html_parser.ts
+++ b/modules/@angular/compiler/src/i18n/i18n_html_parser.ts
@@ -14,14 +14,12 @@ import {HtmlAst, HtmlAstVisitor, HtmlAttrAst, HtmlCommentAst, HtmlElementAst, Ht
 import {HtmlParseTreeResult, HtmlParser} from '../html_parser';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../interpolation_config';
 import {ParseError, ParseSourceSpan} from '../parse_util';
-
-import {expandNodes} from './expander';
 import {Message, id} from './message';
 import {I18N_ATTR, I18N_ATTR_PREFIX, I18nError, Part, dedupePhName, extractPhNameFromInterpolation, messageFromAttribute, messageFromI18nAttribute, partition} from './shared';
 
 const _PLACEHOLDER_ELEMENT = 'ph';
 const _NAME_ATTR = 'name';
-let _PLACEHOLDER_EXPANDED_REGEXP = /<ph(\s)+name=("(\w)+")><\/ph>/gi;
+const _PLACEHOLDER_EXPANDED_REGEXP = /<ph(\s)+name=("(\w)+")><\/ph>/gi;
 
 /**
  * Creates an i18n-ed version of the parsed template.
@@ -72,9 +70,7 @@ export class I18nHtmlParser implements HtmlParser {
       return res;
     }
 
-    const expanded = expandNodes(res.rootNodes);
-    const nodes = this._recurse(expanded.nodes);
-    this.errors.push(...expanded.errors);
+    const nodes = this._recurse(res.rootNodes);
 
     return this.errors.length > 0 ? new HtmlParseTreeResult([], this.errors) :
                                     new HtmlParseTreeResult(nodes, []);

--- a/modules/@angular/compiler/src/i18n/shared.ts
+++ b/modules/@angular/compiler/src/i18n/shared.ts
@@ -70,7 +70,8 @@ export class Part {
       return this.rootTextNode.sourceSpan;
     }
 
-    return this.children[0].sourceSpan;
+    return new ParseSourceSpan(
+        this.children[0].sourceSpan.start, this.children[this.children.length - 1].sourceSpan.end);
   }
 
   createMessage(parser: ExpressionParser, interpolationConfig: InterpolationConfig): Message {
@@ -117,8 +118,8 @@ export function description(i18n: string): string {
 export function messageFromI18nAttribute(
     parser: ExpressionParser, interpolationConfig: InterpolationConfig, p: HtmlElementAst,
     i18nAttr: HtmlAttrAst): Message {
-  let expectedName = i18nAttr.name.substring(5);
-  let attr = p.attrs.find(a => a.name == expectedName);
+  const expectedName = i18nAttr.name.substring(5);
+  const attr = p.attrs.find(a => a.name == expectedName);
 
   if (attr) {
     return messageFromAttribute(
@@ -131,7 +132,7 @@ export function messageFromI18nAttribute(
 export function messageFromAttribute(
     parser: ExpressionParser, interpolationConfig: InterpolationConfig, attr: HtmlAttrAst,
     meaning: string = null, description: string = null): Message {
-  let value = removeInterpolation(attr.value, attr.sourceSpan, parser, interpolationConfig);
+  const value = removeInterpolation(attr.value, attr.sourceSpan, parser, interpolationConfig);
   return new Message(value, meaning, description);
 }
 

--- a/modules/@angular/compiler/src/i18n/xmb_serializer.ts
+++ b/modules/@angular/compiler/src/i18n/xmb_serializer.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Lexer as ExpressionLexer} from '@angular/compiler/src/expression_parser/lexer';
+import {Parser as ExpressionParser} from '@angular/compiler/src/expression_parser/parser';
+
 import {RegExpWrapper, isBlank, isPresent} from '../facade/lang';
 import {HtmlAst, HtmlElementAst} from '../html_ast';
 import {HtmlParser} from '../html_parser';
@@ -34,9 +37,11 @@ export class XmbDeserializationError extends ParseError {
 }
 
 export function deserializeXmb(content: string, url: string): XmbDeserializationResult {
-  let parser = new HtmlParser();
-  let normalizedContent = _expandPlaceholder(content.trim());
-  let parsed = parser.parse(normalizedContent, url);
+  const expLexer = new ExpressionLexer();
+  const expParser = new ExpressionParser(expLexer);
+  const parser = new HtmlParser(expParser);
+  const normalizedContent = _expandPlaceholder(content.trim());
+  const parsed = parser.parse(normalizedContent, url);
 
   if (parsed.errors.length > 0) {
     return new XmbDeserializationResult(null, {}, parsed.errors);

--- a/modules/@angular/compiler/src/i18n/xmb_serializer.ts
+++ b/modules/@angular/compiler/src/i18n/xmb_serializer.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Lexer as ExpressionLexer} from '@angular/compiler/src/expression_parser/lexer';
-import {Parser as ExpressionParser} from '@angular/compiler/src/expression_parser/parser';
-
 import {RegExpWrapper, isBlank, isPresent} from '../facade/lang';
 import {HtmlAst, HtmlElementAst} from '../html_ast';
 import {HtmlParser} from '../html_parser';
@@ -37,9 +34,7 @@ export class XmbDeserializationError extends ParseError {
 }
 
 export function deserializeXmb(content: string, url: string): XmbDeserializationResult {
-  const expLexer = new ExpressionLexer();
-  const expParser = new ExpressionParser(expLexer);
-  const parser = new HtmlParser(expParser);
+  const parser = new HtmlParser();
   const normalizedContent = _expandPlaceholder(content.trim());
   const parsed = parser.parse(normalizedContent, url);
 

--- a/modules/@angular/compiler/src/interpolation_config.ts
+++ b/modules/@angular/compiler/src/interpolation_config.ts
@@ -6,12 +6,22 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export interface InterpolationConfig {
-  start: string;
-  end: string;
+import {assertInterpolationSymbols} from './assertions';
+import {isBlank} from './facade/lang';
+
+export class InterpolationConfig {
+  static fromArray(markers: [string, string]): InterpolationConfig {
+    if (isBlank(markers)) {
+      // TODO:bad ??
+      return DEFAULT_INTERPOLATION_CONFIG;
+    }
+
+    assertInterpolationSymbols('interpolation', markers);
+    return new InterpolationConfig(markers[0], markers[1]);
+  }
+
+  constructor(public start: string, public end: string){};
 }
 
-export const DEFAULT_INTERPOLATION_CONFIG: InterpolationConfig = {
-  start: '{{',
-  end: '}}'
-};
+export const DEFAULT_INTERPOLATION_CONFIG: InterpolationConfig =
+    new InterpolationConfig('{{', '}}');

--- a/modules/@angular/compiler/src/interpolation_config.ts
+++ b/modules/@angular/compiler/src/interpolation_config.ts
@@ -11,8 +11,7 @@ import {isBlank} from './facade/lang';
 
 export class InterpolationConfig {
   static fromArray(markers: [string, string]): InterpolationConfig {
-    if (isBlank(markers)) {
-      // TODO:bad ??
+    if (!markers) {
       return DEFAULT_INTERPOLATION_CONFIG;
     }
 

--- a/modules/@angular/compiler/src/metadata_resolver.ts
+++ b/modules/@angular/compiler/src/metadata_resolver.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AnimationAnimateMetadata, AnimationEntryMetadata, AnimationGroupMetadata, AnimationKeyframesSequenceMetadata, AnimationMetadata, AnimationStateDeclarationMetadata, AnimationStateMetadata, AnimationStateTransitionMetadata, AnimationStyleMetadata, AnimationWithStepsMetadata, AppModuleMetadata, AttributeMetadata, ComponentMetadata, HostMetadata, Inject, InjectMetadata, Injectable, Optional, OptionalMetadata, Provider, QueryMetadata, SelfMetadata, SkipSelfMetadata, ViewMetadata, ViewQueryMetadata, resolveForwardRef} from '@angular/core';
+import {AnimationAnimateMetadata, AnimationEntryMetadata, AnimationGroupMetadata, AnimationKeyframesSequenceMetadata, AnimationMetadata, AnimationStateDeclarationMetadata, AnimationStateMetadata, AnimationStateTransitionMetadata, AnimationStyleMetadata, AnimationWithStepsMetadata, AppModuleMetadata, AttributeMetadata, ChangeDetectionStrategy, ComponentMetadata, HostMetadata, Inject, InjectMetadata, Injectable, Optional, OptionalMetadata, Provider, QueryMetadata, SelfMetadata, SkipSelfMetadata, ViewMetadata, ViewQueryMetadata, resolveForwardRef} from '@angular/core';
 
 import {LIFECYCLE_HOOKS_VALUES, ReflectorReader, createProvider, isProviderLiteral, reflector} from '../core_private';
 import {StringMapWrapper} from '../src/facade/collection';

--- a/modules/@angular/compiler/src/metadata_resolver.ts
+++ b/modules/@angular/compiler/src/metadata_resolver.ts
@@ -111,8 +111,8 @@ export class CompileMetadataResolver {
     if (isBlank(meta)) {
       var dirMeta = this._directiveResolver.resolve(directiveType);
       var templateMeta: cpl.CompileTemplateMetadata = null;
-      var changeDetectionStrategy: any /** TODO #9100 */ = null;
-      var viewProviders: any[] /** TODO #9100 */ = [];
+      var changeDetectionStrategy: ChangeDetectionStrategy = null;
+      var viewProviders: Array<cpl.CompileProviderMetadata|cpl.CompileTypeMetadata|any[]> = [];
       var moduleUrl = staticTypeModuleUrl(directiveType);
       var precompileTypes: cpl.CompileTypeMetadata[] = [];
       if (dirMeta instanceof ComponentMetadata) {
@@ -147,7 +147,7 @@ export class CompileMetadataResolver {
         }
       }
 
-      var providers: any[] /** TODO #9100 */ = [];
+      var providers: Array<cpl.CompileProviderMetadata|cpl.CompileTypeMetadata|any[]> = [];
       if (isPresent(dirMeta.providers)) {
         providers = this.getProvidersMetadata(
             verifyNonBlankProviders(directiveType, dirMeta.providers, 'providers'),
@@ -492,14 +492,13 @@ export class CompileMetadataResolver {
   getQueriesMetadata(
       queries: {[key: string]: QueryMetadata}, isViewQuery: boolean,
       directiveType: Type): cpl.CompileQueryMetadata[] {
-    var compileQueries: any[] /** TODO #9100 */ = [];
-    StringMapWrapper.forEach(
-        queries, (query: any /** TODO #9100 */, propertyName: any /** TODO #9100 */) => {
-          if (query.isViewQuery === isViewQuery) {
-            compileQueries.push(this.getQueryMetadata(query, propertyName, directiveType));
-          }
-        });
-    return compileQueries;
+    var res: cpl.CompileQueryMetadata[] = [];
+    StringMapWrapper.forEach(queries, (query: QueryMetadata, propertyName: string) => {
+      if (query.isViewQuery === isViewQuery) {
+        res.push(this.getQueryMetadata(query, propertyName, directiveType));
+      }
+    });
+    return res;
   }
 
   getQueryMetadata(q: QueryMetadata, propertyName: string, typeOrFunc: Type|Function):

--- a/modules/@angular/compiler/src/template_parser.ts
+++ b/modules/@angular/compiler/src/template_parser.ts
@@ -101,7 +101,6 @@ export class TemplateParser {
   tryParse(
       component: CompileDirectiveMetadata, template: string, directives: CompileDirectiveMetadata[],
       pipes: CompilePipeMetadata[], templateUrl: string): TemplateParseResult {
-    // TODO: bad ???
     let interpolationConfig: any;
     if (component.template) {
       interpolationConfig = InterpolationConfig.fromArray(component.template.interpolation);

--- a/modules/@angular/compiler/test/expander_spec.ts
+++ b/modules/@angular/compiler/test/expander_spec.ts
@@ -6,12 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HtmlAttrAst, HtmlElementAst, HtmlTextAst} from '@angular/compiler/src/html_ast';
-import {HtmlParser} from '@angular/compiler/src/html_parser';
-import {ExpansionResult, expandNodes} from '@angular/compiler/src/i18n/expander';
-import {ParseError} from '@angular/compiler/src/parse_util';
-import {humanizeNodes} from '@angular/compiler/test/html_ast_spec_utils';
-import {ddescribe, describe, expect, iit, it} from '@angular/core/testing/testing_internal';
+import {ddescribe, describe, expect, iit, it} from '../../core/testing/testing_internal';
+import {ExpansionResult, expandNodes} from '../src/expander';
+import {HtmlAttrAst, HtmlElementAst, HtmlTextAst} from '../src/html_ast';
+import {HtmlParser} from '../src/html_parser';
+import {ParseError} from '../src/parse_util';
+
+import {humanizeNodes} from './html_ast_spec_utils';
 
 export function main() {
   describe('Expander', () => {

--- a/modules/@angular/compiler/test/expression_parser/lexer_spec.ts
+++ b/modules/@angular/compiler/test/expression_parser/lexer_spec.ts
@@ -8,47 +8,45 @@
 
 import {Lexer, Token} from '@angular/compiler/src/expression_parser/lexer';
 
-import {StringWrapper} from '../../src/facade/lang';
-
 function lex(text: string): any[] {
   return new Lexer().tokenize(text);
 }
 
-function expectToken(token: any, index: any) {
+function expectToken(token: any, index: number) {
   expect(token instanceof Token).toBe(true);
   expect(token.index).toEqual(index);
 }
 
-function expectCharacterToken(token: any, index: any, character: any) {
+function expectCharacterToken(token: any, index: number, character: string) {
   expect(character.length).toBe(1);
   expectToken(token, index);
-  expect(token.isCharacter(StringWrapper.charCodeAt(character, 0))).toBe(true);
+  expect(token.isCharacter(character.charCodeAt(0))).toBe(true);
 }
 
-function expectOperatorToken(token: any, index: any, operator: any) {
+function expectOperatorToken(token: any, index: number, operator: string) {
   expectToken(token, index);
   expect(token.isOperator(operator)).toBe(true);
 }
 
-function expectNumberToken(token: any, index: any, n: any) {
+function expectNumberToken(token: any, index: number, n: number) {
   expectToken(token, index);
   expect(token.isNumber()).toBe(true);
   expect(token.toNumber()).toEqual(n);
 }
 
-function expectStringToken(token: any, index: any, str: any) {
+function expectStringToken(token: any, index: number, str: string) {
   expectToken(token, index);
   expect(token.isString()).toBe(true);
   expect(token.toString()).toEqual(str);
 }
 
-function expectIdentifierToken(token: any, index: any, identifier: any) {
+function expectIdentifierToken(token: any, index: number, identifier: string) {
   expectToken(token, index);
   expect(token.isIdentifier()).toBe(true);
   expect(token.toString()).toEqual(identifier);
 }
 
-function expectKeywordToken(token: any, index: any, keyword: any) {
+function expectKeywordToken(token: any, index: number, keyword: string) {
   expectToken(token, index);
   expect(token.isKeyword()).toBe(true);
   expect(token.toString()).toEqual(keyword);
@@ -212,12 +210,6 @@ export function main() {
         var tokens: Token[] = lex('0.5');
         expectNumberToken(tokens[0], 0, 0.5);
       });
-
-      // NOTE(deboer): NOT A LEXER TEST
-      //    it('should tokenize negative number', () => {
-      //      var tokens:Token[] = lex("-0.5");
-      //      expectNumberToken(tokens[0], 0, -0.5);
-      //    });
 
       it('should tokenize number with exponent', function() {
         var tokens: Token[] = lex('0.5E-10');

--- a/modules/@angular/compiler/test/html_lexer_spec.ts
+++ b/modules/@angular/compiler/test/html_lexer_spec.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Lexer as ExpressionLexer} from '@angular/compiler/src/expression_parser/lexer';
-import {Parser as ExpressionParser} from '@angular/compiler/src/expression_parser/parser';
 import {HtmlToken, HtmlTokenError, HtmlTokenType, tokenizeHtml} from '@angular/compiler/src/html_lexer';
 import {InterpolationConfig} from '@angular/compiler/src/interpolation_config';
 import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '@angular/compiler/src/parse_util';
@@ -18,33 +16,41 @@ export function main() {
     describe('line/column numbers', () => {
       it('should work without newlines', () => {
         expect(tokenizeAndHumanizeLineColumn('<t>a</t>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, '0:0'], [HtmlTokenType.TAG_OPEN_END, '0:2'],
-          [HtmlTokenType.TEXT, '0:3'], [HtmlTokenType.TAG_CLOSE, '0:4'],
-          [HtmlTokenType.EOF, '0:8']
+          [HtmlTokenType.TAG_OPEN_START, '0:0'],
+          [HtmlTokenType.TAG_OPEN_END, '0:2'],
+          [HtmlTokenType.TEXT, '0:3'],
+          [HtmlTokenType.TAG_CLOSE, '0:4'],
+          [HtmlTokenType.EOF, '0:8'],
         ]);
       });
 
       it('should work with one newline', () => {
         expect(tokenizeAndHumanizeLineColumn('<t>\na</t>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, '0:0'], [HtmlTokenType.TAG_OPEN_END, '0:2'],
-          [HtmlTokenType.TEXT, '0:3'], [HtmlTokenType.TAG_CLOSE, '1:1'],
-          [HtmlTokenType.EOF, '1:5']
+          [HtmlTokenType.TAG_OPEN_START, '0:0'],
+          [HtmlTokenType.TAG_OPEN_END, '0:2'],
+          [HtmlTokenType.TEXT, '0:3'],
+          [HtmlTokenType.TAG_CLOSE, '1:1'],
+          [HtmlTokenType.EOF, '1:5'],
         ]);
       });
 
       it('should work with multiple newlines', () => {
         expect(tokenizeAndHumanizeLineColumn('<t\n>\na</t>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, '0:0'], [HtmlTokenType.TAG_OPEN_END, '1:0'],
-          [HtmlTokenType.TEXT, '1:1'], [HtmlTokenType.TAG_CLOSE, '2:1'],
-          [HtmlTokenType.EOF, '2:5']
+          [HtmlTokenType.TAG_OPEN_START, '0:0'],
+          [HtmlTokenType.TAG_OPEN_END, '1:0'],
+          [HtmlTokenType.TEXT, '1:1'],
+          [HtmlTokenType.TAG_CLOSE, '2:1'],
+          [HtmlTokenType.EOF, '2:5'],
         ]);
       });
 
       it('should work with CR and LF', () => {
         expect(tokenizeAndHumanizeLineColumn('<t\n>\r\na\r</t>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, '0:0'], [HtmlTokenType.TAG_OPEN_END, '1:0'],
-          [HtmlTokenType.TEXT, '1:1'], [HtmlTokenType.TAG_CLOSE, '2:1'],
-          [HtmlTokenType.EOF, '2:5']
+          [HtmlTokenType.TAG_OPEN_START, '0:0'],
+          [HtmlTokenType.TAG_OPEN_END, '1:0'],
+          [HtmlTokenType.TEXT, '1:1'],
+          [HtmlTokenType.TAG_CLOSE, '2:1'],
+          [HtmlTokenType.EOF, '2:5'],
         ]);
       });
     });
@@ -52,15 +58,19 @@ export function main() {
     describe('comments', () => {
       it('should parse comments', () => {
         expect(tokenizeAndHumanizeParts('<!--t\ne\rs\r\nt-->')).toEqual([
-          [HtmlTokenType.COMMENT_START], [HtmlTokenType.RAW_TEXT, 't\ne\ns\nt'],
-          [HtmlTokenType.COMMENT_END], [HtmlTokenType.EOF]
+          [HtmlTokenType.COMMENT_START],
+          [HtmlTokenType.RAW_TEXT, 't\ne\ns\nt'],
+          [HtmlTokenType.COMMENT_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should store the locations',
          () => {expect(tokenizeAndHumanizeSourceSpans('<!--t\ne\rs\r\nt-->')).toEqual([
-           [HtmlTokenType.COMMENT_START, '<!--'], [HtmlTokenType.RAW_TEXT, 't\ne\rs\r\nt'],
-           [HtmlTokenType.COMMENT_END, '-->'], [HtmlTokenType.EOF, '']
+           [HtmlTokenType.COMMENT_START, '<!--'],
+           [HtmlTokenType.RAW_TEXT, 't\ne\rs\r\nt'],
+           [HtmlTokenType.COMMENT_END, '-->'],
+           [HtmlTokenType.EOF, ''],
          ])});
 
       it('should report <!- without -', () => {
@@ -77,15 +87,19 @@ export function main() {
 
       it('should accept comments finishing by too many dashes (even number)', () => {
         expect(tokenizeAndHumanizeSourceSpans('<!-- test ---->')).toEqual([
-          [HtmlTokenType.COMMENT_START, '<!--'], [HtmlTokenType.RAW_TEXT, ' test --'],
-          [HtmlTokenType.COMMENT_END, '-->'], [HtmlTokenType.EOF, '']
+          [HtmlTokenType.COMMENT_START, '<!--'],
+          [HtmlTokenType.RAW_TEXT, ' test --'],
+          [HtmlTokenType.COMMENT_END, '-->'],
+          [HtmlTokenType.EOF, ''],
         ]);
       });
 
       it('should accept comments finishing by too many dashes (odd number)', () => {
         expect(tokenizeAndHumanizeSourceSpans('<!-- test --->')).toEqual([
-          [HtmlTokenType.COMMENT_START, '<!--'], [HtmlTokenType.RAW_TEXT, ' test -'],
-          [HtmlTokenType.COMMENT_END, '-->'], [HtmlTokenType.EOF, '']
+          [HtmlTokenType.COMMENT_START, '<!--'],
+          [HtmlTokenType.RAW_TEXT, ' test -'],
+          [HtmlTokenType.COMMENT_END, '-->'],
+          [HtmlTokenType.EOF, ''],
         ]);
       });
     });
@@ -93,13 +107,15 @@ export function main() {
     describe('doctype', () => {
       it('should parse doctypes', () => {
         expect(tokenizeAndHumanizeParts('<!doctype html>')).toEqual([
-          [HtmlTokenType.DOC_TYPE, 'doctype html'], [HtmlTokenType.EOF]
+          [HtmlTokenType.DOC_TYPE, 'doctype html'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should store the locations', () => {
         expect(tokenizeAndHumanizeSourceSpans('<!doctype html>')).toEqual([
-          [HtmlTokenType.DOC_TYPE, '<!doctype html>'], [HtmlTokenType.EOF, '']
+          [HtmlTokenType.DOC_TYPE, '<!doctype html>'],
+          [HtmlTokenType.EOF, ''],
         ]);
       });
 
@@ -113,15 +129,19 @@ export function main() {
     describe('CDATA', () => {
       it('should parse CDATA', () => {
         expect(tokenizeAndHumanizeParts('<![CDATA[t\ne\rs\r\nt]]>')).toEqual([
-          [HtmlTokenType.CDATA_START], [HtmlTokenType.RAW_TEXT, 't\ne\ns\nt'],
-          [HtmlTokenType.CDATA_END], [HtmlTokenType.EOF]
+          [HtmlTokenType.CDATA_START],
+          [HtmlTokenType.RAW_TEXT, 't\ne\ns\nt'],
+          [HtmlTokenType.CDATA_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should store the locations', () => {
         expect(tokenizeAndHumanizeSourceSpans('<![CDATA[t\ne\rs\r\nt]]>')).toEqual([
-          [HtmlTokenType.CDATA_START, '<![CDATA['], [HtmlTokenType.RAW_TEXT, 't\ne\rs\r\nt'],
-          [HtmlTokenType.CDATA_END, ']]>'], [HtmlTokenType.EOF, '']
+          [HtmlTokenType.CDATA_START, '<![CDATA['],
+          [HtmlTokenType.RAW_TEXT, 't\ne\rs\r\nt'],
+          [HtmlTokenType.CDATA_END, ']]>'],
+          [HtmlTokenType.EOF, ''],
         ]);
       });
 
@@ -141,36 +161,41 @@ export function main() {
     describe('open tags', () => {
       it('should parse open tags without prefix', () => {
         expect(tokenizeAndHumanizeParts('<test>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 'test'], [HtmlTokenType.TAG_OPEN_END],
-          [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 'test'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse namespace prefix', () => {
         expect(tokenizeAndHumanizeParts('<ns1:test>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, 'ns1', 'test'], [HtmlTokenType.TAG_OPEN_END],
-          [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, 'ns1', 'test'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse void tags', () => {
         expect(tokenizeAndHumanizeParts('<test/>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 'test'], [HtmlTokenType.TAG_OPEN_END_VOID],
-          [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 'test'],
+          [HtmlTokenType.TAG_OPEN_END_VOID],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should allow whitespace after the tag name', () => {
         expect(tokenizeAndHumanizeParts('<test >')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 'test'], [HtmlTokenType.TAG_OPEN_END],
-          [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 'test'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should store the locations', () => {
         expect(tokenizeAndHumanizeSourceSpans('<test>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, '<test'], [HtmlTokenType.TAG_OPEN_END, '>'],
-          [HtmlTokenType.EOF, '']
+          [HtmlTokenType.TAG_OPEN_START, '<test'],
+          [HtmlTokenType.TAG_OPEN_END, '>'],
+          [HtmlTokenType.EOF, ''],
         ]);
       });
 
@@ -179,88 +204,134 @@ export function main() {
     describe('attributes', () => {
       it('should parse attributes without prefix', () => {
         expect(tokenizeAndHumanizeParts('<t a>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 't'], [HtmlTokenType.ATTR_NAME, null, 'a'],
-          [HtmlTokenType.TAG_OPEN_END], [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 't'],
+          [HtmlTokenType.ATTR_NAME, null, 'a'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
+        ]);
+      });
+
+      it('should parse attributes with interpolation', () => {
+        expect(tokenizeAndHumanizeParts('<t a="{{v}}" b="s{{m}}e" c="s{{m//c}}e">')).toEqual([
+          [HtmlTokenType.TAG_OPEN_START, null, 't'],
+          [HtmlTokenType.ATTR_NAME, null, 'a'],
+          [HtmlTokenType.ATTR_VALUE, '{{v}}'],
+          [HtmlTokenType.ATTR_NAME, null, 'b'],
+          [HtmlTokenType.ATTR_VALUE, 's{{m}}e'],
+          [HtmlTokenType.ATTR_NAME, null, 'c'],
+          [HtmlTokenType.ATTR_VALUE, 's{{m//c}}e'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse attributes with prefix', () => {
         expect(tokenizeAndHumanizeParts('<t ns1:a>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 't'], [HtmlTokenType.ATTR_NAME, 'ns1', 'a'],
-          [HtmlTokenType.TAG_OPEN_END], [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 't'],
+          [HtmlTokenType.ATTR_NAME, 'ns1', 'a'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse attributes whose prefix is not valid', () => {
         expect(tokenizeAndHumanizeParts('<t (ns1:a)>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 't'], [HtmlTokenType.ATTR_NAME, null, '(ns1:a)'],
-          [HtmlTokenType.TAG_OPEN_END], [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 't'],
+          [HtmlTokenType.ATTR_NAME, null, '(ns1:a)'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse attributes with single quote value', () => {
         expect(tokenizeAndHumanizeParts('<t a=\'b\'>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 't'], [HtmlTokenType.ATTR_NAME, null, 'a'],
-          [HtmlTokenType.ATTR_VALUE, 'b'], [HtmlTokenType.TAG_OPEN_END], [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 't'],
+          [HtmlTokenType.ATTR_NAME, null, 'a'],
+          [HtmlTokenType.ATTR_VALUE, 'b'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse attributes with double quote value', () => {
         expect(tokenizeAndHumanizeParts('<t a="b">')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 't'], [HtmlTokenType.ATTR_NAME, null, 'a'],
-          [HtmlTokenType.ATTR_VALUE, 'b'], [HtmlTokenType.TAG_OPEN_END], [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 't'],
+          [HtmlTokenType.ATTR_NAME, null, 'a'],
+          [HtmlTokenType.ATTR_VALUE, 'b'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse attributes with unquoted value', () => {
         expect(tokenizeAndHumanizeParts('<t a=b>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 't'], [HtmlTokenType.ATTR_NAME, null, 'a'],
-          [HtmlTokenType.ATTR_VALUE, 'b'], [HtmlTokenType.TAG_OPEN_END], [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 't'],
+          [HtmlTokenType.ATTR_NAME, null, 'a'],
+          [HtmlTokenType.ATTR_VALUE, 'b'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should allow whitespace', () => {
         expect(tokenizeAndHumanizeParts('<t a = b >')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 't'], [HtmlTokenType.ATTR_NAME, null, 'a'],
-          [HtmlTokenType.ATTR_VALUE, 'b'], [HtmlTokenType.TAG_OPEN_END], [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 't'],
+          [HtmlTokenType.ATTR_NAME, null, 'a'],
+          [HtmlTokenType.ATTR_VALUE, 'b'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse attributes with entities in values', () => {
         expect(tokenizeAndHumanizeParts('<t a="&#65;&#x41;">')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 't'], [HtmlTokenType.ATTR_NAME, null, 'a'],
-          [HtmlTokenType.ATTR_VALUE, 'AA'], [HtmlTokenType.TAG_OPEN_END], [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 't'],
+          [HtmlTokenType.ATTR_NAME, null, 'a'],
+          [HtmlTokenType.ATTR_VALUE, 'AA'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should not decode entities without trailing ";"', () => {
         expect(tokenizeAndHumanizeParts('<t a="&amp" b="c&&d">')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 't'], [HtmlTokenType.ATTR_NAME, null, 'a'],
-          [HtmlTokenType.ATTR_VALUE, '&amp'], [HtmlTokenType.ATTR_NAME, null, 'b'],
-          [HtmlTokenType.ATTR_VALUE, 'c&&d'], [HtmlTokenType.TAG_OPEN_END], [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 't'],
+          [HtmlTokenType.ATTR_NAME, null, 'a'],
+          [HtmlTokenType.ATTR_VALUE, '&amp'],
+          [HtmlTokenType.ATTR_NAME, null, 'b'],
+          [HtmlTokenType.ATTR_VALUE, 'c&&d'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse attributes with "&" in values', () => {
         expect(tokenizeAndHumanizeParts('<t a="b && c &">')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 't'], [HtmlTokenType.ATTR_NAME, null, 'a'],
-          [HtmlTokenType.ATTR_VALUE, 'b && c &'], [HtmlTokenType.TAG_OPEN_END], [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 't'],
+          [HtmlTokenType.ATTR_NAME, null, 'a'],
+          [HtmlTokenType.ATTR_VALUE, 'b && c &'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse values with CR and LF', () => {
         expect(tokenizeAndHumanizeParts('<t a=\'t\ne\rs\r\nt\'>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 't'], [HtmlTokenType.ATTR_NAME, null, 'a'],
-          [HtmlTokenType.ATTR_VALUE, 't\ne\ns\nt'], [HtmlTokenType.TAG_OPEN_END],
-          [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 't'],
+          [HtmlTokenType.ATTR_NAME, null, 'a'],
+          [HtmlTokenType.ATTR_VALUE, 't\ne\ns\nt'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should store the locations', () => {
         expect(tokenizeAndHumanizeSourceSpans('<t a=b>')).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, '<t'], [HtmlTokenType.ATTR_NAME, 'a'],
-          [HtmlTokenType.ATTR_VALUE, 'b'], [HtmlTokenType.TAG_OPEN_END, '>'],
-          [HtmlTokenType.EOF, '']
+          [HtmlTokenType.TAG_OPEN_START, '<t'],
+          [HtmlTokenType.ATTR_NAME, 'a'],
+          [HtmlTokenType.ATTR_VALUE, 'b'],
+          [HtmlTokenType.TAG_OPEN_END, '>'],
+          [HtmlTokenType.EOF, ''],
         ]);
       });
 
@@ -269,25 +340,29 @@ export function main() {
     describe('closing tags', () => {
       it('should parse closing tags without prefix', () => {
         expect(tokenizeAndHumanizeParts('</test>')).toEqual([
-          [HtmlTokenType.TAG_CLOSE, null, 'test'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_CLOSE, null, 'test'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse closing tags with prefix', () => {
         expect(tokenizeAndHumanizeParts('</ns1:test>')).toEqual([
-          [HtmlTokenType.TAG_CLOSE, 'ns1', 'test'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_CLOSE, 'ns1', 'test'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should allow whitespace', () => {
         expect(tokenizeAndHumanizeParts('</ test >')).toEqual([
-          [HtmlTokenType.TAG_CLOSE, null, 'test'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_CLOSE, null, 'test'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should store the locations', () => {
         expect(tokenizeAndHumanizeSourceSpans('</test>')).toEqual([
-          [HtmlTokenType.TAG_CLOSE, '</test>'], [HtmlTokenType.EOF, '']
+          [HtmlTokenType.TAG_CLOSE, '</test>'],
+          [HtmlTokenType.EOF, ''],
         ]);
       });
 
@@ -307,25 +382,29 @@ export function main() {
     describe('entities', () => {
       it('should parse named entities', () => {
         expect(tokenizeAndHumanizeParts('a&amp;b')).toEqual([
-          [HtmlTokenType.TEXT, 'a&b'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TEXT, 'a&b'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse hexadecimal entities', () => {
         expect(tokenizeAndHumanizeParts('&#x41;&#X41;')).toEqual([
-          [HtmlTokenType.TEXT, 'AA'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TEXT, 'AA'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse decimal entities', () => {
         expect(tokenizeAndHumanizeParts('&#65;')).toEqual([
-          [HtmlTokenType.TEXT, 'A'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TEXT, 'A'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should store the locations', () => {
         expect(tokenizeAndHumanizeSourceSpans('a&amp;b')).toEqual([
-          [HtmlTokenType.TEXT, 'a&amp;b'], [HtmlTokenType.EOF, '']
+          [HtmlTokenType.TEXT, 'a&amp;b'],
+          [HtmlTokenType.EOF, ''],
         ]);
       });
 
@@ -350,55 +429,57 @@ export function main() {
     describe('regular text', () => {
       it('should parse text', () => {
         expect(tokenizeAndHumanizeParts('a')).toEqual([
-          [HtmlTokenType.TEXT, 'a'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TEXT, 'a'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse interpolation', () => {
-        expect(tokenizeAndHumanizeParts('{{ a }}')).toEqual([
-          [HtmlTokenType.TEXT, '{{ a }}'], [HtmlTokenType.EOF]
-        ]);
-      });
-
-      it('should detect interpolation end', () => {
-        expect(tokenizeAndHumanizeParts('{{value|filter:{params: {strict: true}}}}')).toEqual([
-          [HtmlTokenType.TEXT, '{{ a }}'], [HtmlTokenType.EOF]
+        expect(tokenizeAndHumanizeParts('{{ a }}b{{ c // comment }}')).toEqual([
+          [HtmlTokenType.TEXT, '{{ a }}b{{ c // comment }}'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse interpolation with custom markers', () => {
         expect(tokenizeAndHumanizeParts('{% a %}', null, {start: '{%', end: '%}'})).toEqual([
-          [HtmlTokenType.TEXT, '{% a %}'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TEXT, '{% a %}'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should handle CR & LF', () => {
         expect(tokenizeAndHumanizeParts('t\ne\rs\r\nt')).toEqual([
-          [HtmlTokenType.TEXT, 't\ne\ns\nt'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TEXT, 't\ne\ns\nt'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse entities', () => {
         expect(tokenizeAndHumanizeParts('a&amp;b')).toEqual([
-          [HtmlTokenType.TEXT, 'a&b'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TEXT, 'a&b'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse text starting with "&"', () => {
         expect(tokenizeAndHumanizeParts('a && b &')).toEqual([
-          [HtmlTokenType.TEXT, 'a && b &'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TEXT, 'a && b &'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should store the locations', () => {
         expect(tokenizeAndHumanizeSourceSpans('a')).toEqual([
-          [HtmlTokenType.TEXT, 'a'], [HtmlTokenType.EOF, '']
+          [HtmlTokenType.TEXT, 'a'],
+          [HtmlTokenType.EOF, ''],
         ]);
       });
 
       it('should allow "<" in text nodes', () => {
         expect(tokenizeAndHumanizeParts('{{ a < b ? c : d }}')).toEqual([
-          [HtmlTokenType.TEXT, '{{ a < b ? c : d }}'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TEXT, '{{ a < b ? c : d }}'],
+          [HtmlTokenType.EOF],
         ]);
 
         expect(tokenizeAndHumanizeSourceSpans('<p>a<b</p>')).toEqual([
@@ -410,103 +491,124 @@ export function main() {
         ]);
 
         expect(tokenizeAndHumanizeParts('< a>')).toEqual([
-          [HtmlTokenType.TEXT, '< a>'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TEXT, '< a>'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
-      // TODO(vicb): make the lexer aware of Angular expressions
-      // see https://github.com/angular/angular/issues/5679
       it('should parse valid start tag in interpolation', () => {
         expect(tokenizeAndHumanizeParts('{{ a <b && c > d }}')).toEqual([
-          [HtmlTokenType.TEXT, '{{ a '], [HtmlTokenType.TAG_OPEN_START, null, 'b'],
-          [HtmlTokenType.ATTR_NAME, null, '&&'], [HtmlTokenType.ATTR_NAME, null, 'c'],
-          [HtmlTokenType.TAG_OPEN_END], [HtmlTokenType.TEXT, ' d }}'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TEXT, '{{ a '],
+          [HtmlTokenType.TAG_OPEN_START, null, 'b'],
+          [HtmlTokenType.ATTR_NAME, null, '&&'],
+          [HtmlTokenType.ATTR_NAME, null, 'c'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.TEXT, ' d }}'],
+          [HtmlTokenType.EOF],
         ]);
       });
-
     });
 
     describe('raw text', () => {
       it('should parse text', () => {
         expect(tokenizeAndHumanizeParts(`<script>t\ne\rs\r\nt</script>`)).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 'script'], [HtmlTokenType.TAG_OPEN_END],
-          [HtmlTokenType.RAW_TEXT, 't\ne\ns\nt'], [HtmlTokenType.TAG_CLOSE, null, 'script'],
-          [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 'script'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.RAW_TEXT, 't\ne\ns\nt'],
+          [HtmlTokenType.TAG_CLOSE, null, 'script'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should not detect entities', () => {
         expect(tokenizeAndHumanizeParts(`<script>&amp;</SCRIPT>`)).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 'script'], [HtmlTokenType.TAG_OPEN_END],
-          [HtmlTokenType.RAW_TEXT, '&amp;'], [HtmlTokenType.TAG_CLOSE, null, 'script'],
-          [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 'script'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.RAW_TEXT, '&amp;'],
+          [HtmlTokenType.TAG_CLOSE, null, 'script'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should ignore other opening tags', () => {
         expect(tokenizeAndHumanizeParts(`<script>a<div></script>`)).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 'script'], [HtmlTokenType.TAG_OPEN_END],
-          [HtmlTokenType.RAW_TEXT, 'a<div>'], [HtmlTokenType.TAG_CLOSE, null, 'script'],
-          [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 'script'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.RAW_TEXT, 'a<div>'],
+          [HtmlTokenType.TAG_CLOSE, null, 'script'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should ignore other closing tags', () => {
         expect(tokenizeAndHumanizeParts(`<script>a</test></script>`)).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 'script'], [HtmlTokenType.TAG_OPEN_END],
-          [HtmlTokenType.RAW_TEXT, 'a</test>'], [HtmlTokenType.TAG_CLOSE, null, 'script'],
-          [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 'script'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.RAW_TEXT, 'a</test>'],
+          [HtmlTokenType.TAG_CLOSE, null, 'script'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should store the locations', () => {
         expect(tokenizeAndHumanizeSourceSpans(`<script>a</script>`)).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, '<script'], [HtmlTokenType.TAG_OPEN_END, '>'],
-          [HtmlTokenType.RAW_TEXT, 'a'], [HtmlTokenType.TAG_CLOSE, '</script>'],
-          [HtmlTokenType.EOF, '']
+          [HtmlTokenType.TAG_OPEN_START, '<script'],
+          [HtmlTokenType.TAG_OPEN_END, '>'],
+          [HtmlTokenType.RAW_TEXT, 'a'],
+          [HtmlTokenType.TAG_CLOSE, '</script>'],
+          [HtmlTokenType.EOF, ''],
         ]);
       });
-
     });
 
     describe('escapable raw text', () => {
       it('should parse text', () => {
         expect(tokenizeAndHumanizeParts(`<title>t\ne\rs\r\nt</title>`)).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 'title'], [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.TAG_OPEN_START, null, 'title'],
+          [HtmlTokenType.TAG_OPEN_END],
           [HtmlTokenType.ESCAPABLE_RAW_TEXT, 't\ne\ns\nt'],
-          [HtmlTokenType.TAG_CLOSE, null, 'title'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_CLOSE, null, 'title'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should detect entities', () => {
         expect(tokenizeAndHumanizeParts(`<title>&amp;</title>`)).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 'title'], [HtmlTokenType.TAG_OPEN_END],
-          [HtmlTokenType.ESCAPABLE_RAW_TEXT, '&'], [HtmlTokenType.TAG_CLOSE, null, 'title'],
-          [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 'title'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.ESCAPABLE_RAW_TEXT, '&'],
+          [HtmlTokenType.TAG_CLOSE, null, 'title'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should ignore other opening tags', () => {
         expect(tokenizeAndHumanizeParts(`<title>a<div></title>`)).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 'title'], [HtmlTokenType.TAG_OPEN_END],
-          [HtmlTokenType.ESCAPABLE_RAW_TEXT, 'a<div>'], [HtmlTokenType.TAG_CLOSE, null, 'title'],
-          [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 'title'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.ESCAPABLE_RAW_TEXT, 'a<div>'],
+          [HtmlTokenType.TAG_CLOSE, null, 'title'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should ignore other closing tags', () => {
         expect(tokenizeAndHumanizeParts(`<title>a</test></title>`)).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, null, 'title'], [HtmlTokenType.TAG_OPEN_END],
-          [HtmlTokenType.ESCAPABLE_RAW_TEXT, 'a</test>'], [HtmlTokenType.TAG_CLOSE, null, 'title'],
-          [HtmlTokenType.EOF]
+          [HtmlTokenType.TAG_OPEN_START, null, 'title'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.ESCAPABLE_RAW_TEXT, 'a</test>'],
+          [HtmlTokenType.TAG_CLOSE, null, 'title'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should store the locations', () => {
         expect(tokenizeAndHumanizeSourceSpans(`<title>a</title>`)).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, '<title'], [HtmlTokenType.TAG_OPEN_END, '>'],
-          [HtmlTokenType.ESCAPABLE_RAW_TEXT, 'a'], [HtmlTokenType.TAG_CLOSE, '</title>'],
-          [HtmlTokenType.EOF, '']
+          [HtmlTokenType.TAG_OPEN_START, '<title'],
+          [HtmlTokenType.TAG_OPEN_END, '>'],
+          [HtmlTokenType.ESCAPABLE_RAW_TEXT, 'a'],
+          [HtmlTokenType.TAG_CLOSE, '</title>'],
+          [HtmlTokenType.EOF, ''],
         ]);
       });
 
@@ -516,65 +618,94 @@ export function main() {
       it('should parse an expansion form', () => {
         expect(tokenizeAndHumanizeParts('{one.two, three, =4 {four} =5 {five} foo {bar} }', true))
             .toEqual([
-              [HtmlTokenType.EXPANSION_FORM_START], [HtmlTokenType.RAW_TEXT, 'one.two'],
-              [HtmlTokenType.RAW_TEXT, 'three'], [HtmlTokenType.EXPANSION_CASE_VALUE, '=4'],
-              [HtmlTokenType.EXPANSION_CASE_EXP_START], [HtmlTokenType.TEXT, 'four'],
-              [HtmlTokenType.EXPANSION_CASE_EXP_END], [HtmlTokenType.EXPANSION_CASE_VALUE, '=5'],
-              [HtmlTokenType.EXPANSION_CASE_EXP_START], [HtmlTokenType.TEXT, 'five'],
-              [HtmlTokenType.EXPANSION_CASE_EXP_END], [HtmlTokenType.EXPANSION_CASE_VALUE, 'foo'],
-              [HtmlTokenType.EXPANSION_CASE_EXP_START], [HtmlTokenType.TEXT, 'bar'],
-              [HtmlTokenType.EXPANSION_CASE_EXP_END], [HtmlTokenType.EXPANSION_FORM_END],
-              [HtmlTokenType.EOF]
+              [HtmlTokenType.EXPANSION_FORM_START],
+              [HtmlTokenType.RAW_TEXT, 'one.two'],
+              [HtmlTokenType.RAW_TEXT, 'three'],
+              [HtmlTokenType.EXPANSION_CASE_VALUE, '=4'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_START],
+              [HtmlTokenType.TEXT, 'four'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_END],
+              [HtmlTokenType.EXPANSION_CASE_VALUE, '=5'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_START],
+              [HtmlTokenType.TEXT, 'five'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_END],
+              [HtmlTokenType.EXPANSION_CASE_VALUE, 'foo'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_START],
+              [HtmlTokenType.TEXT, 'bar'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_END],
+              [HtmlTokenType.EXPANSION_FORM_END],
+              [HtmlTokenType.EOF],
             ]);
       });
 
       it('should parse an expansion form with text elements surrounding it', () => {
         expect(tokenizeAndHumanizeParts('before{one.two, three, =4 {four}}after', true)).toEqual([
-          [HtmlTokenType.TEXT, 'before'], [HtmlTokenType.EXPANSION_FORM_START],
-          [HtmlTokenType.RAW_TEXT, 'one.two'], [HtmlTokenType.RAW_TEXT, 'three'],
-          [HtmlTokenType.EXPANSION_CASE_VALUE, '=4'], [HtmlTokenType.EXPANSION_CASE_EXP_START],
-          [HtmlTokenType.TEXT, 'four'], [HtmlTokenType.EXPANSION_CASE_EXP_END],
-          [HtmlTokenType.EXPANSION_FORM_END], [HtmlTokenType.TEXT, 'after'], [HtmlTokenType.EOF]
+          [HtmlTokenType.TEXT, 'before'],
+          [HtmlTokenType.EXPANSION_FORM_START],
+          [HtmlTokenType.RAW_TEXT, 'one.two'],
+          [HtmlTokenType.RAW_TEXT, 'three'],
+          [HtmlTokenType.EXPANSION_CASE_VALUE, '=4'],
+          [HtmlTokenType.EXPANSION_CASE_EXP_START],
+          [HtmlTokenType.TEXT, 'four'],
+          [HtmlTokenType.EXPANSION_CASE_EXP_END],
+          [HtmlTokenType.EXPANSION_FORM_END],
+          [HtmlTokenType.TEXT, 'after'],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse an expansion forms with elements in it', () => {
         expect(tokenizeAndHumanizeParts('{one.two, three, =4 {four <b>a</b>}}', true)).toEqual([
-          [HtmlTokenType.EXPANSION_FORM_START], [HtmlTokenType.RAW_TEXT, 'one.two'],
-          [HtmlTokenType.RAW_TEXT, 'three'], [HtmlTokenType.EXPANSION_CASE_VALUE, '=4'],
-          [HtmlTokenType.EXPANSION_CASE_EXP_START], [HtmlTokenType.TEXT, 'four '],
-          [HtmlTokenType.TAG_OPEN_START, null, 'b'], [HtmlTokenType.TAG_OPEN_END],
-          [HtmlTokenType.TEXT, 'a'], [HtmlTokenType.TAG_CLOSE, null, 'b'],
-          [HtmlTokenType.EXPANSION_CASE_EXP_END], [HtmlTokenType.EXPANSION_FORM_END],
-          [HtmlTokenType.EOF]
+          [HtmlTokenType.EXPANSION_FORM_START],
+          [HtmlTokenType.RAW_TEXT, 'one.two'],
+          [HtmlTokenType.RAW_TEXT, 'three'],
+          [HtmlTokenType.EXPANSION_CASE_VALUE, '=4'],
+          [HtmlTokenType.EXPANSION_CASE_EXP_START],
+          [HtmlTokenType.TEXT, 'four '],
+          [HtmlTokenType.TAG_OPEN_START, null, 'b'],
+          [HtmlTokenType.TAG_OPEN_END],
+          [HtmlTokenType.TEXT, 'a'],
+          [HtmlTokenType.TAG_CLOSE, null, 'b'],
+          [HtmlTokenType.EXPANSION_CASE_EXP_END],
+          [HtmlTokenType.EXPANSION_FORM_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
-      it('should parse an expansion forms with interpolation in it', () => {
+      it('should parse an expansion forms containing an interpolation', () => {
         expect(tokenizeAndHumanizeParts('{one.two, three, =4 {four {{a}}}}', true)).toEqual([
-          [HtmlTokenType.EXPANSION_FORM_START], [HtmlTokenType.RAW_TEXT, 'one.two'],
-          [HtmlTokenType.RAW_TEXT, 'three'], [HtmlTokenType.EXPANSION_CASE_VALUE, '=4'],
-          [HtmlTokenType.EXPANSION_CASE_EXP_START], [HtmlTokenType.TEXT, 'four {{a}}'],
-          [HtmlTokenType.EXPANSION_CASE_EXP_END], [HtmlTokenType.EXPANSION_FORM_END],
-          [HtmlTokenType.EOF]
+          [HtmlTokenType.EXPANSION_FORM_START],
+          [HtmlTokenType.RAW_TEXT, 'one.two'],
+          [HtmlTokenType.RAW_TEXT, 'three'],
+          [HtmlTokenType.EXPANSION_CASE_VALUE, '=4'],
+          [HtmlTokenType.EXPANSION_CASE_EXP_START],
+          [HtmlTokenType.TEXT, 'four {{a}}'],
+          [HtmlTokenType.EXPANSION_CASE_EXP_END],
+          [HtmlTokenType.EXPANSION_FORM_END],
+          [HtmlTokenType.EOF],
         ]);
       });
 
       it('should parse nested expansion forms', () => {
         expect(tokenizeAndHumanizeParts(`{one.two, three, =4 { {xx, yy, =x {one}} }}`, true))
             .toEqual([
-              [HtmlTokenType.EXPANSION_FORM_START], [HtmlTokenType.RAW_TEXT, 'one.two'],
-              [HtmlTokenType.RAW_TEXT, 'three'], [HtmlTokenType.EXPANSION_CASE_VALUE, '=4'],
+              [HtmlTokenType.EXPANSION_FORM_START],
+              [HtmlTokenType.RAW_TEXT, 'one.two'],
+              [HtmlTokenType.RAW_TEXT, 'three'],
+              [HtmlTokenType.EXPANSION_CASE_VALUE, '=4'],
               [HtmlTokenType.EXPANSION_CASE_EXP_START],
-
-              [HtmlTokenType.EXPANSION_FORM_START], [HtmlTokenType.RAW_TEXT, 'xx'],
-              [HtmlTokenType.RAW_TEXT, 'yy'], [HtmlTokenType.EXPANSION_CASE_VALUE, '=x'],
-              [HtmlTokenType.EXPANSION_CASE_EXP_START], [HtmlTokenType.TEXT, 'one'],
-              [HtmlTokenType.EXPANSION_CASE_EXP_END], [HtmlTokenType.EXPANSION_FORM_END],
+              [HtmlTokenType.EXPANSION_FORM_START],
+              [HtmlTokenType.RAW_TEXT, 'xx'],
+              [HtmlTokenType.RAW_TEXT, 'yy'],
+              [HtmlTokenType.EXPANSION_CASE_VALUE, '=x'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_START],
+              [HtmlTokenType.TEXT, 'one'],
+              [HtmlTokenType.EXPANSION_CASE_EXP_END],
+              [HtmlTokenType.EXPANSION_FORM_END],
               [HtmlTokenType.TEXT, ' '],
-
-              [HtmlTokenType.EXPANSION_CASE_EXP_END], [HtmlTokenType.EXPANSION_FORM_END],
-              [HtmlTokenType.EOF]
+              [HtmlTokenType.EXPANSION_CASE_EXP_END],
+              [HtmlTokenType.EXPANSION_FORM_END],
+              [HtmlTokenType.EOF],
             ]);
       });
     });
@@ -594,8 +725,11 @@ export function main() {
     describe('unicode characters', () => {
       it('should support unicode characters', () => {
         expect(tokenizeAndHumanizeSourceSpans(`<p>İ</p>`)).toEqual([
-          [HtmlTokenType.TAG_OPEN_START, '<p'], [HtmlTokenType.TAG_OPEN_END, '>'],
-          [HtmlTokenType.TEXT, 'İ'], [HtmlTokenType.TAG_CLOSE, '</p>'], [HtmlTokenType.EOF, '']
+          [HtmlTokenType.TAG_OPEN_START, '<p'],
+          [HtmlTokenType.TAG_OPEN_END, '>'],
+          [HtmlTokenType.TEXT, 'İ'],
+          [HtmlTokenType.TAG_CLOSE, '</p>'],
+          [HtmlTokenType.EOF, ''],
         ]);
       });
     });
@@ -606,8 +740,7 @@ export function main() {
 function tokenizeWithoutErrors(
     input: string, tokenizeExpansionForms: boolean = false,
     interpolationConfig?: InterpolationConfig): HtmlToken[] {
-  var tokenizeResult = tokenizeHtml(
-      input, 'someUrl', _getExpressionParser(), tokenizeExpansionForms, interpolationConfig);
+  var tokenizeResult = tokenizeHtml(input, 'someUrl', tokenizeExpansionForms, interpolationConfig);
 
   if (tokenizeResult.errors.length > 0) {
     const errorString = tokenizeResult.errors.join('\n');
@@ -638,10 +771,6 @@ function tokenizeAndHumanizeLineColumn(input: string): any[] {
 }
 
 function tokenizeAndHumanizeErrors(input: string): any[] {
-  return tokenizeHtml(input, 'someUrl', _getExpressionParser())
+  return tokenizeHtml(input, 'someUrl')
       .errors.map(e => [<any>e.tokenType, e.msg, humanizeLineColumn(e.span.start)]);
-}
-
-function _getExpressionParser(): ExpressionParser {
-  return new ExpressionParser(new ExpressionLexer());
 }

--- a/modules/@angular/compiler/test/html_lexer_spec.ts
+++ b/modules/@angular/compiler/test/html_lexer_spec.ts
@@ -507,6 +507,22 @@ export function main() {
           [HtmlTokenType.EOF],
         ]);
       });
+
+      it('should be able to escape {', () => {
+        expect(tokenizeAndHumanizeParts('{{ "{" }}')).toEqual([
+          [HtmlTokenType.TEXT, '{{ "{" }}'],
+          [HtmlTokenType.EOF],
+        ]);
+      });
+
+      it('should be able to escape {{', () => {
+        expect(tokenizeAndHumanizeParts('{{ "{{" }}')).toEqual([
+          [HtmlTokenType.TEXT, '{{ "{{" }}'],
+          [HtmlTokenType.EOF],
+        ]);
+      });
+
+
     });
 
     describe('raw text', () => {

--- a/modules/@angular/compiler/test/html_parser_spec.ts
+++ b/modules/@angular/compiler/test/html_parser_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Lexer as ExpressionLexer} from '@angular/compiler/src/expression_parser/lexer';
+import {Parser as ExpressionParser} from '@angular/compiler/src/expression_parser/parser';
 import {HtmlAttrAst, HtmlCommentAst, HtmlElementAst, HtmlExpansionAst, HtmlExpansionCaseAst, HtmlTextAst} from '@angular/compiler/src/html_ast';
 import {HtmlTokenType} from '@angular/compiler/src/html_lexer';
 import {HtmlParseTreeResult, HtmlParser, HtmlTreeError} from '@angular/compiler/src/html_parser';
@@ -17,7 +19,14 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './html_as
 export function main() {
   describe('HtmlParser', () => {
     var parser: HtmlParser;
-    beforeEach(() => { parser = new HtmlParser(); });
+    var expLexer: ExpressionLexer;
+    var expParser: ExpressionParser;
+
+    beforeEach(() => {
+      expLexer = new ExpressionLexer();
+      expParser = new ExpressionParser(expLexer);
+      parser = new HtmlParser(expParser);
+    });
 
     describe('parse', () => {
       describe('text nodes', () => {
@@ -412,12 +421,12 @@ export function main() {
 }
 
 export function humanizeErrors(errors: ParseError[]): any[] {
-  return errors.map(error => {
-    if (error instanceof HtmlTreeError) {
+  return errors.map(e => {
+    if (e instanceof HtmlTreeError) {
       // Parser errors
-      return [<any>error.elementName, error.msg, humanizeLineColumn(error.span.start)];
+      return [<any>e.elementName, e.msg, humanizeLineColumn(e.span.start)];
     }
     // Tokenizer errors
-    return [(<any>error).tokenType, error.msg, humanizeLineColumn(error.span.start)];
+    return [(<any>e).tokenType, e.msg, humanizeLineColumn(e.span.start)];
   });
 }

--- a/modules/@angular/compiler/test/html_parser_spec.ts
+++ b/modules/@angular/compiler/test/html_parser_spec.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Lexer as ExpressionLexer} from '@angular/compiler/src/expression_parser/lexer';
-import {Parser as ExpressionParser} from '@angular/compiler/src/expression_parser/parser';
 import {HtmlAttrAst, HtmlCommentAst, HtmlElementAst, HtmlExpansionAst, HtmlExpansionCaseAst, HtmlTextAst} from '@angular/compiler/src/html_ast';
 import {HtmlTokenType} from '@angular/compiler/src/html_lexer';
 import {HtmlParseTreeResult, HtmlParser, HtmlTreeError} from '@angular/compiler/src/html_parser';
@@ -19,14 +17,8 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './html_as
 export function main() {
   describe('HtmlParser', () => {
     var parser: HtmlParser;
-    var expLexer: ExpressionLexer;
-    var expParser: ExpressionParser;
 
-    beforeEach(() => {
-      expLexer = new ExpressionLexer();
-      expParser = new ExpressionParser(expLexer);
-      parser = new HtmlParser(expParser);
-    });
+    beforeEach(() => { parser = new HtmlParser(); });
 
     describe('parse', () => {
       describe('text nodes', () => {

--- a/modules/@angular/compiler/test/i18n/expander_spec.ts
+++ b/modules/@angular/compiler/test/i18n/expander_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Lexer as ExpressionLexer} from '@angular/compiler/src/expression_parser/lexer';
+import {Parser as ExpressionParser} from '@angular/compiler/src/expression_parser/parser';
 import {HtmlAttrAst, HtmlElementAst, HtmlTextAst} from '@angular/compiler/src/html_ast';
 import {HtmlParser} from '@angular/compiler/src/html_parser';
 import {ExpansionResult, expandNodes} from '@angular/compiler/src/i18n/expander';
@@ -16,7 +18,9 @@ import {ddescribe, describe, expect, iit, it} from '@angular/core/testing/testin
 export function main() {
   describe('Expander', () => {
     function expand(template: string): ExpansionResult {
-      const htmlParser = new HtmlParser();
+      const expLexer = new ExpressionLexer();
+      const expParser = new ExpressionParser(expLexer);
+      const htmlParser = new HtmlParser(expParser);
       const res = htmlParser.parse(template, 'url', true);
       return expandNodes(res.rootNodes);
     }

--- a/modules/@angular/compiler/test/i18n/expander_spec.ts
+++ b/modules/@angular/compiler/test/i18n/expander_spec.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Lexer as ExpressionLexer} from '@angular/compiler/src/expression_parser/lexer';
-import {Parser as ExpressionParser} from '@angular/compiler/src/expression_parser/parser';
 import {HtmlAttrAst, HtmlElementAst, HtmlTextAst} from '@angular/compiler/src/html_ast';
 import {HtmlParser} from '@angular/compiler/src/html_parser';
 import {ExpansionResult, expandNodes} from '@angular/compiler/src/i18n/expander';
@@ -18,9 +16,7 @@ import {ddescribe, describe, expect, iit, it} from '@angular/core/testing/testin
 export function main() {
   describe('Expander', () => {
     function expand(template: string): ExpansionResult {
-      const expLexer = new ExpressionLexer();
-      const expParser = new ExpressionParser(expLexer);
-      const htmlParser = new HtmlParser(expParser);
+      const htmlParser = new HtmlParser();
       const res = htmlParser.parse(template, 'url', true);
       return expandNodes(res.rootNodes);
     }

--- a/modules/@angular/compiler/test/i18n/i18n_html_parser_spec.ts
+++ b/modules/@angular/compiler/test/i18n/i18n_html_parser_spec.ts
@@ -67,8 +67,9 @@ export function main() {
 
     it('should handle interpolation', () => {
       let translations: {[key: string]: string} = {};
-      translations[id(new Message('<ph name="0"/> and <ph name="1"/>', null, null))] =
-          '<ph name="1"/> or <ph name="0"/>';
+      translations[id(new Message(
+          '<ph name="INTERPOLATION_0"/> and <ph name="INTERPOLATION_1"/>', null, null))] =
+          '<ph name="INTERPOLATION_1"/> or <ph name="INTERPOLATION_0"/>';
 
       expect(humanizeDom(parse('<div value=\'{{a}} and {{b}}\' i18n-value></div>', translations)))
           .toEqual([[HtmlElementAst, 'div', 0], [HtmlAttrAst, 'value', '{{b}} or {{a}}']]);
@@ -76,8 +77,9 @@ export function main() {
 
     it('should handle interpolation with config', () => {
       let translations: {[key: string]: string} = {};
-      translations[id(new Message('<ph name="0"/> and <ph name="1"/>', null, null))] =
-          '<ph name="1"/> or <ph name="0"/>';
+      translations[id(new Message(
+          '<ph name="INTERPOLATION_0"/> and <ph name="INTERPOLATION_1"/>', null, null))] =
+          '<ph name="INTERPOLATION_1"/> or <ph name="INTERPOLATION_0"/>';
 
       expect(humanizeDom(parse(
                  '<div value=\'{%a%} and {%b%}\' i18n-value></div>', translations, [], {},
@@ -135,8 +137,9 @@ export function main() {
     it('should support interpolation', () => {
       let translations: {[key: string]: string} = {};
       translations[id(new Message(
-          '<ph name="e0">a</ph><ph name="e2"><ph name="t3">b<ph name="0"/></ph></ph>', null,
-          null))] = '<ph name="e2"><ph name="t3"><ph name="0"/>B</ph></ph><ph name="e0">A</ph>';
+          '<ph name="e0">a</ph><ph name="e2"><ph name="t3">b<ph name="INTERPOLATION_0"/></ph></ph>',
+          null, null))] =
+          '<ph name="e2"><ph name="t3"><ph name="INTERPOLATION_0"/>B</ph></ph><ph name="e0">A</ph>';
       expect(humanizeDom(parse('<div i18n><a>a</a><b>b{{i}}</b></div>', translations))).toEqual([
         [HtmlElementAst, 'div', 0],
         [HtmlElementAst, 'b', 1],
@@ -237,11 +240,12 @@ export function main() {
 
       it('should error when the translation refers to an invalid expression', () => {
         let translations: {[key: string]: string} = {};
-        translations[id(new Message('hi <ph name="0"/>', null, null))] = 'hi <ph name="99"/>';
+        translations[id(new Message('hi <ph name="INTERPOLATION_0"/>', null, null))] =
+            'hi <ph name="INTERPOLATION_99"/>';
 
         expect(
             humanizeErrors(parse('<div value=\'hi {{a}}\' i18n-value></div>', translations).errors))
-            .toEqual(['Invalid interpolation name \'99\'']);
+            .toEqual(['Invalid interpolation name \'INTERPOLATION_99\'']);
       });
     });
 

--- a/modules/@angular/compiler/test/i18n/i18n_html_parser_spec.ts
+++ b/modules/@angular/compiler/test/i18n/i18n_html_parser_spec.ts
@@ -26,13 +26,14 @@ export function main() {
         template: string, messages: {[key: string]: string}, implicitTags: string[] = [],
         implicitAttrs: {[k: string]: string[]} = {},
         interpolation?: InterpolationConfig): HtmlParseTreeResult {
-      var expParser = new ExpressionParser(new ExpressionLexer());
-      let htmlParser = new HtmlParser(expParser);
+      let htmlParser = new HtmlParser();
 
       let msgs = '';
       StringMapWrapper.forEach(
           messages, (v: string, k: string) => msgs += `<msg id="${k}">${v}</msg>`);
       let res = deserializeXmb(`<message-bundle>${msgs}</message-bundle>`, 'someUrl');
+
+      const expParser = new ExpressionParser(new ExpressionLexer());
 
       return new I18nHtmlParser(
                  htmlParser, expParser, res.content, res.messages, implicitTags, implicitAttrs)

--- a/modules/@angular/compiler/test/i18n/message_extractor_spec.ts
+++ b/modules/@angular/compiler/test/i18n/message_extractor_spec.ts
@@ -6,21 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Lexer} from '@angular/compiler/src/expression_parser/lexer';
-import {Parser} from '@angular/compiler/src/expression_parser/parser';
+import {Lexer as ExpressionLexer} from '@angular/compiler/src/expression_parser/lexer';
+import {Parser as ExpressionParser} from '@angular/compiler/src/expression_parser/parser';
 import {HtmlParser} from '@angular/compiler/src/html_parser';
 import {Message} from '@angular/compiler/src/i18n/message';
 import {MessageExtractor, removeDuplicates} from '@angular/compiler/src/i18n/message_extractor';
 import {beforeEach, ddescribe, describe, expect, iit, inject, it, xdescribe, xit} from '@angular/core/testing/testing_internal';
+
 
 export function main() {
   describe('MessageExtractor', () => {
     let extractor: MessageExtractor;
 
     beforeEach(() => {
-      const htmlParser = new HtmlParser();
-      const parser = new Parser(new Lexer());
-      extractor = new MessageExtractor(htmlParser, parser, ['i18n-tag'], {'i18n-el': ['trans']});
+      const expParser = new ExpressionParser(new ExpressionLexer());
+      const htmlParser = new HtmlParser(expParser);
+      // TODO: pass expression parser
+      extractor = new MessageExtractor(htmlParser, expParser, ['i18n-tag'], {'i18n-el': ['trans']});
     });
 
     it('should extract from elements with the i18n attr', () => {

--- a/modules/@angular/compiler/test/i18n/message_extractor_spec.ts
+++ b/modules/@angular/compiler/test/i18n/message_extractor_spec.ts
@@ -82,14 +82,15 @@ export function main() {
     it('should replace interpolation with placeholders (text nodes)', () => {
       let res = extractor.extract('<div i18n>Hi {{one}} and {{two}}</div>', 'someurl');
       expect(res.messages).toEqual([new Message(
-          '<ph name="t0">Hi <ph name="0"/> and <ph name="1"/></ph>', null, null)]);
+          '<ph name="t0">Hi <ph name="INTERPOLATION_0"/> and <ph name="INTERPOLATION_1"/></ph>',
+          null, null)]);
     });
 
     it('should replace interpolation with placeholders (attributes)', () => {
       let res =
           extractor.extract('<div title=\'Hi {{one}} and {{two}}\' i18n-title></div>', 'someurl');
       expect(res.messages).toEqual([new Message(
-          'Hi <ph name="0"/> and <ph name="1"/>', null, null)]);
+          'Hi <ph name="INTERPOLATION_0"/> and <ph name="INTERPOLATION_1"/>', null, null)]);
     });
 
     it('should replace interpolation with named placeholders if provided (text nodes)', () => {
@@ -142,7 +143,7 @@ export function main() {
       let res =
           extractor.extract('<div i18n><div>zero{{a}}<div>{{b}}</div></div></div>', 'someurl');
       expect(res.messages).toEqual([new Message(
-          '<ph name="e0"><ph name="t1">zero<ph name="0"/></ph><ph name="e2"><ph name="t3"><ph name="0"/></ph></ph></ph>',
+          '<ph name="e0"><ph name="t1">zero<ph name="INTERPOLATION_0"/></ph><ph name="e2"><ph name="t3"><ph name="INTERPOLATION_0"/></ph></ph></ph>',
           null, null)]);
     });
 

--- a/modules/@angular/compiler/test/i18n/message_extractor_spec.ts
+++ b/modules/@angular/compiler/test/i18n/message_extractor_spec.ts
@@ -20,7 +20,7 @@ export function main() {
 
     beforeEach(() => {
       const expParser = new ExpressionParser(new ExpressionLexer());
-      const htmlParser = new HtmlParser(expParser);
+      const htmlParser = new HtmlParser();
       // TODO: pass expression parser
       extractor = new MessageExtractor(htmlParser, expParser, ['i18n-tag'], {'i18n-el': ['trans']});
     });

--- a/modules/@angular/compiler/test/schema/dom_element_schema_registry_spec.ts
+++ b/modules/@angular/compiler/test/schema/dom_element_schema_registry_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Lexer as ExpressionLexer} from '@angular/compiler/src/expression_parser/lexer';
+import {Parser as ExpressionParser} from '@angular/compiler/src/expression_parser/parser';
 import {HtmlElementAst} from '@angular/compiler/src/html_ast';
 import {HtmlParser} from '@angular/compiler/src/html_parser';
 import {DomElementSchemaRegistry} from '@angular/compiler/src/schema/dom_element_schema_registry';
@@ -68,7 +70,9 @@ export function main() {
     });
 
     it('should detect properties on namespaced elements', () => {
-      let htmlAst = new HtmlParser().parse('<svg:style>', 'TestComp');
+      const expLexer = new ExpressionLexer();
+      const expParser = new ExpressionParser(expLexer);
+      let htmlAst = new HtmlParser(expParser).parse('<svg:style>', 'TestComp');
       let nodeName = (<HtmlElementAst>htmlAst.rootNodes[0]).name;
       expect(registry.hasProperty(nodeName, 'type')).toBeTruthy();
     });

--- a/modules/@angular/compiler/test/schema/dom_element_schema_registry_spec.ts
+++ b/modules/@angular/compiler/test/schema/dom_element_schema_registry_spec.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Lexer as ExpressionLexer} from '@angular/compiler/src/expression_parser/lexer';
-import {Parser as ExpressionParser} from '@angular/compiler/src/expression_parser/parser';
 import {HtmlElementAst} from '@angular/compiler/src/html_ast';
 import {HtmlParser} from '@angular/compiler/src/html_parser';
 import {DomElementSchemaRegistry} from '@angular/compiler/src/schema/dom_element_schema_registry';
@@ -70,10 +68,8 @@ export function main() {
     });
 
     it('should detect properties on namespaced elements', () => {
-      const expLexer = new ExpressionLexer();
-      const expParser = new ExpressionParser(expLexer);
-      let htmlAst = new HtmlParser(expParser).parse('<svg:style>', 'TestComp');
-      let nodeName = (<HtmlElementAst>htmlAst.rootNodes[0]).name;
+      const htmlAst = new HtmlParser().parse('<svg:style>', 'TestComp');
+      const nodeName = (<HtmlElementAst>htmlAst.rootNodes[0]).name;
       expect(registry.hasProperty(nodeName, 'type')).toBeTruthy();
     });
 

--- a/modules/@angular/compiler/test/template_parser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser_spec.ts
@@ -30,8 +30,6 @@ var MOCK_SCHEMA_REGISTRY = [{
   useValue: new MockSchemaRegistry({'invalidProp': false}, {'mappedAttr': 'mappedProp'})
 }];
 
-let zeConsole = console;
-
 export function main() {
   var ngIf: CompileDirectiveMetadata;
   var parse:
@@ -864,19 +862,18 @@ There is no directive with "exportAs" set to "dirA" ("<div [ERROR ->]#a="dirA"><
         });
 
         it('should report duplicate reference names', () => {
-            expect(() => parse('<div #a></div><div #a></div>', []))  .toThrowError(
-              `Template parse errors:
+          expect(() => parse('<div #a></div><div #a></div>', []))
+              .toThrowError(`Template parse errors:
 Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>"): TestComp@0:19`);
 
         });
 
-            it(
-            'should not throw error when there is same reference name in different templates',
-            () => {
-                expect(() => parse('<div #a><template #a><span>OK</span></template></div>', []))
-                  .not.toThrowError();
+        it('should not throw error when there is same reference name in different templates',
+           () => {
+             expect(() => parse('<div #a><template #a><span>OK</span></template></div>', []))
+                 .not.toThrowError();
 
-            });
+           });
 
         it('should assign references with empty value to components', () => {
           var dirA = CompileDirectiveMetadata.create({
@@ -1505,6 +1502,38 @@ Property binding a not used by any directive on an embedded template. Make sure 
 The pipe 'test' could not be found ("[ERROR ->]{{a | test}}"): TestComp@0:0`);
       });
 
+    });
+
+    describe('ICU messages', () => {
+      it('should expand plural messages', () => {
+        const shortForm = '{ count, plural, =0 {small} many {big} }';
+        const expandedForm = '<ng-container [ngPlural]="count">' +
+            '<template ngPluralCase="=0">small</template>' +
+            '<template ngPluralCase="many">big</template>' +
+            '</ng-container>';
+
+        expect(humanizeTplAst(parse(shortForm, []))).toEqual(humanizeTplAst(parse(expandedForm, [
+        ])));
+      });
+
+      it('should expand other messages', () => {
+        const shortForm = '{ sex, gender, =f {foo} other {bar} }';
+        const expandedForm = '<ng-container [ngSwitch]="sex">' +
+            '<template ngSwitchCase="=f">foo</template>' +
+            '<template ngSwitchCase="other">bar</template>' +
+            '</ng-container>';
+
+        expect(humanizeTplAst(parse(shortForm, []))).toEqual(humanizeTplAst(parse(expandedForm, [
+        ])));
+      });
+
+      it('should be possible to escape ICU messages', () => {
+        const escapedForm = 'escaped {{ "{" }}  }';
+
+        expect(humanizeTplAst(parse(escapedForm, []))).toEqual([
+          [BoundTextAst, 'escaped {{ "{" }}  }'],
+        ]);
+      });
     });
   });
 }

--- a/modules/@angular/router-deprecated/test/integration/bootstrap_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/bootstrap_spec.ts
@@ -58,7 +58,7 @@ export function main() {
          ]).then((applicationRef) => {
            var router = applicationRef.instance.router;
            router.subscribe((_: any /** TODO #9100 */) => {
-             expect(el).toHaveText('outer { hello }');
+             expect(el).toHaveText('outer [ hello ]');
              expect(applicationRef.instance.location.path()).toEqual('');
              async.done();
            });
@@ -95,9 +95,9 @@ export function main() {
                  var position = 0;
                  var flipped = false;
                  var history = [
-                   ['/parent/child', 'root { parent { hello } }', '/super-parent/child'],
-                   ['/super-parent/child', 'root { super-parent { hello2 } }', '/parent/child'],
-                   ['/parent/child', 'root { parent { hello } }', false]
+                   ['/parent/child', 'root [ parent [ hello ] ]', '/super-parent/child'],
+                   ['/super-parent/child', 'root [ super-parent [ hello2 ] ]', '/parent/child'],
+                   ['/parent/child', 'root [ parent [ hello ] ]', false]
                  ];
 
                  router.subscribe((_: any /** TODO #9100 */) => {
@@ -147,7 +147,7 @@ export function main() {
                  var router = fixture.debugElement.componentInstance.router;
                  router.subscribe((_: any /** TODO #9100 */) => {
                    expect(fixture.debugElement.nativeElement)
-                       .toHaveText('root { parent { hello } }');
+                       .toHaveText('root [ parent [ hello ] ]');
                    expect(fixture.debugElement.componentInstance.location.path())
                        .toEqual('/parent/child');
                    async.done();
@@ -168,7 +168,7 @@ export function main() {
                    var router = fixture.debugElement.componentInstance.router;
                    router.subscribe((_: any /** TODO #9100 */) => {
                      expect(fixture.debugElement.nativeElement)
-                         .toHaveText('root { parent { hello } }');
+                         .toHaveText('root [ parent [ hello ] ]');
                      expect(fixture.debugElement.componentInstance.location.path())
                          .toEqual('/my/app/parent/child');
                      async.done();
@@ -252,7 +252,7 @@ class Hello2Cmp {
 
 @Component({
   selector: 'app-cmp',
-  template: `outer { <router-outlet></router-outlet> }`,
+  template: `outer [ <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([new Route({path: '/', component: HelloCmp})])
@@ -288,7 +288,7 @@ class AppWithOutletListeners {
 
 @Component({
   selector: 'parent-cmp',
-  template: `parent { <router-outlet></router-outlet> }`,
+  template: `parent [ <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([new Route({path: '/child', component: HelloCmp})])
@@ -297,7 +297,7 @@ class ParentCmp {
 
 @Component({
   selector: 'super-parent-cmp',
-  template: `super-parent { <router-outlet></router-outlet> }`,
+  template: `super-parent [ <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([new Route({path: '/child', component: Hello2Cmp})])
@@ -306,7 +306,7 @@ class SuperParentCmp {
 
 @Component({
   selector: 'app-cmp',
-  template: `root { <router-outlet></router-outlet> }`,
+  template: `root [ <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([
@@ -340,7 +340,7 @@ class BrokenCmp {
 
 @Component({
   selector: 'app-cmp',
-  template: `outer { <router-outlet></router-outlet> }`,
+  template: `outer [ <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([new Route({path: '/cause-error', component: BrokenCmp})])

--- a/modules/@angular/router-deprecated/test/integration/impl/async_route_spec_impl.ts
+++ b/modules/@angular/router-deprecated/test/integration/impl/async_route_spec_impl.ts
@@ -261,27 +261,27 @@ function asyncRoutesWithSyncChildrenWithoutDefaultRoutes() {
       }));
 
   it('should navigate by URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `outer { <router-outlet></router-outlet> }`)
+       compile(tcb, `outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/a/...', loader: parentCmpLoader, name: 'Parent'})]))
            .then((_) => rtr.navigateByUrl('/a/b'))
            .then((_) => {
              fixture.detectChanges();
-             expect(fixture.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+             expect(fixture.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
              async.done();
            });
      }));
 
   it('should navigate by link DSL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `outer { <router-outlet></router-outlet> }`)
+       compile(tcb, `outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/a/...', loader: parentCmpLoader, name: 'Parent'})]))
            .then((_) => rtr.navigate(['/Parent', 'Child']))
            .then((_) => {
              fixture.detectChanges();
-             expect(fixture.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+             expect(fixture.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
              async.done();
            });
      }));
@@ -289,7 +289,7 @@ function asyncRoutesWithSyncChildrenWithoutDefaultRoutes() {
   it('should generate a link URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
        compile(
            tcb,
-           `<a [routerLink]="['Parent']">nav to child</a> | outer { <router-outlet></router-outlet> }`)
+           `<a [routerLink]="['Parent']">nav to child</a> | outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/a/...', loader: parentCmpLoader, name: 'Parent'})]))
@@ -306,18 +306,18 @@ function asyncRoutesWithSyncChildrenWithoutDefaultRoutes() {
          (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
            compile(
                tcb,
-               `<a [routerLink]="['Parent', 'Child']">nav to child</a> | outer { <router-outlet></router-outlet> }`)
+               `<a [routerLink]="['Parent', 'Child']">nav to child</a> | outer [ <router-outlet></router-outlet> ]`)
                .then((rtc) => {fixture = rtc})
                .then((_) => rtr.config([new AsyncRoute(
                          {path: '/a/...', loader: parentCmpLoader, name: 'Parent'})]))
                .then((_) => {
                  fixture.detectChanges();
-                 expect(fixture.debugElement.nativeElement).toHaveText('nav to child | outer {  }');
+                 expect(fixture.debugElement.nativeElement).toHaveText('nav to child | outer [  ]');
 
                  rtr.subscribe((_: any /** TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
-                       .toHaveText('nav to child | outer { inner { hello } }');
+                       .toHaveText('nav to child | outer [ inner [ hello ] ]');
                    expect(location.urlChanges).toEqual(['/a/b']);
                    async.done();
                  });
@@ -343,27 +343,27 @@ function asyncRoutesWithSyncChildrenWithDefaultRoutes() {
       }));
 
   it('should navigate by URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `outer { <router-outlet></router-outlet> }`)
+       compile(tcb, `outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/a/...', loader: parentWithDefaultCmpLoader, name: 'Parent'})]))
            .then((_) => rtr.navigateByUrl('/a'))
            .then((_) => {
              fixture.detectChanges();
-             expect(fixture.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+             expect(fixture.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
              async.done();
            });
      }));
 
   it('should navigate by link DSL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `outer { <router-outlet></router-outlet> }`)
+       compile(tcb, `outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/a/...', loader: parentWithDefaultCmpLoader, name: 'Parent'})]))
            .then((_) => rtr.navigate(['/Parent']))
            .then((_) => {
              fixture.detectChanges();
-             expect(fixture.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+             expect(fixture.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
              async.done();
            });
      }));
@@ -371,7 +371,7 @@ function asyncRoutesWithSyncChildrenWithDefaultRoutes() {
   it('should generate a link URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
        compile(
            tcb,
-           `<a [routerLink]="['/Parent']">link to inner</a> | outer { <router-outlet></router-outlet> }`)
+           `<a [routerLink]="['/Parent']">link to inner</a> | outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/a/...', loader: parentWithDefaultCmpLoader, name: 'Parent'})]))
@@ -388,19 +388,19 @@ function asyncRoutesWithSyncChildrenWithDefaultRoutes() {
          (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
            compile(
                tcb,
-               `<a [routerLink]="['/Parent']">link to inner</a> | outer { <router-outlet></router-outlet> }`)
+               `<a [routerLink]="['/Parent']">link to inner</a> | outer [ <router-outlet></router-outlet> ]`)
                .then((rtc) => {fixture = rtc})
                .then((_) => rtr.config([new AsyncRoute(
                          {path: '/a/...', loader: parentWithDefaultCmpLoader, name: 'Parent'})]))
                .then((_) => {
                  fixture.detectChanges();
                  expect(fixture.debugElement.nativeElement)
-                     .toHaveText('link to inner | outer {  }');
+                     .toHaveText('link to inner | outer [  ]');
 
                  rtr.subscribe((_: any /** TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
-                       .toHaveText('link to inner | outer { inner { hello } }');
+                       .toHaveText('link to inner | outer [ inner [ hello ] ]');
                    expect(location.urlChanges).toEqual(['/a/b']);
                    async.done();
                  });
@@ -426,27 +426,27 @@ function asyncRoutesWithAsyncChildrenWithoutParamsWithoutDefaultRoutes() {
       }));
 
   it('should navigate by URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `outer { <router-outlet></router-outlet> }`)
+       compile(tcb, `outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {rootTC = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/a/...', loader: asyncParentCmpLoader, name: 'Parent'})]))
            .then((_) => rtr.navigateByUrl('/a/b'))
            .then((_) => {
              rootTC.detectChanges();
-             expect(rootTC.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+             expect(rootTC.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
              async.done();
            });
      }));
 
   it('should navigate by link DSL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `outer { <router-outlet></router-outlet> }`)
+       compile(tcb, `outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {rootTC = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/a/...', loader: asyncParentCmpLoader, name: 'Parent'})]))
            .then((_) => rtr.navigate(['/Parent', 'Child']))
            .then((_) => {
              rootTC.detectChanges();
-             expect(rootTC.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+             expect(rootTC.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
              async.done();
            });
      }));
@@ -454,7 +454,7 @@ function asyncRoutesWithAsyncChildrenWithoutParamsWithoutDefaultRoutes() {
   it('should generate a link URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
        compile(
            tcb,
-           `<a [routerLink]="['Parent', 'Child']">nav to child</a> | outer { <router-outlet></router-outlet> }`)
+           `<a [routerLink]="['Parent', 'Child']">nav to child</a> | outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {rootTC = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/a/...', loader: asyncParentCmpLoader, name: 'Parent'})]))
@@ -471,18 +471,18 @@ function asyncRoutesWithAsyncChildrenWithoutParamsWithoutDefaultRoutes() {
          (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
            compile(
                tcb,
-               `<a [routerLink]="['Parent', 'Child']">nav to child</a> | outer { <router-outlet></router-outlet> }`)
+               `<a [routerLink]="['Parent', 'Child']">nav to child</a> | outer [ <router-outlet></router-outlet> ]`)
                .then((rtc) => {rootTC = rtc})
                .then((_) => rtr.config([new AsyncRoute(
                          {path: '/a/...', loader: asyncParentCmpLoader, name: 'Parent'})]))
                .then((_) => {
                  rootTC.detectChanges();
-                 expect(rootTC.debugElement.nativeElement).toHaveText('nav to child | outer {  }');
+                 expect(rootTC.debugElement.nativeElement).toHaveText('nav to child | outer [  ]');
 
                  rtr.subscribe((_: any /** TODO #9100 */) => {
                    rootTC.detectChanges();
                    expect(rootTC.debugElement.nativeElement)
-                       .toHaveText('nav to child | outer { inner { hello } }');
+                       .toHaveText('nav to child | outer [ inner [ hello ] ]');
                    expect(location.urlChanges).toEqual(['/a/b']);
                    async.done();
                  });
@@ -508,27 +508,27 @@ function asyncRoutesWithAsyncChildrenWithoutParamsWithDefaultRoutes() {
       }));
 
   it('should navigate by URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `outer { <router-outlet></router-outlet> }`)
+       compile(tcb, `outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {rootTC = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/a/...', loader: asyncDefaultParentCmpLoader, name: 'Parent'})]))
            .then((_) => rtr.navigateByUrl('/a'))
            .then((_) => {
              rootTC.detectChanges();
-             expect(rootTC.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+             expect(rootTC.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
              async.done();
            });
      }));
 
   it('should navigate by link DSL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `outer { <router-outlet></router-outlet> }`)
+       compile(tcb, `outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {rootTC = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/a/...', loader: asyncDefaultParentCmpLoader, name: 'Parent'})]))
            .then((_) => rtr.navigate(['/Parent']))
            .then((_) => {
              rootTC.detectChanges();
-             expect(rootTC.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+             expect(rootTC.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
              async.done();
            });
      }));
@@ -536,7 +536,7 @@ function asyncRoutesWithAsyncChildrenWithoutParamsWithDefaultRoutes() {
   it('should generate a link URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
        compile(
            tcb,
-           `<a [routerLink]="['Parent']">nav to child</a> | outer { <router-outlet></router-outlet> }`)
+           `<a [routerLink]="['Parent']">nav to child</a> | outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {rootTC = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/a/...', loader: asyncDefaultParentCmpLoader, name: 'Parent'})]))
@@ -553,18 +553,18 @@ function asyncRoutesWithAsyncChildrenWithoutParamsWithDefaultRoutes() {
          (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
            compile(
                tcb,
-               `<a [routerLink]="['Parent']">nav to child</a> | outer { <router-outlet></router-outlet> }`)
+               `<a [routerLink]="['Parent']">nav to child</a> | outer [ <router-outlet></router-outlet> ]`)
                .then((rtc) => {rootTC = rtc})
                .then((_) => rtr.config([new AsyncRoute(
                          {path: '/a/...', loader: asyncDefaultParentCmpLoader, name: 'Parent'})]))
                .then((_) => {
                  rootTC.detectChanges();
-                 expect(rootTC.debugElement.nativeElement).toHaveText('nav to child | outer {  }');
+                 expect(rootTC.debugElement.nativeElement).toHaveText('nav to child | outer [  ]');
 
                  rtr.subscribe((_: any /** TODO #9100 */) => {
                    rootTC.detectChanges();
                    expect(rootTC.debugElement.nativeElement)
-                       .toHaveText('nav to child | outer { inner { hello } }');
+                       .toHaveText('nav to child | outer [ inner [ hello ] ]');
                    expect(location.urlChanges).toEqual(['/a/b']);
                    async.done();
                  });
@@ -590,7 +590,7 @@ function asyncRoutesWithAsyncChildrenWithParamsWithoutDefaultRoutes() {
       }));
 
   it('should navigate by URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `{ <router-outlet></router-outlet> }`)
+       compile(tcb, `[ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/team/:id/...', loader: asyncTeamLoader, name: 'Team'})]))
@@ -598,13 +598,13 @@ function asyncRoutesWithAsyncChildrenWithParamsWithoutDefaultRoutes() {
            .then((_) => {
              fixture.detectChanges();
              expect(fixture.debugElement.nativeElement)
-                 .toHaveText('{ team angular | user { hello matias } }');
+                 .toHaveText('[ team angular | user [ hello matias ] ]');
              async.done();
            });
      }));
 
   it('should navigate by link DSL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `{ <router-outlet></router-outlet> }`)
+       compile(tcb, `[ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/team/:id/...', loader: asyncTeamLoader, name: 'Team'})]))
@@ -612,7 +612,7 @@ function asyncRoutesWithAsyncChildrenWithParamsWithoutDefaultRoutes() {
            .then((_) => {
              fixture.detectChanges();
              expect(fixture.debugElement.nativeElement)
-                 .toHaveText('{ team angular | user { hello matias } }');
+                 .toHaveText('[ team angular | user [ hello matias ] ]');
              async.done();
            });
      }));
@@ -620,7 +620,7 @@ function asyncRoutesWithAsyncChildrenWithParamsWithoutDefaultRoutes() {
   it('should generate a link URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
        compile(
            tcb,
-           `<a [routerLink]="['/Team', {id: 'angular'}, 'User', {name: 'matias'}]">nav to matias</a> { <router-outlet></router-outlet> }`)
+           `<a [routerLink]="['/Team', {id: 'angular'}, 'User', {name: 'matias'}]">nav to matias</a> [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new AsyncRoute(
                      {path: '/team/:id/...', loader: asyncTeamLoader, name: 'Team'})]))
@@ -637,18 +637,18 @@ function asyncRoutesWithAsyncChildrenWithParamsWithoutDefaultRoutes() {
          (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
            compile(
                tcb,
-               `<a [routerLink]="['/Team', {id: 'angular'}, 'User', {name: 'matias'}]">nav to matias</a> { <router-outlet></router-outlet> }`)
+               `<a [routerLink]="['/Team', {id: 'angular'}, 'User', {name: 'matias'}]">nav to matias</a> [ <router-outlet></router-outlet> ]`)
                .then((rtc) => {fixture = rtc})
                .then((_) => rtr.config([new AsyncRoute(
                          {path: '/team/:id/...', loader: asyncTeamLoader, name: 'Team'})]))
                .then((_) => {
                  fixture.detectChanges();
-                 expect(fixture.debugElement.nativeElement).toHaveText('nav to matias {  }');
+                 expect(fixture.debugElement.nativeElement).toHaveText('nav to matias [  ]');
 
                  rtr.subscribe((_: any /** TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
-                       .toHaveText('nav to matias { team angular | user { hello matias } }');
+                       .toHaveText('nav to matias [ team angular | user [ hello matias ] ]');
                    expect(location.urlChanges).toEqual(['/team/angular/user/matias']);
                    async.done();
                  });

--- a/modules/@angular/router-deprecated/test/integration/impl/aux_route_spec_impl.ts
+++ b/modules/@angular/router-deprecated/test/integration/impl/aux_route_spec_impl.ts
@@ -37,7 +37,7 @@ function auxRoutes() {
      inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
        compile(
            tcb,
-           `main {<router-outlet></router-outlet>} | aux {<router-outlet name="modal"></router-outlet>}`)
+           `main [<router-outlet></router-outlet>] | aux [<router-outlet name="modal"></router-outlet>]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([
              new Route({path: '/hello', component: HelloCmp, name: 'Hello'}),
@@ -46,7 +46,7 @@ function auxRoutes() {
            .then((_) => rtr.navigateByUrl('/(modal)'))
            .then((_) => {
              fixture.detectChanges();
-             expect(fixture.debugElement.nativeElement).toHaveText('main {} | aux {modal}');
+             expect(fixture.debugElement.nativeElement).toHaveText('main [] | aux [modal]');
              async.done();
            });
      }));
@@ -55,7 +55,7 @@ function auxRoutes() {
      inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
        compile(
            tcb,
-           `main {<router-outlet></router-outlet>} | aux {<router-outlet name="modal"></router-outlet>}`)
+           `main [<router-outlet></router-outlet>] | aux [<router-outlet name="modal"></router-outlet>]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([
              new Route({path: '/hello', component: HelloCmp, name: 'Hello'}),
@@ -64,7 +64,7 @@ function auxRoutes() {
            .then((_) => rtr.navigate(['/', ['Modal']]))
            .then((_) => {
              fixture.detectChanges();
-             expect(fixture.debugElement.nativeElement).toHaveText('main {} | aux {modal}');
+             expect(fixture.debugElement.nativeElement).toHaveText('main [] | aux [modal]');
              async.done();
            });
      }));
@@ -72,7 +72,7 @@ function auxRoutes() {
   it('should generate a link URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
        compile(
            tcb,
-           `<a [routerLink]="['/', ['Modal']]">open modal</a> | main {<router-outlet></router-outlet>} | aux {<router-outlet name="modal"></router-outlet>}`)
+           `<a [routerLink]="['/', ['Modal']]">open modal</a> | main [<router-outlet></router-outlet>] | aux [<router-outlet name="modal"></router-outlet>]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([
              new Route({path: '/hello', component: HelloCmp, name: 'Hello'}),
@@ -91,7 +91,7 @@ function auxRoutes() {
          (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
            compile(
                tcb,
-               `<a [routerLink]="['/', ['Modal']]">open modal</a> | <a [routerLink]="['/Hello']">hello</a> | main {<router-outlet></router-outlet>} | aux {<router-outlet name="modal"></router-outlet>}`)
+               `<a [routerLink]="['/', ['Modal']]">open modal</a> | <a [routerLink]="['/Hello']">hello</a> | main [<router-outlet></router-outlet>] | aux [<router-outlet name="modal"></router-outlet>]`)
                .then((rtc) => {fixture = rtc})
                .then((_) => rtr.config([
                  new Route({path: '/hello', component: HelloCmp, name: 'Hello'}),
@@ -100,7 +100,7 @@ function auxRoutes() {
                .then((_) => {
                  fixture.detectChanges();
                  expect(fixture.debugElement.nativeElement)
-                     .toHaveText('open modal | hello | main {} | aux {}');
+                     .toHaveText('open modal | hello | main [] | aux []');
 
                  var navCount = 0;
 
@@ -109,7 +109,7 @@ function auxRoutes() {
                    fixture.detectChanges();
                    if (navCount == 1) {
                      expect(fixture.debugElement.nativeElement)
-                         .toHaveText('open modal | hello | main {} | aux {modal}');
+                         .toHaveText('open modal | hello | main [] | aux [modal]');
                      expect(location.urlChanges).toEqual(['/(modal)']);
                      expect(getHref(getLinkElement(fixture, 0))).toEqual('/(modal)');
                      expect(getHref(getLinkElement(fixture, 1))).toEqual('/hello(modal)');
@@ -118,7 +118,7 @@ function auxRoutes() {
                      clickOnElement(getLinkElement(fixture, 1));
                    } else if (navCount == 2) {
                      expect(fixture.debugElement.nativeElement)
-                         .toHaveText('open modal | hello | main {hello} | aux {modal}');
+                         .toHaveText('open modal | hello | main [hello] | aux [modal]');
                      expect(location.urlChanges).toEqual(['/(modal)', '/hello(modal)']);
                      expect(getHref(getLinkElement(fixture, 0))).toEqual('/hello(modal)');
                      expect(getHref(getLinkElement(fixture, 1))).toEqual('/hello(modal)');
@@ -150,7 +150,7 @@ function auxRoutesWithAPrimaryRoute() {
      inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
        compile(
            tcb,
-           `main {<router-outlet></router-outlet>} | aux {<router-outlet name="modal"></router-outlet>}`)
+           `main [<router-outlet></router-outlet>] | aux [<router-outlet name="modal"></router-outlet>]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([
              new Route({path: '/hello', component: HelloCmp, name: 'Hello'}),
@@ -159,7 +159,7 @@ function auxRoutesWithAPrimaryRoute() {
            .then((_) => rtr.navigateByUrl('/hello(modal)'))
            .then((_) => {
              fixture.detectChanges();
-             expect(fixture.debugElement.nativeElement).toHaveText('main {hello} | aux {modal}');
+             expect(fixture.debugElement.nativeElement).toHaveText('main [hello] | aux [modal]');
              async.done();
            });
      }));
@@ -168,7 +168,7 @@ function auxRoutesWithAPrimaryRoute() {
      inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
        compile(
            tcb,
-           `main {<router-outlet></router-outlet>} | aux {<router-outlet name="modal"></router-outlet>}`)
+           `main [<router-outlet></router-outlet>] | aux [<router-outlet name="modal"></router-outlet>]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([
              new Route({path: '/hello', component: HelloCmp, name: 'Hello'}),
@@ -177,7 +177,7 @@ function auxRoutesWithAPrimaryRoute() {
            .then((_) => rtr.navigate(['/Hello', ['Modal']]))
            .then((_) => {
              fixture.detectChanges();
-             expect(fixture.debugElement.nativeElement).toHaveText('main {hello} | aux {modal}');
+             expect(fixture.debugElement.nativeElement).toHaveText('main [hello] | aux [modal]');
              async.done();
            });
      }));
@@ -185,7 +185,7 @@ function auxRoutesWithAPrimaryRoute() {
   it('should generate a link URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
        compile(
            tcb,
-           `<a [routerLink]="['/Hello', ['Modal']]">open modal</a> | main {<router-outlet></router-outlet>} | aux {<router-outlet name="modal"></router-outlet>}`)
+           `<a [routerLink]="['/Hello', ['Modal']]">open modal</a> | main [<router-outlet></router-outlet>] | aux [<router-outlet name="modal"></router-outlet>]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([
              new Route({path: '/hello', component: HelloCmp, name: 'Hello'}),
@@ -204,7 +204,7 @@ function auxRoutesWithAPrimaryRoute() {
          (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
            compile(
                tcb,
-               `<a [routerLink]="['/Hello', ['Modal']]">open modal</a> | main {<router-outlet></router-outlet>} | aux {<router-outlet name="modal"></router-outlet>}`)
+               `<a [routerLink]="['/Hello', ['Modal']]">open modal</a> | main [<router-outlet></router-outlet>] | aux [<router-outlet name="modal"></router-outlet>]`)
                .then((rtc) => {fixture = rtc})
                .then((_) => rtr.config([
                  new Route({path: '/hello', component: HelloCmp, name: 'Hello'}),
@@ -213,12 +213,12 @@ function auxRoutesWithAPrimaryRoute() {
                .then((_) => {
                  fixture.detectChanges();
                  expect(fixture.debugElement.nativeElement)
-                     .toHaveText('open modal | main {} | aux {}');
+                     .toHaveText('open modal | main [] | aux []');
 
                  rtr.subscribe((_: any /** TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
-                       .toHaveText('open modal | main {hello} | aux {modal}');
+                       .toHaveText('open modal | main [hello] | aux [modal]');
                    expect(location.urlChanges).toEqual(['/hello(modal)']);
                    async.done();
                  });
@@ -246,8 +246,8 @@ class ModalCmp {
 
 @Component({
   selector: 'aux-cmp',
-  template: 'main {<router-outlet></router-outlet>} | ' +
-      'aux {<router-outlet name="modal"></router-outlet>}',
+  template: 'main [<router-outlet></router-outlet>] | ' +
+      'aux [<router-outlet name="modal"></router-outlet>]',
   directives: [ROUTER_DIRECTIVES],
 })
 @RouteConfig([

--- a/modules/@angular/router-deprecated/test/integration/impl/fixture_components.ts
+++ b/modules/@angular/router-deprecated/test/integration/impl/fixture_components.ts
@@ -43,7 +43,7 @@ export function userCmpLoader() {
 
 @Component({
   selector: 'parent-cmp',
-  template: `inner { <router-outlet></router-outlet> }`,
+  template: `inner [ <router-outlet></router-outlet> ]`,
   directives: [ROUTER_DIRECTIVES],
 })
 @RouteConfig([new Route({path: '/b', component: HelloCmp, name: 'Child'})])
@@ -57,7 +57,7 @@ export function parentCmpLoader() {
 
 @Component({
   selector: 'parent-cmp',
-  template: `inner { <router-outlet></router-outlet> }`,
+  template: `inner [ <router-outlet></router-outlet> ]`,
   directives: [ROUTER_DIRECTIVES],
 })
 @RouteConfig([new AsyncRoute({path: '/b', loader: helloCmpLoader, name: 'Child'})])
@@ -70,7 +70,7 @@ export function asyncParentCmpLoader() {
 
 @Component({
   selector: 'parent-cmp',
-  template: `inner { <router-outlet></router-outlet> }`,
+  template: `inner [ <router-outlet></router-outlet> ]`,
   directives: [ROUTER_DIRECTIVES],
 })
 @RouteConfig(
@@ -85,7 +85,7 @@ export function asyncDefaultParentCmpLoader() {
 
 @Component({
   selector: 'parent-cmp',
-  template: `inner { <router-outlet></router-outlet> }`,
+  template: `inner [ <router-outlet></router-outlet> ]`,
   directives: [ROUTER_DIRECTIVES],
 })
 @RouteConfig([new Route({path: '/b', component: HelloCmp, name: 'Child', useAsDefault: true})])
@@ -99,7 +99,7 @@ export function parentWithDefaultCmpLoader() {
 
 @Component({
   selector: 'team-cmp',
-  template: `team {{id}} | user { <router-outlet></router-outlet> }`,
+  template: `team {{id}} | user [ <router-outlet></router-outlet> ]`,
   directives: [ROUTER_DIRECTIVES],
 })
 @RouteConfig([new Route({path: '/user/:name', component: UserCmp, name: 'User'})])
@@ -110,7 +110,7 @@ export class TeamCmp {
 
 @Component({
   selector: 'team-cmp',
-  template: `team {{id}} | user { <router-outlet></router-outlet> }`,
+  template: `team {{id}} | user [ <router-outlet></router-outlet> ]`,
   directives: [ROUTER_DIRECTIVES],
 })
 @RouteConfig([new AsyncRoute({path: '/user/:name', loader: userCmpLoader, name: 'User'})])
@@ -140,7 +140,7 @@ export class RedirectToParentCmp {
 }
 
 
-@Component({selector: 'dynamic-loader-cmp', template: `{ <div #viewport></div> }`})
+@Component({selector: 'dynamic-loader-cmp', template: `[ <div #viewport></div> ]`})
 @RouteConfig([new Route({path: '/', component: HelloCmp})])
 export class DynamicLoaderCmp {
   private _componentRef: ComponentRef<any> = null;

--- a/modules/@angular/router-deprecated/test/integration/impl/sync_route_spec_impl.ts
+++ b/modules/@angular/router-deprecated/test/integration/impl/sync_route_spec_impl.ts
@@ -221,7 +221,7 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithoutParams() {
       }));
 
   it('should navigate by URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `outer { <router-outlet></router-outlet> }`)
+       compile(tcb, `outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then(
                (_) =>
@@ -229,13 +229,13 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithoutParams() {
            .then((_) => rtr.navigateByUrl('/a/b'))
            .then((_) => {
              fixture.detectChanges();
-             expect(fixture.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+             expect(fixture.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
              async.done();
            });
      }));
 
   it('should navigate by link DSL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `outer { <router-outlet></router-outlet> }`)
+       compile(tcb, `outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then(
                (_) =>
@@ -243,7 +243,7 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithoutParams() {
            .then((_) => rtr.navigate(['/Parent', 'Child']))
            .then((_) => {
              fixture.detectChanges();
-             expect(fixture.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+             expect(fixture.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
              async.done();
            });
      }));
@@ -251,7 +251,7 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithoutParams() {
   it('should generate a link URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
        compile(
            tcb,
-           `<a [routerLink]="['Parent', 'Child']">nav to child</a> | outer { <router-outlet></router-outlet> }`)
+           `<a [routerLink]="['Parent', 'Child']">nav to child</a> | outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then(
                (_) =>
@@ -269,18 +269,18 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithoutParams() {
          (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
            compile(
                tcb,
-               `<a [routerLink]="['Parent', 'Child']">nav to child</a> | outer { <router-outlet></router-outlet> }`)
+               `<a [routerLink]="['Parent', 'Child']">nav to child</a> | outer [ <router-outlet></router-outlet> ]`)
                .then((rtc) => {fixture = rtc})
                .then((_) => rtr.config([new Route(
                          {path: '/a/...', component: ParentCmp, name: 'Parent'})]))
                .then((_) => {
                  fixture.detectChanges();
-                 expect(fixture.debugElement.nativeElement).toHaveText('nav to child | outer {  }');
+                 expect(fixture.debugElement.nativeElement).toHaveText('nav to child | outer [  ]');
 
                  rtr.subscribe((_: any /** TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
-                       .toHaveText('nav to child | outer { inner { hello } }');
+                       .toHaveText('nav to child | outer [ inner [ hello ] ]');
                    expect(location.urlChanges).toEqual(['/a/b']);
                    async.done();
                  });
@@ -306,7 +306,7 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithParams() {
       }));
 
   it('should navigate by URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `{ <router-outlet></router-outlet> }`)
+       compile(tcb, `[ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new Route(
                      {path: '/team/:id/...', component: TeamCmp, name: 'Team'})]))
@@ -314,13 +314,13 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithParams() {
            .then((_) => {
              fixture.detectChanges();
              expect(fixture.debugElement.nativeElement)
-                 .toHaveText('{ team angular | user { hello matias } }');
+                 .toHaveText('[ team angular | user [ hello matias ] ]');
              async.done();
            });
      }));
 
   it('should navigate by link DSL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `{ <router-outlet></router-outlet> }`)
+       compile(tcb, `[ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new Route(
                      {path: '/team/:id/...', component: TeamCmp, name: 'Team'})]))
@@ -328,7 +328,7 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithParams() {
            .then((_) => {
              fixture.detectChanges();
              expect(fixture.debugElement.nativeElement)
-                 .toHaveText('{ team angular | user { hello matias } }');
+                 .toHaveText('[ team angular | user [ hello matias ] ]');
              async.done();
            });
      }));
@@ -336,7 +336,7 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithParams() {
   it('should generate a link URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
        compile(
            tcb,
-           `<a [routerLink]="['/Team', {id: 'angular'}, 'User', {name: 'matias'}]">nav to matias</a> { <router-outlet></router-outlet> }`)
+           `<a [routerLink]="['/Team', {id: 'angular'}, 'User', {name: 'matias'}]">nav to matias</a> [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new Route(
                      {path: '/team/:id/...', component: TeamCmp, name: 'Team'})]))
@@ -353,18 +353,18 @@ function syncRoutesWithSyncChildrenWithoutDefaultRoutesWithParams() {
          (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
            compile(
                tcb,
-               `<a [routerLink]="['/Team', {id: 'angular'}, 'User', {name: 'matias'}]">nav to matias</a> { <router-outlet></router-outlet> }`)
+               `<a [routerLink]="['/Team', {id: 'angular'}, 'User', {name: 'matias'}]">nav to matias</a> [ <router-outlet></router-outlet> ]`)
                .then((rtc) => {fixture = rtc})
                .then((_) => rtr.config([new Route(
                          {path: '/team/:id/...', component: TeamCmp, name: 'Team'})]))
                .then((_) => {
                  fixture.detectChanges();
-                 expect(fixture.debugElement.nativeElement).toHaveText('nav to matias {  }');
+                 expect(fixture.debugElement.nativeElement).toHaveText('nav to matias [  ]');
 
                  rtr.subscribe((_: any /** TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
-                       .toHaveText('nav to matias { team angular | user { hello matias } }');
+                       .toHaveText('nav to matias [ team angular | user [ hello matias ] ]');
                    expect(location.urlChanges).toEqual(['/team/angular/user/matias']);
                    async.done();
                  });
@@ -390,27 +390,27 @@ function syncRoutesWithSyncChildrenWithDefaultRoutesWithoutParams() {
       }));
 
   it('should navigate by URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `outer { <router-outlet></router-outlet> }`)
+       compile(tcb, `outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new Route(
                      {path: '/a/...', component: ParentWithDefaultCmp, name: 'Parent'})]))
            .then((_) => rtr.navigateByUrl('/a'))
            .then((_) => {
              fixture.detectChanges();
-             expect(fixture.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+             expect(fixture.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
              async.done();
            });
      }));
 
   it('should navigate by link DSL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-       compile(tcb, `outer { <router-outlet></router-outlet> }`)
+       compile(tcb, `outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new Route(
                      {path: '/a/...', component: ParentWithDefaultCmp, name: 'Parent'})]))
            .then((_) => rtr.navigate(['/Parent']))
            .then((_) => {
              fixture.detectChanges();
-             expect(fixture.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+             expect(fixture.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
              async.done();
            });
      }));
@@ -418,7 +418,7 @@ function syncRoutesWithSyncChildrenWithDefaultRoutesWithoutParams() {
   it('should generate a link URL', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
        compile(
            tcb,
-           `<a [routerLink]="['/Parent']">link to inner</a> | outer { <router-outlet></router-outlet> }`)
+           `<a [routerLink]="['/Parent']">link to inner</a> | outer [ <router-outlet></router-outlet> ]`)
            .then((rtc) => {fixture = rtc})
            .then((_) => rtr.config([new Route(
                      {path: '/a/...', component: ParentWithDefaultCmp, name: 'Parent'})]))
@@ -435,19 +435,19 @@ function syncRoutesWithSyncChildrenWithDefaultRoutesWithoutParams() {
          (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
            compile(
                tcb,
-               `<a [routerLink]="['/Parent']">link to inner</a> | outer { <router-outlet></router-outlet> }`)
+               `<a [routerLink]="['/Parent']">link to inner</a> | outer [ <router-outlet></router-outlet> ]`)
                .then((rtc) => {fixture = rtc})
                .then((_) => rtr.config([new Route(
                          {path: '/a/...', component: ParentWithDefaultCmp, name: 'Parent'})]))
                .then((_) => {
                  fixture.detectChanges();
                  expect(fixture.debugElement.nativeElement)
-                     .toHaveText('link to inner | outer {  }');
+                     .toHaveText('link to inner | outer [  ]');
 
                  rtr.subscribe((_: any /** TODO #9100 */) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
-                       .toHaveText('link to inner | outer { inner { hello } }');
+                       .toHaveText('link to inner | outer [ inner [ hello ] ]');
                    expect(location.urlChanges).toEqual(['/a/b']);
                    async.done();
                  });
@@ -481,7 +481,7 @@ function syncRoutesWithDynamicComponents() {
                  .then((_) => rtr.config([new Route({path: '/', component: HelloCmp})]))
                  .then((_) => {
                    fixture.detectChanges();
-                   expect(fixture.debugElement.nativeElement).toHaveText('{  }');
+                   expect(fixture.debugElement.nativeElement).toHaveText('[  ]');
                    return fixture.componentInstance.onSomeAction();
                  })
                  .then((_) => {
@@ -490,7 +490,7 @@ function syncRoutesWithDynamicComponents() {
                  })
                  .then((_) => {
                    fixture.detectChanges();
-                   expect(fixture.debugElement.nativeElement).toHaveText('{ hello }');
+                   expect(fixture.debugElement.nativeElement).toHaveText('[ hello ]');
 
                    return fixture.componentInstance.onSomeAction();
                  })
@@ -502,7 +502,7 @@ function syncRoutesWithDynamicComponents() {
                    // stable and we don't know when that is, only zones know.
                    PromiseWrapper.resolve(null).then((_) => {
                      fixture.detectChanges();
-                     expect(fixture.debugElement.nativeElement).toHaveText('{ hello }');
+                     expect(fixture.debugElement.nativeElement).toHaveText('[ hello ]');
                      async.done();
                    });
                  })}));

--- a/modules/@angular/router-deprecated/test/integration/lifecycle_hook_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/lifecycle_hook_spec.ts
@@ -71,7 +71,7 @@ export function main() {
                });
                rtr.navigateByUrl('/parent-activate/child-activate').then((_) => {
                  fixture.detectChanges();
-                 expect(fixture.debugElement.nativeElement).toHaveText('parent {activate cmp}');
+                 expect(fixture.debugElement.nativeElement).toHaveText('parent [activate cmp]');
                  expect(log).toEqual([
                    'parent activate: null -> /parent-activate', 'activate: null -> /child-activate'
                  ]);
@@ -106,7 +106,7 @@ export function main() {
                  if (ev.startsWith('deactivate')) {
                    completer.resolve(true);
                    fixture.detectChanges();
-                   expect(fixture.debugElement.nativeElement).toHaveText('parent {deactivate cmp}');
+                   expect(fixture.debugElement.nativeElement).toHaveText('parent [deactivate cmp]');
                  }
                });
                rtr.navigateByUrl('/a').then((_) => {
@@ -130,14 +130,14 @@ export function main() {
              .then((_) => {
                fixture.detectChanges();
                expect(log).toEqual([]);
-               expect(fixture.debugElement.nativeElement).toHaveText('reuse {A}');
+               expect(fixture.debugElement.nativeElement).toHaveText('reuse [A]');
                expect(cmpInstanceCount).toBe(1);
              })
              .then((_) => rtr.navigateByUrl('/on-reuse/2/b'))
              .then((_) => {
                fixture.detectChanges();
                expect(log).toEqual(['reuse: /on-reuse/1 -> /on-reuse/2']);
-               expect(fixture.debugElement.nativeElement).toHaveText('reuse {B}');
+               expect(fixture.debugElement.nativeElement).toHaveText('reuse [B]');
                expect(cmpInstanceCount).toBe(1);
                async.done();
              });
@@ -153,14 +153,14 @@ export function main() {
              .then((_) => {
                fixture.detectChanges();
                expect(log).toEqual([]);
-               expect(fixture.debugElement.nativeElement).toHaveText('reuse {A}');
+               expect(fixture.debugElement.nativeElement).toHaveText('reuse [A]');
                expect(cmpInstanceCount).toBe(1);
              })
              .then((_) => rtr.navigateByUrl('/never-reuse/2/b'))
              .then((_) => {
                fixture.detectChanges();
                expect(log).toEqual([]);
-               expect(fixture.debugElement.nativeElement).toHaveText('reuse {B}');
+               expect(fixture.debugElement.nativeElement).toHaveText('reuse [B]');
                expect(cmpInstanceCount).toBe(2);
                async.done();
              });
@@ -180,7 +180,7 @@ export function main() {
                });
                rtr.navigateByUrl('/can-activate/a').then((_) => {
                  fixture.detectChanges();
-                 expect(fixture.debugElement.nativeElement).toHaveText('routerCanActivate {A}');
+                 expect(fixture.debugElement.nativeElement).toHaveText('routerCanActivate [A]');
                  expect(log).toEqual(['routerCanActivate: null -> /can-activate']);
                  async.done();
                });
@@ -215,7 +215,7 @@ export function main() {
              .then((_) => rtr.navigateByUrl('/can-deactivate/a'))
              .then((_) => {
                fixture.detectChanges();
-               expect(fixture.debugElement.nativeElement).toHaveText('routerCanDeactivate {A}');
+               expect(fixture.debugElement.nativeElement).toHaveText('routerCanDeactivate [A]');
                expect(log).toEqual([]);
 
                ObservableWrapper.subscribe<string>(eventBus, (ev) => {
@@ -241,7 +241,7 @@ export function main() {
              .then((_) => rtr.navigateByUrl('/can-deactivate/a'))
              .then((_) => {
                fixture.detectChanges();
-               expect(fixture.debugElement.nativeElement).toHaveText('routerCanDeactivate {A}');
+               expect(fixture.debugElement.nativeElement).toHaveText('routerCanDeactivate [A]');
                expect(log).toEqual([]);
 
                ObservableWrapper.subscribe<string>(eventBus, (ev) => {
@@ -252,7 +252,7 @@ export function main() {
 
                rtr.navigateByUrl('/a').then((_) => {
                  fixture.detectChanges();
-                 expect(fixture.debugElement.nativeElement).toHaveText('routerCanDeactivate {A}');
+                 expect(fixture.debugElement.nativeElement).toHaveText('routerCanDeactivate [A]');
                  expect(log).toEqual(['routerCanDeactivate: /can-deactivate -> /a']);
                  async.done();
                });
@@ -380,7 +380,7 @@ class ActivateCmp implements OnActivate {
 
 @Component({
   selector: 'parent-activate-cmp',
-  template: `parent {<router-outlet></router-outlet>}`,
+  template: `parent [<router-outlet></router-outlet>]`,
   directives: [RouterOutlet]
 })
 @RouteConfig([new Route({path: '/child-activate', component: ActivateCmp})])
@@ -410,7 +410,7 @@ class WaitDeactivateCmp implements OnDeactivate {
 
 @Component({
   selector: 'parent-deactivate-cmp',
-  template: `parent {<router-outlet></router-outlet>}`,
+  template: `parent [<router-outlet></router-outlet>]`,
   directives: [RouterOutlet]
 })
 @RouteConfig([new Route({path: '/child-deactivate', component: WaitDeactivateCmp})])
@@ -422,7 +422,7 @@ class ParentDeactivateCmp implements OnDeactivate {
 
 @Component({
   selector: 'reuse-cmp',
-  template: `reuse {<router-outlet></router-outlet>}`,
+  template: `reuse [<router-outlet></router-outlet>]`,
   directives: [RouterOutlet]
 })
 @RouteConfig([new Route({path: '/a', component: A}), new Route({path: '/b', component: B})])
@@ -437,7 +437,7 @@ class ReuseCmp implements OnReuse,
 
 @Component({
   selector: 'never-reuse-cmp',
-  template: `reuse {<router-outlet></router-outlet>}`,
+  template: `reuse [<router-outlet></router-outlet>]`,
   directives: [RouterOutlet]
 })
 @RouteConfig([new Route({path: '/a', component: A}), new Route({path: '/b', component: B})])
@@ -452,7 +452,7 @@ class NeverReuseCmp implements OnReuse,
 
 @Component({
   selector: 'can-activate-cmp',
-  template: `routerCanActivate {<router-outlet></router-outlet>}`,
+  template: `routerCanActivate [<router-outlet></router-outlet>]`,
   directives: [RouterOutlet]
 })
 @RouteConfig([new Route({path: '/a', component: A}), new Route({path: '/b', component: B})])
@@ -468,7 +468,7 @@ class CanActivateCmp {
 
 @Component({
   selector: 'can-deactivate-cmp',
-  template: `routerCanDeactivate {<router-outlet></router-outlet>}`,
+  template: `routerCanDeactivate [<router-outlet></router-outlet>]`,
   directives: [RouterOutlet]
 })
 @RouteConfig([new Route({path: '/a', component: A}), new Route({path: '/b', component: B})])

--- a/modules/@angular/router-deprecated/test/integration/navigation_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/navigation_spec.ts
@@ -72,13 +72,13 @@ export function main() {
 
     it('should navigate to child routes',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-         compile(tcb, 'outer { <router-outlet></router-outlet> }')
+         compile(tcb, 'outer [ <router-outlet></router-outlet> ]')
              .then((rtc) => {fixture = rtc})
              .then((_) => rtr.config([new Route({path: '/a/...', component: ParentCmp})]))
              .then((_) => rtr.navigateByUrl('/a/b'))
              .then((_) => {
                fixture.detectChanges();
-               expect(fixture.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+               expect(fixture.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
                async.done();
              });
        }));
@@ -86,13 +86,13 @@ export function main() {
     it('should navigate to child routes that capture an empty path',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
 
-         compile(tcb, 'outer { <router-outlet></router-outlet> }')
+         compile(tcb, 'outer [ <router-outlet></router-outlet> ]')
              .then((rtc) => {fixture = rtc})
              .then((_) => rtr.config([new Route({path: '/a/...', component: ParentCmp})]))
              .then((_) => rtr.navigateByUrl('/a'))
              .then((_) => {
                fixture.detectChanges();
-               expect(fixture.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+               expect(fixture.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
                async.done();
              });
        }));
@@ -101,14 +101,14 @@ export function main() {
        inject(
            [AsyncTestCompleter, Location],
            (async: AsyncTestCompleter, location: any /** TODO #9100 */) => {
-             compile(tcb, 'outer { <router-outlet></router-outlet> }')
+             compile(tcb, 'outer [ <router-outlet></router-outlet> ]')
                  .then((rtc) => {fixture = rtc})
                  .then((_) => rtr.config([new Route({path: '/...', component: ParentCmp})]))
                  .then((_) => rtr.navigateByUrl('/b'))
                  .then((_) => {
                    fixture.detectChanges();
                    expect(fixture.debugElement.nativeElement)
-                       .toHaveText('outer { inner { hello } }');
+                       .toHaveText('outer [ inner [ hello ] ]');
                    expect(location.urlChanges).toEqual(['/b']);
                    async.done();
                  });
@@ -116,13 +116,13 @@ export function main() {
 
     it('should navigate to child routes of async routes',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-         compile(tcb, 'outer { <router-outlet></router-outlet> }')
+         compile(tcb, 'outer [ <router-outlet></router-outlet> ]')
              .then((rtc) => {fixture = rtc})
              .then((_) => rtr.config([new AsyncRoute({path: '/a/...', loader: parentLoader})]))
              .then((_) => rtr.navigateByUrl('/a/b'))
              .then((_) => {
                fixture.detectChanges();
-               expect(fixture.debugElement.nativeElement).toHaveText('outer { inner { hello } }');
+               expect(fixture.debugElement.nativeElement).toHaveText('outer [ inner [ hello ] ]');
                async.done();
              });
        }));
@@ -154,14 +154,14 @@ export function main() {
              .then((_) => {
                fixture.detectChanges();
                expect(cmpInstanceCount).toBe(1);
-               expect(fixture.debugElement.nativeElement).toHaveText('team angular { hello rado }');
+               expect(fixture.debugElement.nativeElement).toHaveText('team angular [ hello rado ]');
              })
              .then((_) => rtr.navigateByUrl('/team/angular/user/victor'))
              .then((_) => {
                fixture.detectChanges();
                expect(cmpInstanceCount).toBe(1);
                expect(fixture.debugElement.nativeElement)
-                   .toHaveText('team angular { hello victor }');
+                   .toHaveText('team angular [ hello victor ]');
                async.done();
              });
        }));
@@ -176,14 +176,14 @@ export function main() {
                fixture.detectChanges();
                expect(cmpInstanceCount).toBe(1);
                expect(childCmpInstanceCount).toBe(1);
-               expect(fixture.debugElement.nativeElement).toHaveText('team angular { hello rado }');
+               expect(fixture.debugElement.nativeElement).toHaveText('team angular [ hello rado ]');
              })
              .then((_) => rtr.navigateByUrl('/team/dart/user/rado'))
              .then((_) => {
                fixture.detectChanges();
                expect(cmpInstanceCount).toBe(2);
                expect(childCmpInstanceCount).toBe(2);
-               expect(fixture.debugElement.nativeElement).toHaveText('team dart { hello rado }');
+               expect(fixture.debugElement.nativeElement).toHaveText('team dart [ hello rado ]');
                async.done();
              });
        }));
@@ -284,7 +284,7 @@ function parentLoader() {
 
 @Component({
   selector: 'parent-cmp',
-  template: `inner { <router-outlet></router-outlet> }`,
+  template: `inner [ <router-outlet></router-outlet> ]`,
   directives: [RouterOutlet],
 })
 @RouteConfig([
@@ -297,7 +297,7 @@ class ParentCmp {
 
 @Component({
   selector: 'team-cmp',
-  template: `team {{id}} { <router-outlet></router-outlet> }`,
+  template: `team {{id}} [ <router-outlet></router-outlet> ]`,
   directives: [RouterOutlet],
 })
 @RouteConfig([new Route({path: '/user/:name', component: UserCmp})])

--- a/modules/@angular/router-deprecated/test/integration/router_link_spec.ts
+++ b/modules/@angular/router-deprecated/test/integration/router_link_spec.ts
@@ -440,9 +440,9 @@ function parentCmpLoader() {
 
 @Component({
   selector: 'parent-cmp',
-  template: `{ <a [routerLink]="['./Grandchild']" class="grandchild-link">Grandchild</a>
+  template: `[ <a [routerLink]="['./Grandchild']" class="grandchild-link">Grandchild</a>
                <a [routerLink]="['./BetterGrandchild']" class="better-grandchild-link">Better Grandchild</a>
-               <router-outlet></router-outlet> }`,
+               <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([

--- a/modules/@angular/router-deprecated/test/route_config/route_config_spec.ts
+++ b/modules/@angular/router-deprecated/test/route_config/route_config_spec.ts
@@ -59,7 +59,7 @@ export function main() {
          bootstrap(HierarchyAppCmp, testBindings).then((applicationRef) => {
            var router = applicationRef.instance.router;
            router.subscribe((_: any /** TODO #9100 */) => {
-             expect(el).toHaveText('root { parent { hello } }');
+             expect(el).toHaveText('root [ parent [ hello ] ]');
              expect(applicationRef.instance.location.path()).toEqual('/parent/child');
              async.done();
            });
@@ -73,7 +73,7 @@ export function main() {
          bootstrap(RedirectAppCmp, testBindings).then((applicationRef) => {
            var router = applicationRef.instance.router;
            router.subscribe((_: any /** TODO #9100 */) => {
-             expect(el).toHaveText('root { hello }');
+             expect(el).toHaveText('root [ hello ]');
              expect(applicationRef.instance.location.path()).toEqual('/after');
              async.done();
            });
@@ -87,7 +87,7 @@ export function main() {
          bootstrap(AsyncAppCmp, testBindings).then((applicationRef) => {
            var router = applicationRef.instance.router;
            router.subscribe((_: any /** TODO #9100 */) => {
-             expect(el).toHaveText('root { hello }');
+             expect(el).toHaveText('root [ hello ]');
              expect(applicationRef.instance.location.path()).toEqual('/hello');
              async.done();
            });
@@ -101,7 +101,7 @@ export function main() {
          bootstrap(AuxAppCmp, testBindings).then((applicationRef) => {
            var router = applicationRef.instance.router;
            router.subscribe((_: any /** TODO #9100 */) => {
-             expect(el).toHaveText('root { hello } aside { hello }');
+             expect(el).toHaveText('root [ hello ] aside [ hello ]');
              expect(applicationRef.instance.location.path()).toEqual('/hello(aside)');
              async.done();
            });
@@ -115,7 +115,7 @@ export function main() {
          bootstrap(ConciseAsyncAppCmp, testBindings).then((applicationRef) => {
            var router = applicationRef.instance.router;
            router.subscribe((_: any /** TODO #9100 */) => {
-             expect(el).toHaveText('root { hello }');
+             expect(el).toHaveText('root [ hello ]');
              expect(applicationRef.instance.location.path()).toEqual('/hello');
              async.done();
            });
@@ -129,7 +129,7 @@ export function main() {
          bootstrap(ExplicitConstructorAppCmp, testBindings).then((applicationRef) => {
            var router = applicationRef.instance.router;
            router.subscribe((_: any /** TODO #9100 */) => {
-             expect(el).toHaveText('root { hello }');
+             expect(el).toHaveText('root [ hello ]');
              expect(applicationRef.instance.location.path()).toEqual('/hello');
              async.done();
            });
@@ -181,7 +181,7 @@ class HelloCmp {
 
 @Component({
   selector: 'app-cmp',
-  template: `root { <router-outlet></router-outlet> }`,
+  template: `root [ <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([
@@ -197,7 +197,7 @@ function HelloLoader(): Promise<any> {
 
 @Component({
   selector: 'app-cmp',
-  template: `root { <router-outlet></router-outlet> }`,
+  template: `root [ <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([
@@ -209,7 +209,7 @@ class AsyncAppCmp {
 
 @Component({
   selector: 'app-cmp',
-  template: `root { <router-outlet></router-outlet> }`,
+  template: `root [ <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([
@@ -222,7 +222,7 @@ class ConciseAsyncAppCmp {
 @Component({
   selector: 'app-cmp',
   template:
-      `root { <router-outlet></router-outlet> } aside { <router-outlet name="aside"></router-outlet> }`,
+      `root [ <router-outlet></router-outlet> ] aside [ <router-outlet name="aside"></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([{path: '/hello', component: HelloCmp}, {aux: 'aside', component: HelloCmp}])
@@ -232,7 +232,7 @@ class AuxAppCmp {
 
 @Component({
   selector: 'app-cmp',
-  template: `root { <router-outlet></router-outlet> }`,
+  template: `root [ <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([
@@ -244,7 +244,7 @@ class ExplicitConstructorAppCmp {
 
 @Component({
   selector: 'parent-cmp',
-  template: `parent { <router-outlet></router-outlet> }`,
+  template: `parent [ <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([{path: '/child', component: HelloCmp}])
@@ -253,7 +253,7 @@ class ParentCmp {
 
 @Component({
   selector: 'app-cmp',
-  template: `root { <router-outlet></router-outlet> }`,
+  template: `root [ <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([{path: '/parent/...', component: ParentCmp}])
@@ -263,7 +263,7 @@ class HierarchyAppCmp {
 
 @Component({
   selector: 'app-cmp',
-  template: `root { <router-outlet></router-outlet> }`,
+  template: `root [ <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([{path: '/hello'}])
@@ -272,7 +272,7 @@ class WrongConfigCmp {
 
 @Component({
   selector: 'app-cmp',
-  template: `root { <router-outlet></router-outlet> }`,
+  template: `root [ <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([{path: '/child', component: HelloCmp, name: 'child'}])
@@ -281,7 +281,7 @@ class BadAliasNameCmp {
 
 @Component({
   selector: 'app-cmp',
-  template: `root { <router-outlet></router-outlet> }`,
+  template: `root [ <router-outlet></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 @RouteConfig([

--- a/modules/@angular/router/test/router.spec.ts
+++ b/modules/@angular/router/test/router.spec.ts
@@ -1,7 +1,7 @@
 import 'rxjs/add/operator/map';
 
 import {Location} from '@angular/common';
-import {AppModule, AppModuleFactory, AppModuleFactoryLoader, Compiler, Component, Injectable} from '@angular/core';
+import {AppModule, AppModuleFactoryLoader, Component} from '@angular/core';
 import {ComponentFixture, TestComponentBuilder} from '@angular/core/testing';
 import {addProviders, configureModule, fakeAsync, inject, tick} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/matchers';
@@ -118,7 +118,7 @@ describe('Integration', () => {
            (<any>location).simulateHashChange('/team/22/user/fedor');
            advance(fixture);
 
-           expect(fixture.debugElement.nativeElement).toHaveText('team 22 { user fedor, right:  }');
+           expect(fixture.debugElement.nativeElement).toHaveText('team 22 [ user fedor, right:  ]');
          })));
 
   it('should update the location when the matched route does not change',
@@ -162,7 +162,7 @@ describe('Integration', () => {
            advance(fixture);
 
            expect(fixture.debugElement.nativeElement)
-               .toHaveText('team 22 { user victor, right: simple }');
+               .toHaveText('team 22 [ user victor, right: simple ]');
          })));
 
   it('should deactivate outlets',
@@ -186,7 +186,7 @@ describe('Integration', () => {
            advance(fixture);
 
            expect(fixture.debugElement.nativeElement)
-               .toHaveText('team 22 { user victor, right:  }');
+               .toHaveText('team 22 [ user victor, right:  ]');
          })));
 
   it('should deactivate nested outlets',
@@ -394,27 +394,27 @@ describe('Integration', () => {
            advance(fixture);
            expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
            expect(fixture.debugElement.nativeElement)
-               .toHaveText('primary {simple} right {user victor}');
+               .toHaveText('primary [simple] right [user victor]');
 
            // navigate to the same route with different params (reuse)
            router.navigateByUrl('/parent/22/(simple//right:user/fedor)');
            advance(fixture);
            expect(location.path()).toEqual('/parent/22/(simple//right:user/fedor)');
            expect(fixture.debugElement.nativeElement)
-               .toHaveText('primary {simple} right {user fedor}');
+               .toHaveText('primary [simple] right [user fedor]');
 
            // navigate to a normal route (check deactivation)
            router.navigateByUrl('/user/victor');
            advance(fixture);
            expect(location.path()).toEqual('/user/victor');
-           expect(fixture.debugElement.nativeElement).toHaveText('primary {user victor} right {}');
+           expect(fixture.debugElement.nativeElement).toHaveText('primary [user victor] right []');
 
            // navigate back to a componentless route
            router.navigateByUrl('/parent/11/(simple//right:user/victor)');
            advance(fixture);
            expect(location.path()).toEqual('/parent/11/(simple//right:user/victor)');
            expect(fixture.debugElement.nativeElement)
-               .toHaveText('primary {simple} right {user victor}');
+               .toHaveText('primary [simple] right [user victor]');
          })));
 
   it('should emit an event when an outlet gets activated',
@@ -538,14 +538,14 @@ describe('Integration', () => {
 
              router.navigateByUrl('/team/22/link');
              advance(fixture);
-             expect(fixture.debugElement.nativeElement).toHaveText('team 22 { link, right:  }');
+             expect(fixture.debugElement.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
              const native = fixture.debugElement.nativeElement.querySelector('a');
              expect(native.getAttribute('href')).toEqual('/team/33/simple');
              native.click();
              advance(fixture);
 
-             expect(fixture.debugElement.nativeElement).toHaveText('team 33 { simple, right:  }');
+             expect(fixture.debugElement.nativeElement).toHaveText('team 33 [ simple, right:  ]');
            })));
 
     it('should update hrefs when query params change',
@@ -591,13 +591,13 @@ describe('Integration', () => {
 
              router.navigateByUrl('/team/22/link');
              advance(fixture);
-             expect(fixture.debugElement.nativeElement).toHaveText('team 22 { link, right:  }');
+             expect(fixture.debugElement.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
              const native = fixture.debugElement.nativeElement.querySelector('button');
              native.click();
              advance(fixture);
 
-             expect(fixture.debugElement.nativeElement).toHaveText('team 33 { simple, right:  }');
+             expect(fixture.debugElement.nativeElement).toHaveText('team 33 [ simple, right:  ]');
            })));
 
     it('should support absolute router links',
@@ -616,14 +616,14 @@ describe('Integration', () => {
 
              router.navigateByUrl('/team/22/link');
              advance(fixture);
-             expect(fixture.debugElement.nativeElement).toHaveText('team 22 { link, right:  }');
+             expect(fixture.debugElement.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
              const native = fixture.debugElement.nativeElement.querySelector('a');
              expect(native.getAttribute('href')).toEqual('/team/33/simple');
              native.click();
              advance(fixture);
 
-             expect(fixture.debugElement.nativeElement).toHaveText('team 33 { simple, right:  }');
+             expect(fixture.debugElement.nativeElement).toHaveText('team 33 [ simple, right:  ]');
            })));
 
     it('should support relative router links',
@@ -642,14 +642,14 @@ describe('Integration', () => {
 
              router.navigateByUrl('/team/22/link');
              advance(fixture);
-             expect(fixture.debugElement.nativeElement).toHaveText('team 22 { link, right:  }');
+             expect(fixture.debugElement.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
              const native = fixture.debugElement.nativeElement.querySelector('a');
              expect(native.getAttribute('href')).toEqual('/team/22/simple');
              native.click();
              advance(fixture);
 
-             expect(fixture.debugElement.nativeElement).toHaveText('team 22 { simple, right:  }');
+             expect(fixture.debugElement.nativeElement).toHaveText('team 22 [ simple, right:  ]');
            })));
 
     it('should support top-level link',
@@ -702,7 +702,7 @@ describe('Integration', () => {
              native.click();
              advance(fixture);
 
-             expect(fixture.debugElement.nativeElement).toHaveText('team 22 { simple, right:  }');
+             expect(fixture.debugElement.nativeElement).toHaveText('team 22 [ simple, right:  ]');
 
              expect(location.path()).toEqual('/team/22/simple?q=1#f');
            })));
@@ -1127,7 +1127,7 @@ describe('Integration', () => {
                      loader: SpyAppModuleFactoryLoader) => {
                       @Component({
                         selector: 'lazy',
-                        template: 'lazy-loaded-parent {<router-outlet></router-outlet>}',
+                        template: 'lazy-loaded-parent [<router-outlet></router-outlet>]',
                         directives: ROUTER_DIRECTIVES
                       })
                       class ParentLazyLoadedComponent {
@@ -1160,7 +1160,7 @@ describe('Integration', () => {
 
                       expect(location.path()).toEqual('/lazy/loaded/child');
                       expect(fixture.debugElement.nativeElement)
-                          .toHaveText('lazy-loaded-parent {lazy-loaded-child}');
+                          .toHaveText('lazy-loaded-parent [lazy-loaded-child]');
                     })));
 
     it('error emit an error when cannot load a config',
@@ -1287,7 +1287,7 @@ class BlankCmp {
 @Component({
   selector: 'team-cmp',
   template:
-      `team {{id | async}} { <router-outlet></router-outlet>, right: <router-outlet name="right"></router-outlet> }`,
+      `team {{id | async}} [ <router-outlet></router-outlet>, right: <router-outlet name="right"></router-outlet> ]`,
   directives: ROUTER_DIRECTIVES
 })
 class TeamCmp {
@@ -1376,7 +1376,7 @@ class RootCmp {
 @Component({
   selector: 'root-cmp',
   template:
-      `primary {<router-outlet></router-outlet>} right {<router-outlet name="right"></router-outlet>}`,
+      `primary [<router-outlet></router-outlet>] right [<router-outlet name="right"></router-outlet>]`,
   directives: [ROUTER_DIRECTIVES],
   precompile: [BlankCmp, SimpleCmp, RouteCmp, UserCmp]
 })


### PR DESCRIPTION
The main change here is that ICU messages are parsed even when I18N is not enabled.

This is a breaking change as "`{`" is now used to mark start of ICU messages.

"`{{ '{' }}`" should be used to escape opening brace. Note that the commit message details the breaking change.

Other changes are still a WIP and I18N will further evolve.
