### PR TITLE
Added @link to responseType property of RequestOptions

### DIFF
--- a/modules/@angular/http/src/base_request_options.ts
+++ b/modules/@angular/http/src/base_request_options.ts
@@ -70,7 +70,7 @@ export class RequestOptions {
    */
   withCredentials: boolean;
   /*
-   * Select a buffer to store the response, such as ArrayBuffer, Blob, Json (or Document)
+   * Select a buffer to store the response, such as ArrayBuffer, Blob, Json (or Document) {@link Request}.
    */
   responseType: ResponseContentType;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Documentation
```

**What is the current behavior?** (You can also link to an open issue here)

`response` on the http modules `RequestOptions` missed a `@link` in it's documentation

**What is the new behavior?**

the `@link` has been added

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
