### PR TITLE
refactor(compiler): move test/test_bindings to testing/test_bindings

### DIFF
--- a/modules/@angular/compiler/test/directive_normalizer_spec.ts
+++ b/modules/@angular/compiler/test/directive_normalizer_spec.ts
@@ -11,12 +11,12 @@ import {CompilerConfig} from '@angular/compiler/src/config';
 import {DirectiveNormalizer} from '@angular/compiler/src/directive_normalizer';
 import {ResourceLoader} from '@angular/compiler/src/resource_loader';
 import {MockResourceLoader} from '@angular/compiler/testing/resource_loader_mock';
+import {TEST_COMPILER_PROVIDERS} from '@angular/compiler/testing/test_bindings';
 import {ViewEncapsulation} from '@angular/core/src/metadata/view';
 import {TestBed} from '@angular/core/testing';
 import {AsyncTestCompleter, beforeEach, beforeEachProviders, ddescribe, describe, expect, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
 
 import {SpyResourceLoader} from './spies';
-import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
 export function main() {
   describe('DirectiveNormalizer', () => {

--- a/modules/@angular/compiler/test/metadata_resolver_spec.ts
+++ b/modules/@angular/compiler/test/metadata_resolver_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {CompilerConfig} from '@angular/compiler/src/config';
+import {TEST_COMPILER_PROVIDERS} from '@angular/compiler/testing/test_bindings';
 import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, Component, Directive, DoCheck, Injectable, NgModule, OnChanges, OnDestroy, OnInit, Pipe, SimpleChanges, ViewEncapsulation} from '@angular/core';
 import {LIFECYCLE_HOOKS_VALUES} from '@angular/core/src/metadata/lifecycle_hooks';
 import {TestBed} from '@angular/core/testing';
@@ -17,7 +18,6 @@ import {stringify} from '../src/facade/lang';
 import {CompileMetadataResolver} from '../src/metadata_resolver';
 
 import {MalformedStylesComponent} from './metadata_resolver_fixture';
-import {TEST_COMPILER_PROVIDERS} from './test_bindings';
 
 export function main() {
   describe('CompileMetadataResolver', () => {

--- a/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
@@ -12,6 +12,7 @@ import {ElementSchemaRegistry} from '@angular/compiler/src/schema/element_schema
 import {AttrAst, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, DirectiveAst, ElementAst, EmbeddedTemplateAst, NgContentAst, PropertyBindingType, ProviderAstType, ReferenceAst, TemplateAst, TemplateAstVisitor, TextAst, VariableAst, templateVisitAll} from '@angular/compiler/src/template_parser/template_ast';
 import {TEMPLATE_TRANSFORMS, TemplateParser, splitClasses} from '@angular/compiler/src/template_parser/template_parser';
 import {MockSchemaRegistry} from '@angular/compiler/testing';
+import {TEST_COMPILER_PROVIDERS} from '@angular/compiler/testing/test_bindings';
 import {SchemaMetadata, SecurityContext} from '@angular/core';
 import {Console} from '@angular/core/src/console';
 import {TestBed} from '@angular/core/testing';
@@ -20,7 +21,6 @@ import {afterEach, beforeEach, beforeEachProviders, ddescribe, describe, expect,
 import {Identifiers, identifierToken} from '../../src/identifiers';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../src/ml_parser/interpolation_config';
 import {unparse} from '../expression_parser/unparser';
-import {TEST_COMPILER_PROVIDERS} from '../test_bindings';
 
 var someModuleUrl = 'package:someModule';
 

--- a/modules/@angular/compiler/testing/test_bindings.ts
+++ b/modules/@angular/compiler/testing/test_bindings.ts
@@ -11,6 +11,9 @@ import {createUrlResolverWithoutPackagePrefix} from '@angular/compiler/src/url_r
 import {MockSchemaRegistry} from '@angular/compiler/testing';
 import {MockResourceLoader} from '@angular/compiler/testing/resource_loader_mock';
 
+// This provider is put here just so that we can access it from multiple
+// internal test packages.
+// TODO: get rid of it or move to a separate @angular/internal_testing package
 export var TEST_COMPILER_PROVIDERS: any[] = [
   {provide: ElementSchemaRegistry, useValue: new MockSchemaRegistry({}, {})},
   {provide: ResourceLoader, useClass: MockResourceLoader},

--- a/modules/@angular/core/test/linker/change_detection_integration_spec.ts
+++ b/modules/@angular/core/test/linker/change_detection_integration_spec.ts
@@ -8,8 +8,8 @@
 
 import {AsyncPipe, NgFor} from '@angular/common';
 import {ElementSchemaRegistry} from '@angular/compiler/src/schema/element_schema_registry';
-import {TEST_COMPILER_PROVIDERS} from '@angular/compiler/test/test_bindings';
 import {MockSchemaRegistry} from '@angular/compiler/testing';
+import {TEST_COMPILER_PROVIDERS} from '@angular/compiler/testing/test_bindings';
 import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ComponentMetadata, DebugElement, Directive, DoCheck, Injectable, Input, OnChanges, OnDestroy, OnInit, Output, Pipe, PipeTransform, RenderComponentType, Renderer, RootRenderer, SimpleChange, SimpleChanges, TemplateRef, Type, ViewContainerRef, WrappedValue, forwardRef} from '@angular/core';
 import {DebugDomRenderer} from '@angular/core/src/debug/debug_renderer';
 import {ViewMetadata} from '@angular/core/src/metadata/view';


### PR DESCRIPTION
`test_bindings` is used in core test cases too, but `test` should be private to the package, so it should live in `testing`.

//cc: @IgorMinar 

**Please check if the PR fulfills these requirements**
- The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- Tests for the changes have been added (for bug fixes / features)
- Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
Refactoring (no functional changes, no api changes)
```

**Does this PR introduce a breaking change?** (check one with "x")

```
No
```
