### PR TITLE
fix(compiler): no longer uses assert location for token identity.

### DIFF
--- a/modules/@angular/compiler-cli/src/static_reflection_capabilities.ts
+++ b/modules/@angular/compiler-cli/src/static_reflection_capabilities.ts
@@ -42,6 +42,16 @@ export class StaticAndDynamicReflectionCapabilities {
   setter(name: string) { return this.dynamicDelegate.setter(name); }
   method(name: string) { return this.dynamicDelegate.method(name); }
   importUri(type: any): string { return this.staticDelegate.importUri(type); }
+  resolveType(name: string, moduleUrl: string) {
+    return this.staticDelegate.resolveType(name, moduleUrl);
+  }
+  resolveEnum(enumType: any, name: string): any {
+    if (isStaticType(enumType)) {
+      return this.staticDelegate.resolveEnum(enumType, name);
+    } else {
+      return null;
+    }
+  }
 }
 
 function isStaticType(type: any): boolean {

--- a/modules/@angular/compiler-cli/src/static_reflector.ts
+++ b/modules/@angular/compiler-cli/src/static_reflector.ts
@@ -74,6 +74,16 @@ export class StaticReflector implements ReflectorReader {
     return staticSymbol ? staticSymbol.filePath : null;
   }
 
+  resolveType(name: string, moduleUrl: string): any {
+    const result = this.host.findDeclaration(moduleUrl, name, '');
+    return result;
+  }
+
+  resolveEnum(enumType: any, name: string): any {
+    const staticSymbol: StaticSymbol = enumType;
+    return this.host.getStaticSymbol(staticSymbol.filePath, staticSymbol.name, [name]);
+  }
+
   public annotations(type: StaticSymbol): any[] {
     let annotations = this.annotationCache.get(type);
     if (!annotations) {

--- a/modules/@angular/compiler/src/animation/animation_compiler.ts
+++ b/modules/@angular/compiler/src/animation/animation_compiler.ts
@@ -10,7 +10,7 @@ import {ANY_STATE, AnimationOutput, DEFAULT_STATE, EMPTY_STATE} from '../../core
 import {CompileDirectiveMetadata} from '../compile_metadata';
 import {StringMapWrapper} from '../facade/collection';
 import {isBlank, isPresent} from '../facade/lang';
-import {Identifiers} from '../identifiers';
+import {Identifiers, resolveIdentifier} from '../identifiers';
 import * as o from '../output/output_ast';
 import * as t from '../template_parser/template_ast';
 
@@ -114,8 +114,8 @@ class _AnimationBuilder implements AnimationAstVisitor {
           o.literalMap(StringMapWrapper.keys(entry).map(key => [key, o.literal(entry[key])])));
     });
 
-    return o.importExpr(Identifiers.AnimationStyles).instantiate([
-      o.importExpr(Identifiers.collectAndResolveStyles).callFn([
+    return o.importExpr(resolveIdentifier(Identifiers.AnimationStyles)).instantiate([
+      o.importExpr(resolveIdentifier(Identifiers.collectAndResolveStyles)).callFn([
         _ANIMATION_COLLECTED_STYLES, o.literalArr(stylesArr)
       ])
     ]);
@@ -123,7 +123,7 @@ class _AnimationBuilder implements AnimationAstVisitor {
 
   visitAnimationKeyframe(ast: AnimationKeyframeAst, context: _AnimationBuilderContext):
       o.Expression {
-    return o.importExpr(Identifiers.AnimationKeyframe).instantiate([
+    return o.importExpr(resolveIdentifier(Identifiers.AnimationKeyframe)).instantiate([
       o.literal(ast.offset), ast.styles.visit(this, context)
     ]);
   }
@@ -144,10 +144,11 @@ class _AnimationBuilder implements AnimationAstVisitor {
   _visitEndStateAnimation(ast: AnimationStepAst, context: _AnimationBuilderContext): o.Expression {
     var startingStylesExpr = ast.startingStyles.visit(this, context);
     var keyframeExpressions = ast.keyframes.map(keyframe => keyframe.visit(this, context));
-    var keyframesExpr = o.importExpr(Identifiers.balanceAnimationKeyframes).callFn([
-      _ANIMATION_COLLECTED_STYLES, _ANIMATION_END_STATE_STYLES_VAR,
-      o.literalArr(keyframeExpressions)
-    ]);
+    var keyframesExpr =
+        o.importExpr(resolveIdentifier(Identifiers.balanceAnimationKeyframes)).callFn([
+          _ANIMATION_COLLECTED_STYLES, _ANIMATION_END_STATE_STYLES_VAR,
+          o.literalArr(keyframeExpressions)
+        ]);
 
     return this._callAnimateMethod(ast, startingStylesExpr, keyframesExpr, context);
   }
@@ -166,13 +167,16 @@ class _AnimationBuilder implements AnimationAstVisitor {
   visitAnimationSequence(ast: AnimationSequenceAst, context: _AnimationBuilderContext):
       o.Expression {
     var playerExprs = ast.steps.map(step => step.visit(this, context));
-    return o.importExpr(Identifiers.AnimationSequencePlayer).instantiate([o.literalArr(
-        playerExprs)]);
+    return o.importExpr(resolveIdentifier(Identifiers.AnimationSequencePlayer)).instantiate([
+      o.literalArr(playerExprs)
+    ]);
   }
 
   visitAnimationGroup(ast: AnimationGroupAst, context: _AnimationBuilderContext): o.Expression {
     var playerExprs = ast.steps.map(step => step.visit(this, context));
-    return o.importExpr(Identifiers.AnimationGroupPlayer).instantiate([o.literalArr(playerExprs)]);
+    return o.importExpr(resolveIdentifier(Identifiers.AnimationGroupPlayer)).instantiate([
+      o.literalArr(playerExprs)
+    ]);
   }
 
   visitAnimationStateDeclaration(
@@ -265,18 +269,18 @@ class _AnimationBuilder implements AnimationAstVisitor {
         _ANIMATION_END_STATE_STYLES_VAR.equals(o.NULL_EXPR),
         [_ANIMATION_END_STATE_STYLES_VAR.set(_ANIMATION_DEFAULT_STATE_VAR).toStmt()]));
 
-    var RENDER_STYLES_FN = o.importExpr(Identifiers.renderStyles);
+    var RENDER_STYLES_FN = o.importExpr(resolveIdentifier(Identifiers.renderStyles));
 
     // before we start any animation we want to clear out the starting
     // styles from the element's style property (since they were placed
     // there at the end of the last animation
-    statements.push(
-        RENDER_STYLES_FN
-            .callFn([
-              _ANIMATION_FACTORY_ELEMENT_VAR, _ANIMATION_FACTORY_RENDERER_VAR,
-              o.importExpr(Identifiers.clearStyles).callFn([_ANIMATION_START_STATE_STYLES_VAR])
-            ])
-            .toStmt());
+    statements.push(RENDER_STYLES_FN
+                        .callFn([
+                          _ANIMATION_FACTORY_ELEMENT_VAR, _ANIMATION_FACTORY_RENDERER_VAR,
+                          o.importExpr(resolveIdentifier(Identifiers.clearStyles))
+                              .callFn([_ANIMATION_START_STATE_STYLES_VAR])
+                        ])
+                        .toStmt());
 
     ast.stateTransitions.forEach(transAst => statements.push(transAst.visit(this, context)));
 
@@ -284,7 +288,8 @@ class _AnimationBuilder implements AnimationAstVisitor {
     // so that the onDone callback can be used for tracking
     statements.push(new o.IfStmt(
         _ANIMATION_PLAYER_VAR.equals(o.NULL_EXPR),
-        [_ANIMATION_PLAYER_VAR.set(o.importExpr(Identifiers.NoOpAnimationPlayer).instantiate([]))
+        [_ANIMATION_PLAYER_VAR
+             .set(o.importExpr(resolveIdentifier(Identifiers.NoOpAnimationPlayer)).instantiate([]))
              .toStmt()]));
 
     // once complete we want to apply the styles on the element
@@ -295,14 +300,16 @@ class _AnimationBuilder implements AnimationAstVisitor {
             .callMethod(
                 'onDone',
                 [o.fn(
-                    [], [RENDER_STYLES_FN
-                             .callFn([
-                               _ANIMATION_FACTORY_ELEMENT_VAR, _ANIMATION_FACTORY_RENDERER_VAR,
-                               o.importExpr(Identifiers.prepareFinalAnimationStyles).callFn([
+                    [],
+                    [RENDER_STYLES_FN
+                         .callFn([
+                           _ANIMATION_FACTORY_ELEMENT_VAR, _ANIMATION_FACTORY_RENDERER_VAR,
+                           o.importExpr(resolveIdentifier(Identifiers.prepareFinalAnimationStyles))
+                               .callFn([
                                  _ANIMATION_START_STATE_STYLES_VAR, _ANIMATION_END_STATE_STYLES_VAR
                                ])
-                             ])
-                             .toStmt()])])
+                         ])
+                         .toStmt()])])
             .toStmt());
 
     statements.push(_ANIMATION_FACTORY_VIEW_VAR
@@ -319,7 +326,7 @@ class _AnimationBuilder implements AnimationAstVisitor {
         [
           new o.FnParam(
               _ANIMATION_FACTORY_VIEW_VAR.name,
-              o.importType(Identifiers.AppView, [o.DYNAMIC_TYPE])),
+              o.importType(resolveIdentifier(Identifiers.AppView), [o.DYNAMIC_TYPE])),
           new o.FnParam(_ANIMATION_FACTORY_ELEMENT_VAR.name, o.DYNAMIC_TYPE),
           new o.FnParam(_ANIMATION_CURRENT_STATE_VAR.name, o.DYNAMIC_TYPE),
           new o.FnParam(_ANIMATION_NEXT_STATE_VAR.name, o.DYNAMIC_TYPE)

--- a/modules/@angular/compiler/src/config.ts
+++ b/modules/@angular/compiler/src/config.ts
@@ -9,7 +9,7 @@
 import {ViewEncapsulation, isDevMode} from '@angular/core';
 
 import {CompileIdentifierMetadata} from './compile_metadata';
-import {Identifiers} from './identifiers';
+import {Identifiers, resolveIdentifier} from './identifiers';
 
 function unimplemented(): any {
   throw new Error('unimplemented');
@@ -61,7 +61,7 @@ export abstract class RenderTypes {
 }
 
 export class DefaultRenderTypes implements RenderTypes {
-  renderer = Identifiers.Renderer;
+  get renderer() { return resolveIdentifier(Identifiers.Renderer); };
   renderText: any = null;
   renderElement: any = null;
   renderComment: any = null;

--- a/modules/@angular/compiler/src/identifiers.ts
+++ b/modules/@angular/compiler/src/identifiers.ts
@@ -8,7 +8,7 @@
 
 import {ANALYZE_FOR_ENTRY_COMPONENTS, ChangeDetectionStrategy, ChangeDetectorRef, ComponentFactory, ComponentFactoryResolver, ElementRef, Injector, LOCALE_ID as LOCALE_ID_, NgModuleFactory, QueryList, RenderComponentType, Renderer, SecurityContext, SimpleChange, TRANSLATIONS_FORMAT as TRANSLATIONS_FORMAT_, TemplateRef, ViewContainerRef, ViewEncapsulation} from '@angular/core';
 
-import {AnimationGroupPlayer as AnimationGroupPlayer_, AnimationKeyframe as AnimationKeyframe_, AnimationOutput as AnimationOutput_, AnimationSequencePlayer as AnimationSequencePlayer_, AnimationStyles as AnimationStyles_, AppElement, AppView, ChangeDetectorStatus, CodegenComponentFactoryResolver, DebugAppView, DebugContext, EMPTY_ARRAY, EMPTY_MAP, NgModuleInjector, NoOpAnimationPlayer as NoOpAnimationPlayer_, StaticNodeDebugInfo, TemplateRef_, UNINITIALIZED, ValueUnwrapper, ViewType, ViewUtils, balanceAnimationKeyframes as impBalanceAnimationKeyframes, castByValue, checkBinding, clearStyles as impClearStyles, collectAndResolveStyles as impCollectAndResolveStyles, devModeEqual, flattenNestedViewRenderNodes, interpolate, prepareFinalAnimationStyles as impBalanceAnimationStyles, pureProxy1, pureProxy10, pureProxy2, pureProxy3, pureProxy4, pureProxy5, pureProxy6, pureProxy7, pureProxy8, pureProxy9, renderStyles as impRenderStyles} from '../core_private';
+import {AnimationGroupPlayer as AnimationGroupPlayer_, AnimationKeyframe as AnimationKeyframe_, AnimationOutput as AnimationOutput_, AnimationSequencePlayer as AnimationSequencePlayer_, AnimationStyles as AnimationStyles_, AppElement, AppView, ChangeDetectorStatus, CodegenComponentFactoryResolver, DebugAppView, DebugContext, EMPTY_ARRAY, EMPTY_MAP, NgModuleInjector, NoOpAnimationPlayer as NoOpAnimationPlayer_, StaticNodeDebugInfo, TemplateRef_, UNINITIALIZED, ValueUnwrapper, ViewType, ViewUtils, balanceAnimationKeyframes as impBalanceAnimationKeyframes, castByValue, checkBinding, clearStyles as impClearStyles, collectAndResolveStyles as impCollectAndResolveStyles, devModeEqual, flattenNestedViewRenderNodes, interpolate, prepareFinalAnimationStyles as impBalanceAnimationStyles, pureProxy1, pureProxy10, pureProxy2, pureProxy3, pureProxy4, pureProxy5, pureProxy6, pureProxy7, pureProxy8, pureProxy9, reflector, renderStyles as impRenderStyles} from '../core_private';
 
 import {CompileIdentifierMetadata, CompileTokenMetadata} from './compile_metadata';
 import {assetUrl} from './util';
@@ -58,215 +58,286 @@ var impAnimationOutput = AnimationOutput_;
 
 var ANIMATION_STYLE_UTIL_ASSET_URL = assetUrl('core', 'animation/animation_style_util');
 
+export interface IdentifierSpec {
+  name: string;
+  moduleUrl: string;
+  runtime: any;
+}
+
 export class Identifiers {
-  static ANALYZE_FOR_ENTRY_COMPONENTS = new CompileIdentifierMetadata({
+  static ANALYZE_FOR_ENTRY_COMPONENTS: IdentifierSpec = {
     name: 'ANALYZE_FOR_ENTRY_COMPONENTS',
     moduleUrl: assetUrl('core', 'metadata/di'),
     runtime: ANALYZE_FOR_ENTRY_COMPONENTS
-  });
-  static ViewUtils = new CompileIdentifierMetadata(
-      {name: 'ViewUtils', moduleUrl: assetUrl('core', 'linker/view_utils'), runtime: impViewUtils});
-  static AppView = new CompileIdentifierMetadata(
-      {name: 'AppView', moduleUrl: APP_VIEW_MODULE_URL, runtime: impAppView});
-  static DebugAppView = new CompileIdentifierMetadata(
-      {name: 'DebugAppView', moduleUrl: APP_VIEW_MODULE_URL, runtime: impDebugAppView});
-  static AppElement = new CompileIdentifierMetadata(
-      {name: 'AppElement', moduleUrl: assetUrl('core', 'linker/element'), runtime: impAppElement});
-  static ElementRef = new CompileIdentifierMetadata({
+  };
+  static ViewUtils: IdentifierSpec = {
+    name: 'ViewUtils',
+    moduleUrl: assetUrl('core', 'linker/view_utils'),
+    runtime: impViewUtils
+  };
+  static AppView:
+      IdentifierSpec = {name: 'AppView', moduleUrl: APP_VIEW_MODULE_URL, runtime: impAppView};
+  static DebugAppView: IdentifierSpec = {
+    name: 'DebugAppView',
+    moduleUrl: APP_VIEW_MODULE_URL,
+    runtime: impDebugAppView
+  };
+  static AppElement: IdentifierSpec = {
+    name: 'AppElement',
+    moduleUrl: assetUrl('core', 'linker/element'),
+    runtime: impAppElement
+  };
+  static ElementRef: IdentifierSpec = {
     name: 'ElementRef',
     moduleUrl: assetUrl('core', 'linker/element_ref'),
     runtime: impElementRef
-  });
-  static ViewContainerRef = new CompileIdentifierMetadata({
+  };
+  static ViewContainerRef: IdentifierSpec = {
     name: 'ViewContainerRef',
     moduleUrl: assetUrl('core', 'linker/view_container_ref'),
     runtime: impViewContainerRef
-  });
-  static ChangeDetectorRef = new CompileIdentifierMetadata({
+  };
+  static ChangeDetectorRef: IdentifierSpec = {
     name: 'ChangeDetectorRef',
     moduleUrl: assetUrl('core', 'change_detection/change_detector_ref'),
     runtime: impChangeDetectorRef
-  });
-  static RenderComponentType = new CompileIdentifierMetadata({
+  };
+  static RenderComponentType: IdentifierSpec = {
     name: 'RenderComponentType',
     moduleUrl: assetUrl('core', 'render/api'),
     runtime: impRenderComponentType
-  });
-  static QueryList = new CompileIdentifierMetadata(
-      {name: 'QueryList', moduleUrl: assetUrl('core', 'linker/query_list'), runtime: impQueryList});
-  static TemplateRef = new CompileIdentifierMetadata({
+  };
+  static QueryList: IdentifierSpec = {
+    name: 'QueryList',
+    moduleUrl: assetUrl('core', 'linker/query_list'),
+    runtime: impQueryList
+  };
+  static TemplateRef: IdentifierSpec = {
     name: 'TemplateRef',
     moduleUrl: assetUrl('core', 'linker/template_ref'),
     runtime: impTemplateRef
-  });
-  static TemplateRef_ = new CompileIdentifierMetadata({
+  };
+  static TemplateRef_: IdentifierSpec = {
     name: 'TemplateRef_',
     moduleUrl: assetUrl('core', 'linker/template_ref'),
     runtime: impTemplateRef_
-  });
-  static CodegenComponentFactoryResolver = new CompileIdentifierMetadata({
+  };
+  static CodegenComponentFactoryResolver: IdentifierSpec = {
     name: 'CodegenComponentFactoryResolver',
     moduleUrl: assetUrl('core', 'linker/component_factory_resolver'),
     runtime: CodegenComponentFactoryResolver
-  });
-  static ComponentFactoryResolver = new CompileIdentifierMetadata({
+  };
+  static ComponentFactoryResolver: IdentifierSpec = {
     name: 'ComponentFactoryResolver',
     moduleUrl: assetUrl('core', 'linker/component_factory_resolver'),
     runtime: ComponentFactoryResolver
-  });
-  static ComponentFactory = new CompileIdentifierMetadata({
+  };
+  static ComponentFactory: IdentifierSpec = {
     name: 'ComponentFactory',
     runtime: ComponentFactory,
     moduleUrl: assetUrl('core', 'linker/component_factory')
-  });
-  static NgModuleFactory = new CompileIdentifierMetadata({
+  };
+  static NgModuleFactory: IdentifierSpec = {
     name: 'NgModuleFactory',
     runtime: NgModuleFactory,
     moduleUrl: assetUrl('core', 'linker/ng_module_factory')
-  });
-  static NgModuleInjector = new CompileIdentifierMetadata({
+  };
+  static NgModuleInjector: IdentifierSpec = {
     name: 'NgModuleInjector',
     runtime: NgModuleInjector,
     moduleUrl: assetUrl('core', 'linker/ng_module_factory')
-  });
-  static ValueUnwrapper = new CompileIdentifierMetadata(
-      {name: 'ValueUnwrapper', moduleUrl: CD_MODULE_URL, runtime: impValueUnwrapper});
-  static Injector = new CompileIdentifierMetadata(
-      {name: 'Injector', moduleUrl: assetUrl('core', 'di/injector'), runtime: impInjector});
-  static ViewEncapsulation = new CompileIdentifierMetadata({
+  };
+  static ValueUnwrapper: IdentifierSpec = {
+    name: 'ValueUnwrapper',
+    moduleUrl: CD_MODULE_URL,
+    runtime: impValueUnwrapper
+  };
+  static Injector: IdentifierSpec = {
+    name: 'Injector',
+    moduleUrl: assetUrl('core', 'di/injector'),
+    runtime: impInjector
+  };
+  static ViewEncapsulation: IdentifierSpec = {
     name: 'ViewEncapsulation',
     moduleUrl: assetUrl('core', 'metadata/view'),
     runtime: impViewEncapsulation
-  });
-  static ViewType = new CompileIdentifierMetadata(
-      {name: 'ViewType', moduleUrl: assetUrl('core', 'linker/view_type'), runtime: impViewType});
-  static ChangeDetectionStrategy = new CompileIdentifierMetadata({
+  };
+  static ViewType: IdentifierSpec = {
+    name: 'ViewType',
+    moduleUrl: assetUrl('core', 'linker/view_type'),
+    runtime: impViewType
+  };
+  static ChangeDetectionStrategy: IdentifierSpec = {
     name: 'ChangeDetectionStrategy',
     moduleUrl: CD_MODULE_URL,
     runtime: impChangeDetectionStrategy
-  });
-  static StaticNodeDebugInfo = new CompileIdentifierMetadata({
+  };
+  static StaticNodeDebugInfo: IdentifierSpec = {
     name: 'StaticNodeDebugInfo',
     moduleUrl: assetUrl('core', 'linker/debug_context'),
     runtime: impStaticNodeDebugInfo
-  });
-  static DebugContext = new CompileIdentifierMetadata({
+  };
+  static DebugContext: IdentifierSpec = {
     name: 'DebugContext',
     moduleUrl: assetUrl('core', 'linker/debug_context'),
     runtime: impDebugContext
-  });
-  static Renderer = new CompileIdentifierMetadata(
-      {name: 'Renderer', moduleUrl: assetUrl('core', 'render/api'), runtime: impRenderer});
-  static SimpleChange = new CompileIdentifierMetadata(
-      {name: 'SimpleChange', moduleUrl: CD_MODULE_URL, runtime: impSimpleChange});
-  static UNINITIALIZED = new CompileIdentifierMetadata(
-      {name: 'UNINITIALIZED', moduleUrl: CD_MODULE_URL, runtime: impUNINITIALIZED});
-  static ChangeDetectorStatus = new CompileIdentifierMetadata(
-      {name: 'ChangeDetectorStatus', moduleUrl: CD_MODULE_URL, runtime: impChangeDetectorStatus});
-  static checkBinding = new CompileIdentifierMetadata(
-      {name: 'checkBinding', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: impCheckBinding});
-  static flattenNestedViewRenderNodes = new CompileIdentifierMetadata({
+  };
+  static Renderer: IdentifierSpec = {
+    name: 'Renderer',
+    moduleUrl: assetUrl('core', 'render/api'),
+    runtime: impRenderer
+  };
+  static SimpleChange:
+      IdentifierSpec = {name: 'SimpleChange', moduleUrl: CD_MODULE_URL, runtime: impSimpleChange};
+  static UNINITIALIZED:
+      IdentifierSpec = {name: 'UNINITIALIZED', moduleUrl: CD_MODULE_URL, runtime: impUNINITIALIZED};
+  static ChangeDetectorStatus: IdentifierSpec = {
+    name: 'ChangeDetectorStatus',
+    moduleUrl: CD_MODULE_URL,
+    runtime: impChangeDetectorStatus
+  };
+  static checkBinding: IdentifierSpec = {
+    name: 'checkBinding',
+    moduleUrl: VIEW_UTILS_MODULE_URL,
+    runtime: impCheckBinding
+  };
+  static flattenNestedViewRenderNodes: IdentifierSpec = {
     name: 'flattenNestedViewRenderNodes',
     moduleUrl: VIEW_UTILS_MODULE_URL,
     runtime: impFlattenNestedViewRenderNodes
-  });
-  static devModeEqual = new CompileIdentifierMetadata(
-      {name: 'devModeEqual', moduleUrl: CD_MODULE_URL, runtime: impDevModeEqual});
-  static interpolate = new CompileIdentifierMetadata(
-      {name: 'interpolate', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: impInterpolate});
-  static castByValue = new CompileIdentifierMetadata(
-      {name: 'castByValue', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: impCastByValue});
-  static EMPTY_ARRAY = new CompileIdentifierMetadata(
-      {name: 'EMPTY_ARRAY', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: impEMPTY_ARRAY});
-  static EMPTY_MAP = new CompileIdentifierMetadata(
-      {name: 'EMPTY_MAP', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: impEMPTY_MAP});
+  };
+  static devModeEqual:
+      IdentifierSpec = {name: 'devModeEqual', moduleUrl: CD_MODULE_URL, runtime: impDevModeEqual};
+  static interpolate: IdentifierSpec = {
+    name: 'interpolate',
+    moduleUrl: VIEW_UTILS_MODULE_URL,
+    runtime: impInterpolate
+  };
+  static castByValue: IdentifierSpec = {
+    name: 'castByValue',
+    moduleUrl: VIEW_UTILS_MODULE_URL,
+    runtime: impCastByValue
+  };
+  static EMPTY_ARRAY: IdentifierSpec = {
+    name: 'EMPTY_ARRAY',
+    moduleUrl: VIEW_UTILS_MODULE_URL,
+    runtime: impEMPTY_ARRAY
+  };
+  static EMPTY_MAP:
+      IdentifierSpec = {name: 'EMPTY_MAP', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: impEMPTY_MAP};
 
   static pureProxies = [
     null,
-    new CompileIdentifierMetadata(
-        {name: 'pureProxy1', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy1}),
-    new CompileIdentifierMetadata(
-        {name: 'pureProxy2', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy2}),
-    new CompileIdentifierMetadata(
-        {name: 'pureProxy3', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy3}),
-    new CompileIdentifierMetadata(
-        {name: 'pureProxy4', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy4}),
-    new CompileIdentifierMetadata(
-        {name: 'pureProxy5', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy5}),
-    new CompileIdentifierMetadata(
-        {name: 'pureProxy6', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy6}),
-    new CompileIdentifierMetadata(
-        {name: 'pureProxy7', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy7}),
-    new CompileIdentifierMetadata(
-        {name: 'pureProxy8', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy8}),
-    new CompileIdentifierMetadata(
-        {name: 'pureProxy9', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy9}),
-    new CompileIdentifierMetadata(
-        {name: 'pureProxy10', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy10}),
+    {name: 'pureProxy1', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy1},
+    {name: 'pureProxy2', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy2},
+    {name: 'pureProxy3', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy3},
+    {name: 'pureProxy4', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy4},
+    {name: 'pureProxy5', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy5},
+    {name: 'pureProxy6', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy6},
+    {name: 'pureProxy7', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy7},
+    {name: 'pureProxy8', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy8},
+    {name: 'pureProxy9', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy9},
+    {name: 'pureProxy10', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: pureProxy10},
   ];
-  static SecurityContext = new CompileIdentifierMetadata({
+  static SecurityContext: IdentifierSpec = {
     name: 'SecurityContext',
     moduleUrl: assetUrl('core', 'security'),
     runtime: SecurityContext,
-  });
-  static AnimationKeyframe = new CompileIdentifierMetadata({
+  };
+  static AnimationKeyframe: IdentifierSpec = {
     name: 'AnimationKeyframe',
     moduleUrl: assetUrl('core', 'animation/animation_keyframe'),
     runtime: impAnimationKeyframe
-  });
-  static AnimationStyles = new CompileIdentifierMetadata({
+  };
+  static AnimationStyles: IdentifierSpec = {
     name: 'AnimationStyles',
     moduleUrl: assetUrl('core', 'animation/animation_styles'),
     runtime: impAnimationStyles
-  });
-  static NoOpAnimationPlayer = new CompileIdentifierMetadata({
+  };
+  static NoOpAnimationPlayer: IdentifierSpec = {
     name: 'NoOpAnimationPlayer',
     moduleUrl: assetUrl('core', 'animation/animation_player'),
     runtime: impNoOpAnimationPlayer
-  });
-  static AnimationGroupPlayer = new CompileIdentifierMetadata({
+  };
+  static AnimationGroupPlayer: IdentifierSpec = {
     name: 'AnimationGroupPlayer',
     moduleUrl: assetUrl('core', 'animation/animation_group_player'),
     runtime: impAnimationGroupPlayer
-  });
-  static AnimationSequencePlayer = new CompileIdentifierMetadata({
+  };
+  static AnimationSequencePlayer: IdentifierSpec = {
     name: 'AnimationSequencePlayer',
     moduleUrl: assetUrl('core', 'animation/animation_sequence_player'),
     runtime: impAnimationSequencePlayer
-  });
-  static prepareFinalAnimationStyles = new CompileIdentifierMetadata({
+  };
+  static prepareFinalAnimationStyles: IdentifierSpec = {
     name: 'prepareFinalAnimationStyles',
     moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL,
     runtime: impBalanceAnimationStyles
-  });
-  static balanceAnimationKeyframes = new CompileIdentifierMetadata({
+  };
+  static balanceAnimationKeyframes: IdentifierSpec = {
     name: 'balanceAnimationKeyframes',
     moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL,
     runtime: impBalanceAnimationKeyframes
-  });
-  static clearStyles = new CompileIdentifierMetadata(
-      {name: 'clearStyles', moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL, runtime: impClearStyles});
-  static renderStyles = new CompileIdentifierMetadata(
-      {name: 'renderStyles', moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL, runtime: impRenderStyles});
-  static collectAndResolveStyles = new CompileIdentifierMetadata({
+  };
+  static clearStyles: IdentifierSpec = {
+    name: 'clearStyles',
+    moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL,
+    runtime: impClearStyles
+  };
+  static renderStyles: IdentifierSpec = {
+    name: 'renderStyles',
+    moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL,
+    runtime: impRenderStyles
+  };
+  static collectAndResolveStyles: IdentifierSpec = {
     name: 'collectAndResolveStyles',
     moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL,
     runtime: impCollectAndResolveStyles
-  });
-  static LOCALE_ID = new CompileIdentifierMetadata(
-      {name: 'LOCALE_ID', moduleUrl: assetUrl('core', 'i18n/tokens'), runtime: LOCALE_ID_});
-  static TRANSLATIONS_FORMAT = new CompileIdentifierMetadata({
+  };
+  static LOCALE_ID: IdentifierSpec = {
+    name: 'LOCALE_ID',
+    moduleUrl: assetUrl('core', 'i18n/tokens'),
+    runtime: LOCALE_ID_
+  };
+  static TRANSLATIONS_FORMAT: IdentifierSpec = {
     name: 'TRANSLATIONS_FORMAT',
     moduleUrl: assetUrl('core', 'i18n/tokens'),
     runtime: TRANSLATIONS_FORMAT_
-  });
-  static AnimationOutput = new CompileIdentifierMetadata({
+  };
+  static AnimationOutput: IdentifierSpec = {
     name: 'AnimationOutput',
     moduleUrl: assetUrl('core', 'animation/animation_output'),
     runtime: impAnimationOutput
+  };
+}
+
+export function resolveIdentifier(identifier: IdentifierSpec) {
+  return new CompileIdentifierMetadata({
+    name: identifier.name,
+    moduleUrl: identifier.moduleUrl,
+    runtime: reflector.resolveType(identifier.name, identifier.moduleUrl) || identifier.runtime
   });
 }
 
 export function identifierToken(identifier: CompileIdentifierMetadata): CompileTokenMetadata {
   return new CompileTokenMetadata({identifier: identifier});
+}
+
+export function resolveIdentifierToken(identifier: IdentifierSpec): CompileTokenMetadata {
+  return identifierToken(resolveIdentifier(identifier));
+}
+
+export function resolveEnumIdentifier(
+    enumType: CompileIdentifierMetadata, name: string): CompileIdentifierMetadata {
+  const resolvedEnum = reflector.resolveEnum(enumType, name);
+  if (resolvedEnum) {
+    return new CompileIdentifierMetadata(
+        {name: enumType.name, moduleUrl: enumType.moduleUrl, runtime: resolvedEnum});
+  } else {
+    return new CompileIdentifierMetadata({
+      name: `${enumType.name}.${name}`,
+      moduleUrl: enumType.moduleUrl,
+      runtime: enumType.runtime[name]
+    });
+  }
 }

--- a/modules/@angular/compiler/src/metadata_resolver.ts
+++ b/modules/@angular/compiler/src/metadata_resolver.ts
@@ -15,7 +15,7 @@ import {assertArrayOfStrings, assertInterpolationSymbols} from './assertions';
 import * as cpl from './compile_metadata';
 import {DirectiveResolver} from './directive_resolver';
 import {isArray, isBlank, isPresent, isString, stringify} from './facade/lang';
-import {Identifiers, identifierToken} from './identifiers';
+import {Identifiers, resolveIdentifierToken} from './identifiers';
 import {hasLifecycleHook} from './lifecycle_reflector';
 import {NgModuleResolver} from './ng_module_resolver';
 import {PipeResolver} from './pipe_resolver';
@@ -565,7 +565,7 @@ export class CompileMetadataResolver {
         compileProvider = this.getProvidersMetadata(provider, targetEntryComponents, debugInfo);
       } else if (provider instanceof cpl.ProviderMeta) {
         let tokenMeta = this.getTokenMetadata(provider.token);
-        if (tokenMeta.equalsTo(identifierToken(Identifiers.ANALYZE_FOR_ENTRY_COMPONENTS))) {
+        if (tokenMeta.equalsTo(resolveIdentifierToken(Identifiers.ANALYZE_FOR_ENTRY_COMPONENTS))) {
           targetEntryComponents.push(...this._getEntryComponentsFromProvider(provider));
         } else {
           compileProvider = this.getProviderMetadata(provider);

--- a/modules/@angular/compiler/src/offline_compiler.ts
+++ b/modules/@angular/compiler/src/offline_compiler.ts
@@ -11,7 +11,7 @@ import {SchemaMetadata} from '@angular/core';
 import {CompileDirectiveMetadata, CompileIdentifierMetadata, CompileNgModuleMetadata, CompilePipeMetadata, CompileProviderMetadata, CompileTokenMetadata, StaticSymbol, createHostComponentMeta} from './compile_metadata';
 import {DirectiveNormalizer} from './directive_normalizer';
 import {ListWrapper} from './facade/collection';
-import {Identifiers} from './identifiers';
+import {Identifiers, resolveIdentifier, resolveIdentifierToken} from './identifiers';
 import {CompileMetadataResolver} from './metadata_resolver';
 import {NgModuleCompiler} from './ng_module_compiler';
 import {OutputEmitter} from './output/abstract_emitter';
@@ -108,12 +108,10 @@ export class OfflineCompiler {
   private _compileModule(ngModuleType: StaticSymbol, targetStatements: o.Statement[]): string {
     const ngModule = this._metadataResolver.getNgModuleMetadata(<any>ngModuleType);
     let appCompileResult = this._ngModuleCompiler.compile(ngModule, [
+      new CompileProviderMetadata(
+          {token: resolveIdentifierToken(Identifiers.LOCALE_ID), useValue: this._localeId}),
       new CompileProviderMetadata({
-        token: new CompileTokenMetadata({identifier: Identifiers.LOCALE_ID}),
-        useValue: this._localeId
-      }),
-      new CompileProviderMetadata({
-        token: new CompileTokenMetadata({identifier: Identifiers.TRANSLATIONS_FORMAT}),
+        token: resolveIdentifierToken(Identifiers.TRANSLATIONS_FORMAT),
         useValue: this._translationFormat
       })
     ]);
@@ -134,15 +132,16 @@ export class OfflineCompiler {
     var compFactoryVar = _componentFactoryName(compMeta.type);
     targetStatements.push(
         o.variable(compFactoryVar)
-            .set(o.importExpr(Identifiers.ComponentFactory, [o.importType(compMeta.type)])
+            .set(o.importExpr(resolveIdentifier(Identifiers.ComponentFactory), [o.importType(
+                                                                                   compMeta.type)])
                      .instantiate(
                          [
                            o.literal(compMeta.selector), o.variable(hostViewFactoryVar),
                            o.importExpr(compMeta.type)
                          ],
                          o.importType(
-                             Identifiers.ComponentFactory, [o.importType(compMeta.type)],
-                             [o.TypeModifier.Const])))
+                             resolveIdentifier(Identifiers.ComponentFactory),
+                             [o.importType(compMeta.type)], [o.TypeModifier.Const])))
             .toDeclStmt(null, [o.StmtModifier.Final]));
     return compFactoryVar;
   }

--- a/modules/@angular/compiler/src/provider_analyzer.ts
+++ b/modules/@angular/compiler/src/provider_analyzer.ts
@@ -10,7 +10,7 @@
 import {CompileDiDependencyMetadata, CompileDirectiveMetadata, CompileIdentifierMap, CompileNgModuleMetadata, CompileProviderMetadata, CompileQueryMetadata, CompileTokenMetadata, CompileTypeMetadata} from './compile_metadata';
 import {ListWrapper} from './facade/collection';
 import {isArray, isBlank, isPresent, normalizeBlank} from './facade/lang';
-import {Identifiers, identifierToken} from './identifiers';
+import {Identifiers, resolveIdentifierToken} from './identifiers';
 import {ParseError, ParseSourceSpan} from './parse_util';
 import {AttrAst, DirectiveAst, ProviderAst, ProviderAstType, ReferenceAst, VariableAst} from './template_parser/template_ast';
 
@@ -65,7 +65,7 @@ export class ProviderElementContext {
     refs.forEach((refAst) => {
       this._addQueryReadsTo(new CompileTokenMetadata({value: refAst.name}), queriedTokens);
     });
-    if (isPresent(queriedTokens.get(identifierToken(Identifiers.ViewContainerRef)))) {
+    if (isPresent(queriedTokens.get(resolveIdentifierToken(Identifiers.ViewContainerRef)))) {
       this._hasViewContainer = true;
     }
 
@@ -206,18 +206,18 @@ export class ProviderElementContext {
       // access builtints
       if ((requestingProviderType === ProviderAstType.Directive ||
            requestingProviderType === ProviderAstType.Component)) {
-        if (dep.token.equalsTo(identifierToken(Identifiers.Renderer)) ||
-            dep.token.equalsTo(identifierToken(Identifiers.ElementRef)) ||
-            dep.token.equalsTo(identifierToken(Identifiers.ChangeDetectorRef)) ||
-            dep.token.equalsTo(identifierToken(Identifiers.TemplateRef))) {
+        if (dep.token.equalsTo(resolveIdentifierToken(Identifiers.Renderer)) ||
+            dep.token.equalsTo(resolveIdentifierToken(Identifiers.ElementRef)) ||
+            dep.token.equalsTo(resolveIdentifierToken(Identifiers.ChangeDetectorRef)) ||
+            dep.token.equalsTo(resolveIdentifierToken(Identifiers.TemplateRef))) {
           return dep;
         }
-        if (dep.token.equalsTo(identifierToken(Identifiers.ViewContainerRef))) {
+        if (dep.token.equalsTo(resolveIdentifierToken(Identifiers.ViewContainerRef))) {
           this._hasViewContainer = true;
         }
       }
       // access the injector
-      if (dep.token.equalsTo(identifierToken(Identifiers.Injector))) {
+      if (dep.token.equalsTo(resolveIdentifierToken(Identifiers.Injector))) {
         return dep;
       }
       // access providers
@@ -254,7 +254,7 @@ export class ProviderElementContext {
       // check @Host restriction
       if (isBlank(result)) {
         if (!dep.isHost || this._viewContext.component.type.isHost ||
-            identifierToken(this._viewContext.component.type).equalsTo(dep.token) ||
+            resolveIdentifierToken(this._viewContext.component.type).equalsTo(dep.token) ||
             isPresent(this._viewContext.viewProviders.get(dep.token))) {
           result = dep;
         } else {
@@ -363,8 +363,8 @@ export class NgModuleProviderAnalyzer {
     var foundLocal = false;
     if (!dep.isSkipSelf && isPresent(dep.token)) {
       // access the injector
-      if (dep.token.equalsTo(identifierToken(Identifiers.Injector)) ||
-          dep.token.equalsTo(identifierToken(Identifiers.ComponentFactoryResolver))) {
+      if (dep.token.equalsTo(resolveIdentifierToken(Identifiers.Injector)) ||
+          dep.token.equalsTo(resolveIdentifierToken(Identifiers.ComponentFactoryResolver))) {
         foundLocal = true;
         // access providers
       } else if (isPresent(this._getOrCreateLocalProvider(dep.token, eager))) {

--- a/modules/@angular/compiler/src/template_parser/template_parser.ts
+++ b/modules/@angular/compiler/src/template_parser/template_parser.ts
@@ -15,7 +15,7 @@ import {Parser} from '../expression_parser/parser';
 import {ListWrapper, SetWrapper, StringMapWrapper} from '../facade/collection';
 import {isBlank, isPresent, isString} from '../facade/lang';
 import {HtmlParser} from '../i18n/html_parser';
-import {Identifiers, identifierToken} from '../identifiers';
+import {Identifiers, identifierToken, resolveIdentifierToken} from '../identifiers';
 import * as html from '../ml_parser/ast';
 import {ParseTreeResult} from '../ml_parser/html_parser';
 import {expandNodes} from '../ml_parser/icu_ast_expander';
@@ -732,7 +732,7 @@ class TemplateParseVisitor implements html.Visitor {
       } else if (isBlank(component)) {
         let refToken: CompileTokenMetadata = null;
         if (isTemplateElement) {
-          refToken = identifierToken(Identifiers.TemplateRef);
+          refToken = resolveIdentifierToken(Identifiers.TemplateRef);
         }
         targetReferences.push(new ReferenceAst(elOrDirRef.name, refToken, elOrDirRef.sourceSpan));
       }

--- a/modules/@angular/compiler/src/view_compiler/compile_pipe.ts
+++ b/modules/@angular/compiler/src/view_compiler/compile_pipe.ts
@@ -9,7 +9,7 @@
 
 import {CompilePipeMetadata} from '../compile_metadata';
 import {isBlank, isPresent} from '../facade/lang';
-import {Identifiers, identifierToken} from '../identifiers';
+import {Identifiers, identifierToken, resolveIdentifier, resolveIdentifierToken} from '../identifiers';
 import * as o from '../output/output_ast';
 
 import {CompileView} from './compile_view';
@@ -42,7 +42,7 @@ export class CompilePipe {
   constructor(public view: CompileView, public meta: CompilePipeMetadata) {
     this.instance = o.THIS_EXPR.prop(`_pipe_${meta.name}_${view.pipeCount++}`);
     var deps = this.meta.type.diDeps.map((diDep) => {
-      if (diDep.token.equalsTo(identifierToken(Identifiers.ChangeDetectorRef))) {
+      if (diDep.token.equalsTo(resolveIdentifierToken(Identifiers.ChangeDetectorRef))) {
         return getPropertyInView(o.THIS_EXPR.prop('ref'), this.view, this.view.componentView);
       }
       return injectFromViewParentInjector(diDep.token, false);
@@ -66,7 +66,7 @@ export class CompilePipe {
           pipeInstanceSeenFromPureProxy.prop('transform')
               .callMethod(o.BuiltinMethod.Bind, [pipeInstanceSeenFromPureProxy]),
           args.length, purePipeProxyInstance, callingView);
-      return o.importExpr(Identifiers.castByValue)
+      return o.importExpr(resolveIdentifier(Identifiers.castByValue))
           .callFn([purePipeProxyInstance, pipeInstanceSeenFromPureProxy.prop('transform')])
           .callFn(args);
     } else {

--- a/modules/@angular/compiler/src/view_compiler/compile_query.ts
+++ b/modules/@angular/compiler/src/view_compiler/compile_query.ts
@@ -9,7 +9,7 @@
 import {CompileIdentifierMap, CompileQueryMetadata, CompileTokenMetadata} from '../compile_metadata';
 import {ListWrapper} from '../facade/collection';
 import {isBlank, isPresent} from '../facade/lang';
-import {Identifiers} from '../identifiers';
+import {Identifiers, resolveIdentifier} from '../identifiers';
 import * as o from '../output/output_ast';
 
 import {CompileElement} from './compile_element';
@@ -115,12 +115,13 @@ function mapNestedViews(
 export function createQueryList(
     query: CompileQueryMetadata, directiveInstance: o.Expression, propertyName: string,
     compileView: CompileView): o.Expression {
-  compileView.fields.push(
-      new o.ClassField(propertyName, o.importType(Identifiers.QueryList, [o.DYNAMIC_TYPE])));
+  compileView.fields.push(new o.ClassField(
+      propertyName, o.importType(resolveIdentifier(Identifiers.QueryList), [o.DYNAMIC_TYPE])));
   var expr = o.THIS_EXPR.prop(propertyName);
   compileView.createMethod.addStmt(
       o.THIS_EXPR.prop(propertyName)
-          .set(o.importExpr(Identifiers.QueryList, [o.DYNAMIC_TYPE]).instantiate([]))
+          .set(o.importExpr(resolveIdentifier(Identifiers.QueryList), [o.DYNAMIC_TYPE])
+                   .instantiate([]))
           .toStmt());
   return expr;
 }

--- a/modules/@angular/compiler/src/view_compiler/compile_view.ts
+++ b/modules/@angular/compiler/src/view_compiler/compile_view.ts
@@ -12,7 +12,7 @@ import {CompileDirectiveMetadata, CompileIdentifierMap, CompileIdentifierMetadat
 import {CompilerConfig} from '../config';
 import {ListWrapper} from '../facade/collection';
 import {isBlank, isPresent} from '../facade/lang';
-import {Identifiers} from '../identifiers';
+import {Identifiers, resolveIdentifier} from '../identifiers';
 import * as o from '../output/output_ast';
 import {createDiTokenExpression} from '../util';
 
@@ -150,7 +150,7 @@ export class CompileView implements NameResolver {
 
   createLiteralArray(values: o.Expression[]): o.Expression {
     if (values.length === 0) {
-      return o.importExpr(Identifiers.EMPTY_ARRAY);
+      return o.importExpr(resolveIdentifier(Identifiers.EMPTY_ARRAY));
     }
     var proxyExpr = o.THIS_EXPR.prop(`_arr_${this.literalArrayCount++}`);
     var proxyParams: o.FnParam[] = [];
@@ -170,7 +170,7 @@ export class CompileView implements NameResolver {
 
   createLiteralMap(entries: Array<Array<string|o.Expression>>): o.Expression {
     if (entries.length === 0) {
-      return o.importExpr(Identifiers.EMPTY_MAP);
+      return o.importExpr(resolveIdentifier(Identifiers.EMPTY_MAP));
     }
     var proxyExpr = o.THIS_EXPR.prop(`_map_${this.literalMapCount++}`);
     var proxyParams: o.FnParam[] = [];

--- a/modules/@angular/compiler/src/view_compiler/constants.ts
+++ b/modules/@angular/compiler/src/view_compiler/constants.ts
@@ -10,56 +10,80 @@ import {ChangeDetectionStrategy, ViewEncapsulation} from '@angular/core';
 
 import {ChangeDetectorStatus, ViewType} from '../../core_private';
 import {CompileIdentifierMetadata} from '../compile_metadata';
-import {isBlank, resolveEnumToken} from '../facade/lang';
-import {Identifiers} from '../identifiers';
+import {isBlank} from '../facade/lang';
+import {Identifiers, resolveEnumIdentifier, resolveIdentifier} from '../identifiers';
 import * as o from '../output/output_ast';
 
-function _enumExpression(classIdentifier: CompileIdentifierMetadata, value: any): o.Expression {
-  if (isBlank(value)) return o.NULL_EXPR;
-  var name = resolveEnumToken(classIdentifier.runtime, value);
-  return o.importExpr(new CompileIdentifierMetadata({
-    name: `${classIdentifier.name}.${name}`,
-    moduleUrl: classIdentifier.moduleUrl,
-    runtime: value
-  }));
+function _enumExpression(classIdentifier: CompileIdentifierMetadata, name: string): o.Expression {
+  return o.importExpr(resolveEnumIdentifier(classIdentifier, name));
 }
 
 export class ViewTypeEnum {
   static fromValue(value: ViewType): o.Expression {
-    return _enumExpression(Identifiers.ViewType, value);
+    const viewType = resolveIdentifier(Identifiers.ViewType);
+    switch (value) {
+      case ViewType.HOST:
+        return _enumExpression(viewType, 'HOST');
+      case ViewType.COMPONENT:
+        return _enumExpression(viewType, 'COMPONENT');
+      case ViewType.EMBEDDED:
+        return _enumExpression(viewType, 'EMBEDDED');
+      default:
+        throw Error(`Inavlid ViewType value: ${value}`);
+    }
   }
-  static HOST = ViewTypeEnum.fromValue(ViewType.HOST);
-  static COMPONENT = ViewTypeEnum.fromValue(ViewType.COMPONENT);
-  static EMBEDDED = ViewTypeEnum.fromValue(ViewType.EMBEDDED);
 }
 
 export class ViewEncapsulationEnum {
   static fromValue(value: ViewEncapsulation): o.Expression {
-    return _enumExpression(Identifiers.ViewEncapsulation, value);
+    const viewEncapsulation = resolveIdentifier(Identifiers.ViewEncapsulation);
+    switch (value) {
+      case ViewEncapsulation.Emulated:
+        return _enumExpression(viewEncapsulation, 'Emulated');
+      case ViewEncapsulation.Native:
+        return _enumExpression(viewEncapsulation, 'Native');
+      case ViewEncapsulation.None:
+        return _enumExpression(viewEncapsulation, 'None');
+      default:
+        throw Error(`Inavlid ViewEncapsulation value: ${value}`);
+    }
   }
-  static Emulated = ViewEncapsulationEnum.fromValue(ViewEncapsulation.Emulated);
-  static Native = ViewEncapsulationEnum.fromValue(ViewEncapsulation.Native);
-  static None = ViewEncapsulationEnum.fromValue(ViewEncapsulation.None);
 }
 
 export class ChangeDetectionStrategyEnum {
   static fromValue(value: ChangeDetectionStrategy): o.Expression {
-    return _enumExpression(Identifiers.ChangeDetectionStrategy, value);
+    const changeDetectionStrategy = resolveIdentifier(Identifiers.ChangeDetectionStrategy);
+    switch (value) {
+      case ChangeDetectionStrategy.OnPush:
+        return _enumExpression(changeDetectionStrategy, 'OnPush');
+      case ChangeDetectionStrategy.Default:
+        return _enumExpression(changeDetectionStrategy, 'Default');
+      default:
+        throw Error(`Inavlid ChangeDetectionStrategy value: ${value}`);
+    }
   }
-  static OnPush = ChangeDetectionStrategyEnum.fromValue(ChangeDetectionStrategy.OnPush);
-  static Default = ChangeDetectionStrategyEnum.fromValue(ChangeDetectionStrategy.Default);
 }
 
 export class ChangeDetectorStatusEnum {
   static fromValue(value: ChangeDetectorStatusEnum): o.Expression {
-    return _enumExpression(Identifiers.ChangeDetectorStatus, value);
+    const changeDetectorStatus = resolveIdentifier(Identifiers.ChangeDetectorStatus);
+    switch (value) {
+      case ChangeDetectorStatus.CheckOnce:
+        return _enumExpression(changeDetectorStatus, 'CheckOnce');
+      case ChangeDetectorStatus.Checked:
+        return _enumExpression(changeDetectorStatus, 'Checked');
+      case ChangeDetectorStatus.CheckAlways:
+        return _enumExpression(changeDetectorStatus, 'CheckAlways');
+      case ChangeDetectorStatus.Detached:
+        return _enumExpression(changeDetectorStatus, 'Detached');
+      case ChangeDetectorStatus.Errored:
+        return _enumExpression(changeDetectorStatus, 'Errored');
+      case ChangeDetectorStatus.Destroyed:
+        return _enumExpression(changeDetectorStatus, 'Destroyed');
+      default:
+        throw Error(`Inavlid ChangeDetectorStatus value: ${value}`);
+    }
   }
-  static CheckOnce = ChangeDetectorStatusEnum.fromValue(ChangeDetectorStatus.CheckOnce);
-  static Checked = ChangeDetectorStatusEnum.fromValue(ChangeDetectorStatus.Checked);
-  static CheckAlways = ChangeDetectorStatusEnum.fromValue(ChangeDetectorStatus.CheckAlways);
-  static Detached = ChangeDetectorStatusEnum.fromValue(ChangeDetectorStatus.Detached);
-  static Errored = ChangeDetectorStatusEnum.fromValue(ChangeDetectorStatus.Errored);
-  static Destroyed = ChangeDetectorStatusEnum.fromValue(ChangeDetectorStatus.Destroyed);
 }
 
 export class ViewConstructorVars {

--- a/modules/@angular/compiler/src/view_compiler/event_binder.ts
+++ b/modules/@angular/compiler/src/view_compiler/event_binder.ts
@@ -10,7 +10,7 @@ import {AnimationOutput} from '../../core_private';
 import {CompileDirectiveMetadata} from '../compile_metadata';
 import {ListWrapper, StringMapWrapper} from '../facade/collection';
 import {StringWrapper, isBlank, isPresent} from '../facade/lang';
-import {Identifiers, identifierToken} from '../identifiers';
+import {Identifiers, identifierToken, resolveIdentifier} from '../identifiers';
 import * as o from '../output/output_ast';
 import {BoundEventAst, DirectiveAst} from '../template_parser/template_ast';
 
@@ -130,7 +130,7 @@ export class CompileEventListener {
                        'registerAnimationOutput',
                        [
                          this.compileElement.renderNode,
-                         o.importExpr(Identifiers.AnimationOutput).instantiate([
+                         o.importExpr(resolveIdentifier(Identifiers.AnimationOutput)).instantiate([
                            o.literal(output.name), o.literal(output.phase)
                          ]),
                          outputListener

--- a/modules/@angular/compiler/src/view_compiler/expression_converter.ts
+++ b/modules/@angular/compiler/src/view_compiler/expression_converter.ts
@@ -9,7 +9,7 @@
 
 import * as cdAst from '../expression_parser/ast';
 import {isArray, isBlank, isPresent} from '../facade/lang';
-import {Identifiers} from '../identifiers';
+import {Identifiers, resolveIdentifier} from '../identifiers';
 import * as o from '../output/output_ast';
 
 export interface NameResolver {
@@ -193,7 +193,7 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
       args.push(this.visit(ast.expressions[i], _Mode.Expression));
     }
     args.push(o.literal(ast.strings[ast.strings.length - 1]));
-    return o.importExpr(Identifiers.interpolate).callFn(args);
+    return o.importExpr(resolveIdentifier(Identifiers.interpolate)).callFn(args);
   }
 
   visitKeyedRead(ast: cdAst.KeyedRead, mode: _Mode): any {

--- a/modules/@angular/compiler/src/view_compiler/util.ts
+++ b/modules/@angular/compiler/src/view_compiler/util.ts
@@ -9,7 +9,7 @@
 
 import {CompileDirectiveMetadata, CompileTokenMetadata} from '../compile_metadata';
 import {isBlank, isPresent} from '../facade/lang';
-import {Identifiers} from '../identifiers';
+import {Identifiers, resolveIdentifier} from '../identifiers';
 import * as o from '../output/output_ast';
 import {createDiTokenExpression} from '../util';
 
@@ -87,6 +87,7 @@ export function createPureProxy(
   if (isBlank(pureProxyId)) {
     throw new Error(`Unsupported number of argument for pure functions: ${argCount}`);
   }
-  view.createMethod.addStmt(
-      o.THIS_EXPR.prop(pureProxyProp.name).set(o.importExpr(pureProxyId).callFn([fn])).toStmt());
+  view.createMethod.addStmt(o.THIS_EXPR.prop(pureProxyProp.name)
+                                .set(o.importExpr(resolveIdentifier(pureProxyId)).callFn([fn]))
+                                .toStmt());
 }

--- a/modules/@angular/compiler/src/view_compiler/view_builder.ts
+++ b/modules/@angular/compiler/src/view_compiler/view_builder.ts
@@ -13,7 +13,7 @@ import {AnimationCompiler} from '../animation/animation_compiler';
 import {CompileDirectiveMetadata, CompileIdentifierMetadata, CompileTokenMetadata, CompileTypeMetadata} from '../compile_metadata';
 import {ListWrapper, SetWrapper, StringMapWrapper} from '../facade/collection';
 import {StringWrapper, isPresent} from '../facade/lang';
-import {Identifiers, identifierToken} from '../identifiers';
+import {Identifiers, identifierToken, resolveIdentifier, resolveIdentifierToken} from '../identifiers';
 import * as o from '../output/output_ast';
 import {AttrAst, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, DirectiveAst, ElementAst, EmbeddedTemplateAst, NgContentAst, ProviderAst, ReferenceAst, TemplateAst, TemplateAstVisitor, TextAst, VariableAst, templateVisitAll} from '../template_parser/template_ast';
 import {createDiTokenExpression} from '../util';
@@ -148,7 +148,8 @@ class ViewBuilderVisitor implements TemplateAstVisitor {
                   'projectNodes',
                   [
                     parentRenderNode,
-                    o.importExpr(Identifiers.flattenNestedViewRenderNodes).callFn([nodesExpression])
+                    o.importExpr(resolveIdentifier(Identifiers.flattenNestedViewRenderNodes))
+                        .callFn([nodesExpression])
                   ])
               .toStmt());
     } else if (this._isRootNode(parent)) {
@@ -396,7 +397,8 @@ function createViewTopLevelStmts(view: CompileView, targetStatements: o.Statemen
             .set(o.literalArr(
                 view.nodes.map(createStaticNodeDebugInfo),
                 new o.ArrayType(
-                    new o.ExternalType(Identifiers.StaticNodeDebugInfo), [o.TypeModifier.Const])))
+                    new o.ExternalType(resolveIdentifier(Identifiers.StaticNodeDebugInfo)),
+                    [o.TypeModifier.Const])))
             .toDeclStmt(null, [o.StmtModifier.Final]));
   }
 
@@ -404,8 +406,9 @@ function createViewTopLevelStmts(view: CompileView, targetStatements: o.Statemen
   var renderCompTypeVar: o.ReadVarExpr =
       o.variable(`renderType_${view.component.type.name}`);  // fix highlighting: `
   if (view.viewIndex === 0) {
-    targetStatements.push(renderCompTypeVar.set(o.NULL_EXPR)
-                              .toDeclStmt(o.importType(Identifiers.RenderComponentType)));
+    targetStatements.push(
+        renderCompTypeVar.set(o.NULL_EXPR)
+            .toDeclStmt(o.importType(resolveIdentifier(Identifiers.RenderComponentType))));
   }
 
   var viewClass = createViewClass(view, renderCompTypeVar, nodeDebugInfosVar);
@@ -429,23 +432,29 @@ function createStaticNodeDebugInfo(node: CompileNode): o.Expression {
               [varName, isPresent(token) ? createDiTokenExpression(token) : o.NULL_EXPR]);
         });
   }
-  return o.importExpr(Identifiers.StaticNodeDebugInfo)
+  return o.importExpr(resolveIdentifier(Identifiers.StaticNodeDebugInfo))
       .instantiate(
           [
             o.literalArr(providerTokens, new o.ArrayType(o.DYNAMIC_TYPE, [o.TypeModifier.Const])),
             componentToken,
             o.literalMap(varTokenEntries, new o.MapType(o.DYNAMIC_TYPE, [o.TypeModifier.Const]))
           ],
-          o.importType(Identifiers.StaticNodeDebugInfo, null, [o.TypeModifier.Const]));
+          o.importType(
+              resolveIdentifier(Identifiers.StaticNodeDebugInfo), null, [o.TypeModifier.Const]));
 }
 
 function createViewClass(
     view: CompileView, renderCompTypeVar: o.ReadVarExpr,
     nodeDebugInfosVar: o.Expression): o.ClassStmt {
   var viewConstructorArgs = [
-    new o.FnParam(ViewConstructorVars.viewUtils.name, o.importType(Identifiers.ViewUtils)),
-    new o.FnParam(ViewConstructorVars.parentInjector.name, o.importType(Identifiers.Injector)),
-    new o.FnParam(ViewConstructorVars.declarationEl.name, o.importType(Identifiers.AppElement))
+    new o.FnParam(
+        ViewConstructorVars.viewUtils.name, o.importType(resolveIdentifier(Identifiers.ViewUtils))),
+    new o.FnParam(
+        ViewConstructorVars.parentInjector.name,
+        o.importType(resolveIdentifier(Identifiers.Injector))),
+    new o.FnParam(
+        ViewConstructorVars.declarationEl.name,
+        o.importType(resolveIdentifier(Identifiers.AppElement)))
   ];
   var superConstructorArgs = [
     o.variable(view.className), renderCompTypeVar, ViewTypeEnum.fromValue(view.viewType),
@@ -462,7 +471,7 @@ function createViewClass(
   var viewMethods = [
     new o.ClassMethod(
         'createInternal', [new o.FnParam(rootSelectorVar.name, o.STRING_TYPE)],
-        generateCreateMethod(view), o.importType(Identifiers.AppElement)),
+        generateCreateMethod(view), o.importType(resolveIdentifier(Identifiers.AppElement))),
     new o.ClassMethod(
         'injectorGetInternal',
         [
@@ -482,17 +491,23 @@ function createViewClass(
   ].concat(view.eventHandlerMethods);
   var superClass = view.genConfig.genDebugInfo ? Identifiers.DebugAppView : Identifiers.AppView;
   var viewClass = new o.ClassStmt(
-      view.className, o.importExpr(superClass, [getContextType(view)]), view.fields, view.getters,
-      viewConstructor, viewMethods.filter((method) => method.body.length > 0));
+      view.className, o.importExpr(resolveIdentifier(superClass), [getContextType(view)]),
+      view.fields, view.getters, viewConstructor,
+      viewMethods.filter((method) => method.body.length > 0));
   return viewClass;
 }
 
 function createViewFactory(
     view: CompileView, viewClass: o.ClassStmt, renderCompTypeVar: o.ReadVarExpr): o.Statement {
   var viewFactoryArgs = [
-    new o.FnParam(ViewConstructorVars.viewUtils.name, o.importType(Identifiers.ViewUtils)),
-    new o.FnParam(ViewConstructorVars.parentInjector.name, o.importType(Identifiers.Injector)),
-    new o.FnParam(ViewConstructorVars.declarationEl.name, o.importType(Identifiers.AppElement))
+    new o.FnParam(
+        ViewConstructorVars.viewUtils.name, o.importType(resolveIdentifier(Identifiers.ViewUtils))),
+    new o.FnParam(
+        ViewConstructorVars.parentInjector.name,
+        o.importType(resolveIdentifier(Identifiers.Injector))),
+    new o.FnParam(
+        ViewConstructorVars.declarationEl.name,
+        o.importType(resolveIdentifier(Identifiers.AppElement)))
   ];
   var initRenderCompTypeStmts: any[] = [];
   var templateUrlInfo: string;
@@ -522,7 +537,7 @@ function createViewFactory(
                                o.variable(viewClass.name)
                                    .instantiate(viewClass.constructorMethod.params.map(
                                        (param) => o.variable(param.name))))]),
-          o.importType(Identifiers.AppView, [getContextType(view)]))
+          o.importType(resolveIdentifier(Identifiers.AppView), [getContextType(view)]))
       .toDeclStmt(view.viewFactory.name, [o.StmtModifier.Final]);
 }
 
@@ -589,12 +604,14 @@ function generateDetectChangesMethod(view: CompileView): o.Statement[] {
     varStmts.push(DetectChangesVars.changed.set(o.literal(true)).toDeclStmt(o.BOOL_TYPE));
   }
   if (SetWrapper.has(readVars, DetectChangesVars.changes.name)) {
-    varStmts.push(DetectChangesVars.changes.set(o.NULL_EXPR)
-                      .toDeclStmt(new o.MapType(o.importType(Identifiers.SimpleChange))));
+    varStmts.push(
+        DetectChangesVars.changes.set(o.NULL_EXPR)
+            .toDeclStmt(new o.MapType(o.importType(resolveIdentifier(Identifiers.SimpleChange)))));
   }
   if (SetWrapper.has(readVars, DetectChangesVars.valUnwrapper.name)) {
     varStmts.push(
-        DetectChangesVars.valUnwrapper.set(o.importExpr(Identifiers.ValueUnwrapper).instantiate([]))
+        DetectChangesVars.valUnwrapper
+            .set(o.importExpr(resolveIdentifier(Identifiers.ValueUnwrapper)).instantiate([]))
             .toDeclStmt(null, [o.StmtModifier.Final]));
   }
   return varStmts.concat(stmts);

--- a/modules/@angular/compiler/test/compiler_spec.ts
+++ b/modules/@angular/compiler/test/compiler_spec.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {expect} from '@angular/platform-browser/testing/matchers';
+
+export function main() {
+  describe('Compiler', () => {
+    it('should generate the correct output when constructors have the same name', () => {
+      function ComponentFactory(selector: string, template: string) {
+        @Component({selector, template})
+        class MyComponent {
+        }
+        return MyComponent;
+      }
+      const HeroComponent = ComponentFactory('my-hero', 'my hero');
+      const VillianComponent = ComponentFactory('a-villian', 'a villian');
+      const MainComponent = ComponentFactory(
+          'my-app', 'I was saved by <my-hero></my-hero> from <a-villian></a-villian>.');
+
+      TestBed.configureTestingModule(
+          {declarations: [HeroComponent, VillianComponent, MainComponent]});
+      const fixture = TestBed.createComponent(MainComponent);
+      expect(fixture.debugElement.nativeElement)
+          .toHaveText('I was saved by my hero from a villian.');
+    });
+  });
+}

--- a/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
@@ -13,12 +13,12 @@ import {AttrAst, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventA
 import {TEMPLATE_TRANSFORMS, TemplateParser, splitClasses} from '@angular/compiler/src/template_parser/template_parser';
 import {MockSchemaRegistry} from '@angular/compiler/testing';
 import {TEST_COMPILER_PROVIDERS} from '@angular/compiler/testing/test_bindings';
-import {SchemaMetadata, SecurityContext} from '@angular/core';
+import {SchemaMetadata, SecurityContext, Type} from '@angular/core';
 import {Console} from '@angular/core/src/console';
 import {TestBed} from '@angular/core/testing';
 import {afterEach, beforeEach, beforeEachProviders, ddescribe, describe, expect, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
 
-import {Identifiers, identifierToken} from '../../src/identifiers';
+import {Identifiers, identifierToken, resolveIdentifierToken} from '../../src/identifiers';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../src/ml_parser/interpolation_config';
 import {unparse} from '../expression_parser/unparser';
 
@@ -44,12 +44,14 @@ export function main() {
     beforeEach(inject([TemplateParser], (parser: TemplateParser) => {
       var component = CompileDirectiveMetadata.create({
         selector: 'root',
-        type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'Root'}),
+        type: new CompileTypeMetadata(
+            {moduleUrl: someModuleUrl, name: 'Root', runtime: {} as Type<any>}),
         isComponent: true
       });
       ngIf = CompileDirectiveMetadata.create({
         selector: '[ngIf]',
-        type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'NgIf'}),
+        type: new CompileTypeMetadata(
+            {moduleUrl: someModuleUrl, name: 'NgIf', runtime: {} as Type<any>}),
         inputs: ['ngIf']
       });
 
@@ -176,7 +178,8 @@ export function main() {
          inject([TemplateParser], (parser: TemplateParser) => {
            const component = CompileDirectiveMetadata.create({
              selector: 'test',
-             type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'Test'}),
+             type: new CompileTypeMetadata(
+                 {moduleUrl: someModuleUrl, name: 'Test', runtime: {} as Type<any>}),
              isComponent: true,
              template: new CompileTemplateMetadata({interpolation: ['{%', '%}']})
            });
@@ -305,7 +308,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
            () => {
              var dirA = CompileDirectiveMetadata.create({
                selector: 'div',
-               type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+               type: new CompileTypeMetadata(
+                   {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
                host: {'[@prop]': 'expr'}
              });
 
@@ -316,7 +320,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
         it('should throw descriptive error when a host binding is not a string expression', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: 'broken',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
             host: {'[class.foo]': null}
           });
 
@@ -328,7 +333,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
         it('should throw descriptive error when a host event is not a string expression', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: 'broken',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
             host: {'(click)': null}
           });
 
@@ -390,7 +396,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
              var dirA = CompileDirectiveMetadata.create({
                selector: 'template',
                outputs: ['e'],
-               type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'})
+               type: new CompileTypeMetadata(
+                   {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>})
              });
              expect(humanizeTplAst(parse('<template (e)="f"></template>', [dirA]))).toEqual([
                [EmbeddedTemplateAst],
@@ -426,15 +433,18 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
            () => {
              var dirA = CompileDirectiveMetadata.create({
                selector: '[a]',
-               type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'})
+               type: new CompileTypeMetadata(
+                   {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>})
              });
              var dirB = CompileDirectiveMetadata.create({
                selector: '[b]',
-               type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirB'})
+               type: new CompileTypeMetadata(
+                   {moduleUrl: someModuleUrl, name: 'DirB', runtime: {} as Type<any>})
              });
              var dirC = CompileDirectiveMetadata.create({
                selector: '[c]',
-               type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirC'})
+               type: new CompileTypeMetadata(
+                   {moduleUrl: someModuleUrl, name: 'DirC', runtime: {} as Type<any>})
              });
              expect(humanizeTplAst(parse('<div a c b a b>', [dirA, dirB, dirC]))).toEqual([
                [ElementAst, 'div'], [AttrAst, 'a', ''], [AttrAst, 'c', ''], [AttrAst, 'b', ''],
@@ -446,11 +456,13 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
         it('should locate directives in property bindings', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: '[a=b]',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'})
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>})
           });
           var dirB = CompileDirectiveMetadata.create({
             selector: '[b]',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirB'})
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirB', runtime: {} as Type<any>})
           });
           expect(humanizeTplAst(parse('<div [a]="b">', [dirA, dirB]))).toEqual([
             [ElementAst, 'div'],
@@ -462,7 +474,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
         it('should locate directives in event bindings', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: '[a]',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirB'})
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirB', runtime: {} as Type<any>})
           });
 
           expect(humanizeTplAst(parse('<div (a)="b">', [dirA]))).toEqual([
@@ -473,7 +486,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
         it('should parse directive host properties', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: 'div',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
             host: {'[a]': 'expr'}
           });
           expect(humanizeTplAst(parse('<div></div>', [dirA]))).toEqual([
@@ -485,7 +499,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
         it('should parse directive host listeners', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: 'div',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
             host: {'(a)': 'expr'}
           });
           expect(humanizeTplAst(parse('<div></div>', [dirA]))).toEqual([
@@ -496,7 +511,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
         it('should parse directive properties', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: 'div',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
             inputs: ['aProp']
           });
           expect(humanizeTplAst(parse('<div [aProp]="expr"></div>', [dirA]))).toEqual([
@@ -508,7 +524,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
         it('should parse renamed directive properties', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: 'div',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
             inputs: ['b:a']
           });
           expect(humanizeTplAst(parse('<div [a]="expr"></div>', [dirA]))).toEqual([
@@ -519,7 +536,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
         it('should parse literal directive properties', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: 'div',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
             inputs: ['a']
           });
           expect(humanizeTplAst(parse('<div a="literal"></div>', [dirA]))).toEqual([
@@ -531,7 +549,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
         it('should favor explicit bound properties over literal properties', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: 'div',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
             inputs: ['a']
           });
           expect(humanizeTplAst(parse('<div a="literal" [a]="\'literal2\'"></div>', [dirA])))
@@ -544,7 +563,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
         it('should support optional directive properties', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: 'div',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
             inputs: ['a']
           });
           expect(humanizeTplAst(parse('<div></div>', [dirA]))).toEqual([
@@ -560,9 +580,10 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
         function createToken(value: string): CompileTokenMetadata {
           let token: CompileTokenMetadata;
           if (value.startsWith('type:')) {
+            const name = value.substring(5);
             token = new CompileTokenMetadata({
-              identifier:
-                  new CompileTypeMetadata({moduleUrl: someModuleUrl, name: value.substring(5)})
+              identifier: new CompileTypeMetadata(
+                  {moduleUrl: someModuleUrl, name, runtime: name as any as Type<any>})
             });
           } else {
             token = new CompileTokenMetadata({value: value});
@@ -593,10 +614,11 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
         function createProvider(
             token: string, {multi = false, deps = []}: {multi?: boolean, deps?: string[]} = {}):
             CompileProviderMetadata {
+          const name = `provider${nextProviderId++}`;
           return new CompileProviderMetadata({
             token: createToken(token),
             multi: multi,
-            useClass: new CompileTypeMetadata({name: `provider${nextProviderId++}`}),
+            useClass: new CompileTypeMetadata({name, runtime: name as any as Type<any>}),
             deps: deps.map(createDep)
           });
         }
@@ -611,8 +633,12 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
           var isComponent = !selector.startsWith('[');
           return CompileDirectiveMetadata.create({
             selector: selector,
-            type: new CompileTypeMetadata(
-                {moduleUrl: someModuleUrl, name: selector, diDeps: deps.map(createDep)}),
+            type: new CompileTypeMetadata({
+              moduleUrl: someModuleUrl,
+              name: selector,
+              diDeps: deps.map(createDep),
+              runtime: selector as any as Type<any>
+            }),
             isComponent: isComponent,
             template: new CompileTemplateMetadata({ngContentSelectors: []}),
             providers: providers,
@@ -860,7 +886,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
         it('should assign references to directives via exportAs', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: '[a]',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
             exportAs: 'dirA'
           });
           expect(humanizeTplAst(parse('<div a #a="dirA"></div>', [dirA]))).toEqual([
@@ -904,7 +931,8 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
           var dirA = CompileDirectiveMetadata.create({
             selector: '[a]',
             isComponent: true,
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
             exportAs: 'dirA',
             template: new CompileTemplateMetadata({ngContentSelectors: []})
           });
@@ -919,7 +947,8 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
         it('should not locate directives in references', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: '[a]',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'})
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>})
           });
           expect(humanizeTplAst(parse('<div ref-a>', [dirA]))).toEqual([
             [ElementAst, 'div'], [ReferenceAst, 'a', null]
@@ -945,13 +974,15 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
 
         it('should support references via #...', () => {
           expect(humanizeTplAst(parse('<template #a>', []))).toEqual([
-            [EmbeddedTemplateAst], [ReferenceAst, 'a', identifierToken(Identifiers.TemplateRef)]
+            [EmbeddedTemplateAst],
+            [ReferenceAst, 'a', resolveIdentifierToken(Identifiers.TemplateRef)]
           ]);
         });
 
         it('should support references via ref-...', () => {
           expect(humanizeTplAst(parse('<template ref-a>', []))).toEqual([
-            [EmbeddedTemplateAst], [ReferenceAst, 'a', identifierToken(Identifiers.TemplateRef)]
+            [EmbeddedTemplateAst],
+            [ReferenceAst, 'a', resolveIdentifierToken(Identifiers.TemplateRef)]
           ]);
         });
 
@@ -963,7 +994,8 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
         it('should not locate directives in variables', () => {
           var dirA = CompileDirectiveMetadata.create({
             selector: '[a]',
-            type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'})
+            type: new CompileTypeMetadata(
+                {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>})
           });
           expect(humanizeTplAst(parse('<template let-a="b"></template>', [dirA]))).toEqual([
             [EmbeddedTemplateAst], [VariableAst, 'a', 'b']
@@ -1005,12 +1037,14 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
           it('should locate directives in property bindings', () => {
             var dirA = CompileDirectiveMetadata.create({
               selector: '[a=b]',
-              type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+              type: new CompileTypeMetadata(
+                  {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
               inputs: ['a']
             });
             var dirB = CompileDirectiveMetadata.create({
               selector: '[b]',
-              type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirB'})
+              type: new CompileTypeMetadata(
+                  {moduleUrl: someModuleUrl, name: 'DirB', runtime: {} as Type<any>})
             });
             expect(humanizeTplAst(parse('<div template="a b" b>', [dirA, dirB]))).toEqual([
               [EmbeddedTemplateAst], [DirectiveAst, dirA], [BoundDirectivePropertyAst, 'a', 'b'],
@@ -1021,7 +1055,8 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
           it('should not locate directives in variables', () => {
             var dirA = CompileDirectiveMetadata.create({
               selector: '[a]',
-              type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'})
+              type: new CompileTypeMetadata(
+                  {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>})
             });
             expect(humanizeTplAst(parse('<div template="let a=b">', [dirA]))).toEqual([
               [EmbeddedTemplateAst], [VariableAst, 'a', 'b'], [ElementAst, 'div']
@@ -1031,7 +1066,8 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
           it('should not locate directives in references', () => {
             var dirA = CompileDirectiveMetadata.create({
               selector: '[a]',
-              type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'})
+              type: new CompileTypeMetadata(
+                  {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>})
             });
             expect(humanizeTplAst(parse('<div ref-a>', [dirA]))).toEqual([
               [ElementAst, 'div'], [ReferenceAst, 'a', null]
@@ -1065,8 +1101,11 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
         return CompileDirectiveMetadata.create({
           selector: selector,
           isComponent: true,
-          type:
-              new CompileTypeMetadata({moduleUrl: someModuleUrl, name: `SomeComp${compCounter++}`}),
+          type: new CompileTypeMetadata({
+            moduleUrl: someModuleUrl,
+            name: `SomeComp${compCounter++}`,
+            runtime: {} as Type<any>
+          }),
           template: new CompileTemplateMetadata({ngContentSelectors: ngContentSelectors})
         });
       }
@@ -1074,8 +1113,11 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
       function createDir(selector: string): CompileDirectiveMetadata {
         return CompileDirectiveMetadata.create({
           selector: selector,
-          type: new CompileTypeMetadata(
-              {moduleUrl: someModuleUrl, name: `SomeDir${compCounter++}`})
+          type: new CompileTypeMetadata({
+            moduleUrl: someModuleUrl,
+            name: `SomeDir${compCounter++}`,
+            runtime: {} as Type<any>
+          })
         });
       }
 
@@ -1242,7 +1284,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'div'. ("<div [ER
       it('should report invalid host property names', () => {
         var dirA = CompileDirectiveMetadata.create({
           selector: 'div',
-          type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+          type: new CompileTypeMetadata(
+              {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
           host: {'[invalidProp]': 'someProp'}
         });
         expect(() => parse('<div></div>', [dirA])).toThrowError(`Template parse errors:
@@ -1258,7 +1301,8 @@ Parser Error: Unexpected token 'b' at column 3 in [a b] in TestComp@0:5 ("<div [
          () => {
            var dirA = CompileDirectiveMetadata.create({
              selector: 'div',
-             type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+             type: new CompileTypeMetadata(
+                 {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
              inputs: ['invalidProp']
            });
            expect(() => parse('<div [invalid-prop]></div>', [dirA])).not.toThrow();
@@ -1268,13 +1312,15 @@ Parser Error: Unexpected token 'b' at column 3 in [a b] in TestComp@0:5 ("<div [
         var dirA = CompileDirectiveMetadata.create({
           selector: 'div',
           isComponent: true,
-          type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+          type: new CompileTypeMetadata(
+              {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
           template: new CompileTemplateMetadata({ngContentSelectors: []})
         });
         var dirB = CompileDirectiveMetadata.create({
           selector: 'div',
           isComponent: true,
-          type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirB'}),
+          type: new CompileTypeMetadata(
+              {moduleUrl: someModuleUrl, name: 'DirB', runtime: {} as Type<any>}),
           template: new CompileTemplateMetadata({ngContentSelectors: []})
         });
         expect(() => parse('<div>', [dirB, dirA])).toThrowError(`Template parse errors:
@@ -1286,7 +1332,8 @@ More than one component: DirB,DirA ("[ERROR ->]<div>"): TestComp@0:0`);
            var dirA = CompileDirectiveMetadata.create({
              selector: '[a]',
              isComponent: true,
-             type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+             type: new CompileTypeMetadata(
+                 {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
              template: new CompileTemplateMetadata({ngContentSelectors: []})
            });
            expect(() => parse('<template [a]="b" (e)="f"></template>', [dirA]))
@@ -1300,7 +1347,8 @@ Property binding a not used by any directive on an embedded template. Make sure 
         var dirA = CompileDirectiveMetadata.create({
           selector: '[a]',
           isComponent: true,
-          type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+          type: new CompileTypeMetadata(
+              {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
           template: new CompileTemplateMetadata({ngContentSelectors: []})
         });
         expect(() => parse('<div *a="b"></div>', [dirA])).toThrowError(`Template parse errors:
@@ -1452,12 +1500,14 @@ Property binding a not used by any directive on an embedded template. Make sure 
       it('should support directive', () => {
         var dirA = CompileDirectiveMetadata.create({
           selector: '[a]',
-          type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'})
+          type: new CompileTypeMetadata(
+              {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>})
         });
         var comp = CompileDirectiveMetadata.create({
           selector: 'div',
           isComponent: true,
-          type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'ZComp'}),
+          type: new CompileTypeMetadata(
+              {moduleUrl: someModuleUrl, name: 'ZComp', runtime: {} as Type<any>}),
           template: new CompileTemplateMetadata({ngContentSelectors: []})
         });
         expect(humanizeTplAstSourceSpans(parse('<div a>', [dirA, comp]))).toEqual([
@@ -1469,11 +1519,13 @@ Property binding a not used by any directive on an embedded template. Make sure 
       it('should support directive in namespace', () => {
         var tagSel = CompileDirectiveMetadata.create({
           selector: 'circle',
-          type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'elDir'})
+          type: new CompileTypeMetadata(
+              {moduleUrl: someModuleUrl, name: 'elDir', runtime: {} as Type<any>})
         });
         var attrSel = CompileDirectiveMetadata.create({
           selector: '[href]',
-          type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'attrDir'})
+          type: new CompileTypeMetadata(
+              {moduleUrl: someModuleUrl, name: 'attrDir', runtime: {} as Type<any>})
         });
 
         expect(humanizeTplAstSourceSpans(
@@ -1491,7 +1543,8 @@ Property binding a not used by any directive on an embedded template. Make sure 
       it('should support directive property', () => {
         var dirA = CompileDirectiveMetadata.create({
           selector: 'div',
-          type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'}),
+          type: new CompileTypeMetadata(
+              {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>}),
           inputs: ['aProp']
         });
         expect(humanizeTplAstSourceSpans(parse('<div [aProp]="foo"></div>', [dirA]))).toEqual([
@@ -1506,7 +1559,8 @@ Property binding a not used by any directive on an embedded template. Make sure 
       it('should allow pipes that have been defined as dependencies', () => {
         var testPipe = new CompilePipeMetadata({
           name: 'test',
-          type: new CompileTypeMetadata({moduleUrl: someModuleUrl, name: 'DirA'})
+          type: new CompileTypeMetadata(
+              {moduleUrl: someModuleUrl, name: 'DirA', runtime: {} as Type<any>})
         });
         expect(() => parse('{{a | test}}', [], [testPipe])).not.toThrow();
       });

--- a/modules/@angular/core/src/reflection/platform_reflection_capabilities.ts
+++ b/modules/@angular/core/src/reflection/platform_reflection_capabilities.ts
@@ -21,4 +21,6 @@ export interface PlatformReflectionCapabilities {
   setter(name: string): SetterFn;
   method(name: string): MethodFn;
   importUri(type: Type<any>): string;
+  resolveType(name: string, moduleUrl: string): any;
+  resolveEnum(enumType: any, name: string): any;
 }

--- a/modules/@angular/core/src/reflection/reflection_capabilities.ts
+++ b/modules/@angular/core/src/reflection/reflection_capabilities.ts
@@ -172,6 +172,9 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
     // Runtime type
     return `./${stringify(type)}`;
   }
+
+  resolveType(name: string, moduleUrl: string): any { return null; }
+  resolveEnum(enumType: any, name: string): any { return null; }
 }
 
 function convertTsickleDecoratorIntoMetadata(decoratorInvocations: any[]): any[] {

--- a/modules/@angular/core/src/reflection/reflector.ts
+++ b/modules/@angular/core/src/reflection/reflector.ts
@@ -176,6 +176,13 @@ export class Reflector extends ReflectorReader {
   _containsReflectionInfo(typeOrFunc: any) { return this._injectableInfo.has(typeOrFunc); }
 
   importUri(type: any): string { return this.reflectionCapabilities.importUri(type); }
+
+  resolveType(name: string, moduleUrl: string): any {
+    return this.reflectionCapabilities.resolveType(name, moduleUrl);
+  }
+  resolveEnum(type: any, name: string): any {
+    return this.reflectionCapabilities.resolveEnum(type, name);
+  }
 }
 
 function _mergeMaps(target: Map<string, Function>, config: {[key: string]: Function}): void {

--- a/modules/@angular/core/src/reflection/reflector_reader.ts
+++ b/modules/@angular/core/src/reflection/reflector_reader.ts
@@ -15,4 +15,6 @@ export abstract class ReflectorReader {
   abstract annotations(typeOrFunc: /*Type*/ any): any[];
   abstract propMetadata(typeOrFunc: /*Type*/ any): {[key: string]: any[]};
   abstract importUri(typeOrFunc: /*Type*/ any): string;
+  abstract resolveType(name: string, moduleUrl: string): any;
+  abstract resolveEnum(type: any, name: string): any;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Two components or directives that have the same asset location are considered identical even if they have different functions.

**What is the new behavior?**

Asset location is no longer used for identity, the constructor function is used during JIT and the `SymbolSymbol`, which is guaranteed unique by the `ReflectorHost`, is used during AoT

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
