### PR TITLE
chore(github): update issue template to hide comments

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,24 +5,26 @@
 [ ] support request => Please do not submit support request here, instead see https://github.com/angular/angular/blob/master/CONTRIBUTING.md#question
 ```
 
-**Current behavior**
-
-Describe how the bug manifests. 
+**Current behavior** 
+<!-- Describe how the bug manifests. -->
 
 **Expected behavior**
-
-Describe what the behavior would be without bug.
+<!-- Describe what the behavior would be without the bug. -->
 
 **Reproduction of the problem**
-If the current behavior is a bug or you can illustrate your feature request better with an example, please provide the steps to reproduce and if possible a minimal demo of the problem via https://plnkr.co or similar (you can use this template as a starting point: http://plnkr.co/edit/tpl:AvJOMERrnz94ekVua0u5).
+<!-- If the current behavior is a bug or you can illustrate your feature request better with an example, please provide the steps to reproduce and if possible a minimal demo of the problem via https://plnkr.co or similar (you can use this template as a starting point: http://plnkr.co/edit/tpl:AvJOMERrnz94ekVua0u5). -->
 
 **What is the motivation / use case for changing the behavior?**
+<!-- Describe the motivation or the concrete use case -->
 
 **Please tell us about your environment:**
+<!-- Operating system, IDE, package manager, HTTP server, ... -->
 
 * **Angular version:** 2.0.0-rc.X
- 
+<!-- Check whether this is still an issue in the most recent Angular version -->
+
 * **Browser:** [all | Chrome XX | Firefox XX | IE XX | Safari XX | Mobile Chrome XX | Android X.X Web Browser | iOS XX Safari | iOS XX UIWebView | iOS XX WKWebView ] 
+<!-- All browsers where this could be reproduced -->
  
 * **Language:** [all | TypeScript X.X | ES6/7 | ES5]
  


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe: GitHub issue template
```

**What is the current behavior?** (You can also link to an open issue here)

Created issues contain the additional explanation which results in a lot of noise in created issues

**What is the new behavior?**

Additional explanation will only be shown while an issue is edited.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

replaces #11448

Wrap additional descriptions in comments so that they are hidden in created issues (only visible during editing)
