### PR TITLE
feat(facade): add support for all thenables

### DIFF
--- a/modules/@angular/facade/src/lang.ts
+++ b/modules/@angular/facade/src/lang.ts
@@ -133,7 +133,9 @@ export function isStrictStringMap(obj: any): boolean {
 }
 
 export function isPromise(obj: any): boolean {
-  return obj instanceof (<any>_global).Promise;
+  // allow any Promise/A+ compliant thenable.
+  // It's up to the caller to ensure that obj.then conforms to the spec
+  return isPresent(obj) && isFunction(obj.then);
 }
 
 export function isArray(obj: any): boolean {

--- a/modules/@angular/facade/test/lang_spec.ts
+++ b/modules/@angular/facade/test/lang_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NumberWrapper, RegExpMatcherWrapper, RegExpWrapper, StringWrapper, escapeRegExp, hasConstructor, isPresent, resolveEnumToken} from '../src/lang';
+import {NumberWrapper, RegExpMatcherWrapper, RegExpWrapper, StringWrapper, escapeRegExp, hasConstructor, isPresent, isPromise, resolveEnumToken} from '../src/lang';
 
 enum UsefulEnum {
   MyToken,
@@ -182,6 +182,24 @@ export function main() {
 
       it('should be false for subtypes',
          () => { expect(hasConstructor(new MySubclass(), MySuperclass)).toEqual(false); });
+    });
+  });
+  describe('isPromise', () => {
+    it('should be true for native Promises',
+       () => expect(isPromise(Promise.resolve(true))).toEqual(true));
+
+    it('should be true for thenables',
+       () => expect(isPromise({then: function() {}})).toEqual(true));
+
+    it('should be false if "then" is not a function',
+       () => expect(isPromise({then: 0})).toEqual(false));
+
+    it('should be false if the argument has no "then" function',
+       () => expect(isPromise({})).toEqual(false));
+
+    it('should be false if the argument is undefined or null', () => {
+      expect(isPromise(undefined)).toEqual(false);
+      expect(isPromise(null)).toEqual(false);
     });
   });
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Currently, promises which are not instances of the `Promise` constructor defined globally will resolve to false when passed to `isPromise`.

**What is the new behavior?**

All objects that have a `then` function will be considered `Promise`s

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

The purpose of this PR is to better support hybrid Angular1/Angular2 apps. It will allow the use of `$q` promises where only native promises were previously allowed.
