### PR TITLE
fix(testing): Add platform directives to the shim that keeps setBaseTestProviders running

### DIFF
--- a/modules/@angular/platform-browser-dynamic/testing.ts
+++ b/modules/@angular/platform-browser-dynamic/testing.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {COMMON_DIRECTIVES, COMMON_PIPES} from '@angular/common';
 import {CompilerConfig, DirectiveResolver, ViewResolver} from '@angular/compiler';
 import {MockDirectiveResolver, MockViewResolver, OverridingTestComponentBuilder} from '@angular/compiler/testing';
-import {AppModule, Compiler, CompilerFactory, PlatformRef, Provider, ReflectiveInjector, Type, createPlatformFactory} from '@angular/core';
+import {AppModule, Compiler, CompilerFactory, PLATFORM_DIRECTIVES, PLATFORM_PIPES, PlatformRef, Provider, ReflectiveInjector, Type, createPlatformFactory} from '@angular/core';
 import {TestComponentBuilder, TestComponentRenderer} from '@angular/core/testing';
 import {BrowserTestModule, TEST_BROWSER_APPLICATION_PROVIDERS, TEST_BROWSER_PLATFORM_PROVIDERS} from '@angular/platform-browser/testing';
 
@@ -62,11 +63,26 @@ export const browserDynamicTestPlatform =
 export class BrowserDynamicTestModule {
 }
 
+// Used only as a shim until TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS is deprecated.
+const BROWSER_DYNAMIC_TEST_COMPILER_FACTORY_OLD = BROWSER_DYNAMIC_COMPILER_FACTORY.withDefaults({
+  providers: [
+    {provide: DirectiveResolver, useClass: MockDirectiveResolver},
+    {provide: ViewResolver, useClass: MockViewResolver}
+  ],
+  deprecatedAppProviders: [
+    {provide: PLATFORM_DIRECTIVES, useValue: COMMON_DIRECTIVES, multi: true},
+    {provide: PLATFORM_PIPES, useValue: COMMON_PIPES, multi: true}
+  ]
+});
+
 /**
  * @deprecated Use initTestEnvironment with browserDynamicTestPlatform instead.
  */
-export const TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
-    BROWSER_DYNAMIC_TEST_PLATFORM_PROVIDERS;
+export const TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[]*/> = [
+  TEST_BROWSER_PLATFORM_PROVIDERS,
+  BROWSER_DYNAMIC_PLATFORM_PROVIDERS,
+  {provide: CompilerFactory, useValue: BROWSER_DYNAMIC_TEST_COMPILER_FACTORY_OLD},
+];
 
 
 /**

--- a/modules/@angular/platform-browser/test/testing_public_spec.ts
+++ b/modules/@angular/platform-browser/test/testing_public_spec.ts
@@ -39,11 +39,7 @@ class MockChildComp {
 class ParentComp {
 }
 
-@Component({
-  selector: 'my-if-comp',
-  template: `MyIf(<span *ngIf="showMore">More</span>)`,
-  directives: [NgIf]
-})
+@Component({selector: 'my-if-comp', template: `MyIf(<span *ngIf="showMore">More</span>)`})
 @Injectable()
 class MyIfComp {
   showMore: boolean = false;


### PR DESCRIPTION
Due to https://github.com/angular/angular/commit/daa9da404711bf10d5b9098a36819abb585a30c7,
tests using the setBaseTestProviders stopped working with ambient directives such as
`ngIf`. Add them back in to keep the shim working.
