### PR TITLE
bug(router): Allowing multiple query params of the same name to be se…

### DIFF
--- a/modules/@angular/router/src/url_tree.ts
+++ b/modules/@angular/router/src/url_tree.ts
@@ -240,8 +240,11 @@ function serializeParams(params: {[key: string]: string}): string {
   return pairs(params).map(p => `;${encode(p.first)}=${encode(p.second)}`).join('');
 }
 
-function serializeQueryParams(params: {[key: string]: string}): string {
-  const strs = pairs(params).map(p => `${encode(p.first)}=${encode(p.second)}`);
+function serializeQueryParams(params: {[key: string]: any}): string {
+  const strs = pairs(params).map(
+      p => Array.isArray(p.second) ?
+          p.second.map(v => `${encode(p.first)}=${encode(v)}`).join('&') :
+          `${encode(p.first)}=${encode(p.second)}`);
   return strs.length > 0 ? `?${strs.join("&")}` : '';
 }
 
@@ -419,7 +422,13 @@ class UrlParser {
         this.capture(value);
       }
     }
-    params[decode(key)] = decode(value);
+
+    if (params[key] != null) {
+      params[decode(key)] = Array.isArray(params[key]) ? params[key].concat([decode(value)]) :
+                                                         [params[key], decode(value)];
+    } else {
+      params[decode(key)] = decode(value);
+    }
   }
 
   parseParens(allowPrimary: boolean): {[key: string]: UrlSegmentGroup} {

--- a/modules/@angular/router/test/url_serializer.spec.ts
+++ b/modules/@angular/router/test/url_serializer.spec.ts
@@ -160,6 +160,11 @@ describe('url serializer', () => {
     expect(url.serialize(tree)).toEqual('/one?a=');
   });
 
+  it('should handle multiple query params of the same name into an array', () => {
+    const tree = url.parse('/one?a=foo&a=bar&a=swaz');
+    expect(tree.queryParams).toEqual({a: ['foo', 'bar', 'swaz']});
+  });
+
   it('should parse fragment', () => {
     const tree = url.parse('/one#two');
     expect(tree.fragment).toEqual('two');


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Currently when going to a url with multiple query parameters with the same key the DefaultUrlSerializer is removing all but the last one from the url.

`/something/route?room=a1&room=a4&room=a6`

This link will be rewritten to:

`/something/route?room=a6`

**What is the new behavior?**

Links with multiple query parameters will be left in the url as is and the parameters will be serialized into an array.

`/something/route?room=a1&room=a4&room=a6`

`room["a1", "a4", "a6"]`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
