### PR TITLE
docs(cheatsheet): copy edit built-in-directives.md

### DIFF
--- a/modules/@angular/docs/cheatsheet/built-in-directives.md
+++ b/modules/@angular/docs/cheatsheet/built-in-directives.md
@@ -4,7 +4,6 @@ Built-in directives
 @description
 {@target ts}`import { CommonModule } from '@angular/common';`{@endtarget}
 {@target js}Available using the `ng.common.CommonModule` module{@endtarget}
-{@target dart}Available using `platform_directives` in pubspec{@endtarget}
 
 @cheatsheetItem
 syntax:
@@ -32,4 +31,4 @@ Conditionally swaps the contents of the div by selecting one of the embedded tem
 syntax:
 `<div [ngClass]="{active: isActive, disabled: isDisabled}">`|`[ngClass]`
 description:
-Binds the presence of CSS classes on the element to the truthiness of the associated map values. The right-hand side expression should return {class-name: true/false} map.
+Binds the presence of CSS classes on the element to the truthiness of the associated map values. The right-hand expression should return {class-name: true/false} map.


### PR DESCRIPTION
Also remove Dart-specific code, since the Dart cheatsheet is produced
from dart-lang/angular2.
