### PR TITLE
fix(UrlParser): stop setting default value 'true'

### DIFF
--- a/modules/@angular/router/src/url_tree.ts
+++ b/modules/@angular/router/src/url_tree.ts
@@ -406,7 +406,7 @@ class UrlParser {
       return;
     }
     this.capture(key);
-    let value: any = 'true';
+    let value: any = '';
     if (this.peekStartsWith('=')) {
       this.capture('=');
       var valueMatch = matchUrlQueryParamValue(this.remaining);

--- a/modules/@angular/router/test/url_serializer.spec.ts
+++ b/modules/@angular/router/test/url_serializer.spec.ts
@@ -142,12 +142,22 @@ describe('url serializer', () => {
 
   it('should parse key only query params', () => {
     const tree = url.parse('/one?a');
-    expect(tree.queryParams).toEqual({a: 'true'});
+    expect(tree.queryParams).toEqual({a: ''});
+  });
+
+  it('should parse a value-empty query param', () => {
+    const tree = url.parse('/one?a=');
+    expect(tree.queryParams).toEqual({a: ''});
+  });
+
+  it('should parse value-empty query params', () => {
+    const tree = url.parse('/one?a=&b=');
+    expect(tree.queryParams).toEqual({a: '', b: ''});
   });
 
   it('should serializer query params', () => {
     const tree = url.parse('/one?a');
-    expect(url.serialize(tree)).toEqual('/one?a=true');
+    expect(url.serialize(tree)).toEqual('/one?a=');
   });
 
   it('should parse fragment', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

UrlParser sets `'true'` as default value for query parameters

**What is the new behavior?**

default value is an empty string

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Close #10397 
