### PR TITLE
fix(compiler): don't convert undefined to null literals

### DIFF
--- a/modules/@angular/compiler/src/output/abstract_emitter.ts
+++ b/modules/@angular/compiler/src/output/abstract_emitter.ts
@@ -250,13 +250,11 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     ctx.print(`)`);
     return null;
   }
-  visitLiteralExpr(ast: o.LiteralExpr, ctx: EmitterVisitorContext, absentValue: string = 'null'):
-      any {
-    var value = ast.value;
+
+  visitLiteralExpr(ast: o.LiteralExpr, ctx: EmitterVisitorContext): any {
+    const value = ast.value;
     if (typeof value === 'string') {
       ctx.print(escapeIdentifier(value, this._escapeDollarInStrings));
-    } else if (isBlank(value)) {
-      ctx.print(absentValue);
     } else {
       ctx.print(`${value}`);
     }

--- a/modules/@angular/compiler/src/output/ts_emitter.ts
+++ b/modules/@angular/compiler/src/output/ts_emitter.ts
@@ -68,7 +68,12 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
   }
 
   visitLiteralExpr(ast: o.LiteralExpr, ctx: EmitterVisitorContext): any {
-    super.visitLiteralExpr(ast, ctx, '(null as any)');
+    const value = ast.value;
+    if (isBlank(value)) {
+      ctx.print(`(${value} as any)`);
+      return null;
+    }
+    return super.visitLiteralExpr(ast, ctx);
   }
 
 

--- a/modules/@angular/compiler/test/output/js_emitter_spec.ts
+++ b/modules/@angular/compiler/test/output/js_emitter_spec.ts
@@ -105,6 +105,11 @@ export function main() {
       expect(emitStmt(o.literalMap([['someKey', o.literal(1)]]).toStmt())).toEqual(`{someKey: 1};`);
     });
 
+    it('should support blank literals', () => {
+      expect(emitStmt(o.literal(null).toStmt())).toEqual('null;');
+      expect(emitStmt(o.literal(undefined).toStmt())).toEqual('undefined;');
+    });
+
     it('should support external identifiers', () => {
       expect(emitStmt(o.importExpr(sameModuleIdentifier).toStmt())).toEqual('someLocalId;');
       expect(emitStmt(o.importExpr(externalModuleIdentifier).toStmt())).toEqual([

--- a/modules/@angular/compiler/test/output/ts_emitter_spec.ts
+++ b/modules/@angular/compiler/test/output/ts_emitter_spec.ts
@@ -107,6 +107,11 @@ export function main() {
       expect(emitStmt(o.literalMap([['someKey', o.literal(1)]]).toStmt())).toEqual(`{someKey: 1};`);
     });
 
+    it('should support blank literals', () => {
+      expect(emitStmt(o.literal(null).toStmt())).toEqual('(null as any);');
+      expect(emitStmt(o.literal(undefined).toStmt())).toEqual('(undefined as any);');
+    });
+
     it('should support external identifiers', () => {
       expect(emitStmt(o.importExpr(sameModuleIdentifier).toStmt())).toEqual('someLocalId;');
       expect(emitStmt(o.importExpr(externalModuleIdentifier).toStmt())).toEqual([

--- a/modules/@angular/core/test/linker/integration_spec.ts
+++ b/modules/@angular/core/test/linker/integration_spec.ts
@@ -61,6 +61,15 @@ function declareTests({useJit}: {useJit: boolean}) {
         expect(fixture.nativeElement).toHaveText('');
       });
 
+      it('should allow both null and undefined in expressions', () => {
+        const template = '<div>{{null == undefined}}|{{null === undefined}}</div>';
+        const fixture = TestBed.configureTestingModule({declarations: [MyComp]})
+                            .overrideComponent(MyComp, {set: {template}})
+                            .createComponent(MyComp);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveText('true|false');
+      });
+
       it('should consume element binding changes', () => {
         TestBed.configureTestingModule({declarations: [MyComp]});
         const template = '<div [id]="ctxProp"></div>';


### PR DESCRIPTION
Fixes #11493
