### PR TITLE
fix(ngc): don't quote properties in literal maps

### DIFF
--- a/modules/@angular/compiler/test/output/abstract_emitter_spec.ts
+++ b/modules/@angular/compiler/test/output/abstract_emitter_spec.ts
@@ -6,27 +6,30 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {escapeSingleQuoteString} from '@angular/compiler/src/output/abstract_emitter';
+import {escapeIdentifier} from '@angular/compiler/src/output/abstract_emitter';
 import {beforeEach, ddescribe, describe, expect, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
 
 export function main() {
   describe('AbstractEmitter', () => {
-    describe('escapeSingleQuoteString', () => {
+    describe('escapeIdentifier', () => {
       it('should escape single quotes',
-         () => { expect(escapeSingleQuoteString(`'`, false)).toEqual(`'\\''`); });
+         () => { expect(escapeIdentifier(`'`, false)).toEqual(`'\\''`); });
 
       it('should escape backslash',
-         () => { expect(escapeSingleQuoteString('\\', false)).toEqual(`'\\\\'`); });
+         () => { expect(escapeIdentifier('\\', false)).toEqual(`'\\\\'`); });
 
       it('should escape newlines',
-         () => { expect(escapeSingleQuoteString('\n', false)).toEqual(`'\\n'`); });
+         () => { expect(escapeIdentifier('\n', false)).toEqual(`'\\n'`); });
 
       it('should escape carriage returns',
-         () => { expect(escapeSingleQuoteString('\r', false)).toEqual(`'\\r'`); });
+         () => { expect(escapeIdentifier('\r', false)).toEqual(`'\\r'`); });
 
-      it('should escape $', () => { expect(escapeSingleQuoteString('$', true)).toEqual(`'\\$'`); });
-      it('should not escape $',
-         () => { expect(escapeSingleQuoteString('$', false)).toEqual(`'$'`); });
+      it('should escape $', () => { expect(escapeIdentifier('$', true)).toEqual(`'\\$'`); });
+      it('should not escape $', () => { expect(escapeIdentifier('$', false)).toEqual(`'$'`); });
+      it('should add quotes for non-identifiers',
+         () => { expect(escapeIdentifier('==', false, false)).toEqual(`'=='`); });
+      it('does not escape class (but it probably should)',
+         () => { expect(escapeIdentifier('class', false, false)).toEqual('class'); });
     });
 
   });

--- a/modules/@angular/compiler/test/output/js_emitter_spec.ts
+++ b/modules/@angular/compiler/test/output/js_emitter_spec.ts
@@ -104,8 +104,7 @@ export function main() {
       expect(emitStmt(o.literal(true).toStmt())).toEqual('true;');
       expect(emitStmt(o.literal('someStr').toStmt())).toEqual(`'someStr';`);
       expect(emitStmt(o.literalArr([o.literal(1)]).toStmt())).toEqual(`[1];`);
-      expect(emitStmt(o.literalMap([['someKey', o.literal(1)]]).toStmt()))
-          .toEqual(`{'someKey': 1};`);
+      expect(emitStmt(o.literalMap([['someKey', o.literal(1)]]).toStmt())).toEqual(`{someKey: 1};`);
     });
 
     it('should support external identifiers', () => {

--- a/modules/@angular/compiler/test/output/ts_emitter_spec.ts
+++ b/modules/@angular/compiler/test/output/ts_emitter_spec.ts
@@ -106,8 +106,7 @@ export function main() {
       expect(emitStmt(o.literal(true).toStmt())).toEqual('true;');
       expect(emitStmt(o.literal('someStr').toStmt())).toEqual(`'someStr';`);
       expect(emitStmt(o.literalArr([o.literal(1)]).toStmt())).toEqual(`[1];`);
-      expect(emitStmt(o.literalMap([['someKey', o.literal(1)]]).toStmt()))
-          .toEqual(`{'someKey': 1};`);
+      expect(emitStmt(o.literalMap([['someKey', o.literal(1)]]).toStmt())).toEqual(`{someKey: 1};`);
     });
 
     it('should support external identifiers', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Closure compiler treats quoted properties specially, and doesn't rename them.
