### PR TITLE
fix(compiler): make ShadowCSS shim work on Android browser

### DIFF
--- a/modules/@angular/compiler/src/shadow_css.ts
+++ b/modules/@angular/compiler/src/shadow_css.ts
@@ -383,6 +383,8 @@ export class ShadowCss {
   // scope via name and [is=name]
   private _applySimpleSelectorScope(selector: string, scopeSelector: string, hostSelector: string):
       string {
+    // In Android browser, the lastIndex is not reset when the regex is used in String.replace()
+    _polyfillHostRe.lastIndex = 0;
     if (_polyfillHostRe.test(selector)) {
       const replaceBy = this.strictStyling ? `[${hostSelector}]` : scopeSelector;
       selector = StringWrapper.replace(selector, _polyfillHostNoCombinator, replaceBy);


### PR DESCRIPTION
The root cause here is that we use a global regex to test several strings.
It works because, apparently, using the same regex in String.replace() resets the state of the regex.
Except in the Android browser where it needs to be reset manually.

Fixes #11123 
