### PR TITLE
fix(metadata): treat empty array of metadata like absent file

### DIFF
--- a/modules/@angular/compiler-cli/src/reflector_host.ts
+++ b/modules/@angular/compiler-cli/src/reflector_host.ts
@@ -238,7 +238,8 @@ export class ReflectorHost implements StaticReflectorHost, ImportGenerator {
     if (DTS.test(filePath)) {
       const metadataPath = filePath.replace(DTS, '.metadata.json');
       if (this.context.fileExists(metadataPath)) {
-        return this.readMetadata(metadataPath);
+        const metadata = this.readMetadata(metadataPath);
+        return (Array.isArray(metadata) && metadata.length == 0) ? undefined : metadata;
       }
     } else {
       const sf = this.program.getSourceFile(filePath);

--- a/modules/@angular/compiler-cli/test/reflector_host_spec.ts
+++ b/modules/@angular/compiler-cli/test/reflector_host_spec.ts
@@ -203,6 +203,11 @@ describe('reflector_host', () => {
         .toBeUndefined();
   });
 
+  it('should be able to read empty metadata ', () => {
+    expect(reflectorNestedGenDir.getMetadataFor('node_modules/@angular/empty.d.ts'))
+        .toBeUndefined();
+  });
+
   it('should return undefined for missing modules', () => {
     expect(reflectorNestedGenDir.getMetadataFor('node_modules/@angular/missing.d.ts'))
         .toBeUndefined();
@@ -328,7 +333,9 @@ const FILES: Entry = {
           'core.metadata.json':
               `{"__symbolic":"module", "version": 1, "metadata": {"foo": {"__symbolic": "class"}}}`,
           'router': {'index.d.ts': dummyModule, 'src': {'providers.d.ts': dummyModule}},
-          'unused.d.ts': dummyModule
+          'unused.d.ts': dummyModule,
+          'empty.d.ts': 'export declare var a: string;',
+          'empty.metadata.json': '[]',
         }
       }
     },


### PR DESCRIPTION
needed for Bazel support, since we cannot omit declared outputs of an action.
