### PR TITLE
Improve Route Dev Ergonomics

### DIFF
--- a/modules/@angular/router/src/create_router_state.ts
+++ b/modules/@angular/router/src/create_router_state.ts
@@ -13,9 +13,7 @@ import {TreeNode} from './utils/tree';
 
 export function createRouterState(curr: RouterStateSnapshot, prevState: RouterState): RouterState {
   const root = createNode(curr._root, prevState ? prevState._root : undefined);
-  const queryParams = prevState ? prevState.queryParams : new BehaviorSubject(curr.queryParams);
-  const fragment = prevState ? prevState.fragment : new BehaviorSubject(curr.fragment);
-  return new RouterState(root, queryParams, fragment, curr);
+  return new RouterState(root, curr);
 }
 
 function createNode(curr: TreeNode<ActivatedRouteSnapshot>, prevState?: TreeNode<ActivatedRoute>):
@@ -48,8 +46,8 @@ function createOrReuseChildren(
 
 function createActivatedRoute(c: ActivatedRouteSnapshot) {
   return new ActivatedRoute(
-      new BehaviorSubject(c.url), new BehaviorSubject(c.params), new BehaviorSubject(c.data),
-      c.outlet, c.component, c);
+      new BehaviorSubject(c.url), new BehaviorSubject(c.params), new BehaviorSubject(c.queryParams),
+      new BehaviorSubject(c.fragment), new BehaviorSubject(c.data), c.outlet, c.component, c);
 }
 
 function equalRouteSnapshots(a: ActivatedRouteSnapshot, b: ActivatedRouteSnapshot): boolean {

--- a/modules/@angular/router/src/recognize.ts
+++ b/modules/@angular/router/src/recognize.ts
@@ -40,47 +40,131 @@ class InheritedFromParent {
 
 export function recognize(rootComponentType: Type, config: Routes, urlTree: UrlTree, url: string):
     Observable<RouterStateSnapshot> {
-  try {
-    const rootSegmentGroup = split(urlTree.root, [], [], config).segmentGroup;
-    const children = processSegmentGroup(
-        config, rootSegmentGroup, InheritedFromParent.empty(null), PRIMARY_OUTLET);
-    const root = new ActivatedRouteSnapshot(
-        [], Object.freeze({}), {}, PRIMARY_OUTLET, rootComponentType, null, urlTree.root, -1,
-        InheritedResolve.empty);
-    const rootNode = new TreeNode<ActivatedRouteSnapshot>(root, children);
-    return of (new RouterStateSnapshot(
-        url, rootNode, Object.freeze(urlTree.queryParams), urlTree.fragment));
-  } catch (e) {
-    if (e instanceof NoMatch) {
-      return new Observable<RouterStateSnapshot>(
-          (obs: Observer<RouterStateSnapshot>) =>
-              obs.error(new Error(`Cannot match any routes: '${e.segmentGroup}'`)));
-    } else {
-      return new Observable<RouterStateSnapshot>(
-          (obs: Observer<RouterStateSnapshot>) => obs.error(e));
+  return new Recognizer(rootComponentType, config, urlTree, url).recognize();
+}
+
+class Recognizer {
+  constructor(
+      private rootComponentType: Type, private config: Routes, private urlTree: UrlTree,
+      private url: string) {}
+
+  recognize(): Observable<RouterStateSnapshot> {
+    try {
+      const rootSegmentGroup = split(this.urlTree.root, [], [], this.config).segmentGroup;
+
+      const children = this.processSegmentGroup(
+          this.config, rootSegmentGroup, InheritedFromParent.empty(null), PRIMARY_OUTLET);
+
+      const root = new ActivatedRouteSnapshot(
+          [], Object.freeze({}), Object.freeze(this.urlTree.queryParams), this.urlTree.fragment, {},
+          PRIMARY_OUTLET, this.rootComponentType, null, this.urlTree.root, -1,
+          InheritedResolve.empty);
+
+      const rootNode = new TreeNode<ActivatedRouteSnapshot>(root, children);
+
+      return of (new RouterStateSnapshot(this.url, rootNode));
+
+    } catch (e) {
+      if (e instanceof NoMatch) {
+        return new Observable<RouterStateSnapshot>(
+            (obs: Observer<RouterStateSnapshot>) =>
+                obs.error(new Error(`Cannot match any routes: '${e.segmentGroup}'`)));
+      } else {
+        return new Observable<RouterStateSnapshot>(
+            (obs: Observer<RouterStateSnapshot>) => obs.error(e));
+      }
     }
   }
-}
 
-function processSegmentGroup(
-    config: Route[], segmentGroup: UrlSegmentGroup, inherited: InheritedFromParent,
-    outlet: string): TreeNode<ActivatedRouteSnapshot>[] {
-  if (segmentGroup.segments.length === 0 && segmentGroup.hasChildren()) {
-    return processChildren(config, segmentGroup, inherited);
-  } else {
-    return processSegment(config, segmentGroup, 0, segmentGroup.segments, inherited, outlet);
+
+  processSegmentGroup(
+      config: Route[], segmentGroup: UrlSegmentGroup, inherited: InheritedFromParent,
+      outlet: string): TreeNode<ActivatedRouteSnapshot>[] {
+    if (segmentGroup.segments.length === 0 && segmentGroup.hasChildren()) {
+      return this.processChildren(config, segmentGroup, inherited);
+    } else {
+      return this.processSegment(config, segmentGroup, 0, segmentGroup.segments, inherited, outlet);
+    }
   }
-}
 
-function processChildren(
-    config: Route[], segmentGroup: UrlSegmentGroup,
-    inherited: InheritedFromParent): TreeNode<ActivatedRouteSnapshot>[] {
-  const children = mapChildrenIntoArray(
-      segmentGroup,
-      (child, childOutlet) => processSegmentGroup(config, child, inherited, childOutlet));
-  checkOutletNameUniqueness(children);
-  sortActivatedRouteSnapshots(children);
-  return children;
+  processChildren(config: Route[], segmentGroup: UrlSegmentGroup, inherited: InheritedFromParent):
+      TreeNode<ActivatedRouteSnapshot>[] {
+    const children = mapChildrenIntoArray(
+        segmentGroup,
+        (child, childOutlet) => this.processSegmentGroup(config, child, inherited, childOutlet));
+    checkOutletNameUniqueness(children);
+    sortActivatedRouteSnapshots(children);
+    return children;
+  }
+
+  processSegment(
+      config: Route[], segmentGroup: UrlSegmentGroup, pathIndex: number, segments: UrlSegment[],
+      inherited: InheritedFromParent, outlet: string): TreeNode<ActivatedRouteSnapshot>[] {
+    for (let r of config) {
+      try {
+        return this.processSegmentAgainstRoute(
+            r, segmentGroup, pathIndex, segments, inherited, outlet);
+      } catch (e) {
+        if (!(e instanceof NoMatch)) throw e;
+      }
+    }
+    throw new NoMatch(segmentGroup);
+  }
+
+  processSegmentAgainstRoute(
+      route: Route, rawSegment: UrlSegmentGroup, pathIndex: number, segments: UrlSegment[],
+      inherited: InheritedFromParent, outlet: string): TreeNode<ActivatedRouteSnapshot>[] {
+    if (route.redirectTo) throw new NoMatch();
+
+    if ((route.outlet ? route.outlet : PRIMARY_OUTLET) !== outlet) throw new NoMatch();
+
+    const newInheritedResolve = new InheritedResolve(inherited.resolve, getResolve(route));
+
+    if (route.path === '**') {
+      const params = segments.length > 0 ? last(segments).parameters : {};
+      const snapshot = new ActivatedRouteSnapshot(
+          segments, Object.freeze(merge(inherited.allParams, params)),
+          Object.freeze(this.urlTree.queryParams), this.urlTree.fragment,
+          merge(inherited.allData, getData(route)), outlet, route.component, route,
+          getSourceSegmentGroup(rawSegment), getPathIndexShift(rawSegment) + segments.length,
+          newInheritedResolve);
+      return [new TreeNode<ActivatedRouteSnapshot>(snapshot, [])];
+    }
+
+    const {consumedSegments, parameters, lastChild} =
+        match(rawSegment, route, segments, inherited.snapshot);
+    const rawSlicedSegments = segments.slice(lastChild);
+    const childConfig = getChildConfig(route);
+
+    const {segmentGroup, slicedSegments} =
+        split(rawSegment, consumedSegments, rawSlicedSegments, childConfig);
+
+    const snapshot = new ActivatedRouteSnapshot(
+        consumedSegments, Object.freeze(merge(inherited.allParams, parameters)),
+        Object.freeze(this.urlTree.queryParams), this.urlTree.fragment,
+        merge(inherited.allData, getData(route)), outlet, route.component, route,
+        getSourceSegmentGroup(rawSegment), getPathIndexShift(rawSegment) + consumedSegments.length,
+        newInheritedResolve);
+
+    const newInherited = route.component ?
+        InheritedFromParent.empty(snapshot) :
+        new InheritedFromParent(
+            inherited, snapshot, parameters, getData(route), newInheritedResolve);
+
+    if (slicedSegments.length === 0 && segmentGroup.hasChildren()) {
+      const children = this.processChildren(childConfig, segmentGroup, newInherited);
+      return [new TreeNode<ActivatedRouteSnapshot>(snapshot, children)];
+
+    } else if (childConfig.length === 0 && slicedSegments.length === 0) {
+      return [new TreeNode<ActivatedRouteSnapshot>(snapshot, [])];
+
+    } else {
+      const children = this.processSegment(
+          childConfig, segmentGroup, pathIndex + lastChild, slicedSegments, newInherited,
+          PRIMARY_OUTLET);
+      return [new TreeNode<ActivatedRouteSnapshot>(snapshot, children)];
+    }
+  }
 }
 
 function sortActivatedRouteSnapshots(nodes: TreeNode<ActivatedRouteSnapshot>[]): void {
@@ -89,71 +173,6 @@ function sortActivatedRouteSnapshots(nodes: TreeNode<ActivatedRouteSnapshot>[]):
     if (b.value.outlet === PRIMARY_OUTLET) return 1;
     return a.value.outlet.localeCompare(b.value.outlet);
   });
-}
-
-function processSegment(
-    config: Route[], segmentGroup: UrlSegmentGroup, pathIndex: number, segments: UrlSegment[],
-    inherited: InheritedFromParent, outlet: string): TreeNode<ActivatedRouteSnapshot>[] {
-  for (let r of config) {
-    try {
-      return processSegmentAgainstRoute(r, segmentGroup, pathIndex, segments, inherited, outlet);
-    } catch (e) {
-      if (!(e instanceof NoMatch)) throw e;
-    }
-  }
-  throw new NoMatch(segmentGroup);
-}
-
-function processSegmentAgainstRoute(
-    route: Route, rawSegment: UrlSegmentGroup, pathIndex: number, segments: UrlSegment[],
-    inherited: InheritedFromParent, outlet: string): TreeNode<ActivatedRouteSnapshot>[] {
-  if (route.redirectTo) throw new NoMatch();
-
-  if ((route.outlet ? route.outlet : PRIMARY_OUTLET) !== outlet) throw new NoMatch();
-
-  const newInheritedResolve = new InheritedResolve(inherited.resolve, getResolve(route));
-
-  if (route.path === '**') {
-    const params = segments.length > 0 ? last(segments).parameters : {};
-    const snapshot = new ActivatedRouteSnapshot(
-        segments, Object.freeze(merge(inherited.allParams, params)),
-        merge(inherited.allData, getData(route)), outlet, route.component, route,
-        getSourceSegmentGroup(rawSegment), getPathIndexShift(rawSegment) + segments.length,
-        newInheritedResolve);
-    return [new TreeNode<ActivatedRouteSnapshot>(snapshot, [])];
-  }
-
-  const {consumedSegments, parameters, lastChild} =
-      match(rawSegment, route, segments, inherited.snapshot);
-  const rawSlicedSegments = segments.slice(lastChild);
-  const childConfig = getChildConfig(route);
-
-  const {segmentGroup, slicedSegments} =
-      split(rawSegment, consumedSegments, rawSlicedSegments, childConfig);
-
-  const snapshot = new ActivatedRouteSnapshot(
-      consumedSegments, Object.freeze(merge(inherited.allParams, parameters)),
-      merge(inherited.allData, getData(route)), outlet, route.component, route,
-      getSourceSegmentGroup(rawSegment), getPathIndexShift(rawSegment) + consumedSegments.length,
-      newInheritedResolve);
-
-  const newInherited = route.component ?
-      InheritedFromParent.empty(snapshot) :
-      new InheritedFromParent(inherited, snapshot, parameters, getData(route), newInheritedResolve);
-
-  if (slicedSegments.length === 0 && segmentGroup.hasChildren()) {
-    const children = processChildren(childConfig, segmentGroup, newInherited);
-    return [new TreeNode<ActivatedRouteSnapshot>(snapshot, children)];
-
-  } else if (childConfig.length === 0 && slicedSegments.length === 0) {
-    return [new TreeNode<ActivatedRouteSnapshot>(snapshot, [])];
-
-  } else {
-    const children = processSegment(
-        childConfig, segmentGroup, pathIndex + lastChild, slicedSegments, newInherited,
-        PRIMARY_OUTLET);
-    return [new TreeNode<ActivatedRouteSnapshot>(snapshot, children)];
-  }
 }
 
 function getChildConfig(route: Route): Route[] {

--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -649,7 +649,6 @@ class ActivateRoutes {
     const currRoot = this.currState ? this.currState._root : null;
     advanceActivatedRoute(this.futureState.root);
     this.activateChildRoutes(futureRoot, currRoot, parentOutletMap);
-    pushQueryParamsAndFragment(this.futureState);
   }
 
   private activateChildRoutes(
@@ -756,16 +755,6 @@ function closestLoadedConfig(
     return config && config._loadedConfig && s !== snapshot;
   });
   return b.length > 0 ? (<any>b[b.length - 1])._routeConfig._loadedConfig : null;
-}
-
-function pushQueryParamsAndFragment(state: RouterState): void {
-  if (!shallowEqual(state.snapshot.queryParams, (<any>state.queryParams).value)) {
-    (<any>state.queryParams).next(state.snapshot.queryParams);
-  }
-
-  if (state.snapshot.fragment !== (<any>state.fragment).value) {
-    (<any>state.fragment).next(state.snapshot.fragment);
-  }
 }
 
 function nodeChildrenAsMap(node: TreeNode<any>) {

--- a/modules/@angular/router/src/utils/tree.ts
+++ b/modules/@angular/router/src/utils/tree.ts
@@ -38,8 +38,6 @@ export class Tree<T> {
   }
 
   pathFromRoot(t: T): T[] { return findPath(t, this._root, []).map(s => s.value); }
-
-  contains(tree: Tree<T>): boolean { return contains(this._root, tree._root); }
 }
 
 function findNode<T>(expected: T, c: TreeNode<T>): TreeNode<T> {
@@ -62,18 +60,6 @@ function findPath<T>(expected: T, c: TreeNode<T>, collected: TreeNode<T>[]): Tre
   }
 
   return [];
-}
-
-function contains<T>(tree: TreeNode<T>, subtree: TreeNode<T>): boolean {
-  if (tree.value !== subtree.value) return false;
-
-  for (let subtreeNode of subtree.children) {
-    const s = tree.children.filter(child => child.value === subtreeNode.value);
-    if (s.length === 0) return false;
-    if (!contains(s[0], subtreeNode)) return false;
-  }
-
-  return true;
 }
 
 export class TreeNode<T> {

--- a/modules/@angular/router/src/utils/tree.ts
+++ b/modules/@angular/router/src/utils/tree.ts
@@ -14,21 +14,33 @@ export class Tree<T> {
 
   get root(): T { return this._root.value; }
 
+  /**
+   * @deprecated (use ActivatedRoute.parent instead)
+   */
   parent(t: T): T {
     const p = this.pathFromRoot(t);
     return p.length > 1 ? p[p.length - 2] : null;
   }
 
+  /**
+   * @deprecated (use ActivatedRoute.children instead)
+   */
   children(t: T): T[] {
     const n = findNode(t, this._root);
     return n ? n.children.map(t => t.value) : [];
   }
 
+  /**
+   * @deprecated (use ActivatedRoute.firstChild instead)
+   */
   firstChild(t: T): T {
     const n = findNode(t, this._root);
     return n && n.children.length > 0 ? n.children[0].value : null;
   }
 
+  /**
+   * @deprecated
+   */
   siblings(t: T): T[] {
     const p = findPath(t, this._root, []);
     if (p.length < 2) return [];
@@ -37,6 +49,9 @@ export class Tree<T> {
     return c.filter(cc => cc !== t);
   }
 
+  /**
+   * @deprecated (use ActivatedRoute.pathFromRoot instead)
+   */
   pathFromRoot(t: T): T[] { return findPath(t, this._root, []).map(s => s.value); }
 }
 

--- a/modules/@angular/router/test/create_url_tree.spec.ts
+++ b/modules/@angular/router/test/create_url_tree.spec.ts
@@ -200,10 +200,11 @@ describe('createUrlTree', () => {
 
 function createRoot(tree: UrlTree, commands: any[], queryParams?: Params, fragment?: string) {
   const s = new ActivatedRouteSnapshot(
-      [], <any>{}, <any>{}, PRIMARY_OUTLET, 'someComponent', null, tree.root, -1, <any>null);
+      [], <any>{}, <any>{}, '', <any>{}, PRIMARY_OUTLET, 'someComponent', null, tree.root, -1,
+      <any>null);
   const a = new ActivatedRoute(
       new BehaviorSubject(null), new BehaviorSubject(null), new BehaviorSubject(null),
-      PRIMARY_OUTLET, 'someComponent', s);
+      new BehaviorSubject(null), new BehaviorSubject(null), PRIMARY_OUTLET, 'someComponent', s);
   advanceActivatedRoute(a);
   return createUrlTree(a, tree, commands, queryParams, fragment);
 }
@@ -215,11 +216,11 @@ function create(
     expect(segment).toBeDefined();
   }
   const s = new ActivatedRouteSnapshot(
-      [], <any>{}, <any>{}, PRIMARY_OUTLET, 'someComponent', null, <any>segment, startIndex,
-      <any>null);
+      [], <any>{}, <any>{}, '', <any>{}, PRIMARY_OUTLET, 'someComponent', null, <any>segment,
+      startIndex, <any>null);
   const a = new ActivatedRoute(
       new BehaviorSubject(null), new BehaviorSubject(null), new BehaviorSubject(null),
-      PRIMARY_OUTLET, 'someComponent', s);
+      new BehaviorSubject(null), new BehaviorSubject(null), PRIMARY_OUTLET, 'someComponent', s);
   advanceActivatedRoute(a);
   return createUrlTree(a, tree, commands, queryParams, fragment);
 }

--- a/modules/@angular/router/test/router.spec.ts
+++ b/modules/@angular/router/test/router.spec.ts
@@ -28,7 +28,7 @@ describe('Integration', () => {
         BlankCmp, SimpleCmp, TeamCmp, UserCmp, StringLinkCmp, DummyLinkCmp, AbsoluteLinkCmp,
         RelativeLinkCmp, DummyLinkWithParentCmp, LinkWithQueryParamsAndFragment, CollectParamsCmp,
         QueryParamsAndFragmentCmp, StringLinkButtonCmp, WrapperCmp, LinkInNgIf,
-        ComponentRecordingQueryParams, ComponentRecordingRoutePathAndUrl, RouteCmp
+        ComponentRecordingRoutePathAndUrl, RouteCmp
       ]
     });
   });
@@ -287,29 +287,6 @@ describe('Integration', () => {
            router.navigateByUrl('/query?name=2#fragment2');
            advance(fixture);
            expect(fixture.debugElement.nativeElement).toHaveText('query: 2 fragment: fragment2');
-         })));
-
-  it('should not push query params into components that will be deactivated',
-     fakeAsync(
-         inject([Router, TestComponentBuilder], (router: Router, tcb: TestComponentBuilder) => {
-
-           router.resetConfig([
-             {path: '', component: ComponentRecordingQueryParams},
-             {path: 'simple', component: SimpleCmp}
-           ]);
-
-           const fixture = createRoot(tcb, router, RootCmp);
-           router.navigateByUrl('/?a=v1');
-           advance(fixture);
-
-           const c = fixture.debugElement.children[1].componentInstance;
-
-           expect(c.recordedQueryParams).toEqual([{}, {a: 'v1'}]);
-
-           router.navigateByUrl('/simple?a=v2');
-           advance(fixture);
-
-           expect(c.recordedQueryParams).toEqual([{}, {a: 'v1'}]);
          })));
 
   it('should push params only when they change',
@@ -1682,18 +1659,6 @@ class DummyLinkWithParentCmp {
   constructor(route: ActivatedRoute) { this.exact = (<any>route.snapshot.params).exact === 'true'; }
 }
 
-
-@Component({template: ''})
-class ComponentRecordingQueryParams {
-  recordedQueryParams: any[] = [];
-  subscription: any;
-  constructor(r: Router) {
-    this.subscription = r.routerState.queryParams.subscribe(r => this.recordedQueryParams.push(r));
-  }
-
-  ngOnDestroy() { this.subscription.unsubscribe(); }
-}
-
 @Component({selector: 'cmp', template: ''})
 class ComponentRecordingRoutePathAndUrl {
   private path: any;
@@ -1713,7 +1678,7 @@ class ComponentRecordingRoutePathAndUrl {
     BlankCmp, SimpleCmp, TeamCmp, UserCmp, StringLinkCmp, DummyLinkCmp, AbsoluteLinkCmp,
     RelativeLinkCmp, DummyLinkWithParentCmp, LinkWithQueryParamsAndFragment, CollectParamsCmp,
     QueryParamsAndFragmentCmp, StringLinkButtonCmp, WrapperCmp, LinkInNgIf,
-    ComponentRecordingQueryParams, ComponentRecordingRoutePathAndUrl
+    ComponentRecordingRoutePathAndUrl
   ]
 })
 class RootCmp {

--- a/modules/@angular/router/test/router_state.spec.ts
+++ b/modules/@angular/router/test/router_state.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot} from '../src/router_state';
+import {TreeNode} from '../src/utils/tree';
+
+describe('RouterState & Snapshot', () => {
+  describe('RouterStateSnapshot', () => {
+    let state: RouterStateSnapshot;
+    let a: ActivatedRouteSnapshot;
+    let b: ActivatedRouteSnapshot;
+    let c: ActivatedRouteSnapshot;
+
+    beforeEach(() => {
+      a = createActivatedRouteSnapshot('a');
+      b = createActivatedRouteSnapshot('b');
+      c = createActivatedRouteSnapshot('c');
+
+      const root = new TreeNode(a, [new TreeNode(b, []), new TreeNode(c, [])]);
+
+      state = new RouterStateSnapshot('url', root, {}, '');
+    });
+
+    it('should return first child', () => { expect(state.root.firstChild).toBe(b); });
+
+    it('should return children', () => {
+      const cc = state.root.children;
+      expect(cc[0]).toBe(b);
+      expect(cc[1]).toBe(c);
+    });
+
+    it('should return root', () => {
+      const b = state.root.firstChild;
+      expect(b.parent).toBe(state.root);
+    });
+
+    it('should return path from root', () => {
+      const b = state.root.firstChild;
+      const p = b.pathFromRoot;
+      expect(p[0]).toBe(state.root);
+      expect(p[1]).toBe(b);
+    });
+  });
+
+  describe('RouterState', () => {
+    let state: RouterState;
+    let a: ActivatedRoute;
+    let b: ActivatedRoute;
+    let c: ActivatedRoute;
+
+    beforeEach(() => {
+      a = createActivatedRoute('a');
+      b = createActivatedRoute('b');
+      c = createActivatedRoute('c');
+
+      const root = new TreeNode(a, [new TreeNode(b, []), new TreeNode(c, [])]);
+
+      state = new RouterState(root, <any>null, <any>null, <any>null);
+    });
+
+    it('should return first child', () => { expect(state.root.firstChild).toBe(b); });
+
+    it('should return children', () => {
+      const cc = state.root.children;
+      expect(cc[0]).toBe(b);
+      expect(cc[1]).toBe(c);
+    });
+
+    it('should return root', () => {
+      const b = state.root.firstChild;
+      expect(b.parent).toBe(state.root);
+    });
+
+    it('should return path from root', () => {
+      const b = state.root.firstChild;
+      const p = b.pathFromRoot;
+      expect(p[0]).toBe(state.root);
+      expect(p[1]).toBe(b);
+    });
+  });
+});
+
+function createActivatedRouteSnapshot(cmp: string) {
+  return new ActivatedRouteSnapshot(
+      <any>null, <any>null, <any>null, <any>null, <any>cmp, <any>null, <any>null, -1, null);
+}
+
+function createActivatedRoute(cmp: string) {
+  return new ActivatedRoute(<any>null, <any>null, <any>null, <any>null, <any>cmp, <any>null);
+}

--- a/modules/@angular/router/test/router_state.spec.ts
+++ b/modules/@angular/router/test/router_state.spec.ts
@@ -23,7 +23,7 @@ describe('RouterState & Snapshot', () => {
 
       const root = new TreeNode(a, [new TreeNode(b, []), new TreeNode(c, [])]);
 
-      state = new RouterStateSnapshot('url', root, {}, '');
+      state = new RouterStateSnapshot('url', root);
     });
 
     it('should return first child', () => { expect(state.root.firstChild).toBe(b); });
@@ -60,7 +60,7 @@ describe('RouterState & Snapshot', () => {
 
       const root = new TreeNode(a, [new TreeNode(b, []), new TreeNode(c, [])]);
 
-      state = new RouterState(root, <any>null, <any>null, <any>null);
+      state = new RouterState(root, <any>null);
     });
 
     it('should return first child', () => { expect(state.root.firstChild).toBe(b); });
@@ -87,9 +87,11 @@ describe('RouterState & Snapshot', () => {
 
 function createActivatedRouteSnapshot(cmp: string) {
   return new ActivatedRouteSnapshot(
-      <any>null, <any>null, <any>null, <any>null, <any>cmp, <any>null, <any>null, -1, null);
+      <any>null, <any>null, <any>null, <any>null, <any>null, <any>null, <any>cmp, <any>null,
+      <any>null, -1, null);
 }
 
 function createActivatedRoute(cmp: string) {
-  return new ActivatedRoute(<any>null, <any>null, <any>null, <any>null, <any>cmp, <any>null);
+  return new ActivatedRoute(
+      <any>null, <any>null, <any>null, <any>null, <any>null, <any>null, <any>cmp, <any>null);
 }

--- a/modules/@angular/router/test/utils/tree.spec.ts
+++ b/modules/@angular/router/test/utils/tree.spec.ts
@@ -43,23 +43,4 @@ describe('tree', () => {
     const t = new Tree<any>(new TreeNode<number>(1, [new TreeNode<number>(2, [])]));
     expect(t.pathFromRoot(2)).toEqual([1, 2]);
   });
-
-  describe('contains', () => {
-    it('should work', () => {
-      const tree = new Tree<any>(
-          new TreeNode<number>(1, [new TreeNode<number>(2, []), new TreeNode<number>(3, [])]));
-      const subtree1 = new Tree<any>(new TreeNode<number>(1, []));
-      const subtree2 = new Tree<any>(new TreeNode<number>(1, [new TreeNode<number>(2, [])]));
-      const subtree3 = new Tree<any>(new TreeNode<number>(1, [new TreeNode<number>(3, [])]));
-      const notSubtree1 = new Tree<any>(new TreeNode<number>(1, [new TreeNode<number>(4, [])]));
-      const notSubtree2 = new Tree<any>(
-          new TreeNode<number>(1, [new TreeNode<number>(2, [new TreeNode<number>(4, [])])]));
-
-      expect(tree.contains(subtree1)).toEqual(true);
-      expect(tree.contains(subtree2)).toEqual(true);
-      expect(tree.contains(subtree3)).toEqual(true);
-      expect(tree.contains(notSubtree1)).toEqual(false);
-      expect(tree.contains(notSubtree2)).toEqual(false);
-    });
-  });
 });

--- a/modules/@angular/router/tsconfig.json
+++ b/modules/@angular/router/tsconfig.json
@@ -32,6 +32,7 @@
     "test/create_router_state.spec.ts",
     "test/create_url_tree.spec.ts",
     "test/config.spec.ts",
+    "test/router_state.spec.ts",
     "test/router.spec.ts",
     "../../../node_modules/@types/jasmine/index.d.ts"
   ]

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -1,9 +1,15 @@
 /** @stable */
 export declare class ActivatedRoute {
+    children: ActivatedRoute[];
     component: Type | string;
     data: Observable<Data>;
+    firstChild: ActivatedRoute;
+    fragment: Observable<string>;
     outlet: string;
     params: Observable<Params>;
+    parent: ActivatedRoute;
+    pathFromRoot: ActivatedRoute[];
+    queryParams: Observable<Params>;
     routeConfig: Route;
     snapshot: ActivatedRouteSnapshot;
     url: Observable<UrlSegment[]>;
@@ -12,10 +18,16 @@ export declare class ActivatedRoute {
 
 /** @stable */
 export declare class ActivatedRouteSnapshot {
+    children: ActivatedRouteSnapshot[];
     component: Type | string;
     data: Data;
+    firstChild: ActivatedRouteSnapshot;
+    fragment: string;
     outlet: string;
     params: Params;
+    parent: ActivatedRouteSnapshot;
+    pathFromRoot: ActivatedRouteSnapshot[];
+    queryParams: Params;
     routeConfig: Route;
     url: UrlSegment[];
     toString(): string;
@@ -249,16 +261,16 @@ export declare class RouterOutletMap {
 
 /** @stable */
 export declare class RouterState extends Tree<ActivatedRoute> {
-    fragment: Observable<string>;
-    queryParams: Observable<Params>;
+    /** @deprecated */ fragment: Observable<string>;
+    /** @deprecated */ queryParams: Observable<Params>;
     snapshot: RouterStateSnapshot;
     toString(): string;
 }
 
 /** @stable */
 export declare class RouterStateSnapshot extends Tree<ActivatedRouteSnapshot> {
-    fragment: string;
-    queryParams: Params;
+    /** @deprecated */ fragment: string;
+    /** @deprecated */ queryParams: Params;
     url: string;
     toString(): string;
 }


### PR DESCRIPTION
This PR implements two changes:
## Tree Navigation

It adds parent, children, etc to ActivatedRoute and ActivatedRouteSnapshot. 

Previously, to get a route's parent, you would have to do this:

```
class MyComponent {
  constructor(router: Router, route: ActivatedRoute) {
    const parent = router.routerState.parent(route);
  }
}
```

Now you can do the following:

```
class MyComponent {
  constructor(route: ActivatedRoute) {
    route.parent;
  }
}
```
## Query Params and Fragment Are Local to a Route

Before

```
class MyComponent {
  subscription;

  constructor(router: Router, route: ActivatedRoute) {
    route.params.forEach(s => {}); // no need to worry about subscriptions as everything is local
    this.subscription = router.queryParams.subscribe(s => {});
  }

  ngOnDestroy() {
    this.subscription.unsubscribe(); // we have to do it because the queryParams observable is not local!
  }
}
```

After

```
class MyComponent {
  subscription;

  constructor(router: Router, route: ActivatedRoute) {
    route.params.forEach(s => {}); // no need to worry about subscriptions as everything is local
    route.queryParams.forEach(s => {}); // no need to worry about subscriptions as everything is local
  }
}
```
