### PR TITLE
feat(validations): add support to bind validation attributes

### DIFF
--- a/modules/@angular/forms/test/reactive_integration_spec.ts
+++ b/modules/@angular/forms/test/reactive_integration_spec.ts
@@ -27,8 +27,8 @@ export function main() {
           FormControlComp, FormGroupComp, FormArrayComp, FormArrayNestedGroup,
           FormControlNameSelect, FormControlNumberInput, FormControlRadioButtons, WrappedValue,
           WrappedValueForm, MyInput, MyInputForm, FormGroupNgModel, FormControlNgModel,
-          LoginIsEmptyValidator, LoginIsEmptyWrapper, UniqLoginValidator, UniqLoginWrapper,
-          NestedFormGroupComp
+          LoginIsEmptyValidator, LoginIsEmptyWrapper, ValidationBindingsForm, UniqLoginValidator,
+          UniqLoginWrapper, NestedFormGroupComp
         ]
       });
     });
@@ -933,37 +933,175 @@ export function main() {
     describe('validations', () => {
       it('should use sync validators defined in html', () => {
         const fixture = TestBed.createComponent(LoginIsEmptyWrapper);
-        const form = new FormGroup(
-            {'login': new FormControl(''), 'min': new FormControl(''), 'max': new FormControl('')});
+        const form = new FormGroup({
+          'login': new FormControl(''),
+          'min': new FormControl(''),
+          'max': new FormControl(''),
+          'pattern': new FormControl('')
+        });
         fixture.debugElement.componentInstance.form = form;
         fixture.detectChanges();
 
         const required = fixture.debugElement.query(By.css('[required]'));
         const minLength = fixture.debugElement.query(By.css('[minlength]'));
         const maxLength = fixture.debugElement.query(By.css('[maxlength]'));
+        const pattern = fixture.debugElement.query(By.css('[pattern]'));
 
         required.nativeElement.value = '';
         minLength.nativeElement.value = '1';
         maxLength.nativeElement.value = '1234';
+        pattern.nativeElement.value = '12';
 
         dispatchEvent(required.nativeElement, 'input');
         dispatchEvent(minLength.nativeElement, 'input');
         dispatchEvent(maxLength.nativeElement, 'input');
+        dispatchEvent(pattern.nativeElement, 'input');
 
         expect(form.hasError('required', ['login'])).toEqual(true);
         expect(form.hasError('minlength', ['min'])).toEqual(true);
         expect(form.hasError('maxlength', ['max'])).toEqual(true);
+        expect(form.hasError('pattern', ['pattern'])).toEqual(true);
         expect(form.hasError('loginIsEmpty')).toEqual(true);
 
         required.nativeElement.value = '1';
         minLength.nativeElement.value = '123';
         maxLength.nativeElement.value = '123';
+        pattern.nativeElement.value = '123';
 
         dispatchEvent(required.nativeElement, 'input');
         dispatchEvent(minLength.nativeElement, 'input');
         dispatchEvent(maxLength.nativeElement, 'input');
+        dispatchEvent(pattern.nativeElement, 'input');
 
         expect(form.valid).toEqual(true);
+      });
+
+      it('should use sync validators using bindings', () => {
+        const fixture = TestBed.createComponent(ValidationBindingsForm);
+        const form = new FormGroup({
+          'login': new FormControl(''),
+          'min': new FormControl(''),
+          'max': new FormControl(''),
+          'pattern': new FormControl('')
+        });
+        fixture.debugElement.componentInstance.form = form;
+        fixture.debugElement.componentInstance.required = true;
+        fixture.debugElement.componentInstance.minLen = 3;
+        fixture.debugElement.componentInstance.maxLen = 3;
+        fixture.debugElement.componentInstance.pattern = '.{3,}';
+        fixture.detectChanges();
+
+        const required = fixture.debugElement.query(By.css('[name=required]'));
+        const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
+        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
+        const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+
+        required.nativeElement.value = '';
+        minLength.nativeElement.value = '1';
+        maxLength.nativeElement.value = '1234';
+        pattern.nativeElement.value = '12';
+
+        dispatchEvent(required.nativeElement, 'input');
+        dispatchEvent(minLength.nativeElement, 'input');
+        dispatchEvent(maxLength.nativeElement, 'input');
+        dispatchEvent(pattern.nativeElement, 'input');
+
+        expect(form.hasError('required', ['login'])).toEqual(true);
+        expect(form.hasError('minlength', ['min'])).toEqual(true);
+        expect(form.hasError('maxlength', ['max'])).toEqual(true);
+        expect(form.hasError('pattern', ['pattern'])).toEqual(true);
+
+        required.nativeElement.value = '1';
+        minLength.nativeElement.value = '123';
+        maxLength.nativeElement.value = '123';
+        pattern.nativeElement.value = '123';
+
+        dispatchEvent(required.nativeElement, 'input');
+        dispatchEvent(minLength.nativeElement, 'input');
+        dispatchEvent(maxLength.nativeElement, 'input');
+        dispatchEvent(pattern.nativeElement, 'input');
+
+        expect(form.valid).toEqual(true);
+      });
+
+      it('changes on binded properties should change the validation state of the form', () => {
+        const fixture = TestBed.createComponent(ValidationBindingsForm);
+        const form = new FormGroup({
+          'login': new FormControl(''),
+          'min': new FormControl(''),
+          'max': new FormControl(''),
+          'pattern': new FormControl('')
+        });
+        fixture.debugElement.componentInstance.form = form;
+        fixture.detectChanges();
+
+        const required = fixture.debugElement.query(By.css('[name=required]'));
+        const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
+        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
+        const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+
+        required.nativeElement.value = '';
+        minLength.nativeElement.value = '1';
+        maxLength.nativeElement.value = '1234';
+        pattern.nativeElement.value = '12';
+
+        dispatchEvent(required.nativeElement, 'input');
+        dispatchEvent(minLength.nativeElement, 'input');
+        dispatchEvent(maxLength.nativeElement, 'input');
+        dispatchEvent(pattern.nativeElement, 'input');
+
+        expect(form.hasError('required', ['login'])).toEqual(false);
+        expect(form.hasError('minlength', ['min'])).toEqual(false);
+        expect(form.hasError('maxlength', ['max'])).toEqual(false);
+        expect(form.hasError('pattern', ['pattern'])).toEqual(false);
+        expect(form.valid).toEqual(true);
+
+        fixture.debugElement.componentInstance.required = true;
+        fixture.debugElement.componentInstance.minLen = 3;
+        fixture.debugElement.componentInstance.maxLen = 3;
+        fixture.debugElement.componentInstance.pattern = '.{3,}';
+        fixture.detectChanges();
+
+        dispatchEvent(required.nativeElement, 'input');
+        dispatchEvent(minLength.nativeElement, 'input');
+        dispatchEvent(maxLength.nativeElement, 'input');
+        dispatchEvent(pattern.nativeElement, 'input');
+
+        expect(form.hasError('required', ['login'])).toEqual(true);
+        expect(form.hasError('minlength', ['min'])).toEqual(true);
+        expect(form.hasError('maxlength', ['max'])).toEqual(true);
+        expect(form.hasError('pattern', ['pattern'])).toEqual(true);
+        expect(form.valid).toEqual(false);
+
+        expect(required.nativeElement.getAttribute('required')).toEqual('');
+        expect(fixture.debugElement.componentInstance.minLen.toString())
+            .toEqual(minLength.nativeElement.getAttribute('minlength'));
+        expect(fixture.debugElement.componentInstance.maxLen.toString())
+            .toEqual(maxLength.nativeElement.getAttribute('maxlength'));
+        expect(fixture.debugElement.componentInstance.pattern.toString())
+            .toEqual(pattern.nativeElement.getAttribute('pattern'));
+
+        fixture.debugElement.componentInstance.required = false;
+        fixture.debugElement.componentInstance.minLen = null;
+        fixture.debugElement.componentInstance.maxLen = null;
+        fixture.debugElement.componentInstance.pattern = null;
+        fixture.detectChanges();
+
+        dispatchEvent(required.nativeElement, 'input');
+        dispatchEvent(minLength.nativeElement, 'input');
+        dispatchEvent(maxLength.nativeElement, 'input');
+        dispatchEvent(pattern.nativeElement, 'input');
+
+        expect(form.hasError('required', ['login'])).toEqual(false);
+        expect(form.hasError('minlength', ['min'])).toEqual(false);
+        expect(form.hasError('maxlength', ['max'])).toEqual(false);
+        expect(form.hasError('pattern', ['pattern'])).toEqual(false);
+        expect(form.valid).toEqual(true);
+
+        expect(required.nativeElement.getAttribute('required')).toEqual(null);
+        expect(required.nativeElement.getAttribute('minlength')).toEqual(null);
+        expect(required.nativeElement.getAttribute('maxlength')).toEqual(null);
+        expect(required.nativeElement.getAttribute('pattern')).toEqual(null);
       });
 
       it('should use async validators defined in the html', fakeAsync(() => {
@@ -1486,12 +1624,33 @@ class FormControlNgModel {
       <input type="text" formControlName="login" required>
       <input type="text" formControlName="min" minlength="3">
       <input type="text" formControlName="max" maxlength="3">
+      <input type="text" formControlName="pattern" pattern=".{3,}">
    </div>
   `
 })
 class LoginIsEmptyWrapper {
   form: FormGroup;
 }
+
+@Component({
+  selector: 'validation-bindings-form',
+  template: `
+    <div [formGroup]="form">
+      <input name="required" type="text" formControlName="login" [required]="required">
+      <input name="minlength" type="text" formControlName="min" [minlength]="minLen">
+      <input name="maxlength" type="text" formControlName="max" [maxlength]="maxLen">
+      <input name="pattern" type="text" formControlName="pattern" [pattern]="pattern">
+   </div>
+  `
+})
+class ValidationBindingsForm {
+  form: FormGroup;
+  required: boolean;
+  minLen: number;
+  maxLen: number;
+  pattern: string;
+}
+
 @Component({
   selector: 'uniq-login-wrapper',
   template: `

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -316,16 +316,18 @@ export declare class FormsModule {
 }
 
 /** @stable */
-export declare class MaxLengthValidator implements Validator {
-    constructor(maxLength: string);
+export declare class MaxLengthValidator implements Validator, OnChanges {
+    maxlength: string;
+    ngOnChanges(changes: SimpleChanges): void;
     validate(c: AbstractControl): {
         [key: string]: any;
     };
 }
 
 /** @stable */
-export declare class MinLengthValidator implements Validator {
-    constructor(minLength: string);
+export declare class MinLengthValidator implements Validator, OnChanges {
+    minlength: string;
+    ngOnChanges(changes: SimpleChanges): void;
     validate(c: AbstractControl): {
         [key: string]: any;
     };
@@ -424,8 +426,9 @@ export declare class NgSelectOption implements OnDestroy {
 }
 
 /** @stable */
-export declare class PatternValidator implements Validator {
-    constructor(pattern: string);
+export declare class PatternValidator implements Validator, OnChanges {
+    pattern: string;
+    ngOnChanges(changes: SimpleChanges): void;
     validate(c: AbstractControl): {
         [key: string]: any;
     };
@@ -436,7 +439,11 @@ export declare class ReactiveFormsModule {
 }
 
 /** @stable */
-export declare class RequiredValidator {
+export declare class RequiredValidator implements Validator {
+    required: boolean;
+    validate(c: AbstractControl): {
+        [key: string]: any;
+    };
 }
 
 /** @stable */


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently you can't bind `[minlength]` and `[maxlength]` directly. You can bind these as attributes using [attr.minlength] and [attr.maxlength] but the validatiors doesn't works.
You can bind `[pattern]` validator but the validator don't work correctly.
You can see: #10505 for details.

**What is the new behavior?**
You can bind `maxlength`, `minlength` and `pattern` using brackets or interpolation strings.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

This change enables to bind the validations attributes `required`, `minlength`,
`maxlength` and `pattern`.

Closes: #10505, #7393
