### PR TITLE
fix(compiler): No longer writes 0 length files outside of genDir

### DIFF
--- a/modules/@angular/compiler-cli/test/mocks.ts
+++ b/modules/@angular/compiler-cli/test/mocks.ts
@@ -17,9 +17,11 @@ export interface Directory { [name: string]: Entry; }
 export class MockContext implements ReflectorHostContext {
   constructor(public currentDirectory: string, private files: Entry) {}
 
-  exists(fileName: string): boolean { return this.getEntry(fileName) !== undefined; }
+  fileExists(fileName: string): boolean { return typeof this.getEntry(fileName) === 'string'; }
 
-  read(fileName: string): string|undefined {
+  directoryExists(path: string): boolean { return typeof this.getEntry(path) === 'object' }
+
+  readFile(fileName: string): string|undefined {
     let data = this.getEntry(fileName);
     if (typeof data === 'string') {
       return data;
@@ -27,7 +29,7 @@ export class MockContext implements ReflectorHostContext {
     return undefined;
   }
 
-  write(fileName: string, data: string): void {
+  writeFile(fileName: string, data: string): void {
     let parts = fileName.split('/');
     let name = parts.pop();
     let entry = this.getEntry(parts);
@@ -35,6 +37,8 @@ export class MockContext implements ReflectorHostContext {
       entry[name] = data;
     }
   }
+
+  assumeFileExists(fileName: string): void { this.writeFile(fileName, ''); }
 
   getEntry(fileName: string|string[]): Entry|undefined {
     let parts = typeof fileName === 'string' ? fileName.split('/') : fileName;
@@ -79,16 +83,18 @@ function normalize(parts: string[]): string[] {
 export class MockCompilerHost implements ts.CompilerHost {
   constructor(private context: MockContext) {}
 
-  fileExists(fileName: string): boolean { return this.context.exists(fileName); }
+  fileExists(fileName: string): boolean { return this.context.fileExists(fileName); }
 
-  readFile(fileName: string): string { return this.context.read(fileName); }
+  readFile(fileName: string): string { return this.context.readFile(fileName); }
 
-  directoryExists(directoryName: string): boolean { return this.context.exists(directoryName); }
+  directoryExists(directoryName: string): boolean {
+    return this.context.directoryExists(directoryName);
+  }
 
   getSourceFile(
       fileName: string, languageVersion: ts.ScriptTarget,
       onError?: (message: string) => void): ts.SourceFile {
-    let sourceText = this.context.read(fileName);
+    let sourceText = this.context.readFile(fileName);
     if (sourceText) {
       return ts.createSourceFile(fileName, sourceText, languageVersion);
     } else {
@@ -100,7 +106,7 @@ export class MockCompilerHost implements ts.CompilerHost {
     return ts.getDefaultLibFileName(options);
   }
 
-  writeFile: ts.WriteFileCallback = (fileName, text) => { this.context.write(fileName, text); }
+  writeFile: ts.WriteFileCallback = (fileName, text) => { this.context.writeFile(fileName, text); }
 
   getCurrentDirectory(): string {
     return this.context.currentDirectory;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The compiler would write 0 length files that it assumed would be overwritten. These path of these files didn't account for the `genDir` option and also are strictly needed since they were written just to get file exists to return `true` which can be done more directly.

**What is the new behavior?**

The `ReflectorHost` now just records which files the module resolve needs to assume exists instead of writing out a 0 length file.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

Fixes: #9984
