### PR TITLE
fix(closure): replace property accesses

### DIFF
--- a/modules/@angular/core/src/di/reflective_provider.ts
+++ b/modules/@angular/core/src/di/reflective_provider.ts
@@ -185,7 +185,7 @@ function _normalizeProviders(providers: Provider[], res: Provider[]): Provider[]
     if (b instanceof Type) {
       res.push({provide: b, useClass: b});
 
-    } else if (b && typeof b == 'object' && b.hasOwnProperty('provide')) {
+    } else if (b && typeof b == 'object' && (b as any).provide !== undefined) {
       res.push(b as NormalizedProvider);
 
     } else if (b instanceof Array) {

--- a/modules/@angular/platform-browser/src/browser/testability.ts
+++ b/modules/@angular/platform-browser/src/browser/testability.ts
@@ -68,10 +68,10 @@ export class BrowserGetTestability implements GetTestability {
       });
     };
 
-    if (!global.frameworkStabilizers) {
-      global.frameworkStabilizers = ListWrapper.createGrowableSize(0);
+    if (!global['frameworkStabilizers']) {
+      global['frameworkStabilizers'] = ListWrapper.createGrowableSize(0);
     }
-    global.frameworkStabilizers.push(whenAllStable);
+    global['frameworkStabilizers'].push(whenAllStable);
   }
 
   findTestabilityInTree(registry: TestabilityRegistry, elem: any, findInAncestors: boolean):


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Accessing a property on the window object must be done with square brackets.
Otherwise closure compiler may collide the symbol's alias between the property
and variable mappings.
Also, accessing the 'provide' property must be done with dot syntax, so that
it can be renamed along with the code that declares such a property.
