### PR TITLE
fix(compiler): Do not embed templateUrl in view factories in non-debug mode

### DIFF
--- a/modules/@angular/compiler/src/view_compiler/view_builder.ts
+++ b/modules/@angular/compiler/src/view_compiler/view_builder.ts
@@ -513,18 +513,19 @@ function createViewFactory(
   }
   if (view.viewIndex === 0) {
     var animationsExpr = o.literalMap(view.animations.map(entry => [entry.name, entry.fnExp]));
-    initRenderCompTypeStmts = [new o.IfStmt(renderCompTypeVar.identical(o.NULL_EXPR), [
-      renderCompTypeVar
-          .set(ViewConstructorVars.viewUtils.callMethod(
-              'createRenderComponentType',
-              [
-                o.literal(templateUrlInfo),
-                o.literal(view.component.template.ngContentSelectors.length),
-                ViewEncapsulationEnum.fromValue(view.component.template.encapsulation), view.styles,
-                animationsExpr
-              ]))
-          .toStmt()
-    ])];
+    initRenderCompTypeStmts = [new o.IfStmt(
+        renderCompTypeVar.identical(o.NULL_EXPR),
+        [renderCompTypeVar
+             .set(ViewConstructorVars.viewUtils.callMethod(
+                 'createRenderComponentType',
+                 [
+                   view.genConfig.genDebugInfo ? o.literal(templateUrlInfo) : o.literal(''),
+                   o.literal(view.component.template.ngContentSelectors.length),
+                   ViewEncapsulationEnum.fromValue(view.component.template.encapsulation),
+                   view.styles,
+                   animationsExpr,
+                 ]))
+             .toStmt()])];
   }
   return o
       .fn(viewFactoryArgs, initRenderCompTypeStmts.concat([new o.ReturnStatement(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
In prod(non-debug) mode the template URL is being embedded in the factories generated by the AOT  compiler.

**What is the new behavior?**
Template URL is output in the factories only in debug mode.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```

Fixes #11117.
