### PR TITLE
feat(core): map for property to htmlFor

### DIFF
--- a/modules/@angular/compiler/src/schema/dom_element_schema_registry.ts
+++ b/modules/@angular/compiler/src/schema/dom_element_schema_registry.ts
@@ -231,6 +231,7 @@ const SCHEMA:
 
 const _ATTR_TO_PROP: {[name: string]: string} = {
   'class': 'className',
+  'for': 'htmlFor',
   'formaction': 'formAction',
   'innerHtml': 'innerHTML',
   'readonly': 'readOnly',

--- a/modules/@angular/core/test/linker/integration_spec.ts
+++ b/modules/@angular/core/test/linker/integration_spec.ts
@@ -217,6 +217,19 @@ function declareTests({useJit}: {useJit: boolean}) {
         expect(nativeEl).not.toHaveCssClass('initial');
       });
 
+      it('should consume binding to htmlFor using for alias', () => {
+        const template = '<label [for]="ctxProp"></label>';
+        const fixture = TestBed.configureTestingModule({declarations: [MyComp]})
+                            .overrideComponent(MyComp, {set: {template}})
+                            .createComponent(MyComp);
+
+        const nativeEl = fixture.debugElement.children[0].nativeElement;
+        fixture.debugElement.componentInstance.ctxProp = 'foo';
+        fixture.detectChanges();
+
+        expect(nativeEl.htmlFor).toBe('foo');
+      });
+
       it('should consume directive watch expression change.', () => {
         TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
         const template = '<span>' +


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Feature
```

**What is the current behavior?** (You can also link to an open issue here)

Can't write `<label [for]="ctxProp">`. People need to use `<label [htmlFor]="ctxProp">` or `<label [attr.for]="ctxProp">` which is a common source of confusion.

**What is the new behavior?**

People can write `<label [for]="ctxProp">` and it is equivalent to `<label [htmlFor]="ctxProp">`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] No
```

**Other information**:

Changes in `template_parser.ts` are due to clang-format run.

This improves ergonomics a bit by allowing people to write:
`<label [for]="ctxProp"></label>`.
This is similar to the exisiting class -> className mapping.

Closes #7516
