### PR TITLE
fix(http): headers should be case-insensitive. spec at https://tools.…

### DIFF
--- a/modules/@angular/http/src/headers.ts
+++ b/modules/@angular/http/src/headers.ts
@@ -11,6 +11,16 @@ import {isBlank} from '../src/facade/lang';
 
 import {isListLikeIterable, iterateListLike, Map, MapWrapper, StringMapWrapper, ListWrapper,} from '../src/facade/collection';
 
+// "HTTP character sets are identified by case-insensitive tokens"
+// Spec at https://tools.ietf.org/html/rfc2616
+// This implementation is same as NodeJS.
+// see https://nodejs.org/dist/latest-v6.x/docs/api/http.html#http_message_headers
+export class HeadersMap extends Map<string, string[]> {
+  set(key: string, value: string[]):HeadersMap {
+    super.set(key.toLowerCase(), value);
+    return this;
+  }
+}
 /**
  * Polyfill for [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers/Headers), as
  * specified in the [Fetch Spec](https://fetch.spec.whatwg.org/#headers-class).
@@ -41,14 +51,14 @@ import {isListLikeIterable, iterateListLike, Map, MapWrapper, StringMapWrapper, 
  */
 export class Headers {
   /** @internal */
-  _headersMap: Map<string, string[]>;
+  _headersMap: HeadersMap;
   constructor(headers?: Headers|{[key: string]: any}) {
     if (headers instanceof Headers) {
       this._headersMap = (<Headers>headers)._headersMap;
       return;
     }
 
-    this._headersMap = new Map<string, string[]>();
+    this._headersMap = new HeadersMap();
 
     if (isBlank(headers)) {
       return;

--- a/modules/@angular/http/test/headers_spec.ts
+++ b/modules/@angular/http/test/headers_spec.ts
@@ -20,6 +20,10 @@ export function main() {
       var firstHeaders = new Headers();  // Currently empty
       firstHeaders.append('Content-Type', 'image/jpeg');
       expect(firstHeaders.get('Content-Type')).toBe('image/jpeg');
+      // "HTTP character sets are identified by case-insensitive tokens"
+      // Spec at https://tools.ietf.org/html/rfc2616
+      expect(firstHeaders.get('content-type')).toBe('image/jpeg');
+      expect(firstHeaders.get('content-Type')).toBe('image/jpeg');
       var httpHeaders = StringMapWrapper.create();
       StringMapWrapper.set(httpHeaders, 'Content-Type', 'image/jpeg');
       StringMapWrapper.set(httpHeaders, 'Accept-Charset', 'utf-8');
@@ -28,7 +32,6 @@ export function main() {
       var secondHeadersObj = new Headers(secondHeaders);
       expect(secondHeadersObj.get('Content-Type')).toBe('image/jpeg');
     });
-
 
     describe('initialization', () => {
       it('should merge values in provided dictionary', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Could not get http headers by it's lowercase, etc.

**What is the new behavior?**

Convert header's key/name to lowercase before save it to internal map, so that it's case-insensitive. It's same as NodeJS. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Spec at https://tools.ietf.org/html/rfc2616
