### PR TITLE
ci(travis): enable fast finish mode for optional modes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ env:
    - CI_MODE=browserstack_optional
 
 matrix:
+  fast_finish: true
   allow_failures:
     - env: "CI_MODE=saucelabs_optional"
     - env: "CI_MODE=browserstack_optional"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
-  Travis CI runs the optional tasks in "waiting" mode, which means that the whole build is only ready once the optional tasks are also ready.
  
  > e.g https://travis-ci.org/angular/angular/builds/150844963
  
  This build lost about 48 minutes just from an optional mode.

**What is the new behavior?**
- The Travis Fast Finish mode will mark the build as finished, once all "required" tasks have finished.
  https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```

**Other Information**

| Before | After |
| --- | --- |
|  |  |
| ![image](https://cloud.githubusercontent.com/assets/4987015/17512455/30025898-5e28-11e6-9f3c-ebd9fabf4213.png) | ![image](https://cloud.githubusercontent.com/assets/4987015/17512462/347a63f2-5e28-11e6-97ac-d052eff3af93.png) |

> The **real** elapsed time got reduced significantly, because the optional tasks (~ 45 minutes) dropped.
