### PR TITLE
test(router): make tests pass in all browsers

### DIFF
--- a/modules/@angular/compiler/src/template_parser/template_parser.ts
+++ b/modules/@angular/compiler/src/template_parser/template_parser.ts
@@ -15,12 +15,12 @@ import {Parser} from '../expression_parser/parser';
 import {ListWrapper, SetWrapper, StringMapWrapper} from '../facade/collection';
 import {BaseException} from '../facade/exceptions';
 import {isBlank, isPresent} from '../facade/lang';
+import {Identifiers, identifierToken} from '../identifiers';
 import * as html from '../ml_parser/ast';
 import {HtmlParser, ParseTreeResult} from '../ml_parser/html_parser';
 import {expandNodes} from '../ml_parser/icu_ast_expander';
 import {InterpolationConfig} from '../ml_parser/interpolation_config';
 import {mergeNsAndName, splitNsName} from '../ml_parser/tags';
-import {Identifiers, identifierToken} from '../identifiers';
 import {ParseError, ParseErrorLevel, ParseSourceSpan} from '../parse_util';
 import {ProviderElementContext, ProviderViewContext} from '../provider_analyzer';
 import {ElementSchemaRegistry} from '../schema/element_schema_registry';
@@ -30,6 +30,7 @@ import {splitAtColon} from '../util';
 
 import {AttrAst, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, DirectiveAst, ElementAst, EmbeddedTemplateAst, NgContentAst, PropertyBindingType, ReferenceAst, TemplateAst, TemplateAstVisitor, TextAst, VariableAst, templateVisitAll} from './template_ast';
 import {PreparsedElementType, preparseElement} from './template_preparser';
+
 
 
 // Group 1 = "bind-"

--- a/modules/@angular/router/karma.conf.js
+++ b/modules/@angular/router/karma.conf.js
@@ -12,6 +12,7 @@ module.exports = function(config) {
       // Polyfills.
       'node_modules/es6-shim/es6-shim.js',
       'node_modules/reflect-metadata/Reflect.js',
+      'shims_for_IE.js',
 
       // System.js for module loading
       'node_modules/systemjs/dist/system-polyfills.js',
@@ -76,6 +77,10 @@ module.exports = function(config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['Chrome'],
-    singleRun: false
+    singleRun: false,
+    captureTimeout: 60000,
+    browserDisconnectTimeout : 60000,
+    browserDisconnectTolerance : 3,
+    browserNoActivityTimeout : 60000
   });
 };

--- a/modules/@angular/router/test/recognize.spec.ts
+++ b/modules/@angular/router/test/recognize.spec.ts
@@ -24,7 +24,7 @@ describe('recognize', () => {
     checkRecognize([{path: 'a/:id', component: ComponentA}], 'a/10', (s: RouterStateSnapshot) => {
       checkActivatedRoute(s.root, '', {}, RootComponent);
       const child = s.firstChild(s.root);
-      expect(() => child.params['prop'] = 'new').toThrowError(/Can't add property/);
+      expect(Object.isFrozen(child.params)).toBeTruthy();
     });
   });
 
@@ -637,7 +637,7 @@ describe('recognize', () => {
 
     it('should freeze query params object', () => {
       checkRecognize([{path: 'a', component: ComponentA}], 'a?q=11', (s: RouterStateSnapshot) => {
-        expect(() => s.queryParams['prop'] = 'new').toThrowError(/Can't add property/);
+        expect(Object.isFrozen(s.queryParams)).toBeTruthy();
       });
     });
   });

--- a/modules/@angular/router/test/router.spec.ts
+++ b/modules/@angular/router/test/router.spec.ts
@@ -11,6 +11,7 @@ import 'rxjs/add/operator/map';
 import {Location} from '@angular/common';
 import {Component, NgModule, NgModuleFactoryLoader} from '@angular/core';
 import {ComponentFixture, TestBed, TestComponentBuilder, addProviders, fakeAsync, inject, tick} from '@angular/core/testing';
+import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {expect} from '@angular/platform-browser/testing/matchers';
 import {Observable} from 'rxjs/Observable';
 import {of } from 'rxjs/observable/of';
@@ -664,7 +665,7 @@ describe('Integration', () => {
 
              const native = fixture.debugElement.nativeElement.querySelector('a');
              expect(native.getAttribute('href')).toEqual('/team/33/simple');
-             native.click();
+             dispatchClick(native);
              advance(fixture);
 
              expect(fixture.debugElement.nativeElement).toHaveText('team 33 [ simple, right:  ]');
@@ -742,7 +743,7 @@ describe('Integration', () => {
              expect(fixture.debugElement.nativeElement).toHaveText('team 22 [ link, right:  ]');
 
              const native = fixture.debugElement.nativeElement.querySelector('button');
-             native.click();
+             dispatchClick(native);
              advance(fixture);
 
              expect(fixture.debugElement.nativeElement).toHaveText('team 33 [ simple, right:  ]');
@@ -768,7 +769,7 @@ describe('Integration', () => {
 
              const native = fixture.debugElement.nativeElement.querySelector('a');
              expect(native.getAttribute('href')).toEqual('/team/33/simple');
-             native.click();
+             dispatchClick(native);
              advance(fixture);
 
              expect(fixture.debugElement.nativeElement).toHaveText('team 33 [ simple, right:  ]');
@@ -794,7 +795,7 @@ describe('Integration', () => {
 
              const native = fixture.debugElement.nativeElement.querySelector('a');
              expect(native.getAttribute('href')).toEqual('/team/22/simple');
-             native.click();
+             dispatchClick(native);
              advance(fixture);
 
              expect(fixture.debugElement.nativeElement).toHaveText('team 22 [ simple, right:  ]');
@@ -821,7 +822,7 @@ describe('Integration', () => {
              const native = fixture.debugElement.nativeElement.querySelector('a');
 
              expect(native.getAttribute('href')).toEqual('/simple');
-             native.click();
+             dispatchClick(native);
              advance(fixture);
 
              expect(fixture.debugElement.nativeElement).toHaveText('link simple');
@@ -847,7 +848,7 @@ describe('Integration', () => {
 
              const native = fixture.debugElement.nativeElement.querySelector('a');
              expect(native.getAttribute('href')).toEqual('/team/22/simple?q=1#f');
-             native.click();
+             dispatchClick(native);
              advance(fixture);
 
              expect(fixture.debugElement.nativeElement).toHaveText('team 22 [ simple, right:  ]');
@@ -1803,4 +1804,9 @@ function createRoot(tcb: TestComponentBuilder, router: Router, type: any): Compo
   router.initialNavigation();
   advance(f);
   return f;
+}
+
+function dispatchClick(target: HTMLElement): void {
+  const dispatchedEvent = getDOM().createMouseEvent('click');
+  getDOM().dispatchEvent(target, dispatchedEvent);
 }


### PR DESCRIPTION
I've run the router test campaign in all the browsers I can access: Chrome, Firefox, Safari 9, IE 9, IE 10, IE 11, Edge, Android 4.X, Android 5.X.

With the small fixes of this PR, it is successful everywhere, except only one issue in Chrome mobile 30 (Android 4.4.2): https://github.com/angular/angular/issues/10589

About the fixes:
- older browsers (IE9, Android) need longer Karma timers and polyfills to run the campaign
- relying on an exception to ensure an object doesn't work as each browser returns a different message, et some don't even throw
- the Android browser does not support `element.click()`
