### PR TITLE
fix(ng upgrade): do not compile ng2 components until after ng1 bootstrap

### DIFF
--- a/modules/@angular/upgrade/src/upgrade_adapter.ts
+++ b/modules/@angular/upgrade/src/upgrade_adapter.ts
@@ -383,11 +383,8 @@ export class UpgradeAdapter {
       }
     });
 
-    Promise
-        .all([
-          this.compileNg2Components(compiler, componentFactoryRefMap), ng1BootstrapPromise,
-          ng1compilePromise
-        ])
+    Promise.all([ng1BootstrapPromise, ng1compilePromise])
+        .then(() => { return this.compileNg2Components(compiler, componentFactoryRefMap); })
         .then(() => {
           ngZone.run(() => {
             if (rootScopePrototype) {

--- a/modules/playground/e2e_test/upgrade/upgrade_spec.ts
+++ b/modules/playground/e2e_test/upgrade/upgrade_spec.ts
@@ -8,20 +8,28 @@
 
 import {verifyNoBrowserErrors} from "e2e_util/e2e_util";
 
-// TODO(i): reenable once we fix issue with exposing testability to protractor when using ngUpgrade
-// https://github.com/angular/angular/issues/9407
+// TODO(i): reenable once we are using a version of protractor containing the
+// change in https://github.com/angular/protractor/pull/3403
 xdescribe('ngUpgrade', function() {
   var URL = 'all/playground/src/upgrade/index.html';
 
-  beforeEach(function() { browser.get(URL); });
+  beforeEach(function() {
+    browser.rootEl = 'body';
+    (<any>browser).ng12Hybrid = true;
+    browser.get(URL);
+  });
 
-  afterEach(verifyNoBrowserErrors);
+  afterEach(function() {
+    (<any>browser).useAllAngular2AppRoots();
+    (<any>browser).ng12Hybrid = false;
+    verifyNoBrowserErrors();
+  });
 
   it('should bootstrap Angular 1 and Angular 2 apps together', function() {
-    var ng1NameInput = element(by.css('input[ng-model]=name'));
+    var ng1NameInput = element(by.css('input[ng-model="name"]'));
     expect(ng1NameInput.getAttribute('value')).toEqual('World');
 
     var userSpan = element(by.css('user span'));
-    expect(userSpan.getText()).toMatch('/World$/');
+    expect(userSpan.getText()).toMatch(/World$/);
   });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

See #9407

**What is the new behavior?**

No bug

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Closes #9407 and angular/protractor#2944
