### PR TITLE
fix: put all `ngc` files into a single directory

### DIFF
--- a/modules/@angular/compiler-cli/src/codegen.ts
+++ b/modules/@angular/compiler-cli/src/codegen.ts
@@ -80,7 +80,14 @@ export class CodeGenerator {
       }
     }
 
-    return path.join(this.options.genDir, path.relative(root, filePath));
+    // transplant the codegen path to be inside the `genDir`
+    var relativePath: string = path.relative(root, filePath);
+    while (relativePath.startsWith('..' + path.sep)) {
+      // Strip out any `..` path such as: `../node_modules/@foo` as we want to put everything
+      // into `genDir`.
+      relativePath = relativePath.substr(3);
+    }
+    return path.join(this.options.genDir, relativePath);
   }
 
   codegen(): Promise<any> {

--- a/modules/@angular/compiler/src/output/ts_emitter.ts
+++ b/modules/@angular/compiler/src/output/ts_emitter.ts
@@ -254,7 +254,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
   }
 
   getBuiltinMethodName(method: o.BuiltinMethod): string {
-    var name: any /** TODO #9100 */;
+    var name: string;
     switch (method) {
       case o.BuiltinMethod.ConcatArray:
         name = 'concat';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[X] Feature
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] No
```

**Other information**:

Prior to this change `ngc` would place generated files which refer
to components in the node_modules into the node_module. This is an
issue. Now all of the files are forced into a single directory
as specified in `tsconfig.json` by the `genDir` option.

see: https://docs.google.com/document/d/1OgP1RIpZ-lWUc4113J3w13HTDcW-1-0o7TuGz0tGx0g
