### PR TITLE
fix(http): headers should be case-insensitive. spec at https://tools.…

### DIFF
--- a/modules/@angular/http/src/backends/xhr_backend.ts
+++ b/modules/@angular/http/src/backends/xhr_backend.ts
@@ -152,18 +152,18 @@ export class XHRConnection implements Connection {
       case ContentType.NONE:
         break;
       case ContentType.JSON:
-        _xhr.setRequestHeader('Content-Type', 'application/json');
+        _xhr.setRequestHeader('content-type', 'application/json');
         break;
       case ContentType.FORM:
-        _xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
+        _xhr.setRequestHeader('content-type', 'application/x-www-form-urlencoded;charset=UTF-8');
         break;
       case ContentType.TEXT:
-        _xhr.setRequestHeader('Content-Type', 'text/plain');
+        _xhr.setRequestHeader('content-type', 'text/plain');
         break;
       case ContentType.BLOB:
         var blob = req.blob();
         if (blob.type) {
-          _xhr.setRequestHeader('Content-Type', blob.type);
+          _xhr.setRequestHeader('content-type', blob.type);
         }
         break;
     }

--- a/modules/@angular/http/src/headers.ts
+++ b/modules/@angular/http/src/headers.ts
@@ -64,13 +64,18 @@ export class Headers {
    * Returns a new Headers instance from the given DOMString of Response Headers
    */
   static fromResponseHeaderString(headersString: string): Headers {
-    return headersString.trim()
-        .split('\n')
-        .map(val => val.split(':'))
-        .map(([key, ...parts]) => ([key.trim(), parts.join(':').trim()]))
-        .reduce(
-            (headers, [key, value]) => !headers.set(normalize(key), value) && headers,
-            new Headers());
+    let headers = new Headers();
+
+    headersString.split('\n').forEach(line => {
+      const index = line.indexOf(':');
+      if (index > 0) {
+        const key = line.substring(0, index);
+        const value = line.substring(index + 1).trim();
+        headers.set(key, value);
+      }
+    });
+
+    return headers;
   }
 
   /**

--- a/modules/@angular/http/test/backends/xhr_backend_spec.ts
+++ b/modules/@angular/http/test/backends/xhr_backend_spec.ts
@@ -555,9 +555,9 @@ export function main() {
                sampleRequest, new MockBrowserXHR(), new ResponseOptions({status: statusCode}));
 
            let responseHeaderString = `Date: Fri, 20 Nov 2015 01:45:26 GMT
-               Content-Type: application/json; charset=utf-8
-               Transfer-Encoding: chunked
-               Connection: keep-alive`;
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive`;
 
            connection.response.subscribe((res: Response) => {
              expect(res.headers.get('Date')).toEqual('Fri, 20 Nov 2015 01:45:26 GMT');

--- a/modules/@angular/http/test/backends/xhr_backend_spec.ts
+++ b/modules/@angular/http/test/backends/xhr_backend_spec.ts
@@ -236,9 +236,9 @@ export function main() {
         var connection = new XHRConnection(
             new Request(base.merge(new RequestOptions({headers: headers}))), new MockBrowserXHR());
         connection.response.subscribe();
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('Content-Type', 'text/xml');
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('Breaking-Bad', '<3');
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('X-Multi', 'a,b');
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('content-type', 'text/xml');
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('breaking-bad', '<3');
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('x-multi', 'a,b');
       });
 
       it('should skip content type detection if custom content type header is set', () => {
@@ -249,8 +249,8 @@ export function main() {
             new Request(base.merge(new RequestOptions({body: body, headers: headers}))),
             new MockBrowserXHR());
         connection.response.subscribe();
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('Content-Type', 'text/plain');
-        expect(setRequestHeaderSpy).not.toHaveBeenCalledWith('Content-Type', 'application/json');
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('content-type', 'text/plain');
+        expect(setRequestHeaderSpy).not.toHaveBeenCalledWith('content-type', 'application/json');
       });
 
       it('should use object body and detect content type header to the request', () => {
@@ -260,7 +260,7 @@ export function main() {
             new Request(base.merge(new RequestOptions({body: body}))), new MockBrowserXHR());
         connection.response.subscribe();
         expect(sendSpy).toHaveBeenCalledWith(Json.stringify(body));
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('Content-Type', 'application/json');
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('content-type', 'application/json');
       });
 
       it('should use number body and detect content type header to the request', () => {
@@ -270,7 +270,7 @@ export function main() {
             new Request(base.merge(new RequestOptions({body: body}))), new MockBrowserXHR());
         connection.response.subscribe();
         expect(sendSpy).toHaveBeenCalledWith('23');
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('Content-Type', 'text/plain');
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('content-type', 'text/plain');
       });
 
       it('should use string body and detect content type header to the request', () => {
@@ -280,7 +280,7 @@ export function main() {
             new Request(base.merge(new RequestOptions({body: body}))), new MockBrowserXHR());
         connection.response.subscribe();
         expect(sendSpy).toHaveBeenCalledWith(body);
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('Content-Type', 'text/plain');
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('content-type', 'text/plain');
       });
 
       it('should use URLSearchParams body and detect content type header to the request', () => {
@@ -294,7 +294,7 @@ export function main() {
         expect(sendSpy).toHaveBeenCalledWith('test1=val1&test2=val2');
         expect(setRequestHeaderSpy)
             .toHaveBeenCalledWith(
-                'Content-Type', 'application/x-www-form-urlencoded;charset=UTF-8');
+                'content-type', 'application/x-www-form-urlencoded;charset=UTF-8');
       });
 
       if ((global as any /** TODO #9100 */)['Blob']) {
@@ -319,7 +319,7 @@ export function main() {
               new Request(base.merge(new RequestOptions({body: body}))), new MockBrowserXHR());
           connection.response.subscribe();
           expect(sendSpy).toHaveBeenCalledWith(body);
-          expect(setRequestHeaderSpy).toHaveBeenCalledWith('Content-Type', 'text/css');
+          expect(setRequestHeaderSpy).toHaveBeenCalledWith('content-type', 'text/css');
         });
 
         it('should use blob body without type to the request', () => {
@@ -342,7 +342,7 @@ export function main() {
                  new MockBrowserXHR());
              connection.response.subscribe();
              expect(sendSpy).toHaveBeenCalledWith(body);
-             expect(setRequestHeaderSpy).toHaveBeenCalledWith('Content-Type', 'text/css');
+             expect(setRequestHeaderSpy).toHaveBeenCalledWith('content-type', 'text/css');
            });
 
         it('should use array buffer body to the request', () => {
@@ -373,7 +373,7 @@ export function main() {
                  new MockBrowserXHR());
              connection.response.subscribe();
              expect(sendSpy).toHaveBeenCalledWith(body);
-             expect(setRequestHeaderSpy).toHaveBeenCalledWith('Content-Type', 'text/css');
+             expect(setRequestHeaderSpy).toHaveBeenCalledWith('content-type', 'text/css');
            });
       }
 

--- a/modules/@angular/http/test/headers_spec.ts
+++ b/modules/@angular/http/test/headers_spec.ts
@@ -109,9 +109,9 @@ export function main() {
     it('should parse a response header string', () => {
 
       let responseHeaderString = `Date: Fri, 20 Nov 2015 01:45:26 GMT
-        Content-Type: application/json; charset=utf-8
-        Transfer-Encoding: chunked
-        Connection: keep-alive`;
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive`;
 
       let responseHeaders = Headers.fromResponseHeaderString(responseHeaderString);
 

--- a/modules/@angular/http/test/headers_spec.ts
+++ b/modules/@angular/http/test/headers_spec.ts
@@ -20,6 +20,10 @@ export function main() {
       var firstHeaders = new Headers();  // Currently empty
       firstHeaders.append('Content-Type', 'image/jpeg');
       expect(firstHeaders.get('Content-Type')).toBe('image/jpeg');
+      // "HTTP character sets are identified by case-insensitive tokens"
+      // Spec at https://tools.ietf.org/html/rfc2616
+      expect(firstHeaders.get('content-type')).toBe('image/jpeg');
+      expect(firstHeaders.get('content-Type')).toBe('image/jpeg');
       var httpHeaders = StringMapWrapper.create();
       StringMapWrapper.set(httpHeaders, 'Content-Type', 'image/jpeg');
       StringMapWrapper.set(httpHeaders, 'Accept-Charset', 'utf-8');
@@ -72,7 +76,7 @@ export function main() {
       beforeEach(() => {
         headers = new Headers();
         inputArr = ['application/jeisen', 'application/jason', 'application/patrickjs'];
-        obj = {'Accept': inputArr};
+        obj = {'accept': inputArr};
         headers.set('Accept', inputArr);
       });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Could not get http headers by it's lowercase, etc.

**What is the new behavior?**

Convert header's key/name to lowercase before save it to internal map, so that it's case-insensitive. It's same as NodeJS. 

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Spec at https://tools.ietf.org/html/rfc2616
