### PR TITLE
test: reactivate the remaining disabled tests in Edge

### DIFF
--- a/modules/@angular/common/test/pipes/slice_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/slice_pipe_spec.ts
@@ -70,19 +70,15 @@ export function main() {
         expect(pipe.transform(str, 99)).toEqual('');
       });
 
-      // Makes Edge to disconnect when running the full unit test campaign
-      // TODO: remove when issue is solved: https://github.com/angular/angular/issues/4756
-      if (!browserDetection.isEdge) {
-        it('should return entire input if START is negative and greater than input length', () => {
-          expect(pipe.transform(list, -99)).toEqual([1, 2, 3, 4, 5]);
-          expect(pipe.transform(str, -99)).toEqual('tuvwxyz');
-        });
+      it('should return entire input if START is negative and greater than input length', () => {
+        expect(pipe.transform(list, -99)).toEqual([1, 2, 3, 4, 5]);
+        expect(pipe.transform(str, -99)).toEqual('tuvwxyz');
+      });
 
-        it('should not modify the input list', () => {
-          expect(pipe.transform(list, 2)).toEqual([3, 4, 5]);
-          expect(list).toEqual([1, 2, 3, 4, 5]);
-        });
-      }
+      it('should not modify the input list', () => {
+        expect(pipe.transform(list, 2)).toEqual([3, 4, 5]);
+        expect(list).toEqual([1, 2, 3, 4, 5]);
+      });
 
     });
 

--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -546,7 +546,7 @@ export class Router {
                   resolvePromise(false);
                 }
               },
-            (e: any) => {
+              (e: any) => {
                 if (e instanceof NavigationCancelingError) {
                   this.navigated = true;
                   this.routerEvents.next(


### PR DESCRIPTION
Fixes #4756

These 2 unit tests now pass successfully when running the campaign in the latest stable Edge (13.10586).
With this PR, there are no more disabled tests in Edge.

Note: the changes in `router.ts` are for a formatting issue that made it to master
