### PR TITLE
Fix(http): invalidStateError if response body without content

### DIFF
--- a/modules/@angular/http/src/backends/xhr_backend.ts
+++ b/modules/@angular/http/src/backends/xhr_backend.ts
@@ -54,9 +54,8 @@ export class XHRConnection implements Connection {
       let onLoad = () => {
         // responseText is the old-school way of retrieving response (supported by IE8 & 9)
         // response/responseType properties were introduced in ResourceLoader Level2 spec (supported
-        // by
-        // IE10)
-        let body = isPresent(_xhr.response) ? _xhr.response : _xhr.responseText;
+        // by IE10)
+        let body = _xhr.response === undefined ? _xhr.responseText : _xhr.response;
         // Implicitly strip a potential XSSI prefix.
         if (isString(body)) body = body.replace(XSSI_PREFIX, '');
         let headers = Headers.fromResponseHeaderString(_xhr.getAllResponseHeaders());

--- a/modules/@angular/http/test/backends/xhr_backend_spec.ts
+++ b/modules/@angular/http/test/backends/xhr_backend_spec.ts
@@ -686,6 +686,23 @@ Connection: keep-alive`;
            existingXHRs[0].setStatusCode(statusCode);
            existingXHRs[0].dispatchEvent('load');
          }));
+
+      it('should not throw invalidStateError if response without body and responseType not equal to text',
+         inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+           const base = new BaseRequestOptions();
+           const connection = new XHRConnection(
+               new Request(
+                   base.merge(new RequestOptions({responseType: ResponseContentType.Json}))),
+               new MockBrowserXHR());
+
+           connection.response.subscribe((res: Response) => {
+             expect(res.json()).toBe(null);
+             async.done();
+           });
+
+           existingXHRs[0].setStatusCode(204);
+           existingXHRs[0].dispatchEvent('load');
+         }));
     });
   });
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

If the responseType has been specified and other than 'text', responseText throw an InvalidStateError exception.
See XHR doc => https://xhr.spec.whatwg.org/#the-responsetext-attribute

**What is the new behavior?**

When responseType is empty or equals to 'text', body take responseText also take null. Avoid access to responseText property and the throw of the invalidStateError exception.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
