### PR TITLE
feat(forms): add NgForm method that resets submit state

### DIFF
--- a/modules/@angular/forms/src/directives/ng_form.ts
+++ b/modules/@angular/forms/src/directives/ng_form.ts
@@ -174,7 +174,12 @@ export class NgForm extends ControlContainer implements Form {
     return false;
   }
 
-  onReset(): void { this.form.reset(); }
+  onReset(): void { this.resetForm(); }
+
+  resetForm(value: any = undefined): void {
+    this.form.reset(value);
+    this._submitted = false;
+  }
 
   /** @internal */
   _findContainer(path: string[]): FormGroup {

--- a/modules/@angular/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/modules/@angular/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -185,7 +185,12 @@ export class FormGroupDirective extends ControlContainer implements Form,
     return false;
   }
 
-  onReset(): void { this.form.reset(); }
+  onReset(): void { this.resetForm(); }
+
+  resetForm(value: any = undefined): void {
+    this.form.reset(value);
+    this._submitted = false;
+  }
 
   /** @internal */
   _updateDomValue() {

--- a/modules/@angular/forms/test/template_integration_spec.ts
+++ b/modules/@angular/forms/test/template_integration_spec.ts
@@ -150,6 +150,33 @@ export function main() {
          expect(form.value.name).toEqual(null);
        })));
 
+    it('should reset the form submit state when reset button is clicked',
+       fakeAsync(inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {
+         const t = `
+                <form>
+                  <input name="name" [(ngModel)]="name">
+                </form>
+               `;
+
+         const fixture = tcb.overrideTemplate(MyComp8, t).createFakeAsync(MyComp8);
+         tick();
+         fixture.debugElement.componentInstance.name = '';
+         fixture.detectChanges();
+         tick();
+
+         const form = fixture.debugElement.children[0].injector.get(NgForm);
+         const formEl = fixture.debugElement.query(By.css('form'));
+
+         dispatchEvent(formEl.nativeElement, 'submit');
+         fixture.detectChanges();
+         tick();
+
+         dispatchEvent(formEl.nativeElement, 'reset');
+         fixture.detectChanges();
+         tick();
+         expect(form.submitted).toEqual(false);
+       })));
+
 
     it('should emit valueChanges and statusChanges on init',
        fakeAsync(inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -301,6 +301,7 @@ export declare class FormGroupDirective extends ControlContainer implements Form
     removeControl(dir: NgControl): void;
     removeFormArray(dir: FormArrayName): void;
     removeFormGroup(dir: FormGroupName): void;
+    resetForm(value?: any): void;
     updateModel(dir: NgControl, value: any): void;
 }
 
@@ -378,6 +379,7 @@ export declare class NgForm extends ControlContainer implements Form {
     onSubmit(): boolean;
     removeControl(dir: NgModel): void;
     removeFormGroup(dir: NgModelGroup): void;
+    resetForm(value?: any): void;
     setValue(value: {
         [key: string]: any;
     }): void;


### PR DESCRIPTION
This PR adds a `resetForm` method to top level form directives: `NgForm` and `FormGroupDirective`.   These directives have a concept of submission (through the `submitted` property) that does not exist for form control models, so it cannot just fall through to the existing resetting mechanism on `AbstractControls`.    So when you'd like to reset the form from the top level and set `submitted` to false, use `resetForm()` instead.

This PR also ensures that native reset buttons will reset submitted to false as well.

**Before**

``` ts
@Component({
   selector: 'my-comp',
   template: `
     <form>
        <input name="first" ngModel>
     </form>
  `
})
class MyComp {
  @ViewChild(NgForm) form: NgForm;

  reset() {
    this.form.reset();    // calls FormGroup reset(), submitted == true;
  }

}
```

**After**

``` ts
@Component({
   selector: 'my-comp',
   template: `
     <form>
        <input name="first" ngModel>
     </form>
  `
})
class MyComp {
  @ViewChild(NgForm) form: NgForm;

  reset() {
    this.form.resetForm();       // calls FormGroup reset(), submitted == false
  }
}
```

Note: this is not a breaking change, as the original `reset()` method of `NgForm` still exists and works the same way.
