### PR TITLE
docs(cheatsheet): update for rc5

### DIFF
--- a/modules/@angular/core/src/application_ref.ts
+++ b/modules/@angular/core/src/application_ref.ts
@@ -95,7 +95,7 @@ export function createPlatform(injector: Injector): PlatformRef {
 export type PlatformFactory = (extraProviders?: any[]) => PlatformRef;
 
 /**
- * Creates a fatory for a platform
+ * Creates a factory for a platform
  *
  * @experimental APIs related to application bootstrap are currently under review.
  */

--- a/modules/@angular/docs/cheatsheet/bootstrapping.md
+++ b/modules/@angular/docs/cheatsheet/bootstrapping.md
@@ -2,17 +2,15 @@
 Bootstrapping
 @cheatsheetIndex 0
 @description
-{@target ts}`import { bootstrap } from '@angular/platform-browser-dynamic';`{@endtarget}
-{@target js}Available from the `ng.platform.browser` namespace{@endtarget}
+{@target ts}`import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';`{@endtarget}
+{@target js}Available from the `ng.platformBrowser` namespace{@endtarget}
 {@target dart}`import 'package:angular2/platform/browser.dart';`{@endtarget}
 
 @cheatsheetItem
 syntax(ts dart):
-`bootstrap​(MyAppComponent, [MyService, { provide: ... }]);`|`provide`
+`platformBrowserDynamic().bootstrapModule(MyAppModule);`|`platformBrowserDynamic().bootstrapModule`
 syntax(js):
 `document.addEventListener('DOMContentLoaded', function () {
-  ng.platform.browser.bootstrap(MyAppComponent,
-    [MyService, { provide: ... }]);
-});`|`provide`
+  ng.platformBrowser.platformBrowserDynamic().bootstrapModuleDynamic(MyAppModule);`|`platformBrowserDynamic().bootstrapModule`
 description:
-Bootstraps an application with MyAppComponent as the root component and configures the DI providers. {@target js}Must be wrapped in the event listener to fire when the page loads.{@endtarget}
+Bootstraps an application defined as MyAppModule ng module using the Just in Time compiler.{@target js}Must be wrapped in the event listener to fire when the page loads.{@endtarget}

--- a/modules/@angular/docs/cheatsheet/bootstrapping.md
+++ b/modules/@angular/docs/cheatsheet/bootstrapping.md
@@ -3,14 +3,17 @@ Bootstrapping
 @cheatsheetIndex 0
 @description
 {@target ts}`import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';`{@endtarget}
-{@target js}Available from the `ng.platformBrowser` namespace{@endtarget}
+{@target js}Available from the `ng.platformBrowserDynamic` namespace{@endtarget}
 {@target dart}`import 'package:angular2/platform/browser.dart';`{@endtarget}
 
 @cheatsheetItem
 syntax(ts dart):
 `platformBrowserDynamic().bootstrapModule(MyAppModule);`|`platformBrowserDynamic().bootstrapModule`
 syntax(js):
-`document.addEventListener('DOMContentLoaded', function () {
-  ng.platformBrowser.platformBrowserDynamic().bootstrapModuleDynamic(MyAppModule);`|`platformBrowserDynamic().bootstrapModule`
+`document.addEventListener('DOMContentLoaded', function() {
+  ng.platformBrowserDynamic
+    .platformBrowserDynamic()
+    .bootstrapModule(app.AppModule);
+});`|`platformBrowserDynamic().bootstrapModule`
 description:
-Bootstraps an application defined as MyAppModule ng module using the Just in Time compiler.{@target js}Must be wrapped in the event listener to fire when the page loads.{@endtarget}
+Bootstraps an application defined as AppModule ng module using the Just in Time compiler.{@target js}Must be wrapped in the event listener to fire when the page loads.{@endtarget}

--- a/modules/@angular/docs/cheatsheet/built-in-directives.md
+++ b/modules/@angular/docs/cheatsheet/built-in-directives.md
@@ -2,8 +2,8 @@
 Built-in directives
 @cheatsheetIndex 3
 @description
-{@target ts}`import {NgIf, ...} from '@angular/common';`{@endtarget}
-{@target js}Available from the `ng.common` namespace{@endtarget}
+{@target ts}`import { CommonModule } from '@angular/common';`{@endtarget}
+{@target js}Available from the `ng.common.CommonModule` namespace{@endtarget}
 {@target dart}Available using `platform_directives` in pubspec{@endtarget}
 
 @cheatsheetItem

--- a/modules/@angular/docs/cheatsheet/built-in-directives.md
+++ b/modules/@angular/docs/cheatsheet/built-in-directives.md
@@ -1,6 +1,6 @@
 @cheatsheetSection
 Built-in directives
-@cheatsheetIndex 2
+@cheatsheetIndex 3
 @description
 {@target ts}`import {NgIf, ...} from '@angular/common';`{@endtarget}
 {@target js}Available from the `ng.common` namespace{@endtarget}

--- a/modules/@angular/docs/cheatsheet/class-decorators.md
+++ b/modules/@angular/docs/cheatsheet/class-decorators.md
@@ -1,6 +1,6 @@
 @cheatsheetSection
 Class decorators
-@cheatsheetIndex 4
+@cheatsheetIndex 5
 @description
 {@target ts}`import {Directive, ...} from '@angular/core';`{@endtarget}
 {@target js}Available from the `ng.core` namespace{@endtarget}

--- a/modules/@angular/docs/cheatsheet/class-decorators.md
+++ b/modules/@angular/docs/cheatsheet/class-decorators.md
@@ -2,7 +2,7 @@
 Class decorators
 @cheatsheetIndex 5
 @description
-{@target ts}`import {Directive, ...} from '@angular/core';`{@endtarget}
+{@target ts}`import { Directive, ... } from '@angular/core';`{@endtarget}
 {@target js}Available from the `ng.core` namespace{@endtarget}
 {@target dart}`import 'package:angular2/core.dart';`{@endtarget}
 

--- a/modules/@angular/docs/cheatsheet/component-configuration.md
+++ b/modules/@angular/docs/cheatsheet/component-configuration.md
@@ -1,6 +1,6 @@
 @cheatsheetSection
 Component configuration
-@cheatsheetIndex 6
+@cheatsheetIndex 7
 @description
 {@target js}`ng.core.Component` extends `ng.core.Directive`,
 so the `ng.core.Directive` configuration applies to components as well{@endtarget}
@@ -36,17 +36,3 @@ syntax:
 styleUrls: ['my-component.css']`|`styles:`|`styleUrls:`
 description:
 List of inline CSS styles / external stylesheet URLs for styling component’s view.
-
-
-@cheatsheetItem
-syntax:
-`directives: [MyDirective, MyComponent]`|`directives:`
-description:
-List of directives used in the the component’s template.
-
-
-@cheatsheetItem
-syntax:
-`pipes: [MyPipe, OtherPipe]`|`pipes:`
-description:
-List of pipes used in the component's template.

--- a/modules/@angular/docs/cheatsheet/dependency-injection.md
+++ b/modules/@angular/docs/cheatsheet/dependency-injection.md
@@ -1,6 +1,6 @@
 @cheatsheetSection
 Dependency injection configuration
-@cheatsheetIndex 9
+@cheatsheetIndex 10
 @description
 {@target dart}`import 'package:angular2/core.dart';`{@endtarget}
 

--- a/modules/@angular/docs/cheatsheet/directive-and-component-decorators.md
+++ b/modules/@angular/docs/cheatsheet/directive-and-component-decorators.md
@@ -2,7 +2,7 @@
 Class field decorators for directives and components
 @cheatsheetIndex 8
 @description
-{@target ts}`import {Input, ...} from '@angular/core';`{@endtarget}
+{@target ts}`import { Input, ... } from '@angular/core';`{@endtarget}
 {@target js}Available from the `ng.core` namespace{@endtarget}
 {@target dart}`import 'package:angular2/core.dart';`{@endtarget}
 

--- a/modules/@angular/docs/cheatsheet/directive-and-component-decorators.md
+++ b/modules/@angular/docs/cheatsheet/directive-and-component-decorators.md
@@ -1,6 +1,6 @@
 @cheatsheetSection
 Class field decorators for directives and components
-@cheatsheetIndex 7
+@cheatsheetIndex 8
 @description
 {@target ts}`import {Input, ...} from '@angular/core';`{@endtarget}
 {@target js}Available from the `ng.core` namespace{@endtarget}

--- a/modules/@angular/docs/cheatsheet/directive-configuration.md
+++ b/modules/@angular/docs/cheatsheet/directive-configuration.md
@@ -1,6 +1,6 @@
 @cheatsheetSection
 Directive configuration
-@cheatsheetIndex 5
+@cheatsheetIndex 6
 @description
 {@target ts}`@Directive({ property1: value1, ... })`{@endtarget}
 {@target js}`ng.core.Directive({ property1: value1, ... }).Class({...})`{@endtarget}

--- a/modules/@angular/docs/cheatsheet/forms.md
+++ b/modules/@angular/docs/cheatsheet/forms.md
@@ -1,9 +1,9 @@
 @cheatsheetSection
 Forms
-@cheatsheetIndex 3
+@cheatsheetIndex 4
 @description
-{@target ts}`import {FORM_DIRECTIVES} from '@angular/common';`{@endtarget}
-{@target js}Available from `ng.common.FORM_DIRECTIVES`{@endtarget}
+{@target ts}`import {FormsModule} from '@angular/forms';`{@endtarget}
+{@target js}Available from `ng.forms.FormsModule`{@endtarget}
 {@target dart}Available using `platform_directives` in pubspec{@endtarget}
 
 @cheatsheetItem

--- a/modules/@angular/docs/cheatsheet/forms.md
+++ b/modules/@angular/docs/cheatsheet/forms.md
@@ -2,7 +2,7 @@
 Forms
 @cheatsheetIndex 4
 @description
-{@target ts}`import {FormsModule} from '@angular/forms';`{@endtarget}
+{@target ts}`import { FormsModule } from '@angular/forms';`{@endtarget}
 {@target js}Available from `ng.forms.FormsModule`{@endtarget}
 {@target dart}Available using `platform_directives` in pubspec{@endtarget}
 

--- a/modules/@angular/docs/cheatsheet/lifecycle hooks.md
+++ b/modules/@angular/docs/cheatsheet/lifecycle hooks.md
@@ -1,6 +1,6 @@
 @cheatsheetSection
 Directive and component change detection and lifecycle hooks
-@cheatsheetIndex 8
+@cheatsheetIndex 9
 @description
 {@target ts dart}(implemented as class methods){@endtarget}
 {@target js}(implemented as component properties){@endtarget}

--- a/modules/@angular/docs/cheatsheet/ngmodules.md
+++ b/modules/@angular/docs/cheatsheet/ngmodules.md
@@ -1,0 +1,45 @@
+@cheatsheetSection
+NgModules
+@cheatsheetIndex 1
+@description
+{@target ts js}`import { NgModule } from '@angular/core';`{@endtarget}
+
+@cheatsheetItem
+syntax(ts js):
+`@NgModule({ declarations: ... , imports: ..., exports: ..., bootstrap: ...})
+class MyModule {}`|`NgModule`
+description:
+Defines a module that contains components, directives, pipes and providers.
+
+
+@cheatsheetItem
+syntax(ts js):
+`declarations: [MyRedComponent, MyBlueComponent, MyDatePipe]`|`declarations:`
+description:
+List of components, directives and pipes that belong to this module.
+
+@cheatsheetItem
+syntax(ts js):
+`imports: [BrowserModule, SomeOtherModule]`|`imports:`
+description:
+List of modules that are being imported into this module. Everything from the imported modules will
+be available to `declarations` of this module.
+
+@cheatsheetItem
+syntax(ts js):
+`exports: [MyRedComponent, MyDatePipe]`|`exports:`
+description:
+List of components, directives and pipes that will be visible to modules that import this module.
+
+@cheatsheetItem
+syntax(ts js):
+`providers: [MyService, { provide: ... }]`|`providers:`
+description:
+Array of dependency injection providers visible to contents of this module as well as everyone
+importing this module.
+
+@cheatsheetItem
+syntax(ts js):
+`bootstrap: [MyAppComponent]`|`bootstrap:`
+description:
+Array of components to bootstrap when this module is bootstrapped.

--- a/modules/@angular/docs/cheatsheet/routing.md
+++ b/modules/@angular/docs/cheatsheet/routing.md
@@ -9,7 +9,7 @@ Routing and navigation
 
 @cheatsheetItem
 syntax(ts):
-`let routes: Routes = [
+`const routes: Routes = [
   { path: '', HomeComponent },
   { path: 'path/:routeParam', component: MyComponent },
   { path: 'staticPath', component: ... },
@@ -18,7 +18,7 @@ syntax(ts):
   { path: ..., component: ..., data: { message: 'Custom' } }
 ]);
 
-provideRouter(routes);`|`Routes`
+const routing = RouterModule.forRoot(routes);`|`Routes`
 syntax(js):
 `var routes = [
   { path: '', HomeComponent },
@@ -29,7 +29,7 @@ syntax(js):
   { path: ..., component: ..., data: { message: 'Custom' } }
 ]);
 
-ng.router.provideRouter(routes)`|`ng.router.Routes`
+var routing = ng.router.RouterModule.forRoot(routes);`|`ng.router.Routes`
 syntax(dart):
 `@RouteConfig(const [
   const Route(path: 'path', component: MyComponent, name: 'MyCmp' ),
@@ -48,6 +48,7 @@ Marks the location to load the component of the active route.
 @cheatsheetItem
 syntax(ts js):
 `
+<a routerLink="/path">
 <a [routerLink]="[ '/path', routeParam ]">
 <a [routerLink]="[ '/path', { matrixParam: 'value' } ]">
 <a [routerLink]="[ '/path' ]" [queryParams]="{ page: 1 }">

--- a/modules/@angular/docs/cheatsheet/routing.md
+++ b/modules/@angular/docs/cheatsheet/routing.md
@@ -2,33 +2,40 @@
 Routing and navigation
 @cheatsheetIndex 11
 @description
-{@target ts}`import {provideRouter, RouteConfig, ROUTER_DIRECTIVES, ...} from '@angular/router';`{@endtarget}
+{@target ts}`import { Routes, RouterModule, ... } from '@angular/router';`{@endtarget}
 {@target js}Available from the `ng.router` namespace{@endtarget}
 {@target dart}`import 'package:angular2/router.dart';`{@endtarget}
 
 
 @cheatsheetItem
 syntax(ts):
-`@RouteConfig([
-  { path: '/:myParam', component: MyComponent, name: 'MyCmp' },
-  { path: '/staticPath', component: ..., name: ...},
-  { path: '/*wildCardParam', component: ..., name: ...}
-])
-class MyComponent() {}`|`@RouteConfig`
+`let routes: Routes = [
+  { path: '', HomeComponent },
+  { path: 'path/:routeParam', component: MyComponent },
+  { path: 'staticPath', component: ... },
+  { path: '**', component: ... },
+  { path: 'oldPath', redirectTo: '/staticPath' },
+  { path: ..., component: ..., data: { message: 'Custom' } }
+]);
+
+provideRouter(routes);`|`Routes`
 syntax(js):
-`var MyComponent = ng.router.RouteConfig([
-  { path: '/:myParam', component: MyComponent, name: 'MyCmp' },
-  { path: '/staticPath', component: ..., name: ...},
-  { path: '/*wildCardParam', component: ..., name: ...}
-]).Class({
-  constructor: function() {}
-});`|`ng.router.RouteConfig`
+`var routes = [
+  { path: '', HomeComponent },
+  { path: ':routeParam', component: MyComponent },
+  { path: 'staticPath', component: ... },
+  { path: '**', component: ... },
+  { path: 'oldPath', redirectTo: '/staticPath' },
+  { path: ..., component: ..., data: { message: 'Custom' } }
+]);
+
+ng.router.provideRouter(routes)`|`ng.router.Routes`
 syntax(dart):
 `@RouteConfig(const [
-  const Route(path: '/:myParam', component: MyComponent, name: 'MyCmp' ),
+  const Route(path: 'path', component: MyComponent, name: 'MyCmp' ),
 ])`|`@RouteConfig`
 description:
-Configures routes for the decorated component. Supports static, parameterized, and wildcard routes.
+Configures routes for the application. Supports static, parameterized, redirect and wildcard routes. Also supports custom route data and resolve.
 
 
 @cheatsheetItem
@@ -39,63 +46,128 @@ Marks the location to load the component of the active route.
 
 
 @cheatsheetItem
-syntax:
-`<a [routerLink]="[ '/MyCmp', {myParam: 'value' } ]">`|`[routerLink]`
+syntax(ts js):
+`
+<a [routerLink]="[ '/path', routeParam ]">
+<a [routerLink]="[ '/path', { matrixParam: 'value' } ]">
+<a [routerLink]="[ '/path' ]" [queryParams]="{ page: 1 }">
+<a [routerLink]="[ '/path' ]" fragment="anchor">
+`|`[routerLink]`
+syntax(dart):
+`<a [routerLink]="[ '/MyCmp', { routeParam: 'value' } ]">Link</a>`|`[routerLink]`
 description:
-Creates a link to a different view based on a route instruction consisting of a route name and optional parameters. The route name matches the as property of a configured route. Add the '/' prefix to navigate to a root route; add the './' prefix for a child route.
+Creates a link to a different view based on a route instruction consisting of a route path, required and optional parameters, query parameters and a fragment. Add the '/' prefix to navigate to a root route; add the './' prefix for a child route; add the '../sibling' prefix for a sibling or parent route.
+
+@cheatsheetItem
+syntax(ts js):
+`<a [routerLink]="[ '/path' ]" routerLinkActive="active">`
+syntax(dart):
+`<a [routerLink]="[ '/MyCmp', { myParam: 'value' } ]">`|`[routerLink]`
+description:
+The provided class(es) will be added to the element when the routerLink becomes the current active route.
+
+@cheatsheetItem
+syntax(ts):
+`class CanActivateGuard implements CanActivate {
+    canActivate(
+      route: ActivatedRouteSnapshot,
+      state: RouterStateSnapshot
+    ): Observable<boolean> | boolean { ... }
+}
+
+{ path: ..., canActivate: [CanActivateGuard] }`|`CanActivate`
+syntax(js):
+`var CanActivateGuard = ng.core.Class({
+  canActivate: function(route, state) {
+    // return Observable boolean or boolean
+  }
+});
+
+{ path: ..., canActivate: [CanActivateGuard] }`|`CanActivate`
+syntax(dart):
+`@CanActivate(() => ...)class MyComponent() {}`|`@CanActivate`
+description:
+{@target js ts}An interface for defining a class that the router should call first to determine if it should activate this component. Should return a boolean or a Observable that resolves a boolean{@endtarget}
+{@target dart}A component decorator defining a function that the router should call first to determine if it should activate this component. Should return a boolean or a future.{@endtarget}
+
+@cheatsheetItem
+syntax(ts):
+`class CanDeactivateGuard implements CanDeactivate<T> {
+    canDeactivate(
+      component: T,
+      route: ActivatedRouteSnapshot,
+      state: RouterStateSnapshot
+    ): Observable<boolean> | boolean { ... }
+}
+
+{ path: ..., canDeactivate: [CanDeactivateGuard] }`|`CanDeactivate`
+syntax(js):
+`var CanDeactivateGuard = ng.core.Class({
+  canDeactivate: function(component, route, state) {
+    // return Observable boolean or boolean
+  }
+});
+
+{ path: ..., canDeactivate: [CanDeactivateGuard] }`|`CanDeactivate`
+syntax(dart):
+`routerCanDeactivate(nextInstruction, prevInstruction) { ... }`|`routerCanDeactivate`
+description:
+{@target js ts}An interface for defining a class that the router should call first to determine if it should deactivate this component after a navigation. Should return a boolean or a Observable that resolves a boolean{@endtarget}
+{@target dart}
+The router calls the routerCanDeactivate methods (if defined) of every component that would be removed after a navigation. The navigation proceeds if and only if all such methods return true or a future that completes successfully{@endtarget}.
 
 
 @cheatsheetItem
 syntax(ts):
-`@CanActivate(() => { ... })class MyComponent() {}`|`@CanActivate`
+`class ResolveGuard implements Resolve<T> {
+    resolve(
+      route: ActivatedRouteSnapshot,
+      state: RouterStateSnapshot
+    ): Observable<any> | any { ... }
+}
+
+{ path: ..., resolve: [ResolveGuard] }`|`Resolve`
 syntax(js):
-`var MyComponent = ng.router.CanActivate(function() { ... }).Component({...}).Class({constructor: ...});`|`ng.router.CanActivate(function() { ... })`
+`var ResolveGuard = ng.core.Class({
+  resolve: function(route, state) {
+    // return Observable value or value
+  }
+});
+
+{ path: ..., resolve: [ResolveGuard] }`|`Resolve`
+description:
+{@target js ts}An interface for defining a class that the router should call first to resolve route data before rendering the route. Should return a value or an Observable that resolves a value{@endtarget}
+
+@cheatsheetItem
 syntax(dart):
-`@CanActivate(() => ...)class MyComponent() {}`|`@CanActivate`
-description:
-A component decorator defining a function that the router should call first to determine if it should activate this component. Should return a boolean or a {@target js ts}promise{@endtarget}{@target dart}future{@endtarget}.
-
-
-@cheatsheetItem
-syntax(ts dart):
 `routerOnActivate(nextInstruction, prevInstruction) { ... }`|`routerOnActivate`
-syntax(js):
-`routerOnActivate: function(nextInstruction, prevInstruction) { ... }`|`routerOnActivate`
 description:
-After navigating to a component, the router calls the component's routerOnActivate method (if defined).
+{@target dart}After navigating to a component, the router calls the component's routerOnActivate method (if defined).{@endtarget}
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(dart):
 `routerCanReuse(nextInstruction, prevInstruction) { ... }`|`routerCanReuse`
-syntax(js):
-`routerCanReuse: function(nextInstruction, prevInstruction) { ... }`|`routerCanReuse`
 description:
-The router calls a component's routerCanReuse method (if defined) to determine whether to reuse the instance or destroy it and create a new instance. Should return a boolean or a {@target js ts}promise{@endtarget}{@target dart}future{@endtarget}.
+{@target dart}The router calls a component's routerCanReuse method (if defined) to determine whether to reuse the instance or destroy it and create a new instance. Should return a boolean or a future{@endtarget}.
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(dart):
 `routerOnReuse(nextInstruction, prevInstruction) { ... }`|`routerOnReuse`
-syntax(js):
-`routerOnReuse: function(nextInstruction, prevInstruction) { ... }`|`routerOnReuse`
 description:
-The router calls the component's routerOnReuse method (if defined) when it re-uses a component instance.
+{@target dart}The router calls the component's routerOnReuse method (if defined) when it re-uses a component instance.{@endtarget}
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(dart):
 `routerCanDeactivate(nextInstruction, prevInstruction) { ... }`|`routerCanDeactivate`
-syntax(js):
-`routerCanDeactivate: function(nextInstruction, prevInstruction) { ... }`|`routerCanDeactivate`
 description:
-The router calls the routerCanDeactivate methods (if defined) of every component that would be removed after a navigation. The navigation proceeds if and only if all such methods return true or a {@target js ts}promise that is resolved{@endtarget}{@target dart}future that completes successfully{@endtarget}.
+{@target dart}The router calls the routerCanDeactivate methods (if defined) of every component that would be removed after a navigation. The navigation proceeds if and only if all such methods return true or a future that completes successfully.{@endtarget}
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(dart):
 `routerOnDeactivate(nextInstruction, prevInstruction) { ... }`|`routerOnDeactivate`
-syntax(js):
-`routerOnDeactivate: function(nextInstruction, prevInstruction) { ... }`|`routerOnDeactivate`
 description:
-Called before the directive is removed as the result of a route change. May return a {@target js ts}promise{@endtarget}{@target dart}future{@endtarget} that pauses removing the directive until the {@target js ts}promise resolves{@endtarget}{@target dart}future completes{@endtarget}.
+{@target dart}Called before the directive is removed as the result of a route change. May return a future that pauses removing the directive until the future completes.{@endtarget}

--- a/modules/@angular/docs/cheatsheet/routing.md
+++ b/modules/@angular/docs/cheatsheet/routing.md
@@ -1,6 +1,6 @@
 @cheatsheetSection
 Routing and navigation
-@cheatsheetIndex 10
+@cheatsheetIndex 11
 @description
 {@target ts}`import {provideRouter, RouteConfig, ROUTER_DIRECTIVES, ...} from '@angular/router';`{@endtarget}
 {@target js}Available from the `ng.router` namespace{@endtarget}

--- a/modules/@angular/docs/cheatsheet/template-syntax.md
+++ b/modules/@angular/docs/cheatsheet/template-syntax.md
@@ -1,6 +1,6 @@
 @cheatsheetSection
 Template syntax
-@cheatsheetIndex 1
+@cheatsheetIndex 2
 @description
 
 @cheatsheetItem


### PR DESCRIPTION
This updates the Cheatsheet for RC5 (Typescript and JS side). Dart has a warning and will be fixed soon.

The Router part is a ripoff of #9898 with import updates.

Closes #9898
