### PR TITLE
fix(http): headers should be case-insensitive. spec at https://tools.…

### DIFF
--- a/modules/@angular/http/src/headers.ts
+++ b/modules/@angular/http/src/headers.ts
@@ -68,23 +68,25 @@ export class Headers {
         .split('\n')
         .map(val => val.split(':'))
         .map(([key, ...parts]) => ([key.trim(), parts.join(':').trim()]))
-        .reduce((headers, [key, value]) => !headers.set(key, value) && headers, new Headers());
+        .reduce(
+            (headers, [key, value]) => !headers.set(normalizeHeaderName(key), value) && headers,
+            new Headers());
   }
 
   /**
    * Appends a header to existing list of header values for a given header name.
    */
   append(name: string, value: string): void {
-    var mapName = this._headersMap.get(name);
+    var mapName = this._headersMap.get(normalizeHeaderName(name));
     var list = isListLikeIterable(mapName) ? mapName : [];
     list.push(value);
-    this._headersMap.set(name, list);
+    this._headersMap.set(normalizeHeaderName(name), list);
   }
 
   /**
    * Deletes all header values for the given name.
    */
-  delete (name: string): void { this._headersMap.delete(name); }
+  delete (name: string): void { this._headersMap.delete(normalizeHeaderName(name)); }
 
   forEach(fn: (values: string[], name: string, headers: Map<string, string[]>) => void): void {
     this._headersMap.forEach(fn);
@@ -93,12 +95,14 @@ export class Headers {
   /**
    * Returns first header that matches given name.
    */
-  get(header: string): string { return ListWrapper.first(this._headersMap.get(header)); }
+  get(header: string): string {
+    return ListWrapper.first(this._headersMap.get(normalizeHeaderName(header)));
+  }
 
   /**
    * Check for existence of header by given name.
    */
-  has(header: string): boolean { return this._headersMap.has(header); }
+  has(header: string): boolean { return this._headersMap.has(normalizeHeaderName(header)); }
 
   /**
    * Provides names of set headers
@@ -118,7 +122,7 @@ export class Headers {
       list.push(<string>value);
     }
 
-    this._headersMap.set(header, list);
+    this._headersMap.set(normalizeHeaderName(header), list);
   }
 
   /**
@@ -146,7 +150,7 @@ export class Headers {
    * Returns list of header values for a given name.
    */
   getAll(header: string): string[] {
-    var headers = this._headersMap.get(header);
+    var headers = this._headersMap.get(normalizeHeaderName(header));
     return isListLikeIterable(headers) ? headers : [];
   }
 
@@ -154,4 +158,12 @@ export class Headers {
    * This method is not implemented.
    */
   entries() { throw new BaseException('"entries" method is not implemented on Headers class'); }
+}
+
+// "HTTP character sets are identified by case-insensitive tokens"
+// Spec at https://tools.ietf.org/html/rfc2616
+// This implementation is same as NodeJS.
+// see https://nodejs.org/dist/latest-v6.x/docs/api/http.html#http_message_headers
+function normalizeHeaderName(headerName: string): string {
+  return headerName.toLowerCase();
 }

--- a/modules/@angular/http/test/headers_spec.ts
+++ b/modules/@angular/http/test/headers_spec.ts
@@ -20,6 +20,10 @@ export function main() {
       var firstHeaders = new Headers();  // Currently empty
       firstHeaders.append('Content-Type', 'image/jpeg');
       expect(firstHeaders.get('Content-Type')).toBe('image/jpeg');
+      // "HTTP character sets are identified by case-insensitive tokens"
+      // Spec at https://tools.ietf.org/html/rfc2616
+      expect(firstHeaders.get('content-type')).toBe('image/jpeg');
+      expect(firstHeaders.get('content-Type')).toBe('image/jpeg');
       var httpHeaders = StringMapWrapper.create();
       StringMapWrapper.set(httpHeaders, 'Content-Type', 'image/jpeg');
       StringMapWrapper.set(httpHeaders, 'Accept-Charset', 'utf-8');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Could not get http headers by it's lowercase, etc.

**What is the new behavior?**

Convert header's key/name to lowercase before save it to internal map, so that it's case-insensitive. It's same as NodeJS. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Spec at https://tools.ietf.org/html/rfc2616
