### PR TITLE
test: improve perfs by removing unneeded TestBed.compileComponents() …

### DIFF
--- a/modules/@angular/compiler/test/i18n/integration_spec.ts
+++ b/modules/@angular/compiler/test/i18n/integration_spec.ts
@@ -30,8 +30,6 @@ export function main() {
       });
 
       TestBed.configureTestingModule({declarations: [I18nComponent]});
-
-      TestBed.compileComponents();
     }));
 
 

--- a/modules/@angular/core/test/debug/debug_node_spec.ts
+++ b/modules/@angular/core/test/debug/debug_node_spec.ts
@@ -189,7 +189,6 @@ export function main() {
           Logger,
         ]
       });
-      TestBed.compileComponents();
     }));
 
     it('should list all child nodes', () => {

--- a/modules/@angular/core/test/linker/entry_components_integration_spec.ts
+++ b/modules/@angular/core/test/linker/entry_components_integration_spec.ts
@@ -31,7 +31,6 @@ function declareTests({useJit}: {useJit: boolean}) {
       TestBed.configureCompiler(
           {useJit: useJit, providers: [{provide: Console, useValue: console}]});
       TestBed.configureTestingModule({declarations: [MainComp, ChildComp, NestedChildComp]});
-      TestBed.compileComponents();
     });
 
     it('should resolve ComponentFactories from the same component', () => {

--- a/modules/@angular/core/test/linker/integration_spec.ts
+++ b/modules/@angular/core/test/linker/integration_spec.ts
@@ -894,7 +894,6 @@ function declareTests({useJit}: {useJit: boolean}) {
           TestBed.configureTestingModule({imports: [MyModule]});
           TestBed.overrideComponent(
               MyComp, {add: {template: '<div><dynamic-vp #dynamic></dynamic-vp></div>'}});
-          return TestBed.compileComponents();
         });
 
 

--- a/modules/@angular/forms/test/reactive_integration_spec.ts
+++ b/modules/@angular/forms/test/reactive_integration_spec.ts
@@ -30,7 +30,6 @@ export function main() {
           LoginIsEmptyValidator, LoginIsEmptyWrapper, UniqLoginValidator, UniqLoginWrapper
         ]
       });
-      TestBed.compileComponents();
     });
 
     describe('basic functionality', () => {

--- a/modules/@angular/forms/test/template_integration_spec.ts
+++ b/modules/@angular/forms/test/template_integration_spec.ts
@@ -29,7 +29,6 @@ export function main() {
         ],
         imports: [FormsModule]
       });
-      TestBed.compileComponents();
     });
 
     describe('basic functionality', () => {


### PR DESCRIPTION
…calls

This is especially noticeable in the forms tests.
Overall, the time to run the full test suite was reduced by 15% on my machine.
