### PR TITLE
fix(closure): prevent closure renaming of testability interface

### DIFF
--- a/modules/@angular/core/index.ts
+++ b/modules/@angular/core/index.ts
@@ -21,7 +21,7 @@ export * from './src/zone';
 export * from './src/render';
 export * from './src/linker';
 export {DebugElement, DebugNode, asNativeElements, getDebugNode} from './src/debug/debug_node';
-export * from './src/testability/testability';
+export {GetTestability, Testability, TestabilityRegistry, setTestabilityGetter} from './src/testability/testability';
 export * from './src/change_detection';
 export * from './src/platform_core_providers';
 export {TRANSLATIONS, TRANSLATIONS_FORMAT, LOCALE_ID} from './src/i18n/tokens';

--- a/modules/@angular/core/src/testability/testability.ts
+++ b/modules/@angular/core/src/testability/testability.ts
@@ -11,7 +11,17 @@ import {Map, MapWrapper} from '../facade/collection';
 import {scheduleMicroTask} from '../facade/lang';
 import {NgZone} from '../zone/ng_zone';
 
-
+/**
+ * Testability API.
+ * `declare` keyword causes tsickle to generate externs, so these methods are
+ * not renamed by Closure Compiler.
+ * @experimental
+ */
+export declare interface PublicTestability {
+  isStable(): boolean;
+  whenStable(callback: Function): void;
+  findProviders(using: any, provider: string, exactMatch: boolean): any[];
+}
 
 /**
  * The Testability service provides testing hooks that can be accessed from
@@ -20,7 +30,7 @@ import {NgZone} from '../zone/ng_zone';
  * @experimental
  */
 @Injectable()
-export class Testability {
+export class Testability implements PublicTestability {
   /** @internal */
   _pendingCount: number = 0;
   /** @internal */

--- a/modules/@angular/platform-browser/src/browser/testability.ts
+++ b/modules/@angular/platform-browser/src/browser/testability.ts
@@ -12,27 +12,6 @@ import {getDOM} from '../dom/dom_adapter';
 import {ListWrapper} from '../facade/collection';
 import {global, isPresent} from '../facade/lang';
 
-
-
-class PublicTestability {
-  /** @internal */
-  _testability: Testability;
-
-  constructor(testability: Testability) { this._testability = testability; }
-
-  isStable(): boolean { return this._testability.isStable(); }
-
-  whenStable(callback: Function) { this._testability.whenStable(callback); }
-
-  findBindings(using: any, provider: string, exactMatch: boolean): any[] {
-    return this.findProviders(using, provider, exactMatch);
-  }
-
-  findProviders(using: any, provider: string, exactMatch: boolean): any[] {
-    return this._testability.findBindings(using, provider, exactMatch);
-  }
-}
-
 export class BrowserGetTestability implements GetTestability {
   static init() { setTestabilityGetter(new BrowserGetTestability()); }
 
@@ -42,13 +21,10 @@ export class BrowserGetTestability implements GetTestability {
       if (testability == null) {
         throw new Error('Could not find testability for element.');
       }
-      return new PublicTestability(testability);
+      return testability;
     };
 
-    global.getAllAngularTestabilities = () => {
-      var testabilities = registry.getAllTestabilities();
-      return testabilities.map((testability) => { return new PublicTestability(testability); });
-    };
+    global.getAllAngularTestabilities = () => { return registry.getAllTestabilities(); };
 
     global.getAllAngularRootElements = () => registry.getAllRootElements();
 

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -1120,7 +1120,7 @@ export declare abstract class TemplateRef<C> {
 }
 
 /** @experimental */
-export declare class Testability {
+export declare class Testability implements PublicTestability {
     constructor(_ngZone: NgZone);
     decreasePendingRequestCount(): number;
     findBindings(using: any, provider: string, exactMatch: boolean): any[];


### PR DESCRIPTION
Needed to enable closure compiler ADVANCED_OPTIMIZATIONS
