### PR TITLE
[i18n] xliff support

### DIFF
--- a/modules/@angular/compiler-cli/integrationtest/src/messages.fi.xlf
+++ b/modules/@angular/compiler-cli/integrationtest/src/messages.fi.xlf
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" datatype="plaintext" original="ng2.template">
+        <body>
+            <trans-unit id="76e1eccb1b772fa9f294ef9c146ea6d0efa8a2d4" datatype="html">
+                <source>translate me</source>
+                <target>käännä teksti</target>
+                <note priority="1" from="description">desc</note>
+                <note priority="1" from="meaning">meaning</note>
+            </trans-unit>
+            <trans-unit id="65cc4ab3b4c438e07c89be2b677d08369fb62da2" datatype="html">
+                <source>Welcome</source>
+                <target>tervetuloa</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/modules/@angular/compiler-cli/integrationtest/src/messages.fi.xtb
+++ b/modules/@angular/compiler-cli/integrationtest/src/messages.fi.xtb
@@ -1,3 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE translationbundle [<!ELEMENT translationbundle (translation)*>
+<!ATTLIST translationbundle lang CDATA #REQUIRED>
+<!ELEMENT translation (#PCDATA|ph)*>
+<!ATTLIST translation id CDATA #REQUIRED>
+<!ELEMENT ph EMPTY>
+<!ATTLIST ph name CDATA #REQUIRED>
+]>
 <translationbundle>
   <translation id="76e1eccb1b772fa9f294ef9c146ea6d0efa8a2d4">käännä teksti</translation>
   <translation id="65cc4ab3b4c438e07c89be2b677d08369fb62da2">tervetuloa</translation>

--- a/modules/@angular/compiler-cli/integrationtest/test/basic_spec.ts
+++ b/modules/@angular/compiler-cli/integrationtest/test/basic_spec.ts
@@ -73,7 +73,7 @@ describe('template codegen output', () => {
 
     it('should inject the translations format into the component', () => {
       const compFixture = createComponent(BasicComp);
-      expect(compFixture.componentInstance.translationsFormat).toEqual('xtb');
+      expect(compFixture.componentInstance.translationsFormat).toEqual('xlf');
     });
 
     it('should support i18n for content tags', () => {

--- a/modules/@angular/compiler-cli/integrationtest/test/i18n_spec.ts
+++ b/modules/@angular/compiler-cli/integrationtest/test/i18n_spec.ts
@@ -15,7 +15,7 @@ describe('template i18n extraction output', () => {
   const outDir = '';
 
   it('should extract i18n messages', () => {
-    const EXPECTED = `<? xml version="1.0" encoding="UTF-8" ?>
+    const EXPECTED = `<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE messagebundle [
 <!ELEMENT messagebundle (msg)*>
 <!ATTLIST messagebundle class CDATA #IMPLIED>

--- a/modules/@angular/compiler-cli/integrationtest/test/i18n_spec.ts
+++ b/modules/@angular/compiler-cli/integrationtest/test/i18n_spec.ts
@@ -11,11 +11,7 @@ import './init';
 import * as fs from 'fs';
 import * as path from 'path';
 
-describe('template i18n extraction output', () => {
-  const outDir = '';
-
-  it('should extract i18n messages', () => {
-    const EXPECTED = `<?xml version="1.0" encoding="UTF-8" ?>
+const EXPECTED_XMB = `<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE messagebundle [
 <!ELEMENT messagebundle (msg)*>
 <!ATTLIST messagebundle class CDATA #IMPLIED>
@@ -42,9 +38,39 @@ describe('template i18n extraction output', () => {
   <msg id="65cc4ab3b4c438e07c89be2b677d08369fb62da2">Welcome</msg>
 </messagebundle>`;
 
+const EXPECTED_XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+ <file source-language="en" datatype="plaintext" original="ng2.template">
+   <body>
+     <trans-unit id="76e1eccb1b772fa9f294ef9c146ea6d0efa8a2d4" datatype="html">
+       <source>translate me</source>
+       <target/>
+       <note priority="1" from="description">desc</note>
+       <note priority="1" from="meaning">meaning</note>
+     </trans-unit>
+     <trans-unit id="65cc4ab3b4c438e07c89be2b677d08369fb62da2" datatype="html">
+       <source>Welcome</source>
+       <target/>
+     </trans-unit>
+   </body>
+ </file>
+</xliff>`;
+
+describe('template i18n extraction output', () => {
+  const outDir = '';
+
+  it('should extract i18n messages as xmb', () => {
     const xmbOutput = path.join(outDir, 'messages.xmb');
     expect(fs.existsSync(xmbOutput)).toBeTruthy();
     const xmb = fs.readFileSync(xmbOutput, {encoding: 'utf-8'});
-    expect(xmb).toEqual(EXPECTED);
+    expect(xmb).toEqual(EXPECTED_XMB);
   });
+
+  it('should extract i18n messages as xliff', () => {
+    const xlfOutput = path.join(outDir, 'messages.xlf');
+    expect(fs.existsSync(xlfOutput)).toBeTruthy();
+    const xlf = fs.readFileSync(xlfOutput, {encoding: 'utf-8'});
+    expect(xlf).toEqual(EXPECTED_XLIFF);
+  });
+
 });

--- a/modules/@angular/compiler-cli/src/codegen.ts
+++ b/modules/@angular/compiler-cli/src/codegen.ts
@@ -144,7 +144,8 @@ export class CodeGenerator {
     const reflectorHost = new ReflectorHost(program, compilerHost, options, reflectorHostContext);
     const staticReflector = new StaticReflector(reflectorHost);
     StaticAndDynamicReflectionCapabilities.install(staticReflector);
-    const htmlParser = new compiler.i18n.HtmlParser(new HtmlParser(), transContent);
+    const htmlParser =
+        new compiler.i18n.HtmlParser(new HtmlParser(), transContent, cliOptions.i18nFormat);
     const config = new compiler.CompilerConfig({
       genDebugInfo: options.debug === true,
       defaultEncapsulation: ViewEncapsulation.Emulated,
@@ -161,6 +162,7 @@ export class CodeGenerator {
         new compiler.NgModuleResolver(staticReflector),
         new compiler.DirectiveResolver(staticReflector), new compiler.PipeResolver(staticReflector),
         config, console, elementSchemaRegistry, staticReflector);
+    // TODO(vicb): do not pass cliOptions.i18nFormat here
     const offlineCompiler = new compiler.OfflineCompiler(
         resolver, normalizer, tmplParser, new StyleCompiler(urlResolver), new ViewCompiler(config),
         new NgModuleCompiler(), new TypeScriptEmitter(reflectorHost), cliOptions.locale,

--- a/modules/@angular/compiler/index.ts
+++ b/modules/@angular/compiler/index.ts
@@ -14,7 +14,7 @@
 import * as i18n from './src/i18n/index';
 
 export {COMPILER_PROVIDERS, CompileDiDependencyMetadata, CompileDirectiveMetadata, CompileFactoryMetadata, CompileIdentifierMetadata, CompileMetadataWithIdentifier, CompilePipeMetadata, CompileProviderMetadata, CompileQueryMetadata, CompileTemplateMetadata, CompileTokenMetadata, CompileTypeMetadata, CompilerConfig, DEFAULT_PACKAGE_URL_PROVIDER, DirectiveResolver, NgModuleResolver, OfflineCompiler, PipeResolver, RenderTypes, RuntimeCompiler, SourceModule, TEMPLATE_TRANSFORMS, UrlResolver, XHR, analyzeAppProvidersForDeprecatedConfiguration, createOfflineCompileUrlResolver, platformCoreDynamic} from './src/compiler';
-export {InterpolationConfig} from './src/ml_parser/interpolation_config';
+export {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from './src/ml_parser/interpolation_config';
 export {ElementSchemaRegistry} from './src/schema/element_schema_registry';
 export {i18n};
 

--- a/modules/@angular/compiler/src/compiler.ts
+++ b/modules/@angular/compiler/src/compiler.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {COMPILER_OPTIONS, Compiler, CompilerFactory, CompilerOptions, Component, Inject, Injectable, OptionalMetadata, PLATFORM_INITIALIZER, PlatformRef, Provider, ReflectiveInjector, TRANSLATIONS, Type, ViewEncapsulation, createPlatformFactory, isDevMode, platformCore} from '@angular/core';
+import {COMPILER_OPTIONS, Compiler, CompilerFactory, CompilerOptions, Component, Inject, Injectable, OptionalMetadata, PLATFORM_INITIALIZER, PlatformRef, Provider, ReflectiveInjector, TRANSLATIONS, TRANSLATIONS_FORMAT, Type, ViewEncapsulation, createPlatformFactory, isDevMode, platformCore} from '@angular/core';
 
 export * from './template_parser/template_ast';
 export {TEMPLATE_TRANSFORMS} from './template_parser/template_parser';
@@ -63,9 +63,13 @@ export const COMPILER_PROVIDERS: Array<any|Type<any>|{[k: string]: any}|any[]> =
   HtmlParser,
   {
     provide: i18n.HtmlParser,
-    useFactory: (parser: HtmlParser, translations: string) =>
-                    new i18n.HtmlParser(parser, translations),
-    deps: [HtmlParser, [new OptionalMetadata(), new Inject(TRANSLATIONS)]]
+    useFactory: (parser: HtmlParser, translations: string, format: string) =>
+                    new i18n.HtmlParser(parser, translations, format),
+    deps: [
+      HtmlParser,
+      [new OptionalMetadata(), new Inject(TRANSLATIONS)],
+      [new OptionalMetadata(), new Inject(TRANSLATIONS_FORMAT)],
+    ]
   },
   TemplateParser,
   DirectiveNormalizer,

--- a/modules/@angular/compiler/src/i18n/index.ts
+++ b/modules/@angular/compiler/src/i18n/index.ts
@@ -9,5 +9,6 @@
 export {HtmlParser} from './html_parser';
 export {MessageBundle} from './message_bundle';
 export {Serializer} from './serializers/serializer';
+export {Xliff} from './serializers/xliff';
 export {Xmb} from './serializers/xmb';
 export {Xtb} from './serializers/xtb';

--- a/modules/@angular/compiler/src/i18n/serializers/xliff.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/xliff.ts
@@ -1,0 +1,289 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ListWrapper} from '../../facade/collection';
+import * as ml from '../../ml_parser/ast';
+import {HtmlParser} from '../../ml_parser/html_parser';
+import {InterpolationConfig} from '../../ml_parser/interpolation_config';
+import {XmlParser} from '../../ml_parser/xml_parser';
+import {ParseError} from '../../parse_util';
+import * as i18n from '../i18n_ast';
+import {MessageBundle} from '../message_bundle';
+import {I18nError} from '../parse_util';
+
+import {Serializer, extractPlaceholderToIds, extractPlaceholders} from './serializer';
+import * as xml from './xml_helper';
+
+const _VERSION = '1.2';
+const _XMLNS = 'urn:oasis:names:tc:xliff:document:1.2';
+// TODO(vicb): make this a param (s/_/-/)
+const _SOURCE_LANG = 'en';
+const _PLACEHOLDER_TAG = 'x';
+const _SOURCE_TAG = 'source';
+const _TARGET_TAG = 'target';
+const _UNIT_TAG = 'trans-unit';
+const _CR = (ws: number = 0) => new xml.Text(`\n${new Array(ws).join(' ')}`);
+
+// http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html
+// http://docs.oasis-open.org/xliff/v1.2/xliff-profile-html/xliff-profile-html-1.2.html
+export class Xliff implements Serializer {
+  constructor(private _htmlParser: HtmlParser, private _interpolationConfig: InterpolationConfig) {}
+
+  write(messageMap: {[id: string]: i18n.Message}): string {
+    const visitor = new _WriteVisitor();
+
+    const transUnits: xml.Node[] = [];
+
+    Object.keys(messageMap).forEach((id) => {
+      const message = messageMap[id];
+
+      let transUnit = new xml.Tag(_UNIT_TAG, {id: id, datatype: 'html'});
+      transUnit.children.push(
+          _CR(8), new xml.Tag(_SOURCE_TAG, {}, visitor.serialize(message.nodes)), _CR(8),
+          new xml.Tag(_TARGET_TAG));
+
+      if (message.description) {
+        transUnit.children.push(
+            _CR(8),
+            new xml.Tag(
+                'note', {priority: '1', from: 'description'}, [new xml.Text(message.description)]));
+      }
+
+      if (message.meaning) {
+        transUnit.children.push(
+            _CR(8),
+            new xml.Tag('note', {priority: '1', from: 'meaning'}, [new xml.Text(message.meaning)]));
+      }
+
+      transUnit.children.push(_CR(6));
+
+      transUnits.push(_CR(6), transUnit);
+    });
+
+    const body = new xml.Tag('body', {}, [...transUnits, _CR(4)]);
+    const file = new xml.Tag(
+        'file', {'source-language': _SOURCE_LANG, datatype: 'plaintext', original: 'ng2.template'},
+        [_CR(4), body, _CR(2)]);
+    const xliff = new xml.Tag('xliff', {version: _VERSION, xmlns: _XMLNS}, [_CR(2), file, _CR()]);
+
+    return xml.serialize([new xml.Declaration({version: '1.0', encoding: 'UTF-8'}), _CR(), xliff]);
+  }
+
+  load(content: string, url: string, messageBundle: MessageBundle): {[id: string]: ml.Node[]} {
+    // Parse the xtb file into xml nodes
+    const result = new XmlParser().parse(content, url);
+
+    if (result.errors.length) {
+      throw new Error(`xtb parse errors:\n${result.errors.join('\n')}`);
+    }
+
+    // Replace the placeholders, messages are now string
+    const {messages, errors} = new _LoadVisitor().parse(result.rootNodes, messageBundle);
+
+    if (errors.length) {
+      throw new Error(`xtb parse errors:\n${errors.join('\n')}`);
+    }
+
+    // Convert the string messages to html ast
+    // TODO(vicb): map error message back to the original message in xtb
+    let messageMap: {[id: string]: ml.Node[]} = {};
+    const parseErrors: ParseError[] = [];
+
+    Object.keys(messages).forEach((id) => {
+      const res = this._htmlParser.parse(messages[id], url, true, this._interpolationConfig);
+      parseErrors.push(...res.errors);
+      messageMap[id] = res.rootNodes;
+    });
+
+    if (parseErrors.length) {
+      throw new Error(`xtb parse errors:\n${parseErrors.join('\n')}`);
+    }
+
+    return messageMap;
+  }
+}
+
+class _WriteVisitor implements i18n.Visitor {
+  private _isInIcu: boolean;
+
+  visitText(text: i18n.Text, context?: any): xml.Node[] { return [new xml.Text(text.value)]; }
+
+  visitContainer(container: i18n.Container, context?: any): xml.Node[] {
+    const nodes: xml.Node[] = [];
+    container.children.forEach((node: i18n.Node) => nodes.push(...node.visit(this)));
+    return nodes;
+  }
+
+  visitIcu(icu: i18n.Icu, context?: any): xml.Node[] {
+    if (this._isInIcu) {
+      // nested ICU is not supported
+      throw new Error('xliff does not support nested ICU messages');
+    }
+    this._isInIcu = true;
+
+    // TODO(vicb): support ICU messages
+    // https://lists.oasis-open.org/archives/xliff/201201/msg00028.html
+    // http://docs.oasis-open.org/xliff/v1.2/xliff-profile-po/xliff-profile-po-1.2-cd02.html
+    const nodes: xml.Node[] = [];
+
+    this._isInIcu = false;
+
+    return nodes;
+  }
+
+  visitTagPlaceholder(ph: i18n.TagPlaceholder, context?: any): xml.Node[] {
+    const startTagPh = new xml.Tag(_PLACEHOLDER_TAG, {id: ph.startName, ctype: ph.tag});
+    if (ph.isVoid) {
+      // void tags have no children nor closing tags
+      return [startTagPh];
+    }
+
+    const closeTagPh = new xml.Tag(_PLACEHOLDER_TAG, {id: ph.closeName, ctype: ph.tag});
+
+    return [startTagPh, ...this.serialize(ph.children), closeTagPh];
+  }
+
+  visitPlaceholder(ph: i18n.Placeholder, context?: any): xml.Node[] {
+    return [new xml.Tag(_PLACEHOLDER_TAG, {id: ph.name})];
+  }
+
+  visitIcuPlaceholder(ph: i18n.IcuPlaceholder, context?: any): xml.Node[] {
+    return [new xml.Tag(_PLACEHOLDER_TAG, {id: ph.name})];
+  }
+
+  serialize(nodes: i18n.Node[]): xml.Node[] {
+    this._isInIcu = false;
+    return ListWrapper.flatten(nodes.map(node => node.visit(this)));
+  }
+}
+
+// TODO(vicb): add error management (structure)
+// TODO(vicb): factorize (xtb) ?
+class _LoadVisitor implements ml.Visitor {
+  private _messageNodes: [string, ml.Node[]][];
+  private _translatedMessages: {[id: string]: string};
+  private _msgId: string;
+  private _target: ml.Node[];
+  private _errors: I18nError[];
+  private _placeholders: {[name: string]: string};
+  private _placeholderToIds: {[name: string]: string};
+
+  parse(nodes: ml.Node[], messageBundle: MessageBundle):
+      {messages: {[k: string]: string}, errors: I18nError[]} {
+    this._messageNodes = [];
+    this._translatedMessages = {};
+    this._msgId = '';
+    this._target = [];
+    this._errors = [];
+
+    // Find all messages
+    ml.visitAll(this, nodes, null);
+
+    const messageMap = messageBundle.getMessageMap();
+    const placeholders = extractPlaceholders(messageBundle);
+    const placeholderToIds = extractPlaceholderToIds(messageBundle);
+
+    this._messageNodes
+        .filter(message => {
+          // Remove any messages that is not present in the source message bundle.
+          return messageMap.hasOwnProperty(message[0]);
+        })
+        .sort((a, b) => {
+          // Because there could be no ICU placeholders inside an ICU message,
+          // we do not need to take into account the `placeholderToMsgIds` of the referenced
+          // messages, those would always be empty
+          // TODO(vicb): overkill - create 2 buckets and [...woDeps, ...wDeps].process()
+          if (Object.keys(messageMap[a[0]].placeholderToMsgIds).length == 0) {
+            return -1;
+          }
+
+          if (Object.keys(messageMap[b[0]].placeholderToMsgIds).length == 0) {
+            return 1;
+          }
+
+          return 0;
+        })
+        .forEach(message => {
+          const id = message[0];
+          this._placeholders = placeholders[id] || {};
+          this._placeholderToIds = placeholderToIds[id] || {};
+          // TODO(vicb): make sure there is no `_TRANSLATIONS_TAG` nor `_TRANSLATION_TAG`
+          this._translatedMessages[id] = ml.visitAll(this, message[1]).join('');
+        });
+
+    return {messages: this._translatedMessages, errors: this._errors};
+  }
+
+  visitElement(element: ml.Element, context: any): any {
+    switch (element.name) {
+      case _UNIT_TAG:
+        this._target = null;
+        const msgId = element.attrs.find((attr) => attr.name === 'id');
+        if (!msgId) {
+          this._addError(element, `<${_UNIT_TAG}> misses the "id" attribute`);
+        } else {
+          this._msgId = msgId.value;
+        }
+        ml.visitAll(this, element.children, null);
+        if (this._msgId !== null) {
+          this._messageNodes.push([this._msgId, this._target]);
+        }
+        break;
+
+      case _SOURCE_TAG:
+        // ignore source message
+        break;
+
+      case _TARGET_TAG:
+        this._target = element.children;
+        break;
+
+      case _PLACEHOLDER_TAG:
+        const idAttr = element.attrs.find((attr) => attr.name === 'id');
+        if (!idAttr) {
+          this._addError(element, `<${_PLACEHOLDER_TAG}> misses the "id" attribute`);
+        } else {
+          const id = idAttr.value;
+          if (this._placeholders.hasOwnProperty(id)) {
+            return this._placeholders[id];
+          }
+          if (this._placeholderToIds.hasOwnProperty(id) &&
+              this._translatedMessages.hasOwnProperty(this._placeholderToIds[id])) {
+            return this._translatedMessages[this._placeholderToIds[id]];
+          }
+          // TODO(vicb): better error message for when
+          // !this._translatedMessages.hasOwnProperty(this._placeholderToIds[id])
+          this._addError(element, `The placeholder "${id}" does not exists in the source message`);
+        }
+        break;
+
+      default:
+        ml.visitAll(this, element.children, null);
+    }
+  }
+
+  visitAttribute(attribute: ml.Attribute, context: any): any {
+    throw new Error('unreachable code');
+  }
+
+  visitText(text: ml.Text, context: any): any { return text.value; }
+
+  visitComment(comment: ml.Comment, context: any): any { return ''; }
+
+  visitExpansion(expansion: ml.Expansion, context: any): any {
+    throw new Error('unreachable code');
+  }
+
+  visitExpansionCase(expansionCase: ml.ExpansionCase, context: any): any {
+    throw new Error('unreachable code');
+  }
+
+  private _addError(node: ml.Node, message: string): void {
+    this._errors.push(new I18nError(node.sourceSpan, message));
+  }
+}

--- a/modules/@angular/compiler/src/i18n/serializers/xml_helper.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/xml_helper.ts
@@ -28,7 +28,7 @@ class _Visitor implements IVisitor {
   visitText(text: Text): string { return text.value; }
 
   visitDeclaration(decl: Declaration): string {
-    return `<? xml${this._serializeAttributes(decl.attrs)} ?>`;
+    return `<?xml${this._serializeAttributes(decl.attrs)} ?>`;
   }
 
   private _serializeAttributes(attrs: {[k: string]: string}) {

--- a/modules/@angular/compiler/src/i18n/serializers/xtb.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/xtb.ts
@@ -35,7 +35,7 @@ export class Xtb implements Serializer {
     }
 
     // Replace the placeholders, messages are now string
-    const {messages, errors} = new _Serializer().parse(result.rootNodes, messageBundle);
+    const {messages, errors} = new _Visitor().parse(result.rootNodes, messageBundle);
 
     if (errors.length) {
       throw new Error(`xtb parse errors:\n${errors.join('\n')}`);
@@ -60,7 +60,7 @@ export class Xtb implements Serializer {
   }
 }
 
-class _Serializer implements ml.Visitor {
+class _Visitor implements ml.Visitor {
   private _messageNodes: [string, ml.Node[]][];
   private _translatedMessages: {[id: string]: string};
   private _bundleDepth: number;

--- a/modules/@angular/compiler/test/i18n/integration_spec.ts
+++ b/modules/@angular/compiler/test/i18n/integration_spec.ts
@@ -8,10 +8,9 @@
 
 import {DirectiveResolver, XHR, i18n} from '@angular/compiler';
 import {MockDirectiveResolver} from '@angular/compiler/testing';
-import {Compiler, Component, DebugElement, Injector, TRANSLATIONS} from '@angular/core';
+import {Compiler, Component, DebugElement, Injector, TRANSLATIONS, TRANSLATIONS_FORMAT} from '@angular/core';
 import {TestBed, fakeAsync} from '@angular/core/testing';
-
-import {beforeEach, TestComponentBuilder, beforeEachProviders, ddescribe, describe, iit, inject, it, xdescribe, xit,} from '@angular/core/testing/testing_internal';
+import {beforeEach, TestComponentBuilder, ddescribe, describe, iit, inject, it, xdescribe, xit,} from '@angular/core/testing/testing_internal';
 import {expect} from '@angular/platform-browser/testing/matchers';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {SpyXHR} from '../spies';
@@ -32,6 +31,7 @@ export function main() {
           {provide: XHR, useClass: SpyXHR},
           {provide: NgLocalization, useClass: FrLocalization},
           {provide: TRANSLATIONS, useValue: XTB},
+          {provide: TRANSLATIONS_FORMAT, useValue: 'xtb'},
         ]
       });
     });

--- a/modules/@angular/compiler/test/i18n/serializers/xliff_spec.ts
+++ b/modules/@angular/compiler/test/i18n/serializers/xliff_spec.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Xliff} from '@angular/compiler/src/i18n/serializers/xliff';
+import {beforeEach, ddescribe, describe, expect, iit, inject, it, xdescribe, xit} from '@angular/core/testing/testing_internal';
+import {MessageBundle} from '../../../src/i18n/message_bundle';
+import {HtmlParser} from '../../../src/ml_parser/html_parser';
+import {DEFAULT_INTERPOLATION_CONFIG} from '../../../src/ml_parser/interpolation_config';
+import {serializeNodes} from '../../ml_parser/ast_serializer_spec';
+
+const HTML = `
+<p i18n-title title="translatable attribute">not translatable</p>
+<p i18n>translatable element <b>with placeholders</b> {{ interpolation}}</p>
+<p i18n="m|d">foo</p>
+`;
+
+const WRITE_XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+ <file source-language="en" datatype="plaintext" original="ng2.template">
+   <body>
+     <trans-unit id="983775b9a51ce14b036be72d4cfd65d68d64e231" datatype="html">
+       <source>translatable attribute</source>
+       <target/>
+     </trans-unit>
+     <trans-unit id="ec1d033f2436133c14ab038286c4f5df4697484a" datatype="html">
+       <source>translatable element <x id="START_BOLD_TEXT" ctype="b"/>with placeholders<x id="CLOSE_BOLD_TEXT" ctype="b"/> <x id="INTERPOLATION"/></source>
+       <target/>
+     </trans-unit>
+     <trans-unit id="db3e0a6a5a96481f60aec61d98c3eecddef5ac23" datatype="html">
+       <source>foo</source>
+       <target/>
+       <note priority="1" from="description">d</note>
+       <note priority="1" from="meaning">m</note>
+     </trans-unit>
+   </body>
+ </file>
+</xliff>`;
+
+const LOAD_XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+ <file source-language="en" datatype="plaintext" original="ng2.template">
+   <body>
+     <trans-unit id="983775b9a51ce14b036be72d4cfd65d68d64e231" datatype="html">
+       <source>translatable attribute</source>
+       <target>etubirtta elbatalsnart</target>
+     </trans-unit>
+     <trans-unit id="ec1d033f2436133c14ab038286c4f5df4697484a" datatype="html">
+       <source>translatable element <x id="START_BOLD_TEXT" ctype="b"/>with placeholders<x id="CLOSE_BOLD_TEXT" ctype="b"/> <x id="INTERPOLATION"/></source>
+       <target><x id="INTERPOLATION"/> footnemele elbatalsnart <x id="START_BOLD_TEXT" ctype="b"/>sredlohecalp htiw<x id="CLOSE_BOLD_TEXT" ctype="b"/></target>
+     </trans-unit>
+     <trans-unit id="db3e0a6a5a96481f60aec61d98c3eecddef5ac23" datatype="html">
+       <source>foo</source>
+       <target>oof</target>
+       <note priority="1" from="description">d</note>
+       <note priority="1" from="meaning">m</note>
+     </trans-unit>
+   </body>
+ </file>
+</xliff>`;
+
+export function main(): void {
+  let serializer: Xliff;
+  let htmlParser: HtmlParser;
+
+  function toXliff(html: string): string {
+    let catalog = new MessageBundle(new HtmlParser, [], {});
+    catalog.updateFromTemplate(html, '', DEFAULT_INTERPOLATION_CONFIG);
+    return catalog.write(serializer);
+  }
+
+  function loadAsText(template: string, xliff: string): {[id: string]: string} {
+    let messageBundle = new MessageBundle(htmlParser, [], {});
+    messageBundle.updateFromTemplate(template, 'url', DEFAULT_INTERPOLATION_CONFIG);
+
+    const asAst = serializer.load(xliff, 'url', messageBundle);
+    let asText: {[id: string]: string} = {};
+    Object.keys(asAst).forEach(id => { asText[id] = serializeNodes(asAst[id]).join(''); });
+
+    return asText;
+  }
+
+  describe('XLIFF serializer', () => {
+
+    beforeEach(() => {
+      htmlParser = new HtmlParser();
+      serializer = new Xliff(htmlParser, DEFAULT_INTERPOLATION_CONFIG);
+    });
+
+
+    describe('write', () => {
+      it('should write a valid xliff file', () => { expect(toXliff(HTML)).toEqual(WRITE_XLIFF); });
+    });
+
+    describe('load', () => {
+      it('should load XLIFF files', () => {
+        expect(loadAsText(HTML, LOAD_XLIFF)).toEqual({
+          '983775b9a51ce14b036be72d4cfd65d68d64e231': 'etubirtta elbatalsnart',
+          'ec1d033f2436133c14ab038286c4f5df4697484a':
+              '{{ interpolation}} footnemele elbatalsnart <b>sredlohecalp htiw</b>',
+          'db3e0a6a5a96481f60aec61d98c3eecddef5ac23': 'oof',
+        });
+      });
+    });
+  });
+}

--- a/modules/@angular/compiler/test/i18n/serializers/xmb_spec.ts
+++ b/modules/@angular/compiler/test/i18n/serializers/xmb_spec.ts
@@ -22,7 +22,7 @@ export function main(): void {
 <p i18n="m|d">foo</p>
 <p i18n>{ count, plural, =0 { { sex, gender, other {<p>deeply nested</p>}} }}</p>`;
 
-    const XMB = `<? xml version="1.0" encoding="UTF-8" ?>
+    const XMB = `<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE messagebundle [
 <!ELEMENT messagebundle (msg)*>
 <!ATTLIST messagebundle class CDATA #IMPLIED>

--- a/modules/@angular/compiler/test/i18n/serializers/xml_helper_spec.ts
+++ b/modules/@angular/compiler/test/i18n/serializers/xml_helper_spec.ts
@@ -14,7 +14,7 @@ export function main(): void {
   describe('XML helper', () => {
     it('should serialize XML declaration', () => {
       expect(xml.serialize([new xml.Declaration({version: '1.0'})]))
-          .toEqual('<? xml version="1.0" ?>');
+          .toEqual('<?xml version="1.0" ?>');
     });
 
     it('should serialize text node',

--- a/modules/@angular/compiler/test/i18n/serializers/xtb_spec.ts
+++ b/modules/@angular/compiler/test/i18n/serializers/xtb_spec.ts
@@ -84,7 +84,7 @@ export function main(): void {
       it('should replace ICU placeholders with their translations', () => {
         const HTML = `<div i18n>-{ count, plural, =0 {<p>bar</p>}}-</div>`;
 
-        const XTB = `<? xml version="1.0" encoding="UTF-8" ?>
+        const XTB = `<?xml version="1.0" encoding="UTF-8" ?>
 <translationbundle>
   <translation id="eb404e202fed4846e25e7d9ac1fcb719fe4da257">*<ph name="ICU"/>*</translation>
   <translation id="fc92b9b781194a02ab773129c8c5a7fc0735efd7">{ count, plural, =1 {<ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/>}}</translation>
@@ -103,7 +103,7 @@ export function main(): void {
 <div i18n="m|d">foo</div>
 <div i18n>{ count, plural, =0 {{ sex, gender, other {<p>bar</p>}} }}</div>`;
 
-        const XTB = `<? xml version="1.0" encoding="UTF-8" ?>
+        const XTB = `<?xml version="1.0" encoding="UTF-8" ?>
 <translationbundle>
   <translation id="7103b4b13b616270a0044efade97d8b4f96f2ca6"><ph name="INTERPOLATION"/><ph name="START_BOLD_TEXT"/>rab<ph name="CLOSE_BOLD_TEXT"/> oof</translation>
   <translation id="fc92b9b781194a02ab773129c8c5a7fc0735efd7">{ count, plural, =1 {<ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/>}}</translation>

--- a/scripts/ci-lite/offline_compiler_test.sh
+++ b/scripts/ci-lite/offline_compiler_test.sh
@@ -33,8 +33,11 @@ cp -v package.json $TMP
 
   ./node_modules/.bin/tsc --version
   # Compile the compiler-cli integration tests
-  ./node_modules/.bin/ngc --i18nFile=src/messages.fi.xtb --locale=fi --i18nFormat=xtb
-  ./node_modules/.bin/ng-xi18n
+  # TODO(vicb): restore the test for .xtb
+  #./node_modules/.bin/ngc --i18nFile=src/messages.fi.xtb --locale=fi --i18nFormat=xtb
+  ./node_modules/.bin/ngc --i18nFile=src/messages.fi.xlf --locale=fi --i18nFormat=xlf
+  ./node_modules/.bin/ng-xi18n --i18nFormat=xlf
+  ./node_modules/.bin/ng-xi18n --i18nFormat=xmb
 
   ./node_modules/.bin/jasmine init
   # Run compiler-cli integration tests in node


### PR DESCRIPTION
The messages.fi.xlf has been created with ng-xi18n and translated with Counterparts.
ngc generates a translated version in the offline_compiler_test

The Xliff serializer code might need some more love (resilience, ICU support) but that's a good start

(rebased version of #10777)
