### PR TITLE
Expression Parser: `this` and `undefined`

### DIFF
--- a/modules/@angular/common/test/directives/ng_for_spec.ts
+++ b/modules/@angular/common/test/directives/ng_for_spec.ts
@@ -16,7 +16,7 @@ import {By} from '@angular/platform-browser/src/dom/debug/by';
 
 export function main() {
   describe('ngFor', () => {
-    var TEMPLATE =
+    const TEMPLATE =
         '<div><copy-me template="ngFor let item of items">{{item.toString()}};</copy-me></div>';
 
     it('should reflect initial elements',
@@ -106,7 +106,7 @@ export function main() {
        inject(
            [TestComponentBuilder, AsyncTestCompleter],
            (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
-             var template =
+             const template =
                  '<ul><li template="ngFor let item of items">{{item["name"]}};</li></ul>';
 
              tcb.overrideTemplate(TestComponent, template)
@@ -139,7 +139,7 @@ export function main() {
        inject(
            [TestComponentBuilder, AsyncTestCompleter],
            (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
-             var template = '<ul><li template="ngFor let item of null">{{item}};</li></ul>';
+             const template = '<ul><li template="ngFor let item of null">{{item}};</li></ul>';
              tcb.overrideTemplate(TestComponent, template)
                  .createAsync(TestComponent)
                  .then((fixture) => {
@@ -176,13 +176,10 @@ export function main() {
            (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
              tcb.overrideTemplate(TestComponent, TEMPLATE).createAsync(TestComponent).then((fixture) => {
                fixture.debugElement.componentInstance.items = 'whaaa';
-               try {
-                 fixture.detectChanges();
-               } catch (e) {
-                 expect(e.message).toContain(
-                     `Cannot find a differ supporting object 'whaaa' of type 'string'. NgFor only supports binding to Iterables such as Arrays.`);
-                 async.done();
-               }
+               expect(() => fixture.detectChanges())
+                   .toThrowError(
+                       /Cannot find a differ supporting object 'whaaa' of type 'string'. NgFor only supports binding to Iterables such as Arrays/);
+               async.done();
              });
            }));
 
@@ -221,7 +218,7 @@ export function main() {
        inject(
            [TestComponentBuilder, AsyncTestCompleter],
            (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
-             var template = '<div>' +
+             const template = '<div>' +
                  '<div template="ngFor let item of items">' +
                  '<div template="ngFor let subitem of item">' +
                  '{{subitem}}-{{item.length}};' +
@@ -250,7 +247,7 @@ export function main() {
        inject(
            [TestComponentBuilder, AsyncTestCompleter],
            (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
-             var template = '<div><template ngFor let-item [ngForOf]="items">' +
+             const template = '<div><template ngFor let-item [ngForOf]="items">' +
                  '<div template="ngFor let subitem of item">' +
                  '{{subitem}}-{{item.length}};' +
                  '</div></template></div>';
@@ -273,15 +270,15 @@ export function main() {
        inject(
            [TestComponentBuilder, AsyncTestCompleter],
            (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
-             var template =
+             const template =
                  `<div><template ngFor let-item [ngForOf]="items" let-i="index"><div>{{i}}|</div>` +
                  `<div *ngIf="i % 2 == 0">even|</div></template></div>`;
 
              tcb.overrideTemplate(TestComponent, template)
                  .createAsync(TestComponent)
                  .then((fixture) => {
-                   var el = fixture.debugElement.nativeElement;
-                   var items = [1];
+                   const el = fixture.debugElement.nativeElement;
+                   const items = [1];
                    fixture.debugElement.componentInstance.items = items;
                    fixture.detectChanges();
                    expect(el).toHaveText('0|even|');
@@ -302,7 +299,7 @@ export function main() {
        inject(
            [TestComponentBuilder, AsyncTestCompleter],
            (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
-             var template =
+             const template =
                  '<div><copy-me template="ngFor: let item of items; let i=index">{{i.toString()}}</copy-me></div>';
 
              tcb.overrideTemplate(TestComponent, template)
@@ -323,7 +320,7 @@ export function main() {
        inject(
            [TestComponentBuilder, AsyncTestCompleter],
            (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
-             var template =
+             const template =
                  '<div><copy-me template="ngFor: let item of items; let isFirst=first">{{isFirst.toString()}}</copy-me></div>';
 
              tcb.overrideTemplate(TestComponent, template)
@@ -344,7 +341,7 @@ export function main() {
        inject(
            [TestComponentBuilder, AsyncTestCompleter],
            (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
-             var template =
+             const template =
                  '<div><copy-me template="ngFor: let item of items; let isLast=last">{{isLast.toString()}}</copy-me></div>';
 
              tcb.overrideTemplate(TestComponent, template)
@@ -365,7 +362,7 @@ export function main() {
        inject(
            [TestComponentBuilder, AsyncTestCompleter],
            (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
-             var template =
+             const template =
                  '<div><copy-me template="ngFor: let item of items; let isEven=even">{{isEven.toString()}}</copy-me></div>';
 
              tcb.overrideTemplate(TestComponent, template)
@@ -386,7 +383,7 @@ export function main() {
        inject(
            [TestComponentBuilder, AsyncTestCompleter],
            (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
-             var template =
+             const template =
                  '<div><copy-me template="ngFor: let item of items; let isOdd=odd">{{isOdd.toString()}}</copy-me></div>';
 
              tcb.overrideTemplate(TestComponent, template)
@@ -415,7 +412,7 @@ export function main() {
                      '<test-cmp><li template="let item; let i=index">{{i}}: {{item}};</li></test-cmp>')
                  .createAsync(ComponentUsingTestComponent)
                  .then((fixture) => {
-                   var testComponent = fixture.debugElement.children[0];
+                   const testComponent = fixture.debugElement.children[0];
                    testComponent.componentInstance.items = ['a', 'b', 'c'];
                    fixture.detectChanges();
                    expect(testComponent.nativeElement).toHaveText('0: a;1: b;2: c;');
@@ -433,7 +430,7 @@ export function main() {
                  .overrideTemplate(ComponentUsingTestComponent, '<test-cmp></test-cmp>')
                  .createAsync(ComponentUsingTestComponent)
                  .then((fixture) => {
-                   var testComponent = fixture.debugElement.children[0];
+                   const testComponent = fixture.debugElement.children[0];
                    testComponent.componentInstance.items = ['a', 'b', 'c'];
                    fixture.detectChanges();
                    expect(testComponent.nativeElement).toHaveText('0: a;1: b;2: c;');
@@ -453,7 +450,7 @@ export function main() {
                      '<test-cmp><li template="let item; let i=index">{{i}}: {{item}};</li></test-cmp>')
                  .createAsync(ComponentUsingTestComponent)
                  .then((fixture) => {
-                   var testComponent = fixture.debugElement.children[0];
+                   const testComponent = fixture.debugElement.children[0];
                    testComponent.componentInstance.items = ['a', 'b', 'c'];
                    fixture.detectChanges();
                    expect(testComponent.nativeElement).toHaveText('0: a;1: b;2: c;');
@@ -462,7 +459,7 @@ export function main() {
                  });
            }));
 
-    describe('track by', function() {
+    describe('track by', () => {
       it('should not replace tracked items',
          inject(
              [TestComponentBuilder, AsyncTestCompleter],
@@ -491,7 +488,7 @@ export function main() {
          inject(
              [TestComponentBuilder, AsyncTestCompleter],
              (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
-               var template =
+               const template =
                    `<div><template ngFor let-item [ngForOf]="items" [ngForTrackBy]="trackById">{{item['color']}}</template></div>`;
                tcb.overrideTemplate(TestComponent, template)
                    .createAsync(TestComponent)
@@ -509,7 +506,7 @@ export function main() {
          inject(
              [TestComponentBuilder, AsyncTestCompleter],
              (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
-               var template =
+               const template =
                    `<div><template ngFor let-item [ngForOf]="items" [ngForTrackBy]="trackById">{{item['color']}}</template></div>`;
                tcb.overrideTemplate(TestComponent, template)
                    .createAsync(TestComponent)
@@ -530,7 +527,7 @@ export function main() {
          inject(
              [TestComponentBuilder, AsyncTestCompleter],
              (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
-               var template =
+               const template =
                    `<div><template ngFor let-item [ngForOf]="items" [ngForTrackBy]="trackByIndex">{{item}}</template></div>`;
                tcb.overrideTemplate(TestComponent, template)
                    .createAsync(TestComponent)

--- a/modules/@angular/common/test/directives/ng_for_spec.ts
+++ b/modules/@angular/common/test/directives/ng_for_spec.ts
@@ -14,6 +14,8 @@ import {NgFor, NgIf} from '@angular/common';
 import {expect} from '@angular/platform-browser/testing/matchers';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 
+let thisArg: any;
+
 export function main() {
   describe('ngFor', () => {
     const TEMPLATE =
@@ -460,6 +462,22 @@ export function main() {
            }));
 
     describe('track by', () => {
+      it('should set the context to the component instance',
+         inject(
+             [TestComponentBuilder, AsyncTestCompleter],
+             (tcb: TestComponentBuilder, async: AsyncTestCompleter) => {
+               const template =
+                   `<template ngFor let-item [ngForOf]="items" [ngForTrackBy]="trackByContext.bind(this)"></template>`;
+               tcb.overrideTemplate(TestComponent, template)
+                   .createAsync(TestComponent)
+                   .then((fixture) => {
+                     thisArg = null;
+                     fixture.detectChanges();
+                     expect(thisArg).toBe(fixture.debugElement.componentInstance);
+                     async.done();
+                   });
+             }));
+
       it('should not replace tracked items',
          inject(
              [TestComponentBuilder, AsyncTestCompleter],
@@ -557,6 +575,7 @@ class TestComponent {
   constructor() { this.items = [1, 2]; }
   trackById(index: number, item: any): string { return item['id']; }
   trackByIndex(index: number, item: any): number { return index; }
+  trackByContext(): void { thisArg = this; }
 }
 
 @Component({selector: 'outer-cmp', directives: [TestComponent], template: ''})

--- a/modules/@angular/compiler/src/expression_parser/lexer.ts
+++ b/modules/@angular/compiler/src/expression_parser/lexer.ts
@@ -8,7 +8,6 @@
 
 import {Injectable} from '@angular/core';
 import * as chars from '../chars';
-import {BaseException} from '../facade/exceptions';
 import {NumberWrapper, StringJoiner, StringWrapper, isPresent} from '../facade/lang';
 
 export enum TokenType {
@@ -21,7 +20,7 @@ export enum TokenType {
   Error
 }
 
-const KEYWORDS = ['var', 'let', 'null', 'undefined', 'true', 'false', 'if', 'else'];
+const KEYWORDS = ['var', 'let', 'null', 'undefined', 'true', 'false', 'if', 'else', 'this'];
 
 @Injectable()
 export class Lexer {
@@ -73,6 +72,8 @@ export class Token {
   isKeywordTrue(): boolean { return this.type == TokenType.Keyword && this.strValue == 'true'; }
 
   isKeywordFalse(): boolean { return this.type == TokenType.Keyword && this.strValue == 'false'; }
+
+  isKeywordThis(): boolean { return this.type == TokenType.Keyword && this.strValue == 'this'; }
 
   isError(): boolean { return this.type == TokenType.Error; }
 

--- a/modules/@angular/compiler/src/expression_parser/parser.ts
+++ b/modules/@angular/compiler/src/expression_parser/parser.ts
@@ -523,6 +523,10 @@ export class _ParseAST {
       this.advance();
       return new LiteralPrimitive(this.span(start), false);
 
+    } else if (this.next.isKeywordThis()) {
+      this.advance();
+      return new ImplicitReceiver(this.span(start));
+
     } else if (this.optionalCharacter(chars.$LBRACKET)) {
       this.rbracketsExpected++;
       const elements = this.parseExpressionList(chars.$RBRACKET);
@@ -780,13 +784,7 @@ class SimpleExpressionChecker implements AstVisitor {
 
   visitKeyedWrite(ast: KeyedWrite, context: any) { this.simple = false; }
 
-  visitAll(asts: any[]): any[] {
-    var res = ListWrapper.createFixedSize(asts.length);
-    for (var i = 0; i < asts.length; ++i) {
-      res[i] = asts[i].visit(this);
-    }
-    return res;
-  }
+  visitAll(asts: any[]): any[] { return asts.map(node => node.visit(this)); }
 
   visitChain(ast: Chain, context: any) { this.simple = false; }
 

--- a/modules/@angular/compiler/src/expression_parser/parser.ts
+++ b/modules/@angular/compiler/src/expression_parser/parser.ts
@@ -511,9 +511,14 @@ export class _ParseAST {
       this.rparensExpected--;
       this.expectCharacter(chars.$RPAREN);
       return result;
-    } else if (this.next.isKeywordNull() || this.next.isKeywordUndefined()) {
+
+    } else if (this.next.isKeywordNull()) {
       this.advance();
       return new LiteralPrimitive(this.span(start), null);
+
+    } else if (this.next.isKeywordUndefined()) {
+      this.advance();
+      return new LiteralPrimitive(this.span(start), void 0);
 
     } else if (this.next.isKeywordTrue()) {
       this.advance();

--- a/modules/@angular/compiler/src/output/abstract_emitter.ts
+++ b/modules/@angular/compiler/src/output/abstract_emitter.ts
@@ -283,7 +283,7 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
   abstract visitDeclareFunctionStmt(stmt: o.DeclareFunctionStmt, context: any): any;
 
   visitBinaryOperatorExpr(ast: o.BinaryOperatorExpr, ctx: EmitterVisitorContext): any {
-    var opStr: any /** TODO #9100 */;
+    var opStr: string;
     switch (ast.operator) {
       case o.BinaryOperator.Equals:
         opStr = '==';

--- a/modules/@angular/compiler/src/output/ts_emitter.ts
+++ b/modules/@angular/compiler/src/output/ts_emitter.ts
@@ -70,10 +70,12 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
       ctx.print(defaultType);
     }
   }
+
   visitExternalExpr(ast: o.ExternalExpr, ctx: EmitterVisitorContext): any {
     this._visitIdentifier(ast.value, ast.typeParams, ctx);
     return null;
   }
+
   visitDeclareVarStmt(stmt: o.DeclareVarStmt, ctx: EmitterVisitorContext): any {
     if (ctx.isExportedVar(stmt.name)) {
       ctx.print(`export `);
@@ -90,6 +92,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     ctx.println(`;`);
     return null;
   }
+
   visitCastExpr(ast: o.CastExpr, ctx: EmitterVisitorContext): any {
     ctx.print(`(<`);
     ast.type.visitType(this, ctx);
@@ -98,6 +101,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     ctx.print(`)`);
     return null;
   }
+
   visitDeclareClassStmt(stmt: o.ClassStmt, ctx: EmitterVisitorContext): any {
     ctx.pushClass(stmt);
     if (ctx.isExportedVar(stmt.name)) {
@@ -121,6 +125,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     ctx.popClass();
     return null;
   }
+
   private _visitClassField(field: o.ClassField, ctx: EmitterVisitorContext) {
     if (field.hasModifier(o.StmtModifier.Private)) {
       ctx.print(`private `);
@@ -130,6 +135,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     this.visitType(field.type, ctx);
     ctx.println(`;`);
   }
+
   private _visitClassGetter(getter: o.ClassGetter, ctx: EmitterVisitorContext) {
     if (getter.hasModifier(o.StmtModifier.Private)) {
       ctx.print(`private `);
@@ -143,6 +149,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     ctx.decIndent();
     ctx.println(`}`);
   }
+
   private _visitClassConstructor(stmt: o.ClassStmt, ctx: EmitterVisitorContext) {
     ctx.print(`constructor(`);
     this._visitParams(stmt.constructorMethod.params, ctx);
@@ -152,6 +159,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     ctx.decIndent();
     ctx.println(`}`);
   }
+
   private _visitClassMethod(method: o.ClassMethod, ctx: EmitterVisitorContext) {
     if (method.hasModifier(o.StmtModifier.Private)) {
       ctx.print(`private `);
@@ -166,6 +174,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     ctx.decIndent();
     ctx.println(`}`);
   }
+
   visitFunctionExpr(ast: o.FunctionExpr, ctx: EmitterVisitorContext): any {
     ctx.print(`(`);
     this._visitParams(ast.params, ctx);
@@ -178,6 +187,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     ctx.print(`}`);
     return null;
   }
+
   visitDeclareFunctionStmt(stmt: o.DeclareFunctionStmt, ctx: EmitterVisitorContext): any {
     if (ctx.isExportedVar(stmt.name)) {
       ctx.print(`export `);
@@ -193,6 +203,7 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     ctx.println(`}`);
     return null;
   }
+
   visitTryCatchStmt(stmt: o.TryCatchStmt, ctx: EmitterVisitorContext): any {
     ctx.println(`try {`);
     ctx.incIndent();
@@ -237,15 +248,18 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     ctx.print(typeStr);
     return null;
   }
+
   visitExternalType(ast: o.ExternalType, ctx: EmitterVisitorContext): any {
     this._visitIdentifier(ast.value, ast.typeParams, ctx);
     return null;
   }
+
   visitArrayType(type: o.ArrayType, ctx: EmitterVisitorContext): any {
     this.visitType(type.of, ctx);
     ctx.print(`[]`);
     return null;
   }
+
   visitMapType(type: o.MapType, ctx: EmitterVisitorContext): any {
     ctx.print(`{[key: string]:`);
     this.visitType(type.valueType, ctx);
@@ -270,7 +284,6 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     }
     return name;
   }
-
 
   private _visitParams(params: o.FnParam[], ctx: EmitterVisitorContext): void {
     this.visitAllObjects((param: any /** TODO #9100 */) => {

--- a/modules/@angular/compiler/src/output/value_util.ts
+++ b/modules/@angular/compiler/src/output/value_util.ts
@@ -21,6 +21,7 @@ class _ValueOutputAstTransformer implements ValueTransformer {
   visitArray(arr: any[], type: o.Type): o.Expression {
     return o.literalArr(arr.map(value => visitValue(value, this, null)), type);
   }
+
   visitStringMap(map: {[key: string]: any}, type: o.MapType): o.Expression {
     var entries: Array<string|o.Expression>[] = [];
     StringMapWrapper.forEach(map, (value: any, key: string) => {
@@ -28,7 +29,9 @@ class _ValueOutputAstTransformer implements ValueTransformer {
     });
     return o.literalMap(entries, type);
   }
+
   visitPrimitive(value: any, type: o.Type): o.Expression { return o.literal(value, type); }
+
   visitOther(value: any, type: o.Type): o.Expression {
     if (value instanceof CompileIdentifierMetadata) {
       return o.importExpr(value);

--- a/modules/@angular/compiler/test/expression_parser/lexer_spec.ts
+++ b/modules/@angular/compiler/test/expression_parser/lexer_spec.ts
@@ -67,6 +67,12 @@ export function main() {
         expectIdentifierToken(tokens[0], 0, 'j');
       });
 
+      it('should tokenize "this"', () => {
+        var tokens: number[] = lex('this');
+        expect(tokens.length).toEqual(1);
+        expectKeywordToken(tokens[0], 0, 'this');
+      });
+
       it('should tokenize a dotted identifier', () => {
         var tokens: number[] = lex('j.k');
         expect(tokens.length).toEqual(3);

--- a/modules/@angular/compiler/test/expression_parser/parser_spec.ts
+++ b/modules/@angular/compiler/test/expression_parser/parser_spec.ts
@@ -163,6 +163,7 @@ export function main() {
       describe('member access', () => {
         it('should parse field access', () => {
           checkAction('a');
+          checkAction('this.a', 'a');
           checkAction('a.a');
         });
 

--- a/modules/@angular/compiler/test/expression_parser/parser_spec.ts
+++ b/modules/@angular/compiler/test/expression_parser/parser_spec.ts
@@ -92,6 +92,8 @@ export function main() {
 
       it('should parse null', () => { checkAction('null'); });
 
+      it('should parse undefined', () => { checkAction('undefined'); });
+
       it('should parse unary - expressions', () => {
         checkAction('-1', '0 - 1');
         checkAction('+1', '1');


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

`ngForTrackBy` is not called with `this` set to the cmp instance. It is not possible to access any methods/properties of the context.

**What is the new behavior?**

`ngForTrackBy` is called with `this` set to the cmp instance. Makes it possible to access methods & props.

**Other information**:

fixes #10485
