### PR TITLE
fix(forms): fix conflicting getter name

### DIFF
--- a/modules/@angular/forms/src/directives/ng_model.ts
+++ b/modules/@angular/forms/src/directives/ng_model.ts
@@ -65,7 +65,7 @@ export class NgModel extends NgControl implements OnChanges,
   viewModel: any;
 
   @Input() name: string;
-  @Input() disabled: boolean;
+  @Input('disabled') isDisabled: boolean;
   @Input('ngModel') model: any;
   @Input('ngModelOptions') options: {name?: string, standalone?: boolean};
 
@@ -83,7 +83,7 @@ export class NgModel extends NgControl implements OnChanges,
               ngOnChanges(changes: SimpleChanges) {
                 this._checkForErrors();
                 if (!this._registered) this._setUpControl();
-                if ('disabled' in changes) {
+                if ('isDisabled' in changes) {
                   this._updateDisabled(changes);
                 }
 
@@ -160,7 +160,7 @@ export class NgModel extends NgControl implements OnChanges,
               }
 
               private _updateDisabled(changes: SimpleChanges) {
-                const disabledValue = changes['disabled'].currentValue;
+                const disabledValue = changes['isDisabled'].currentValue;
                 const isDisabled = disabledValue != null && disabledValue != false;
 
                 resolvedPromise.then(() => {

--- a/modules/@angular/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/modules/@angular/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -82,7 +82,7 @@ export class FormControlDirective extends NgControl implements OnChanges {
   @Output('ngModelChange') update = new EventEmitter();
 
   @Input('disabled')
-  set disabled(isDisabled: boolean) { ReactiveErrors.disabledAttrWarning(); }
+  set isDisabled(isDisabled: boolean) { ReactiveErrors.disabledAttrWarning(); }
 
   constructor(@Optional() @Self() @Inject(NG_VALIDATORS) private _validators:
                   /* Array<Validator|Function> */ any[],

--- a/modules/@angular/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/modules/@angular/forms/src/directives/reactive_directives/form_control_name.ts
@@ -107,7 +107,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
   @Output('ngModelChange') update = new EventEmitter();
 
   @Input('disabled')
-  set disabled(isDisabled: boolean) { ReactiveErrors.disabledAttrWarning(); }
+  set isDisabled(isDisabled: boolean) { ReactiveErrors.disabledAttrWarning(); }
 
   constructor(
       @Optional() @Host() @SkipSelf() private _parent: ControlContainer,

--- a/modules/@angular/forms/test/directives_spec.ts
+++ b/modules/@angular/forms/test/directives_spec.ts
@@ -325,6 +325,8 @@ export function main() {
         expect(form.untouched).toBe(formModel.untouched);
         expect(form.statusChanges).toBe(formModel.statusChanges);
         expect(form.valueChanges).toBe(formModel.valueChanges);
+        expect(form.disabled).toBe(formModel.disabled);
+        expect(form.enabled).toBe(formModel.enabled);
       });
 
       describe('addControl & addFormGroup', () => {
@@ -401,6 +403,8 @@ export function main() {
         expect(controlGroupDir.untouched).toBe(formModel.untouched);
         expect(controlGroupDir.statusChanges).toBe(formModel.statusChanges);
         expect(controlGroupDir.valueChanges).toBe(formModel.valueChanges);
+        expect(controlGroupDir.disabled).toBe(formModel.disabled);
+        expect(controlGroupDir.enabled).toBe(formModel.enabled);
       });
     });
 
@@ -427,6 +431,8 @@ export function main() {
         expect(formArrayDir.dirty).toBe(formModel.dirty);
         expect(formArrayDir.touched).toBe(formModel.touched);
         expect(formArrayDir.untouched).toBe(formModel.untouched);
+        expect(formArrayDir.disabled).toBe(formModel.disabled);
+        expect(formArrayDir.enabled).toBe(formModel.enabled);
       });
     });
 
@@ -446,6 +452,8 @@ export function main() {
         expect(controlDir.untouched).toBe(control.untouched);
         expect(controlDir.statusChanges).toBe(control.statusChanges);
         expect(controlDir.valueChanges).toBe(control.valueChanges);
+        expect(controlDir.disabled).toBe(control.disabled);
+        expect(controlDir.enabled).toBe(control.enabled);
       };
 
       beforeEach(() => {
@@ -499,6 +507,8 @@ export function main() {
         expect(ngModel.untouched).toBe(control.untouched);
         expect(ngModel.statusChanges).toBe(control.statusChanges);
         expect(ngModel.valueChanges).toBe(control.valueChanges);
+        expect(ngModel.disabled).toBe(control.disabled);
+        expect(ngModel.enabled).toBe(control.enabled);
       });
 
       it('should throw when no value accessor with named control', () => {
@@ -557,6 +567,8 @@ export function main() {
         expect(controlNameDir.untouched).toBe(formModel.untouched);
         expect(controlNameDir.statusChanges).toBe(formModel.statusChanges);
         expect(controlNameDir.valueChanges).toBe(formModel.valueChanges);
+        expect(controlNameDir.disabled).toBe(formModel.disabled);
+        expect(controlNameDir.enabled).toBe(formModel.enabled);
       });
     });
   });

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -228,8 +228,8 @@ export declare class FormControl extends AbstractControl {
 export declare class FormControlDirective extends NgControl implements OnChanges {
     asyncValidator: AsyncValidatorFn;
     control: FormControl;
-    disabled: boolean;
     form: FormControl;
+    isDisabled: boolean;
     model: any;
     path: string[];
     update: EventEmitter<{}>;
@@ -244,8 +244,8 @@ export declare class FormControlDirective extends NgControl implements OnChanges
 export declare class FormControlName extends NgControl implements OnChanges, OnDestroy {
     asyncValidator: AsyncValidatorFn;
     control: FormControl;
-    disabled: boolean;
     formDirective: any;
+    isDisabled: boolean;
     model: any;
     name: string;
     path: string[];
@@ -396,8 +396,8 @@ export declare class NgForm extends ControlContainer implements Form {
 export declare class NgModel extends NgControl implements OnChanges, OnDestroy {
     asyncValidator: AsyncValidatorFn;
     control: FormControl;
-    disabled: boolean;
     formDirective: any;
+    isDisabled: boolean;
     model: any;
     name: string;
     options: {


### PR DESCRIPTION
r: @StephenFluin 

Fixes an AOT bug where the disabled prop was being set on the AbstractControlDirective due to a naming conflict.

cc: @vsavkin 
