### PR TITLE
Router: CanActivateChild

### DIFF
--- a/modules/@angular/router/index.ts
+++ b/modules/@angular/router/index.ts
@@ -12,7 +12,7 @@ export {Data, ResolveData, Route, RouterConfig, Routes} from './src/config';
 export {RouterLink, RouterLinkWithHref} from './src/directives/router_link';
 export {RouterLinkActive} from './src/directives/router_link_active';
 export {RouterOutlet} from './src/directives/router_outlet';
-export {CanActivate, CanDeactivate, Resolve} from './src/interfaces';
+export {CanActivate, CanActivateChild, CanDeactivate, Resolve} from './src/interfaces';
 export {Event, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, Router, RoutesRecognized} from './src/router';
 export {ROUTER_DIRECTIVES, RouterModule} from './src/router_module';
 export {RouterOutletMap} from './src/router_outlet_map';

--- a/modules/@angular/router/src/config.ts
+++ b/modules/@angular/router/src/config.ts
@@ -241,9 +241,11 @@ export type RouterConfig = Route[];
  * - `redirectTo` is the url fragment which will replace the current matched segment.
  * - `outlet` is the name of the outlet the component should be placed into.
  * - `canActivate` is an array of DI tokens used to look up CanActivate handlers. See {@link
-  * CanActivate} for more info.
+ * CanActivate} for more info.
+ * - `canActivateChild` is an array of DI tokens used to look up CanActivateChild handlers. See {@link
+ * CanActivateChild} for more info.
  * - `canDeactivate` is an array of DI tokens used to look up CanDeactivate handlers. See {@link
-  * CanDeactivate} for more info.
+ * CanDeactivate} for more info.
  * - `data` is additional data provided to the component via `ActivatedRoute`.
  * - `resolve` is a map of DI tokens used to look up data resolvers. See {@link Resolve} for more
  * info.
@@ -487,6 +489,7 @@ export interface Route {
   redirectTo?: string;
   outlet?: string;
   canActivate?: any[];
+  canActivateChild?: any[];
   canDeactivate?: any[];
   data?: Data;
   resolve?: ResolveData;

--- a/modules/@angular/router/src/config.ts
+++ b/modules/@angular/router/src/config.ts
@@ -242,7 +242,8 @@ export type RouterConfig = Route[];
  * - `outlet` is the name of the outlet the component should be placed into.
  * - `canActivate` is an array of DI tokens used to look up CanActivate handlers. See {@link
  * CanActivate} for more info.
- * - `canActivateChild` is an array of DI tokens used to look up CanActivateChild handlers. See {@link
+ * - `canActivateChild` is an array of DI tokens used to look up CanActivateChild handlers. See
+ * {@link
  * CanActivateChild} for more info.
  * - `canDeactivate` is an array of DI tokens used to look up CanDeactivate handlers. See {@link
  * CanDeactivate} for more info.

--- a/modules/@angular/router/src/interfaces.ts
+++ b/modules/@angular/router/src/interfaces.ts
@@ -53,7 +53,7 @@ import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
  */
 export interface CanActivate {
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot):
-      Observable<boolean>|boolean;
+      Observable<boolean>|Promise<boolean>|boolean;
 }
 
 /**
@@ -114,7 +114,7 @@ export interface CanActivate {
 
 export interface CanActivateChild {
   canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot):
-      Observable<boolean>|boolean;
+      Observable<boolean>|Promise<boolean>|boolean;
 }
 
 /**
@@ -161,7 +161,7 @@ export interface CanActivateChild {
  */
 export interface CanDeactivate<T> {
   canDeactivate(component: T, route: ActivatedRouteSnapshot, state: RouterStateSnapshot):
-      Observable<boolean>|boolean;
+      Observable<boolean>|Promise<boolean>|boolean;
 }
 
 /**
@@ -197,5 +197,6 @@ export interface CanDeactivate<T> {
  * @experimental
  */
 export interface Resolve<T> {
-  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<any>|any;
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot):
+      Observable<any>|Promise<any>|any;
 }

--- a/modules/@angular/router/src/interfaces.ts
+++ b/modules/@angular/router/src/interfaces.ts
@@ -66,7 +66,8 @@ export interface CanActivate {
  * class CanActivateTeam implements CanActivate {
  *   constructor(private permissions: Permissions, private currentUser: UserToken) {}
  *
- *   canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot):Observable<boolean> {
+ *   canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot):Observable<boolean>
+ * {
  *     return this.permissions.canActivate(this.currentUser, this.route.params.id);
  *   }
  * }

--- a/modules/@angular/router/src/interfaces.ts
+++ b/modules/@angular/router/src/interfaces.ts
@@ -57,6 +57,66 @@ export interface CanActivate {
 }
 
 /**
+ * An interface a class can implement to be a guard deciding if a child route can be activated.
+ *
+ * ### Example
+ *
+ * ```
+ * @Injectable()
+ * class CanActivateTeam implements CanActivate {
+ *   constructor(private permissions: Permissions, private currentUser: UserToken) {}
+ *
+ *   canActivateChild(route: ActivatedRouteSnapshot, state: RouterStateSnapshot):Observable<boolean> {
+ *     return this.permissions.canActivate(this.currentUser, this.route.params.id);
+ *   }
+ * }
+ *
+ * bootstrap(AppComponent, [
+ *   CanActivateTeam,
+ *
+ *   provideRouter([
+ *     {
+ *       path: 'root',
+ *       canActivateChild: [CanActivateTeam],
+ *       children: [
+ *        {
+ *          path: 'team/:id',
+ *          component: Team
+ *        }
+ *      ]
+ *    }
+ * ]);
+ * ```
+ *
+ * You can also provide a function with the same signature instead of the class:
+ *
+ * ```
+ * bootstrap(AppComponent, [
+ *   {provide: 'canActivateTeam', useValue: (route: ActivatedRouteSnapshot, state:
+ * RouterStateSnapshot) => true},
+ *   provideRouter([
+ *     {
+ *       path: 'root',
+ *       canActivateChild: [CanActivateTeam],
+ *       children: [
+ *        {
+ *          path: 'team/:id',
+ *          component: Team
+ *        }
+ *      ]
+ *    }
+ * ]);
+ * ```
+ *
+ * @stable
+ */
+
+export interface CanActivateChild {
+  canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot):
+      Observable<boolean>|boolean;
+}
+
+/**
  * An interface a class can implement to be a guard deciding if a route can be deactivated.
  *
  * ### Example

--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -12,6 +12,7 @@ import 'rxjs/add/operator/mergeAll';
 import 'rxjs/add/operator/reduce';
 import 'rxjs/add/operator/every';
 import 'rxjs/add/observable/from';
+import 'rxjs/add/observable/fromPromise';
 import 'rxjs/add/observable/forkJoin';
 import 'rxjs/add/observable/of';
 
@@ -596,6 +597,8 @@ class PreActivation {
 function wrapIntoObservable<T>(value: T | Observable<T>): Observable<T> {
   if (value instanceof Observable) {
     return value;
+  } else if (value instanceof Promise) {
+    return Observable.fromPromise(value);
   } else {
     return Observable.of(value);
   }

--- a/modules/@angular/router/src/router_config_loader.ts
+++ b/modules/@angular/router/src/router_config_loader.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AppModuleFactoryLoader, AppModuleRef, ComponentFactoryResolver, OpaqueToken} from '@angular/core';
+import {AppModuleFactoryLoader, ComponentFactoryResolver, Injector, OpaqueToken} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {fromPromise} from 'rxjs/observable/fromPromise';
 
 import {Route} from './config';
+
 
 /**
  * @deprecated use Routes
@@ -19,16 +20,19 @@ export const ROUTER_CONFIG = new OpaqueToken('ROUTER_CONFIG');
 export const ROUTES = new OpaqueToken('ROUTES');
 
 export class LoadedRouterConfig {
-  constructor(public routes: Route[], public factoryResolver: ComponentFactoryResolver) {}
+  constructor(
+      public routes: Route[], public injector: Injector,
+      public factoryResolver: ComponentFactoryResolver) {}
 }
 
 export class RouterConfigLoader {
   constructor(private loader: AppModuleFactoryLoader) {}
 
-  load(path: string): Observable<LoadedRouterConfig> {
+  load(parentInjector: Injector, path: string): Observable<LoadedRouterConfig> {
     return fromPromise(this.loader.load(path).then(r => {
-      const ref = r.create();
-      return new LoadedRouterConfig(ref.injector.get(ROUTES), ref.componentFactoryResolver);
+      const ref = r.create(parentInjector);
+      return new LoadedRouterConfig(
+          ref.injector.get(ROUTES), ref.injector, ref.componentFactoryResolver);
     }));
   }
 }

--- a/modules/@angular/router/test/router.spec.ts
+++ b/modules/@angular/router/test/router.spec.ts
@@ -891,6 +891,40 @@ describe('Integration', () => {
                  expect(location.path()).toEqual('/');
                })));
       });
+
+      describe('should work when returns a promise', () => {
+        beforeEach(() => {
+          addProviders([{
+            provide: 'CanActivate',
+            useValue: (a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
+              if (a.params['id'] == '22') {
+                return Promise.resolve(true);
+              } else {
+                return Promise.resolve(false);
+              }
+            }
+          }]);
+        });
+
+
+        fit('works',
+            fakeAsync(inject(
+                [Router, TestComponentBuilder, Location],
+                (router: Router, tcb: TestComponentBuilder, location: Location) => {
+                  const fixture = createRoot(tcb, router, RootCmp);
+
+                  router.resetConfig(
+                      [{path: 'team/:id', component: TeamCmp, canActivate: ['CanActivate']}]);
+
+                  router.navigateByUrl('/team/22');
+                  advance(fixture);
+                  expect(location.path()).toEqual('/team/22');
+
+                  router.navigateByUrl('/team/33');
+                  advance(fixture);
+                  expect(location.path()).toEqual('/team/22');
+                })));
+      });
     });
 
     describe('CanDeactivate', () => {

--- a/modules/@angular/router/test/router.spec.ts
+++ b/modules/@angular/router/test/router.spec.ts
@@ -1037,6 +1037,39 @@ describe('Integration', () => {
       });
     });
 
+    describe('CanActivateChild', () => {
+      describe('should be invoked when activating a child', () => {
+        beforeEach(() => {
+          addProviders([{
+            provide: 'alwaysFalse',
+            useValue: (a: any, b: any) => { return a.params.id === '22'; }
+          }]);
+        });
+
+        it('works', fakeAsync(inject(
+                        [Router, TestComponentBuilder, Location],
+                        (router: Router, tcb: TestComponentBuilder, location: Location) => {
+                          const fixture = createRoot(tcb, router, RootCmp);
+
+                          router.resetConfig([{
+                            path: '',
+                            canActivateChild: ['alwaysFalse'],
+                            children: [{path: 'team/:id', component: TeamCmp}]
+                          }]);
+
+                          router.navigateByUrl('/team/22');
+                          advance(fixture);
+
+                          expect(location.path()).toEqual('/team/22');
+
+                          router.navigateByUrl('/team/33').catch(() => {});
+                          advance(fixture);
+
+                          expect(location.path()).toEqual('/team/22');
+                        })));
+      });
+    });
+
     describe('should work when returns an observable', () => {
       beforeEach(() => {
         addProviders([{

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -21,12 +21,17 @@ export declare class ActivatedRouteSnapshot {
 
 /** @stable */
 export interface CanActivate {
-    canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | boolean;
+    canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean;
+}
+
+/** @stable */
+export interface CanActivateChild {
+    canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean;
 }
 
 /** @stable */
 export interface CanDeactivate<T> {
-    canDeactivate(component: T, route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | boolean;
+    canDeactivate(component: T, route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean;
 }
 
 /** @stable */
@@ -101,7 +106,7 @@ export declare function provideRoutes(routes: Routes): any;
 
 /** @experimental */
 export interface Resolve<T> {
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<any> | any;
+    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<any> | Promise<any> | any;
 }
 
 /** @stable */


### PR DESCRIPTION
This PR:
- Add a new guard "CanActivateChild", which is invoked any time a child route is activate
- Add support for Promises, so guards and data resolver can return them instead of observables
