### PR TITLE
fix(http): add content-type override support for http request

### DIFF
--- a/modules/@angular/http/src/static_request.ts
+++ b/modules/@angular/http/src/static_request.ts
@@ -90,20 +90,41 @@ export class Request extends Body {
       }
     }
     this._body = requestOptions.body;
-    this.contentType = this.detectContentType();
     this.method = normalizeMethodName(requestOptions.method);
     // TODO(jeffbcross): implement behavior
     // Defaults to 'omit', consistent with browser
     // TODO(jeffbcross): implement behavior
     this.headers = new Headers(requestOptions.headers);
+    this.contentType = this.detectContentType();
     this.withCredentials = requestOptions.withCredentials;
     this.responseType = requestOptions.responseType;
   }
 
   /**
+   * Returns the content type enum based on header options.
+   */
+  detectContentType(): ContentType {
+    switch (this.headers.get('content-type')) {
+      case 'application/json':
+        return ContentType.JSON;
+      case 'application/x-www-form-urlencoded':
+        return ContentType.FORM;
+      case 'multipart/form-data':
+        return ContentType.FORM_DATA;
+      case 'text/plain':
+      case 'text/html':
+        return ContentType.TEXT;
+      case 'application/octet-stream':
+        return ContentType.BLOB;
+      default:
+        return this.detectContentTypeFromBody();
+    }
+  }
+
+  /**
    * Returns the content type of request's body based on its type.
    */
-  detectContentType() {
+  detectContentTypeFromBody(): ContentType {
     if (this._body == null) {
       return ContentType.NONE;
     } else if (this._body instanceof URLSearchParams) {

--- a/modules/@angular/http/test/static_request_spec.ts
+++ b/modules/@angular/http/test/static_request_spec.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {describe, expect, it} from '@angular/core/testing/testing_internal';
+
+import {RequestOptions} from '../src/base_request_options';
+import {ContentType} from '../src/enums';
+import {Headers} from '../src/headers';
+import {Request} from '../src/static_request';
+
+export function main() {
+  describe('Request', () => {
+    describe('detectContentType', () => {
+      it('should return ContentType.NONE', () => {
+        const req = new Request(new RequestOptions({url: 'test', method: 'GET', body: null}));
+
+        expect(req.detectContentType()).toEqual(ContentType.NONE);
+      });
+
+      it('should return ContentType.JSON', () => {
+        const req = new Request(new RequestOptions({
+          url: 'test',
+          method: 'GET',
+          body: null,
+          headers: new Headers({'content-type': 'application/json'})
+        }));
+
+        expect(req.detectContentType()).toEqual(ContentType.JSON);
+      });
+
+      it('should return ContentType.FORM', () => {
+        const req = new Request(new RequestOptions({
+          url: 'test',
+          method: 'GET',
+          body: null,
+          headers: new Headers({'content-type': 'application/x-www-form-urlencoded'})
+        }));
+
+        expect(req.detectContentType()).toEqual(ContentType.FORM);
+      });
+
+      it('should return ContentType.FORM_DATA', () => {
+        const req = new Request(new RequestOptions({
+          url: 'test',
+          method: 'GET',
+          body: null,
+          headers: new Headers({'content-type': 'multipart/form-data'})
+        }));
+
+        expect(req.detectContentType()).toEqual(ContentType.FORM_DATA);
+      });
+
+      it('should return ContentType.TEXT', () => {
+        const req = new Request(new RequestOptions({
+          url: 'test',
+          method: 'GET',
+          body: null,
+          headers: new Headers({'content-type': 'text/plain'})
+        }));
+
+        expect(req.detectContentType()).toEqual(ContentType.TEXT);
+      });
+
+      it('should return ContentType.BLOB', () => {
+        const req = new Request(new RequestOptions({
+          url: 'test',
+          method: 'GET',
+          body: null,
+          headers: new Headers({'content-type': 'application/octet-stream'})
+        }));
+
+        expect(req.detectContentType()).toEqual(ContentType.BLOB);
+      });
+    });
+  });
+}

--- a/tools/public_api_guard/http/index.d.ts
+++ b/tools/public_api_guard/http/index.d.ts
@@ -125,6 +125,7 @@ export declare class Request extends Body {
     withCredentials: boolean;
     constructor(requestOptions: RequestArgs);
     detectContentType(): ContentType;
+    detectContentTypeFromBody(): ContentType;
     getBody(): any;
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
see #10210 

**What is the new behavior?**
see #10210 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Fix static request to allow the ‘Content-Type’ of a http request to be set from the headers options of the call.
