### PR TITLE
chore(imports): don't import ExceptionHandler from facade

### DIFF
--- a/modules/@angular/common/src/directives/ng_for.ts
+++ b/modules/@angular/common/src/directives/ng_for.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, CollectionChangeRecord, DefaultIterableDiffer, Directive, DoCheck, EmbeddedViewRef, Input, IterableDiffer, IterableDiffers, OnChanges, SimpleChanges, TemplateRef, TrackByFn, ViewContainerRef} from '@angular/core';
+import {BaseException, ChangeDetectorRef, CollectionChangeRecord, DefaultIterableDiffer, Directive, DoCheck, EmbeddedViewRef, Input, IterableDiffer, IterableDiffers, OnChanges, SimpleChanges, TemplateRef, TrackByFn, ViewContainerRef} from '@angular/core';
 
-import {BaseException} from '../facade/exceptions';
 import {getTypeNameForDebugging, isBlank, isPresent} from '../facade/lang';
 
 export class NgForRow {

--- a/modules/@angular/common/src/forms-deprecated/directives/abstract_control_directive.ts
+++ b/modules/@angular/common/src/forms-deprecated/directives/abstract_control_directive.ts
@@ -6,10 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {unimplemented} from '../../facade/exceptions';
+import {BaseException} from '@angular/core';
 import {isPresent} from '../../facade/lang';
 import {AbstractControl} from '../model';
 
+function unimplemented(): any {
+  throw new BaseException('unimplemented');
+}
 
 /**
  * Base class for control directives.

--- a/modules/@angular/common/src/forms-deprecated/directives/ng_control.ts
+++ b/modules/@angular/common/src/forms-deprecated/directives/ng_control.ts
@@ -6,12 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {unimplemented} from '../../facade/exceptions';
-
+import {BaseException} from '@angular/core';
 import {AbstractControlDirective} from './abstract_control_directive';
 import {ControlValueAccessor} from './control_value_accessor';
 import {AsyncValidatorFn, ValidatorFn} from './validators';
 
+function unimplemented(): any {
+  throw new BaseException('unimplemented');
+}
 
 /**
  * A base class that all control directive extend.

--- a/modules/@angular/common/src/forms-deprecated/directives/ng_form_model.ts
+++ b/modules/@angular/common/src/forms-deprecated/directives/ng_form_model.ts
@@ -6,11 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Inject, OnChanges, Optional, Self, SimpleChanges, forwardRef} from '@angular/core';
+import {BaseException, Directive, Inject, OnChanges, Optional, Self, SimpleChanges, forwardRef} from '@angular/core';
 
 import {EventEmitter} from '../../facade/async';
 import {ListWrapper, StringMapWrapper} from '../../facade/collection';
-import {BaseException} from '../../facade/exceptions';
 import {isBlank} from '../../facade/lang';
 import {Control, ControlGroup} from '../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from '../validators';

--- a/modules/@angular/common/src/forms-deprecated/directives/shared.ts
+++ b/modules/@angular/common/src/forms-deprecated/directives/shared.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import {ListWrapper, StringMapWrapper} from '../../facade/collection';
-import {BaseException} from '../../facade/exceptions';
 import {hasConstructor, isBlank, isPresent, looseIdentical} from '../../facade/lang';
 import {Control, ControlGroup} from '../model';
 import {Validators} from '../validators';

--- a/modules/@angular/common/src/location/path_location_strategy.ts
+++ b/modules/@angular/common/src/location/path_location_strategy.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, Optional} from '@angular/core';
+import {BaseException, Inject, Injectable, Optional} from '@angular/core';
 
-import {BaseException} from '../facade/exceptions';
 import {isBlank} from '../facade/lang';
 
 import {Location} from './location';

--- a/modules/@angular/common/src/pipes/invalid_pipe_argument_exception.ts
+++ b/modules/@angular/common/src/pipes/invalid_pipe_argument_exception.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BaseException} from '../facade/exceptions';
+import {BaseException} from '@angular/core';
 import {Type, stringify} from '../facade/lang';
 
 export class InvalidPipeArgumentException extends BaseException {

--- a/modules/@angular/compiler/src/animation/animation_compiler.ts
+++ b/modules/@angular/compiler/src/animation/animation_compiler.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AUTO_STYLE} from '@angular/core';
+import {AUTO_STYLE, BaseException} from '@angular/core';
 
 import {ANY_STATE, DEFAULT_STATE, EMPTY_STATE} from '../../core_private';
 import {CompileDirectiveMetadata} from '../compile_metadata';
 import {StringMapWrapper} from '../facade/collection';
-import {BaseException} from '../facade/exceptions';
 import {isBlank, isPresent} from '../facade/lang';
 import {Identifiers} from '../identifiers';
 import * as o from '../output/output_ast';

--- a/modules/@angular/compiler/src/config.ts
+++ b/modules/@angular/compiler/src/config.ts
@@ -6,12 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ViewEncapsulation, isDevMode} from '@angular/core';
-
-import {unimplemented} from '../src/facade/exceptions';
+import {BaseException, ViewEncapsulation, isDevMode} from '@angular/core';
 
 import {CompileIdentifierMetadata} from './compile_metadata';
 import {Identifiers} from './identifiers';
+
+function unimplemented(): any {
+  throw new BaseException('unimplemented');
+}
 
 export class CompilerConfig {
   public renderTypes: RenderTypes;

--- a/modules/@angular/compiler/src/css_parser/css_lexer.ts
+++ b/modules/@angular/compiler/src/css_parser/css_lexer.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import * as chars from '../chars';
-import {BaseException} from '../facade/exceptions';
 import {StringWrapper, isPresent, resolveEnumToken} from '../facade/lang';
 
 export enum CssTokenType {

--- a/modules/@angular/compiler/src/directive_normalizer.ts
+++ b/modules/@angular/compiler/src/directive_normalizer.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, ViewEncapsulation} from '@angular/core';
+import {BaseException, Injectable, ViewEncapsulation} from '@angular/core';
 
 import {CompileDirectiveMetadata, CompileStylesheetMetadata, CompileTemplateMetadata, CompileTypeMetadata} from './compile_metadata';
 import {CompilerConfig} from './config';
 import {MapWrapper} from './facade/collection';
-import {BaseException} from './facade/exceptions';
 import {isBlank, isPresent} from './facade/lang';
 import * as html from './ml_parser/ast';
 import {HtmlParser} from './ml_parser/html_parser';

--- a/modules/@angular/compiler/src/directive_resolver.ts
+++ b/modules/@angular/compiler/src/directive_resolver.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentMetadata, DirectiveMetadata, HostBindingMetadata, HostListenerMetadata, Injectable, InputMetadata, OutputMetadata, QueryMetadata, resolveForwardRef} from '@angular/core';
+import {BaseException, ComponentMetadata, DirectiveMetadata, HostBindingMetadata, HostListenerMetadata, Injectable, InputMetadata, OutputMetadata, QueryMetadata, resolveForwardRef} from '@angular/core';
 
 import {ReflectorReader, reflector} from '../core_private';
 
 import {StringMapWrapper} from './facade/collection';
-import {BaseException} from './facade/exceptions';
 import {Type, isPresent, stringify} from './facade/lang';
 import {splitAtColon} from './util';
 

--- a/modules/@angular/compiler/src/metadata_resolver.ts
+++ b/modules/@angular/compiler/src/metadata_resolver.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AnimationAnimateMetadata, AnimationEntryMetadata, AnimationGroupMetadata, AnimationKeyframesSequenceMetadata, AnimationMetadata, AnimationStateDeclarationMetadata, AnimationStateMetadata, AnimationStateTransitionMetadata, AnimationStyleMetadata, AnimationWithStepsMetadata, AttributeMetadata, ChangeDetectionStrategy, ComponentMetadata, HostMetadata, Inject, InjectMetadata, Injectable, ModuleWithProviders, NgModule, NgModuleMetadata, Optional, OptionalMetadata, Provider, QueryMetadata, SchemaMetadata, SelfMetadata, SkipSelfMetadata, ViewMetadata, ViewQueryMetadata, resolveForwardRef} from '@angular/core';
+import {AnimationAnimateMetadata, AnimationEntryMetadata, AnimationGroupMetadata, AnimationKeyframesSequenceMetadata, AnimationMetadata, AnimationStateDeclarationMetadata, AnimationStateMetadata, AnimationStateTransitionMetadata, AnimationStyleMetadata, AnimationWithStepsMetadata, AttributeMetadata, BaseException, ChangeDetectionStrategy, ComponentMetadata, HostMetadata, Inject, InjectMetadata, Injectable, ModuleWithProviders, NgModule, NgModuleMetadata, Optional, OptionalMetadata, Provider, QueryMetadata, SchemaMetadata, SelfMetadata, SkipSelfMetadata, ViewMetadata, ViewQueryMetadata, resolveForwardRef} from '@angular/core';
 
 import {Console, LIFECYCLE_HOOKS_VALUES, ReflectorReader, createProvider, isProviderLiteral, reflector} from '../core_private';
 import {StringMapWrapper} from '../src/facade/collection';
@@ -15,7 +15,6 @@ import {assertArrayOfStrings, assertInterpolationSymbols} from './assertions';
 import * as cpl from './compile_metadata';
 import {CompilerConfig} from './config';
 import {DirectiveResolver} from './directive_resolver';
-import {BaseException} from './facade/exceptions';
 import {Type, isArray, isBlank, isPresent, isString, stringify} from './facade/lang';
 import {Identifiers, identifierToken} from './identifiers';
 import {hasLifecycleHook} from './lifecycle_reflector';

--- a/modules/@angular/compiler/src/ng_module_resolver.ts
+++ b/modules/@angular/compiler/src/ng_module_resolver.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, NgModuleMetadata} from '@angular/core';
+import {BaseException, Injectable, NgModuleMetadata} from '@angular/core';
 
 import {ReflectorReader, reflector} from '../core_private';
-import {BaseException} from '../src/facade/exceptions';
+
 import {Type, isPresent, stringify} from './facade/lang';
 
 function _isNgModuleMetadata(obj: any): obj is NgModuleMetadata {

--- a/modules/@angular/compiler/src/offline_compiler.ts
+++ b/modules/@angular/compiler/src/offline_compiler.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {SchemaMetadata} from '@angular/core';
+import {BaseException, SchemaMetadata} from '@angular/core';
+
 import {CompileDirectiveMetadata, CompileIdentifierMetadata, CompileNgModuleMetadata, CompilePipeMetadata, StaticSymbol, createHostComponentMeta} from './compile_metadata';
 import {DirectiveNormalizer} from './directive_normalizer';
 import {ListWrapper} from './facade/collection';
-import {BaseException} from './facade/exceptions';
 import {Identifiers} from './identifiers';
 import {CompileMetadataResolver} from './metadata_resolver';
 import {NgModuleCompiler} from './ng_module_compiler';

--- a/modules/@angular/compiler/src/output/abstract_emitter.ts
+++ b/modules/@angular/compiler/src/output/abstract_emitter.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BaseException} from '../facade/exceptions';
+import {BaseException} from '@angular/core';
 import {StringWrapper, isBlank, isPresent, isString} from '../facade/lang';
 
 import * as o from './output_ast';

--- a/modules/@angular/compiler/src/output/abstract_js_emitter.ts
+++ b/modules/@angular/compiler/src/output/abstract_js_emitter.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BaseException} from '../facade/exceptions';
+import {BaseException} from '@angular/core';
 import {isPresent} from '../facade/lang';
 
 import {AbstractEmitterVisitor, CATCH_ERROR_VAR, CATCH_STACK_VAR, EmitterVisitorContext} from './abstract_emitter';

--- a/modules/@angular/compiler/src/output/output_ast.ts
+++ b/modules/@angular/compiler/src/output/output_ast.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import {CompileIdentifierMetadata} from '../compile_metadata';
 import {StringMapWrapper} from '../facade/collection';
-import {BaseException} from '../facade/exceptions';
 import {isBlank, isPresent, isString} from '../facade/lang';
 import {ValueTransformer, visitValue} from '../util';
 

--- a/modules/@angular/compiler/src/output/path_util.ts
+++ b/modules/@angular/compiler/src/output/path_util.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable} from '@angular/core';
+import {BaseException, Injectable} from '@angular/core';
 
-import {BaseException} from '../facade/exceptions';
 import {Math, isBlank, isPresent} from '../facade/lang';
 
 

--- a/modules/@angular/compiler/src/output/ts_emitter.ts
+++ b/modules/@angular/compiler/src/output/ts_emitter.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import {CompileIdentifierMetadata} from '../compile_metadata';
-import {BaseException} from '../facade/exceptions';
 import {isArray, isBlank, isPresent} from '../facade/lang';
 
 import {AbstractEmitterVisitor, CATCH_ERROR_VAR, CATCH_STACK_VAR, EmitterVisitorContext, OutputEmitter} from './abstract_emitter';

--- a/modules/@angular/compiler/src/output/value_util.ts
+++ b/modules/@angular/compiler/src/output/value_util.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import {CompileIdentifierMetadata} from '../compile_metadata';
 import {StringMapWrapper} from '../facade/collection';
-import {BaseException} from '../facade/exceptions';
 import {ValueTransformer, visitValue} from '../util';
 
 import * as o from './output_ast';

--- a/modules/@angular/compiler/src/pipe_resolver.ts
+++ b/modules/@angular/compiler/src/pipe_resolver.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, PipeMetadata, resolveForwardRef} from '@angular/core';
+import {BaseException, Injectable, PipeMetadata, resolveForwardRef} from '@angular/core';
 
 import {ReflectorReader, reflector} from '../core_private';
-import {BaseException} from './facade/exceptions';
+
 import {Type, isPresent, stringify} from './facade/lang';
 
 function _isPipeMetadata(type: any): boolean {

--- a/modules/@angular/compiler/src/provider_analyzer.ts
+++ b/modules/@angular/compiler/src/provider_analyzer.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import {CompileDiDependencyMetadata, CompileDirectiveMetadata, CompileIdentifierMap, CompileNgModuleMetadata, CompileProviderMetadata, CompileQueryMetadata, CompileTokenMetadata, CompileTypeMetadata} from './compile_metadata';
 import {ListWrapper} from './facade/collection';
-import {BaseException} from './facade/exceptions';
 import {isArray, isBlank, isPresent, normalizeBlank} from './facade/lang';
 import {Identifiers, identifierToken} from './identifiers';
 import {ParseError, ParseSourceSpan} from './parse_util';

--- a/modules/@angular/compiler/src/runtime_compiler.ts
+++ b/modules/@angular/compiler/src/runtime_compiler.ts
@@ -6,14 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Compiler, ComponentFactory, ComponentResolver, ComponentStillLoadingError, Injectable, Injector, ModuleWithComponentFactories, NgModule, NgModuleFactory, NgModuleMetadata, OptionalMetadata, Provider, SchemaMetadata, SkipSelfMetadata} from '@angular/core';
+import {BaseException, Compiler, ComponentFactory, ComponentResolver, ComponentStillLoadingError, Injectable, Injector, ModuleWithComponentFactories, NgModule, NgModuleFactory, NgModuleMetadata, OptionalMetadata, Provider, SchemaMetadata, SkipSelfMetadata} from '@angular/core';
 
 import {Console} from '../core_private';
 
 import {CompileDirectiveMetadata, CompileIdentifierMetadata, CompileNgModuleMetadata, CompilePipeMetadata, createHostComponentMeta} from './compile_metadata';
 import {CompilerConfig} from './config';
 import {DirectiveNormalizer} from './directive_normalizer';
-import {BaseException} from './facade/exceptions';
 import {ConcreteType, Type, isBlank, isString, stringify} from './facade/lang';
 import {CompileMetadataResolver} from './metadata_resolver';
 import {NgModuleCompiler} from './ng_module_compiler';

--- a/modules/@angular/compiler/src/selector.ts
+++ b/modules/@angular/compiler/src/selector.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import {ListWrapper} from './facade/collection';
-import {BaseException} from './facade/exceptions';
 import {StringWrapper, isBlank, isPresent} from './facade/lang';
 
 const _EMPTY_ATTR_VALUE = '';

--- a/modules/@angular/compiler/src/template_parser/template_parser.ts
+++ b/modules/@angular/compiler/src/template_parser/template_parser.ts
@@ -6,14 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, OpaqueToken, Optional, SchemaMetadata, SecurityContext} from '@angular/core';
+import {BaseException, Inject, Injectable, OpaqueToken, Optional, SchemaMetadata, SecurityContext} from '@angular/core';
 
 import {Console, MAX_INTERPOLATION_VALUES} from '../../core_private';
 import {CompileDirectiveMetadata, CompilePipeMetadata, CompileTokenMetadata, removeIdentifierDuplicates} from '../compile_metadata';
 import {AST, ASTWithSource, BindingPipe, EmptyExpr, Interpolation, ParserError, RecursiveAstVisitor, TemplateBinding} from '../expression_parser/ast';
 import {Parser} from '../expression_parser/parser';
 import {ListWrapper, SetWrapper, StringMapWrapper} from '../facade/collection';
-import {BaseException} from '../facade/exceptions';
 import {isBlank, isPresent} from '../facade/lang';
 import {Identifiers, identifierToken} from '../identifiers';
 import * as html from '../ml_parser/ast';

--- a/modules/@angular/compiler/src/view_compiler/compile_pipe.ts
+++ b/modules/@angular/compiler/src/view_compiler/compile_pipe.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import {CompilePipeMetadata} from '../compile_metadata';
-import {BaseException} from '../facade/exceptions';
 import {isBlank, isPresent} from '../facade/lang';
 import {Identifiers, identifierToken} from '../identifiers';
 import * as o from '../output/output_ast';

--- a/modules/@angular/compiler/src/view_compiler/expression_converter.ts
+++ b/modules/@angular/compiler/src/view_compiler/expression_converter.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import * as cdAst from '../expression_parser/ast';
-import {BaseException} from '../facade/exceptions';
 import {isArray, isBlank, isPresent} from '../facade/lang';
 import {Identifiers} from '../identifiers';
 import * as o from '../output/output_ast';

--- a/modules/@angular/compiler/src/view_compiler/util.ts
+++ b/modules/@angular/compiler/src/view_compiler/util.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import {CompileDirectiveMetadata, CompileTokenMetadata} from '../compile_metadata';
-import {BaseException} from '../facade/exceptions';
 import {isBlank, isPresent} from '../facade/lang';
 import {Identifiers} from '../identifiers';
 import * as o from '../output/output_ast';

--- a/modules/@angular/compiler/test/css_parser/css_parser_spec.ts
+++ b/modules/@angular/compiler/test/css_parser/css_parser_spec.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import {afterEach, beforeEach, ddescribe, describe, expect, iit, it, xit} from '../../../core/testing/testing_internal';
 import {CssBlockAst, CssBlockDefinitionRuleAst, CssBlockRuleAst, CssDefinitionAst, CssInlineRuleAst, CssKeyframeDefinitionAst, CssKeyframeRuleAst, CssMediaQueryRuleAst, CssSelectorRuleAst, CssStyleSheetAst, CssStyleValueAst} from '../../src/css_parser/css_ast';
 import {BlockType, CssParseError, CssParser, CssToken, ParsedCssResult} from '../../src/css_parser/css_parser';
-import {BaseException} from '../../src/facade/exceptions';
 import {ParseLocation} from '../../src/parse_util';
 
 export function assertTokens(tokens: CssToken[], valuesArr: string[]) {

--- a/modules/@angular/compiler/test/css_parser/css_visitor_spec.ts
+++ b/modules/@angular/compiler/test/css_parser/css_visitor_spec.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import {afterEach, beforeEach, ddescribe, describe, expect, iit, it, xit} from '../../../core/testing/testing_internal';
 import {CssAst, CssAstVisitor, CssAtRulePredicateAst, CssBlockAst, CssBlockDefinitionRuleAst, CssBlockRuleAst, CssDefinitionAst, CssInlineRuleAst, CssKeyframeDefinitionAst, CssKeyframeRuleAst, CssMediaQueryRuleAst, CssPseudoSelectorAst, CssRuleAst, CssSelectorAst, CssSelectorRuleAst, CssSimpleSelectorAst, CssStyleSheetAst, CssStyleValueAst, CssStylesBlockAst, CssUnknownRuleAst, CssUnknownTokenListAst} from '../../src/css_parser/css_ast';
 import {BlockType, CssParseError, CssParser, CssToken} from '../../src/css_parser/css_parser';
-import {BaseException} from '../../src/facade/exceptions';
 import {isPresent} from '../../src/facade/lang';
 
 function _assertTokens(tokens: CssToken[], valuesArr: string[]): void {

--- a/modules/@angular/compiler/test/ml_parser/ast_spec_utils.ts
+++ b/modules/@angular/compiler/test/ml_parser/ast_spec_utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BaseException} from '../../src/facade/exceptions';
+import {BaseException} from '@angular/core';
 import * as html from '../../src/ml_parser/ast';
 import {ParseTreeResult} from '../../src/ml_parser/html_parser';
 import {ParseLocation} from '../../src/parse_util';

--- a/modules/@angular/compiler/test/output/output_emitter_codegen_typed.ts
+++ b/modules/@angular/compiler/test/output/output_emitter_codegen_typed.ts
@@ -9,10 +9,14 @@
 // ATTENTION: This file will be overwritten with generated code by main()
 import * as o from '@angular/compiler/src/output/output_ast';
 import {TypeScriptEmitter} from '@angular/compiler/src/output/ts_emitter';
+import {BaseException} from '@angular/core';
 
-import {unimplemented} from '../../src/facade/exceptions';
 import {print} from '../../src/facade/lang';
 import {assetUrl} from '../../src/util';
+
+function unimplemented(): any {
+  throw new BaseException('unimplemented');
+}
 
 import {SimpleJsImportGenerator, codegenExportsVars, codegenStmts} from './output_emitter_util';
 

--- a/modules/@angular/compiler/test/output/output_emitter_codegen_untyped.ts
+++ b/modules/@angular/compiler/test/output/output_emitter_codegen_untyped.ts
@@ -8,15 +8,15 @@
 
 // ATTENTION: This file will be overwritten with generated code by main()
 import {JavaScriptEmitter} from '@angular/compiler/src/output/js_emitter';
+import {BaseException} from '@angular/core';
 
-import {unimplemented} from '../../src/facade/exceptions';
 import {print} from '../../src/facade/lang';
 import {assetUrl} from '../../src/util';
 
 import {SimpleJsImportGenerator, codegenExportsVars, codegenStmts} from './output_emitter_util';
 
 export function getExpressions(): any {
-  return unimplemented();
+  throw new BaseException('unimplemented');
 }
 
 // Generator

--- a/modules/@angular/compiler/test/output/output_emitter_util.ts
+++ b/modules/@angular/compiler/test/output/output_emitter_util.ts
@@ -10,10 +10,8 @@ import {CompileIdentifierMetadata} from '@angular/compiler/src/compile_metadata'
 import * as o from '@angular/compiler/src/output/output_ast';
 import {ImportGenerator} from '@angular/compiler/src/output/path_util';
 import {assetUrl} from '@angular/compiler/src/util';
-import {EventEmitter} from '@angular/core';
+import {BaseException, EventEmitter} from '@angular/core';
 import {ViewType} from '@angular/core/src/linker/view_type';
-
-import {BaseException} from '../../src/facade/exceptions';
 
 export class ExternalClass {
   changeable: any;

--- a/modules/@angular/compiler/testing/directive_resolver_mock.ts
+++ b/modules/@angular/compiler/testing/directive_resolver_mock.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AnimationEntryMetadata, Compiler, ComponentMetadata, DirectiveMetadata, Injectable, Injector, ViewMetadata, resolveForwardRef} from '@angular/core';
+import {AnimationEntryMetadata, BaseException, Compiler, ComponentMetadata, DirectiveMetadata, Injectable, Injector, ViewMetadata, resolveForwardRef} from '@angular/core';
 
 import {DirectiveResolver} from '../src/directive_resolver';
 import {Map} from '../src/facade/collection';
-import {BaseException} from '../src/facade/exceptions';
 import {Type, isArray, isPresent, stringify} from '../src/facade/lang';
+
 
 
 /**

--- a/modules/@angular/compiler/testing/metadata_overrider.ts
+++ b/modules/@angular/compiler/testing/metadata_overrider.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
 import {MetadataOverride} from '@angular/core/testing';
 
-import {BaseException} from '../src/facade/exceptions';
 import {ConcreteType, stringify} from '../src/facade/lang';
 
 type StringMap = {

--- a/modules/@angular/forms/src/directives/abstract_control_directive.ts
+++ b/modules/@angular/forms/src/directives/abstract_control_directive.ts
@@ -6,12 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
 import {Observable} from '../facade/async';
-import {unimplemented} from '../facade/exceptions';
 import {isPresent} from '../facade/lang';
 import {AbstractControl} from '../model';
-
-
 
 /**
  * Base class for control directives.
@@ -21,7 +19,7 @@ import {AbstractControl} from '../model';
  * @experimental
  */
 export abstract class AbstractControlDirective {
-  get control(): AbstractControl { return unimplemented(); }
+  get control(): AbstractControl { throw new BaseException('unimplemented'); }
 
   get value(): any { return isPresent(this.control) ? this.control.value : null; }
 

--- a/modules/@angular/forms/src/directives/ng_control.ts
+++ b/modules/@angular/forms/src/directives/ng_control.ts
@@ -6,12 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {unimplemented} from '../facade/exceptions';
+import {BaseException} from '@angular/core';
 
 import {AbstractControlDirective} from './abstract_control_directive';
 import {ControlValueAccessor} from './control_value_accessor';
 import {AsyncValidatorFn, ValidatorFn} from './validators';
 
+function unimplemented(): any {
+  throw new BaseException('unimplemented');
+}
 
 /**
  * A base class that all control directive extend.

--- a/modules/@angular/forms/src/directives/ng_model.ts
+++ b/modules/@angular/forms/src/directives/ng_model.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges, forwardRef} from '@angular/core';
+import {BaseException, Directive, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges, forwardRef} from '@angular/core';
 
 import {EventEmitter} from '../facade/async';
-import {BaseException} from '../facade/exceptions';
 import {FormControl} from '../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
 

--- a/modules/@angular/forms/src/directives/ng_model_group.ts
+++ b/modules/@angular/forms/src/directives/ng_model_group.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Host, Inject, Input, OnDestroy, OnInit, Optional, Self, SkipSelf, forwardRef} from '@angular/core';
+import {BaseException, Directive, Host, Inject, Input, OnDestroy, OnInit, Optional, Self, SkipSelf, forwardRef} from '@angular/core';
 
-import {BaseException} from '../facade/exceptions';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
 
 import {AbstractFormGroupDirective} from './abstract_form_group_directive';

--- a/modules/@angular/forms/src/directives/radio_control_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/radio_control_value_accessor.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Injectable, Injector, Input, OnDestroy, OnInit, Renderer, forwardRef} from '@angular/core';
+import {BaseException, Directive, ElementRef, Injectable, Injector, Input, OnDestroy, OnInit, Renderer, forwardRef} from '@angular/core';
 
 import {ListWrapper} from '../facade/collection';
-import {BaseException} from '../facade/exceptions';
 import {isPresent} from '../facade/lang';
 
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';

--- a/modules/@angular/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/modules/@angular/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -6,11 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Inject, Input, OnChanges, Optional, Output, Self, SimpleChanges, forwardRef} from '@angular/core';
+import {BaseException, Directive, Inject, Input, OnChanges, Optional, Output, Self, SimpleChanges, forwardRef} from '@angular/core';
 
 import {EventEmitter} from '../../facade/async';
 import {ListWrapper, StringMapWrapper} from '../../facade/collection';
-import {BaseException} from '../../facade/exceptions';
 import {isBlank} from '../../facade/lang';
 import {FormArray, FormControl, FormGroup} from '../../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from '../../validators';

--- a/modules/@angular/forms/src/directives/reactive_errors.ts
+++ b/modules/@angular/forms/src/directives/reactive_errors.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BaseException} from '../facade/exceptions';
+import {BaseException} from '@angular/core';
 
 import {FormErrorExamples as Examples} from './error_examples';
 

--- a/modules/@angular/forms/src/directives/shared.ts
+++ b/modules/@angular/forms/src/directives/shared.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import {ListWrapper, StringMapWrapper} from '../facade/collection';
-import {BaseException} from '../facade/exceptions';
 import {hasConstructor, isBlank, isPresent, looseIdentical} from '../facade/lang';
 import {FormArray, FormControl, FormGroup} from '../model';
 import {Validators} from '../validators';

--- a/modules/@angular/forms/src/directives/template_driven_errors.ts
+++ b/modules/@angular/forms/src/directives/template_driven_errors.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BaseException} from '../facade/exceptions';
+import {BaseException} from '@angular/core';
 import {FormErrorExamples as Examples} from './error_examples';
 
 export class TemplateDrivenErrors {

--- a/modules/@angular/forms/src/model.ts
+++ b/modules/@angular/forms/src/model.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
 import {PromiseObservable} from 'rxjs/observable/PromiseObservable';
 
 import {composeAsyncValidators, composeValidators} from './directives/shared';
 import {AsyncValidatorFn, ValidatorFn} from './directives/validators';
 import {EventEmitter, Observable} from './facade/async';
 import {ListWrapper, StringMapWrapper} from './facade/collection';
-import {BaseException} from './facade/exceptions';
 import {isBlank, isPresent, isPromise, normalizeBool} from './facade/lang';
 
 

--- a/modules/@angular/http/src/headers.ts
+++ b/modules/@angular/http/src/headers.ts
@@ -6,9 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import {ListWrapper, Map, MapWrapper, StringMapWrapper, isListLikeIterable, iterateListLike} from '../src/facade/collection';
-import {BaseException} from '../src/facade/exceptions';
 import {isBlank} from '../src/facade/lang';
+
 
 
 /**

--- a/modules/@angular/http/src/static_response.ts
+++ b/modules/@angular/http/src/static_response.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BaseException} from '../src/facade/exceptions';
+import {BaseException} from '@angular/core';
 import {Json, isString} from '../src/facade/lang';
 
 import {ResponseOptions} from './base_response_options';

--- a/modules/@angular/http/testing/mock_backend.ts
+++ b/modules/@angular/http/testing/mock_backend.ts
@@ -6,17 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable} from '@angular/core';
+import {BaseException, Injectable} from '@angular/core';
 import {ReplaySubject} from 'rxjs/ReplaySubject';
 import {Subject} from 'rxjs/Subject';
 import {take} from 'rxjs/operator/take';
 
 import {ReadyState} from '../src/enums';
-import {BaseException} from '../src/facade/exceptions';
 import {isPresent} from '../src/facade/lang';
 import {Connection, ConnectionBackend} from '../src/interfaces';
 import {Request} from '../src/static_request';
 import {Response} from '../src/static_response';
+
 
 
 /**

--- a/modules/@angular/platform-browser-dynamic/src/xhr/xhr_cache.ts
+++ b/modules/@angular/platform-browser-dynamic/src/xhr/xhr_cache.ts
@@ -7,7 +7,7 @@
  */
 
 import {XHR} from '@angular/compiler';
-import {BaseException} from '../facade/exceptions';
+import {BaseException} from '@angular/core';
 import {global} from '../facade/lang';
 
 /**

--- a/modules/@angular/platform-browser-dynamic/test/xhr/xhr_cache_spec.ts
+++ b/modules/@angular/platform-browser-dynamic/test/xhr/xhr_cache_spec.ts
@@ -7,12 +7,11 @@
  */
 
 import {UrlResolver, XHR} from '@angular/compiler';
-import {Component} from '@angular/core';
+import {BaseException, Component} from '@angular/core';
 import {TestBed, TestComponentBuilder, fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {AsyncTestCompleter, beforeEach, beforeEachProviders, ddescribe, describe, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
 import {expect} from '@angular/platform-browser/testing/matchers';
 
-import {BaseException} from '../../src/facade/exceptions';
 import {CachedXHR} from '../../src/xhr/xhr_cache';
 
 import {setTemplateCache} from './xhr_cache_setter';

--- a/modules/@angular/platform-browser/src/dom/dom_renderer.ts
+++ b/modules/@angular/platform-browser/src/dom/dom_renderer.ts
@@ -6,11 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, OpaqueToken, RenderComponentType, Renderer, RootRenderer, ViewEncapsulation} from '@angular/core';
+import {BaseException, Inject, Injectable, OpaqueToken, RenderComponentType, Renderer, RootRenderer, ViewEncapsulation} from '@angular/core';
 
 import {AnimationKeyframe, AnimationPlayer, AnimationStyles, RenderDebugInfo} from '../../core_private';
 import {StringMapWrapper} from '../facade/collection';
-import {BaseException} from '../facade/exceptions';
 import {Json, StringWrapper, isArray, isBlank, isPresent, isString, stringify} from '../facade/lang';
 
 import {AnimationDriver} from './animation_driver';

--- a/modules/@angular/platform-browser/src/dom/events/event_manager.ts
+++ b/modules/@angular/platform-browser/src/dom/events/event_manager.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, NgZone, OpaqueToken} from '@angular/core';
+import {BaseException, Inject, Injectable, NgZone, OpaqueToken} from '@angular/core';
 
 import {ListWrapper} from '../../facade/collection';
-import {BaseException} from '../../facade/exceptions';
+
 
 
 /**

--- a/modules/@angular/platform-browser/src/dom/events/hammer_gestures.ts
+++ b/modules/@angular/platform-browser/src/dom/events/hammer_gestures.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, OpaqueToken} from '@angular/core';
+import {BaseException, Inject, Injectable, OpaqueToken} from '@angular/core';
 
-import {BaseException} from '../../facade/exceptions';
 import {isPresent} from '../../facade/lang';
 
 import {HammerGesturesPluginCommon} from './hammer_common';

--- a/modules/@angular/platform-browser/src/web_workers/shared/post_message_bus.ts
+++ b/modules/@angular/platform-browser/src/web_workers/shared/post_message_bus.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, NgZone} from '@angular/core';
+import {BaseException, Injectable, NgZone} from '@angular/core';
 
 import {EventEmitter} from '../../facade/async';
 import {StringMapWrapper} from '../../facade/collection';
-import {BaseException} from '../../facade/exceptions';
 
 import {MessageBus, MessageBusSink, MessageBusSource} from './message_bus';
+
 
 
 // TODO(jteplitz602) Replace this with the definition in lib.webworker.d.ts(#3492)

--- a/modules/@angular/platform-browser/src/web_workers/shared/serializer.ts
+++ b/modules/@angular/platform-browser/src/web_workers/shared/serializer.ts
@@ -6,15 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable, RenderComponentType, ViewEncapsulation} from '@angular/core';
+import {BaseException, Injectable, RenderComponentType, ViewEncapsulation} from '@angular/core';
 
 import {VIEW_ENCAPSULATION_VALUES} from '../../../core_private';
 import {Map, MapWrapper, StringMapWrapper} from '../../facade/collection';
-import {BaseException} from '../../facade/exceptions';
 import {Type, isArray, isPresent, serializeEnum} from '../../facade/lang';
 
 import {RenderStore} from './render_store';
 import {LocationType} from './serialized_types';
+
 
 
 // PRIMITIVE is any type that does not need to be serialized (string, number, boolean)

--- a/modules/@angular/platform-browser/src/web_workers/ui/event_dispatcher.ts
+++ b/modules/@angular/platform-browser/src/web_workers/ui/event_dispatcher.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import {EventEmitter} from '../../facade/async';
-import {BaseException} from '../../facade/exceptions';
 import {RenderStoreObject, Serializer} from '../shared/serializer';
 
 import {serializeEventWithTarget, serializeGenericEvent, serializeKeyboardEvent, serializeMouseEvent, serializeTransitionEvent} from './event_serializer';

--- a/modules/@angular/platform-browser/src/web_workers/worker/platform_location.ts
+++ b/modules/@angular/platform-browser/src/web_workers/worker/platform_location.ts
@@ -7,11 +7,10 @@
  */
 
 import {PlatformLocation, UrlChangeListener} from '@angular/common';
-import {Injectable} from '@angular/core';
+import {BaseException, Injectable} from '@angular/core';
 
 import {EventEmitter} from '../../facade/async';
 import {StringMapWrapper} from '../../facade/collection';
-import {BaseException} from '../../facade/exceptions';
 import {StringWrapper} from '../../facade/lang';
 import {ClientMessageBroker, ClientMessageBrokerFactory, FnArg, UiArguments} from '../shared/client_message_broker';
 import {MessageBus} from '../shared/message_bus';

--- a/modules/@angular/platform-browser/src/worker_render.ts
+++ b/modules/@angular/platform-browser/src/worker_render.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ExceptionHandler, Injectable, Injector, NgZone, OpaqueToken, PLATFORM_COMMON_PROVIDERS, PLATFORM_INITIALIZER, PlatformRef, ReflectiveInjector, RootRenderer, Testability, assertPlatform, createPlatform, createPlatformFactory, getPlatform, isDevMode, platformCore} from '@angular/core';
+import {BaseException, ExceptionHandler, Injectable, Injector, NgZone, OpaqueToken, PLATFORM_COMMON_PROVIDERS, PLATFORM_INITIALIZER, PlatformRef, ReflectiveInjector, RootRenderer, Testability, assertPlatform, createPlatform, createPlatformFactory, getPlatform, isDevMode, platformCore} from '@angular/core';
 
 import {wtfInit} from '../core_private';
 
@@ -22,7 +22,6 @@ import {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 import {HAMMER_GESTURE_CONFIG, HammerGestureConfig, HammerGesturesPlugin} from './dom/events/hammer_gestures';
 import {KeyEventsPlugin} from './dom/events/key_events';
 import {DomSharedStylesHost, SharedStylesHost} from './dom/shared_styles_host';
-import {BaseException} from './facade/exceptions';
 import {isBlank} from './facade/lang';
 import {ON_WEB_WORKER} from './web_workers/shared/api';
 import {ClientMessageBrokerFactory, ClientMessageBrokerFactory_} from './web_workers/shared/client_message_broker';

--- a/modules/@angular/platform-browser/test/web_workers/shared/web_worker_test_util.ts
+++ b/modules/@angular/platform-browser/test/web_workers/shared/web_worker_test_util.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
 import {NgZone} from '@angular/core/src/zone/ng_zone';
 import {ClientMessageBroker, ClientMessageBrokerFactory_, UiArguments} from '@angular/platform-browser/src/web_workers/shared/client_message_broker';
 import {MessageBus, MessageBusSink, MessageBusSource} from '@angular/platform-browser/src/web_workers/shared/message_bus';
+
 import {ListWrapper, StringMapWrapper} from '../../../src/facade/collection';
-import {BaseException} from '../../../src/facade/exceptions';
 import {Type, isPresent} from '../../../src/facade/lang';
 import {SpyMessageBroker} from '../worker/spies';
 

--- a/modules/@angular/platform-browser/testing/benchmark_util.ts
+++ b/modules/@angular/platform-browser/testing/benchmark_util.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BaseException} from '@angular/core';
+
 import {BrowserDomAdapter} from '../src/browser/browser_adapter';
 import {document, window} from '../src/facade/browser';
-import {BaseException} from '../src/facade/exceptions';
 import {NumberWrapper, isBlank} from '../src/facade/lang';
 
 var DOM = new BrowserDomAdapter();

--- a/modules/@angular/platform-server/src/parse5_adapter.ts
+++ b/modules/@angular/platform-server/src/parse5_adapter.ts
@@ -11,7 +11,7 @@ var parse5 = require('parse5/index');
 import {ListWrapper, StringMapWrapper} from '../src/facade/collection';
 import {DomAdapter, setRootDomAdapter} from '../platform_browser_private';
 import {isPresent, isBlank, global, Type, setValueOnPath, DateWrapper} from '../src/facade/lang';
-import {BaseException} from '../src/facade/exceptions';
+import {BaseException} from '@angular/core';
 import {SelectorMatcher, CssSelector} from '../compiler_private';
 import {XHR} from '@angular/compiler';
 

--- a/modules/playground/src/sourcemap/index.ts
+++ b/modules/playground/src/sourcemap/index.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component} from '@angular/core';
-import {BaseException} from '@angular/core/src/facade/exceptions';
+import {BaseException} from '@angular/core';
 import {bootstrap} from '@angular/platform-browser-dynamic';
 
 @Component({


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This lets us skip src/facade/exception\* when compiling modules other than core.
It prevents having many conflicting declarations
