### PR TITLE
fix: allow users to pass in absolute paths to ngc

### DIFF
--- a/tools/@angular/tsc-wrapped/src/main.ts
+++ b/tools/@angular/tsc-wrapped/src/main.ts
@@ -16,8 +16,9 @@ export function main(project: string, basePath?: string, codegen?: CodegenExtens
     if (fs.lstatSync(project).isFile()) {
       projectDir = path.dirname(project);
     }
+
     // file names in tsconfig are resolved relative to this absolute path
-    basePath = path.join(process.cwd(), basePath || projectDir);
+    basePath = path.resolve(process.cwd(), basePath || projectDir);
 
     // read the configuration options from wherever you store them
     const {parsed, ngOptions} = tsc.readConfiguration(project, basePath);


### PR DESCRIPTION
Bugfix for `ngc`.

When an absolute path was passed as the `-p` argument to `ngc` command line, it would create a `basePath` variable with the absolute path twice (as it's a simple `path.join`). Using `path.resolve` instead allow people to pass in absolute paths and will resolve accordingly.
