### PR TITLE
fix(forms): fix disabled support for empty form containers

### DIFF
--- a/modules/@angular/forms/src/model.ts
+++ b/modules/@angular/forms/src/model.ts
@@ -732,7 +732,7 @@ export class FormGroup extends AbstractControl {
         return false;
       }
     }
-    return !StringMapWrapper.isEmpty(this.controls);
+    return Object.keys(this.controls).length > 0 || this.disabled;
   }
 
   /** @internal */
@@ -911,7 +911,7 @@ export class FormArray extends AbstractControl {
     for (let control of this.controls) {
       if (control.enabled) return false;
     }
-    return !!this.controls.length;
+    return this.controls.length > 0 || this.disabled;
   }
 
   private _registerControl(control: AbstractControl) {

--- a/modules/@angular/forms/test/form_array_spec.ts
+++ b/modules/@angular/forms/test/form_array_spec.ts
@@ -773,6 +773,32 @@ export function main() {
         expect(g.touched).toEqual(true);
       });
 
+      it('should keep empty, disabled arrays disabled when updating validity', () => {
+        const arr = new FormArray([]);
+        expect(arr.status).toEqual('VALID');
+
+        arr.disable();
+        expect(arr.status).toEqual('DISABLED');
+
+        arr.updateValueAndValidity();
+        expect(arr.status).toEqual('DISABLED');
+
+        arr.push(new FormControl({value: '', disabled: true}));
+        expect(arr.status).toEqual('DISABLED');
+
+        arr.push(new FormControl());
+        expect(arr.status).toEqual('VALID');
+      });
+
+      it('should re-enable empty, disabled arrays', () => {
+        const arr = new FormArray([]);
+        arr.disable();
+        expect(arr.status).toEqual('DISABLED');
+
+        arr.enable();
+        expect(arr.status).toEqual('VALID');
+      });
+
       describe('disabled events', () => {
         let logger: string[];
         let c: FormControl;

--- a/modules/@angular/forms/test/form_group_spec.ts
+++ b/modules/@angular/forms/test/form_group_spec.ts
@@ -775,6 +775,32 @@ export function main() {
         expect(g.touched).toEqual(true);
       });
 
+      it('should keep empty, disabled groups disabled when updating validity', () => {
+        const group = new FormGroup({});
+        expect(group.status).toEqual('VALID');
+
+        group.disable();
+        expect(group.status).toEqual('DISABLED');
+
+        group.updateValueAndValidity();
+        expect(group.status).toEqual('DISABLED');
+
+        group.addControl('one', new FormControl({value: '', disabled: true}));
+        expect(group.status).toEqual('DISABLED');
+
+        group.addControl('two', new FormControl());
+        expect(group.status).toEqual('VALID');
+      });
+
+      it('should re-enable empty, disabled groups', () => {
+        const group = new FormGroup({});
+        group.disable();
+        expect(group.status).toEqual('DISABLED');
+
+        group.enable();
+        expect(group.status).toEqual('VALID');
+      });
+
       describe('disabled events', () => {
         let logger: string[];
         let c: FormControl;


### PR DESCRIPTION
Fixes the following case:

``` ts
const arr  = new FormArray([]);
console.log(arr.status);   // VALID

arr.disable();
console.log(arr.status);  // DISABLED

arr.updateValueAndValidity();
console.log(arr.status);    // should be DISABLED, but is currently VALID
```

Empty form containers should be able to stay disabled until the model breaks (i.e. an enabled child is added).

Closes https://github.com/angular/angular/issues/11386.
