### PR TITLE
fix(forms): disabled controls should never be invalid

### DIFF
--- a/modules/@angular/forms/src/model.ts
+++ b/modules/@angular/forms/src/model.ts
@@ -360,10 +360,10 @@ export abstract class AbstractControl {
 
 
   private _calculateStatus(): string {
+    if (this._allControlsDisabled()) return DISABLED;
     if (isPresent(this._errors)) return INVALID;
     if (this._anyControlsHaveStatus(PENDING)) return PENDING;
     if (this._anyControlsHaveStatus(INVALID)) return INVALID;
-    if (this._allControlsDisabled()) return DISABLED;
     return VALID;
   }
 

--- a/modules/@angular/forms/test/form_control_spec.ts
+++ b/modules/@angular/forms/test/form_control_spec.ts
@@ -56,6 +56,13 @@ export function main() {
         expect(c.status).toBe('DISABLED');
       });
 
+      it('should honor boxed value with disabled control when validating', () => {
+        const c = new FormControl({value: '', disabled: true}, Validators.required);
+        expect(c.disabled).toBe(true);
+        expect(c.valid).toBe(false);
+        expect(c.status).toBe('DISABLED');
+      });
+
       it('should not treat objects as boxed values if they have more than two props', () => {
         const c = new FormControl({value: '', disabled: true, test: 'test'}, null, null);
         expect(c.value).toEqual({value: '', disabled: true, test: 'test'});


### PR DESCRIPTION
We were running the disabled check too late, so sometimes individual controls that were instantiated as invalid _and_ disabled were mistakenly calculated to be 'invalid'.  The disabled status should always trump any other status.
