### PR TITLE
fix(compiler): properly type `forwardRef` and `resolveForwardRef`

### DIFF
--- a/packages/core/src/di/provider.ts
+++ b/packages/core/src/di/provider.ts
@@ -7,6 +7,7 @@
  */
 
 import {Type} from '../type';
+import {ForwardRefFn} from './forward_ref';
 
 /**
  * @whatItDoes Configures the {@link Injector} to return an instance of `Type` when `Type' is used
@@ -103,7 +104,7 @@ export interface ClassProvider {
   /**
    * Class to instantiate for the `token`.
    */
-  useClass: Type<any>;
+  useClass: Type<any>|ForwardRefFn<any>;
 
   /**
    * If true, then injector returns an array of instances. This is useful to allow multiple
@@ -216,5 +217,5 @@ export interface FactoryProvider {
  *
  * @stable
  */
-export type Provider =
-    TypeProvider | ValueProvider | ClassProvider | ExistingProvider | FactoryProvider | any[];
+export type Provider = TypeProvider | ValueProvider | ClassProvider | ExistingProvider |
+    FactoryProvider | ForwardRefFn<any>| any[];

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Provider} from '../di';
+import {ForwardRefFn, Provider} from '../di';
 import {Type} from '../type';
 import {TypeDecorator, makeDecorator} from '../util/decorators';
+
 
 /**
  * A wrapper around a module that also includes the providers.
@@ -112,7 +113,7 @@ export interface NgModule {
    * }
    * ```
    */
-  declarations?: Array<Type<any>|any[]>;
+  declarations?: Array<Type<any>|ForwardRefFn<any>|any[]>;
 
   /**
    * Specifies a list of modules whose exported directives/pipes
@@ -129,7 +130,7 @@ export interface NgModule {
    * }
    * ```
    */
-  imports?: Array<Type<any>|ModuleWithProviders|any[]>;
+  imports?: Array<Type<any>|ModuleWithProviders|ForwardRefFn<any>|any[]>;
 
   /**
    * Specifies a list of directives/pipes/modules that can be used within the template
@@ -146,7 +147,7 @@ export interface NgModule {
    * }
    * ```
    */
-  exports?: Array<Type<any>|any[]>;
+  exports?: Array<Type<any>|ForwardRefFn<any>|any[]>;
 
   /**
    * Specifies a list of components that should be compiled when this module is defined.

--- a/packages/upgrade/src/dynamic/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_adapter.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Compiler, CompilerOptions, Directive, Injector, NgModule, NgModuleRef, NgZone, Provider, Testability, Type} from '@angular/core';
+import {Compiler, CompilerOptions, Directive, ForwardRefFn, Injector, NgModule, NgModuleRef, NgZone, Provider, Testability, Type} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
 import * as angular from '../common/angular1';
@@ -116,7 +116,9 @@ export class UpgradeAdapter {
   private moduleRef: NgModuleRef<any>|null = null;
   private ng2BootstrapDeferred: Deferred<angular.IInjectorService>;
 
-  constructor(private ng2AppModule: Type<any>, private compilerOptions?: CompilerOptions) {
+  constructor(
+      private ng2AppModule: Type<any>|ForwardRefFn<Type<any>>,
+      private compilerOptions?: CompilerOptions) {
     if (!ng2AppModule) {
       throw new Error(
           'UpgradeAdapter cannot be instantiated without an NgModule of the Angular app.');

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -178,7 +178,7 @@ export declare type ClassDefinition = {
 export interface ClassProvider {
     multi?: boolean;
     provide: any;
-    useClass: Type<any>;
+    useClass: Type<any> | ForwardRefFn<any>;
 }
 
 /** @deprecated */
@@ -421,11 +421,12 @@ export interface FactoryProvider {
 }
 
 /** @experimental */
-export declare function forwardRef(forwardRefFn: ForwardRefFn): Type<any>;
+export declare function forwardRef<T>(typeFactory: () => T): ForwardRefFn<T>;
 
 /** @experimental */
-export interface ForwardRefFn {
-    (): any;
+export interface ForwardRefFn<T> {
+    __forward_ref__: Function;
+    (): T;
 }
 
 /** @experimental */
@@ -731,7 +732,7 @@ export interface Predicate<T> {
 }
 
 /** @stable */
-export declare type Provider = TypeProvider | ValueProvider | ClassProvider | ExistingProvider | FactoryProvider | any[];
+export declare type Provider = TypeProvider | ValueProvider | ClassProvider | ExistingProvider | FactoryProvider | ForwardRefFn<any> | any[];
 
 /** @stable */
 export declare abstract class Query {
@@ -882,7 +883,7 @@ export interface ResolvedReflectiveProvider {
 }
 
 /** @experimental */
-export declare function resolveForwardRef(type: any): any;
+export declare function resolveForwardRef<T>(type: T | ForwardRefFn<T>): T;
 
 /** @deprecated */
 export declare abstract class RootRenderer {

--- a/tools/public_api_guard/upgrade/upgrade.d.ts
+++ b/tools/public_api_guard/upgrade/upgrade.d.ts
@@ -1,6 +1,6 @@
 /** @stable */
 export declare class UpgradeAdapter {
-    constructor(ng2AppModule: Type<any>, compilerOptions?: CompilerOptions);
+    constructor(ng2AppModule: Type<any> | ForwardRefFn<Type<any>>, compilerOptions?: CompilerOptions);
     bootstrap(element: Element, modules?: any[], config?: angular.IAngularBootstrapConfig): UpgradeAdapterRef;
     downgradeNg2Component(component: Type<any>): Function;
     downgradeNg2Provider(token: any): Function;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
#11638

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Makes `forwardRef` and `resolveForwardRef` return more meaningful  types. Now when resolving a forward reference, TypeScript knows what type the returned reference is.

Closes #11638
