### PR TITLE
docs(injector): API docs - remove lone code-block backticks

### DIFF
--- a/modules/@angular/core/src/di/injector.ts
+++ b/modules/@angular/core/src/di/injector.ts
@@ -51,7 +51,6 @@ export abstract class Injector {
    * - Throws {@link NoProviderError} if no `notFoundValue` that is not equal to
    * Injector.THROW_IF_NOT_FOUND is given
    * - Returns the `notFoundValue` otherwise
-   * ```
    */
   get(token: any, notFoundValue?: any): any { return unimplemented(); }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Docs have been added / updated (for bug fixes / features)

**API doc cleanup**:

The triple backticks in the markdown of the API entry are unbalanced.
