### PR TITLE
test(http): add spy for responseType

### DIFF
--- a/modules/@angular/http/test/backends/xhr_backend_spec.ts
+++ b/modules/@angular/http/test/backends/xhr_backend_spec.ts
@@ -26,6 +26,7 @@ import {URLSearchParams} from '../../src/url_search_params';
 var abortSpy: any;
 var sendSpy: any;
 var openSpy: any;
+var responseTypeSpy: any;
 var setRequestHeaderSpy: any;
 var addEventListenerSpy: any;
 var existingXHRs: MockBrowserXHR[] = [];
@@ -52,6 +53,7 @@ class MockBrowserXHR extends BrowserXhr {
     this.abort = abortSpy = spy.spy('abort');
     this.send = sendSpy = spy.spy('send');
     this.open = openSpy = spy.spy('open');
+    this.responseType = responseTypeSpy = spy.spy('responseType');
     this.setRequestHeader = setRequestHeaderSpy = spy.spy('setRequestHeader');
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ x ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x ] Other : Test
```

**What is the current behavior?**
The attribute `responseType` is isolated in the `XHRBackend` and therefore can't be tested.

**What is the new behavior?**
It introduces a spy for this attribute, which will allow to add test in `XHRBackend` for #7260 and #10190  

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```

**Other information**:
