### PR TITLE
fix(common): fix ngOnChanges signature of NgTemplateOutlet directive

### DIFF
--- a/modules/@angular/common/src/directives/ng_template_outlet.ts
+++ b/modules/@angular/common/src/directives/ng_template_outlet.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, EmbeddedViewRef, Input, OnChanges, TemplateRef, ViewContainerRef} from '@angular/core';
+import {Directive, EmbeddedViewRef, Input, OnChanges, SimpleChanges, TemplateRef, ViewContainerRef} from '@angular/core';
 
 /**
  * @ngModule CommonModule
@@ -44,7 +44,7 @@ export class NgTemplateOutlet implements OnChanges {
   @Input()
   set ngTemplateOutlet(templateRef: TemplateRef<Object>) { this._templateRef = templateRef; }
 
-  ngOnChanges() {
+  ngOnChanges(changes: SimpleChanges) {
     if (this._viewRef) {
       this._viewContainerRef.remove(this._viewContainerRef.indexOf(this._viewRef));
     }

--- a/tools/public_api_guard/common/index.d.ts
+++ b/tools/public_api_guard/common/index.d.ts
@@ -181,7 +181,7 @@ export declare class NgTemplateOutlet implements OnChanges {
     ngOutletContext: Object;
     ngTemplateOutlet: TemplateRef<Object>;
     constructor(_viewContainerRef: ViewContainerRef);
-    ngOnChanges(): void;
+    ngOnChanges(changes: SimpleChanges): void;
 }
 
 /** @stable */


### PR DESCRIPTION
When a component uses the NgTemplateOutlet, ngc generates code like the following in the factory:

```
...
detectChangesInternal(throwOnChange:boolean):void {
...
  if ((changes !== (null as any))) { this._NgTemplateOutlet_2_6.ngOnChanges(changes); }
...
}
...
```

Due to bad signature, compiling the factory then raises errors like:
`mycomponent.ngfactory.ts(272,40): error TS2346: Supplied parameters do not match any signature of call target`
