### PR TITLE
fix(http): return empty string if no body is present

### DIFF
--- a/modules/@angular/http/src/body.ts
+++ b/modules/@angular/http/src/body.ts
@@ -49,6 +49,10 @@ export abstract class Body {
       return String.fromCharCode.apply(null, new Uint16Array(<ArrayBuffer>this._body));
     }
 
+    if (this._body === null) {
+      return '';
+    }
+
     if (isJsObject(this._body)) {
       return Json.stringify(this._body);
     }

--- a/modules/@angular/http/test/static_request_spec.ts
+++ b/modules/@angular/http/test/static_request_spec.ts
@@ -77,5 +77,16 @@ export function main() {
         expect(req.detectContentType()).toEqual(ContentType.BLOB);
       });
     });
+
+    it('should return empty string if no body is present', () => {
+      const req = new Request(new RequestOptions({
+        url: 'test',
+        method: 'GET',
+        body: null,
+        headers: new Headers({'content-type': 'application/json'})
+      }));
+
+      expect(req.text()).toEqual('');
+    });
   });
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
#10612

**What is the new behavior?**
Use 'isPresent' to check whether a body is present. If not return an empty string. 
This was the behavior before commit e7a8e2757b06d572f614f53b648d2fd75df370d2.

**Does this PR introduce a breaking change?** (check one with "x")

```
- [ ] Yes
- [x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Obsoletes #10635, but other solution and with tests
