### PR TITLE
refactor: remove requestAnimationFrame from polyfills and platforms

### DIFF
--- a/modules/@angular/platform-browser/src/browser/browser_adapter.ts
+++ b/modules/@angular/platform-browser/src/browser/browser_adapter.ts
@@ -397,10 +397,6 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   getComputedStyle(element: any /** TODO #9100 */): any { return getComputedStyle(element); }
   // TODO(tbosch): move this into a separate environment class once we have it
   setGlobalVar(path: string, value: any) { setValueOnPath(global, path, value); }
-  requestAnimationFrame(callback: any /** TODO #9100 */): number {
-    return window.requestAnimationFrame(callback);
-  }
-  cancelAnimationFrame(id: number) { window.cancelAnimationFrame(id); }
   supportsWebAnimation(): boolean { return isFunction((<any>Element).prototype['animate']); }
   performanceNow(): number {
     // performance.now() is not available in all browsers, see

--- a/modules/@angular/platform-browser/src/dom/dom_adapter.ts
+++ b/modules/@angular/platform-browser/src/dom/dom_adapter.ts
@@ -177,8 +177,6 @@ export abstract class DomAdapter {
   abstract getComputedStyle(element: any /** TODO #9100 */): any;
   abstract getData(element: any /** TODO #9100 */, name: string): string;
   abstract setGlobalVar(name: string, value: any): any /** TODO #9100 */;
-  abstract requestAnimationFrame(callback: any /** TODO #9100 */): number;
-  abstract cancelAnimationFrame(id: any /** TODO #9100 */): any /** TODO #9100 */;
   abstract supportsWebAnimation(): boolean;
   abstract performanceNow(): number;
   abstract getAnimationPrefix(): string;

--- a/modules/@angular/platform-browser/src/web_workers/worker/worker_adapter.ts
+++ b/modules/@angular/platform-browser/src/web_workers/worker/worker_adapter.ts
@@ -198,8 +198,6 @@ export class WorkerDomAdapter extends DomAdapter {
   getComputedStyle(element: any /** TODO #9100 */): any { throw 'not implemented'; }
   getData(element: any /** TODO #9100 */, name: string): string { throw 'not implemented'; }
   setGlobalVar(name: string, value: any) { throw 'not implemented'; }
-  requestAnimationFrame(callback: any /** TODO #9100 */): number { throw 'not implemented'; }
-  cancelAnimationFrame(id: any /** TODO #9100 */) { throw 'not implemented'; }
   performanceNow(): number { throw 'not implemented'; }
   getAnimationPrefix(): string { throw 'not implemented'; }
   getTransitionEnd(): string { throw 'not implemented'; }

--- a/modules/@angular/platform-server/src/parse5_adapter.ts
+++ b/modules/@angular/platform-server/src/parse5_adapter.ts
@@ -604,8 +604,6 @@ export class Parse5DomAdapter extends DomAdapter {
   }
   // TODO(tbosch): move this into a separate environment class once we have it
   setGlobalVar(path: string, value: any) { setValueOnPath(global, path, value); }
-  requestAnimationFrame(callback: any /** TODO #9100 */): number { return setTimeout(callback, 0); }
-  cancelAnimationFrame(id: number) { clearTimeout(id); }
   supportsWebAnimation(): boolean { return false; }
   performanceNow(): number { return DateWrapper.toMillis(DateWrapper.now()); }
   getAnimationPrefix(): string { return ''; }

--- a/shims_for_IE.js
+++ b/shims_for_IE.js
@@ -100,35 +100,6 @@ if (!window.console.error) window.console.error = function () { };
 if (!window.console.warn) window.console.warn = function () { };
 if (!window.console.assert) window.console.assert = function () { };
 
-//RequestAnimationFrame (IE9, Android 4.1, 4.2, 4.3)
-/*! @author Paul Irish */
-/*! @source https://gist.github.com/paulirish/1579671 */
-// http://paulirish.com/2011/requestanimationframe-for-smart-animating/
-// http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
-
-// requestAnimationFrame polyfill by Erik Möller. fixes from Paul Irish and Tino Zijdel
-
-// MIT license
-
-(function() {
-    var lastTime = 0;
-
-    if (!window.requestAnimationFrame)
-        window.requestAnimationFrame = function(callback, element) {
-            var currTime = Date.now();
-            var timeToCall = Math.max(0, 16 - (currTime - lastTime));
-            var id = window.setTimeout(function() { callback(currTime + timeToCall); },
-              timeToCall);
-            lastTime = currTime + timeToCall;
-            return id;
-        };
-
-    if (!window.cancelAnimationFrame)
-        window.cancelAnimationFrame = function(id) {
-            clearTimeout(id);
-        };
-}());
-
 //Typed Array (IE9)
 /*! @source https://github.com/inexorabletash/polyfill/blob/master/typedarray.js */
 /*


### PR DESCRIPTION
rAF isn't used anymore, that's one less polyfill needed for the browsers which don't support rAF (IE9, Android 4.1, 4.2, 4.3)
