### PR TITLE
fix(compiler): allow tsc-wrapped to be compile with TypeScript 2.0

### DIFF
--- a/tools/@angular/tsc-wrapped/src/compiler_host.ts
+++ b/tools/@angular/tsc-wrapped/src/compiler_host.ts
@@ -22,6 +22,8 @@ export abstract class DelegatingHost implements ts.CompilerHost {
   getDefaultLibLocation = () => this.delegate.getDefaultLibLocation();
   writeFile: ts.WriteFileCallback = this.delegate.writeFile;
   getCurrentDirectory = () => this.delegate.getCurrentDirectory();
+  getDirectories = (path: string): string[] =>
+      (this.delegate as any).getDirectories?(this.delegate as any).getDirectories(path): [];
   getCanonicalFileName = (fileName: string) => this.delegate.getCanonicalFileName(fileName);
   useCaseSensitiveFileNames = () => this.delegate.useCaseSensitiveFileNames();
   getNewLine = () => this.delegate.getNewLine();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

`tsc-watch` `CompilerHost` implementations don't implement the newly required method `getDirectories()`.

**What is the new behavior?**

Implemented `getDirectories()` in `DelegatingCompilerHost` to allow using compiling `tsc-watch` with TypeScript 2.0's `.d.ts`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
