### PR TITLE
feat(compiler): Added "strictMetadataEmit" option to ngc

### DIFF
--- a/modules/@angular/common/tsconfig-es2015.json
+++ b/modules/@angular/common/tsconfig-es2015.json
@@ -19,5 +19,8 @@
     "index.ts",
     "testing.ts",
     "../../../node_modules/zone.js/dist/zone.js.d.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/@angular/common/tsconfig-es5.json
+++ b/modules/@angular/common/tsconfig-es5.json
@@ -20,5 +20,8 @@
     "index.ts",
     "testing.ts",
     "../../../node_modules/zone.js/dist/zone.js.d.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/@angular/compiler-cli/src/static_reflector.ts
+++ b/modules/@angular/compiler-cli/src/static_reflector.ts
@@ -572,13 +572,13 @@ function expandedMessage(error: any): string {
   switch (error.message) {
     case 'Reference to non-exported class':
       if (error.context && error.context.className) {
-        return `Reference to a non-exported class ${error.context.className}`;
+        return `Reference to a non-exported class ${error.context.className}. Consider exporting the class`;
       }
       break;
     case 'Variable not initialized':
-      return 'Only initialized variables and constants can be referenced';
+      return 'Only initialized variables and constants can be referenced because the value of this variable is needed by the template compiler';
     case 'Destructuring not supported':
-      return 'Referencing an exported destructured variable or constant is not supported';
+      return 'Referencing an exported destructured variable or constant is not supported by the template compiler. Consider simplifying this to avoid destructuring';
     case 'Could not resolve type':
       if (error.context && error.context.typeName) {
         return `Could not resolve type ${error.context.typeName}`;

--- a/modules/@angular/compiler-cli/test/reflector_host_spec.ts
+++ b/modules/@angular/compiler-cli/test/reflector_host_spec.ts
@@ -38,6 +38,7 @@ describe('reflector_host', () => {
           genDir: '/tmp/project/src/gen/',
           basePath: '/tmp/project/src',
           skipMetadataEmit: false,
+          strictMetadataEmit: false,
           skipTemplateCodegen: false,
           trace: false
         },
@@ -47,6 +48,7 @@ describe('reflector_host', () => {
           genDir: '/tmp/project/gen',
           basePath: '/tmp/project/src/',
           skipMetadataEmit: false,
+          strictMetadataEmit: false,
           skipTemplateCodegen: false,
           trace: false
         },

--- a/modules/@angular/core/tsconfig-es2015.json
+++ b/modules/@angular/core/tsconfig-es2015.json
@@ -20,5 +20,8 @@
     "testing.ts",
     "../../../node_modules/zone.js/dist/zone.js.d.ts",
     "../../system.d.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/@angular/core/tsconfig-es5.json
+++ b/modules/@angular/core/tsconfig-es5.json
@@ -21,5 +21,8 @@
     "testing.ts",
     "../../../node_modules/zone.js/dist/zone.js.d.ts",
     "../../system.d.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/@angular/forms/tsconfig-es2015.json
+++ b/modules/@angular/forms/tsconfig-es2015.json
@@ -23,5 +23,8 @@
   "files": [
     "index.ts",
     "../../../node_modules/zone.js/dist/zone.js.d.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/@angular/forms/tsconfig-es5.json
+++ b/modules/@angular/forms/tsconfig-es5.json
@@ -24,5 +24,8 @@
   "files": [
     "index.ts",
     "../../../node_modules/zone.js/dist/zone.js.d.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/@angular/http/tsconfig-es2015.json
+++ b/modules/@angular/http/tsconfig-es2015.json
@@ -21,5 +21,8 @@
     "index.ts",
     "testing.ts",
     "../../../node_modules/zone.js/dist/zone.js.d.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/@angular/http/tsconfig-es5.json
+++ b/modules/@angular/http/tsconfig-es5.json
@@ -22,5 +22,8 @@
     "index.ts",
     "testing.ts",
     "../../../node_modules/zone.js/dist/zone.js.d.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/@angular/platform-browser/index.ts
+++ b/modules/@angular/platform-browser/index.ts
@@ -27,5 +27,5 @@ export {WORKER_UI_LOCATION_PROVIDERS} from './src/web_workers/ui/location_provid
 
 export {NgProbeToken} from './src/dom/debug/ng_probe';
 export * from './src/worker_render';
-export * from './src/worker_app';
+export {platformWorkerApp, WorkerAppModule} from './src/worker_app';
 export * from './private_export';

--- a/modules/@angular/platform-browser/src/worker_app.ts
+++ b/modules/@angular/platform-browser/src/worker_app.ts
@@ -21,7 +21,12 @@ import {ServiceMessageBrokerFactory, ServiceMessageBrokerFactory_} from './web_w
 import {WebWorkerRootRenderer} from './web_workers/worker/renderer';
 import {WorkerDomAdapter} from './web_workers/worker/worker_adapter';
 
-class PrintLogger {
+/**
+ * Logger for web workers.
+ *
+ * @experimental
+ */
+export class PrintLogger {
   log = print;
   logError = print;
   logGroup = print;
@@ -33,7 +38,12 @@ class PrintLogger {
  */
 export const platformWorkerApp = createPlatformFactory(platformCore, 'workerApp');
 
-function _exceptionHandler(): ExceptionHandler {
+/**
+ * Exception handler factory function.
+ *
+ * @experimental
+ */
+export function exceptionHandler(): ExceptionHandler {
   return new ExceptionHandler(new PrintLogger());
 }
 
@@ -44,7 +54,12 @@ let _postMessage = {
   }
 };
 
-function createMessageBus(zone: NgZone): MessageBus {
+/**
+ * MessageBus factory function.
+ *
+ * @experimental
+ */
+export function createMessageBus(zone: NgZone): MessageBus {
   let sink = new PostMessageBusSink(_postMessage);
   let source = new PostMessageBusSource();
   let bus = new PostMessageBus(sink, source);
@@ -52,7 +67,12 @@ function createMessageBus(zone: NgZone): MessageBus {
   return bus;
 }
 
-function setupWebWorker(): void {
+/**
+ * Application initializer for web workers.
+ *
+ * @experimental
+ */
+export function setupWebWorker(): void {
   WorkerDomAdapter.makeCurrent();
 }
 
@@ -68,7 +88,7 @@ function setupWebWorker(): void {
     {provide: ServiceMessageBrokerFactory, useClass: ServiceMessageBrokerFactory_},
     WebWorkerRootRenderer, {provide: RootRenderer, useExisting: WebWorkerRootRenderer},
     {provide: ON_WEB_WORKER, useValue: true}, RenderStore,
-    {provide: ExceptionHandler, useFactory: _exceptionHandler, deps: []},
+    {provide: ExceptionHandler, useFactory: exceptionHandler, deps: []},
     {provide: MessageBus, useFactory: createMessageBus, deps: [NgZone]},
     {provide: APP_INITIALIZER, useValue: setupWebWorker, multi: true}
   ],

--- a/modules/@angular/platform-browser/testing/browser.ts
+++ b/modules/@angular/platform-browser/testing/browser.ts
@@ -13,15 +13,11 @@ import {BrowserDomAdapter} from '../src/browser/browser_adapter';
 import {AnimationDriver} from '../src/dom/animation_driver';
 import {ELEMENT_PROBE_PROVIDERS} from '../src/dom/debug/ng_probe';
 
-import {BrowserDetection} from './browser_util';
+import {BrowserDetection, createNgZone} from './browser_util';
 
 function initBrowserTests() {
   BrowserDomAdapter.makeCurrent();
   BrowserDetection.setup();
-}
-
-function createNgZone(): NgZone {
-  return new NgZone({enableLongStackTrace: true});
 }
 
 const _TEST_BROWSER_PLATFORM_PROVIDERS: Provider[] =

--- a/modules/@angular/platform-browser/testing/browser_util.ts
+++ b/modules/@angular/platform-browser/testing/browser_util.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {NgZone} from '@angular/core';
 import {getDOM} from '../src/dom/dom_adapter';
 import {ListWrapper} from '../src/facade/collection';
 import {RegExp, StringWrapper, global, isPresent, isString} from '../src/facade/lang';
@@ -129,3 +130,7 @@ export function stringifyElement(el: any /** TODO #9100 */): string {
 }
 
 export var browserDetection: BrowserDetection = new BrowserDetection(null);
+
+export function createNgZone(): NgZone {
+  return new NgZone({enableLongStackTrace: true});
+}

--- a/modules/@angular/platform-browser/tsconfig-es2015.json
+++ b/modules/@angular/platform-browser/tsconfig-es2015.json
@@ -29,5 +29,8 @@
     "../../../node_modules/@types/jasmine/index.d.ts",
     "../../../node_modules/@types/protractor/index.d.ts",
     "../../../node_modules/zone.js/dist/zone.js.d.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/@angular/platform-browser/tsconfig-es5.json
+++ b/modules/@angular/platform-browser/tsconfig-es5.json
@@ -30,5 +30,8 @@
     "../../../node_modules/@types/jasmine/index.d.ts",
     "../../../node_modules/@types/protractor/index.d.ts",
     "../../../node_modules/zone.js/dist/zone.js.d.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/@angular/platform-server/tsconfig-es2015.json
+++ b/modules/@angular/platform-server/tsconfig-es2015.json
@@ -30,5 +30,8 @@
     "../../../node_modules/@types/jasmine/index.d.ts",
     "../../../node_modules/@types/node/index.d.ts",
     "../../../node_modules/zone.js/dist/zone.js.d.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/@angular/platform-server/tsconfig-es5.json
+++ b/modules/@angular/platform-server/tsconfig-es5.json
@@ -31,5 +31,8 @@
     "../../../node_modules/@types/jasmine/index.d.ts",
     "../../../node_modules/@types/node/index.d.ts",
     "../../../node_modules/zone.js/dist/zone.js.d.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/@angular/router/testing/router_testing_module.ts
+++ b/modules/@angular/router/testing/router_testing_module.ts
@@ -39,7 +39,12 @@ export class SpyNgModuleFactoryLoader implements NgModuleFactoryLoader {
   }
 }
 
-function setupTestingRouter(
+/**
+ * Router setup factory function used for testing.
+ *
+ * @experimental
+ */
+export function setupTestingRouter(
     urlSerializer: UrlSerializer, outletMap: RouterOutletMap, location: Location,
     loader: NgModuleFactoryLoader, compiler: Compiler, injector: Injector, routes: Route[][]) {
   return new Router(

--- a/modules/@angular/router/tsconfig-es2015.json
+++ b/modules/@angular/router/tsconfig-es2015.json
@@ -24,5 +24,8 @@
   "files": [
     "index.ts",
     "testing.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/@angular/router/tsconfig-es5.json
+++ b/modules/@angular/router/tsconfig-es5.json
@@ -24,7 +24,8 @@
   "files": [
     "index.ts",
     "testing.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }
-
-

--- a/modules/@angular/upgrade/tsconfig-es2015.json
+++ b/modules/@angular/upgrade/tsconfig-es2015.json
@@ -22,5 +22,8 @@
   "files": [
     "index.ts",
     "../../../node_modules/zone.js/dist/zone.js.d.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/@angular/upgrade/tsconfig-es5.json
+++ b/modules/@angular/upgrade/tsconfig-es5.json
@@ -23,5 +23,8 @@
   "files": [
     "index.ts",
     "../../../node_modules/zone.js/dist/zone.js.d.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true
+  }
 }

--- a/modules/playground/src/web_workers/kitchen_sink/index_common.ts
+++ b/modules/playground/src/web_workers/kitchen_sink/index_common.ts
@@ -19,7 +19,7 @@ export class GreetingService {
 // Directives are light-weight. They don't allow new
 // expression contexts (use @Component for those needs).
 @Directive({selector: '[red]'})
-class RedDec {
+export class RedDec {
   // ElementRef is always injectable and it wraps the element on which the
   // directive was found by the compiler.
   constructor(el: ElementRef, renderer: Renderer) {

--- a/tools/@angular/tsc-wrapped/src/compiler_host.ts
+++ b/tools/@angular/tsc-wrapped/src/compiler_host.ts
@@ -2,6 +2,7 @@ import {writeFileSync} from 'fs';
 import {convertDecorators} from 'tsickle';
 import * as ts from 'typescript';
 
+import NgOptions from './options';
 import {MetadataCollector} from './collector';
 
 
@@ -66,14 +67,18 @@ const IGNORED_FILES = /\.ngfactory\.js$|\.css\.js$|\.css\.shim\.js$/;
 
 export class MetadataWriterHost extends DelegatingHost {
   private metadataCollector = new MetadataCollector();
-  constructor(delegate: ts.CompilerHost, private program: ts.Program) { super(delegate); }
+  constructor(
+      delegate: ts.CompilerHost, private program: ts.Program, private ngOptions: NgOptions) {
+    super(delegate);
+  }
 
   private writeMetadata(emitFilePath: string, sourceFile: ts.SourceFile) {
     // TODO: replace with DTS filePath when https://github.com/Microsoft/TypeScript/pull/8412 is
     // released
     if (/*DTS*/ /\.js$/.test(emitFilePath)) {
       const path = emitFilePath.replace(/*DTS*/ /\.js$/, '.metadata.json');
-      const metadata = this.metadataCollector.getMetadata(sourceFile);
+      const metadata =
+          this.metadataCollector.getMetadata(sourceFile, !!this.ngOptions.strictMetadataEmit);
       if (metadata && metadata.metadata) {
         const metadataText = JSON.stringify(metadata);
         writeFileSync(path, metadataText, {encoding: 'utf-8'});

--- a/tools/@angular/tsc-wrapped/src/main.ts
+++ b/tools/@angular/tsc-wrapped/src/main.ts
@@ -50,7 +50,7 @@ export function main(
         // decorators which we want to read or document.
         // Do this emit second since TypeScript will create missing directories for us
         // in the standard emit.
-        const metadataWriter = new MetadataWriterHost(host, newProgram);
+        const metadataWriter = new MetadataWriterHost(host, newProgram, ngOptions);
         tsc.emit(metadataWriter, newProgram);
       }
     });

--- a/tools/@angular/tsc-wrapped/src/options.ts
+++ b/tools/@angular/tsc-wrapped/src/options.ts
@@ -10,6 +10,9 @@ interface Options extends ts.CompilerOptions {
   // Don't produce .metadata.json files (they don't work for bundled emit with --out)
   skipMetadataEmit: boolean;
 
+  // Produce an error if the metadata written for a class would produce an error if used.
+  strictMetadataEmit: boolean;
+
   // Don't produce .ngfactory.ts or .css.shim.ts files
   skipTemplateCodegen: boolean;
 

--- a/tools/@angular/tsc-wrapped/src/schema.ts
+++ b/tools/@angular/tsc-wrapped/src/schema.ts
@@ -9,11 +9,13 @@
 
 export const VERSION = 1;
 
+export type MetadataEntry = ClassMetadata | FunctionMetadata | MetadataValue;
+
 export interface ModuleMetadata {
   __symbolic: 'module';
   version: number;
   exports?: ModuleExportMetadata[];
-  metadata: {[name: string]: (ClassMetadata | FunctionMetadata | MetadataValue)};
+  metadata: {[name: string]: MetadataEntry};
 }
 export function isModuleMetadata(value: any): value is ModuleMetadata {
   return value && value.__symbolic === 'module';
@@ -56,7 +58,7 @@ export interface MethodMetadata extends MemberMetadata {
   __symbolic: 'constructor'|'method';
   parameterDecorators?: (MetadataSymbolicExpression|MetadataError)[][];
 }
-export function isMethodMetadata(value: any): value is MemberMetadata {
+export function isMethodMetadata(value: any): value is MethodMetadata {
   return value && (value.__symbolic === 'constructor' || value.__symbolic === 'method');
 }
 

--- a/tools/@angular/tsc-wrapped/test/evaluator.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/evaluator.spec.ts
@@ -24,7 +24,7 @@ describe('Evaluator', () => {
     program = service.getProgram();
     typeChecker = program.getTypeChecker();
     symbols = new Symbols(null);
-    evaluator = new Evaluator(symbols);
+    evaluator = new Evaluator(symbols, new Map());
   });
 
   it('should not have typescript errors in test data', () => {
@@ -138,7 +138,7 @@ describe('Evaluator', () => {
 
   it('should return new expressions', () => {
     symbols.define('Value', {__symbolic: 'reference', module: './classes', name: 'Value'});
-    evaluator = new Evaluator(symbols);
+    evaluator = new Evaluator(symbols, new Map());
     const newExpression = program.getSourceFile('newExpression.ts');
     expect(evaluator.evaluateNode(findVar(newExpression, 'someValue').initializer)).toEqual({
       __symbolic: 'new',
@@ -167,13 +167,13 @@ describe('Evaluator', () => {
     const fDecl = findVar(errors, 'f');
     expect(evaluator.evaluateNode(fDecl.initializer))
         .toEqual(
-            {__symbolic: 'error', message: 'Function call not supported', line: 1, character: 11});
+            {__symbolic: 'error', message: 'Function call not supported', line: 1, character: 12});
     const eDecl = findVar(errors, 'e');
     expect(evaluator.evaluateNode(eDecl.type)).toEqual({
       __symbolic: 'error',
       message: 'Could not resolve type',
       line: 2,
-      character: 10,
+      character: 11,
       context: {typeName: 'NotFound'}
     });
     const sDecl = findVar(errors, 's');
@@ -181,7 +181,7 @@ describe('Evaluator', () => {
       __symbolic: 'error',
       message: 'Name expected',
       line: 3,
-      character: 13,
+      character: 14,
       context: {received: '1'}
     });
     const tDecl = findVar(errors, 't');
@@ -189,7 +189,7 @@ describe('Evaluator', () => {
       __symbolic: 'error',
       message: 'Expression form not supported',
       line: 4,
-      character: 11
+      character: 12
     });
   });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

It is possible to modify the metadata of a class that will introduce an error that will only be detected if the class is used in an AoT test. #10907 

**What is the new behavior?**

A package can now request that metadata errors to be reported when the metadata is produced to validate that all metadata emitted for exported classes will no produce an error when used by the `StaticReflector` and `ngc`.

This is opt-in because a module might contain annotations that are not intended to be used by the `StaticReflector` and will not generate an error when the module is used with `ngc`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

ngc can now validate metadata before emitting to verify it doesn't
contain an error symbol that will result in a runtime error if
it is used by the StaticReflector.

To enable this add the section,

  "angularCompilerOptions": {
    "strictMetadataEmit": true
  }

to the top level of the tsconfig.json file passed to ngc.

Enabled metadata validation for packages that are intended to be
used statically.
