### PR TITLE
fix(forms): rename validator change fn due to conflict

### DIFF
--- a/modules/@angular/forms/src/directives/shared.ts
+++ b/modules/@angular/forms/src/directives/shared.ts
@@ -67,21 +67,22 @@ export function setUpControl(control: FormControl, dir: NgControl): void {
 
   // re-run validation when validator binding changes, e.g. minlength=3 -> minlength=4
   dir._rawValidators.forEach((validator: Validator | ValidatorFn) => {
-    if ((<Validator>validator).registerOnChange)
-      (<Validator>validator).registerOnChange(() => control.updateValueAndValidity());
+    if ((<Validator>validator).registerOnValidatorChange)
+      (<Validator>validator).registerOnValidatorChange(() => control.updateValueAndValidity());
   });
 
   dir._rawAsyncValidators.forEach((validator: Validator | ValidatorFn) => {
-    if ((<Validator>validator).registerOnChange)
-      (<Validator>validator).registerOnChange(() => control.updateValueAndValidity());
+    if ((<Validator>validator).registerOnValidatorChange)
+      (<Validator>validator).registerOnValidatorChange(() => control.updateValueAndValidity());
   });
 }
 
 export function cleanUpControl(control: FormControl, dir: NgControl) {
   dir.valueAccessor.registerOnChange(() => _noControlError(dir));
   dir.valueAccessor.registerOnTouched(() => _noControlError(dir));
-  dir._rawValidators.forEach((validator: Validator) => validator.registerOnChange(null));
-  dir._rawAsyncValidators.forEach((validator: Validator) => validator.registerOnChange(null));
+  dir._rawValidators.forEach((validator: Validator) => validator.registerOnValidatorChange(null));
+  dir._rawAsyncValidators.forEach(
+      (validator: Validator) => validator.registerOnValidatorChange(null));
   if (control) control._clearChangeFns();
 }
 

--- a/modules/@angular/forms/src/directives/validators.ts
+++ b/modules/@angular/forms/src/directives/validators.ts
@@ -35,7 +35,7 @@ import {NG_VALIDATORS, Validators} from '../validators';
  */
 export interface Validator {
   validate(c: AbstractControl): {[key: string]: any};
-  registerOnChange?(fn: () => void): void;
+  registerOnValidatorChange?(fn: () => void): void;
 }
 
 export const REQUIRED_VALIDATOR: any = {
@@ -77,7 +77,7 @@ export class RequiredValidator implements Validator {
     return this.required ? Validators.required(c) : null;
   }
 
-  registerOnChange(fn: () => void) { this._onChange = fn; }
+  registerOnValidatorChange(fn: () => void) { this._onChange = fn; }
 }
 
 /**
@@ -138,7 +138,7 @@ export class MinLengthValidator implements Validator,
     return isPresent(this.minlength) ? this._validator(c) : null;
   }
 
-  registerOnChange(fn: () => void) { this._onChange = fn; }
+  registerOnValidatorChange(fn: () => void) { this._onChange = fn; }
 }
 
 /**
@@ -188,7 +188,7 @@ export class MaxLengthValidator implements Validator,
     return isPresent(this.maxlength) ? this._validator(c) : null;
   }
 
-  registerOnChange(fn: () => void) { this._onChange = fn; }
+  registerOnValidatorChange(fn: () => void) { this._onChange = fn; }
 }
 
 
@@ -237,5 +237,5 @@ export class PatternValidator implements Validator,
     return isPresent(this.pattern) ? this._validator(c) : null;
   }
 
-  registerOnChange(fn: () => void) { this._onChange = fn; }
+  registerOnValidatorChange(fn: () => void) { this._onChange = fn; }
 }

--- a/modules/@angular/forms/test/form_array_spec.ts
+++ b/modules/@angular/forms/test/form_array_spec.ts
@@ -8,7 +8,7 @@
 
 import {fakeAsync, tick} from '@angular/core/testing';
 import {AsyncTestCompleter, beforeEach, ddescribe, describe, iit, inject, it, xit} from '@angular/core/testing/testing_internal';
-import {FormArray, FormControl, FormGroup} from '@angular/forms';
+import {AbstractControl, FormArray, FormControl, FormGroup} from '@angular/forms';
 
 import {isPresent} from '../src/facade/lang';
 import {Validators} from '../src/validators';

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -321,7 +321,7 @@ export declare class FormsModule {
 export declare class MaxLengthValidator implements Validator, OnChanges {
     maxlength: string;
     ngOnChanges(changes: SimpleChanges): void;
-    registerOnChange(fn: () => void): void;
+    registerOnValidatorChange(fn: () => void): void;
     validate(c: AbstractControl): {
         [key: string]: any;
     };
@@ -331,7 +331,7 @@ export declare class MaxLengthValidator implements Validator, OnChanges {
 export declare class MinLengthValidator implements Validator, OnChanges {
     minlength: string;
     ngOnChanges(changes: SimpleChanges): void;
-    registerOnChange(fn: () => void): void;
+    registerOnValidatorChange(fn: () => void): void;
     validate(c: AbstractControl): {
         [key: string]: any;
     };
@@ -433,7 +433,7 @@ export declare class NgSelectOption implements OnDestroy {
 export declare class PatternValidator implements Validator, OnChanges {
     pattern: string;
     ngOnChanges(changes: SimpleChanges): void;
-    registerOnChange(fn: () => void): void;
+    registerOnValidatorChange(fn: () => void): void;
     validate(c: AbstractControl): {
         [key: string]: any;
     };
@@ -446,7 +446,7 @@ export declare class ReactiveFormsModule {
 /** @stable */
 export declare class RequiredValidator implements Validator {
     required: boolean;
-    registerOnChange(fn: () => void): void;
+    registerOnValidatorChange(fn: () => void): void;
     validate(c: AbstractControl): {
         [key: string]: any;
     };
@@ -478,7 +478,7 @@ export declare class SelectMultipleControlValueAccessor implements ControlValueA
 
 /** @stable */
 export interface Validator {
-    registerOnChange?(fn: () => void): void;
+    registerOnValidatorChange?(fn: () => void): void;
     validate(c: AbstractControl): {
         [key: string]: any;
     };


### PR DESCRIPTION
The optional `registerOnChange()` function introduced in RC.6 for built-in validator directives has a naming conflict with `ControlValueAccessor`'s `registerOnChange()` if they are used on the same component class.  This PR fixes the naming conflict so they can be used together.

Closes #11479.
