### PR TITLE
fix(core): optional eventObj for DebugNode.triggerEventHandler

### DIFF
--- a/modules/@angular/core/src/debug/debug_node.ts
+++ b/modules/@angular/core/src/debug/debug_node.ts
@@ -131,7 +131,7 @@ export class DebugElement extends DebugNode {
     return children;
   }
 
-  triggerEventHandler(eventName: string, eventObj: any) {
+  triggerEventHandler(eventName: string, eventObj?: any) {
     this.listeners.forEach((listener) => {
       if (listener.name == eventName) {
         listener.callback(eventObj);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
  **What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[?] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Many (most?) triggers don't have an event object. Yet forced to write `btn.triggerEventHandler('click', null);`

The code works (or doesn't) when the event object is null or undefined. This change has no effect on that. It just makes the TypeScript syntax friendlier to the developer.

**What is the new behavior?**

Can write  `btn.triggerEventHandler('click');`

It's easier and makes sense.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Can write `btn.triggerEventHandler('click')` instead of  `btn.triggerEventHandler('click', null)`
