### PR TITLE
fix(router): canLoad should cancel a navigation instead of failing it

### DIFF
--- a/modules/@angular/router/src/apply_redirects.ts
+++ b/modules/@angular/router/src/apply_redirects.ts
@@ -19,7 +19,7 @@ import {EmptyError} from 'rxjs/util/EmptyError';
 
 import {Route, Routes} from './config';
 import {LoadedRouterConfig, RouterConfigLoader} from './router_config_loader';
-import {PRIMARY_OUTLET} from './shared';
+import {NavigationCancelingError, PRIMARY_OUTLET} from './shared';
 import {UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
 import {andObservables, merge, waitForMap, wrapIntoObservable} from './utils/collection';
 
@@ -43,7 +43,7 @@ function absoluteRedirect(segments: UrlSegment[]): Observable<UrlSegmentGroup> {
 
 function canLoadFails(route: Route): Observable<LoadedRouterConfig> {
   return new Observable<LoadedRouterConfig>(
-      (obs: Observer<LoadedRouterConfig>) => obs.error(new Error(
+      (obs: Observer<LoadedRouterConfig>) => obs.error(new NavigationCancelingError(
           `Cannot load children because the guard of the route "path: '${route.path}'" returned false`)));
 }
 

--- a/modules/@angular/router/src/shared.ts
+++ b/modules/@angular/router/src/shared.ts
@@ -22,3 +22,12 @@ export const PRIMARY_OUTLET = 'primary';
 export type Params = {
   [key: string]: any
 };
+
+export class NavigationCancelingError extends Error {
+  public stack: any;
+  constructor(public message: string) {
+    super(message);
+    this.stack = (<any>new Error(message)).stack;
+  }
+  toString(): string { return this.message; }
+}

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -1230,13 +1230,14 @@ describe('Integration', () => {
 
 
                  // failed navigation
-                 router.navigateByUrl('/lazyFalse/loaded').catch(s => {});
+                 router.navigateByUrl('/lazyFalse/loaded');
                  advance(fixture);
 
                  expect(location.path()).toEqual('/');
 
                  expectEvents(recordedEvents, [
-                   [NavigationStart, '/lazyFalse/loaded'], [NavigationError, '/lazyFalse/loaded']
+                   [NavigationStart, '/lazyFalse/loaded'],
+                   [NavigationCancel, '/lazyFalse/loaded']
                  ]);
 
                  recordedEvents.splice(0);

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -84,8 +84,9 @@ export declare type LoadChildrenCallback = () => Type<any> | Promise<Type<any>> 
 /** @stable */
 export declare class NavigationCancel {
     id: number;
+    reason: string;
     url: string;
-    constructor(id: number, url: string);
+    constructor(id: number, url: string, reason: string);
     toString(): string;
 }
 


### PR DESCRIPTION
Currently canLoad returning false fails a navigation instead of canceling it. This is different from canActivate. 

This PR changes it so canLoad behaves similar to canActivate.
