### PR TITLE
docs(cheatsheet): copy edit bootstrapping.md

### DIFF
--- a/modules/@angular/docs/cheatsheet/bootstrapping.md
+++ b/modules/@angular/docs/cheatsheet/bootstrapping.md
@@ -4,11 +4,10 @@ Bootstrapping
 @description
 {@target ts}`import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';`{@endtarget}
 {@target js}Available from the `ng.platformBrowserDynamic` namespace{@endtarget}
-{@target dart}`import 'package:angular2/platform/browser.dart';`{@endtarget}
 
 @cheatsheetItem
-syntax(ts dart):
-`platformBrowserDynamic().bootstrapModule(MyAppModule);`|`platformBrowserDynamic().bootstrapModule`
+syntax(ts):
+`platformBrowserDynamic().bootstrapModule(AppModule);`|`platformBrowserDynamic().bootstrapModule`
 syntax(js):
 `document.addEventListener('DOMContentLoaded', function() {
   ng.platformBrowserDynamic
@@ -16,4 +15,4 @@ syntax(js):
     .bootstrapModule(app.AppModule);
 });`|`platformBrowserDynamic().bootstrapModule`
 description:
-Bootstraps an application defined as AppModule ng module using the Just in Time compiler.{@target js}Must be wrapped in the event listener to fire when the page loads.{@endtarget}
+Bootstraps the app, using the root component from the specified `NgModule`. {@target js}Must be wrapped in the event listener to fire when the page loads.{@endtarget}


### PR DESCRIPTION
Also remove Dart-specific code, since the Dart cheatsheet is produced
from dart-lang/angular2.

@Foxandxss could you please review? I figured since "dynamic" was in the API name, we didn't need to belabor the JIT/dynamic stuff, but maybe we do? Could we be clearer while still being succinct? Should we link to less dynamic ways of bootstrapping?
