### PR TITLE
fix(xsrf): overwrite already set xsrf header

### DIFF
--- a/modules/@angular/http/src/backends/xhr_backend.ts
+++ b/modules/@angular/http/src/backends/xhr_backend.ts
@@ -188,7 +188,7 @@ export class CookieXSRFStrategy implements XSRFStrategy {
 
   configureRequest(req: Request) {
     let xsrfToken = __platform_browser_private__.getDOM().getCookie(this._cookieName);
-    if (xsrfToken && !req.headers.has(this._headerName)) {
+    if (xsrfToken) {
       req.headers.set(this._headerName, xsrfToken);
     }
   }

--- a/modules/@angular/http/test/backends/xhr_backend_spec.ts
+++ b/modules/@angular/http/test/backends/xhr_backend_spec.ts
@@ -128,11 +128,11 @@ export function main() {
           backend.createConnection(sampleRequest);
           expect(sampleRequest.headers.get('X-XSRF-TOKEN')).toBe('magic XSRF value');
         });
-        it('respects existing headers', () => {
+        it('should allow overwriting of existing headers', () => {
           getDOM().setCookie('XSRF-TOKEN', 'magic XSRF value');
           sampleRequest.headers.set('X-XSRF-TOKEN', 'already set');
           backend.createConnection(sampleRequest);
-          expect(sampleRequest.headers.get('X-XSRF-TOKEN')).toBe('already set');
+          expect(sampleRequest.headers.get('X-XSRF-TOKEN')).toBe('magic XSRF value');
         });
 
         describe('configuration', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently the Http service sets the X-XSRF-TOKEN header based on the XSRF-TOKEN found in the cookie but if the aforementioned header was already set in an older request it doesn't overwrite the header's value.
This behavior breaks the feature for the following use cases:
- undeleted but invalid XSRF-TOKEN cookie will be sent and the valid token in the cookie won't be sent
- the option to have new xsrf token with every request

**What is the new behavior?**
If an older request set the X-XSRF-TOKEN header and the header was cached the XSRFStrategy now overwrites the header with the latest value of the cookie.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
