### PR TITLE
chore: move injector to being non-internal but private

### DIFF
--- a/modules/@angular/compiler/src/runtime_compiler.ts
+++ b/modules/@angular/compiler/src/runtime_compiler.ts
@@ -44,13 +44,13 @@ export class RuntimeCompiler implements Compiler {
   private _compiledNgModuleCache = new Map<Type, NgModuleFactory<any>>();
 
   constructor(
-      private _injector: Injector, private _metadataResolver: CompileMetadataResolver,
+      private __injector: Injector, private _metadataResolver: CompileMetadataResolver,
       private _templateNormalizer: DirectiveNormalizer, private _templateParser: TemplateParser,
       private _styleCompiler: StyleCompiler, private _viewCompiler: ViewCompiler,
       private _ngModuleCompiler: NgModuleCompiler, private _compilerConfig: CompilerConfig,
       private _console: Console) {}
 
-  get injector(): Injector { return this._injector; }
+  get _injector(): Injector { return this.__injector; }
 
   compileModuleSync<T>(moduleType: ConcreteType<T>): NgModuleFactory<T> {
     return this._compileModuleAndComponents(moduleType, true).syncResult;
@@ -381,7 +381,7 @@ class ModuleBoundCompiler implements Compiler, ComponentResolver {
       private _delegate: RuntimeCompiler, private _ngModule: ConcreteType<any>,
       private _parentComponentResolver: ComponentResolver, private _console: Console) {}
 
-  get injector(): Injector { return this._delegate.injector; }
+  get _injector(): Injector { return this._delegate._injector; }
 
   resolveComponent(component: Type|string): Promise<ComponentFactory<any>> {
     if (isString(component)) {

--- a/modules/@angular/core/src/linker/compiler.ts
+++ b/modules/@angular/core/src/linker/compiler.ts
@@ -41,10 +41,8 @@ export class ComponentStillLoadingError extends BaseException {
 export class Compiler {
   /**
    * Returns the injector with which the compiler has been created.
-   *
-   * @internal
    */
-  get injector(): Injector {
+  get _injector(): Injector {
     throw new BaseException(`Runtime compiler is not loaded. Tried to read the injector.`);
   }
 

--- a/modules/@angular/core/testing/test_bed.ts
+++ b/modules/@angular/core/testing/test_bed.ts
@@ -168,7 +168,7 @@ export class TestBed implements Injector {
     // Tests can inject things from the ng module and from the compiler,
     // but the ng module can't inject things from the compiler and vice versa.
     let result = this._moduleRef.injector.get(token, UNDEFINED);
-    return result === UNDEFINED ? this._compiler.injector.get(token, notFoundValue) : result;
+    return result === UNDEFINED ? this._compiler._injector.get(token, notFoundValue) : result;
   }
 
   execute(tokens: any[], fn: Function): any {

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -237,6 +237,7 @@ export declare class CollectionChangeRecord {
 
 /** @stable */
 export declare class Compiler {
+    _injector: Injector;
     clearCache(): void;
     clearCacheFor(type: Type): void;
     compileComponentAsync<T>(component: ConcreteType<T>, ngModule?: Type): Promise<ComponentFactory<T>>;


### PR DESCRIPTION
In google3, the `core/testing` package does not have visibility to `core`, and thus cannot see the `injector()` getter.
