### PR TITLE
fix(router): inherit resolved data on child route change

### DIFF
--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -843,6 +843,13 @@ export class PreActivation {
     return map.call(this.resolveNode(resolve.current, future), (resolvedData: any): any => {
       resolve.resolvedData = resolvedData;
       future.data = merge(future.data, resolve.flattenedResolvedData);
+      if (future.parent && future.parent.data) {
+        resolve.flattenedAttributes
+            .filter(
+                attrib =>
+                    future.data[attrib] === undefined && future.parent.data[attrib] !== undefined)
+            .forEach(attrib => future.data[attrib] = future.parent.data[attrib]);
+      }
       return null;
     });
   }

--- a/modules/@angular/router/src/router_state.ts
+++ b/modules/@angular/router/src/router_state.ts
@@ -223,6 +223,19 @@ export class InheritedResolve {
                          this.resolvedData;
   }
 
+  /**
+   * Gets the names of all resolved attributes
+   * @internal
+   */
+  get flattenedAttributes(): string[] {
+    let keys = Object.keys(this.current);
+    if (this.parent) {
+      keys = keys.concat(
+          this.parent.flattenedAttributes.filter(attrib => keys.indexOf(attrib) === -1));
+    }
+    return keys;
+  }
+
   static get empty(): InheritedResolve { return new InheritedResolve(null, {}); }
 }
 

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -627,6 +627,33 @@ describe('Integration', () => {
            {one: 1, five: 5, two: 2, six: 6}, {one: 1, five: 5, two: 2, six: 6}
          ]);
        })));
+
+    it('should inherit resolved data',
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = createRoot(router, RootCmpWithTwoOutlets);
+
+         router.resetConfig([{
+           path: 'parent/:id',
+           data: {one: 1},
+           resolve: {two: 'resolveTwo'},
+           children: [
+             {path: 'a', data: {three: 3}, resolve: {four: 'resolveFour'}, component: RouteCmp}, {
+               path: 'b',
+               data: {five: 5},
+               resolve: {six: 'resolveSix'},
+               component: RouteCmp,
+             }
+           ]
+         }]);
+
+         router.navigateByUrl('/parent/1/a');
+         advance(fixture);
+         router.navigateByUrl('/parent/1/b');
+         advance(fixture);
+
+         const primaryCmp = fixture.debugElement.children[1].componentInstance;
+         expect(primaryCmp.route.data.getValue()).toEqual({one: 1, two: 2, five: 5, six: 6});
+       })));
   });
 
   describe('router links', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The router state inherits the data for componentless nodes to child nodes. The resolved data is added when the route is activated.
If the parent route is already active, the "flattenedResolvedData" for this route is empty -> the changed child route tries to inherit an empty object. 
Because of this, the child route can not access the previous resolved data.

**What is the new behavior?**
After a child route is resolved it checks which attributes should be resolved (flattenedAttributes). All these attributes are copied in to the current data set from the parent data set (if not already existent).

Now the child route can access the resolved data.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
