### PR TITLE
fix: use the function as a key to create unique IDs per function

### DIFF
--- a/modules/@angular/compiler/src/compile_metadata.ts
+++ b/modules/@angular/compiler/src/compile_metadata.ts
@@ -87,6 +87,10 @@ export class CompileAnimationGroupMetadata extends CompileAnimationWithStepsMeta
   constructor(steps: CompileAnimationMetadata[] = null) { super(steps); }
 }
 
+
+const identifierHashKey = '__identifierHashKey__';
+let nextAssetCacheKeyId = 1;
+
 export class CompileIdentifierMetadata implements CompileMetadataWithIdentifier {
   runtime: any;
   name: string;
@@ -113,7 +117,14 @@ export class CompileIdentifierMetadata implements CompileMetadataWithIdentifier 
     if (this._assetCacheKey === UNDEFINED) {
       if (isPresent(this.moduleUrl) && isPresent(getUrlScheme(this.moduleUrl))) {
         var uri = reflector.importUri({'filePath': this.moduleUrl, 'name': this.name});
-        this._assetCacheKey = `${this.name}|${uri}`;
+        if (this.runtime) {
+          if (!this.runtime[identifierHashKey]) {
+            this.runtime[identifierHashKey] = ++nextAssetCacheKeyId;
+          }
+          this._assetCacheKey = `${this.name}|${uri}|${this.runtime[identifierHashKey]}`;
+        } else {
+          this._assetCacheKey = `${this.name}|${uri}`;
+        }
       } else {
         this._assetCacheKey = null;
       }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
The code uses the name of the function, but when it's minimized (or the same component class name) it collides and think that both components are the same.

Fixes #10618
