### PR TITLE
fix: offline compiler should consider any "shim" file as generated

### DIFF
--- a/modules/@angular/compiler-cli/src/reflector_host.ts
+++ b/modules/@angular/compiler-cli/src/reflector_host.ts
@@ -17,7 +17,7 @@ import {StaticReflectorHost, StaticSymbol} from './static_reflector';
 const EXT = /(\.ts|\.d\.ts|\.js|\.jsx|\.tsx)$/;
 const DTS = /\.d\.ts$/;
 const NODE_MODULES = '/node_modules/';
-const IS_GENERATED = /\.(ngfactory|css(\.shim)?)$/;
+const IS_GENERATED = /\.(ngfactory|css|shim)$/;
 
 export interface ReflectorHostContext {
   fileExists(fileName: string): boolean;


### PR DESCRIPTION
Right now, if a URL contains doesn't contain `css` for the style shim, the `getImportPath()` return the path relative to the original component's module. This behaviour is incorrect for resources in the CLI because they can have a different extension.
