### PR TITLE
feat(http): add options method to Http

### DIFF
--- a/modules/@angular/http/src/http.ts
+++ b/modules/@angular/http/src/http.ts
@@ -186,6 +186,15 @@ export class Http {
         this._backend,
         new Request(mergeOptions(this._defaultOptions, options, RequestMethod.Head, url)));
   }
+
+  /**
+   * Performs a request with `options` http method.
+   */
+  options(url: string, options?: RequestOptionsArgs): Observable<Response> {
+    return httpRequest(
+        this._backend,
+        new Request(mergeOptions(this._defaultOptions, options, RequestMethod.Options, url)));
+  }
 }
 
 

--- a/modules/@angular/http/test/http_spec.ts
+++ b/modules/@angular/http/test/http_spec.ts
@@ -310,6 +310,19 @@ export function main() {
       });
 
 
+      describe('.options()', () => {
+        it('should perform an options request for given url',
+           inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+             backend.connections.subscribe((c: MockConnection) => {
+               expect(c.request.method).toBe(RequestMethod.Options);
+               backend.resolveAllConnections();
+               async.done();
+             });
+             http.options(url).subscribe((res: Response) => {});
+           }));
+      });
+
+
       describe('searchParams', () => {
         it('should append search params to url',
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {

--- a/tools/public_api_guard/http/index.d.ts
+++ b/tools/public_api_guard/http/index.d.ts
@@ -64,6 +64,7 @@ export declare class Http {
     delete(url: string, options?: RequestOptionsArgs): Observable<Response>;
     get(url: string, options?: RequestOptionsArgs): Observable<Response>;
     head(url: string, options?: RequestOptionsArgs): Observable<Response>;
+    options(url: string, options?: RequestOptionsArgs): Observable<Response>;
     patch(url: string, body: any, options?: RequestOptionsArgs): Observable<Response>;
     post(url: string, body: any, options?: RequestOptionsArgs): Observable<Response>;
     put(url: string, body: any, options?: RequestOptionsArgs): Observable<Response>;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently we are not able to execute directly OPTIONS request from the Http class.
#10500, #7918

**What is the new behavior?**
We could use this method to perform a request with options method.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Add options method to the Http object, which could be useful when using self-describing RESTful APIs.

This closes #10500, closes #7918
