### PR TITLE
fix(ngc): gather metadata for OpaqueToken

### DIFF
--- a/modules/@angular/core/src/di/opaque_token.ts
+++ b/modules/@angular/core/src/di/opaque_token.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Injectable} from './decorators';
+
 /**
  * Creates a token that can be used in a DI Provider.
  *
@@ -28,6 +30,7 @@
  * error messages.
  * @stable
  */
+@Injectable()  // so that metadata is gathered for this class
 export class OpaqueToken {
   constructor(private _desc: string) {}
 


### PR DESCRIPTION
Please advise if there's a proper location to integration-test this. Do we have a setup that relies on the new mode where angular2 .d.ts files aren't included in the program?
