### PR TITLE
test: reactivate some of the disabled tests in Edge

### DIFF
--- a/modules/@angular/core/test/reflection/reflector_spec.ts
+++ b/modules/@angular/core/test/reflection/reflector_spec.ts
@@ -110,39 +110,35 @@ export function main() {
         expect(obj.b).toEqual(2);
       });
 
-      // Makes Edge to disconnect when running the full unit test campaign
-      // TODO: remove when issue is solved: https://github.com/angular/angular/issues/4756
-      if (!browserDetection.isEdge) {
-        it('should check args from no to max', () => {
-          var f = (t: any /** TODO #9100 */) => reflector.factory(t);
-          var checkArgs = (obj: any /** TODO #9100 */, args: any /** TODO #9100 */) =>
-              expect(obj.args).toEqual(args);
+      it('should check args from no to max', () => {
+        var f = (t: any /** TODO #9100 */) => reflector.factory(t);
+        var checkArgs = (obj: any /** TODO #9100 */, args: any /** TODO #9100 */) =>
+            expect(obj.args).toEqual(args);
 
-          // clang-format off
-          checkArgs(f(TestObjWith00Args)(), []);
-          checkArgs(f(TestObjWith01Args)(1), [1]);
-          checkArgs(f(TestObjWith02Args)(1, 2), [1, 2]);
-          checkArgs(f(TestObjWith03Args)(1, 2, 3), [1, 2, 3]);
-          checkArgs(f(TestObjWith04Args)(1, 2, 3, 4), [1, 2, 3, 4]);
-          checkArgs(f(TestObjWith05Args)(1, 2, 3, 4, 5), [1, 2, 3, 4, 5]);
-          checkArgs(f(TestObjWith06Args)(1, 2, 3, 4, 5, 6), [1, 2, 3, 4, 5, 6]);
-          checkArgs(f(TestObjWith07Args)(1, 2, 3, 4, 5, 6, 7), [1, 2, 3, 4, 5, 6, 7]);
-          checkArgs(f(TestObjWith08Args)(1, 2, 3, 4, 5, 6, 7, 8), [1, 2, 3, 4, 5, 6, 7, 8]);
-          checkArgs(f(TestObjWith09Args)(1, 2, 3, 4, 5, 6, 7, 8, 9), [1, 2, 3, 4, 5, 6, 7, 8, 9]);
-          checkArgs(f(TestObjWith10Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-          checkArgs(f(TestObjWith11Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-          checkArgs(f(TestObjWith12Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-          checkArgs(f(TestObjWith13Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
-          checkArgs(f(TestObjWith14Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
-          checkArgs(f(TestObjWith15Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-          checkArgs(f(TestObjWith16Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
-          checkArgs(f(TestObjWith17Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]);
-          checkArgs(f(TestObjWith18Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]);
-          checkArgs(f(TestObjWith19Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
-          checkArgs(f(TestObjWith20Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
-          // clang-format on
-        });
-      }
+        // clang-format off
+        checkArgs(f(TestObjWith00Args)(), []);
+        checkArgs(f(TestObjWith01Args)(1), [1]);
+        checkArgs(f(TestObjWith02Args)(1, 2), [1, 2]);
+        checkArgs(f(TestObjWith03Args)(1, 2, 3), [1, 2, 3]);
+        checkArgs(f(TestObjWith04Args)(1, 2, 3, 4), [1, 2, 3, 4]);
+        checkArgs(f(TestObjWith05Args)(1, 2, 3, 4, 5), [1, 2, 3, 4, 5]);
+        checkArgs(f(TestObjWith06Args)(1, 2, 3, 4, 5, 6), [1, 2, 3, 4, 5, 6]);
+        checkArgs(f(TestObjWith07Args)(1, 2, 3, 4, 5, 6, 7), [1, 2, 3, 4, 5, 6, 7]);
+        checkArgs(f(TestObjWith08Args)(1, 2, 3, 4, 5, 6, 7, 8), [1, 2, 3, 4, 5, 6, 7, 8]);
+        checkArgs(f(TestObjWith09Args)(1, 2, 3, 4, 5, 6, 7, 8, 9), [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        checkArgs(f(TestObjWith10Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        checkArgs(f(TestObjWith11Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+        checkArgs(f(TestObjWith12Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+        checkArgs(f(TestObjWith13Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+        checkArgs(f(TestObjWith14Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
+        checkArgs(f(TestObjWith15Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+        checkArgs(f(TestObjWith16Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+        checkArgs(f(TestObjWith17Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]);
+        checkArgs(f(TestObjWith18Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]);
+        checkArgs(f(TestObjWith19Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
+        checkArgs(f(TestObjWith20Args)(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+        // clang-format on
+      });
 
       it('should throw when more than 20 arguments',
          () => { expect(() => reflector.factory(TestObjWith21Args)).toThrowError(); });

--- a/modules/@angular/facade/test/async_spec.ts
+++ b/modules/@angular/facade/test/async_spec.ts
@@ -56,51 +56,47 @@ export function main() {
       expect(called).toBe(true);
     });
 
-    // Makes Edge to disconnect when running the full unit test campaign
-    // TODO: remove when issue is solved: https://github.com/angular/angular/issues/4756
-    if (!browserDetection.isEdge) {
-      it('delivers next and error events synchronously',
-         inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-           let log: any[] /** TODO #9100 */ = [];
-           ObservableWrapper.subscribe(
-               emitter,
-               (x) => {
-                 log.push(x);
-                 expect(log).toEqual([1, 2]);
-               },
-               (err) => {
-                 log.push(err);
-                 expect(log).toEqual([1, 2, 3, 4]);
-                 async.done();
-               });
-           log.push(1);
-           ObservableWrapper.callEmit(emitter, 2);
-           log.push(3);
-           ObservableWrapper.callError(emitter, 4);
-           log.push(5);
-         }));
+    it('delivers next and error events synchronously',
+       inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+         let log: any[] /** TODO #9100 */ = [];
+         ObservableWrapper.subscribe(
+             emitter,
+             (x) => {
+               log.push(x);
+               expect(log).toEqual([1, 2]);
+             },
+             (err) => {
+               log.push(err);
+               expect(log).toEqual([1, 2, 3, 4]);
+               async.done();
+             });
+         log.push(1);
+         ObservableWrapper.callEmit(emitter, 2);
+         log.push(3);
+         ObservableWrapper.callError(emitter, 4);
+         log.push(5);
+       }));
 
-      it('delivers next and complete events synchronously', () => {
-        let log: any[] /** TODO #9100 */ = [];
-        ObservableWrapper.subscribe(
-            emitter,
-            (x) => {
-              log.push(x);
-              expect(log).toEqual([1, 2]);
-            },
-            null,
-            () => {
-              log.push(4);
-              expect(log).toEqual([1, 2, 3, 4]);
-            });
-        log.push(1);
-        ObservableWrapper.callEmit(emitter, 2);
-        log.push(3);
-        ObservableWrapper.callComplete(emitter);
-        log.push(5);
-        expect(log).toEqual([1, 2, 3, 4, 5]);
-      });
-    }
+    it('delivers next and complete events synchronously', () => {
+      let log: any[] /** TODO #9100 */ = [];
+      ObservableWrapper.subscribe(
+          emitter,
+          (x) => {
+            log.push(x);
+            expect(log).toEqual([1, 2]);
+          },
+          null,
+          () => {
+            log.push(4);
+            expect(log).toEqual([1, 2, 3, 4]);
+          });
+      log.push(1);
+      ObservableWrapper.callEmit(emitter, 2);
+      log.push(3);
+      ObservableWrapper.callComplete(emitter);
+      log.push(5);
+      expect(log).toEqual([1, 2, 3, 4, 5]);
+    });
 
     it('delivers events asynchronously when forced to async mode',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {

--- a/modules/@angular/platform-browser/test/web_workers/shared/service_message_broker_spec.ts
+++ b/modules/@angular/platform-browser/test/web_workers/shared/service_message_broker_spec.ts
@@ -46,24 +46,20 @@ export function main() {
              {'method': TEST_METHOD, 'args': [PASSED_ARG_1, PASSED_ARG_2]});
        }));
 
-    // TODO(pkozlowski): this fails only in Edge with
-    //   "No provider for RenderStore! (Serializer -> RenderStore)"
-    if (!browserDetection.isEdge) {
-      it('should return promises to the worker', inject([Serializer], (serializer: Serializer) => {
-           var broker = new ServiceMessageBroker_(messageBuses.ui, serializer, CHANNEL);
-           broker.registerMethod(TEST_METHOD, [PRIMITIVE], (arg1) => {
-             expect(arg1).toEqual(PASSED_ARG_1);
-             return PromiseWrapper.wrap(() => { return RESULT; });
-           });
-           ObservableWrapper.callEmit(
-               messageBuses.worker.to(CHANNEL),
-               {'method': TEST_METHOD, 'id': ID, 'args': [PASSED_ARG_1]});
-           ObservableWrapper.subscribe(messageBuses.worker.from(CHANNEL), (data: any) => {
-             expect(data.type).toEqual('result');
-             expect(data.id).toEqual(ID);
-             expect(data.value).toEqual(RESULT);
-           });
-         }));
-    }
+    it('should return promises to the worker', inject([Serializer], (serializer: Serializer) => {
+         var broker = new ServiceMessageBroker_(messageBuses.ui, serializer, CHANNEL);
+         broker.registerMethod(TEST_METHOD, [PRIMITIVE], (arg1) => {
+           expect(arg1).toEqual(PASSED_ARG_1);
+           return PromiseWrapper.wrap(() => { return RESULT; });
+         });
+         ObservableWrapper.callEmit(
+             messageBuses.worker.to(CHANNEL),
+             {'method': TEST_METHOD, 'id': ID, 'args': [PASSED_ARG_1]});
+         ObservableWrapper.subscribe(messageBuses.worker.from(CHANNEL), (data: any) => {
+           expect(data.type).toEqual('result');
+           expect(data.id).toEqual(ID);
+           expect(data.value).toEqual(RESULT);
+         });
+       }));
   });
 }


### PR DESCRIPTION
These 4 unit tests now pass successfully when running the campaign in the latest stable Edge (13.10586).

With this, #4756 is almost solved, only 2 unit tests are still commented out in `slice_pipe_spec.ts`.
According to the preview already available, it won't be a problem with the next version of the browser (14.xxxxx).
