### PR TITLE
only call getUrlScheme with string of moduleId

### DIFF
--- a/modules/@angular/compiler/src/metadata_resolver.ts
+++ b/modules/@angular/compiler/src/metadata_resolver.ts
@@ -794,7 +794,7 @@ function componentModuleUrl(
 
   if (isPresent(cmpMetadata.moduleId)) {
     var moduleId = cmpMetadata.moduleId;
-    var scheme = getUrlScheme(moduleId);
+    var scheme = getUrlScheme(moduleId.toString());
     return isPresent(scheme) && scheme.length > 0 ? moduleId :
                                                     `package:${moduleId}${MODULE_SUFFIX}`;
   }

--- a/modules/@angular/compiler/src/metadata_resolver.ts
+++ b/modules/@angular/compiler/src/metadata_resolver.ts
@@ -792,9 +792,9 @@ function componentModuleUrl(
     return staticTypeModuleUrl(type);
   }
 
-  if (isPresent(cmpMetadata.moduleId)) {
+  if (isPresent(cmpMetadata.moduleId) && typeof cmpMetadata.moduleId === 'string') {
     var moduleId = cmpMetadata.moduleId;
-    var scheme = getUrlScheme(moduleId.toString());
+    var scheme = getUrlScheme(moduleId);
     return isPresent(scheme) && scheme.length > 0 ? moduleId :
                                                     `package:${moduleId}${MODULE_SUFFIX}`;
   }


### PR DESCRIPTION
https://github.com/angular/angular/pull/10512/files and specifically the line below have caused an uncaught TypeError for the function componentModuleUrl.

https://github.com/jasonchoimtt/angular/blob/a5b544e8736d4e0fa40744ca610b682fff2eec07/modules/%40angular/compiler/src/url_resolver.ts#L263

Changing _split to use String.match instead of RegEx.exec has caused an error of `Uncaught TypeError: uri.match is not a function` when _split is called with something other than a string. 

This change will ensure that getUrlScheme is called with a string and subsequently _split is called with a string. 
