### PR TITLE
fix(lazy-loading): fix an issue with webpack and lazy loader.

### DIFF
--- a/modules/@angular/core/src/linker/system_js_ng_module_factory_loader.ts
+++ b/modules/@angular/core/src/linker/system_js_ng_module_factory_loader.ts
@@ -48,13 +48,7 @@ const DEFAULT_CONFIG: SystemJsNgModuleLoaderConfig = {
 export class SystemJsNgModuleLoader implements NgModuleFactoryLoader {
   private _config: SystemJsNgModuleLoaderConfig;
 
-  /**
-   * @internal
-   */
-  _system: any;
-
   constructor(private _compiler: Compiler, @Optional() config?: SystemJsNgModuleLoaderConfig) {
-    this._system = () => System;
     this._config = config || DEFAULT_CONFIG;
   }
 
@@ -67,8 +61,7 @@ export class SystemJsNgModuleLoader implements NgModuleFactoryLoader {
     let [module, exportName] = path.split(_SEPARATOR);
     if (exportName === undefined) exportName = 'default';
 
-    return this._system()
-        .import(module)
+    return System.import(module)
         .then((module: any) => module[exportName])
         .then((type: any) => checkNotEmpty(type, module, exportName))
         .then((type: any) => this._compiler.compileModuleAsync(type));
@@ -82,8 +75,7 @@ export class SystemJsNgModuleLoader implements NgModuleFactoryLoader {
       factoryClassSuffix = '';
     }
 
-    return this._system()
-        .import(this._config.factoryPathPrefix + module + this._config.factoryPathSuffix)
+    return System.import(this._config.factoryPathPrefix + module + this._config.factoryPathSuffix)
         .then((module: any) => module[exportName + factoryClassSuffix])
         .then((factory: any) => checkNotEmpty(factory, module, exportName));
   }

--- a/modules/@angular/core/test/linker/system_ng_module_factory_loader_spec.ts
+++ b/modules/@angular/core/test/linker/system_ng_module_factory_loader_spec.ts
@@ -6,32 +6,41 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {global} from '@angular/common/src/facade/lang';
 import {Compiler, SystemJsNgModuleLoader} from '@angular/core';
 import {async, tick} from '@angular/core/testing';
-import {beforeEach, ddescribe, describe, expect, iit, it, xit} from '@angular/core/testing/testing_internal';
+import {afterEach, beforeEach, describe, expect, it} from '@angular/core/testing/testing_internal';
 
-function mockSystem(module: string, contents: any) {
+function mockSystem(modules: {[module: string]: any}) {
   return {
     'import': (target: string) => {
-      expect(target).toBe(module);
-      return Promise.resolve(contents);
+      expect(modules[target]).not.toBe(undefined);
+      return Promise.resolve(modules[target]);
     }
   };
 }
 
 export function main() {
   describe('SystemJsNgModuleLoader', () => {
+    let oldSystem: any = null;
+    beforeEach(() => {
+      oldSystem = (global as any).System;
+      (global as any).System = mockSystem({
+        'test.ngfactory':
+            {'default': 'test module factory', 'NamedNgFactory': 'test NamedNgFactory'},
+        'prefixed/test/suffixed': {'NamedNgFactory': 'test module factory'}
+      });
+    });
+    afterEach(() => { (global as any).System = oldSystem; });
+
     it('loads a default factory by appending the factory suffix', async(() => {
          let loader = new SystemJsNgModuleLoader(new Compiler());
-         loader._system = () => mockSystem('test.ngfactory', {'default': 'test module factory'});
          loader.load('test').then(contents => { expect(contents).toBe('test module factory'); });
        }));
     it('loads a named factory by appending the factory suffix', async(() => {
          let loader = new SystemJsNgModuleLoader(new Compiler());
-         loader._system = () =>
-             mockSystem('test.ngfactory', {'NamedNgFactory': 'test module factory'});
          loader.load('test#Named').then(contents => {
-           expect(contents).toBe('test module factory');
+           expect(contents).toBe('test NamedNgFactory');
          });
        }));
     it('loads a named factory with a configured prefix and suffix', async(() => {
@@ -39,8 +48,6 @@ export function main() {
            factoryPathPrefix: 'prefixed/',
            factoryPathSuffix: '/suffixed',
          });
-         loader._system = () =>
-             mockSystem('prefixed/test/suffixed', {'NamedNgFactory': 'test module factory'});
          loader.load('test#Named').then(contents => {
            expect(contents).toBe('test module factory');
          });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[X] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)
Webpack will not recognize the call to `System.import()` following PR #11049.

**What is the new behavior?**
Webpack will recognize the call to `System.import()` and properly inject its logic to load the bundle.
