### PR TITLE
fix(linker/compiler): rename const to avoid duplicate declaration

### DIFF
--- a/modules/@angular/compiler/src/compiler.ts
+++ b/modules/@angular/compiler/src/compiler.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Compiler, CompilerFactory, CompilerOptions, Component, Inject, Injectable, PLATFORM_DIRECTIVES, PLATFORM_INITIALIZER, PLATFORM_PIPES, PlatformRef, ReflectiveInjector, Type, ViewEncapsulation, createPlatformFactory, isDevMode, platformCore} from '@angular/core';
+import {COMPILER_OPTIONS, Compiler, CompilerFactory, CompilerOptions, Component, Inject, Injectable, PLATFORM_DIRECTIVES, PLATFORM_INITIALIZER, PLATFORM_PIPES, PlatformRef, ReflectiveInjector, Type, ViewEncapsulation, createPlatformFactory, isDevMode, platformCore} from '@angular/core';
 
 export * from './template_parser/template_ast';
 export {TEMPLATE_TRANSFORMS} from './template_parser/template_parser';
@@ -152,7 +152,7 @@ export function analyzeAppProvidersForDeprecatedConfiguration(appProviders: any[
 @Injectable()
 export class RuntimeCompilerFactory implements CompilerFactory {
   private _defaultOptions: CompilerOptions[];
-  constructor(@Inject(CompilerOptions) defaultOptions: CompilerOptions[]) {
+  constructor(@Inject(COMPILER_OPTIONS) defaultOptions: CompilerOptions[]) {
     this._defaultOptions = [<CompilerOptions>{
                              useDebug: isDevMode(),
                              useJit: true,
@@ -196,7 +196,7 @@ function _initReflector() {
  * @experimental
  */
 export const platformCoreDynamic = createPlatformFactory(platformCore, 'coreDynamic', [
-  {provide: CompilerOptions, useValue: {}, multi: true},
+  {provide: COMPILER_OPTIONS, useValue: {}, multi: true},
   {provide: CompilerFactory, useClass: RuntimeCompilerFactory},
   {provide: PLATFORM_INITIALIZER, useValue: _initReflector, multi: true},
 ]);

--- a/modules/@angular/compiler/testing.ts
+++ b/modules/@angular/compiler/testing.ts
@@ -13,7 +13,7 @@ export * from './testing/ng_module_resolver_mock';
 export * from './testing/pipe_resolver_mock';
 
 import {ConcreteType, Type} from './src/facade/lang';
-import {createPlatformFactory, ModuleWithComponentFactories, Injectable, CompilerOptions, PlatformRef, CompilerFactory, ComponentFactory, NgModuleFactory, Injector, NgModuleMetadata, NgModuleMetadataType, ComponentMetadata, ComponentMetadataType, DirectiveMetadata, DirectiveMetadataType, PipeMetadata, PipeMetadataType} from '@angular/core';
+import {createPlatformFactory, ModuleWithComponentFactories, Injectable, CompilerOptions, COMPILER_OPTIONS, PlatformRef, CompilerFactory, ComponentFactory, NgModuleFactory, Injector, NgModuleMetadata, NgModuleMetadataType, ComponentMetadata, ComponentMetadataType, DirectiveMetadata, DirectiveMetadataType, PipeMetadata, PipeMetadataType} from '@angular/core';
 import {MetadataOverride} from '@angular/core/testing';
 import {TestingCompilerFactory, TestingCompiler} from './core_private_testing';
 import {platformCoreDynamic, RuntimeCompiler, DirectiveResolver, NgModuleResolver, PipeResolver} from './index';
@@ -99,7 +99,7 @@ export class TestingCompilerImpl implements TestingCompiler {
 export const platformCoreDynamicTesting =
     createPlatformFactory(platformCoreDynamic, 'coreDynamicTesting', [
       {
-        provide: CompilerOptions,
+        provide: COMPILER_OPTIONS,
         useValue: {
           providers: [
             MockPipeResolver, {provide: PipeResolver, useExisting: MockPipeResolver},

--- a/modules/@angular/core/src/linker.ts
+++ b/modules/@angular/core/src/linker.ts
@@ -7,7 +7,7 @@
  */
 
 // Public API for compiler
-export {Compiler, CompilerFactory, CompilerOptions, ComponentStillLoadingError, ModuleWithComponentFactories} from './linker/compiler';
+export {COMPILER_OPTIONS, Compiler, CompilerFactory, CompilerOptions, ComponentStillLoadingError, ModuleWithComponentFactories} from './linker/compiler';
 export {ComponentFactory, ComponentRef} from './linker/component_factory';
 export {ComponentFactoryResolver, NoComponentFactoryError} from './linker/component_factory_resolver';
 export {ComponentResolver} from './linker/component_resolver';

--- a/modules/@angular/core/src/linker/compiler.ts
+++ b/modules/@angular/core/src/linker/compiler.ts
@@ -126,7 +126,7 @@ export type CompilerOptions = {
  *
  * @experimental
  */
-export const CompilerOptions = new OpaqueToken('compilerOptions');
+export const COMPILER_OPTIONS = new OpaqueToken('compilerOptions');
 
 /**
  * A factory for creating a Compiler

--- a/modules/@angular/platform-browser-dynamic/index.ts
+++ b/modules/@angular/platform-browser-dynamic/index.ts
@@ -7,7 +7,7 @@
  */
 
 import {XHR, analyzeAppProvidersForDeprecatedConfiguration, platformCoreDynamic} from '@angular/compiler';
-import {ApplicationRef, Compiler, CompilerFactory, CompilerOptions, ComponentRef, ComponentResolver, ExceptionHandler, NgModule, NgModuleRef, OpaqueToken, PLATFORM_DIRECTIVES, PLATFORM_INITIALIZER, PLATFORM_PIPES, PlatformRef, ReflectiveInjector, SchemaMetadata, Type, assertPlatform, createPlatform, createPlatformFactory, getPlatform, isDevMode} from '@angular/core';
+import {ApplicationRef, COMPILER_OPTIONS, Compiler, CompilerFactory, CompilerOptions, ComponentRef, ComponentResolver, ExceptionHandler, NgModule, NgModuleRef, OpaqueToken, PLATFORM_DIRECTIVES, PLATFORM_INITIALIZER, PLATFORM_PIPES, PlatformRef, ReflectiveInjector, SchemaMetadata, Type, assertPlatform, createPlatform, createPlatformFactory, getPlatform, isDevMode} from '@angular/core';
 import {BROWSER_PLATFORM_PROVIDERS, BrowserModule, WORKER_APP_PLATFORM_PROVIDERS, WORKER_SCRIPT, WorkerAppModule, platformBrowser, platformWorkerApp, platformWorkerUi} from '@angular/platform-browser';
 
 import {Console} from './core_private';
@@ -206,7 +206,7 @@ export function bootstrapWorkerUi(
  */
 export const platformWorkerAppDynamic =
     createPlatformFactory(platformCoreDynamic, 'workerAppDynamic', [{
-                            provide: CompilerOptions,
+                            provide: COMPILER_OPTIONS,
                             useValue: {providers: [{provide: XHR, useClass: XHRImpl}]},
                             multi: true
                           }]);

--- a/modules/@angular/platform-browser-dynamic/src/platform_providers.ts
+++ b/modules/@angular/platform-browser-dynamic/src/platform_providers.ts
@@ -7,7 +7,7 @@
  */
 
 import {XHR} from '@angular/compiler';
-import {CompilerOptions} from '@angular/core';
+import {COMPILER_OPTIONS} from '@angular/core';
 
 import {INTERNAL_BROWSER_PLATFORM_PROVIDERS} from '../platform_browser_private';
 
@@ -16,7 +16,7 @@ import {XHRImpl} from './xhr/xhr_impl';
 export const INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS: any[] = [
   INTERNAL_BROWSER_PLATFORM_PROVIDERS,
   {
-    provide: CompilerOptions,
+    provide: COMPILER_OPTIONS,
     useValue: {providers: [{provide: XHR, useClass: XHRImpl}]},
     multi: true
   },

--- a/modules/@angular/platform-browser-dynamic/testing.ts
+++ b/modules/@angular/platform-browser-dynamic/testing.ts
@@ -8,7 +8,7 @@
 
 import {CompilerConfig, DirectiveResolver, NgModuleResolver, analyzeAppProvidersForDeprecatedConfiguration} from '@angular/compiler';
 import {OverridingTestComponentBuilder, platformCoreDynamicTesting} from '@angular/compiler/testing';
-import {Compiler, CompilerFactory, CompilerOptions, NgModule, PlatformRef, Provider, ReflectiveInjector, Type, createPlatform, createPlatformFactory} from '@angular/core';
+import {COMPILER_OPTIONS, Compiler, CompilerFactory, NgModule, PlatformRef, Provider, ReflectiveInjector, Type, createPlatform, createPlatformFactory} from '@angular/core';
 import {TestBed, TestComponentBuilder, TestComponentRenderer} from '@angular/core/testing';
 import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 
@@ -50,7 +50,7 @@ export const TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS: Array<any /*Type | Provide
       const deprecatedConfiguration = analyzeAppProvidersForDeprecatedConfiguration(appProviders);
       const platformRef =
           createPlatformFactory(platformBrowserDynamicTesting, 'browserDynamicTestingDeprecated', [{
-                                  provide: CompilerOptions,
+                                  provide: COMPILER_OPTIONS,
                                   useValue: deprecatedConfiguration.compilerOptions,
                                   multi: true
                                 }])();

--- a/modules/@angular/platform-server/testing/server.ts
+++ b/modules/@angular/platform-server/testing/server.ts
@@ -8,7 +8,7 @@
 
 import {analyzeAppProvidersForDeprecatedConfiguration} from '@angular/compiler';
 import {platformCoreDynamicTesting} from '@angular/compiler/testing';
-import {CompilerFactory, CompilerOptions, NgModule, OpaqueToken, PLATFORM_COMMON_PROVIDERS, PLATFORM_INITIALIZER, PlatformRef, ReflectiveInjector, assertPlatform, createPlatform, createPlatformFactory, getPlatform} from '@angular/core';
+import {COMPILER_OPTIONS, CompilerFactory, NgModule, OpaqueToken, PLATFORM_COMMON_PROVIDERS, PLATFORM_INITIALIZER, PlatformRef, ReflectiveInjector, assertPlatform, createPlatform, createPlatformFactory, getPlatform} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {BrowserDynamicTestingModule, TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS, platformBrowserDynamicTesting} from '@angular/platform-browser-dynamic/testing';
 
@@ -16,6 +16,7 @@ import {Console} from '../core_private';
 import {platformServer} from '../index';
 import {Parse5DomAdapter} from '../src/parse5_adapter';
 import {INTERNAL_SERVER_PLATFORM_PROVIDERS} from '../src/server';
+
 
 /**
  * Platform for testing
@@ -51,7 +52,7 @@ export const TEST_SERVER_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[]
     [(appProviders: any[]) => {
       const deprecatedConfiguration = analyzeAppProvidersForDeprecatedConfiguration(appProviders);
       const platformRef = createPlatformFactory(platformServerTesting, 'serverTestingDeprecated', [{
-                                                  provide: CompilerOptions,
+                                                  provide: COMPILER_OPTIONS,
                                                   useValue: deprecatedConfiguration.compilerOptions,
                                                   multi: true
                                                 }])();

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -259,12 +259,20 @@ export declare class Compiler {
 }
 
 /** @experimental */
+export declare const COMPILER_OPTIONS: OpaqueToken;
+
+/** @experimental */
 export declare abstract class CompilerFactory {
     abstract createCompiler(options?: CompilerOptions[]): Compiler;
 }
 
 /** @experimental */
-export declare const CompilerOptions: OpaqueToken;
+export declare type CompilerOptions = {
+    useDebug?: boolean;
+    useJit?: boolean;
+    defaultEncapsulation?: ViewEncapsulation;
+    providers?: any[];
+};
 
 /** @stable */
 export declare var Component: ComponentMetadataFactory;


### PR DESCRIPTION
Currently in the `linker/compiler.ts` file, the **same identifier** is used in **two declarations**:

``` typescript
export type CompilerOptions = { … }
…
export const CompilerOptions = new OpaqueToken('compilerOptions');
```

This breaks the API doc generation. I’m surprised that this was not flagged by the tsc.

The duplicate declaration was introduced in https://github.com/angular/angular/commit/46b212706b9162c22fb1523032d7e37c9155015a.
