### PR TITLE
feat(forms): add get method for easy access to child controls

### DIFF
--- a/modules/@angular/forms/src/model.ts
+++ b/modules/@angular/forms/src/model.ts
@@ -34,11 +34,11 @@ export function isControl(control: Object): boolean {
   return control instanceof AbstractControl;
 }
 
-function _find(control: AbstractControl, path: Array<string|number>| string) {
+function _find(control: AbstractControl, path: Array<string|number>| string, delimiter: string) {
   if (isBlank(path)) return null;
 
   if (!(path instanceof Array)) {
-    path = (<string>path).split('/');
+    path = (<string>path).split(delimiter);
   }
   if (path instanceof Array && ListWrapper.isEmpty(path)) return null;
 
@@ -251,7 +251,12 @@ export abstract class AbstractControl {
     this._updateControlsErrors(emitEvent);
   }
 
-  find(path: Array<string|number>|string): AbstractControl { return _find(this, path); }
+  /**
+   * @deprecated - use get() instead
+   */
+  find(path: Array<string|number>|string): AbstractControl { return _find(this, path, '/'); }
+
+  get(path: Array<string|number>|string): AbstractControl { return _find(this, path, '.'); }
 
   getError(errorCode: string, path: string[] = null): any {
     var control = isPresent(path) && !ListWrapper.isEmpty(path) ? this.find(path) : this;

--- a/modules/@angular/forms/test/model_spec.ts
+++ b/modules/@angular/forms/test/model_spec.ts
@@ -1626,6 +1626,42 @@ export function main() {
         });
       });
 
+      describe('get', () => {
+        it('should return null when path is null', () => {
+          var g = new FormGroup({});
+          expect(g.get(null)).toEqual(null);
+        });
+
+        it('should return null when path is empty', () => {
+          var g = new FormGroup({});
+          expect(g.get([])).toEqual(null);
+        });
+
+        it('should return null when path is invalid', () => {
+          var g = new FormGroup({});
+          expect(g.get('invalid')).toEqual(null);
+        });
+
+        it('should return a child of a control group', () => {
+          var g = new FormGroup({
+            'one': new FormControl('111'),
+            'nested': new FormGroup({'two': new FormControl('222')})
+          });
+
+          expect(g.get(['one']).value).toEqual('111');
+          expect(g.get('one').value).toEqual('111');
+          expect(g.get(['nested', 'two']).value).toEqual('222');
+          expect(g.get('nested.two').value).toEqual('222');
+        });
+
+        it('should return an element of an array', () => {
+          var g = new FormGroup({'array': new FormArray([new FormControl('111')])});
+
+          expect(g.get(['array', 0]).value).toEqual('111');
+        });
+      });
+
+
       describe('asyncValidator', () => {
         it('should run the async validator', fakeAsync(() => {
              var c = new FormControl('value');

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -19,7 +19,8 @@ export declare abstract class AbstractControl {
     constructor(validator: ValidatorFn, asyncValidator: AsyncValidatorFn);
     clearAsyncValidators(): void;
     clearValidators(): void;
-    find(path: Array<string | number> | string): AbstractControl;
+    /** @deprecated */ find(path: Array<string | number> | string): AbstractControl;
+    get(path: Array<string | number> | string): AbstractControl;
     getError(errorCode: string, path?: string[]): any;
     hasError(errorCode: string, path?: string[]): boolean;
     markAsDirty({onlySelf}?: {


### PR DESCRIPTION
This PR adds the `get()` method as an alias for `find()`.  Rather than delimiting by slashes, it uses dots.

Example:

To access a form control called 'name'

``` ts
this.form.get('name')
```

To access a form control called 'name', nested in group called 'person'

``` ts
this.form.get('person.name')
```

old: `this.form.controls.person.controls.name`
