### PR TITLE
fix(forms): properly validate empty strings with patterns

### DIFF
--- a/modules/@angular/forms/src/validators.ts
+++ b/modules/@angular/forms/src/validators.ts
@@ -94,7 +94,6 @@ export class Validators {
    */
   static pattern(pattern: string): ValidatorFn {
     return (control: AbstractControl): {[key: string]: any} => {
-      if (isPresent(Validators.required(control))) return null;
       let regex = new RegExp(`^${pattern}$`);
       let v: string = control.value;
       return regex.test(v) ? null :

--- a/modules/@angular/forms/test/validators_spec.ts
+++ b/modules/@angular/forms/test/validators_spec.ts
@@ -91,6 +91,9 @@ export function main() {
       it('should not error on null',
          () => { expect(Validators.pattern('[a-zA-Z ]*')(new FormControl(null))).toEqual(null); });
 
+      it('should not error on null value and "null" pattern',
+         () => { expect(Validators.pattern('null')(new FormControl(null))).toEqual(null); });
+
       it('should not error on valid strings', () => {
         expect(Validators.pattern('[a-zA-Z ]*')(new FormControl('aaAA'))).toEqual(null);
       });
@@ -98,6 +101,12 @@ export function main() {
       it('should error on failure to match string', () => {
         expect(Validators.pattern('[a-zA-Z ]*')(new FormControl('aaa0'))).toEqual({
           'pattern': {'requiredPattern': '^[a-zA-Z ]*$', 'actualValue': 'aaa0'}
+        });
+      });
+
+      it('should error on failure to match empty string', () => {
+        expect(Validators.pattern('[a-zA-Z]+')(new FormControl(''))).toEqual({
+          'pattern': {'requiredPattern': '^[a-zA-Z]+$', 'actualValue': ''}
         });
       });
     });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

Inputs with `pattern` validator would mark an empty string as valid even if a given given RegExp doesn't match empty strings. Ex. `<input [(ngModel)]="test" pattern="[a-z]+">` would be marked as valid for an empty string, even if it clearly doesn't match the provided pattern.

**What is the new behavior?**

In the situation described above a control is marked as invalid.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] No
```

@kara I've bumped into this one today while reproducing another issue related to forms. The line I've deleted in this PR definitively looks fishy and it repeated in other validators (I will send PRs for those as well if / when we determine proper behaviour). 

It _might_ be that the intention was that for an empty string we would be getting `{required: ...}` error instead of `{requiredPattern: ...}` one but:
- the current imp is definitively buggy
- personally I would find it confusing that a pattern validator gives me `required` error.

Let's determine what the proper validation output should be here but in any case the current code is broken for empty strings.
