### PR TITLE
docs(NgControlStatus) directive applied on form elements

### DIFF
--- a/modules/@angular/forms/src/directives/ng_control_status.ts
+++ b/modules/@angular/forms/src/directives/ng_control_status.ts
@@ -14,7 +14,7 @@ import {NgControl} from './ng_control';
 
 
 /**
- * Directive automatically applied to Angular forms that sets CSS classes
+ * Directive automatically applied to Angular form elements that sets CSS classes
  * based on control status (valid/invalid/dirty/etc).
  *
  * @experimental


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe: Documentation
```

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

According to the selector defined in the @Directive decorator, the ngControlStatus directive is applied on Angular2 form elements, not Angular2 forms as it was in the documentation.
