### PR TITLE
refactor(testing): remove deprecated test setup functions

### DIFF
--- a/modules/@angular/core/testing/test_bed.ts
+++ b/modules/@angular/core/testing/test_bed.ts
@@ -379,46 +379,6 @@ export function getTestBed() {
 }
 
 /**
- * @deprecated use getTestBed instead.
- */
-export function getTestInjector() {
-  return getTestBed();
-}
-
-/**
- * Set the providers that the test injector should use. These should be providers
- * common to every test in the suite.
- *
- * This may only be called once, to set up the common providers for the current test
- * suite on the current platform. If you absolutely need to change the providers,
- * first use `resetBaseTestProviders`.
- *
- * Test modules and platforms for individual platforms are available from
- * 'angular2/platform/testing/<platform_name>'.
- *
- * @deprecated Use TestBed.initTestEnvironment instead
- */
-export function setBaseTestProviders(
-    platformProviders: Array<Type|Provider|any[]>,
-    applicationProviders: Array<Type|Provider|any[]>) {
-  if (platformProviders.length === 1 && typeof platformProviders[0] === 'function') {
-    (<any>platformProviders[0])(applicationProviders);
-  } else {
-    throw new Error(
-        `setBaseTestProviders is deprecated and only supports platformProviders that are predefined by Angular. Use 'TestBed.initTestEnvironment' instead.`);
-  }
-}
-
-/**
- * Reset the providers for the test injector.
- *
- * @deprecated Use TestBed.resetTestEnvironment instead.
- */
-export function resetBaseTestProviders() {
-  TestBed.resetTestEnvironment();
-}
-
-/**
  * Allows injecting dependencies in `beforeEach()` and `it()`.
  *
  * Example:

--- a/modules/@angular/platform-browser-dynamic/testing.ts
+++ b/modules/@angular/platform-browser-dynamic/testing.ts
@@ -6,13 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CompilerConfig, DirectiveResolver, NgModuleResolver, analyzeAppProvidersForDeprecatedConfiguration} from '@angular/compiler';
 import {OverridingTestComponentBuilder, platformCoreDynamicTesting} from '@angular/compiler/testing';
-import {COMPILER_OPTIONS, Compiler, CompilerFactory, NgModule, PlatformRef, Provider, ReflectiveInjector, Type, createPlatform, createPlatformFactory} from '@angular/core';
-import {TestBed, TestComponentBuilder, TestComponentRenderer} from '@angular/core/testing';
-import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
+import {NgModule, PlatformRef, createPlatformFactory} from '@angular/core';
+import {TestComponentBuilder, TestComponentRenderer} from '@angular/core/testing';
+import {BrowserTestingModule} from '@angular/platform-browser/testing';
 
-import {Console} from './core_private';
 import {INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS} from './src/platform_providers';
 import {DOMTestComponentRenderer} from './testing/dom_test_component_renderer';
 
@@ -39,36 +37,3 @@ export const platformBrowserDynamicTesting = createPlatformFactory(
 })
 export class BrowserDynamicTestingModule {
 }
-
-/**
- * @deprecated Use initTestEnvironment with platformBrowserDynamicTesting instead.
- */
-export const TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
-    // Note: This is not a real provider but a hack to still support the deprecated
-    // `setBaseTestProviders` method!
-    [(appProviders: any[]) => {
-      const deprecatedConfiguration = analyzeAppProvidersForDeprecatedConfiguration(appProviders);
-      const platformRef =
-          createPlatformFactory(platformBrowserDynamicTesting, 'browserDynamicTestingDeprecated', [{
-                                  provide: COMPILER_OPTIONS,
-                                  useValue: deprecatedConfiguration.compilerOptions,
-                                  multi: true
-                                }])();
-
-      @NgModule({
-        exports: [BrowserDynamicTestingModule],
-        declarations: [deprecatedConfiguration.moduleDeclarations]
-      })
-      class DynamicTestModule {
-      }
-
-      const testInjector = TestBed.initTestEnvironment(DynamicTestModule, platformRef);
-      const console: Console = testInjector.get(Console);
-      deprecatedConfiguration.deprecationMessages.forEach((msg) => console.warn(msg));
-    }];
-
-/**
- * @deprecated Use initTestEnvironment with BrowserDynamicTestingModule instead.
- */
-export const TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
-    [];

--- a/modules/@angular/platform-browser/testing/browser.ts
+++ b/modules/@angular/platform-browser/testing/browser.ts
@@ -29,34 +29,12 @@ const _TEST_BROWSER_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
     [{provide: PLATFORM_INITIALIZER, useValue: initBrowserTests, multi: true}];
 
 /**
- * Providers for the browser test platform
- *
- * @deprecated Use `platformBrowserTesting()` or create a custom platform factory via
- * `createPlatformFactory(platformBrowserTesting, ...)`
- */
-export const TEST_BROWSER_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
-    [PLATFORM_COMMON_PROVIDERS, _TEST_BROWSER_PLATFORM_PROVIDERS];
-
-/**
- * @deprecated Use initTestEnvironment with BrowserTestModule instead. This is empty for backwards
- * compatibility,
- * as all of our bootstrap methods add a module implicitly, i.e. keeping this filled would add the
- * providers 2x.
- */
-export const TEST_BROWSER_APPLICATION_PROVIDERS: Array<any /*Type | Provider | any[]*/> = [];
-
-/**
  * Platform for testing
  *
  * @experimental API related to bootstrapping are still under review.
  */
 export const platformBrowserTesting =
     createPlatformFactory(platformCore, 'browserTesting', _TEST_BROWSER_PLATFORM_PROVIDERS);
-
-/**
- * @deprecated Use {@link platformBrowserTesting} instead
- */
-export const browserTestingPlatform = platformBrowserTesting;
 
 /**
  * NgModule for testing.

--- a/modules/@angular/platform-server/testing/server.ts
+++ b/modules/@angular/platform-server/testing/server.ts
@@ -6,15 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {analyzeAppProvidersForDeprecatedConfiguration} from '@angular/compiler';
 import {platformCoreDynamicTesting} from '@angular/compiler/testing';
-import {COMPILER_OPTIONS, CompilerFactory, NgModule, OpaqueToken, PLATFORM_COMMON_PROVIDERS, PLATFORM_INITIALIZER, PlatformRef, ReflectiveInjector, assertPlatform, createPlatform, createPlatformFactory, getPlatform} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
-import {BrowserDynamicTestingModule, TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS, platformBrowserDynamicTesting} from '@angular/platform-browser-dynamic/testing';
+import {NgModule, PlatformRef, createPlatformFactory} from '@angular/core';
+import {BrowserDynamicTestingModule,} from '@angular/platform-browser-dynamic/testing';
 
-import {Console} from '../core_private';
-import {platformServer} from '../index';
-import {Parse5DomAdapter} from '../src/parse5_adapter';
 import {INTERNAL_SERVER_PLATFORM_PROVIDERS} from '../src/server';
 
 
@@ -27,11 +22,6 @@ export const platformServerTesting = createPlatformFactory(
     platformCoreDynamicTesting, 'serverTesting', INTERNAL_SERVER_PLATFORM_PROVIDERS);
 
 /**
- * @deprecated Use {@link platformServerTesting} instead
- */
-export const serverTestingPlatform = platformServerTesting;
-
-/**
  * NgModule for testing.
  *
  * @experimental API related to bootstrapping are still under review.
@@ -39,40 +29,3 @@ export const serverTestingPlatform = platformServerTesting;
 @NgModule({exports: [BrowserDynamicTestingModule]})
 export class ServerTestingModule {
 }
-
-/**
- * Providers of the `serverTestingPlatform` to be used for creating own platform based on this.
- *
- * @deprecated Use `platformServerTesting()` or create a custom platform factory via
- * `createPlatformFactory(platformServerTesting, ...)`
- */
-export const TEST_SERVER_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[]*/> =
-    // Note: This is not a real provider but a hack to still support the deprecated
-    // `setBaseTestProviders` method!
-    [(appProviders: any[]) => {
-      const deprecatedConfiguration = analyzeAppProvidersForDeprecatedConfiguration(appProviders);
-      const platformRef = createPlatformFactory(platformServerTesting, 'serverTestingDeprecated', [{
-                                                  provide: COMPILER_OPTIONS,
-                                                  useValue: deprecatedConfiguration.compilerOptions,
-                                                  multi: true
-                                                }])();
-
-      @NgModule({
-        exports: [ServerTestingModule],
-        declarations: [deprecatedConfiguration.moduleDeclarations]
-      })
-      class DynamicTestModule {
-      }
-
-      const testInjector = TestBed.initTestEnvironment(DynamicTestModule, platformRef);
-      const console: Console = testInjector.get(Console);
-      deprecatedConfiguration.deprecationMessages.forEach((msg) => console.warn(msg));
-    }];
-
-/**
- * @deprecated Use initTestEnvironment with ServerTestModule instead. This is empty for backwards
- * compatibility,
- * as all of our bootstrap methods add a module implicitly, i.e. keeping this filled would add the
- * providers 2x.
- */
-export const TEST_SERVER_APPLICATION_PROVIDERS: Array<any /*Type | Provider | any[]*/> = [];

--- a/tools/cjs-jasmine/test-cjs-main.ts
+++ b/tools/cjs-jasmine/test-cjs-main.ts
@@ -2,4 +2,4 @@ var testingPlatformServer = require('../../all/@angular/platform-server/testing/
 var testing = require('../../all/@angular/core/testing');
 
 testing.TestBed.initTestEnvironment(
-    testingPlatformServer.ServerTestingModule, testingPlatformServer.serverTestingPlatform());
+    testingPlatformServer.ServerTestingModule, testingPlatformServer.platformServerTesting());

--- a/tools/public_api_guard/core/testing.d.ts
+++ b/tools/public_api_guard/core/testing.d.ts
@@ -40,9 +40,6 @@ export declare function flushMicrotasks(): void;
 /** @experimental */
 export declare function getTestBed(): TestBed;
 
-/** @deprecated */
-export declare function getTestInjector(): TestBed;
-
 /** @stable */
 export declare function inject(tokens: any[], fn: Function): () => any;
 
@@ -59,14 +56,8 @@ export declare type MetadataOverride<T> = {
     set?: T;
 };
 
-/** @deprecated */
-export declare function resetBaseTestProviders(): void;
-
 /** @experimental */
 export declare function resetFakeAsyncZone(): void;
-
-/** @deprecated */
-export declare function setBaseTestProviders(platformProviders: Array<Type | Provider | any[]>, applicationProviders: Array<Type | Provider | any[]>): void;
 
 /** @experimental */
 export declare class TestBed implements Injector {

--- a/tools/public_api_guard/platform-browser-dynamic/testing.d.ts
+++ b/tools/public_api_guard/platform-browser-dynamic/testing.d.ts
@@ -4,9 +4,3 @@ export declare class BrowserDynamicTestingModule {
 
 /** @experimental */
 export declare const platformBrowserDynamicTesting: (extraProviders?: any[]) => PlatformRef;
-
-/** @deprecated */
-export declare const TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS: Array<any>;
-
-/** @deprecated */
-export declare const TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS: Array<any>;

--- a/tools/public_api_guard/platform-browser/testing.d.ts
+++ b/tools/public_api_guard/platform-browser/testing.d.ts
@@ -2,14 +2,5 @@
 export declare class BrowserTestingModule {
 }
 
-/** @deprecated */
-export declare const browserTestingPlatform: (extraProviders?: any[]) => PlatformRef;
-
 /** @experimental */
 export declare const platformBrowserTesting: (extraProviders?: any[]) => PlatformRef;
-
-/** @deprecated */
-export declare const TEST_BROWSER_APPLICATION_PROVIDERS: Array<any>;
-
-/** @deprecated */
-export declare const TEST_BROWSER_PLATFORM_PROVIDERS: Array<any>;

--- a/tools/public_api_guard/platform-server/testing.d.ts
+++ b/tools/public_api_guard/platform-server/testing.d.ts
@@ -4,12 +4,3 @@ export declare const platformServerTesting: (extraProviders?: any[]) => Platform
 /** @experimental */
 export declare class ServerTestingModule {
 }
-
-/** @deprecated */
-export declare const serverTestingPlatform: (extraProviders?: any[]) => PlatformRef;
-
-/** @deprecated */
-export declare const TEST_SERVER_APPLICATION_PROVIDERS: Array<any>;
-
-/** @deprecated */
-export declare const TEST_SERVER_PLATFORM_PROVIDERS: Array<any>;


### PR DESCRIPTION
Remove test setup functions which were deprecated in rc5. See the
changelog for rc5 for how to update. In brief, instead of
`setBaseTestProviders`, use `TestBed.initTestEnvironment`.
