### PR TITLE
feat(upgrade): compilerOptions in bootstrap

### DIFF
--- a/modules/@angular/upgrade/src/upgrade_adapter.ts
+++ b/modules/@angular/upgrade/src/upgrade_adapter.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Compiler, ComponentFactory, Injector, NgModule, NgModuleRef, NgZone, Provider, Testability, Type} from '@angular/core';
+import {Compiler, CompilerOptions, ComponentFactory, Injector, NgModule, NgModuleRef, NgZone, Provider, Testability, Type} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
 import * as angular from './angular_js';
@@ -58,7 +58,7 @@ var upgradeCount: number = 0;
  * ### Example
  *
  * ```
- * var adapter = new UpgradeAdapter(forwardRef(() => MyNg2Module));
+ * var adapter = new UpgradeAdapter(forwardRef(() => MyNg2Module), myCompilerOptions);
  * var module = angular.module('myExample', []);
  * module.directive('ng2Comp', adapter.downgradeNg2Component(Ng2Component));
  *
@@ -114,7 +114,7 @@ export class UpgradeAdapter {
   /* @internal */
   private providers: Provider[] = [];
 
-  constructor(private ng2AppModule: Type<any>) {
+  constructor(private ng2AppModule: Type<any>, private compilerOptions?: CompilerOptions) {
     if (!ng2AppModule) {
       throw new Error(
           'UpgradeAdapter cannot be instantiated without an NgModule of the Angular 2 app.');
@@ -399,7 +399,7 @@ export class UpgradeAdapter {
 
                 (platformBrowserDynamic() as any)
                     ._bootstrapModuleWithZone(
-                        DynamicNgUpgradeModule, undefined, ngZone,
+                        DynamicNgUpgradeModule, this.compilerOptions, ngZone,
                         (componentFactories: ComponentFactory<any>[]) => {
                           componentFactories.forEach((componentFactory: ComponentFactory<any>) => {
                             var type: Type<any> = componentFactory.componentType;

--- a/tools/public_api_guard/upgrade/index.d.ts
+++ b/tools/public_api_guard/upgrade/index.d.ts
@@ -1,6 +1,6 @@
 /** @stable */
 export declare class UpgradeAdapter {
-    constructor(ng2AppModule: Type<any>);
+    constructor(ng2AppModule: Type<any>, compilerOptions?: CompilerOptions);
     bootstrap(element: Element, modules?: any[], config?: angular.IAngularBootstrapConfig): UpgradeAdapterRef;
     downgradeNg2Component(type: Type<any>): Function;
     downgradeNg2Provider(token: any): Function;


### PR DESCRIPTION
Specifically needed to support cached resources in downgraded ng2 components.

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
No way to specify compilerOptions 

**What is the new behavior?**
May optionally specify compilerOptions when calling bootstrap on the upgrade adaptor.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
