### PR TITLE
test(tools): make the test suite to pass on Windows

### DIFF
--- a/tools/@angular/tsc-wrapped/test/typescript.mocks.ts
+++ b/tools/@angular/tsc-wrapped/test/typescript.mocks.ts
@@ -29,7 +29,7 @@ export class Host implements ts.LanguageServiceHost {
   getDefaultLibFileName(options: ts.CompilerOptions): string { return 'lib.d.ts'; }
 
   private getFileContent(fileName: string): string {
-    const names = fileName.split(path.sep);
+    const names = fileName.split('/');
     if (names[names.length - 1] === 'lib.d.ts') {
       return fs.readFileSync(ts.getDefaultLibFilePath(this.getCompilationSettings()), 'utf8');
     }


### PR DESCRIPTION
A quick fix to have a successful `./test.sh tools` on Windows.

Again, even on Windows, TS handles paths with only forward slashes.
