### PR TITLE
fixing debug-renderer to accept non-array nodes

### DIFF
--- a/modules/@angular/core/src/debug/debug_renderer.ts
+++ b/modules/@angular/core/src/debug/debug_renderer.ts
@@ -60,7 +60,9 @@ export class DebugDomRenderer implements Renderer {
     var debugParent = getDebugNode(parentElement);
     if (isPresent(debugParent) && debugParent instanceof DebugElement) {
       let debugElement = debugParent;
-      nodes.forEach((node) => { debugElement.addChild(getDebugNode(node)); });
+      for (var i = 0; i < nodes.length; i++) {
+        debugElement.addChild(getDebugNode(nodes[i]));
+      }
     }
     this._delegate.projectNodes(parentElement, nodes);
   }
@@ -71,7 +73,9 @@ export class DebugDomRenderer implements Renderer {
       var debugParent = debugNode.parent;
       if (viewRootNodes.length > 0 && isPresent(debugParent)) {
         var debugViewRootNodes: DebugNode[] = [];
-        viewRootNodes.forEach((rootNode) => debugViewRootNodes.push(getDebugNode(rootNode)));
+        for (var i = 0; i < viewRootNodes.length; i++) {
+          debugViewRootNodes.push(getDebugNode(viewRootNodes[i]));
+        }
         debugParent.insertChildrenAfter(debugNode, debugViewRootNodes);
       }
     }
@@ -79,17 +83,19 @@ export class DebugDomRenderer implements Renderer {
   }
 
   detachView(viewRootNodes: any[]) {
-    viewRootNodes.forEach((node) => {
-      var debugNode = getDebugNode(node);
+    for (var i = 0; i < viewRootNodes.length; i++) {
+      var debugNode = getDebugNode(viewRootNodes[i]);
       if (isPresent(debugNode) && isPresent(debugNode.parent)) {
         debugNode.parent.removeChild(debugNode);
       }
-    });
+    }
     this._delegate.detachView(viewRootNodes);
   }
 
   destroyView(hostElement: any, viewAllNodes: any[]) {
-    viewAllNodes.forEach((node) => { removeDebugNodeFromIndex(getDebugNode(node)); });
+    for (var i = 0; i < viewAllNodes.length; i++) {
+      removeDebugNodeFromIndex(getDebugNode(viewAllNodes[i]));
+    }
     this._delegate.destroyView(hostElement, viewAllNodes);
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
If we call `renderer.detachView(element.children)`, this will give an error while it should be valid. The reason that it gave error is that `element.children` does not have `forEach` function.

The workaround before this fix would be as follows:
`renderer.detachView(Array.prototype.slice.apply(element.children))`
This essentially forcefully create a proper array from `element.children`.

**What is the new behavior?**
The new behavior is that `renderer.detachView` and `renderer.attachViewAfter` could accept an array of nodes without needing `forEach`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
