### PR TITLE
fix(testing): override metadata subclasses properly

### DIFF
--- a/modules/@angular/compiler/test/metadata_overrider_spec.ts
+++ b/modules/@angular/compiler/test/metadata_overrider_spec.ts
@@ -15,6 +15,10 @@ interface SomeMetadataType {
   arrayProp?: any[];
 }
 
+interface OtherMetadataType extends SomeMetadataType {
+  otherPlainProp?: string;
+}
+
 class SomeMetadata implements SomeMetadataType {
   plainProp: string;
   private _getterProp: string;
@@ -25,6 +29,20 @@ class SomeMetadata implements SomeMetadataType {
     this.plainProp = options.plainProp;
     this._getterProp = options.getterProp;
     this.arrayProp = options.arrayProp;
+  }
+}
+
+class OtherMetadata extends SomeMetadata implements OtherMetadataType {
+  otherPlainProp: string;
+
+  constructor(options: OtherMetadataType) {
+    super({
+      plainProp: options.plainProp,
+      getterProp: options.getterProp,
+      arrayProp: options.arrayProp
+    });
+
+    this.otherPlainProp = options.otherPlainProp;
   }
 }
 
@@ -111,6 +129,24 @@ export function main() {
         expect(instance3).toEqual(new SomeMetadata({arrayProp: [Class2]}));
 
       });
+    });
+
+    describe('subclasses', () => {
+      it('should set individual properties and keep others', () => {
+        const oldInstance = new OtherMetadata({
+          plainProp: 'somePlainProp',
+          getterProp: 'someGetterProp',
+          otherPlainProp: 'newOtherProp'
+        });
+        const newInstance = overrider.overrideMetadata(
+            OtherMetadata, oldInstance, {set: {plainProp: 'newPlainProp'}});
+        expect(newInstance).toEqual(new OtherMetadata({
+          plainProp: 'newPlainProp',
+          getterProp: 'someGetterProp',
+          otherPlainProp: 'newOtherProp'
+        }));
+      });
+
     });
   });
 }

--- a/modules/@angular/compiler/testing/metadata_overrider.ts
+++ b/modules/@angular/compiler/testing/metadata_overrider.ts
@@ -118,13 +118,16 @@ function _valueProps(obj: any): string[] {
       props.push(prop);
     }
   });
+
   // getters
-  const proto = Object.getPrototypeOf(obj);
-  Object.keys(proto).forEach((protoProp) => {
-    var desc = Object.getOwnPropertyDescriptor(proto, protoProp);
-    if (!protoProp.startsWith('_') && desc && 'get' in desc) {
-      props.push(protoProp);
-    }
-  });
+  let proto = obj;
+  while (proto = Object.getPrototypeOf(proto)) {
+    Object.keys(proto).forEach((protoProp) => {
+      var desc = Object.getOwnPropertyDescriptor(proto, protoProp);
+      if (!protoProp.startsWith('_') && desc && 'get' in desc) {
+        props.push(protoProp);
+      }
+    });
+  }
   return props;
 }


### PR DESCRIPTION
This fixes an issue where `TestBed.overrideComponent(MyComp, {})`
would remove some properties including `providers` from the component.

This was due to the override not properly dealing with getter fields
on subclasses.
