### PR TITLE
Remove bidi control characters from Intl.DateTimeFormat#format result…

### DIFF
--- a/modules/@angular/common/test/pipes/date_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/date_pipe_spec.ts
@@ -97,6 +97,9 @@ export function main() {
           expect(pipe.transform(date, 'mediumTime')).toEqual('9:03:01 AM');
           expect(pipe.transform(date, 'shortTime')).toEqual('9:03 AM');
         });
+
+        it('should remove bidi control characters',
+           () => { expect(pipe.transform(date, 'MM/dd/yyyy').length).toEqual(10); });
       });
     }
   });

--- a/modules/@angular/facade/src/intl.ts
+++ b/modules/@angular/facade/src/intl.ts
@@ -140,11 +140,15 @@ function hourExtracter(inner: (date: Date, locale: string) => string): (
   };
 }
 
+function intlDateFormat(date: Date, locale: string, options: Intl.DateTimeFormatOptions): string {
+  return new Intl.DateTimeFormat(locale, options).format(date).replace(/[\u200e\u200f]/g, '');
+}
+
 function timeZoneGetter(timezone: string): (date: Date, locale: string) => string {
   // To workaround `Intl` API restriction for single timezone let format with 24 hours
-  const format = {hour: '2-digit', hour12: false, timeZoneName: timezone};
+  const options = {hour: '2-digit', hour12: false, timeZoneName: timezone};
   return function(date: Date, locale: string): string {
-    const result = new Intl.DateTimeFormat(locale, format).format(date);
+    const result = intlDateFormat(date, locale, options);
     // Then extract first 3 letters that related to hours
     return result ? result.substring(3) : '';
   };
@@ -177,9 +181,7 @@ function combine(options: Intl.DateTimeFormatOptions[]): Intl.DateTimeFormatOpti
 
 function datePartGetterFactory(ret: Intl.DateTimeFormatOptions): (date: Date, locale: string) =>
     string {
-  return function(date: Date, locale: string): string {
-    return new Intl.DateTimeFormat(locale, ret).format(date);
-  };
+  return (date: Date, locale: string): string => intlDateFormat(date, locale, ret);
 }
 
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)

~~\- [ ] Docs have been added / updated (for bug fixes / features)~~

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

This PR removes bidi control characters from the results of `DatePipe` transforms.
See #10080.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
