### PR TITLE
build: workaround to run presubmit.sh on Windows

### DIFF
--- a/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
@@ -1220,8 +1220,9 @@ Can't have multiple template bindings on one element. Use only one attribute nam
       });
 
       it('should report when mix of template and *attrs are used on the same element', () => {
-        expect(() => parse('<div template="ngIf" *ngFor>', [])).toThrowError(`Template parse errors:
-Can't have multiple template bindings on one element. Use only one attribute named 'template' or prefixed with * ("<div template="ngIf" [ERROR ->]*ngFor>"): TestComp@0:21`);
+        expect(() => parse('<span template="ngIf" *ngFor>', []))
+            .toThrowError(`Template parse errors:
+Can't have multiple template bindings on one element. Use only one attribute named 'template' or prefixed with * ("<span template="ngIf" [ERROR ->]*ngFor>"): TestComp@0:22`);
       });
 
       it('should report invalid property names', () => {


### PR DESCRIPTION
This PR is a workaround to be able to run `./presubmit.sh` successfully on Windows.

There is a conflict on this precise line of code. On windows, clang-format wants to split it on 2 lines. On Mac it wants to keep it on one line.
Making the line one character longer brings the two to an agreement: 2 lines.

@mprobst this is still happening with version 1.0.43 of clang-format.
On top of that, this version has issues with back-tick strings. It tries to format the content and does it in different ways depending on the OS.
