### PR TITLE
feat(forms): add invalid prop to abstract controls

### DIFF
--- a/modules/@angular/forms/src/directives/abstract_control_directive.ts
+++ b/modules/@angular/forms/src/directives/abstract_control_directive.ts
@@ -27,6 +27,10 @@ export abstract class AbstractControlDirective {
 
   get valid(): boolean { return isPresent(this.control) ? this.control.valid : null; }
 
+  get invalid(): boolean { return isPresent(this.control) ? this.control.invalid : null; }
+
+  get pending(): boolean { return isPresent(this.control) ? this.control.pending : null; }
+
   get errors(): {[key: string]: any} {
     return isPresent(this.control) ? this.control.errors : null;
   }

--- a/modules/@angular/forms/src/model.ts
+++ b/modules/@angular/forms/src/model.ts
@@ -83,7 +83,6 @@ export abstract class AbstractControl {
   private _parent: FormGroup|FormArray;
   private _asyncValidationSubscription: any;
 
-
   constructor(public validator: ValidatorFn, public asyncValidator: AsyncValidatorFn) {}
 
   get value(): any { return this._value; }
@@ -91,6 +90,8 @@ export abstract class AbstractControl {
   get status(): string { return this._status; }
 
   get valid(): boolean { return this._status === VALID; }
+
+  get invalid(): boolean { return this._status === INVALID; }
 
   /**
    * Returns the errors of this control.

--- a/modules/@angular/forms/test/directives_spec.ts
+++ b/modules/@angular/forms/test/directives_spec.ts
@@ -151,6 +151,8 @@ export function main() {
         expect(form.control).toBe(formModel);
         expect(form.value).toBe(formModel.value);
         expect(form.valid).toBe(formModel.valid);
+        expect(form.invalid).toBe(formModel.invalid);
+        expect(form.pending).toBe(formModel.pending);
         expect(form.errors).toBe(formModel.errors);
         expect(form.pristine).toBe(formModel.pristine);
         expect(form.dirty).toBe(formModel.dirty);
@@ -318,6 +320,8 @@ export function main() {
         expect(form.control).toBe(formModel);
         expect(form.value).toBe(formModel.value);
         expect(form.valid).toBe(formModel.valid);
+        expect(form.invalid).toBe(formModel.invalid);
+        expect(form.pending).toBe(formModel.pending);
         expect(form.errors).toBe(formModel.errors);
         expect(form.pristine).toBe(formModel.pristine);
         expect(form.dirty).toBe(formModel.dirty);
@@ -392,6 +396,8 @@ export function main() {
         expect(controlGroupDir.control).toBe(formModel);
         expect(controlGroupDir.value).toBe(formModel.value);
         expect(controlGroupDir.valid).toBe(formModel.valid);
+        expect(controlGroupDir.invalid).toBe(formModel.invalid);
+        expect(controlGroupDir.pending).toBe(formModel.pending);
         expect(controlGroupDir.errors).toBe(formModel.errors);
         expect(controlGroupDir.pristine).toBe(formModel.pristine);
         expect(controlGroupDir.dirty).toBe(formModel.dirty);
@@ -418,6 +424,8 @@ export function main() {
         expect(formArrayDir.control).toBe(formModel);
         expect(formArrayDir.value).toBe(formModel.value);
         expect(formArrayDir.valid).toBe(formModel.valid);
+        expect(formArrayDir.invalid).toBe(formModel.invalid);
+        expect(formArrayDir.pending).toBe(formModel.pending);
         expect(formArrayDir.errors).toBe(formModel.errors);
         expect(formArrayDir.pristine).toBe(formModel.pristine);
         expect(formArrayDir.dirty).toBe(formModel.dirty);
@@ -433,6 +441,8 @@ export function main() {
         expect(controlDir.control).toBe(control);
         expect(controlDir.value).toBe(control.value);
         expect(controlDir.valid).toBe(control.valid);
+        expect(controlDir.invalid).toBe(control.invalid);
+        expect(controlDir.pending).toBe(control.pending);
         expect(controlDir.errors).toBe(control.errors);
         expect(controlDir.pristine).toBe(control.pristine);
         expect(controlDir.dirty).toBe(control.dirty);
@@ -484,6 +494,8 @@ export function main() {
         expect(ngModel.control).toBe(control);
         expect(ngModel.value).toBe(control.value);
         expect(ngModel.valid).toBe(control.valid);
+        expect(ngModel.invalid).toBe(control.invalid);
+        expect(ngModel.pending).toBe(control.pending);
         expect(ngModel.errors).toBe(control.errors);
         expect(ngModel.pristine).toBe(control.pristine);
         expect(ngModel.dirty).toBe(control.dirty);
@@ -540,6 +552,8 @@ export function main() {
         expect(controlNameDir.control).toBe(formModel);
         expect(controlNameDir.value).toBe(formModel.value);
         expect(controlNameDir.valid).toBe(formModel.valid);
+        expect(controlNameDir.invalid).toBe(formModel.invalid);
+        expect(controlNameDir.pending).toBe(formModel.pending);
         expect(controlNameDir.errors).toBe(formModel.errors);
         expect(controlNameDir.pristine).toBe(formModel.pristine);
         expect(controlNameDir.dirty).toBe(formModel.dirty);

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -5,6 +5,7 @@ export declare abstract class AbstractControl {
     errors: {
         [key: string]: any;
     };
+    invalid: boolean;
     pending: boolean;
     pristine: boolean;
     root: AbstractControl;
@@ -61,7 +62,9 @@ export declare abstract class AbstractControlDirective {
     errors: {
         [key: string]: any;
     };
+    invalid: boolean;
     path: string[];
+    pending: boolean;
     pristine: boolean;
     statusChanges: Observable<any>;
     touched: boolean;


### PR DESCRIPTION
Currently, we have a getter for `valid` but no getter for `invalid`.  This can be surprising given that we have both `pristine`/`dirty` and `touched`/`untouched`.

This PR adds a getter for `invalid` on both AbstractControl and AbstractControlDirective. It also copies `pending` onto AbstractControlDirectives, so it's no longer necessary to reach down into the control directly.

**Before**

``` html
<button type="submit" [disabled]="!form.valid">SUBMIT</button>
```

``` html
<md-spinner *ngIf="form.form.pending"></md-spinner>
```

**After**

``` html
<button type="submit" [disabled]="form.invalid">SUBMIT</button>
```

``` html
<md-spinner *ngIf="form.pending"></md-spinner>
```
