### PR TITLE
fix(core): run the ngOnDestroy hook before disposing subscriptions

### DIFF
--- a/modules/@angular/core/src/linker/view.ts
+++ b/modules/@angular/core/src/linker/view.ts
@@ -195,10 +195,10 @@ export abstract class AppView<T> {
     for (var i = 0; i < this.disposables.length; i++) {
       this.disposables[i]();
     }
+    this.destroyInternal();
     for (var i = 0; i < this.subscriptions.length; i++) {
       ObservableWrapper.dispose(this.subscriptions[i]);
     }
-    this.destroyInternal();
     this.dirtyParentQueriesInternal();
 
     if (this.animationPlayers.length == 0) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [X] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[X ] Bugfix
[] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The ngOnDestroy hook gets called after disposing the subscriptions disallowing from emitting outputs in the body.

**What is the new behavior?**
The ngOnDestroy hook gets called before disposing the subscriptions, which allows us to emit outputs in the body. That is useful in many cases like the one described in #6984 .

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
