### PR TITLE
docs(cheatsheet): copy edit component-configuration.md

### DIFF
--- a/modules/@angular/docs/cheatsheet/component-configuration.md
+++ b/modules/@angular/docs/cheatsheet/component-configuration.md
@@ -4,17 +4,17 @@ Component configuration
 @description
 {@target js}`ng.core.Component` extends `ng.core.Directive`,
 so the `ng.core.Directive` configuration applies to components as well{@endtarget}
-{@target ts dart}`@Component` extends `@Directive`,
+{@target ts}`@Component` extends `@Directive`,
 so the `@Directive` configuration applies to components as well{@endtarget}
 
 @cheatsheetItem
-syntax(ts js):
+syntax:
 `moduleId: module.id`|`moduleId:`
 description:
-If set, the `templateUrl` and `styleUrl` is resolved relative to the component.
+If set, the `templateUrl` and `styleUrl` are resolved relative to the component.
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `viewProviders: [MyService, { provide: ... }]`|`viewProviders:`
 syntax(js):
 `viewProviders: [MyService, { provide: ... }]`|`viewProviders:`
@@ -27,7 +27,7 @@ syntax:
 `template: 'Hello {{name}}'
 templateUrl: 'my-component.html'`|`template:`|`templateUrl:`
 description:
-Inline template / external template URL of the component's view.
+Inline template or external template URL of the component's view.
 
 
 @cheatsheetItem
@@ -35,4 +35,4 @@ syntax:
 `styles: ['.primary {color: red}']
 styleUrls: ['my-component.css']`|`styles:`|`styleUrls:`
 description:
-List of inline CSS styles / external stylesheet URLs for styling component’s view.
+List of inline CSS styles or external stylesheet URLs for styling the component’s view.


### PR DESCRIPTION
Also remove Dart-specific code, since the Dart cheatsheet is produced
from dart-lang/angular2.

Part of a group of cheatsheet PRs (see #11149).

cc @Foxandxss & @IgorMinar
