### PR TITLE
fix(forms): remove deprecated form provider functions

### DIFF
--- a/modules/@angular/forms/src/form_providers.ts
+++ b/modules/@angular/forms/src/form_providers.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModule, PLATFORM_DIRECTIVES, Type} from '@angular/core';
+import {NgModule, Type} from '@angular/core';
 
-import {FORM_DIRECTIVES, InternalFormsSharedModule, REACTIVE_DRIVEN_DIRECTIVES, REACTIVE_FORM_DIRECTIVES, SHARED_FORM_DIRECTIVES, TEMPLATE_DRIVEN_DIRECTIVES} from './directives';
+import {InternalFormsSharedModule, REACTIVE_DRIVEN_DIRECTIVES, TEMPLATE_DRIVEN_DIRECTIVES} from './directives';
 import {RadioControlRegistry} from './directives/radio_control_value_accessor';
 import {FormBuilder} from './form_builder';
 
@@ -48,20 +48,4 @@ export class FormsModule {
   exports: [InternalFormsSharedModule, REACTIVE_DRIVEN_DIRECTIVES]
 })
 export class ReactiveFormsModule {
-}
-
-/**
- * @deprecated
- */
-export function disableDeprecatedForms(): any[] {
-  return [];
-}
-
-/**
- * @deprecated
- */
-export function provideForms(): any[] {
-  return [
-    {provide: PLATFORM_DIRECTIVES, useValue: FORM_DIRECTIVES, multi: true}, REACTIVE_FORM_PROVIDERS
-  ];
 }

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -125,9 +125,6 @@ export declare class DefaultValueAccessor implements ControlValueAccessor {
     writeValue(value: any): void;
 }
 
-/** @deprecated */
-export declare function disableDeprecatedForms(): any[];
-
 /** @experimental */
 export interface Form {
     addControl(dir: NgControl): void;
@@ -422,9 +419,6 @@ export declare class PatternValidator implements Validator {
         [key: string]: any;
     };
 }
-
-/** @deprecated */
-export declare function provideForms(): any[];
 
 /** @experimental */
 export declare const REACTIVE_FORM_DIRECTIVES: Type<any>[][];


### PR DESCRIPTION
This PR removes the deprecated functions, `provideForms()` and `disableDeprecatedForms()`.  Instead import the `FormsModule` and/or the `ReactiveFormsModule` into your app.
