### PR TITLE
fix(compiler): Only emit metadata for exported enums

### DIFF
--- a/tools/@angular/tsc-wrapped/src/collector.ts
+++ b/tools/@angular/tsc-wrapped/src/collector.ts
@@ -247,43 +247,45 @@ export class MetadataCollector {
           // Otherwise don't record the function.
           break;
         case ts.SyntaxKind.EnumDeclaration:
-          const enumDeclaration = <ts.EnumDeclaration>node;
-          let enumValueHolder: {[name: string]: MetadataValue} = {};
-          const enumName = enumDeclaration.name.text;
-          let nextDefaultValue: MetadataValue = 0;
-          let writtenMembers = 0;
-          for (const member of enumDeclaration.members) {
-            let enumValue: MetadataValue;
-            if (!member.initializer) {
-              enumValue = nextDefaultValue;
-            } else {
-              enumValue = evaluator.evaluateNode(member.initializer);
-            }
-            let name: string = undefined;
-            if (member.name.kind == ts.SyntaxKind.Identifier) {
-              const identifier = <ts.Identifier>member.name;
-              name = identifier.text;
-              enumValueHolder[name] = enumValue;
-              writtenMembers++;
-            }
-            if (typeof enumValue === 'number') {
-              nextDefaultValue = enumValue + 1;
-            } else if (name) {
-              nextDefaultValue = {
-                __symbolic: 'binary',
-                operator: '+',
-                left: {
-                  __symbolic: 'select',
-                  expression: {__symbolic: 'reference', name: enumName}, name
-                }
+          if (node.flags & ts.NodeFlags.Export) {
+            const enumDeclaration = <ts.EnumDeclaration>node;
+            let enumValueHolder: {[name: string]: MetadataValue} = {};
+            const enumName = enumDeclaration.name.text;
+            let nextDefaultValue: MetadataValue = 0;
+            let writtenMembers = 0;
+            for (const member of enumDeclaration.members) {
+              let enumValue: MetadataValue;
+              if (!member.initializer) {
+                enumValue = nextDefaultValue;
+              } else {
+                enumValue = evaluator.evaluateNode(member.initializer);
               }
-            } else {
-              nextDefaultValue = errorSym('Unsuppported enum member name', member.name);
-            };
-          }
-          if (writtenMembers) {
-            if (!metadata) metadata = {};
-            metadata[enumName] = enumValueHolder;
+              let name: string = undefined;
+              if (member.name.kind == ts.SyntaxKind.Identifier) {
+                const identifier = <ts.Identifier>member.name;
+                name = identifier.text;
+                enumValueHolder[name] = enumValue;
+                writtenMembers++;
+              }
+              if (typeof enumValue === 'number') {
+                nextDefaultValue = enumValue + 1;
+              } else if (name) {
+                nextDefaultValue = {
+                  __symbolic: 'binary',
+                  operator: '+',
+                  left: {
+                    __symbolic: 'select',
+                    expression: {__symbolic: 'reference', name: enumName}, name
+                  }
+                }
+              } else {
+                nextDefaultValue = errorSym('Unsuppported enum member name', member.name);
+              };
+            }
+            if (writtenMembers) {
+              if (!metadata) metadata = {};
+              metadata[enumName] = enumValueHolder;
+            }
           }
           break;
         case ts.SyntaxKind.VariableStatement:

--- a/tools/@angular/tsc-wrapped/test/collector.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/collector.spec.ts
@@ -25,6 +25,7 @@ describe('Collector', () => {
       'exported-enum.ts',
       'exported-consts.ts',
       'local-symbol-ref.ts',
+      'private-enum.ts',
       're-exports.ts',
       'static-field-reference.ts',
       'static-method.ts',
@@ -337,6 +338,15 @@ describe('Collector', () => {
     let metadata = collector.getMetadata(enumSource);
     let someEnum: any = metadata.metadata['SomeEnum'];
     expect(someEnum).toEqual({A: 0, B: 1, C: 100, D: 101});
+  });
+
+  it('should ignore a non-export enum', () => {
+    let enumSource = program.getSourceFile('/private-enum.ts');
+    let metadata = collector.getMetadata(enumSource);
+    let publicEnum: any = metadata.metadata['PublicEnum'];
+    let privateEnum: any = metadata.metadata['PrivateEnum'];
+    expect(publicEnum).toEqual({a: 0, b: 1, c: 2});
+    expect(privateEnum).toBeUndefined();
   });
 
   it('should be able to collect enums initialized from consts', () => {
@@ -837,6 +847,10 @@ const FILES: Directory = {
       providers: [REQUIRED_VALIDATOR]
     })
     export class SomeComponent {}
+  `,
+  'private-enum.ts': `
+    export enum PublicEnum { a, b, c }
+    enum PrivateEnum { e, f, g }
   `,
   'node_modules': {
     'angular2': {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The metadata collector emits enum metadata for non-exported enums. #10955 

**What is the new behavior?**

The only exported enums are emitted.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

Closes: #10955
