### PR TITLE
fix(Headers): deep copy for constructor using existing Headers

### DIFF
--- a/modules/@angular/http/src/headers.ts
+++ b/modules/@angular/http/src/headers.ts
@@ -46,7 +46,7 @@ export class Headers {
   _headersMap: Map<string, string[]>;
   constructor(headers?: Headers|{[key: string]: any}) {
     if (headers instanceof Headers) {
-      this._headersMap = (<Headers>headers)._headersMap;
+      this._headersMap = new Map<string, string[]>((<Headers>headers)._headersMap);
       return;
     }
 

--- a/modules/@angular/http/test/headers_spec.ts
+++ b/modules/@angular/http/test/headers_spec.ts
@@ -42,6 +42,14 @@ export function main() {
         expect(headers.get('foo')).toBe('bar');
         expect(headers.getAll('foo')).toEqual(['bar']);
       });
+      it('should not alter the values of a provided header template', () => {
+        // Spec at https://fetch.spec.whatwg.org/#concept-headers-fill
+        // test for https://github.com/angular/angular/issues/6845
+        const firstHeaders = new Headers();
+        const secondHeaders = new Headers(firstHeaders);
+        secondHeaders.append('Content-Type', 'image/jpeg');
+        expect(firstHeaders.has('Content-Type')).toBeFalsy();
+      });
     });
 
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The headersMap of a new Headers object is a reference to the headersMap of an existing Headers object if the Headers object is specified in the constructor. Therefore header values which are added to the new Headers object are also added to the existing Headers object (see [#6845](https://github.com/angular/angular/issues/6845))

**What is the new behavior?**

When creating a new Headers object by passing an existing Headers object the underlying headersMap is now cloned. That also means that the existing Headers object is not altered when adding values to a Headers object which is based on it.
This behavior is in accordance with the [spec](https://fetch.spec.whatwg.org/#concept-headers-fill)

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: 
Breaks existing code which relies on the fact that Headers objects remain linked when based on each other. Since this is not in accordance with the spec the impact should be minimal.

**Other information**:

When creating a new Headers object using an existing Headers object
the existing Headers map is copied by reference. Therefore adding a
new Header value to the new Headers object also added this value to
the existing Headers object which is not in accordance with the
spec.
This commit alters the constructor to create a deep copy of existing
Headers maps and therefore unlink existing Headers from new Headers.

Closes #6845
BREAKING CHANGE: any code which relies on the fact that a newly
created Headers object is referencing an existing Headers map is
now broken, but that should normally not be the case since this
behavior is not documented and not in accordance with the spec.
