### PR TITLE
fix(platform-browser-dynamic): Rename CACHED_TEMPLATE_PROVIDER to RES…

### DIFF
--- a/modules/@angular/platform-browser-dynamic/index.ts
+++ b/modules/@angular/platform-browser-dynamic/index.ts
@@ -39,9 +39,11 @@ export const BROWSER_APP_COMPILER_PROVIDERS: Array<any /*Type | Provider | any[]
 ];
 
 /**
+ * Provider for using the resource cache while fetching template resources
+ *
  * @experimental
  */
-export const CACHED_TEMPLATE_PROVIDER: Array<any /*Type | Provider | any[]*/> =
+export const RESOURCE_CACHE_PROVIDER: Array<any /*Type | Provider | any[]*/> =
     [{provide: XHR, useClass: CachedXHR}];
 
 function initReflector() {

--- a/tools/public_api_guard/platform-browser-dynamic/index.d.ts
+++ b/tools/public_api_guard/platform-browser-dynamic/index.d.ts
@@ -20,4 +20,4 @@ export declare const BROWSER_DYNAMIC_PLATFORM_PROVIDERS: Array<any>;
 export declare const browserDynamicPlatform: () => PlatformRef;
 
 /** @experimental */
-export declare const CACHED_TEMPLATE_PROVIDER: Array<any>;
+export declare const RESOURCE_CACHE_PROVIDER: Array<any>;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

Rename CACHED_TEMPLATE_PROVIDER to RESOURCE_CACHE_PROVIDER

**Other information**:

…OURCE_CACHE_PROVIDER

Closes #9741

BREAKING CHANGE:

`CACHED_TEMPLATE_PROVIDER` is now renamed to `RESOURCE_CACHE_PROVIDER`

Before:

``` js
import {CACHED_TEMPLATE_PROVIDER} from '@angular/platform-browser-dynamic';
```

After:

``` js
import {RESOURCE_CACHE_PROVIDER} from '@angular/platform-browser-dynamic';
```
