### PR TITLE
refactor(core): Removed deprecated properties and events from metadata

### DIFF
--- a/modules/@angular/core/src/metadata/directives.ts
+++ b/modules/@angular/core/src/metadata/directives.ts
@@ -19,9 +19,7 @@ import {ViewEncapsulation} from './view';
  */
 export interface DirectiveMetadataType {
   selector?: string;
-  properties?: string[];
   inputs?: string[];
-  events?: string[];
   outputs?: string[];
   host?: {[key: string]: string};
   providers?: any[];
@@ -492,18 +490,8 @@ export class DirectiveMetadata extends InjectableMetadata implements DirectiveMe
    * ```
    *
    */
-  get inputs(): string[] {
-    return isPresent(this._properties) && this._properties.length > 0 ? this._properties :
-                                                                        this._inputs;
-  }
-  /**
-   * Use `inputs` instead
-   *
-   * @deprecated
-   */
-  get properties(): string[] { return this.inputs; }
+  get inputs(): string[] { return this._inputs; }
   private _inputs: string[];
-  private _properties: string[];
 
   /**
    * Enumerates the set of event-bound output properties.
@@ -550,17 +538,8 @@ export class DirectiveMetadata extends InjectableMetadata implements DirectiveMe
    * ```
    *
    */
-  get outputs(): string[] {
-    return isPresent(this._events) && this._events.length > 0 ? this._events : this._outputs;
-  }
-  /**
-   * Use `outputs` instead
-   *
-   * @deprecated
-   */
-  get events(): string[] { return this.outputs; }
+  get outputs(): string[] { return this._outputs; }
   private _outputs: string[];
-  private _events: string[];
 
   /**
    * Specify the events, actions, properties and attributes related to the host element.
@@ -764,14 +743,11 @@ export class DirectiveMetadata extends InjectableMetadata implements DirectiveMe
   queries: {[key: string]: any};
 
   constructor(
-      {selector, inputs, outputs, properties, events, host, providers, exportAs,
-       queries}: DirectiveMetadataType = {}) {
+      {selector, inputs, outputs, host, providers, exportAs, queries}: DirectiveMetadataType = {}) {
     super();
     this.selector = selector;
     this._inputs = inputs;
-    this._properties = properties;
     this._outputs = outputs;
-    this._events = events;
     this.host = host;
     this.exportAs = exportAs;
     this.queries = queries;
@@ -1022,34 +998,17 @@ export class ComponentMetadata extends DirectiveMetadata implements ComponentMet
    */
   entryComponents: Array<Type<any>|any[]>;
 
-  constructor({selector,
-               inputs,
-               outputs,
-               properties,
-               events,
-               host,
-               exportAs,
-               moduleId,
-               providers,
-               viewProviders,
-               changeDetection = ChangeDetectionStrategy.Default,
-               queries,
-               templateUrl,
-               template,
-               styleUrls,
-               styles,
-               animations,
-               directives,
-               pipes,
-               encapsulation,
-               interpolation,
-               entryComponents}: ComponentMetadataType = {}) {
+  constructor({selector,      inputs,         outputs,
+               host,          exportAs,       moduleId,
+               providers,     viewProviders,  changeDetection = ChangeDetectionStrategy.Default,
+               queries,       templateUrl,    template,
+               styleUrls,     styles,         animations,
+               directives,    pipes,          encapsulation,
+               interpolation, entryComponents}: ComponentMetadataType = {}) {
     super({
       selector: selector,
       inputs: inputs,
       outputs: outputs,
-      properties: properties,
-      events: events,
       host: host,
       exportAs: exportAs,
       providers: providers,

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -310,7 +310,7 @@ export declare class ComponentMetadata extends DirectiveMetadata implements Comp
     template: string;
     templateUrl: string;
     viewProviders: any[];
-    constructor({selector, inputs, outputs, properties, events, host, exportAs, moduleId, providers, viewProviders, changeDetection, queries, templateUrl, template, styleUrls, styles, animations, directives, pipes, encapsulation, interpolation, entryComponents}?: ComponentMetadataType);
+    constructor({selector, inputs, outputs, host, exportAs, moduleId, providers, viewProviders, changeDetection, queries, templateUrl, template, styleUrls, styles, animations, directives, pipes, encapsulation, interpolation, entryComponents}?: ComponentMetadataType);
 }
 
 /** @stable */
@@ -498,20 +498,18 @@ export interface DirectiveDecorator extends TypeDecorator {
 
 /** @stable */
 export declare class DirectiveMetadata extends InjectableMetadata implements DirectiveMetadataType {
-    /** @deprecated */ events: string[];
     exportAs: string;
     host: {
         [key: string]: string;
     };
     inputs: string[];
     outputs: string[];
-    /** @deprecated */ properties: string[];
     providers: any[];
     queries: {
         [key: string]: any;
     };
     selector: string;
-    constructor({selector, inputs, outputs, properties, events, host, providers, exportAs, queries}?: DirectiveMetadataType);
+    constructor({selector, inputs, outputs, host, providers, exportAs, queries}?: DirectiveMetadataType);
 }
 
 /** @stable */
@@ -522,14 +520,12 @@ export interface DirectiveMetadataFactory {
 
 /** @experimental */
 export interface DirectiveMetadataType {
-    events?: string[];
     exportAs?: string;
     host?: {
         [key: string]: string;
     };
     inputs?: string[];
     outputs?: string[];
-    properties?: string[];
     providers?: any[];
     queries?: {
         [key: string]: any;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

`DirectiveMetadataType` contains the deprecated fields `properties` and `events` that need to be removed.

**What is the new behavior?**

Removed `DirectiveMetadataType` the deprecated fields `properties` and `events`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

The type `DirectiveMetadataType` no longer supports `properties` and `events` as alias for `inputs` and `outputs`.

**Other information**:

BREAKING CHANGE: previously deprecated DirectiveMetadataType#properties and DirectiveMetadataType#events were removed; see deprecation notice for migration instructions.
