### PR TITLE
chore: force lf EOL for ts files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,9 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
-# JS files must always use LF for tools to work
+# JS and TS files must always use LF for tools to work
 *.js eol=lf
+*.ts eol=lf
 
 # Must keep Windows line ending to be parsed correctly
 scripts/windows/packages.txt eol=crlf


### PR DESCRIPTION
As #11096 showed, having crlf EOL on Windows can be a problem when using clang-format.
