### PR TITLE
feat(benchpress): add support for WebdriverIO

### DIFF
--- a/modules/@angular/benchpress/index.ts
+++ b/modules/@angular/benchpress/index.ts
@@ -32,3 +32,4 @@ export {ChromeDriverExtension} from './src/webdriver/chrome_driver_extension';
 export {FirefoxDriverExtension} from './src/webdriver/firefox_driver_extension';
 export {IOsDriverExtension} from './src/webdriver/ios_driver_extension';
 export {SeleniumWebDriverAdapter} from './src/webdriver/selenium_webdriver_adapter';
+export {WebdriverIOAdapter} from './src/webdriver/webdriverio_adapter';

--- a/modules/@angular/benchpress/src/webdriver/webdriverio_adapter.ts
+++ b/modules/@angular/benchpress/src/webdriver/webdriverio_adapter.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {WebDriverAdapter} from '../web_driver_adapter';
+
+/**
+ * Adapter for WebdriverIO.
+ */
+export class WebdriverIOAdapter extends WebDriverAdapter {
+  isTestrunner: boolean;
+
+  static WEBDRIVERIO_PROVIDERS = [
+    {provide: WebDriverAdapter, useFactory: () => new WebdriverIOAdapter((<any>global).browser)}
+  ];
+
+  constructor(private _driver: any) {
+    super();
+    this.isTestrunner = Boolean(_driver.options.isWDIO);
+  }
+
+  waitFor(callback: () => any): Promise<any> {
+    /**
+     * execute synchronous with wdio testrunner
+     * wdioSync is a global function that gets registered by wdio-sync, see
+     * (https://github.com/webdriverio/wdio-sync/blob/master/index.js#L123-L138)
+     */
+    if (this.isTestrunner) {
+      return new Promise((resolve) => (<any>global).wdioSync(callback, resolve)());
+    }
+
+    return callback();
+  }
+
+  executeScript(script: string): Promise<any> {
+    const res = this._driver.execute(script);
+
+    /**
+     * handle command asynchronously if in standalone mode or after loosing fibers context
+     */
+    if (typeof res.then === 'function') {
+      return res.then((response: any) => response.value);
+    }
+
+    return new Promise((resolve) => resolve(res.value));
+  }
+
+  executeAsyncScript(script: string): Promise<any> {
+    const res = this._driver.executeAsync(script);
+
+    /**
+     * handle command asynchronously if in standalone mode or after loosing fibers context
+     */
+    if (typeof res.then === 'function') {
+      return res.then((response: any) => response.value);
+    }
+
+    return new Promise((resolve: any) => resolve(res.value));
+  }
+
+  capabilities(): Promise<any> {
+    return new Promise((resolve) => resolve(this._driver.desiredCapabilities));
+  }
+
+  /**
+   * is executed not in the same eventloop and therefor looses fiber context
+   * if testrunner is used
+   */
+  logs(type: string): Promise<any> {
+    return this._driver.log(type).then((response: any) => response.value);
+  }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
  (couldn't find integration tests for adapter)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Feature
```

**What is the current behavior?** (You can also link to an open issue here)

Benchpress does not support WebdriverIO as Webdriver client.

**What is the new behavior?**

This patch adds a new adapter to support WebdriverIO (http://webdriver.io) clients either in standalone mode or running the testrunner. This will allow to build simple services around benchpress that simplifies the way how developer integrate performance tests in their suites (e.g. providing an `it.perf(...)` construct.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:
A reference implementation can be found [here](https://github.com/webdriverio/benchpress-tree).
