### PR TITLE
feat(security): categorize <track src> as a regular URL.

### DIFF
--- a/modules/@angular/compiler/src/schema/dom_security_schema.ts
+++ b/modules/@angular/compiler/src/schema/dom_security_schema.ts
@@ -36,10 +36,10 @@ registerContext(SecurityContext.HTML, [
 registerContext(SecurityContext.STYLE, ['*|style']);
 // NB: no SCRIPT contexts here, they are never allowed due to the parser stripping them.
 registerContext(SecurityContext.URL, [
-  '*|formAction', 'area|href',       'area|ping',       'audio|src', 'a|href',
-  'a|ping',       'blockquote|cite', 'body|background', 'del|cite',  'form|action',
-  'img|src',      'img|srcset',      'input|src',       'ins|cite',  'q|cite',
-  'source|src',   'source|srcset',   'video|poster',    'video|src',
+  '*|formAction', 'area|href',       'area|ping',       'audio|src',    'a|href',
+  'a|ping',       'blockquote|cite', 'body|background', 'del|cite',     'form|action',
+  'img|src',      'img|srcset',      'input|src',       'ins|cite',     'q|cite',
+  'source|src',   'source|srcset',   'track|src',       'video|poster', 'video|src',
 ]);
 registerContext(SecurityContext.RESOURCE_URL, [
   'applet|code',
@@ -55,5 +55,4 @@ registerContext(SecurityContext.RESOURCE_URL, [
   'object|codebase',
   'object|data',
   'script|src',
-  'track|src',
 ]);


### PR DESCRIPTION
After security review, it turns out we were too paranoid about <track src>. Its content is not actually active or dangerous.

Fixes #10089.
