### PR TITLE
feat(router): allow to pass `preventPushState` parameter to navigate/…

### DIFF
--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -243,12 +243,12 @@ export class Router {
    * router.navigateByUrl("/team/33/user/11");
    * ```
    */
-  navigateByUrl(url: string|UrlTree): Promise<boolean> {
+  navigateByUrl(url: string|UrlTree, preventPushState = false): Promise<boolean> {
     if (url instanceof UrlTree) {
-      return this.scheduleNavigation(url, false);
+      return this.scheduleNavigation(url, preventPushState);
     } else {
       const urlTree = this.urlSerializer.parse(url);
-      return this.scheduleNavigation(urlTree, false);
+      return this.scheduleNavigation(urlTree, preventPushState);
     }
   }
 
@@ -267,8 +267,9 @@ export class Router {
    * router.navigate(['team', 33, 'team', '11], {relativeTo: route});
    * ```
    */
-  navigate(commands: any[], extras: NavigationExtras = {}): Promise<boolean> {
-    return this.scheduleNavigation(this.createUrlTree(commands, extras), false);
+  navigate(commands: any[], extras: NavigationExtras = {}, preventPushState = false):
+      Promise<boolean> {
+    return this.scheduleNavigation(this.createUrlTree(commands, extras), preventPushState);
   }
 
   /**

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -127,8 +127,8 @@ export declare class Router {
     url: string;
     constructor(rootComponentType: Type, resolver: ComponentResolver, urlSerializer: UrlSerializer, outletMap: RouterOutletMap, location: Location, injector: Injector, loader: AppModuleFactoryLoader, config: Routes);
     createUrlTree(commands: any[], {relativeTo, queryParams, fragment}?: NavigationExtras): UrlTree;
-    navigate(commands: any[], extras?: NavigationExtras): Promise<boolean>;
-    navigateByUrl(url: string | UrlTree): Promise<boolean>;
+    navigate(commands: any[], extras?: NavigationExtras, preventPushState?: boolean): Promise<boolean>;
+    navigateByUrl(url: string | UrlTree, preventPushState?: boolean): Promise<boolean>;
     parseUrl(url: string): UrlTree;
     resetConfig(config: Routes): void;
     serializeUrl(url: UrlTree): string;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Feature
```

**What is the current behavior?** (You can also link to an open issue here)

`scheduleNavigation`, an internal api, supports `preventPushState` parameter. 
But its callers, `navigate` and `navigateUrl`, cannot pass the parameter from an argument.

**What is the new behavior?**

allow to pass `preventPushState` parameter to `navigate` /`navigateUrl`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
