### PR TITLE
fix(forms): support rebinding nested controls

### DIFF
--- a/modules/@angular/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/modules/@angular/forms/src/directives/reactive_directives/form_control_name.ts
@@ -96,9 +96,11 @@ export const controlNameBinding: any = {
  */
 @Directive({selector: '[formControlName]', providers: [controlNameBinding]})
 export class FormControlName extends NgControl implements OnChanges, OnDestroy {
+  private _added = false;
   /** @internal */
   viewModel: any;
-  private _added = false;
+  /** @internal */
+  _control: FormControl;
 
   @Input('formControlName') name: string;
 
@@ -122,12 +124,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (!this._added) {
-      this._checkParentType();
-      this.formDirective.addControl(this);
-      if (this.control.disabled) this.valueAccessor.setDisabledState(true);
-      this._added = true;
-    }
+    if (!this._added) this._setUpControl();
     if (isPropertyUpdated(changes, this.viewModel)) {
       this.viewModel = this.model;
       this.formDirective.updateModel(this, this.model);
@@ -155,7 +152,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
     return composeAsyncValidators(this._rawAsyncValidators);
   }
 
-  get control(): FormControl { return this.formDirective.getControl(this); }
+  get control(): FormControl { return this._control; }
 
   private _checkParentType(): void {
     if (!(this._parent instanceof FormGroupName) &&
@@ -166,5 +163,12 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
         !(this._parent instanceof FormArrayName)) {
       ReactiveErrors.controlParentException();
     }
+  }
+
+  private _setUpControl() {
+    this._checkParentType();
+    this._control = this.formDirective.addControl(this);
+    if (this.control.disabled) this.valueAccessor.setDisabledState(true);
+    this._added = true;
   }
 }

--- a/modules/@angular/forms/test/directives_spec.ts
+++ b/modules/@angular/forms/test/directives_spec.ts
@@ -552,6 +552,7 @@ export function main() {
         parent.form = new FormGroup({'name': formModel});
         controlNameDir = new FormControlName(parent, [], [], [defaultAccessor]);
         controlNameDir.name = 'name';
+        controlNameDir._control = formModel;
       });
 
       it('should reexport control properties', () => {

--- a/modules/@angular/forms/test/form_array_spec.ts
+++ b/modules/@angular/forms/test/form_array_spec.ts
@@ -806,6 +806,49 @@ export function main() {
 
       });
 
+      describe('setControl()', () => {
+        let c: FormControl;
+        let a: FormArray;
+
+        beforeEach(() => {
+          c = new FormControl('one');
+          a = new FormArray([c]);
+        });
+
+        it('should replace existing control with new control', () => {
+          const c2 = new FormControl('new!', Validators.minLength(10));
+          a.setControl(0, c2);
+
+          expect(a.controls[0]).toEqual(c2);
+          expect(a.value).toEqual(['new!']);
+          expect(a.valid).toBe(false);
+        });
+
+        it('should add control if control did not exist before', () => {
+          const c2 = new FormControl('new!', Validators.minLength(10));
+          a.setControl(1, c2);
+
+          expect(a.controls[1]).toEqual(c2);
+          expect(a.value).toEqual(['one', 'new!']);
+          expect(a.valid).toBe(false);
+        });
+
+        it('should remove control if new control is null', () => {
+          a.setControl(0, null);
+          expect(a.controls[0]).not.toBeDefined();
+          expect(a.value).toEqual([]);
+        });
+
+        it('should only emit value change event once', () => {
+          const logger: string[] = [];
+          const c2 = new FormControl('new!');
+          a.valueChanges.subscribe(() => logger.push('change!'));
+          a.setControl(0, c2);
+          expect(logger).toEqual(['change!']);
+        });
+
+      });
+
     });
   });
 }

--- a/modules/@angular/forms/test/form_group_spec.ts
+++ b/modules/@angular/forms/test/form_group_spec.ts
@@ -842,6 +842,49 @@ export function main() {
 
     });
 
+    describe('setControl()', () => {
+      let c: FormControl;
+      let g: FormGroup;
+
+      beforeEach(() => {
+        c = new FormControl('one');
+        g = new FormGroup({one: c});
+      });
+
+      it('should replace existing control with new control', () => {
+        const c2 = new FormControl('new!', Validators.minLength(10));
+        g.setControl('one', c2);
+
+        expect(g.controls['one']).toEqual(c2);
+        expect(g.value).toEqual({one: 'new!'});
+        expect(g.valid).toBe(false);
+      });
+
+      it('should add control if control did not exist before', () => {
+        const c2 = new FormControl('new!', Validators.minLength(10));
+        g.setControl('two', c2);
+
+        expect(g.controls['two']).toEqual(c2);
+        expect(g.value).toEqual({one: 'one', two: 'new!'});
+        expect(g.valid).toBe(false);
+      });
+
+      it('should remove control if new control is null', () => {
+        g.setControl('one', null);
+        expect(g.controls['one']).not.toBeDefined();
+        expect(g.value).toEqual({});
+      });
+
+      it('should only emit value change event once', () => {
+        const logger: string[] = [];
+        const c2 = new FormControl('new!');
+        g.valueChanges.subscribe(() => logger.push('change!'));
+        g.setControl('one', c2);
+        expect(logger).toEqual(['change!']);
+      });
+
+    });
+
 
   });
 }

--- a/modules/@angular/forms/test/reactive_integration_spec.ts
+++ b/modules/@angular/forms/test/reactive_integration_spec.ts
@@ -256,6 +256,91 @@ export function main() {
         expect(inputs[2]).not.toBeDefined();
       });
 
+      describe('nested control rebinding', () => {
+
+        it('should attach dir to control when leaf control changes', () => {
+          const form = new FormGroup({'login': new FormControl('oldValue')});
+          const fixture = TestBed.createComponent(FormGroupComp);
+          fixture.debugElement.componentInstance.form = form;
+          fixture.detectChanges();
+
+          form.removeControl('login');
+          form.addControl('login', new FormControl('newValue'));
+          fixture.detectChanges();
+
+          const input = fixture.debugElement.query(By.css('input'));
+          expect(input.nativeElement.value).toEqual('newValue');
+
+          input.nativeElement.value = 'user input';
+          dispatchEvent(input.nativeElement, 'input');
+          fixture.detectChanges();
+
+          expect(form.value).toEqual({login: 'user input'});
+
+          form.setValue({login: 'Carson'});
+          fixture.detectChanges();
+          expect(input.nativeElement.value).toEqual('Carson');
+        });
+
+        it('should attach dirs to all child controls when group control changes', () => {
+          const fixture = TestBed.createComponent(NestedFormGroupComp);
+          const form = new FormGroup({
+            signin: new FormGroup(
+                {login: new FormControl('oldLogin'), password: new FormControl('oldPassword')})
+          });
+          fixture.debugElement.componentInstance.form = form;
+          fixture.detectChanges();
+
+          form.removeControl('signin');
+          form.addControl(
+              'signin',
+              new FormGroup(
+                  {login: new FormControl('newLogin'), password: new FormControl('newPassword')}));
+          fixture.detectChanges();
+
+          const inputs = fixture.debugElement.queryAll(By.css('input'));
+          expect(inputs[0].nativeElement.value).toEqual('newLogin');
+          expect(inputs[1].nativeElement.value).toEqual('newPassword');
+
+          inputs[0].nativeElement.value = 'user input';
+          dispatchEvent(inputs[0].nativeElement, 'input');
+          fixture.detectChanges();
+
+          expect(form.value).toEqual({signin: {login: 'user input', password: 'newPassword'}});
+
+          form.setValue({signin: {login: 'Carson', password: 'Drew'}});
+          fixture.detectChanges();
+          expect(inputs[0].nativeElement.value).toEqual('Carson');
+          expect(inputs[1].nativeElement.value).toEqual('Drew');
+        });
+
+        it('should attach dirs to all present child controls when array control changes', () => {
+          const fixture = TestBed.createComponent(FormArrayComp);
+          const cityArray = new FormArray([new FormControl('SF'), new FormControl('NY')]);
+          const form = new FormGroup({cities: cityArray});
+          fixture.debugElement.componentInstance.form = form;
+          fixture.debugElement.componentInstance.cityArray = cityArray;
+          fixture.detectChanges();
+
+          form.removeControl('cities');
+          form.addControl('cities', new FormArray([new FormControl('LA')]));
+          fixture.detectChanges();
+
+          const input = fixture.debugElement.query(By.css('input'));
+          expect(input.nativeElement.value).toEqual('LA');
+
+          input.nativeElement.value = 'MTV';
+          dispatchEvent(input.nativeElement, 'input');
+          fixture.detectChanges();
+
+          expect(form.value).toEqual({cities: ['MTV']});
+
+          form.setValue({cities: ['LA']});
+          fixture.detectChanges();
+          expect(input.nativeElement.value).toEqual('LA');
+        });
+
+      });
 
     });
 

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -167,6 +167,7 @@ export declare class FormArray extends AbstractControl {
     reset(value?: any, {onlySelf}?: {
         onlySelf?: boolean;
     }): void;
+    setControl(index: number, control: AbstractControl): void;
     setValue(value: any[], {onlySelf}?: {
         onlySelf?: boolean;
     }): void;
@@ -272,6 +273,7 @@ export declare class FormGroup extends AbstractControl {
     reset(value?: any, {onlySelf}?: {
         onlySelf?: boolean;
     }): void;
+    setControl(name: string, control: AbstractControl): void;
     setValue(value: {
         [key: string]: any;
     }, {onlySelf}?: {
@@ -282,27 +284,27 @@ export declare class FormGroup extends AbstractControl {
 /** @stable */
 export declare class FormGroupDirective extends ControlContainer implements Form, OnChanges {
     control: FormGroup;
-    directives: NgControl[];
+    directives: FormControlName[];
     form: FormGroup;
     formDirective: Form;
     ngSubmit: EventEmitter<{}>;
     path: string[];
     submitted: boolean;
     constructor(_validators: any[], _asyncValidators: any[]);
-    addControl(dir: NgControl): void;
+    addControl(dir: FormControlName): FormControl;
     addFormArray(dir: FormArrayName): void;
     addFormGroup(dir: FormGroupName): void;
-    getControl(dir: NgControl): FormControl;
+    getControl(dir: FormControlName): FormControl;
     getFormArray(dir: FormArrayName): FormArray;
     getFormGroup(dir: FormGroupName): FormGroup;
     ngOnChanges(changes: SimpleChanges): void;
     onReset(): void;
     onSubmit(): boolean;
-    removeControl(dir: NgControl): void;
+    removeControl(dir: FormControlName): void;
     removeFormArray(dir: FormArrayName): void;
     removeFormGroup(dir: FormGroupName): void;
     resetForm(value?: any): void;
-    updateModel(dir: NgControl, value: any): void;
+    updateModel(dir: FormControlName, value: any): void;
 }
 
 /** @stable */


### PR DESCRIPTION
This PR ensures that it's possible to rebind nested form controls, groups, and arrays.

Previously, if you did this (without an *ngIf):

``` ts
class MyComp {
   form = new FormGroup({first: new FormControl()});

   someMethod() {
      this.form.removeControl('first');
      this.form.addControl('first', new FormControl());
   }
}
```

... the `formControlName` directive would still have a reference to the stale control once `someMethod()` was called.  So typing into the form control would have no effect on the model and vice versa.

Now you can do the above without issue, or for shorthand, you can use `setControl()` to overwrite the existing control:

``` ts
someMethod() {
   this.form.setControl('first', new FormControl());
}
```

This works for nested groups and arrays too, so it can be used to reset those nested controls to a certain state.
