### PR TITLE
fix(UrlParser) stop setting default value 'true' (matrix params)

### DIFF
--- a/modules/@angular/router/src/url_tree.ts
+++ b/modules/@angular/router/src/url_tree.ts
@@ -392,7 +392,7 @@ class UrlParser {
       return;
     }
     this.capture(key);
-    let value: any = 'true';
+    let value: any = '';
     if (this.peekStartsWith('=')) {
       this.capture('=');
       const valueMatch = matchSegments(this.remaining);

--- a/modules/@angular/router/test/url_serializer.spec.ts
+++ b/modules/@angular/router/test/url_serializer.spec.ts
@@ -113,9 +113,9 @@ describe('url serializer', () => {
   it('should parse key only matrix params', () => {
     const tree = url.parse('/one;a');
 
-    expectSegment(tree.root.children[PRIMARY_OUTLET], 'one;a=true');
+    expectSegment(tree.root.children[PRIMARY_OUTLET], 'one;a=');
 
-    expect(url.serialize(tree)).toEqual('/one;a=true');
+    expect(url.serialize(tree)).toEqual('/one;a=');
   });
 
   it('should parse query params (root)', () => {


### PR DESCRIPTION
This was already fixed recently for query params in #10399.
