### PR TITLE
feat(router): export ROUTES token as public api

### DIFF
--- a/modules/@angular/router/index.ts
+++ b/modules/@angular/router/index.ts
@@ -13,6 +13,7 @@ export {RouterLinkActive} from './src/directives/router_link_active';
 export {RouterOutlet} from './src/directives/router_outlet';
 export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, Resolve} from './src/interfaces';
 export {Event, NavigationCancel, NavigationEnd, NavigationError, NavigationExtras, NavigationStart, Router, RoutesRecognized} from './src/router';
+export {ROUTES} from './src/router_config_loader';
 export {ExtraOptions, ROUTER_DIRECTIVES, RouterModule, provideRoutes} from './src/router_module';
 export {RouterOutletMap} from './src/router_outlet_map';
 export {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot} from './src/router_state';

--- a/modules/@angular/router/src/router_config_loader.ts
+++ b/modules/@angular/router/src/router_config_loader.ts
@@ -15,6 +15,9 @@ import {LoadChildren, Route} from './config';
 import {flatten, wrapIntoObservable} from './utils/collection';
 
 
+/**
+ * @experimental
+ */
 export const ROUTES = new OpaqueToken('ROUTES');
 
 export class LoadedRouterConfig {

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -278,6 +278,9 @@ export declare class RouterStateSnapshot extends Tree<ActivatedRouteSnapshot> {
 /** @stable */
 export declare type Routes = Route[];
 
+/** @experimental */
+export declare const ROUTES: OpaqueToken;
+
 /** @stable */
 export declare class RoutesRecognized {
     id: number;


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

If you want to define your routes by a factory that `compile-cli` accepts, you can't use the bundles as the ROUTES token is not public.

**What is the new behavior?**

``` typescript
import {NgModule} from '@angular/core';
import {RouterModule, Routes, ROUTES} from '@angular/router';
import {BrowserModule} from '@angular/platform-browser';

export const _emptyRoutesArray = [];

export function _routes(): Routes {
    return [
        // your routes factory
    ];
}

@NgModule({
    imports: [
        BrowserModule,
        RouterModule.forRoot(_emptyRoutesArray),
    ],
    providers: [
        // provide your routes as a factory
        {provide: ROUTES, multi: true, useFactory: _routes},
    ],
    bootstrap: [
        MyAppComponent
    ],
})
export class MyAppModule {
}
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
