### PR TITLE
feat(core): add type checking to @Pipe (#11126)

### DIFF
--- a/modules/@angular/compiler/test/metadata_resolver_spec.ts
+++ b/modules/@angular/compiler/test/metadata_resolver_spec.ts
@@ -77,6 +77,7 @@ export function main() {
          inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
            @Pipe({name: 'somePipe'})
            class SomePipe {
+             transform(value: any){};
            }
            @NgModule({imports: [SomePipe]})
            class ModuleWithImportedPipe {

--- a/modules/@angular/compiler/test/pipe_resolver_mock_spec.ts
+++ b/modules/@angular/compiler/test/pipe_resolver_mock_spec.ts
@@ -36,4 +36,5 @@ export function main() {
 
 @Pipe({name: 'somePipe'})
 class SomePipe {
+  transform(value: any, modifier: any){};
 }

--- a/modules/@angular/core/src/metadata.ts
+++ b/modules/@angular/core/src/metadata.ts
@@ -11,6 +11,7 @@
  * to be used by the decorator versions of these annotations.
  */
 
+import {PipeTransform} from './change_detection';
 import {AttributeMetadata, ContentChildMetadata, ContentChildrenMetadata, QueryMetadata, ViewChildMetadata, ViewChildrenMetadata, ViewQueryMetadata} from './metadata/di';
 import {ComponentMetadata, ComponentMetadataType, DirectiveMetadata, DirectiveMetadataType, HostBindingMetadata, HostListenerMetadata, InputMetadata, OutputMetadata, PipeMetadata, PipeMetadataType} from './metadata/directives';
 import {ModuleWithProviders, NgModuleMetadata, NgModuleMetadataType, SchemaMetadata} from './metadata/ng_module';
@@ -220,8 +221,8 @@ export interface ViewChildMetadataFactory {
  * @stable
  */
 export interface PipeMetadataFactory {
-  (obj: PipeMetadataType): any;
-  new (obj: PipeMetadataType): any;
+  <T extends new (...args: any[]) => PipeTransform>(obj: PipeMetadataType): (target: T) => any;
+  new<T extends new (...args: any[]) => PipeTransform>(obj: PipeMetadataType): (target: T) => any;
 }
 
 /**

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -874,8 +874,8 @@ export declare class PipeMetadata extends InjectableMetadata implements PipeMeta
 
 /** @stable */
 export interface PipeMetadataFactory {
-    (obj: PipeMetadataType): any;
-    new (obj: PipeMetadataType): any;
+    <T extends new (...args: any[]) => PipeTransform>(obj: PipeMetadataType): (target: T) => any;
+    new <T extends new (...args: any[]) => PipeTransform>(obj: PipeMetadataType): (target: T) => any;
 }
 
 /** @stable */


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
As stated by #11126, `@Pipe` decorator fails at execution time when it decorates a class that doesn't fulfill `PipeTransform` interface signature.

**What is the new behavior?**
The code will not compile and will show an error message.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

Ensures at compile time that only classes that satisfy PipeTrasform interface
can be decorated by @Pipe.

closes angular/angular#11126
