### PR TITLE
fix(forms): support dots in control names in contains()

### DIFF
--- a/modules/@angular/forms/src/model.ts
+++ b/modules/@angular/forms/src/model.ts
@@ -626,8 +626,7 @@ export class FormGroup extends AbstractControl {
    * Check whether there is a control with the given name in the group.
    */
   contains(controlName: string): boolean {
-    const c = StringMapWrapper.contains(this.controls, controlName);
-    return c && this.get(controlName).enabled;
+    return this.controls.hasOwnProperty(controlName) && this.controls[controlName].enabled;
   }
 
   setValue(value: {[key: string]: any}, {onlySelf}: {onlySelf?: boolean} = {}): void {

--- a/modules/@angular/forms/test/form_group_spec.ts
+++ b/modules/@angular/forms/test/form_group_spec.ts
@@ -569,6 +569,13 @@ export function main() {
 
         expect(group.contains('optional')).toEqual(true);
       });
+
+      it('should support controls with dots in their name', () => {
+        expect(group.contains('some.name')).toBe(false);
+        group.addControl('some.name', new FormControl());
+
+        expect(group.contains('some.name')).toBe(true);
+      });
     });
 
 


### PR DESCRIPTION
`contains()` should not fail for control names with dots. Closes https://github.com/angular/angular/issues/11535.
