### PR TITLE
fix(forms): normalize written value in NumberValueAccessor

### DIFF
--- a/modules/@angular/common/src/forms-deprecated/directives/number_value_accessor.ts
+++ b/modules/@angular/common/src/forms-deprecated/directives/number_value_accessor.ts
@@ -8,7 +8,7 @@
 
 import {Directive, ElementRef, Renderer, forwardRef} from '@angular/core';
 
-import {NumberWrapper} from '../../facade/lang';
+import {NumberWrapper, isBlank} from '../../facade/lang';
 
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 
@@ -44,7 +44,9 @@ export class NumberValueAccessor implements ControlValueAccessor {
   constructor(private _renderer: Renderer, private _elementRef: ElementRef) {}
 
   writeValue(value: number): void {
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'value', value);
+    // The value needs to be normalized for IE9, otherwise it is set to 'null' when null
+    const normalizedValue = isBlank(value) ? '' : value;
+    this._renderer.setElementProperty(this._elementRef.nativeElement, 'value', normalizedValue);
   }
 
   registerOnChange(fn: (_: number) => void): void {

--- a/modules/@angular/forms/src/directives/number_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/number_value_accessor.ts
@@ -8,7 +8,7 @@
 
 import {Directive, ElementRef, Renderer, forwardRef} from '@angular/core';
 
-import {NumberWrapper} from '../facade/lang';
+import {NumberWrapper, isBlank} from '../facade/lang';
 
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 
@@ -44,7 +44,9 @@ export class NumberValueAccessor implements ControlValueAccessor {
   constructor(private _renderer: Renderer, private _elementRef: ElementRef) {}
 
   writeValue(value: number): void {
-    this._renderer.setElementProperty(this._elementRef.nativeElement, 'value', value);
+    // The value needs to be normalized for IE9, otherwise it is set to 'null' when null
+    const normalizedValue = isBlank(value) ? '' : value;
+    this._renderer.setElementProperty(this._elementRef.nativeElement, 'value', normalizedValue);
   }
 
   registerOnChange(fn: (_: number) => void): void {


### PR DESCRIPTION
2 unit tests were failing in IE9:

```
E 9.0.0 (Windows 7 0.0.0) integration tests different control types should support <type=number> when value is cleared programmatically FAILED
    Expected 'null' to equal ''.

IE 9.0.0 (Windows 7 0.0.0) reactive forms integration tests different control types should support <type=number> when value is cleared programmatically FAILED
    Expected 'null' to equal ''.
```
