### PR TITLE
build: fix and document the symlinks scripts for Windows

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -119,6 +119,18 @@ use in these instructions.
 *Option 2*: defining a bash alias like `alias nbin='PATH=$(npm bin):$PATH'` as detailed in this
 [Stackoverflow answer](http://stackoverflow.com/questions/9679932/how-to-use-package-installed-locally-in-node-modules/15157360#15157360) and used like this: e.g., `nbin gulp build`.
 
+## Windows only
+
+In order to create the right symlinks, run **as administrator**:
+```shell
+./scripts/windows/create-symlinks.sh
+```
+
+Before submitting a PR, do not forget to remove them:
+```shell
+ ./scripts/windows/remove-symlinks.sh
+ ```
+
 ## Building
 
 To build Angular run:

--- a/scripts/windows/create-symlinks.sh
+++ b/scripts/windows/create-symlinks.sh
@@ -2,8 +2,9 @@
 
 cd `dirname $0`
 
-while read PACKAGE
+while read RAW_PACKAGE
 do
+  PACKAGE=${RAW_PACKAGE: : -1}
   DESTDIR=./../../modules/\@angular/${PACKAGE}/src
   mv ${DESTDIR}/facade ${DESTDIR}/facade.old
   cmd <<< "mklink \"..\\..\\modules\\\@angular\\"${PACKAGE}"\\src\\facade\" \"..\\..\\facade\\src\\\""

--- a/scripts/windows/remove-symlinks.sh
+++ b/scripts/windows/remove-symlinks.sh
@@ -2,8 +2,9 @@
 
 cd `dirname $0`
 
-while read PACKAGE
+while read RAW_PACKAGE
 do
+  PACKAGE=${RAW_PACKAGE: : -1}
   DESTDIR=./../../modules/\@angular/${PACKAGE}/src
   rm ${DESTDIR}/facade
   mv ${DESTDIR}/facade.old ${DESTDIR}/facade


### PR DESCRIPTION
Some more fixes, some commands are still broken and will require more work:

```
./test.sh tools
./test.sh node
```
