### PR TITLE
docs(NgTemplateOutlet): improve documentation

### DIFF
--- a/modules/@angular/common/src/directives/ng_template_outlet.ts
+++ b/modules/@angular/common/src/directives/ng_template_outlet.ts
@@ -19,9 +19,21 @@ import {Directive, EmbeddedViewRef, Input, OnChanges, TemplateRef, ViewContainer
  * ### Syntax
  *
  * ```
- * <template [ngTemplateOutlet]="templateRefExpression"
- *           [ngOutletContext]="objectExpression">
+ * <ng-container [ngTemplateOutlet]="templateRefExpression"
+ *               [ngOutletContext]="objectExpression">
+ * </ng-container>
+ * ```
+ *
+ * ### Example
+ *
+ * ```
+ * <template #t let-foo let-bar="explicit">
+ *   <p>{{foo}}{{bar}}</p>
  * </template>
+ *
+ * <ng-container [ngTemplateOutlet]="t"
+ *               [ngOutletContext]="{'$implicit': 'Foo', explicit: 'Bar'}">
+ * </ng-container>
  * ```
  *
  * @experimental


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Documentation is not enough.

**What is the new behavior?**

Add example code and use `<ng-container>` as the location of `NgTemplateOutlet`.
Currently, `<template>` element is used. Users probably confuse `<template>` with `TemplateRef`.
To simplify, I think `<ng-container>` is good stuff.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
