### PR TITLE
fix(metadata): make metadata collection work in bazel

### DIFF
--- a/tools/@angular/tsc-wrapped/src/symbols.ts
+++ b/tools/@angular/tsc-wrapped/src/symbols.ts
@@ -16,7 +16,7 @@ export class Symbols {
   private get symbols(): Map<string, MetadataValue> {
     let result = this._symbols;
     if (!result) {
-      result = this._symbols = new Map();
+      result = this._symbols = new Map<string, MetadataValue>();
       populateBuiltins(result);
       this.buildImports();
     }


### PR DESCRIPTION
Also fix a type-check error only present in the google3 TS version
