### PR TITLE
fix(http): convert objects passed to requests into a string

### DIFF
--- a/modules/@angular/http/src/static_request.ts
+++ b/modules/@angular/http/src/static_request.ts
@@ -128,7 +128,7 @@ export class Request extends Body {
   getBody(): any {
     switch (this.contentType) {
       case ContentType.JSON:
-        return this.json();
+        return this.text();
       case ContentType.FORM:
         return this.text();
       case ContentType.FORM_DATA:

--- a/modules/@angular/http/test/backends/xhr_backend_spec.ts
+++ b/modules/@angular/http/test/backends/xhr_backend_spec.ts
@@ -9,6 +9,7 @@
 import {afterEach, beforeEach, beforeEachProviders, ddescribe, describe, expect, iit, inject, it, xit,} from '@angular/core/testing/testing_internal';
 import {AsyncTestCompleter, SpyObject} from '@angular/core/testing/testing_internal';
 import {BrowserXhr} from '../../src/backends/browser_xhr';
+import {Json} from '../../src/facade/lang';
 import {XSRFStrategy} from '../../src/interfaces';
 import {XHRConnection, XHRBackend, CookieXSRFStrategy} from '../../src/backends/xhr_backend';
 import {provide, Injector, Injectable, ReflectiveInjector} from '@angular/core';
@@ -256,7 +257,7 @@ export function main() {
         var connection = new XHRConnection(
             new Request(base.merge(new RequestOptions({body: body}))), new MockBrowserXHR());
         connection.response.subscribe();
-        expect(sendSpy).toHaveBeenCalledWith(body);
+        expect(sendSpy).toHaveBeenCalledWith(Json.stringify(body));
         expect(setRequestHeaderSpy).toHaveBeenCalledWith('Content-Type', 'application/json');
       });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ x ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?**
When an object is passed to a request, no modification occurs on that object and therefore is converted to `[object Object]`

Refer to this issue : [#10073](https://github.com/angular/angular/issues/10073)

**What is the new behavior?**

Now objects passed to requests are converted to a string (which was the default behavior in RC4)

**Does this PR introduce a breaking change?** (check one with "x")

This remove a breaking change introduced with this [commit](https://github.com/angular/angular/pull/7260) 

**Other information**:

This remove a breaking change introduced with [commit](https://github.com/angular/angular/pull/7260)  where json objects passed to  requests were not converted into string.
Refer to issue : #10073
