### PR TITLE
fix: use a global System.import() instead of using a property of the …

### DIFF
--- a/modules/@angular/core/src/linker/system_js_ng_module_factory_loader.ts
+++ b/modules/@angular/core/src/linker/system_js_ng_module_factory_loader.ts
@@ -8,11 +8,12 @@
 
 
 import {Injectable, Optional} from '../di';
-import {global} from '../facade/lang';
 
 import {Compiler} from './compiler';
 import {NgModuleFactory} from './ng_module_factory';
 import {NgModuleFactoryLoader} from './ng_module_factory_loader';
+
+declare var System: {import: (module: string) => Promise<any>;};
 
 const _SEPARATOR = '#';
 
@@ -36,8 +37,7 @@ export class SystemJsNgModuleLoader implements NgModuleFactoryLoader {
     let [module, exportName] = path.split(_SEPARATOR);
     if (exportName === undefined) exportName = 'default';
 
-    return (<any>global)
-        .System.import(module)
+    return System.import(module)
         .then((module: any) => module[exportName])
         .then((type: any) => checkNotEmpty(type, module, exportName))
         .then((type: any) => this._compiler.compileModuleAsync(type));
@@ -47,8 +47,7 @@ export class SystemJsNgModuleLoader implements NgModuleFactoryLoader {
     let [module, exportName] = path.split(_SEPARATOR);
     if (exportName === undefined) exportName = 'default';
 
-    return (<any>global)
-        .System.import(module + FACTORY_MODULE_SUFFIX)
+    return System.import(module + FACTORY_MODULE_SUFFIX)
         .then((module: any) => module[exportName + FACTORY_CLASS_SUFFIX])
         .then((factory: any) => checkNotEmpty(factory, module, exportName));
   }

--- a/modules/@angular/core/src/linker/systemjs_component_resolver.ts
+++ b/modules/@angular/core/src/linker/systemjs_component_resolver.ts
@@ -8,10 +8,12 @@
 
 import {Console} from '../console';
 import {Injectable} from '../di';
-import {global, isString} from '../facade/lang';
+import {isString} from '../facade/lang';
 import {Type} from '../type';
 import {ComponentFactory} from './component_factory';
 import {ComponentResolver} from './component_resolver';
+
+declare var System: {import: (module: string) => Promise<any>;};
 
 const _SEPARATOR = '#';
 
@@ -36,9 +38,8 @@ export class SystemJsComponentResolver implements ComponentResolver {
         component = 'default';
       }
 
-      return (<any>global)
-          .System.import(module)
-          .then((module: any) => this._resolver.resolveComponent(module[component]));
+      return System.import(module).then(
+          (module: any) => this._resolver.resolveComponent(module[component]));
     }
 
     return this._resolver.resolveComponent(componentType);
@@ -64,8 +65,7 @@ export class SystemJsCmpFactoryResolver implements ComponentResolver {
     if (isString(componentType)) {
       this._console.warn(ComponentResolver.LazyLoadingDeprecationMsg);
       let [module, factory] = componentType.split(_SEPARATOR);
-      return (<any>global)
-          .System.import(module + FACTORY_MODULE_SUFFIX)
+      return System.import(module + FACTORY_MODULE_SUFFIX)
           .then((module: any) => module[factory + FACTORY_CLASS_SUFFIX]);
     }
 


### PR DESCRIPTION
Some systems (webpack most notably) rely on looking for usage of `System` to make optimizations. Those systems are not clever enough to see that `global.System` is equivalent to `System` and fail to see the optimization in this case.

The only behavioural change is that, if there's no System object globally defined, this code will throw `ReferenceError: System not defined` instead of `TypeError: Cannot read property 'import' of undefined` as it currently does. It will only happen when those functions are called so that shouldn't change the behaviour of code that already works.
