### PR TITLE
fix(http): headers should be case-insensitive. spec at https://tools.…

### DIFF
--- a/modules/@angular/http/test/headers_spec.ts
+++ b/modules/@angular/http/test/headers_spec.ts
@@ -20,6 +20,10 @@ export function main() {
       var firstHeaders = new Headers();  // Currently empty
       firstHeaders.append('Content-Type', 'image/jpeg');
       expect(firstHeaders.get('Content-Type')).toBe('image/jpeg');
+      // "HTTP character sets are identified by case-insensitive tokens"
+      // Spec at https://tools.ietf.org/html/rfc2616
+      expect(firstHeaders.get('content-type')).toBe('image/jpeg');
+      expect(firstHeaders.get('content-Type')).toBe('image/jpeg');
       var httpHeaders = StringMapWrapper.create();
       StringMapWrapper.set(httpHeaders, 'Content-Type', 'image/jpeg');
       StringMapWrapper.set(httpHeaders, 'Accept-Charset', 'utf-8');
@@ -27,6 +31,7 @@ export function main() {
       var secondHeaders = new Headers(httpHeaders);
       var secondHeadersObj = new Headers(secondHeaders);
       expect(secondHeadersObj.get('Content-Type')).toBe('image/jpeg');
+      expect(secondHeadersObj.get('accept-charset')).toBe('utf-8');
     });
 
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Could not get http headers by it's lowercase, etc.

**What is the new behavior?**

Convert header's key/name to lowercase before save it to internal map, so that it's case-insensitive. It's same as NodeJS. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Spec at https://tools.ietf.org/html/rfc2616
