### PR TITLE
fix(http): set body to string when null before processing toString fn

### DIFF
--- a/modules/@angular/http/src/body.ts
+++ b/modules/@angular/http/src/body.ts
@@ -41,6 +41,9 @@ export abstract class Body {
    * Returns the body as a string, presuming `toString()` can be called on the response body.
    */
   text(): string {
+
+    if(typeof this._body === null) this._body = '';
+
     if (this._body instanceof URLSearchParams) {
       return this._body.toString();
     }

--- a/modules/@angular/http/src/body.ts
+++ b/modules/@angular/http/src/body.ts
@@ -42,7 +42,7 @@ export abstract class Body {
    */
   text(): string {
 
-    if(typeof this._body === null) this._body = '';
+    if(this._body === null) this._body = '';
 
     if (this._body instanceof URLSearchParams) {
       return this._body.toString();

--- a/modules/@angular/http/src/body.ts
+++ b/modules/@angular/http/src/body.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Json, isString} from '../src/facade/lang';
+import {Json, isString, isPresent} from '../src/facade/lang';
 
 import {isJsObject, stringToArrayBuffer} from './http_utils';
 import {URLSearchParams} from './url_search_params';
@@ -41,15 +41,16 @@ export abstract class Body {
    * Returns the body as a string, presuming `toString()` can be called on the response body.
    */
   text(): string {
-
-    if(this._body === null) this._body = '';
-
     if (this._body instanceof URLSearchParams) {
       return this._body.toString();
     }
 
     if (this._body instanceof ArrayBuffer) {
       return String.fromCharCode.apply(null, new Uint16Array(<ArrayBuffer>this._body));
+    }
+
+    if (!isPresent(this._body)) {
+      return '';
     }
 
     if (isJsObject(this._body)) {

--- a/modules/@angular/http/test/static_request_spec.ts
+++ b/modules/@angular/http/test/static_request_spec.ts
@@ -77,5 +77,16 @@ export function main() {
         expect(req.detectContentType()).toEqual(ContentType.BLOB);
       });
     });
+
+    it('should return empty string if no body is given', () => {
+      const req = new Request(new RequestOptions({
+        url: 'test',
+        method: 'GET',
+        body: null,
+        headers: new Headers({'content-type': 'application/json'})
+      }));
+
+      expect(req.text()).toEqual('');
+    });
   });
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When body is null, toString function fails.

**What is the new behavior?**
When body is null, it gets converted to an empty string for toString function to work

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

N/A
