### PR TITLE
fix(router): do not emit a NavigationEnd event when navigation w…

### DIFF
--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -412,9 +412,11 @@ export class Router {
           })
           .then(
               () => {
-                this.navigated = true;
-                this.routerEvents.next(
-                    new NavigationEnd(id, this.serializeUrl(url), this.serializeUrl(appliedUrl)));
+                if (navigationIsSuccessful) {
+                  this.navigated = true;
+                  this.routerEvents.next(
+                      new NavigationEnd(id, this.serializeUrl(url), this.serializeUrl(appliedUrl)));
+                }
                 resolvePromise(navigationIsSuccessful);
               },
               e => {

--- a/modules/@angular/router/test/router.spec.ts
+++ b/modules/@angular/router/test/router.spec.ts
@@ -835,10 +835,18 @@ describe('Integration', () => {
                  router.resetConfig(
                      [{path: 'team/:id', component: TeamCmp, canActivate: ['alwaysFalse']}]);
 
+                 const recordedEvents: any[] = [];
+                 router.events.forEach(e => recordedEvents.push(e));
+
                  router.navigateByUrl('/team/22');
                  advance(fixture);
 
                  expect(location.path()).toEqual('/');
+
+                 expectEvents(recordedEvents, [
+                   [NavigationStart, '/team/22'], [RoutesRecognized, '/team/22'],
+                   [NavigationCancel, '/team/22']
+                 ]);
                })));
       });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

CanActivate and/or CanDeactivate guards can prevent navigation to another route. If a guard decides to prevent navigation to take place, both NavigationCancel & NavigationEnd are emitted on Router#events observable. An in-flight cancelled navigation presents a correct behavior, however (no NavigationEnd).

Plunker: http://plnkr.co/edit/vDrUfDr1AOkUeiMOYum5?p=preview

**What is the new behavior?**

A NavigationEnd event is not emitted after a NavigationCancel event, because it didn't end successfully. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

…as cancelled due to guards
