### PR TITLE
feat(security): trust resource URLs as URLs.

### DIFF
--- a/modules/@angular/platform-browser/src/security/dom_sanitization_service.ts
+++ b/modules/@angular/platform-browser/src/security/dom_sanitization_service.ts
@@ -165,7 +165,10 @@ export class DomSanitizationServiceImpl extends DomSanitizationService {
         this.checkNotSafeValue(value, 'Script');
         throw new Error('unsafe value used in a script context');
       case SecurityContext.URL:
-        if (value instanceof SafeUrlImpl) return value.changingThisBreaksApplicationSecurity;
+        if (value instanceof SafeResourceUrlImpl || value instanceof SafeUrlImpl) {
+          // Allow resource URLs in URL contexts, they are strictly more trusted.
+          return value.changingThisBreaksApplicationSecurity;
+        }
         this.checkNotSafeValue(value, 'URL');
         return sanitizeUrl(String(value));
       case SecurityContext.RESOURCE_URL:

--- a/modules/@angular/platform-browser/test/security/dom_sanitization_service_spec.ts
+++ b/modules/@angular/platform-browser/test/security/dom_sanitization_service_spec.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {SecurityContext} from '@angular/core';
+import * as t from '@angular/core/testing/testing_internal';
+
+import {DomSanitizationServiceImpl} from '../../src/security/dom_sanitization_service';
+
+export function main() {
+  t.describe('DOM Sanitization Service', () => {
+    t.it('accepts resource URL values for resource contexts', () => {
+      const svc = new DomSanitizationServiceImpl();
+      const resourceUrl = svc.bypassSecurityTrustResourceUrl('http://hello/world');
+      t.expect(svc.sanitize(SecurityContext.URL, resourceUrl)).toBe('http://hello/world');
+    });
+  });
+}


### PR DESCRIPTION
Resource URLs are strictly "more" trustworthy than plain URLs, so trusting them maintains the same level of security while avoiding to break people when we downgrade a resource URL context to a plain URL context.
