### PR TITLE
fix(core): assigns an overriden name to constructor named constructor

### DIFF
--- a/modules/@angular/core/src/util/decorators.ts
+++ b/modules/@angular/core/src/util/decorators.ts
@@ -243,7 +243,8 @@ export function Class(clsDef: ClassDefinition): Type<any> {
     Reflect.defineMetadata('annotations', this.annotations, constructor);
   }
 
-  if (!constructor['name']) {
+  const constructorName = constructor['name'];
+  if (!constructorName || constructorName === 'constructor') {
     (constructor as any)['overriddenName'] = `class${_nextClassId++}`;
   }
 

--- a/modules/@angular/core/test/util/decorators_spec.ts
+++ b/modules/@angular/core/test/util/decorators_spec.ts
@@ -132,6 +132,10 @@ export function main() {
               .toThrowError(
                   'Class definition \'extends\' property must be a constructor function was: non_type');
         });
+
+        it('should assign an overridden name for anonymous constructor functions', () => {
+          expect((Class({constructor: function() {}}) as any).overriddenName).not.toBeUndefined();
+        });
       });
     });
   });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

Anonymous constructor functions given to `Class` as a constructor function caused Angular to generate the same asset cache key for all similar classes. This is because the name of the function is used in constructing the url of the class and some browsers, such as Chrome, will give anonymous functions given as the value of a object literal property the name of the property (in this case `constructor`).

**What is the new behavior?**

Anonymous of name `constructor` are now treated as if they were unnamed causing them to be given an overridden name and a unique asset cache key.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

Fixes #10545
