### PR TITLE
feat(http): add support for blob as a response type

### DIFF
--- a/modules/@angular/http/src/backends/xhr_backend.ts
+++ b/modules/@angular/http/src/backends/xhr_backend.ts
@@ -120,6 +120,9 @@ export class XHRConnection implements Connection {
           case ResponseContentType.Text:
             _xhr.responseType = 'text';
             break;
+          case ResponseContentType.Blob:
+            _xhr.responseType = 'blob';
+            break;
           default:
             throw new Error('The selected responseType is not supported');
         }

--- a/modules/@angular/http/src/base_response_options.ts
+++ b/modules/@angular/http/src/base_response_options.ts
@@ -46,9 +46,9 @@ import {ResponseOptionsArgs} from './interfaces';
 export class ResponseOptions {
   // TODO: FormData | Blob
   /**
-   * String, Object, ArrayBuffer representing the body of the {@link Response}.
+   * String, Object, ArrayBuffer or Blob representing the body of the {@link Response}.
    */
-  body: string|Object|ArrayBuffer;
+  body: string|Object|ArrayBuffer|Blob;
   /**
    * Http {@link http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html status code}
    * associated with the response.

--- a/modules/@angular/http/src/enums.ts
+++ b/modules/@angular/http/src/enums.ts
@@ -67,7 +67,8 @@ export enum ContentType {
  * @experimental
  */
 export enum ResponseContentType {
-  ArrayBuffer,
+  Text,
   Json,
-  Text
+  ArrayBuffer,
+  Blob
 }

--- a/modules/@angular/http/src/interfaces.ts
+++ b/modules/@angular/http/src/interfaces.ts
@@ -67,8 +67,7 @@ export interface RequestArgs extends RequestOptionsArgs { url: string; }
  * @experimental
  */
 export type ResponseOptionsArgs = {
-  // TODO: Support Blob, JSON
-  body?: string | Object | FormData | ArrayBuffer; status?: number; statusText?: string;
+  body?: string | Object | FormData | ArrayBuffer | Blob; status?: number; statusText?: string;
   headers?: Headers;
   type?: ResponseType;
   url?: string;

--- a/tools/public_api_guard/http/index.d.ts
+++ b/tools/public_api_guard/http/index.d.ts
@@ -179,14 +179,15 @@ export declare class Response extends Body {
 
 /** @experimental */
 export declare enum ResponseContentType {
-    ArrayBuffer = 0,
+    Text = 0,
     Json = 1,
-    Text = 2,
+    ArrayBuffer = 2,
+    Blob = 3,
 }
 
 /** @experimental */
 export declare class ResponseOptions {
-    body: string | Object | ArrayBuffer;
+    body: string | Object | ArrayBuffer | Blob;
     headers: Headers;
     status: number;
     url: string;
@@ -196,7 +197,7 @@ export declare class ResponseOptions {
 
 /** @experimental */
 export declare type ResponseOptionsArgs = {
-    body?: string | Object | FormData | ArrayBuffer;
+    body?: string | Object | FormData | ArrayBuffer | Blob;
     status?: number;
     statusText?: string;
     headers?: Headers;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** 
There is no way to receive a response as a blob.

**What is the new behavior?**
Allow to set the attribute responseType of the request, through the enum ResponseContentType.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```

**Other information**:

In order to add appropriate tests for this feature I have to introduce some change into the MockBrowserXHR, (which will also allow to test arraybuffer, json and text as a responseType), therefore I will add them in a future commit. 
