### PR TITLE
fix(compiler): Generate temporary variables for guarded expressions

### DIFF
--- a/modules/@angular/compiler/src/view_compiler/event_binder.ts
+++ b/modules/@angular/compiler/src/view_compiler/event_binder.ts
@@ -59,7 +59,8 @@ export class CompileEventListener {
     this._method.resetDebugInfo(this.compileElement.nodeIndex, hostEvent);
     var context = isPresent(directiveInstance) ? directiveInstance :
                                                  this.compileElement.view.componentContext;
-    var actionStmts = convertCdStatementToIr(this.compileElement.view, context, hostEvent.handler);
+    var actionStmts = convertCdStatementToIr(
+        this.compileElement.view, context, hostEvent.handler, this.compileElement.nodeIndex);
     var lastIndex = actionStmts.length - 1;
     if (lastIndex >= 0) {
       var lastStatement = actionStmts[lastIndex];


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

When generating code for null guarded expressions (using the `?.` operator) pipes and method calls are called twice. This can lead to incorrect behavior for pipes where the pipe might change value for the second invocation.

**What is the new behavior?**

Pipes and method calls are now only evaluated once and the result is saved in a temporary variable.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

Fixes: #10639
