### PR TITLE
docs(cheatsheet): copy edit class-decorators.md

### DIFF
--- a/modules/@angular/docs/cheatsheet/class-decorators.md
+++ b/modules/@angular/docs/cheatsheet/class-decorators.md
@@ -4,7 +4,6 @@ Class decorators
 @description
 {@target ts}`import { Directive, ... } from '@angular/core';`{@endtarget}
 {@target js}Available from the `ng.core` namespace{@endtarget}
-{@target dart}`import 'package:angular2/core.dart';`{@endtarget}
 
 @cheatsheetItem
 syntax(ts):
@@ -12,9 +11,6 @@ syntax(ts):
 class MyComponent() {}`|`@Component({...})`
 syntax(js):
 `var MyComponent = ng.core.Component({...}).Class({...})`|`ng.core.Component({...})`
-syntax(dart):
-`@Component(...)
-class MyComponent() {}`|`@Component(...)`
 description:
 Declares that a class is a component and provides metadata about the component.
 
@@ -24,9 +20,6 @@ syntax(ts):
 class MyDirective() {}`|`@Directive({...})`
 syntax(js):
 `var MyDirective = ng.core.Directive({...}).Class({...})`|`ng.core.Directive({...})`
-syntax(dart):
-`@Directive(...)
-class MyDirective() {}`|`@Directive(...)`
 description:
 Declares that a class is a directive and provides metadata about the directive.
 
@@ -36,9 +29,6 @@ syntax(ts):
 class MyPipe() {}`|`@Pipe({...})`
 syntax(js):
 `var MyPipe = ng.core.Pipe({...}).Class({...})`|`ng.core.Pipe({...})`
-syntax(dart):
-`@Pipe(...)
-class MyPipe() {}`|`@Pipe(...)`
 description:
 Declares that a class is a pipe and provides metadata about the pipe.
 
@@ -49,11 +39,8 @@ class MyService() {}`|`@Injectable()`
 syntax(js):
 `var OtherService = ng.core.Class({constructor: function() { }});
 var MyService = ng.core.Class({constructor: [OtherService, function(otherService) { }]});`|`var MyService = ng.core.Class({constructor: [OtherService, function(otherService) { }]});`
-syntax(dart):
-`@Injectable()
-class MyService() {}`|`@Injectable()`
 description:
-{@target ts dart}Declares that a class has dependencies that should be injected into the constructor when the dependency injector is creating an instance of this class.
+{@target ts}Declares that a class has dependencies that should be injected into the constructor when the dependency injector is creating an instance of this class.
 {@endtarget}
 {@target js}
 Declares a service to inject into a class by providing an array with the services with the final item being the function which will receive the injected services.


### PR DESCRIPTION
No copy edits to this one, but I removed Dart-specific code, since the
Dart cheatsheet is produced from dart-lang/angular2.

Part of a group of cheatsheet PRs (see https://github.com/angular/angular/pull/11149).

cc @Foxandxss & @IgorMinar 
