### PR TITLE
fix(ngc): propagate errors to main

### DIFF
--- a/modules/@angular/compiler-cli/src/codegen.ts
+++ b/modules/@angular/compiler-cli/src/codegen.ts
@@ -108,23 +108,19 @@ export class CodeGenerator {
       return ngModules;
     }, <StaticSymbol[]>[]);
     const analyzedNgModules = this.compiler.analyzeModules(ngModules);
-    return Promise
-        .all(fileMetas.map(
-            (fileMeta) => this.compiler
-                              .compile(
-                                  fileMeta.fileUrl, analyzedNgModules, fileMeta.components,
-                                  fileMeta.ngModules)
-                              .then((generatedModules) => {
-                                generatedModules.forEach((generatedModule) => {
-                                  const sourceFile = this.program.getSourceFile(fileMeta.fileUrl);
-                                  const emitPath =
-                                      this.calculateEmitPath(generatedModule.moduleUrl);
-                                  this.host.writeFile(
-                                      emitPath, PREAMBLE + generatedModule.source, false, () => {},
-                                      [sourceFile]);
-                                });
-                              })))
-        .catch((e) => { console.error(e.stack); });
+    return Promise.all(fileMetas.map(
+        (fileMeta) =>
+            this.compiler
+                .compile(
+                    fileMeta.fileUrl, analyzedNgModules, fileMeta.components, fileMeta.ngModules)
+                .then((generatedModules) => {
+                  generatedModules.forEach((generatedModule) => {
+                    const sourceFile = this.program.getSourceFile(fileMeta.fileUrl);
+                    const emitPath = this.calculateEmitPath(generatedModule.moduleUrl);
+                    this.host.writeFile(
+                        emitPath, PREAMBLE + generatedModule.source, false, () => {}, [sourceFile]);
+                  });
+                })));
   }
 
   static create(

--- a/modules/@angular/compiler-cli/src/extract_i18n.ts
+++ b/modules/@angular/compiler-cli/src/extract_i18n.ts
@@ -133,8 +133,7 @@ export class Extractor {
                     });
               }));
             }))
-            .then(_ => this.messageBundle)
-            .catch((e) => { console.error(e.stack); });
+            .then(_ => this.messageBundle);
 
     if (errors.length) {
       throw new Error(errors.map(e => e.toString()).join('\n'));


### PR DESCRIPTION
This catch() prevents the rejected promise from being propagated back to the error handling in main.ts

see http://b/31223948
