### PR TITLE
fix(ngc): don't include extension in the StaticSymbol moduleid

### DIFF
--- a/modules/@angular/compiler-cli/src/reflector_host.ts
+++ b/modules/@angular/compiler-cli/src/reflector_host.ts
@@ -226,7 +226,7 @@ export class ReflectorHost implements StaticReflectorHost, ImportGenerator {
     const key = `"${declarationFile}".${name}${memberSuffix}`;
     let result = this.typeCache.get(key);
     if (!result) {
-      result = new StaticSymbol(declarationFile, name, members);
+      result = new StaticSymbol(declarationFile.replace(EXT, ''), name, members);
       this.typeCache.set(key, result);
     }
     return result;

--- a/modules/@angular/compiler-cli/test/reflector_host_spec.ts
+++ b/modules/@angular/compiler-cli/test/reflector_host_spec.ts
@@ -196,28 +196,28 @@ describe('reflector_host', () => {
     const symbol = reflectorNestedGenDir.findDeclaration(
         './reexport/reexport.d.ts', 'One', '/tmp/src/main.ts');
     expect(symbol.name).toEqual('One');
-    expect(symbol.filePath).toEqual('/tmp/src/reexport/src/origin1.d.ts');
+    expect(symbol.filePath).toEqual('/tmp/src/reexport/src/origin1');
   });
 
   it('should be able to trace a renamed export', () => {
     const symbol = reflectorNestedGenDir.findDeclaration(
         './reexport/reexport.d.ts', 'Four', '/tmp/src/main.ts');
     expect(symbol.name).toEqual('Three');
-    expect(symbol.filePath).toEqual('/tmp/src/reexport/src/origin1.d.ts');
+    expect(symbol.filePath).toEqual('/tmp/src/reexport/src/origin1');
   });
 
   it('should be able to trace an export * export', () => {
     const symbol = reflectorNestedGenDir.findDeclaration(
         './reexport/reexport.d.ts', 'Five', '/tmp/src/main.ts');
     expect(symbol.name).toEqual('Five');
-    expect(symbol.filePath).toEqual('/tmp/src/reexport/src/origin5.d.ts');
+    expect(symbol.filePath).toEqual('/tmp/src/reexport/src/origin5');
   });
 
   it('should be able to trace a multi-level re-export', () => {
     const symbol = reflectorNestedGenDir.findDeclaration(
         './reexport/reexport.d.ts', 'Thirty', '/tmp/src/main.ts');
     expect(symbol.name).toEqual('Thirty');
-    expect(symbol.filePath).toEqual('/tmp/src/reexport/src/origin30.d.ts');
+    expect(symbol.filePath).toEqual('/tmp/src/reexport/src/origin30');
   });
 });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

We have some scenarios where both the .ts and .d.ts file are present in the program, and we can
create two different StaticSymbols for a single symbol that differ in the extension.
