### PR TITLE
feat(upgrade): Support ng-model in downgraded components

### DIFF
--- a/modules/@angular/upgrade/src/angular_js.ts
+++ b/modules/@angular/upgrade/src/angular_js.ts
@@ -161,6 +161,37 @@ export interface ITestabilityService {
   whenStable(callback: Function): void;
 }
 
+export interface INgModelController {
+  $render(): void;
+  $isEmpty(value: any): boolean;
+  $setValidity(validationErrorKey: string, isValid: boolean): void;
+  $setPristine(): void;
+  $setDirty(): void;
+  $setUntouched(): void;
+  $setTouched(): void;
+  $rollbackViewValue(): void;
+  $validate(): void;
+  $commitViewValue(): void;
+  $setViewValue(value: any, trigger: string): void;
+
+  $viewValue: any;
+  $modelValue: any;
+  $parsers: Function[];
+  $formatters: Function[];
+  $validators: {[key: string]: Function};
+  $asyncValidators: {[key: string]: Function};
+  $viewChangeListeners: Function[];
+  $error: Object;
+  $pending: Object;
+  $untouched: boolean;
+  $touched: boolean;
+  $pristine: boolean;
+  $dirty: boolean;
+  $valid: boolean;
+  $invalid: boolean;
+  $name: string;
+}
+
 function noNg() {
   throw new Error('AngularJS v1.x is not loaded!');
 }

--- a/modules/@angular/upgrade/src/aot/constants.ts
+++ b/modules/@angular/upgrade/src/aot/constants.ts
@@ -8,6 +8,7 @@
 
 export const UPGRADE_MODULE_NAME = '$$UpgradeModule';
 export const INJECTOR_KEY = '$$angularInjector';
+export const REQUIRE_NG1_MODEL = '?ngModel';
 
 export const $INJECTOR = '$injector';
 export const $PARSE = '$parse';

--- a/modules/@angular/upgrade/src/aot/downgrade_component.ts
+++ b/modules/@angular/upgrade/src/aot/downgrade_component.ts
@@ -10,7 +10,7 @@ import {ComponentFactory, ComponentFactoryResolver, Injector, Type} from '@angul
 
 import * as angular from '../angular_js';
 
-import {$INJECTOR, $PARSE, INJECTOR_KEY} from './constants';
+import {$INJECTOR, $PARSE, INJECTOR_KEY, REQUIRE_NG1_MODEL} from './constants';
 import {DowngradeComponentAdapter} from './downgrade_component_adapter';
 
 let downgradeCount = 0;
@@ -77,14 +77,16 @@ export function downgradeComponent(info: /* ComponentInfo */ {
 
     return {
       restrict: 'E',
-      require: '?^' + INJECTOR_KEY,
+      require: ['?^' + INJECTOR_KEY, REQUIRE_NG1_MODEL],
       link: (scope: angular.IScope, element: angular.IAugmentedJQuery, attrs: angular.IAttributes,
-             parentInjector: Injector, transclude: angular.ITranscludeFunction) => {
+             required: any[], transclude: angular.ITranscludeFunction) => {
 
+        let parentInjector: Injector = required[0];
         if (parentInjector === null) {
           parentInjector = $injector.get(INJECTOR_KEY);
         }
 
+        const ngModel: angular.INgModelController = required[1];
         const componentFactoryResolver: ComponentFactoryResolver =
             parentInjector.get(ComponentFactoryResolver);
         const componentFactory: ComponentFactory<any> =
@@ -95,7 +97,7 @@ export function downgradeComponent(info: /* ComponentInfo */ {
         }
 
         const facade = new DowngradeComponentAdapter(
-            idPrefix + (idCount++), info, element, attrs, scope, parentInjector, $parse,
+            idPrefix + (idCount++), info, element, attrs, scope, ngModel, parentInjector, $parse,
             componentFactory);
         facade.setupInputs();
         facade.createComponent();

--- a/modules/@angular/upgrade/src/aot/downgrade_component_adapter.ts
+++ b/modules/@angular/upgrade/src/aot/downgrade_component_adapter.ts
@@ -9,6 +9,7 @@
 import {ChangeDetectorRef, ComponentFactory, ComponentRef, EventEmitter, Injector, OnChanges, ReflectiveInjector, SimpleChange, SimpleChanges, Type} from '@angular/core';
 
 import * as angular from '../angular_js';
+import {hookupNgModel} from '../util';
 
 import {ComponentInfo, PropertyBinding} from './component_info';
 import {$SCOPE} from './constants';
@@ -31,8 +32,8 @@ export class DowngradeComponentAdapter {
   constructor(
       private id: string, private info: ComponentInfo, private element: angular.IAugmentedJQuery,
       private attrs: angular.IAttributes, private scope: angular.IScope,
-      private parentInjector: Injector, private parse: angular.IParseService,
-      private componentFactory: ComponentFactory<any>) {
+      private ngModel: angular.INgModelController, private parentInjector: Injector,
+      private parse: angular.IParseService, private componentFactory: ComponentFactory<any>) {
     (<any>this.element[0]).id = id;
     this.componentScope = scope.$new();
     this.childNodes = <Node[]><any>element.contents();
@@ -47,6 +48,8 @@ export class DowngradeComponentAdapter {
         childInjector, [[this.contentInsertionPoint]], this.element[0]);
     this.changeDetector = this.componentRef.changeDetectorRef;
     this.component = this.componentRef.instance;
+
+    hookupNgModel(this.ngModel, this.component);
   }
 
   setupInputs(): void {

--- a/modules/@angular/upgrade/src/constants.ts
+++ b/modules/@angular/upgrade/src/constants.ts
@@ -22,3 +22,4 @@ export const NG1_PARSE = '$parse';
 export const NG1_TEMPLATE_CACHE = '$templateCache';
 export const NG1_TESTABILITY = '$$testability';
 export const REQUIRE_INJECTOR = '?^^' + NG2_INJECTOR;
+export const REQUIRE_NG1_MODEL = '?ngModel';

--- a/modules/@angular/upgrade/src/downgrade_ng2_adapter.ts
+++ b/modules/@angular/upgrade/src/downgrade_ng2_adapter.ts
@@ -11,6 +11,7 @@ import {ChangeDetectorRef, ComponentFactory, ComponentRef, EventEmitter, Injecto
 import * as angular from './angular_js';
 import {NG1_SCOPE} from './constants';
 import {ComponentInfo} from './metadata';
+import {hookupNgModel} from './util';
 
 const INITIAL_VALUE = {
   __UNINITIALIZED__: true
@@ -27,8 +28,8 @@ export class DowngradeNg2ComponentAdapter {
   constructor(
       private info: ComponentInfo, private element: angular.IAugmentedJQuery,
       private attrs: angular.IAttributes, private scope: angular.IScope,
-      private parentInjector: Injector, private parse: angular.IParseService,
-      private componentFactory: ComponentFactory<any>) {
+      private ngModel: angular.INgModelController, private parentInjector: Injector,
+      private parse: angular.IParseService, private componentFactory: ComponentFactory<any>) {
     this.componentScope = scope.$new();
   }
 
@@ -40,6 +41,8 @@ export class DowngradeNg2ComponentAdapter {
         this.componentFactory.create(childInjector, projectableNodes, this.element[0]);
     this.changeDetector = this.componentRef.changeDetectorRef;
     this.component = this.componentRef.instance;
+
+    hookupNgModel(this.ngModel, this.component);
   }
 
   setupInputs(): void {

--- a/modules/@angular/upgrade/src/util.ts
+++ b/modules/@angular/upgrade/src/util.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as angular from './angular_js';
+
 export function onError(e: any) {
   // TODO: (misko): We seem to not have a stack trace here!
   if (console.error) {
@@ -44,5 +46,25 @@ export class Deferred<R> {
       this.resolve = res;
       this.reject = rej;
     });
+  }
+}
+
+/**
+ * @return true if the passed-in component implements the subset of
+ *     ControlValueAccessor needed for AngularJS ng-model compatibility.
+ */
+function supportsNgModel(component: any) {
+  return typeof component.writeValue === 'function' &&
+      typeof component.registerOnChange === 'function';
+}
+
+/**
+ * Glue the AngularJS ngModelController if it exists to the component if it
+ * implements the needed subset of ControlValueAccessor.
+ */
+export function hookupNgModel(ngModel: angular.INgModelController, component: any) {
+  if (ngModel && supportsNgModel(component)) {
+    ngModel.$render = () => { component.writeValue(ngModel.$viewValue); };
+    component.registerOnChange(ngModel.$setViewValue.bind(ngModel));
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
No form of ngModel is supported. Components that require it, such as MdInput are not usable via ngDowngrade.

**What is the new behavior?**
The AngularJS ng-model can now bind to Components that implement the ControlValueAccessor interface.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
