### PR TITLE
docs(cheatsheet): edit dependency-injection.md

### DIFF
--- a/modules/@angular/docs/cheatsheet/dependency-injection.md
+++ b/modules/@angular/docs/cheatsheet/dependency-injection.md
@@ -2,10 +2,9 @@
 Dependency injection configuration
 @cheatsheetIndex 10
 @description
-{@target dart}`import 'package:angular2/core.dart';`{@endtarget}
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `{ provide: MyService, useClass: MyMockService }`|`provide`|`useClass`
 syntax(js):
 `{ provide: MyService, useClass: MyMockService }`|`provide`|`useClass`
@@ -14,7 +13,7 @@ Sets or overrides the provider for MyService to the MyMockService class.
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `{ provide: MyService, useFactory: myFactory }`|`provide`|`useFactory`
 syntax(js):
 `{ provide: MyService, useFactory: myFactory }`|`provide`|`useFactory`
@@ -23,7 +22,7 @@ Sets or overrides the provider for MyService to the myFactory factory function.
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `{ provide: MyValue, useValue: 41 }`|`provide`|`useValue`
 syntax(js):
 `{ provide: MyValue, useValue: 41 }`|`provide`|`useValue`


### PR DESCRIPTION
No copy edits to this one, but I removed Dart-specific code, since the
Dart cheatsheet is produced from dart-lang/angular2.

Part of a group of cheatsheet PRs (see #11149).

cc @Foxandxss & @IgorMinar
