### PR TITLE
fix(platform-browser): IEMobile is badly detected when testing

### DIFF
--- a/modules/@angular/platform-browser/test/browser_util_spec.ts
+++ b/modules/@angular/platform-browser/test/browser_util_spec.ts
@@ -86,6 +86,18 @@ export function main() {
         isChromeDesktop: false
       },
       {
+        name: 'IEMobile',
+        ua: 'Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 520) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537',
+        isFirefox: false,
+        isAndroid: false,
+        isEdge: false,
+        isIE: true,
+        isWebkit: false,
+        isIOS7: false,
+        isSlow: true,
+        isChromeDesktop: false
+      },
+      {
         name: 'Edge',
         ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136',
         isFirefox: false,

--- a/modules/@angular/platform-browser/testing/browser_util.ts
+++ b/modules/@angular/platform-browser/testing/browser_util.ts
@@ -28,7 +28,8 @@ export class BrowserDetection {
 
   get isAndroid(): boolean {
     return this._ua.indexOf('Mozilla/5.0') > -1 && this._ua.indexOf('Android') > -1 &&
-        this._ua.indexOf('AppleWebKit') > -1 && this._ua.indexOf('Chrome') == -1;
+        this._ua.indexOf('AppleWebKit') > -1 && this._ua.indexOf('Chrome') == -1 &&
+        this._ua.indexOf('IEMobile') == -1;
   }
 
   get isEdge(): boolean { return this._ua.indexOf('Edge') > -1; }
@@ -36,11 +37,13 @@ export class BrowserDetection {
   get isIE(): boolean { return this._ua.indexOf('Trident') > -1; }
 
   get isWebkit(): boolean {
-    return this._ua.indexOf('AppleWebKit') > -1 && this._ua.indexOf('Edge') == -1;
+    return this._ua.indexOf('AppleWebKit') > -1 && this._ua.indexOf('Edge') == -1 &&
+        this._ua.indexOf('IEMobile') == -1;
   }
 
   get isIOS7(): boolean {
-    return this._ua.indexOf('iPhone OS 7') > -1 || this._ua.indexOf('iPad OS 7') > -1;
+    return (this._ua.indexOf('iPhone OS 7') > -1 || this._ua.indexOf('iPad OS 7') > -1) &&
+        this._ua.indexOf('IEMobile') == -1;
   }
 
   get isSlow(): boolean { return this.isAndroid || this.isIE || this.isIOS7; }


### PR DESCRIPTION
According to https://msdn.microsoft.com/en-us/library/hh869301(v=vs.85).aspx , the user agent of a Windows Phone 8.1 is:

```
Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 520) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
```

The `IEMobile` string must be checked explicitly, otherwise the device is detected as an iPhone, an Android device and a Webkit browser!

One Webkit specific unit test was failing due to this bad detection.
