### PR TITLE
Add internationalization for DecimalPipe

### DIFF
--- a/modules/@angular/common/src/pipes/number_pipe.ts
+++ b/modules/@angular/common/src/pipes/number_pipe.ts
@@ -13,6 +13,7 @@ import {NumberWrapper, RegExpWrapper, Type, isBlank, isNumber, isPresent, isStri
 
 import {InvalidPipeArgumentException} from './invalid_pipe_argument_exception';
 
+var userLocale: string = navigator.language;
 var defaultLocale: string = 'en-US';
 const _NUMBER_FORMAT_REGEXP = /^(\d+)?\.((\d+)(\-(\d+))?)?$/g;
 
@@ -50,7 +51,7 @@ function formatNumber(
       maxFraction = NumberWrapper.parseIntAutoRadix(parts[5]);
     }
   }
-  return NumberFormatter.format(value as number, defaultLocale, style, {
+  return NumberFormatter.format(value as number, userLocale || defaultLocale, style, {
     minimumIntegerDigits: minInt,
     minimumFractionDigits: minFraction,
     maximumFractionDigits: maxFraction,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently, the decimal pipe formats numbers in en-US format only.

**What is the new behavior?**
Decimal pipe checks for the user's locale and uses that when formating numbers. Fallback if not found is still American English (en-US).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
