### PR TITLE
docs(cheatsheet): fix typo NgModule definition

### DIFF
--- a/modules/@angular/docs/cheatsheet/ngmodules.md
+++ b/modules/@angular/docs/cheatsheet/ngmodules.md
@@ -16,7 +16,7 @@ Defines a module that contains components, directives, pipes, and providers.
 syntax(js):
 `ng.core.NgModule({declarations: ..., imports: ...,
      exports: ..., providers: ..., bootstrap: ...}).
-class({ constructor: function() {}})`
+Class({ constructor: function() {}})`
 description:
 Defines a module that contains components, directives, pipes, and providers.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

It fixes a typo: no tests and no docs to add.

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: typo
```

**What is the current behavior?** (You can also link to an open issue here)

n.a.

**What is the new behavior?**

n.a.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: n.a.

**Other information**:

`.Class` and not `.class` in js approach for NgModule definition.
