### PR TITLE
Router Fixes

### DIFF
--- a/modules/@angular/router/src/create_url_tree.ts
+++ b/modules/@angular/router/src/create_url_tree.ts
@@ -101,17 +101,21 @@ function normalizeCommands(commands: any[]): NormalizedNavigationCommands {
       continue;
     }
 
+    if (typeof c === 'object' && c.segmentPath !== undefined) {
+      res.push(c.segmentPath);
+      continue;
+    }
+
     if (!(typeof c === 'string')) {
       res.push(c);
       continue;
     }
 
-    const parts = c.split('/');
-    for (let j = 0; j < parts.length; ++j) {
-      let cc = parts[j];
+    if (i === 0) {
+      const parts = c.split('/');
+      for (let j = 0; j < parts.length; ++j) {
+        let cc = parts[j];
 
-      // first exp is treated in a special way
-      if (i == 0) {
         if (j == 0 && cc == '.') {  //  './a'
           // skip it
         } else if (j == 0 && cc == '') {  //  '/a'
@@ -121,12 +125,9 @@ function normalizeCommands(commands: any[]): NormalizedNavigationCommands {
         } else if (cc != '') {
           res.push(cc);
         }
-
-      } else {
-        if (cc != '') {
-          res.push(cc);
-        }
       }
+    } else {
+      res.push(c);
     }
   }
 

--- a/modules/@angular/router/src/recognize.ts
+++ b/modules/@angular/router/src/recognize.ts
@@ -18,9 +18,7 @@ import {UrlSegment, UrlSegmentGroup, UrlTree, mapChildrenIntoArray} from './url_
 import {last, merge} from './utils/collection';
 import {TreeNode} from './utils/tree';
 
-class NoMatch {
-  constructor(public segmentGroup: UrlSegmentGroup = null) {}
-}
+class NoMatch {}
 
 class InheritedFromParent {
   constructor(
@@ -65,14 +63,8 @@ class Recognizer {
       return of (new RouterStateSnapshot(this.url, rootNode));
 
     } catch (e) {
-      if (e instanceof NoMatch) {
-        return new Observable<RouterStateSnapshot>(
-            (obs: Observer<RouterStateSnapshot>) =>
-                obs.error(new Error(`Cannot match any routes: '${e.segmentGroup}'`)));
-      } else {
-        return new Observable<RouterStateSnapshot>(
-            (obs: Observer<RouterStateSnapshot>) => obs.error(e));
-      }
+      return new Observable<RouterStateSnapshot>(
+          (obs: Observer<RouterStateSnapshot>) => obs.error(e));
     }
   }
 
@@ -108,7 +100,7 @@ class Recognizer {
         if (!(e instanceof NoMatch)) throw e;
       }
     }
-    throw new NoMatch(segmentGroup);
+    throw new NoMatch();
   }
 
   processSegmentAgainstRoute(

--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -219,8 +219,13 @@ export class Router {
    * // create /team/33;expand=true/user/11
    * router.createUrlTree(['/team', 33, {expand: true}, 'user', 11]);
    *
-   * // you can collapse static fragments like this
+   * // you can collapse static segments like this (this works only with the first passed-in value):
    * router.createUrlTree(['/team/33/user', userId]);
+   *
+   * If the first segment can contain slashes, and you do not want the router to split it, you
+   * can do the following:
+   *
+   * router.createUrlTree([{segmentPath: '/one/two'}]);
    *
    * // create /team/33/(user/11//aux:chat)
    * router.createUrlTree(['/team', 33, {outlets: {primary: 'user/11', right: 'chat'}}]);

--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -114,7 +114,8 @@ export class RoutesRecognized {
 /**
  * @stable
  */
-export type Event = NavigationStart | NavigationEnd | NavigationCancel | NavigationError;
+export type Event =
+    NavigationStart | NavigationEnd | NavigationCancel | NavigationError | RoutesRecognized;
 
 /**
  * The `Router` is responsible for mapping URLs to components.

--- a/modules/@angular/router/src/url_tree.ts
+++ b/modules/@angular/router/src/url_tree.ts
@@ -225,19 +225,24 @@ function serializeSegment(segment: UrlSegmentGroup, root: boolean): string {
   }
 }
 
+export function encode(s: string): string {
+  return encodeURIComponent(s);
+}
+
+export function decode(s: string): string {
+  return decodeURIComponent(s);
+}
+
 export function serializePath(path: UrlSegment): string {
-  return `${encodeURIComponent(path.path)}${serializeParams(path.parameters)}`;
+  return `${encode(path.path)}${serializeParams(path.parameters)}`;
 }
 
 function serializeParams(params: {[key: string]: string}): string {
-  return pairs(params)
-      .map(p => `;${encodeURIComponent(p.first)}=${encodeURIComponent(p.second)}`)
-      .join('');
+  return pairs(params).map(p => `;${encode(p.first)}=${encode(p.second)}`).join('');
 }
 
 function serializeQueryParams(params: {[key: string]: string}): string {
-  const strs =
-      pairs(params).map(p => `${encodeURIComponent(p.first)}=${encodeURIComponent(p.second)}`);
+  const strs = pairs(params).map(p => `${encode(p.first)}=${encode(p.second)}`);
   return strs.length > 0 ? `?${strs.join("&")}` : '';
 }
 
@@ -348,7 +353,7 @@ class UrlParser {
     if (this.peekStartsWith(';')) {
       matrixParams = this.parseMatrixParams();
     }
-    return new UrlSegment(decodeURIComponent(path), matrixParams);
+    return new UrlSegment(decode(path), matrixParams);
   }
 
   parseQueryParams(): {[key: string]: any} {
@@ -366,7 +371,7 @@ class UrlParser {
 
   parseFragment(): string {
     if (this.peekStartsWith('#')) {
-      return decodeURIComponent(this.remaining.substring(1));
+      return decode(this.remaining.substring(1));
     } else {
       return null;
     }
@@ -397,7 +402,7 @@ class UrlParser {
       }
     }
 
-    params[decodeURIComponent(key)] = decodeURIComponent(value);
+    params[decode(key)] = decode(value);
   }
 
   parseQueryParam(params: {[key: string]: any}): void {
@@ -415,7 +420,7 @@ class UrlParser {
         this.capture(value);
       }
     }
-    params[decodeURIComponent(key)] = decodeURIComponent(value);
+    params[decode(key)] = decode(value);
   }
 
   parseParens(allowPrimary: boolean): {[key: string]: UrlSegmentGroup} {

--- a/modules/@angular/router/test/apply_redirects.spec.ts
+++ b/modules/@angular/router/test/apply_redirects.spec.ts
@@ -251,6 +251,21 @@ describe('applyRedirects', () => {
               (r) => { compareTrees(r, tree('/a/b')); }, (e) => { throw 'Should not reach'; });
 
     });
+
+    it('should work with absolute redirects', () => {
+      const loadedConfig = new LoadedRouterConfig(
+          [{path: '', component: ComponentB}], <any>'stubInjector', <any>'stubFactoryResolver');
+
+      const loader = {load: (injector: any, p: any) => of (loadedConfig)};
+
+      const config =
+          [{path: '', pathMatch: 'full', redirectTo: '/a'}, {path: 'a', loadChildren: 'children'}];
+
+      applyRedirects(<any>'providedInjector', <any>loader, tree(''), config).forEach(r => {
+        compareTrees(r, tree('a'));
+        expect((<any>config[1])._loadedConfig).toBe(loadedConfig);
+      });
+    });
   });
 
   describe('empty paths', () => {

--- a/modules/@angular/router/test/create_url_tree.spec.ts
+++ b/modules/@angular/router/test/create_url_tree.spec.ts
@@ -13,7 +13,7 @@ import {ActivatedRoute, ActivatedRouteSnapshot, advanceActivatedRoute} from '../
 import {PRIMARY_OUTLET, Params} from '../src/shared';
 import {DefaultUrlSerializer, UrlSegment, UrlSegmentGroup, UrlTree} from '../src/url_tree';
 
-describe('createUrlTree', () => {
+fdescribe('createUrlTree', () => {
   const serializer = new DefaultUrlSerializer();
 
   it('should navigate to the root', () => {
@@ -40,6 +40,12 @@ describe('createUrlTree', () => {
     const params = t.root.children[PRIMARY_OUTLET].segments;
     expect(params[0].path).toEqual('one');
     expect(params[1].path).toEqual('11');
+  });
+
+  it('should support first segments contaings slashes', () => {
+    const p = serializer.parse('/');
+    const t = createRoot(p, [{segmentPath: '/one'}, 'two/three']);
+    expect(serializer.serialize(t)).toEqual('/%2Fone/two%2Fthree');
   });
 
   it('should preserve secondary segments', () => {
@@ -98,7 +104,7 @@ describe('createUrlTree', () => {
 
   it('should create matrix parameters together with other segments', () => {
     const p = serializer.parse('/a');
-    const t = createRoot(p, ['/a', '/b', {aa: 22, bb: 33}]);
+    const t = createRoot(p, ['/a', 'b', {aa: 22, bb: 33}]);
     expect(serializer.serialize(t)).toEqual('/a/b;aa=22;bb=33');
   });
 

--- a/modules/@angular/router/test/create_url_tree.spec.ts
+++ b/modules/@angular/router/test/create_url_tree.spec.ts
@@ -13,7 +13,7 @@ import {ActivatedRoute, ActivatedRouteSnapshot, advanceActivatedRoute} from '../
 import {PRIMARY_OUTLET, Params} from '../src/shared';
 import {DefaultUrlSerializer, UrlSegment, UrlSegmentGroup, UrlTree} from '../src/url_tree';
 
-fdescribe('createUrlTree', () => {
+describe('createUrlTree', () => {
   const serializer = new DefaultUrlSerializer();
 
   it('should navigate to the root', () => {

--- a/modules/@angular/router/test/recognize.spec.ts
+++ b/modules/@angular/router/test/recognize.spec.ts
@@ -259,19 +259,6 @@ describe('recognize', () => {
             });
       });
 
-      it('should not match when terminal', () => {
-        recognize(
-            RootComponent, [{
-              path: '',
-              pathMatch: 'full',
-              component: ComponentA,
-              children: [{path: 'b', component: ComponentB}]
-            }],
-            tree('b'), '')
-            .subscribe(
-                () => {}, (e) => { expect(e.message).toEqual('Cannot match any routes: \'b\''); });
-      });
-
       it('should work (nested case)', () => {
         checkRecognize(
             [{path: '', component: ComponentA, children: [{path: '', component: ComponentB}]}], '',
@@ -676,20 +663,6 @@ describe('recognize', () => {
             expect(s.toString())
                 .toContain(
                     'Two segments cannot have the same outlet name: \'aux:b\' and \'aux:c\'.');
-          });
-    });
-
-    it('should error when no matching routes', () => {
-      recognize(RootComponent, [{path: 'a', component: ComponentA}], tree('invalid'), 'invalid')
-          .subscribe((_) => {}, (s: RouterStateSnapshot) => {
-            expect(s.toString()).toContain('Cannot match any routes');
-          });
-    });
-
-    it('should error when no matching routes (too short)', () => {
-      recognize(RootComponent, [{path: 'a/:id', component: ComponentA}], tree('a'), 'a')
-          .subscribe((_) => {}, (s: RouterStateSnapshot) => {
-            expect(s.toString()).toContain('Cannot match any routes');
           });
     });
   });

--- a/modules/@angular/router/test/url_serializer.spec.ts
+++ b/modules/@angular/router/test/url_serializer.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {PRIMARY_OUTLET} from '../src/shared';
-import {DefaultUrlSerializer, UrlSegmentGroup, serializePath} from '../src/url_tree';
+import {DefaultUrlSerializer, UrlSegmentGroup, decode, encode, serializePath} from '../src/url_tree';
 
 describe('url serializer', () => {
   const url = new DefaultUrlSerializer();
@@ -181,7 +181,7 @@ describe('url serializer', () => {
   describe('encoding/decoding', () => {
     it('should encode/decode path segments and parameters', () => {
       const u =
-          `/${encodeURIComponent("one two")};${encodeURIComponent("p 1")}=${encodeURIComponent("v 1")};${encodeURIComponent("p 2")}=${encodeURIComponent("v 2")}`;
+          `/${encode("one two")};${encode("p 1")}=${encode("v 1")};${encode("p 2")}=${encode("v 2")}`;
       const tree = url.parse(u);
 
       expect(tree.root.children[PRIMARY_OUTLET].segments[0].path).toEqual('one two');
@@ -190,9 +190,16 @@ describe('url serializer', () => {
       expect(url.serialize(tree)).toEqual(u);
     });
 
+    it('should encode/decode "slash" in path segments and parameters', () => {
+      const u = `/${encode("one/two")};${encode("p/1")}=${encode("v/1")}/three`;
+      const tree = url.parse(u);
+      expect(tree.root.children[PRIMARY_OUTLET].segments[0].path).toEqual('one/two');
+      expect(tree.root.children[PRIMARY_OUTLET].segments[0].parameters).toEqual({['p/1']: 'v/1'});
+      expect(url.serialize(tree)).toEqual(u);
+    });
+
     it('should encode/decode query params', () => {
-      const u =
-          `/one?${encodeURIComponent("p 1")}=${encodeURIComponent("v 1")}&${encodeURIComponent("p 2")}=${encodeURIComponent("v 2")}`;
+      const u = `/one?${encode("p 1")}=${encode("v 1")}&${encode("p 2")}=${encode("v 2")}`;
       const tree = url.parse(u);
 
       expect(tree.queryParams).toEqual({['p 1']: 'v 1', ['p 2']: 'v 2'});
@@ -200,7 +207,7 @@ describe('url serializer', () => {
     });
 
     it('should encode/decode fragment', () => {
-      const u = `/one#${encodeURIComponent("one two")}`;
+      const u = `/one#${encode("one two")}`;
       const tree = url.parse(u);
 
       expect(tree.fragment).toEqual('one two');

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -65,7 +65,7 @@ export declare class DefaultUrlSerializer implements UrlSerializer {
 }
 
 /** @stable */
-export declare type Event = NavigationStart | NavigationEnd | NavigationCancel | NavigationError;
+export declare type Event = NavigationStart | NavigationEnd | NavigationCancel | NavigationError | RoutesRecognized;
 
 /** @experimental */
 export interface ExtraOptions {


### PR DESCRIPTION
Closes #10376, #10502

This PR contains two fixes:
## Handling slashes in the link DSL

Currently we take the provided path segments and split them by '/'. This is usually what you want, but not always. Sometimes dynamic URL segments can have slashes in them, and then the splitting is not desirable.

Say the userId in the following example contains a slash:

```
<a [routerLink]="['/users', userId]"></a>
```

The router should escape the slash. After this PR is merged, only the first segment will be split by a slash.  We need to do it for the first segment as often contains '/', '../', etc.

If the first segment is dynamic, which is almost never the case, you can pass the raw value like this:

```
<a [routerLink]="[{segmentPath: userId}]"></a>
```
## Lazy Loading and Redirects

We match the URL twice: once during the applyRedirects phase, and the other time during the recognize phase.

The applyRedirects phase is the one that handles loading modules. Currently, an absolute redirects halts the applyRedirects phase. This PR changes that, so we still do all the matching in the applyRedirects phase even after an absolute redirect. So lazy loading works :) 
