### PR TITLE
docs(cheatsheet): complete the copy edit

### DIFF
--- a/modules/@angular/docs/cheatsheet/built-in-directives.md
+++ b/modules/@angular/docs/cheatsheet/built-in-directives.md
@@ -9,7 +9,7 @@ Built-in directives
 syntax:
 `<section *ngIf="showSection">`|`*ngIf`
 description:
-Removes or recreates a portion of the DOM tree based on the showSection expression.
+Removes or recreates a portion of the DOM tree based on the `showSection` expression.
 
 @cheatsheetItem
 syntax:
@@ -25,7 +25,7 @@ syntax:
   <template ngSwitchDefault>...</template>
 </div>`|`[ngSwitch]`|`[ngSwitchCase]`|`ngSwitchCase`|`ngSwitchDefault`
 description:
-Conditionally swaps the contents of the div by selecting one of the embedded templates based on the current value of conditionExpression.
+Conditionally swaps the contents of the div by selecting one of the embedded templates based on the current value of `conditionExpression`.
 
 @cheatsheetItem
 syntax:

--- a/modules/@angular/docs/cheatsheet/class-decorators.md
+++ b/modules/@angular/docs/cheatsheet/class-decorators.md
@@ -37,11 +37,13 @@ syntax(ts):
 `@Injectable()
 class MyService() {}`|`@Injectable()`
 syntax(js):
-`var OtherService = ng.core.Class({constructor: function() { }});
-var MyService = ng.core.Class({constructor: [OtherService, function(otherService) { }]});`|`var MyService = ng.core.Class({constructor: [OtherService, function(otherService) { }]});`
+`var OtherService = ng.core.Class(
+    {constructor: function() { }});
+var MyService = ng.core.Class(
+    {constructor: [OtherService, function(otherService) { }]});`|`var MyService = ng.core.Class({constructor: [OtherService, function(otherService) { }]});`
 description:
 {@target ts}Declares that a class has dependencies that should be injected into the constructor when the dependency injector is creating an instance of this class.
 {@endtarget}
 {@target js}
-Declares a service to inject into a class by providing an array with the services with the final item being the function which will receive the injected services.
+Declares a service to inject into a class by providing an array with the services, with the final item being the function to receive the injected services.
 {@endtarget}

--- a/modules/@angular/docs/cheatsheet/component-configuration.md
+++ b/modules/@angular/docs/cheatsheet/component-configuration.md
@@ -19,7 +19,7 @@ syntax(ts):
 syntax(js):
 `viewProviders: [MyService, { provide: ... }]`|`viewProviders:`
 description:
-Array of dependency injection providers scoped to this component's view.
+List of dependency injection providers scoped to this component's view.
 
 
 @cheatsheetItem

--- a/modules/@angular/docs/cheatsheet/dependency-injection.md
+++ b/modules/@angular/docs/cheatsheet/dependency-injection.md
@@ -9,7 +9,7 @@ syntax(ts):
 syntax(js):
 `{ provide: MyService, useClass: MyMockService }`|`provide`|`useClass`
 description:
-Sets or overrides the provider for MyService to the MyMockService class.
+Sets or overrides the provider for `MyService` to the `MyMockService` class.
 
 
 @cheatsheetItem
@@ -18,7 +18,7 @@ syntax(ts):
 syntax(js):
 `{ provide: MyService, useFactory: myFactory }`|`provide`|`useFactory`
 description:
-Sets or overrides the provider for MyService to the myFactory factory function.
+Sets or overrides the provider for `MyService` to the `myFactory` factory function.
 
 
 @cheatsheetItem
@@ -27,4 +27,4 @@ syntax(ts):
 syntax(js):
 `{ provide: MyValue, useValue: 41 }`|`provide`|`useValue`
 description:
-Sets or overrides the provider for MyValue to the value 41.
+Sets or overrides the provider for `MyValue` to the value `41`.

--- a/modules/@angular/docs/cheatsheet/directive-and-component-decorators.md
+++ b/modules/@angular/docs/cheatsheet/directive-and-component-decorators.md
@@ -4,77 +4,83 @@ Class field decorators for directives and components
 @description
 {@target ts}`import { Input, ... } from '@angular/core';`{@endtarget}
 {@target js}Available from the `ng.core` namespace{@endtarget}
-{@target dart}`import 'package:angular2/core.dart';`{@endtarget}
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `@Input() myProperty;`|`@Input()`
 syntax(js):
 `ng.core.Input(myProperty, myComponent);`|`ng.core.Input(`|`);`
 description:
-Declares an input property that we can update via property binding (e.g.
+Declares an input property that you can update via property binding (example:
 `<my-cmp [myProperty]="someExpression">`).
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `@Output() myEvent = new EventEmitter();`|`@Output()`
 syntax(js):
-`myEvent = new ng.core.EventEmitter(); ng.core.Output(myEvent, myComponent);`|`ng.core.Output(`|`);`
+`myEvent = new ng.core.EventEmitter();
+ng.core.Output(myEvent, myComponent);`|`ng.core.Output(`|`);`
 description:
-Declares an output property that fires events to which we can subscribe with an event binding (e.g. `<my-cmp (myEvent)="doSomething()">`).
+Declares an output property that fires events that you can subscribe to with an event binding (example: `<my-cmp (myEvent)="doSomething()">`).
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `@HostBinding('[class.valid]') isValid;`|`@HostBinding('[class.valid]')`
 syntax(js):
-`ng.core.HostBinding('[class.valid]', 'isValid', myComponent);`|`ng.core.HostBinding('[class.valid]', 'isValid'`|`);`
+`ng.core.HostBinding('[class.valid]',
+    'isValid', myComponent);`|`ng.core.HostBinding('[class.valid]', 'isValid'`|`);`
 description:
-Binds a host element property (e.g. CSS class valid) to directive/component property (e.g. isValid).
+Binds a host element property (here, the CSS class `valid`) to a directive/component property (`isValid`).
 
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `@HostListener('click', ['$event']) onClick(e) {...}`|`@HostListener('click', ['$event'])`
 syntax(js):
-`ng.core.HostListener('click', ['$event'], onClick(e) {...}, myComponent);`|`ng.core.HostListener('click', ['$event'], onClick(e)`|`);`
+`ng.core.HostListener('click',
+    ['$event'], onClick(e) {...}, myComponent);`|`ng.core.HostListener('click', ['$event'], onClick(e)`|`);`
 description:
-Subscribes to a host element event (e.g. click) with a directive/component method (e.g. onClick), optionally passing an argument ($event).
+Subscribes to a host element event (`click`) with a directive/component method (`onClick`), optionally passing an argument (`$event`).
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `@ContentChild(myPredicate) myChildComponent;`|`@ContentChild(myPredicate)`
 syntax(js):
-`ng.core.ContentChild(myPredicate, 'myChildComponent', myComponent);`|`ng.core.ContentChild(myPredicate,`|`);`
+`ng.core.ContentChild(myPredicate,
+    'myChildComponent', myComponent);`|`ng.core.ContentChild(myPredicate,`|`);`
 description:
-Binds the first result of the component content query (myPredicate) to the myChildComponent property of the class.
+Binds the first result of the component content query (`myPredicate`) to a property (`myChildComponent`) of the class.
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `@ContentChildren(myPredicate) myChildComponents;`|`@ContentChildren(myPredicate)`
 syntax(js):
-`ng.core.ContentChildren(myPredicate, 'myChildComponents', myComponent);`|`ng.core.ContentChildren(myPredicate,`|`);`
+`ng.core.ContentChildren(myPredicate,
+    'myChildComponents', myComponent);`|`ng.core.ContentChildren(myPredicate,`|`);`
 description:
-Binds the results of the component content query (myPredicate) to the myChildComponents property of the class.
+Binds the results of the component content query (`myPredicate`) to a property (`myChildComponents`) of the class.
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `@ViewChild(myPredicate) myChildComponent;`|`@ViewChild(myPredicate)`
 syntax(js):
-`ng.core.ViewChild(myPredicate, 'myChildComponent', myComponent);`|`ng.core.ViewChild(myPredicate,`|`);`
+`ng.core.ViewChild(myPredicate,
+    'myChildComponent', myComponent);`|`ng.core.ViewChild(myPredicate,`|`);`
 description:
-Binds the first result of the component view query (myPredicate) to the myChildComponent property of the class. Not available for directives.
+Binds the first result of the component view query (`myPredicate`) to a property (`myChildComponent`) of the class. Not available for directives.
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `@ViewChildren(myPredicate) myChildComponents;`|`@ViewChildren(myPredicate)`
 syntax(js):
-`ng.core.ViewChildren(myPredicate, 'myChildComponents', myComponent);`|`ng.core.ViewChildren(myPredicate,`|`);`
+`ng.core.ViewChildren(myPredicate,
+    'myChildComponents', myComponent);`|`ng.core.ViewChildren(myPredicate,`|`);`
 description:
-Binds the results of the component view query (myPredicate) to the myChildComponents property of the class. Not available for directives.
+Binds the results of the component view query (`myPredicate`) to a property (`myChildComponents`) of the class. Not available for directives.

--- a/modules/@angular/docs/cheatsheet/directive-configuration.md
+++ b/modules/@angular/docs/cheatsheet/directive-configuration.md
@@ -4,7 +4,6 @@ Directive configuration
 @description
 {@target ts}`@Directive({ property1: value1, ... })`{@endtarget}
 {@target js}`ng.core.Directive({ property1: value1, ... }).Class({...})`{@endtarget}
-{@target dart}`@Directive(property1: value1, ...)`{@endtarget}
 
 @cheatsheetItem
 syntax:
@@ -16,9 +15,9 @@ Specifies a CSS selector that identifies this directive within a template. Suppo
 Does not support parent-child relationship selectors.
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `providers: [MyService, { provide: ... }]`|`providers:`
 syntax(js):
 `providers: [MyService, { provide: ... }]`|`providers:`
 description:
-Array of dependency injection providers for this directive and its children.
+List of dependency injection providers for this directive and its children.

--- a/modules/@angular/docs/cheatsheet/forms.md
+++ b/modules/@angular/docs/cheatsheet/forms.md
@@ -4,10 +4,9 @@ Forms
 @description
 {@target ts}`import { FormsModule } from '@angular/forms';`{@endtarget}
 {@target js}Available using the `ng.forms.FormsModule` module{@endtarget}
-{@target dart}Available using `platform_directives` in pubspec{@endtarget}
 
 @cheatsheetItem
 syntax:
 `<input [(ngModel)]="userName">`|`[(ngModel)]`
 description:
-Provides two-way data-binding, parsing and validation for form controls.
+Provides two-way data-binding, parsing, and validation for form controls.

--- a/modules/@angular/docs/cheatsheet/lifecycle hooks.md
+++ b/modules/@angular/docs/cheatsheet/lifecycle hooks.md
@@ -2,7 +2,7 @@
 Directive and component change detection and lifecycle hooks
 @cheatsheetIndex 9
 @description
-{@target ts dart}(implemented as class methods){@endtarget}
+{@target ts}(implemented as class methods){@endtarget}
 {@target js}(implemented as component properties){@endtarget}
 
 @cheatsheetItem
@@ -10,14 +10,12 @@ syntax(ts):
 `constructor(myService: MyService, ...) { ... }`|`constructor(myService: MyService, ...)`
 syntax(js):
 `constructor: function(MyService, ...) { ... }`|`constructor: function(MyService, ...)`
-syntax(dart):
-`MyAppComponent(MyService myService, ...) { ... }`|`MyAppComponent(MyService myService, ...)`
 description:
-The class constructor is called before any other lifecycle hook. Use it to inject dependencies, but avoid any serious work here.
+Called before any other lifecycle hook. Use it to inject dependencies, but avoid any serious work here.
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `ngOnChanges(changeRecord) { ... }`|`ngOnChanges(changeRecord)`
 syntax(js):
 `ngOnChanges: function(changeRecord) { ... }`|`ngOnChanges: function(changeRecord)`
@@ -26,16 +24,16 @@ Called after every change to input properties and before processing content or c
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `ngOnInit() { ... }`|`ngOnInit()`
 syntax(js):
 `ngOnInit: function() { ... }`|`ngOnInit: function()`
 description:
-Called after the constructor, initializing input properties, and the first call to ngOnChanges.
+Called after the constructor, initializing input properties, and the first call to `ngOnChanges`.
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `ngDoCheck() { ... }`|`ngDoCheck()`
 syntax(js):
 `ngDoCheck: function() { ... }`|`ngDoCheck: function()`
@@ -44,16 +42,16 @@ Called every time that the input properties of a component or a directive are ch
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `ngAfterContentInit() { ... }`|`ngAfterContentInit()`
 syntax(js):
 `ngAfterContentInit: function() { ... }`|`ngAfterContentInit: function()`
 description:
-Called after ngOnInit when the component's or directive's content has been initialized.
+Called after `ngOnInit` when the component's or directive's content has been initialized.
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `ngAfterContentChecked() { ... }`|`ngAfterContentChecked()`
 syntax(js):
 `ngAfterContentChecked: function() { ... }`|`ngAfterContentChecked: function()`
@@ -62,16 +60,16 @@ Called after every check of the component's or directive's content.
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `ngAfterViewInit() { ... }`|`ngAfterViewInit()`
 syntax(js):
 `ngAfterViewInit: function() { ... }`|`ngAfterViewInit: function()`
 description:
-Called after ngAfterContentInit when the component's view has been initialized. Applies to components only.
+Called after `ngAfterContentInit` when the component's view has been initialized. Applies to components only.
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `ngAfterViewChecked() { ... }`|`ngAfterViewChecked()`
 syntax(js):
 `ngAfterViewChecked: function() { ... }`|`ngAfterViewChecked: function()`
@@ -80,7 +78,7 @@ Called after every check of the component's view. Applies to components only.
 
 
 @cheatsheetItem
-syntax(ts dart):
+syntax(ts):
 `ngOnDestroy() { ... }`|`ngOnDestroy()`
 syntax(js):
 `ngOnDestroy: function() { ... }`|`ngOnDestroy: function()`

--- a/modules/@angular/docs/cheatsheet/ngmodules.md
+++ b/modules/@angular/docs/cheatsheet/ngmodules.md
@@ -7,51 +7,52 @@ NgModules
 
 @cheatsheetItem
 syntax(ts):
-`@NgModule({ declarations: ..., imports: ..., exports: ..., bootstrap: ...})
+`@NgModule({ declarations: ..., imports: ...,
+     exports: ..., providers: ..., bootstrap: ...})
 class MyModule {}`|`NgModule`
 description:
-Defines a module that contains components, directives, pipes and providers.
+Defines a module that contains components, directives, pipes, and providers.
 
 syntax(js):
-`ng.core.NgModule({declarations: ..., imports: ..., exports: ..., bootstrap: ...}).
+`ng.core.NgModule({declarations: ..., imports: ...,
+     exports: ..., providers: ..., bootstrap: ...}).
 class({ constructor: function() {}})`
 description:
-Defines a module that contains components, directives, pipes and providers.
+Defines a module that contains components, directives, pipes, and providers.
 
 @cheatsheetItem
-syntax(ts js):
+syntax:
 `declarations: [MyRedComponent, MyBlueComponent, MyDatePipe]`|`declarations:`
 description:
-List of components, directives and pipes that belong to this module.
+List of components, directives, and pipes that belong to this module.
 
 @cheatsheetItem
 syntax(ts):
 `imports: [BrowserModule, SomeOtherModule]`|`imports:`
 description:
-List of modules that are being imported into this module. Everything from the imported modules will
-be available to `declarations` of this module.
+List of modules to import into this module. Everything from the imported modules
+is available to `declarations` of this module.
 
 syntax(js):
 `imports: [ng.platformBrowser.BrowserModule, SomeOtherModule]`|`imports:`
 description:
-List of modules that are being imported into this module. Everything from the imported modules will
-be available to `declarations` of this module.
+List of modules to import into this module. Everything from the imported modules
+is available to `declarations` of this module.
 
 @cheatsheetItem
-syntax(ts js):
+syntax:
 `exports: [MyRedComponent, MyDatePipe]`|`exports:`
 description:
-List of components, directives and pipes that will be visible to modules that import this module.
+List of components, directives, and pipes visible to modules that import this module.
 
 @cheatsheetItem
-syntax(ts js):
+syntax:
 `providers: [MyService, { provide: ... }]`|`providers:`
 description:
-Array of dependency injection providers visible to contents of this module as well as everyone
-importing this module.
+List of dependency injection providers visible both to the contents of this module and to importers of this module.
 
 @cheatsheetItem
-syntax(ts js):
+syntax:
 `bootstrap: [MyAppComponent]`|`bootstrap:`
 description:
-Array of components to bootstrap when this module is bootstrapped.
+List of components to bootstrap when this module is bootstrapped.

--- a/modules/@angular/docs/cheatsheet/routing.md
+++ b/modules/@angular/docs/cheatsheet/routing.md
@@ -4,7 +4,6 @@ Routing and navigation
 @description
 {@target ts}`import { Routes, RouterModule, ... } from '@angular/router';`{@endtarget}
 {@target js}Available from the `ng.router` namespace{@endtarget}
-{@target dart}`import 'package:angular2/router.dart';`{@endtarget}
 
 
 @cheatsheetItem
@@ -30,17 +29,8 @@ syntax(js):
 ]);
 
 var routing = ng.router.RouterModule.forRoot(routes);`|`ng.router.Routes`
-syntax(dart):
-`@RouteConfig(const [
-  const Route(path: '', component: HomeComponent, name: 'Home'),
-  const Route(path: ':routeParam', component: MyComponent, name: 'MyCmp'),
-  const Route(path: 'staticPath', component: ..., name: 'StaticCmp'),
-  const Route(path: '**', component: ..., name: 'WildcardCmp'),
-  const Route(path: '/oldPath', redirectTo: ['/StaticCmp']),
-  const Route(path: ..., component: ..., data: { message: 'Custom' })
-])class MyComponent() {}`|`@RouteConfig`
 description:
-Configures routes for the application. Supports static, parameterized, redirect and wildcard routes. Also supports custom route data{@target ts js} and resolve{@endtarget}.
+Configures routes for the application. Supports static, parameterized, redirect, and wildcard routes. Also supports custom route data and resolve.
 
 
 @cheatsheetItem
@@ -54,7 +44,7 @@ Marks the location to load the component of the active route.
 
 
 @cheatsheetItem
-syntax(ts js):
+syntax:
 `
 <a routerLink="/path">
 <a [routerLink]="[ '/path', routeParam ]">
@@ -62,21 +52,14 @@ syntax(ts js):
 <a [routerLink]="[ '/path' ]" [queryParams]="{ page: 1 }">
 <a [routerLink]="[ '/path' ]" fragment="anchor">
 `|`[routerLink]`
-syntax(dart):
-`
-<a [routerLink]="[ '/MyCmp', { routeParam: 'value' } ]">
-<a [routerLink]="[ '/MyCmp', { matrixParam: 'value' } ]">
-`|`[routerLink]`
 description:
-Creates a link to a different view based on a route instruction consisting of a route path, required and optional parameters, query parameters and a fragment. Add the '/' prefix to navigate to a root route; add the './' prefix for a child route; add the '../sibling' prefix for a sibling or parent route.
+Creates a link to a different view based on a route instruction consisting of a route path, required and optional parameters, query parameters, and a fragment. To navigate to a root route, use the `/` prefix; for a child route, use the `./`prefix; for a sibling or parent, use the `../` prefix.
 
 @cheatsheetItem
-syntax(ts js):
+syntax:
 `<a [routerLink]="[ '/path' ]" routerLinkActive="active">`
-syntax(dart):
-`<a [routerLink]="[ '/MyCmp', { myParam: 'value' } ]">`|`routerLink`
 description:
-The provided class(es) will be added to the element when the routerLink becomes the current active route.
+The provided classes are added to the element when the `routerLink` becomes the current active route.
 
 @cheatsheetItem
 syntax(ts):
@@ -96,11 +79,8 @@ syntax(js):
 });
 
 { path: ..., canActivate: [CanActivateGuard] }`|`CanActivate`
-syntax(dart):
-`@CanActivate(() => ...)class MyComponent() {}`|`@CanActivate`
 description:
-{@target js ts}An interface for defining a class that the router should call first to determine if it should activate this component. Should return an Observable/Promise that resolves a boolean or a boolean{@endtarget}
-{@target dart}A component decorator defining a function that the router should call first to determine if it should activate this component. Should return a boolean or a future.{@endtarget}
+An interface for defining a class that the router should call first to determine if it should activate this component. Should return a boolean or an Observable/Promise that resolves to a boolean.
 
 @cheatsheetItem
 syntax(ts):
@@ -121,12 +101,8 @@ syntax(js):
 });
 
 { path: ..., canDeactivate: [CanDeactivateGuard] }`|`CanDeactivate`
-syntax(dart):
-`routerCanDeactivate(nextInstruction, prevInstruction) { ... }`|`routerCanDeactivate`
 description:
-{@target js ts}An interface for defining a class that the router should call first to determine if it should deactivate this component after a navigation. Should return an Observable/Promise that resolves a boolean or a boolean{@endtarget}
-{@target dart}
-The router calls the routerCanDeactivate methods (if defined) of every component that would be removed after a navigation. The navigation proceeds if and only if all such methods return true or a future that completes successfully{@endtarget}.
+An interface for defining a class that the router should call first to determine if it should deactivate this component after a navigation. Should return a boolean or an Observable/Promise that resolves to a boolean.
 
 @cheatsheetItem
 syntax(ts):
@@ -137,7 +113,8 @@ syntax(ts):
     ): Observable<boolean>|Promise<boolean>|boolean { ... }
 }
 
-{ path: ..., canActivateChild: [CanActivateGuard], children: ... }`|`CanActivateChild`
+{ path: ..., canActivateChild: [CanActivateGuard],
+    children: ... }`|`CanActivateChild`
 syntax(js):
 `var CanActivateChildGuard = ng.core.Class({
   canActivateChild: function(route, state) {
@@ -145,9 +122,10 @@ syntax(js):
   }
 });
 
-{ path: ..., canActivateChild: [CanActivateChildGuard], children: ... }`|`CanActivateChild`
+{ path: ..., canActivateChild: [CanActivateChildGuard],
+    children: ... }`|`CanActivateChild`
 description:
-{@target js ts}An interface for defining a class that the router should call first to determine if it should activate the child route. Should return an Observable/Promise that resolves a boolean or a boolean{@endtarget}
+An interface for defining a class that the router should call first to determine if it should activate the child route. Should return a boolean or an Observable/Promise that resolves to a boolean.
 
 @cheatsheetItem
 syntax(ts):
@@ -168,7 +146,7 @@ syntax(js):
 
 { path: ..., resolve: [ResolveGuard] }`|`Resolve`
 description:
-{@target js ts}An interface for defining a class that the router should call first to resolve route data before rendering the route. Should return an Observable/Promise that resolves a value or a value{@endtarget}
+An interface for defining a class that the router should call first to resolve route data before rendering the route. Should return a value or an Observable/Promise that resolves to a value.
 
 @cheatsheetItem
 syntax(ts):
@@ -188,38 +166,5 @@ syntax(js):
 
 { path: ..., canLoad: [CanLoadGuard], loadChildren: ... }`|`CanLoad`
 description:
-{@target js ts}An interface for defining a class that the router should call first to check if the lazy loaded module should be loaded. Should return an Observable/Promise that resolves a boolean or a boolean{@endtarget}
+An interface for defining a class that the router should call first to check if the lazy loaded module should be loaded. Should return a boolean or an Observable/Promise that resolves to a boolean.
 
-@cheatsheetItem
-syntax(dart):
-`routerOnActivate(nextInstruction, prevInstruction) { ... }`|`routerOnActivate`
-description:
-{@target dart}After navigating to a component, the router calls the component's routerOnActivate method (if defined).{@endtarget}
-
-
-@cheatsheetItem
-syntax(dart):
-`routerCanReuse(nextInstruction, prevInstruction) { ... }`|`routerCanReuse`
-description:
-{@target dart}The router calls a component's routerCanReuse method (if defined) to determine whether to reuse the instance or destroy it and create a new instance. Should return a boolean or a future{@endtarget}.
-
-
-@cheatsheetItem
-syntax(dart):
-`routerOnReuse(nextInstruction, prevInstruction) { ... }`|`routerOnReuse`
-description:
-{@target dart}The router calls the component's routerOnReuse method (if defined) when it re-uses a component instance.{@endtarget}
-
-
-@cheatsheetItem
-syntax(dart):
-`routerCanDeactivate(nextInstruction, prevInstruction) { ... }`|`routerCanDeactivate`
-description:
-{@target dart}The router calls the routerCanDeactivate methods (if defined) of every component that would be removed after a navigation. The navigation proceeds if and only if all such methods return true or a future that completes successfully.{@endtarget}
-
-
-@cheatsheetItem
-syntax(dart):
-`routerOnDeactivate(nextInstruction, prevInstruction) { ... }`|`routerOnDeactivate`
-description:
-{@target dart}Called before the directive is removed as the result of a route change. May return a future that pauses removing the directive until the future completes.{@endtarget}

--- a/modules/@angular/docs/cheatsheet/template-syntax.md
+++ b/modules/@angular/docs/cheatsheet/template-syntax.md
@@ -37,14 +37,14 @@ Calls method `readRainbow` when a click event is triggered on this button elemen
 syntax:
 `<div title="Hello {{ponyName}}">`|`{{ponyName}}`
 description:
-Binds a property to an interpolated string, e.g. "Hello Seabiscuit". Equivalent to:
+Binds a property to an interpolated string, for example, "Hello Seabiscuit". Equivalent to:
 `<div [title]="'Hello ' + ponyName">`
 
 @cheatsheetItem
 syntax:
 `<p>Hello {{ponyName}}</p>`|`{{ponyName}}`
 description:
-Binds text content to an interpolated string, e.g. "Hello Seabiscuit".
+Binds text content to an interpolated string, for example, "Hello Seabiscuit".
 
 @cheatsheetItem
 syntax:
@@ -64,14 +64,14 @@ Creates a local variable `movieplayer` that provides access to the `video` eleme
 syntax:
 `<p *myUnless="myExpression">...</p>`|`*myUnless`
 description:
-The `*` symbol means that the current element will be turned into an embedded template. Equivalent to:
+The `*` symbol turns the current element into an embedded template. Equivalent to:
 `<template [myUnless]="myExpression"><p>...</p></template>`
 
 @cheatsheetItem
 syntax:
-`<p>Card No.: {{cardNumber | myCreditCardNumberFormatter}}</p>`|`{{cardNumber | myCreditCardNumberFormatter}}`
+`<p>Card No.: {{cardNumber | myCardNumberFormatter}}</p>`|`{{cardNumber | myCardNumberFormatter}}`
 description:
-Transforms the current value of expression `cardNumber` via the pipe called `myCreditCardNumberFormatter`.
+Transforms the current value of expression `cardNumber` via the pipe called `myCardNumberFormatter`.
 
 @cheatsheetItem
 syntax:
@@ -83,7 +83,7 @@ The safe navigation operator (`?`) means that the `employer` field is optional a
 syntax:
 `<svg:rect x="0" y="0" width="100" height="100"/>`|`svg:`
 description:
-SVG snippet templates need an `svg:` prefix on their root element to disambiguate the SVG element from an HTML component.
+An SVG snippet template needs an `svg:` prefix on its root element to disambiguate the SVG element from an HTML component.
 
 @cheatsheetItem
 syntax:
@@ -91,4 +91,4 @@ syntax:
   <rect x="0" y="0" width="100" height="100"/>
 </svg>`|`svg`
 description:
-`<svg>` root elements are detected as SVG element automatically without the prefix
+An `<svg>` root element is detected as an SVG element automatically, without the prefix.


### PR DESCRIPTION
…and general cleanup of the cheatsheet.

In some places I added line breaks to examples, to reduce column width and improve page layout. Is a 4-space indent for continued lines OK?

This is the last of a group of cheatsheet PRs (see #11149).

cc @Foxandxss & @IgorMinar 
