### PR TITLE
feat(forms): add support for disabled controls

### DIFF
--- a/modules/@angular/forms/src/directives/abstract_control_directive.ts
+++ b/modules/@angular/forms/src/directives/abstract_control_directive.ts
@@ -41,6 +41,10 @@ export abstract class AbstractControlDirective {
 
   get untouched(): boolean { return isPresent(this.control) ? this.control.untouched : null; }
 
+  get disabled(): boolean { return isPresent(this.control) ? this.control.disabled : null; }
+
+  get enabled(): boolean { return isPresent(this.control) ? this.control.enabled : null; }
+
   get statusChanges(): Observable<any> {
     return isPresent(this.control) ? this.control.statusChanges : null;
   }

--- a/modules/@angular/forms/src/directives/checkbox_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/checkbox_value_accessor.ts
@@ -43,4 +43,8 @@ export class CheckboxControlValueAccessor implements ControlValueAccessor {
   }
   registerOnChange(fn: (_: any) => {}): void { this.onChange = fn; }
   registerOnTouched(fn: () => {}): void { this.onTouched = fn; }
+
+  setDisabledState(isDisabled: boolean): void {
+    this._renderer.setElementProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+  }
 }

--- a/modules/@angular/forms/src/directives/control_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/control_value_accessor.ts
@@ -33,6 +33,14 @@ export interface ControlValueAccessor {
    * Set the function to be called when the control receives a touch event.
    */
   registerOnTouched(fn: any): void;
+
+  /**
+   * This function is called when the control status changes to or from "DISABLED".
+   * Depending on the value, it will enable or disable the appropriate DOM element.
+   *
+   * @param isDisabled
+   */
+  setDisabledState?(isDisabled: boolean): void;
 }
 
 /**

--- a/modules/@angular/forms/src/directives/default_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/default_value_accessor.ts
@@ -51,4 +51,8 @@ export class DefaultValueAccessor implements ControlValueAccessor {
 
   registerOnChange(fn: (_: any) => void): void { this.onChange = fn; }
   registerOnTouched(fn: () => void): void { this.onTouched = fn; }
+
+  setDisabledState(isDisabled: boolean): void {
+    this._renderer.setElementProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+  }
 }

--- a/modules/@angular/forms/src/directives/ng_form.ts
+++ b/modules/@angular/forms/src/directives/ng_form.ts
@@ -104,8 +104,8 @@ export class NgForm extends ControlContainer implements Form {
       @Optional() @Self() @Inject(NG_VALIDATORS) validators: any[],
       @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) asyncValidators: any[]) {
     super();
-    this.form = new FormGroup(
-        {}, null, composeValidators(validators), composeAsyncValidators(asyncValidators));
+    this.form =
+        new FormGroup({}, composeValidators(validators), composeAsyncValidators(asyncValidators));
   }
 
   get submitted(): boolean { return this._submitted; }

--- a/modules/@angular/forms/src/directives/ng_model.ts
+++ b/modules/@angular/forms/src/directives/ng_model.ts
@@ -64,9 +64,11 @@ export class NgModel extends NgControl implements OnChanges,
   _registered = false;
   viewModel: any;
 
-  @Input('ngModel') model: any;
   @Input() name: string;
+  @Input() disabled: boolean;
+  @Input('ngModel') model: any;
   @Input('ngModelOptions') options: {name?: string, standalone?: boolean};
+
   @Output('ngModelChange') update = new EventEmitter();
 
   constructor(@Optional() @Host() private _parent: ControlContainer,
@@ -81,6 +83,9 @@ export class NgModel extends NgControl implements OnChanges,
               ngOnChanges(changes: SimpleChanges) {
                 this._checkForErrors();
                 if (!this._registered) this._setUpControl();
+                if ('disabled' in changes) {
+                  this._updateDisabled(changes);
+                }
 
                 if (isPropertyUpdated(changes, this.viewModel)) {
                   this._updateValue(this.model);
@@ -152,5 +157,18 @@ export class NgModel extends NgControl implements OnChanges,
               private _updateValue(value: any): void {
                 resolvedPromise.then(
                     () => { this.control.setValue(value, {emitViewToModelChange: false}); });
+              }
+
+              private _updateDisabled(changes: SimpleChanges) {
+                const disabledValue = changes['disabled'].currentValue;
+                const isDisabled = disabledValue != null && disabledValue != false;
+
+                resolvedPromise.then(() => {
+                  if (isDisabled && !this.control.disabled) {
+                    this.control.disable();
+                  } else if (!isDisabled && this.control.disabled) {
+                    this.control.enable();
+                  }
+                });
               }
 }

--- a/modules/@angular/forms/src/directives/number_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/number_value_accessor.ts
@@ -53,4 +53,8 @@ export class NumberValueAccessor implements ControlValueAccessor {
     this.onChange = (value) => { fn(value == '' ? null : NumberWrapper.parseFloat(value)); };
   }
   registerOnTouched(fn: () => void): void { this.onTouched = fn; }
+
+  setDisabledState(isDisabled: boolean): void {
+    this._renderer.setElementProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+  }
 }

--- a/modules/@angular/forms/src/directives/radio_control_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/radio_control_value_accessor.ts
@@ -127,6 +127,10 @@ export class RadioControlValueAccessor implements ControlValueAccessor,
 
   registerOnTouched(fn: () => {}): void { this.onTouched = fn; }
 
+  setDisabledState(isDisabled: boolean): void {
+    this._renderer.setElementProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+  }
+
   private _checkName(): void {
     if (this.name && this.formControlName && this.name !== this.formControlName) {
       this._throwNameError();

--- a/modules/@angular/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/modules/@angular/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -12,9 +12,9 @@ import {EventEmitter} from '../../facade/async';
 import {StringMapWrapper} from '../../facade/collection';
 import {FormControl} from '../../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
-
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '../control_value_accessor';
 import {NgControl} from '../ng_control';
+import {ReactiveErrors} from '../reactive_errors';
 import {composeAsyncValidators, composeValidators, isPropertyUpdated, selectValueAccessor, setUpControl} from '../shared';
 import {AsyncValidatorFn, ValidatorFn} from '../validators';
 
@@ -81,6 +81,9 @@ export class FormControlDirective extends NgControl implements OnChanges {
   @Input('ngModel') model: any;
   @Output('ngModelChange') update = new EventEmitter();
 
+  @Input('disabled')
+  set disabled(isDisabled: boolean) { ReactiveErrors.disabledAttrWarning(); }
+
   constructor(@Optional() @Self() @Inject(NG_VALIDATORS) private _validators:
                   /* Array<Validator|Function> */ any[],
               @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) private _asyncValidators:
@@ -94,6 +97,7 @@ export class FormControlDirective extends NgControl implements OnChanges {
               ngOnChanges(changes: SimpleChanges): void {
                 if (this._isControlChanged(changes)) {
                   setUpControl(this.form, this);
+                  if (this.control.disabled) this.valueAccessor.setDisabledState(true);
                   this.form.updateValueAndValidity({emitEvent: false});
                 }
                 if (isPropertyUpdated(changes, this.viewModel)) {

--- a/modules/@angular/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/modules/@angular/forms/src/directives/reactive_directives/form_control_name.ts
@@ -106,57 +106,58 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
   @Input('ngModel') model: any;
   @Output('ngModelChange') update = new EventEmitter();
 
-  constructor(@Optional() @Host() @SkipSelf() private _parent: ControlContainer,
-              @Optional() @Self() @Inject(NG_VALIDATORS) private _validators:
-                  /* Array<Validator|Function> */ any[],
-              @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) private _asyncValidators:
-                  /* Array<Validator|Function> */ any[],
-              @Optional() @Self() @Inject(NG_VALUE_ACCESSOR)
-              valueAccessors: ControlValueAccessor[]) {
-                super();
-                this.valueAccessor = selectValueAccessor(this, valueAccessors);
-              }
+  @Input('disabled')
+  set disabled(isDisabled: boolean) { ReactiveErrors.disabledAttrWarning(); }
 
-              ngOnChanges(changes: SimpleChanges) {
-                if (!this._added) {
-                  this._checkParentType();
-                  this.formDirective.addControl(this);
-                  this._added = true;
-                }
-                if (isPropertyUpdated(changes, this.viewModel)) {
-                  this.viewModel = this.model;
-                  this.formDirective.updateModel(this, this.model);
-                }
-              }
+  constructor(
+      @Optional() @Host() @SkipSelf() private _parent: ControlContainer,
+      @Optional() @Self() @Inject(NG_VALIDATORS) private _validators:
+          /* Array<Validator|Function> */ any[],
+      @Optional() @Self() @Inject(NG_ASYNC_VALIDATORS) private _asyncValidators:
+          /* Array<Validator|Function> */ any[],
+      @Optional() @Self() @Inject(NG_VALUE_ACCESSOR) valueAccessors: ControlValueAccessor[]) {
+    super();
+    this.valueAccessor = selectValueAccessor(this, valueAccessors);
+  }
 
-              ngOnDestroy(): void { this.formDirective.removeControl(this); }
+  ngOnChanges(changes: SimpleChanges) {
+    if (!this._added) {
+      this._checkParentType();
+      this.formDirective.addControl(this);
+      if (this.control.disabled) this.valueAccessor.setDisabledState(true);
+      this._added = true;
+    }
+    if (isPropertyUpdated(changes, this.viewModel)) {
+      this.viewModel = this.model;
+      this.formDirective.updateModel(this, this.model);
+    }
+  }
 
-              viewToModelUpdate(newValue: any): void {
-                this.viewModel = newValue;
-                this.update.emit(newValue);
-              }
+  ngOnDestroy(): void { this.formDirective.removeControl(this); }
 
-              get path(): string[] { return controlPath(this.name, this._parent); }
+  viewToModelUpdate(newValue: any): void {
+    this.viewModel = newValue;
+    this.update.emit(newValue);
+  }
 
-              get formDirective(): any { return this._parent.formDirective; }
+  get path(): string[] { return controlPath(this.name, this._parent); }
 
-              get validator(): ValidatorFn { return composeValidators(this._validators); }
+  get formDirective(): any { return this._parent.formDirective; }
 
-              get asyncValidator(): AsyncValidatorFn {
-                return composeAsyncValidators(this._asyncValidators);
-              }
+  get validator(): ValidatorFn { return composeValidators(this._validators); }
 
-              get control(): FormControl { return this.formDirective.getControl(this); }
+  get asyncValidator(): AsyncValidatorFn { return composeAsyncValidators(this._asyncValidators); }
 
-              private _checkParentType(): void {
-                if (!(this._parent instanceof FormGroupName) &&
-                    this._parent instanceof AbstractFormGroupDirective) {
-                  ReactiveErrors.ngModelGroupException();
-                } else if (
-                    !(this._parent instanceof FormGroupName) &&
-                    !(this._parent instanceof FormGroupDirective) &&
-                    !(this._parent instanceof FormArrayName)) {
-                  ReactiveErrors.controlParentException();
-                }
-              }
+  get control(): FormControl { return this.formDirective.getControl(this); }
+
+  private _checkParentType(): void {
+    if (!(this._parent instanceof FormGroupName) &&
+        this._parent instanceof AbstractFormGroupDirective) {
+      ReactiveErrors.ngModelGroupException();
+    } else if (
+        !(this._parent instanceof FormGroupName) && !(this._parent instanceof FormGroupDirective) &&
+        !(this._parent instanceof FormArrayName)) {
+      ReactiveErrors.controlParentException();
+    }
+  }
 }

--- a/modules/@angular/forms/src/directives/reactive_errors.ts
+++ b/modules/@angular/forms/src/directives/reactive_errors.ts
@@ -61,4 +61,18 @@ export class ReactiveErrors {
 
         ${Examples.formArrayName}`);
   }
+
+  static disabledAttrWarning(): void {
+    console.warn(`
+      It looks like you're using the disabled attribute with a reactive form directive. If you set disabled to true
+      when you set up this control in your component class, the disabled attribute will actually be set in the DOM for
+      you. We recommend using this approach to avoid 'changed after checked' errors.
+       
+      Example: 
+      form = new FormGroup({
+        first: new FormControl({value: 'Nancy', disabled: true}, Validators.required),
+        last: new FormControl('Drew', Validators.required)
+      });
+    `);
+  }
 }

--- a/modules/@angular/forms/src/directives/select_control_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/select_control_value_accessor.ts
@@ -71,6 +71,10 @@ export class SelectControlValueAccessor implements ControlValueAccessor {
   }
   registerOnTouched(fn: () => any): void { this.onTouched = fn; }
 
+  setDisabledState(isDisabled: boolean): void {
+    this._renderer.setElementProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+  }
+
   /** @internal */
   _registerOption(): string { return (this._idCounter++).toString(); }
 

--- a/modules/@angular/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -63,7 +63,7 @@ export class SelectMultipleControlValueAccessor implements ControlValueAccessor 
   onChange = (_: any) => {};
   onTouched = () => {};
 
-  constructor() {}
+  constructor(private _renderer: Renderer, private _elementRef: ElementRef) {}
 
   writeValue(value: any): void {
     this.value = value;
@@ -100,6 +100,10 @@ export class SelectMultipleControlValueAccessor implements ControlValueAccessor 
     };
   }
   registerOnTouched(fn: () => any): void { this.onTouched = fn; }
+
+  setDisabledState(isDisabled: boolean): void {
+    this._renderer.setElementProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+  }
 
   /** @internal */
   _registerOption(value: NgSelectMultipleOption): string {

--- a/modules/@angular/forms/src/directives/shared.ts
+++ b/modules/@angular/forms/src/directives/shared.ts
@@ -58,6 +58,11 @@ export function setUpControl(control: FormControl, dir: NgControl): void {
     if (emitModelEvent) dir.viewToModelUpdate(newValue);
   });
 
+  if (dir.valueAccessor.setDisabledState) {
+    control.registerOnDisabledChange(
+        (isDisabled: boolean) => { dir.valueAccessor.setDisabledState(isDisabled); });
+  }
+
   // touched
   dir.valueAccessor.registerOnTouched(() => control.markAsTouched());
 }
@@ -99,6 +104,15 @@ export function isPropertyUpdated(changes: {[key: string]: any}, viewModel: any)
   return !looseIdentical(viewModel, change.currentValue);
 }
 
+export function isBuiltInAccessor(valueAccessor: ControlValueAccessor): boolean {
+  return (
+      hasConstructor(valueAccessor, CheckboxControlValueAccessor) ||
+      hasConstructor(valueAccessor, NumberValueAccessor) ||
+      hasConstructor(valueAccessor, SelectControlValueAccessor) ||
+      hasConstructor(valueAccessor, SelectMultipleControlValueAccessor) ||
+      hasConstructor(valueAccessor, RadioControlValueAccessor));
+}
+
 // TODO: vsavkin remove it once https://github.com/angular/angular/issues/3011 is implemented
 export function selectValueAccessor(
     dir: NgControl, valueAccessors: ControlValueAccessor[]): ControlValueAccessor {
@@ -111,11 +125,7 @@ export function selectValueAccessor(
     if (hasConstructor(v, DefaultValueAccessor)) {
       defaultAccessor = v;
 
-    } else if (
-        hasConstructor(v, CheckboxControlValueAccessor) || hasConstructor(v, NumberValueAccessor) ||
-        hasConstructor(v, SelectControlValueAccessor) ||
-        hasConstructor(v, SelectMultipleControlValueAccessor) ||
-        hasConstructor(v, RadioControlValueAccessor)) {
+    } else if (isBuiltInAccessor(v)) {
       if (isPresent(builtinAccessor))
         _throwError(dir, 'More than one built-in value accessor matches form control with');
       builtinAccessor = v;

--- a/modules/@angular/forms/src/form_builder.ts
+++ b/modules/@angular/forms/src/form_builder.ts
@@ -64,21 +64,21 @@ export class FormBuilder {
    * See the {@link FormGroup} constructor for more details.
    */
   group(controlsConfig: {[key: string]: any}, extra: {[key: string]: any} = null): FormGroup {
-    var controls = this._reduceControls(controlsConfig);
-    var optionals = <{[key: string]: boolean}>(
-        isPresent(extra) ? StringMapWrapper.get(extra, 'optionals') : null);
-    var validator: ValidatorFn = isPresent(extra) ? StringMapWrapper.get(extra, 'validator') : null;
-    var asyncValidator: AsyncValidatorFn =
+    const controls = this._reduceControls(controlsConfig);
+    const validator: ValidatorFn =
+        isPresent(extra) ? StringMapWrapper.get(extra, 'validator') : null;
+    const asyncValidator: AsyncValidatorFn =
         isPresent(extra) ? StringMapWrapper.get(extra, 'asyncValidator') : null;
-    return new FormGroup(controls, optionals, validator, asyncValidator);
+    return new FormGroup(controls, validator, asyncValidator);
   }
   /**
-   * Construct a new {@link FormControl} with the given `value`,`validator`, and `asyncValidator`.
+   * Construct a new {@link FormControl} with the given `formState`,`validator`, and
+   * `asyncValidator`.
    */
   control(
-      value: Object, validator: ValidatorFn|ValidatorFn[] = null,
+      formState: Object, validator: ValidatorFn|ValidatorFn[] = null,
       asyncValidator: AsyncValidatorFn|AsyncValidatorFn[] = null): FormControl {
-    return new FormControl(value, validator, asyncValidator);
+    return new FormControl(formState, validator, asyncValidator);
   }
 
   /**

--- a/modules/@angular/forms/test/directives_spec.ts
+++ b/modules/@angular/forms/test/directives_spec.ts
@@ -74,7 +74,7 @@ export function main() {
         });
 
         it('should return select multiple accessor when provided', () => {
-          const selectMultipleAccessor = new SelectMultipleControlValueAccessor();
+          const selectMultipleAccessor = new SelectMultipleControlValueAccessor(null, null);
           expect(selectValueAccessor(dir, [
             defaultAccessor, selectMultipleAccessor
           ])).toEqual(selectMultipleAccessor);
@@ -95,7 +95,7 @@ export function main() {
 
         it('should return custom accessor when provided with select multiple', () => {
           const customAccessor = new SpyValueAccessor();
-          const selectMultipleAccessor = new SelectMultipleControlValueAccessor();
+          const selectMultipleAccessor = new SelectMultipleControlValueAccessor(null, null);
           expect(selectValueAccessor(
                      dir, <any>[defaultAccessor, customAccessor, selectMultipleAccessor]))
               .toEqual(customAccessor);
@@ -124,9 +124,9 @@ export function main() {
     });
 
     describe('formGroup', () => {
-      var form: any /** TODO #9100 */;
-      var formModel: FormGroup;
-      var loginControlDir: any /** TODO #9100 */;
+      let form: FormGroupDirective;
+      let formModel: FormGroup;
+      let loginControlDir: FormControlName;
 
       beforeEach(() => {
         form = new FormGroupDirective([], []);
@@ -160,7 +160,7 @@ export function main() {
 
       describe('addControl', () => {
         it('should throw when no control found', () => {
-          var dir = new FormControlName(form, null, null, [defaultAccessor]);
+          const dir = new FormControlName(form, null, null, [defaultAccessor]);
           dir.name = 'invalidName';
 
           expect(() => form.addControl(dir))

--- a/modules/@angular/forms/test/form_builder_spec.ts
+++ b/modules/@angular/forms/test/form_builder_spec.ts
@@ -14,7 +14,7 @@ export function main() {
   function asyncValidator(_: any /** TODO #9100 */) { return Promise.resolve(null); }
 
   describe('Form Builder', () => {
-    var b: any /** TODO #9100 */;
+    let b: FormBuilder;
 
     beforeEach(() => { b = new FormBuilder(); });
 
@@ -22,6 +22,13 @@ export function main() {
       var g = b.group({'login': 'some value'});
 
       expect(g.controls['login'].value).toEqual('some value');
+    });
+
+    it('should create controls from a boxed value', () => {
+      const g = b.group({'login': {value: 'some value', disabled: true}});
+
+      expect(g.controls['login'].value).toEqual('some value');
+      expect(g.controls['login'].disabled).toEqual(true);
     });
 
     it('should create controls from an array', () => {
@@ -40,12 +47,6 @@ export function main() {
       expect(g.controls['login'].value).toEqual('some value');
       expect(g.controls['login'].validator).toBe(syncValidator);
       expect(g.controls['login'].asyncValidator).toBe(asyncValidator);
-    });
-
-    it('should create groups with optional controls', () => {
-      var g = b.group({'login': 'some value'}, {'optionals': {'login': false}});
-
-      expect(g.contains('login')).toEqual(false);
     });
 
     it('should create groups with a custom validator', () => {

--- a/modules/@angular/forms/test/form_control_spec.ts
+++ b/modules/@angular/forms/test/form_control_spec.ts
@@ -12,6 +12,7 @@ import {FormControl, FormGroup, Validators} from '@angular/forms';
 
 import {EventEmitter} from '../src/facade/async';
 import {isPresent} from '../src/facade/lang';
+import {FormArray} from '../src/model';
 
 export function main() {
   function asyncValidator(expected: any /** TODO #9100 */, timeouts = {}) {
@@ -43,18 +44,40 @@ export function main() {
 
   describe('FormControl', () => {
     it('should default the value to null', () => {
-      var c = new FormControl();
+      const c = new FormControl();
       expect(c.value).toBe(null);
+    });
+
+    describe('boxed values', () => {
+      it('should support valid boxed values on creation', () => {
+        const c = new FormControl({value: 'some val', disabled: true}, null, null);
+        expect(c.disabled).toBe(true);
+        expect(c.value).toBe('some val');
+        expect(c.status).toBe('DISABLED');
+      });
+
+      it('should not treat objects as boxed values if they have more than two props', () => {
+        const c = new FormControl({value: '', disabled: true, test: 'test'}, null, null);
+        expect(c.value).toEqual({value: '', disabled: true, test: 'test'});
+        expect(c.disabled).toBe(false);
+      });
+
+      it('should not treat objects as boxed values if disabled is missing', () => {
+        const c = new FormControl({value: '', test: 'test'}, null, null);
+        expect(c.value).toEqual({value: '', test: 'test'});
+        expect(c.disabled).toBe(false);
+      });
+
     });
 
     describe('validator', () => {
       it('should run validator with the initial value', () => {
-        var c = new FormControl('value', Validators.required);
+        const c = new FormControl('value', Validators.required);
         expect(c.valid).toEqual(true);
       });
 
       it('should rerun the validator when the value changes', () => {
-        var c = new FormControl('value', Validators.required);
+        const c = new FormControl('value', Validators.required);
         c.setValue(null);
         expect(c.valid).toEqual(false);
       });
@@ -69,12 +92,12 @@ export function main() {
       });
 
       it('should return errors', () => {
-        var c = new FormControl(null, Validators.required);
+        const c = new FormControl(null, Validators.required);
         expect(c.errors).toEqual({'required': true});
       });
 
       it('should set single validator', () => {
-        var c = new FormControl(null);
+        const c = new FormControl(null);
         expect(c.valid).toEqual(true);
 
         c.setValidators(Validators.required);
@@ -87,7 +110,7 @@ export function main() {
       });
 
       it('should set multiple validators from array', () => {
-        var c = new FormControl('');
+        const c = new FormControl('');
         expect(c.valid).toEqual(true);
 
         c.setValidators([Validators.minLength(5), Validators.required]);
@@ -103,7 +126,7 @@ export function main() {
       });
 
       it('should clear validators', () => {
-        var c = new FormControl('', Validators.required);
+        const c = new FormControl('', Validators.required);
         expect(c.valid).toEqual(false);
 
         c.clearValidators();
@@ -114,7 +137,7 @@ export function main() {
       });
 
       it('should add after clearing', () => {
-        var c = new FormControl('', Validators.required);
+        const c = new FormControl('', Validators.required);
         expect(c.valid).toEqual(false);
 
         c.clearValidators();
@@ -127,7 +150,7 @@ export function main() {
 
     describe('asyncValidator', () => {
       it('should run validator with the initial value', fakeAsync(() => {
-           var c = new FormControl('value', null, asyncValidator('expected'));
+           const c = new FormControl('value', null, asyncValidator('expected'));
            tick();
 
            expect(c.valid).toEqual(false);
@@ -135,7 +158,7 @@ export function main() {
          }));
 
       it('should support validators returning observables', fakeAsync(() => {
-           var c = new FormControl('value', null, asyncValidatorReturningObservable);
+           const c = new FormControl('value', null, asyncValidatorReturningObservable);
            tick();
 
            expect(c.valid).toEqual(false);
@@ -143,7 +166,7 @@ export function main() {
          }));
 
       it('should rerun the validator when the value changes', fakeAsync(() => {
-           var c = new FormControl('value', null, asyncValidator('expected'));
+           const c = new FormControl('value', null, asyncValidator('expected'));
 
            c.setValue('expected');
            tick();
@@ -152,7 +175,7 @@ export function main() {
          }));
 
       it('should run the async validator only when the sync validator passes', fakeAsync(() => {
-           var c = new FormControl('', Validators.required, asyncValidator('expected'));
+           const c = new FormControl('', Validators.required, asyncValidator('expected'));
            tick();
 
            expect(c.errors).toEqual({'required': true});
@@ -164,7 +187,7 @@ export function main() {
          }));
 
       it('should mark the control as pending while running the async validation', fakeAsync(() => {
-           var c = new FormControl('', null, asyncValidator('expected'));
+           const c = new FormControl('', null, asyncValidator('expected'));
 
            expect(c.pending).toEqual(true);
 
@@ -174,7 +197,7 @@ export function main() {
          }));
 
       it('should only use the latest async validation run', fakeAsync(() => {
-           var c = new FormControl(
+           const c = new FormControl(
                '', null, asyncValidator('expected', {'long': 200, 'expected': 100}));
 
            c.setValue('long');
@@ -194,7 +217,7 @@ export function main() {
          }));
 
       it('should add single async validator', fakeAsync(() => {
-           var c = new FormControl('value', null);
+           const c = new FormControl('value', null);
 
            c.setAsyncValidators(asyncValidator('expected'));
            expect(c.asyncValidator).not.toEqual(null);
@@ -206,7 +229,7 @@ export function main() {
          }));
 
       it('should add async validator from array', fakeAsync(() => {
-           var c = new FormControl('value', null);
+           const c = new FormControl('value', null);
 
            c.setAsyncValidators([asyncValidator('expected')]);
            expect(c.asyncValidator).not.toEqual(null);
@@ -218,11 +241,19 @@ export function main() {
          }));
 
       it('should clear async validators', fakeAsync(() => {
-           var c = new FormControl('value', [asyncValidator('expected'), otherAsyncValidator]);
+           const c = new FormControl('value', [asyncValidator('expected'), otherAsyncValidator]);
 
            c.clearValidators();
 
            expect(c.asyncValidator).toEqual(null);
+         }));
+
+      it('should not change validity state if control is disabled while async validating',
+         fakeAsync(() => {
+           const c = new FormControl('value', [asyncValidator('expected')]);
+           c.disable();
+           tick();
+           expect(c.status).toEqual('DISABLED');
          }));
     });
 
@@ -305,6 +336,14 @@ export function main() {
            c.setValue('newValue', {emitEvent: false});
            tick();
          }));
+
+      it('should work on a disabled control', () => {
+        g.addControl('two', new FormControl('two'));
+        c.disable();
+        c.setValue('new value');
+        expect(c.value).toEqual('new value');
+        expect(g.value).toEqual({'two': 'two'});
+      });
     });
 
     describe('patchValue', () => {
@@ -361,6 +400,15 @@ export function main() {
 
            tick();
          }));
+
+      it('should patch value on a disabled control', () => {
+        g.addControl('two', new FormControl('two'));
+        c.disable();
+
+        c.patchValue('new value');
+        expect(c.value).toEqual('new value');
+        expect(g.value).toEqual({'two': 'two'});
+      });
     });
 
     describe('reset()', () => {
@@ -368,11 +416,19 @@ export function main() {
 
       beforeEach(() => { c = new FormControl('initial value'); });
 
-      it('should restore the initial value of the control if passed', () => {
+      it('should reset to a specific value if passed', () => {
         c.setValue('new value');
         expect(c.value).toBe('new value');
 
         c.reset('initial value');
+        expect(c.value).toBe('initial value');
+      });
+
+      it('should reset to a specific value if passed with boxed value', () => {
+        c.setValue('new value');
+        expect(c.value).toBe('new value');
+
+        c.reset({value: 'initial value', disabled: false});
         expect(c.value).toBe('initial value');
       });
 
@@ -401,7 +457,6 @@ export function main() {
         c.reset();
         expect(g.value).toEqual({'one': null});
       });
-
 
       it('should mark the control as pristine', () => {
         c.markAsDirty();
@@ -457,6 +512,20 @@ export function main() {
         expect(g.untouched).toBe(false);
       });
 
+      it('should retain the disabled state of the control', () => {
+        c.disable();
+        c.reset();
+
+        expect(c.disabled).toBe(true);
+      });
+
+      it('should set disabled state based on boxed value if passed', () => {
+        c.disable();
+        c.reset({value: null, disabled: false});
+
+        expect(c.disabled).toBe(false);
+      });
+
       describe('reset() events', () => {
         let g: FormGroup, c2: FormControl, logger: any[];
 
@@ -481,6 +550,15 @@ export function main() {
           c2.statusChanges.subscribe(() => logger.push('control2'));
 
           c.reset();
+          expect(logger).toEqual(['control1', 'group']);
+        });
+
+        it('should emit one statusChange event per disabled control', () => {
+          g.statusChanges.subscribe(() => logger.push('group'));
+          c.statusChanges.subscribe(() => logger.push('control1'));
+          c2.statusChanges.subscribe(() => logger.push('control2'));
+
+          c.reset({value: null, disabled: true});
           expect(logger).toEqual(['control1', 'group']);
         });
       });
@@ -572,7 +650,7 @@ export function main() {
 
     describe('setErrors', () => {
       it('should set errors on a control', () => {
-        var c = new FormControl('someValue');
+        const c = new FormControl('someValue');
 
         c.setErrors({'someError': true});
 
@@ -581,7 +659,7 @@ export function main() {
       });
 
       it('should reset the errors and validity when the value changes', () => {
-        var c = new FormControl('someValue', Validators.required);
+        const c = new FormControl('someValue', Validators.required);
 
         c.setErrors({'someError': true});
         c.setValue('');
@@ -590,8 +668,8 @@ export function main() {
       });
 
       it('should update the parent group\'s validity', () => {
-        var c = new FormControl('someValue');
-        var g = new FormGroup({'one': c});
+        const c = new FormControl('someValue');
+        const g = new FormGroup({'one': c});
 
         expect(g.valid).toEqual(true);
 
@@ -601,8 +679,8 @@ export function main() {
       });
 
       it('should not reset parent\'s errors', () => {
-        var c = new FormControl('someValue');
-        var g = new FormGroup({'one': c});
+        const c = new FormControl('someValue');
+        const g = new FormGroup({'one': c});
 
         g.setErrors({'someGroupError': true});
         c.setErrors({'someError': true});
@@ -611,8 +689,8 @@ export function main() {
       });
 
       it('should reset errors when updating a value', () => {
-        var c = new FormControl('oldValue');
-        var g = new FormGroup({'one': c});
+        const c = new FormControl('oldValue');
+        const g = new FormGroup({'one': c});
 
         g.setErrors({'someGroupError': true});
         c.setErrors({'someError': true});
@@ -621,6 +699,222 @@ export function main() {
 
         expect(c.errors).toEqual(null);
         expect(g.errors).toEqual(null);
+      });
+    });
+
+    describe('disable() & enable()', () => {
+
+      it('should mark the control as disabled', () => {
+        const c = new FormControl(null);
+        expect(c.disabled).toBe(false);
+        expect(c.valid).toBe(true);
+
+        c.disable();
+        expect(c.disabled).toBe(true);
+        expect(c.valid).toBe(false);
+
+        c.enable();
+        expect(c.disabled).toBe(false);
+        expect(c.valid).toBe(true);
+      });
+
+      it('should set the control status as disabled', () => {
+        const c = new FormControl(null);
+        expect(c.status).toEqual('VALID');
+
+        c.disable();
+        expect(c.status).toEqual('DISABLED');
+
+        c.enable();
+        expect(c.status).toEqual('VALID');
+      });
+
+      it('should retain the original value when disabled', () => {
+        const c = new FormControl('some value');
+        expect(c.value).toEqual('some value');
+
+        c.disable();
+        expect(c.value).toEqual('some value');
+
+        c.enable();
+        expect(c.value).toEqual('some value');
+      });
+
+      it('should keep the disabled control in the group, but return false for contains()', () => {
+        const c = new FormControl('');
+        const g = new FormGroup({'one': c});
+
+        expect(g.get('one')).toBeDefined();
+        expect(g.contains('one')).toBe(true);
+
+        c.disable();
+        expect(g.get('one')).toBeDefined();
+        expect(g.contains('one')).toBe(false);
+      });
+
+      it('should mark the parent group disabled if all controls are disabled', () => {
+        const c = new FormControl();
+        const c2 = new FormControl();
+        const g = new FormGroup({'one': c, 'two': c2});
+        expect(g.enabled).toBe(true);
+
+        c.disable();
+        expect(g.enabled).toBe(true);
+
+        c2.disable();
+        expect(g.enabled).toBe(false);
+
+        c.enable();
+        expect(g.enabled).toBe(true);
+      });
+
+      it('should update the parent group value when child control status changes', () => {
+        const c = new FormControl('one');
+        const c2 = new FormControl('two');
+        const g = new FormGroup({'one': c, 'two': c2});
+        expect(g.value).toEqual({'one': 'one', 'two': 'two'});
+
+        c.disable();
+        expect(g.value).toEqual({'two': 'two'});
+
+        c2.disable();
+        expect(g.value).toEqual({'one': 'one', 'two': 'two'});
+
+        c.enable();
+        expect(g.value).toEqual({'one': 'one'});
+      });
+
+      it('should mark the parent array disabled if all controls are disabled', () => {
+        const c = new FormControl();
+        const c2 = new FormControl();
+        const a = new FormArray([c, c2]);
+        expect(a.enabled).toBe(true);
+
+        c.disable();
+        expect(a.enabled).toBe(true);
+
+        c2.disable();
+        expect(a.enabled).toBe(false);
+
+        c.enable();
+        expect(a.enabled).toBe(true);
+      });
+
+      it('should update the parent array value when child control status changes', () => {
+        const c = new FormControl('one');
+        const c2 = new FormControl('two');
+        const a = new FormArray([c, c2]);
+        expect(a.value).toEqual(['one', 'two']);
+
+        c.disable();
+        expect(a.value).toEqual(['two']);
+
+        c2.disable();
+        expect(a.value).toEqual(['one', 'two']);
+
+        c.enable();
+        expect(a.value).toEqual(['one']);
+      });
+
+      it('should ignore disabled controls in validation', () => {
+        const c = new FormControl(null, Validators.required);
+        const c2 = new FormControl(null);
+        const g = new FormGroup({one: c, two: c2});
+        expect(g.valid).toBe(false);
+
+        c.disable();
+        expect(g.valid).toBe(true);
+
+        c.enable();
+        expect(g.valid).toBe(false);
+      });
+
+      it('should ignore disabled controls when serializing value in a group', () => {
+        const c = new FormControl('one');
+        const c2 = new FormControl('two');
+        const g = new FormGroup({one: c, two: c2});
+        expect(g.value).toEqual({one: 'one', two: 'two'});
+
+        c.disable();
+        expect(g.value).toEqual({two: 'two'});
+
+        c.enable();
+        expect(g.value).toEqual({one: 'one', two: 'two'});
+      });
+
+      it('should ignore disabled controls when serializing value in an array', () => {
+        const c = new FormControl('one');
+        const c2 = new FormControl('two');
+        const a = new FormArray([c, c2]);
+        expect(a.value).toEqual(['one', 'two']);
+
+        c.disable();
+        expect(a.value).toEqual(['two']);
+
+        c.enable();
+        expect(a.value).toEqual(['one', 'two']);
+      });
+
+      it('should ignore disabled controls when determining dirtiness', () => {
+        const c = new FormControl('one');
+        const c2 = new FormControl('two');
+        const g = new FormGroup({one: c, two: c2});
+        c.markAsDirty();
+        expect(g.dirty).toBe(true);
+
+        c.disable();
+        expect(c.dirty).toBe(true);
+        expect(g.dirty).toBe(false);
+
+        c.enable();
+        expect(g.dirty).toBe(true);
+      });
+
+      it('should ignore disabled controls when determining touched state', () => {
+        const c = new FormControl('one');
+        const c2 = new FormControl('two');
+        const g = new FormGroup({one: c, two: c2});
+        c.markAsTouched();
+        expect(g.touched).toBe(true);
+
+        c.disable();
+        expect(c.touched).toBe(true);
+        expect(g.touched).toBe(false);
+
+        c.enable();
+        expect(g.touched).toBe(true);
+      });
+
+      describe('disabled events', () => {
+        let logger: string[];
+        let c: FormControl;
+        let g: FormGroup;
+
+        beforeEach(() => {
+          logger = [];
+          c = new FormControl('', Validators.required);
+          g = new FormGroup({one: c});
+        });
+
+        it('should emit a statusChange event when disabled status changes', () => {
+          c.statusChanges.subscribe((status: string) => logger.push(status));
+
+          c.disable();
+          expect(logger).toEqual(['DISABLED']);
+
+          c.enable();
+          expect(logger).toEqual(['DISABLED', 'INVALID']);
+
+        });
+
+        it('should emit status change events in correct order', () => {
+          c.statusChanges.subscribe(() => logger.push('control'));
+          g.statusChanges.subscribe(() => logger.push('group'));
+
+          c.disable();
+          expect(logger).toEqual(['control', 'group']);
+        });
+
       });
     });
   });

--- a/modules/@angular/forms/test/reactive_integration_spec.ts
+++ b/modules/@angular/forms/test/reactive_integration_spec.ts
@@ -161,7 +161,7 @@ export function main() {
     });
 
     describe('programmatic changes', () => {
-      it('should update the value in the DOM when setValue is called', () => {
+      it('should update the value in the DOM when setValue() is called', () => {
         const fixture = TestBed.createComponent(FormGroupComp);
         const login = new FormControl('oldValue');
         const form = new FormGroup({'login': login});
@@ -173,6 +173,89 @@ export function main() {
 
         const input = fixture.debugElement.query(By.css('input'));
         expect(input.nativeElement.value).toEqual('newValue');
+      });
+
+      describe('disabled controls', () => {
+        it('should add disabled attribute to an individual control when instantiated as disabled',
+           () => {
+             const fixture = TestBed.createComponent(FormControlComp);
+             const control = new FormControl({value: 'some value', disabled: true});
+             fixture.debugElement.componentInstance.control = control;
+             fixture.detectChanges();
+
+             const input = fixture.debugElement.query(By.css('input'));
+             expect(input.nativeElement.disabled).toBe(true);
+
+             control.enable();
+             fixture.detectChanges();
+             expect(input.nativeElement.disabled).toBe(false);
+           });
+
+        it('should add disabled attribute to formControlName when instantiated as disabled', () => {
+          const fixture = TestBed.createComponent(FormGroupComp);
+          const control = new FormControl({value: 'some value', disabled: true});
+          fixture.debugElement.componentInstance.form = new FormGroup({login: control});
+          fixture.debugElement.componentInstance.control = control;
+          fixture.detectChanges();
+
+          const input = fixture.debugElement.query(By.css('input'));
+          expect(input.nativeElement.disabled).toBe(true);
+
+          control.enable();
+          fixture.detectChanges();
+          expect(input.nativeElement.disabled).toBe(false);
+        });
+
+        it('should add disabled attribute to an individual control when disable() is called',
+           () => {
+             const fixture = TestBed.createComponent(FormControlComp);
+             const control = new FormControl('some value');
+             fixture.debugElement.componentInstance.control = control;
+             fixture.detectChanges();
+
+             control.disable();
+             fixture.detectChanges();
+
+             const input = fixture.debugElement.query(By.css('input'));
+             expect(input.nativeElement.disabled).toBe(true);
+
+             control.enable();
+             fixture.detectChanges();
+             expect(input.nativeElement.disabled).toBe(false);
+           });
+
+        it('should add disabled attribute to child controls when disable() is called on group',
+           () => {
+             const fixture = TestBed.createComponent(FormGroupComp);
+             const form = new FormGroup({'login': new FormControl('login')});
+             fixture.debugElement.componentInstance.form = form;
+             fixture.detectChanges();
+
+             form.disable();
+             fixture.detectChanges();
+
+             const inputs = fixture.debugElement.queryAll(By.css('input'));
+             expect(inputs[0].nativeElement.disabled).toBe(true);
+
+             form.enable();
+             fixture.detectChanges();
+             expect(inputs[0].nativeElement.disabled).toBe(false);
+           });
+
+
+        it('should not add disabled attribute to custom controls when disable() is called', () => {
+          const fixture = TestBed.createComponent(MyInputForm);
+          const control = new FormControl('some value');
+          fixture.debugElement.componentInstance.form = new FormGroup({login: control});
+          fixture.detectChanges();
+
+          control.disable();
+          fixture.detectChanges();
+
+          const input = fixture.debugElement.query(By.css('my-input'));
+          expect(input.nativeElement.getAttribute('disabled')).toBe(null);
+        });
+
       });
 
     });
@@ -1203,7 +1286,7 @@ class WrappedValueForm {
   template: `
    <div [formGroup]="form">
       <my-input formControlName="login"></my-input>
-    </div>
+   </div>
   `
 })
 class MyInputForm {

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -2,6 +2,8 @@
 export declare abstract class AbstractControl {
     asyncValidator: AsyncValidatorFn;
     dirty: boolean;
+    disabled: boolean;
+    enabled: boolean;
     errors: {
         [key: string]: any;
     };
@@ -20,6 +22,14 @@ export declare abstract class AbstractControl {
     constructor(validator: ValidatorFn, asyncValidator: AsyncValidatorFn);
     clearAsyncValidators(): void;
     clearValidators(): void;
+    disable({onlySelf, emitEvent}?: {
+        onlySelf?: boolean;
+        emitEvent?: boolean;
+    }): void;
+    enable({onlySelf, emitEvent}?: {
+        onlySelf?: boolean;
+        emitEvent?: boolean;
+    }): void;
     get(path: Array<string | number> | string): AbstractControl;
     getError(errorCode: string, path?: string[]): any;
     hasError(errorCode: string, path?: string[]): boolean;
@@ -59,6 +69,8 @@ export declare abstract class AbstractControl {
 export declare abstract class AbstractControlDirective {
     control: AbstractControl;
     dirty: boolean;
+    disabled: boolean;
+    enabled: boolean;
     errors: {
         [key: string]: any;
     };
@@ -98,6 +110,7 @@ export declare class CheckboxControlValueAccessor implements ControlValueAccesso
     constructor(_renderer: Renderer, _elementRef: ElementRef);
     registerOnChange(fn: (_: any) => {}): void;
     registerOnTouched(fn: () => {}): void;
+    setDisabledState(isDisabled: boolean): void;
     writeValue(value: any): void;
 }
 
@@ -112,6 +125,7 @@ export declare class ControlContainer extends AbstractControlDirective {
 export interface ControlValueAccessor {
     registerOnChange(fn: any): void;
     registerOnTouched(fn: any): void;
+    setDisabledState?(isDisabled: boolean): void;
     writeValue(obj: any): void;
 }
 
@@ -122,6 +136,7 @@ export declare class DefaultValueAccessor implements ControlValueAccessor {
     constructor(_renderer: Renderer, _elementRef: ElementRef);
     registerOnChange(fn: (_: any) => void): void;
     registerOnTouched(fn: () => void): void;
+    setDisabledState(isDisabled: boolean): void;
     writeValue(value: any): void;
 }
 
@@ -148,6 +163,7 @@ export declare class FormArray extends AbstractControl {
     length: number;
     constructor(controls: AbstractControl[], validator?: ValidatorFn, asyncValidator?: AsyncValidatorFn);
     at(index: number): AbstractControl;
+    getRawValue(): any[];
     insert(index: number, control: AbstractControl): void;
     patchValue(value: any[], {onlySelf}?: {
         onlySelf?: boolean;
@@ -178,7 +194,7 @@ export declare class FormArrayName extends ControlContainer implements OnInit, O
 /** @stable */
 export declare class FormBuilder {
     array(controlsConfig: any[], validator?: ValidatorFn, asyncValidator?: AsyncValidatorFn): FormArray;
-    control(value: Object, validator?: ValidatorFn | ValidatorFn[], asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[]): FormControl;
+    control(formState: Object, validator?: ValidatorFn | ValidatorFn[], asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[]): FormControl;
     group(controlsConfig: {
         [key: string]: any;
     }, extra?: {
@@ -188,7 +204,7 @@ export declare class FormBuilder {
 
 /** @stable */
 export declare class FormControl extends AbstractControl {
-    constructor(value?: any, validator?: ValidatorFn | ValidatorFn[], asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[]);
+    constructor(formState?: any, validator?: ValidatorFn | ValidatorFn[], asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[]);
     patchValue(value: any, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
@@ -196,7 +212,8 @@ export declare class FormControl extends AbstractControl {
         emitViewToModelChange?: boolean;
     }): void;
     registerOnChange(fn: Function): void;
-    reset(value?: any, {onlySelf}?: {
+    registerOnDisabledChange(fn: (isDisabled: boolean) => void): void;
+    reset(formState?: any, {onlySelf}?: {
         onlySelf?: boolean;
     }): void;
     setValue(value: any, {onlySelf, emitEvent, emitModelToViewChange, emitViewToModelChange}?: {
@@ -211,6 +228,7 @@ export declare class FormControl extends AbstractControl {
 export declare class FormControlDirective extends NgControl implements OnChanges {
     asyncValidator: AsyncValidatorFn;
     control: FormControl;
+    disabled: boolean;
     form: FormControl;
     model: any;
     path: string[];
@@ -226,6 +244,7 @@ export declare class FormControlDirective extends NgControl implements OnChanges
 export declare class FormControlName extends NgControl implements OnChanges, OnDestroy {
     asyncValidator: AsyncValidatorFn;
     control: FormControl;
+    disabled: boolean;
     formDirective: any;
     model: any;
     name: string;
@@ -245,13 +264,10 @@ export declare class FormGroup extends AbstractControl {
     };
     constructor(controls: {
         [key: string]: AbstractControl;
-    }, optionals?: {
-        [key: string]: boolean;
     }, validator?: ValidatorFn, asyncValidator?: AsyncValidatorFn);
     addControl(name: string, control: AbstractControl): void;
     contains(controlName: string): boolean;
-    /** @deprecated */ exclude(controlName: string): void;
-    /** @deprecated */ include(controlName: string): void;
+    getRawValue(): Object;
     patchValue(value: {
         [key: string]: any;
     }, {onlySelf}?: {
@@ -380,6 +396,7 @@ export declare class NgForm extends ControlContainer implements Form {
 export declare class NgModel extends NgControl implements OnChanges, OnDestroy {
     asyncValidator: AsyncValidatorFn;
     control: FormControl;
+    disabled: boolean;
     formDirective: any;
     model: any;
     name: string;
@@ -442,6 +459,7 @@ export declare class SelectControlValueAccessor implements ControlValueAccessor 
     constructor(_renderer: Renderer, _elementRef: ElementRef);
     registerOnChange(fn: (value: any) => any): void;
     registerOnTouched(fn: () => any): void;
+    setDisabledState(isDisabled: boolean): void;
     writeValue(value: any): void;
 }
 
@@ -450,9 +468,10 @@ export declare class SelectMultipleControlValueAccessor implements ControlValueA
     onChange: (_: any) => void;
     onTouched: () => void;
     value: any;
-    constructor();
+    constructor(_renderer: Renderer, _elementRef: ElementRef);
     registerOnChange(fn: (value: any) => any): void;
     registerOnTouched(fn: () => any): void;
+    setDisabledState(isDisabled: boolean): void;
     writeValue(value: any): void;
 }
 


### PR DESCRIPTION
In HTML5 forms, controls marked as disabled are not considered when calculating the validity or serialized value of the parent form.  However in Angular's current forms API, disabled controls still behave like normal controls and are included in all value/validity checks.  

This is confusing because it differs from the HTML5 spec, but it's also confusing because it creates situations where a disabled control can make the whole form invalid, and worse, it's not editable in the UI so this situation cannot be remedied without re-enabling the control.

**Changes:**

We are adding a new status to controls called "DISABLED".   A control can either be:

**VALID**:  control has passed all validation checks
**INVALID**: control has failed a validation check
**PENDING**: control is in the midst of conducting a validation check
**DISABLED**: control is exempt from validation checks

These statuses are mutually exclusive.  We are also adding **disabled** and **enabled** getters to `AbstractControls`.

When you disable a control, it's not included in parent validation or value serialization. So if your disabled control is invalid, the parent form can still be valid if it has other valid controls. Group values will also omit the values of disabled controls.   Group status is always reduced from the statuses of its children, so if all a group's children are disabled, the group is disabled.

**Reactive forms**

Using reactive forms, form controls are disabled in the component class.  When you disable a control, the `disabled` attribute is added for you in the DOM (so no need to do this yourself).

You have a few choices for how to disable a control.  If you want the control to be disabled from the start, you can pass a boxed value as the first arg when you instantiate your `FormControl`.  This boxed value contains all the form state that cannot be calculated (as validation state, dirtiness, and touched are all derived).

``` ts
form = new FormGroup({
   'first': new FormControl({value: 'Nancy', disabled: true}, Validators.required),
   'last': new FormControl('Drew', Validators.required)
})
```

Note that if you don't care to set disabled state, you can just pass in a value without the wrapper object like before.

You can also imperatively enable or disable controls with the `enable()` and `disable()` methods:

``` ts
this.form.disable();                   // disables itself and all children
this.form.get('first').disable();      // disables just this control
```

**Angular 1 style (template-driven) forms**

To disable a control in Angular-1 style forms, just add the disabled attribute or bind to the disabled property. The control will be disabled for you by `ngModel` under the hood.

``` html
<form>
   <input name="first" ngModel>
   <input name="last" ngModel required [disabled]="isDisabled">
</form>
```

Fixes #4460.

Breaking change: this PR also removes the deprecated optionals API, which has significant overlap with the new API.   For more information about that and the changes in this PR, there's more info in the [proposal doc](https://docs.google.com/document/d/1k_iYcgTS1cDJkyXvBWQZGPlkWZhEqAVphC0xyKSAqPs/edit).
