### PR TITLE
fix(compiler-cli): make ngc to work on Windows

### DIFF
--- a/modules/@angular/compiler-cli/src/reflector_host.ts
+++ b/modules/@angular/compiler-cli/src/reflector_host.ts
@@ -16,7 +16,7 @@ import {StaticReflectorHost, StaticSymbol} from './static_reflector';
 
 const EXT = /(\.ts|\.d\.ts|\.js|\.jsx|\.tsx)$/;
 const DTS = /\.d\.ts$/;
-const NODE_MODULES = path.sep + 'node_modules' + path.sep;
+const NODE_MODULES = '/node_modules/';
 const IS_GENERATED = /\.(ngfactory|css(\.shim)?)$/;
 
 export interface ReflectorHostContext {
@@ -36,8 +36,8 @@ export class ReflectorHost implements StaticReflectorHost, ImportGenerator {
       protected program: ts.Program, protected compilerHost: ts.CompilerHost,
       protected options: AngularCompilerOptions, context?: ReflectorHostContext) {
     // normalize the path so that it never ends with '/'.
-    this.basePath = path.normalize(path.join(this.options.basePath, '.'));
-    this.genDir = path.normalize(path.join(this.options.genDir, '.'));
+    this.basePath = path.normalize(path.join(this.options.basePath, '.')).replace(/\\/g, '/');
+    this.genDir = path.normalize(path.join(this.options.genDir, '.')).replace(/\\/g, '/');
 
     this.context = context || new NodeReflectorHostContext();
     var genPath: string = path.relative(this.basePath, this.genDir);
@@ -60,7 +60,8 @@ export class ReflectorHost implements StaticReflectorHost, ImportGenerator {
 
   protected resolve(m: string, containingFile: string) {
     const resolved =
-        ts.resolveModuleName(m, containingFile, this.options, this.context).resolvedModule;
+        ts.resolveModuleName(m, containingFile.replace(/\\/g, '/'), this.options, this.context)
+            .resolvedModule;
     return resolved ? resolved.resolvedFileName : null;
   };
 
@@ -139,7 +140,7 @@ export class ReflectorHost implements StaticReflectorHost, ImportGenerator {
   }
 
   private dotRelative(from: string, to: string): string {
-    var rPath: string = path.relative(from, to);
+    var rPath: string = path.relative(from, to).replace(/\\/g, '/');
     return rPath.startsWith('.') ? rPath : './' + rPath;
   }
 

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,11 @@ if [ $# -eq 0 ]
     echo
 else
   cd `dirname $0`
-  export NODE_PATH=$NODE_PATH:$(pwd)/dist/all:$(pwd)/dist/tools
+  if [ -z ${NODE_PATH+x} ]; then
+    export NODE_PATH=$(pwd)/dist/all:$(pwd)/dist/tools
+  else
+    export NODE_PATH=$NODE_PATH:$(pwd)/dist/all/:$(pwd)/dist/tools/
+  fi
   $(npm bin)/tsc -p tools
   node dist/tools/tsc-watch/ $1 watch
 fi


### PR DESCRIPTION
Fixes #10792

Even on Windows, TS handles paths with only forward slashes.

Note: the change in `test.sh` was needed to be able to run the test suite in Node, i.e. `./test.sh node`. BTW, it is successful after these changes
