### PR TITLE
fix(compiler): Report references to non-exported symbols.

### DIFF
--- a/modules/@angular/common/src/forms-deprecated/directives/select_multiple_control_value_accessor.ts
+++ b/modules/@angular/common/src/forms-deprecated/directives/select_multiple_control_value_accessor.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Host, Input, OnDestroy, Optional, Renderer, forwardRef} from '@angular/core';
+import {Directive, ElementRef, Host, Input, OnDestroy, OpaqueToken, Optional, Renderer, Type, forwardRef} from '@angular/core';
 
 import {MapWrapper} from '../../facade/collection';
 import {StringWrapper, isBlank, isPresent, isPrimitive, isString, looseIdentical} from '../../facade/lang';
 
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 
-const SELECT_MULTIPLE_VALUE_ACCESSOR = {
+export const SELECT_MULTIPLE_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
   useExisting: forwardRef(() => SelectMultipleControlValueAccessor),
   multi: true

--- a/modules/@angular/common/src/forms-deprecated/directives/validators.ts
+++ b/modules/@angular/common/src/forms-deprecated/directives/validators.ts
@@ -35,7 +35,7 @@ import {NG_VALIDATORS, Validators} from '../validators';
  */
 export interface Validator { validate(c: AbstractControl): {[key: string]: any}; }
 
-const REQUIRED = Validators.required;
+export const REQUIRED = Validators.required;
 
 export const REQUIRED_VALIDATOR: any = {
   provide: NG_VALIDATORS,

--- a/modules/@angular/compiler-cli/src/static_reflector.ts
+++ b/modules/@angular/compiler-cli/src/static_reflector.ts
@@ -594,6 +594,10 @@ function expandedMessage(error: any): string {
           error.context && error.context.name ? `Calling function '${error.context.name}', f` : 'F';
       return prefix +
           'unction calls are not supported. Consider replacing the function or lambda with a reference to an exported function';
+    case 'Reference to a local symbol':
+      if (error.context && error.context.name) {
+        return `Reference to a local (non-exported) symbol '${error.context.name}'. Consider exporting the symbol`;
+      }
   }
   return error.message;
 }

--- a/modules/@angular/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Host, Input, OnDestroy, Optional, Renderer, forwardRef} from '@angular/core';
+import {Directive, ElementRef, Host, Input, OnDestroy, OpaqueToken, Optional, Renderer, Type, forwardRef} from '@angular/core';
 
 import {MapWrapper} from '../facade/collection';
 import {StringWrapper, isBlank, isPresent, isPrimitive, isString, looseIdentical} from '../facade/lang';
 
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 
-const SELECT_MULTIPLE_VALUE_ACCESSOR = {
+export const SELECT_MULTIPLE_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
   useExisting: forwardRef(() => SelectMultipleControlValueAccessor),
   multi: true

--- a/tools/@angular/tsc-wrapped/src/collector.ts
+++ b/tools/@angular/tsc-wrapped/src/collector.ts
@@ -297,13 +297,19 @@ export class MetadataCollector {
               } else {
                 varValue = errorSym('Variable not initialized', nameNode);
               }
+              let exported = false;
               if (variableStatement.flags & ts.NodeFlags.Export ||
                   variableDeclaration.flags & ts.NodeFlags.Export) {
                 if (!metadata) metadata = {};
                 metadata[nameNode.text] = varValue;
+                exported = true;
               }
               if (isPrimitive(varValue)) {
                 locals.define(nameNode.text, varValue);
+              } else if (!exported) {
+                locals.define(
+                    nameNode.text,
+                    errorSym('Reference to a local symbol', nameNode, {name: nameNode.text}));
               }
             } else {
               // Destructuring (or binding) declarations are not supported,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

When producing factories, `ngc` will produce code that will error during compile because it generates references to non-exported symbols recorded by the `Collector`. 

**What is the new behavior?**

The collector will now produce error nodes for such references allowing the compiler to flag these as errors before generating an invalid factory.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

Includes fixes to places now reported as errors.

Part of #8310
