### PR TITLE
(router): allow pass array of routes to routes config

### DIFF
--- a/modules/@angular/router/src/apply_redirects.ts
+++ b/modules/@angular/router/src/apply_redirects.ts
@@ -40,7 +40,7 @@ function absoluteRedirect(newPaths: UrlPathWithParams[]): Observable<UrlSegment>
 
 export function applyRedirects(
     injector: Injector, configLoader: RouterConfigLoader, urlTree: UrlTree,
-    config: Routes): Observable<UrlTree> {
+    config: Route[]): Observable<UrlTree> {
   return expandSegment(injector, configLoader, config, urlTree.root, PRIMARY_OUTLET)
       .map(rootSegment => createUrlTree(urlTree, rootSegment))
       .catch(e => {

--- a/modules/@angular/router/src/config.ts
+++ b/modules/@angular/router/src/config.ts
@@ -456,7 +456,7 @@ export type RouterConfig = Route[];
  *
  * @stable use Routes
  */
-export type Routes = Route[];
+export type Routes = Array<Route|Route[]>;
 
 /**
  * See {@link Routes} for more details.
@@ -498,7 +498,7 @@ export interface Route {
   loadChildren?: string;
 }
 
-export function validateConfig(config: Routes): void {
+export function validateConfig(config: Route[]): void {
   config.forEach(validateNode);
 }
 

--- a/modules/@angular/router/src/recognize.ts
+++ b/modules/@angular/router/src/recognize.ts
@@ -38,7 +38,7 @@ class InheritedFromParent {
   }
 }
 
-export function recognize(rootComponentType: Type, config: Routes, urlTree: UrlTree, url: string):
+export function recognize(rootComponentType: Type, config: Route[], urlTree: UrlTree, url: string):
     Observable<RouterStateSnapshot> {
   try {
     const rootSegment = split(urlTree.root, [], [], config).segment;

--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -22,7 +22,7 @@ import {fromPromise} from 'rxjs/observable/fromPromise';
 import {of } from 'rxjs/observable/of';
 
 import {applyRedirects} from './apply_redirects';
-import {ResolveData, Routes, validateConfig} from './config';
+import {ResolveData, Route, Routes, validateConfig} from './config';
 import {createRouterState} from './create_router_state';
 import {createUrlTree} from './create_url_tree';
 import {RouterOutlet} from './directives/router_outlet';
@@ -130,7 +130,7 @@ export class Router {
   private locationSubscription: Subscription;
   private routerEvents: Subject<Event>;
   private navigationId: number = 0;
-  private config: Routes;
+  private config: Route[];
   private configLoader: RouterConfigLoader;
 
   /**
@@ -193,8 +193,9 @@ export class Router {
    * ```
    */
   resetConfig(config: Routes): void {
-    validateConfig(config);
-    this.config = config;
+    let flattenedConfig = [].concat(...config);
+    validateConfig(flattenedConfig);
+    this.config = flattenedConfig;
   }
 
   /**

--- a/modules/@angular/router/test/router.spec.ts
+++ b/modules/@angular/router/test/router.spec.ts
@@ -22,8 +22,10 @@ describe('Integration', () => {
   beforeEach(() => {
     configureModule({
       modules: [RouterTestingModule],
-      providers: [provideRoutes(
-          [{path: '', component: BlankCmp}, {path: 'simple', component: SimpleCmp}])]
+      providers: [provideRoutes([
+        {path: '', component: BlankCmp}, {path: 'simple', component: SimpleCmp},
+        [{path: 'nested', component: SimpleCmp}]
+      ])]
     });
   });
 
@@ -37,6 +39,18 @@ describe('Integration', () => {
            advance(fixture);
 
            expect(location.path()).toEqual('/simple');
+         })));
+
+  it('should navigate with a provided nested config',
+     fakeAsync(inject(
+         [Router, TestComponentBuilder, Location],
+         (router: Router, tcb: TestComponentBuilder, location: Location) => {
+           const fixture = createRoot(tcb, router, RootCmp);
+
+           router.navigateByUrl('/nested');
+           advance(fixture);
+
+           expect(location.path()).toEqual('/nested');
          })));
 
   it('should work when an outlet is in an ngIf',

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -238,7 +238,7 @@ export declare class RouterStateSnapshot extends Tree<ActivatedRouteSnapshot> {
 }
 
 /** @stable */
-export declare type Routes = Route[];
+export declare type Routes = Array<Route | Route[]>;
 
 /** @stable */
 export declare class RoutesRecognized {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
#9876

**What is the new behavior?**
Routes is now of type Array<Route|Route[]> and flattened into Route[] in the router.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Closes #9876
