### PR TITLE
fix(upgrade): bind optional properties when upgrading from ng1

### DIFF
--- a/modules/@angular/upgrade/src/upgrade_ng1_adapter.ts
+++ b/modules/@angular/upgrade/src/upgrade_ng1_adapter.ts
@@ -86,7 +86,10 @@ export class UpgradeNg1ComponentAdapterBuilder {
         if ((<any>context).hasOwnProperty(name)) {
           var localName = context[name];
           var type = localName.charAt(0);
-          localName = localName.substr(1) || name;
+          var typeOptions = localName.charAt(1);
+          localName = typeOptions === '?' ? localName.substr(2) : localName.substr(1);
+          localName = localName || name;
+
           var outputName = 'output_' + name;
           var outputNameRename = outputName + ': ' + name;
           var outputNameRenameChange = outputName + ': ' + name + 'Change';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Previously, optional properties of a directive/component would be wrongly mapped and thus ignored.

See #10181

**What is the new behavior?**

Optional properties of an ng1 directive/component are correctly bound

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Closes #10181
