### PR TITLE
feat(i18n): allow date pipe format with intl options

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,6 +67,7 @@ const publicApiArgs = [
   '--allowModuleIdentifiers', 'jasmine',
   '--allowModuleIdentifiers', 'protractor',
   '--allowModuleIdentifiers', 'angular',
+  '--allowModuleIdentifiers', 'Intl',
   '--onStabilityMissing', 'error',
 ].concat(entrypoints);
 

--- a/modules/@angular/common/test/pipes/date_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/date_pipe_spec.ts
@@ -96,6 +96,8 @@ export function main() {
         if (!browserDetection.isEdge && !browserDetection.isIE ||
             !browserDetection.supportsNativeIntlApi) {
           expect(pipe.transform(date, 'ms')).toEqual('31');
+          expect(pipe.transform(date, {day: 'numeric', month: 'short', weekday: 'short'}))
+              .toEqual('Mon, Jun 15');
         }
         if (!browserDetection.isOldChrome) {
           expect(pipe.transform(date, 'jm')).toEqual('9:03 AM');

--- a/modules/@angular/facade/src/intl.ts
+++ b/modules/@angular/facade/src/intl.ts
@@ -236,4 +236,7 @@ export class DateFormatter {
   static format(date: Date, locale: string, pattern: string): string {
     return dateFormatter(pattern, date, locale);
   }
+  static intlFormat(date: Date, locale: string, format: Intl.DateTimeFormatOptions) {
+    return new Intl.DateTimeFormat(locale, format).format(date);
+  }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Date pipe only allow `string` mask formatting

**What is the new behavior?**

Date pipe allow to format with a `Intl.DateTimeFormatOptions` object

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

closes #11661
