### PR TITLE
fix(compiler): Query expression lambdas should have dynamic type

### DIFF
--- a/modules/@angular/compiler-cli/integrationtest/src/queries.ts
+++ b/modules/@angular/compiler-cli/integrationtest/src/queries.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {NgFor} from '@angular/common';
+import {Component, Directive, QueryList, ViewChild, ViewChildren} from '@angular/core';
 
 @Component({selector: 'comp-for-child-query', template: 'child'})
 export class CompForChildQuery {
@@ -20,4 +21,21 @@ export class CompForChildQuery {
 export class CompWithChildQuery {
   @ViewChild(CompForChildQuery) child: CompForChildQuery;
   @ViewChildren(CompForChildQuery) children: QueryList<CompForChildQuery>;
+}
+
+@Directive({selector: '[directive-for-query]'})
+export class DirectiveForQuery {
+}
+
+@Component({
+  selector: 'comp-with-directive-child',
+  directives: [DirectiveForQuery, NgFor],
+  template: `<div>
+     <div *ngFor="let data of divData" directive-for-query>{{data}}</div>
+  </div>`
+})
+export class CompWithDirectiveChild {
+  @ViewChildren(DirectiveForQuery) children: QueryList<DirectiveForQuery>;
+
+  divData: string[];
 }

--- a/modules/@angular/compiler-cli/integrationtest/src/queries.ts
+++ b/modules/@angular/compiler-cli/integrationtest/src/queries.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgFor} from '@angular/common';
-import {Component, Directive, QueryList, ViewChild, ViewChildren} from '@angular/core';
+import {Component, QueryList, ViewChild, ViewChildren} from '@angular/core';
 
 @Component({selector: 'comp-for-child-query', template: 'child'})
 export class CompForChildQuery {
@@ -21,21 +20,4 @@ export class CompForChildQuery {
 export class CompWithChildQuery {
   @ViewChild(CompForChildQuery) child: CompForChildQuery;
   @ViewChildren(CompForChildQuery) children: QueryList<CompForChildQuery>;
-}
-
-@Directive({selector: '[directive-for-query]'})
-export class DirectiveForQuery {
-}
-
-@Component({
-  selector: 'comp-with-directive-child',
-  directives: [DirectiveForQuery, NgFor],
-  template: `<div>
-     <div *ngFor="let data of divData" directive-for-query>{{data}}</div>
-  </div>`
-})
-export class CompWithDirectiveChild {
-  @ViewChildren(DirectiveForQuery) children: QueryList<DirectiveForQuery>;
-
-  divData: string[];
 }

--- a/modules/@angular/compiler/src/output/ts_emitter.ts
+++ b/modules/@angular/compiler/src/output/ts_emitter.ts
@@ -170,7 +170,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     ctx.print(`(`);
     this._visitParams(ast.params, ctx);
     ctx.print(`):`);
-    this.visitType(ast.type, ctx);
+    this.visitType(ast.type, ctx, 'void');
     ctx.println(` => {`);
     ctx.incIndent();
     this.visitAllStatements(ast.statements, ctx);

--- a/modules/@angular/compiler/src/view_compiler/compile_query.ts
+++ b/modules/@angular/compiler/src/view_compiler/compile_query.ts
@@ -105,9 +105,10 @@ function mapNestedViews(
     return o.replaceVarInExpression(o.THIS_EXPR.name, o.variable('nestedView'), expr);
   });
   return declarationAppElement.callMethod('mapNestedViews', [
-    o.variable(view.className), o.fn(
-                                    [new o.FnParam('nestedView', view.classType)],
-                                    [new o.ReturnStatement(o.literalArr(adjustedExpressions))])
+    o.variable(view.className),
+    o.fn(
+        [new o.FnParam('nestedView', view.classType)],
+        [new o.ReturnStatement(o.literalArr(adjustedExpressions))], o.DYNAMIC_TYPE)
   ]);
 }
 

--- a/modules/@angular/compiler/test/output/ts_emitter_spec.ts
+++ b/modules/@angular/compiler/test/output/ts_emitter_spec.ts
@@ -143,11 +143,11 @@ export function main() {
     });
 
     it('should support function expressions', () => {
-      expect(emitStmt(o.fn([], []).toStmt())).toEqual(['():any => {', '};'].join('\n'));
+      expect(emitStmt(o.fn([], []).toStmt())).toEqual(['():void => {', '};'].join('\n'));
       expect(emitStmt(o.fn([], [new o.ReturnStatement(o.literal(1))], o.INT_TYPE).toStmt()))
           .toEqual(['():number => {', '  return 1;\n};'].join('\n'));
       expect(emitStmt(o.fn([new o.FnParam('param1', o.INT_TYPE)], []).toStmt())).toEqual([
-        '(param1:number):any => {', '};'
+        '(param1:number):void => {', '};'
       ].join('\n'));
     });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Revert of a previous fix and replaced with the recommended fix from @tbosh. 

The function expressions generated for view queries didn't specify a type which results in them being given the `void` type.

**What is the new behavior?**

View query function expressions are now explicitly given the dynamic type which is `any` in TypeScript.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

Fixes: #9875
