### PR TITLE
fix(compiler): handle invalid host bindings and events

### DIFF
--- a/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
@@ -328,6 +328,30 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
              expect(console.warnings.length).toEqual(0);
            });
 
+        it('should throw descriptive error when a host binding is not a string expression', () => {
+          var dirA = CompileDirectiveMetadata.create({
+            selector: 'broken',
+            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+            host: {'[class.foo]': null}
+          });
+
+          expect(() => { parse('<broken></broken>', [dirA]); })
+              .toThrowError(
+                  `Template parse errors:\nValue of the host property binding "class.foo" needs to be a string representing an expression but got "null" (object) ("[ERROR ->]<broken></broken>"): TestComp@0:0, Directive DirA`);
+        });
+
+        it('should throw descriptive error when a host event is not a string expression', () => {
+          var dirA = CompileDirectiveMetadata.create({
+            selector: 'broken',
+            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+            host: {'(click)': null}
+          });
+
+          expect(() => { parse('<broken></broken>', [dirA]); })
+              .toThrowError(
+                  `Template parse errors:\nValue of the host listener "click" needs to be a string representing an expression but got "null" (object) ("[ERROR ->]<broken></broken>"): TestComp@0:0, Directive DirA`);
+        });
+
         it('should not issue a warning when an animation property is bound without an expression',
            () => {
              humanizeTplAst(parse('<div @something>', []));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ x The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

I keep doing:

``` typescript
@Component({
  selector: 'broken',
  host: {'[class.foo]': true},
  template: `...`
})
```

which fails with cryptic `input.indexOf is not a function`.  Can you quickly spot the pb?

**What is the new behavior?**

Fails with descriptive `Value of the host property binding "class.foo" needs to be a string representing an expression but got "true" (boolean) ("[ERROR ->]<broken></broken>`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

Good TS IDEs will mark it as an error but this is not of much help in non-TS envs and in plunkers. Besides it doesn't help with `host: {'[prop]: null}'` (or anything that evaluates to null / undefined).
