### PR TITLE
docs(animation): add plunker for sequence

### DIFF
--- a/modules/@angular/core/src/animation/metadata.ts
+++ b/modules/@angular/core/src/animation/metadata.ts
@@ -266,7 +266,7 @@ export function group(steps: AnimationMetadata[]): AnimationGroupMetadata {
  * ])
  * ```
  *
- * ### Example ([live demo](http://plnkr.co/edit/Kez8XGWBxWue7qP7nNvF?p=preview))
+ * {@liveExample core/animation/ts/dsl embedded}
  *
  * {@example core/animation/ts/dsl/animation_example.ts region='Component'}
  *


### PR DESCRIPTION
This is the companion PR for https://github.com/angular/angular.io/pull/2425

We can remove all the hardcoded plunker links in the API docs with the new `{@liveExample}` tag.

We can do:

```
{@liveExample core/animation/ts/dsl}
```

![](https://puu.sh/riii3/d376571534.png)

---

Embedded mode

```
{@liveExample core/animation/ts/dsl embedded}
```

Closed:

![](https://puu.sh/riim3/c1e189b17d.png)

Opened:

![](https://puu.sh/riinz/ae4acdfa40.png)

---

Not hidden but behind an img:

```
{@liveExample core/animation/ts/dsl embedded -img="devguide/ngmodule/final-plunker.png"}
```

![](https://puu.sh/riiLv/a96ed35126.png)
