### PR TITLE
fix(compiler): Correctly handles references to static methods

### DIFF
--- a/modules/@angular/compiler-cli/integrationtest/src/features.ts
+++ b/modules/@angular/compiler-cli/integrationtest/src/features.ts
@@ -30,12 +30,13 @@ export class CompWithProviders {
 @Component({
   selector: 'cmp-reference',
   template: `
-    <input #a>{{a.value}}
+    <input #a [(ngModel)]="foo" required>{{a.value}}
     <div *ngIf="true">{{a.value}}</div>
   `,
   directives: [wrapInArray(common.NgIf)]
 })
 export class CompWithReferences {
+  foo: string;
 }
 
 @Component({selector: 'cmp-pipes', template: `<div *ngIf>{{test | somePipe}}</div>`})

--- a/modules/@angular/compiler-cli/integrationtest/src/module.ts
+++ b/modules/@angular/compiler-cli/integrationtest/src/module.ts
@@ -33,7 +33,7 @@ import {CompWithChildQuery, CompWithDirectiveChild} from './queries';
   providers: [SomeService],
   entryComponents: [
     AnimateCmp, BasicComp, CompWithEntryComponents, CompWithAnalyzeEntryComponentsProvider,
-    ProjectingComp, CompWithChildQuery, CompUsingRootModuleDirectiveAndPipe
+    ProjectingComp, CompWithChildQuery, CompUsingRootModuleDirectiveAndPipe, CompWithReferences
   ]
 })
 export class MainModule {

--- a/modules/@angular/compiler-cli/src/reflector_host.ts
+++ b/modules/@angular/compiler-cli/src/reflector_host.ts
@@ -221,11 +221,12 @@ export class ReflectorHost implements StaticReflectorHost, ImportGenerator {
    * @param declarationFile the absolute path of the file where the symbol is declared
    * @param name the name of the type.
    */
-  getStaticSymbol(declarationFile: string, name: string): StaticSymbol {
-    let key = `"${declarationFile}".${name}`;
+  getStaticSymbol(declarationFile: string, name: string, members?: string[]): StaticSymbol {
+    const memberSuffix = members ? `.${ members.join('.')}` : '';
+    const key = `"${declarationFile}".${name}${memberSuffix}`;
     let result = this.typeCache.get(key);
     if (!result) {
-      result = new StaticSymbol(declarationFile, name);
+      result = new StaticSymbol(declarationFile, name, members);
       this.typeCache.set(key, result);
     }
     return result;

--- a/modules/@angular/compiler-cli/src/static_reflector.ts
+++ b/modules/@angular/compiler-cli/src/static_reflector.ts
@@ -34,7 +34,7 @@ export interface StaticReflectorHost {
    */
   findDeclaration(modulePath: string, symbolName: string, containingFile?: string): StaticSymbol;
 
-  getStaticSymbol(declarationFile: string, name: string): StaticSymbol;
+  getStaticSymbol(declarationFile: string, name: string, members?: string[]): StaticSymbol;
 
   angularImportLocations(): {
     coreDecorators: string,
@@ -52,7 +52,7 @@ export interface StaticReflectorHost {
  * This token is unique for a filePath and name and can be used as a hash table key.
  */
 export class StaticSymbol {
-  constructor(public filePath: string, public name: string) {}
+  constructor(public filePath: string, public name: string, public members?: string[]) {}
 }
 
 /**
@@ -451,7 +451,12 @@ export class StaticReflector implements ReflectorReader {
                   if (declarationValue && declarationValue.statics) {
                     selectTarget = declarationValue.statics;
                   } else {
-                    return null;
+                    const member: string = expression['member'];
+                    const members = selectTarget.members ?
+                        (selectTarget.members as string[]).concat(member) :
+                        [member];
+                    return _this.host.getStaticSymbol(
+                        selectTarget.filePath, selectTarget.name, members);
                   }
                 }
                 const member = simplify(expression['member']);

--- a/modules/@angular/compiler/src/output/ts_emitter.ts
+++ b/modules/@angular/compiler/src/output/ts_emitter.ts
@@ -319,5 +319,9 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
           (type: any /** TODO #9100 */) => type.visitType(this, ctx), typeParams, ctx, ',');
       ctx.print(`>`);
     }
+    if (value.runtime && value.runtime.members) {
+      ctx.print('.');
+      ctx.print(value.runtime.members.join('.'));
+    }
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

References to static methods in providers and other metadata resulted in a `null` at runtime when using AoT. #10975

**What is the new behavior?**

References to static methods are correctly generated by AoT.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

Fixes: #10975
