### PR TITLE
fix(datePipe): allow float for date pipe input

### DIFF
--- a/modules/@angular/common/src/pipes/date_pipe.ts
+++ b/modules/@angular/common/src/pipes/date_pipe.ts
@@ -104,7 +104,7 @@ export class DatePipe implements PipeTransform {
     }
 
     if (NumberWrapper.isNumeric(value)) {
-      value = DateWrapper.fromMillis(NumberWrapper.parseInt(value, 10));
+      value = DateWrapper.fromMillis(parseFloat(value));
     } else if (isString(value)) {
       value = DateWrapper.fromISOString(value);
     }

--- a/modules/@angular/common/test/pipes/date_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/date_pipe_spec.ts
@@ -36,6 +36,9 @@ export function main() {
         it('should support numeric strings',
            () => { expect(() => pipe.transform('123456789')).not.toThrow(); });
 
+        it('should support decimal strings',
+           () => { expect(() => pipe.transform('123456789.11')).not.toThrow(); });
+
         it('should support ISO string',
            () => { expect(() => pipe.transform('2015-06-15T21:43:11Z')).not.toThrow(); });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Date pipe accept decimal, but fails with Invalid integer literal when parsing  in base 10

**What is the new behavior?**
Date pipe accept decimal and work nice with it

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Closes #10125
