### PR TITLE
docs(readme): fixed visual of browserstack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Downloads](http://img.shields.io/npm/dm/angular2.svg)](https://npmjs.org/package/angular2)
 
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/angular2-ci.svg)](https://saucelabs.com/u/angular2-ci)  
-*Safari (7+), iOS (7+), Edge (14) and IE mobile (11) are tested on [BrowserStack][https://www.browserstack.com/].*
+*Safari (7+), iOS (7+), Edge (14) and IE mobile (11) are tested on [BrowserStack][browserstack].*
 
 Angular
 =========
@@ -29,7 +29,7 @@ Angular 2 is currently in **Release Candidate**.
 Want to file a bug, contribute some code, or improve documentation? Excellent! Read up on our
 guidelines for [contributing][contributing] and then check out one of our issues in the [hotlist: community-help](https://github.com/angular/angular/labels/hotlist%3A%20community-help).
 
-
+[browserstack]: https://www.browserstack.com/
 [contributing]: http://github.com/angular/angular/blob/master/CONTRIBUTING.md
 [dart]: http://www.dartlang.org
 [dartium]: http://www.dartlang.org/tools/dartium


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x ] Other... Please describe: readme fix
```

**What is the current behavior?** (You can also link to an open issue here)
It shows the "BrowserStack" text and next to it the link

**What is the new behavior?**
It will show the text "BrowserStack" in blue and link to the website

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Instead of using a variable for the link of browserstack it was using the direct https link.
That caused to show the text and the link (incorrect markdown).
Moved the https link to the bottom with the other link assignments. It will now only show the blue text with the link to the browserstack.
