### PR TITLE
docs(NgSwitch): fix typo ngSwitch to NgSwitch

### DIFF
--- a/modules/@angular/common/src/directives/ng_switch.ts
+++ b/modules/@angular/common/src/directives/ng_switch.ts
@@ -28,7 +28,7 @@ export class SwitchView {
 /**
  * Adds or removes DOM sub-trees when their match expressions match the switch expression.
  *
- * Elements within `NgSwitch` but without `ngSwitchCase` or `NgSwitchDefault` directives will be
+ * Elements within `NgSwitch` but without `NgSwitchCase` or `NgSwitchDefault` directives will be
  * preserved at the location as specified in the template.
  *
  * `NgSwitch` simply inserts nested elements based on which match expression matches the value
@@ -68,7 +68,7 @@ export class SwitchView {
  *       <template ngSwitchDefault>&gt; 2, STOP!</template>
  *     </p>
  *   `,
- *   directives: [NgSwitch, ngSwitchCase, NgSwitchDefault]
+ *   directives: [NgSwitch, NgSwitchCase, NgSwitchDefault]
  * })
  * export class App {
  *   value = 'init';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: documentation
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

Change references to imported directive NgSwitch from, `ngSwitch` to `NgSwitch`.
