### PR TITLE
chore: convert hash_location_strategy example to a tested spec

### DIFF
--- a/modules/@angular/common/src/location/hash_location_strategy.ts
+++ b/modules/@angular/common/src/location/hash_location_strategy.ts
@@ -27,18 +27,8 @@ import {LocationChangeListener, PlatformLocation} from './platform_location';
  *
  * ### Example
  *
- * ```
- * import {Component, NgModule} from '@angular/core';
- * import {
- *   LocationStrategy,
- *   HashLocationStrategy
- * } from '@angular/common';
- *
- * @NgModule({
- *   providers: [{provide: LocationStrategy, useClass: HashLocationStrategy}]
- * })
- * class AppModule {}
- * ```
+ * {@example common/location/ts/hash_location_strategy/hash_location_strategy_spec.ts
+ * region='hash_location_strategy'}
  *
  * @stable
  */

--- a/modules/@angular/examples/common/location/hash_location_strategy/ts/test/hash_location_strategy_spec.ts
+++ b/modules/@angular/examples/common/location/hash_location_strategy/ts/test/hash_location_strategy_spec.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+// #docplaster
+// #docregion hash_location_strategy
+import {HashLocationStrategy, LocationStrategy} from '@angular/common';
+import {NgModule} from '@angular/core';
+
+// #enddocregion hash_location_strategy
+import {TestBed} from '@angular/core/testing';
+
+// #docregion hash_location_strategy
+@NgModule({providers: [{provide: LocationStrategy, useClass: HashLocationStrategy}]})
+class AppModule {
+}
+// #enddocregion hash_location_strategy
+export function main() {
+  describe('hash_location_strategy examples', () => {
+    let locationStrategy: HashLocationStrategy;
+
+    beforeEach(() => {
+      locationStrategy =
+          TestBed.configureTestingModule({imports: [AppModule]}).get(LocationStrategy);
+    });
+
+    it('hash_location_strategy example works',
+       () => { expect(locationStrategy.prepareExternalUrl('app/foo')).toBe('#app/foo'); });
+  });
+}


### PR DESCRIPTION
This is a follow up on #11088
