### PR TITLE
(docs): removing `addProvider` from `UpgradeAdapter`

### DIFF
--- a/modules/@angular/upgrade/src/upgrade_adapter.ts
+++ b/modules/@angular/upgrade/src/upgrade_adapter.ts
@@ -480,7 +480,6 @@ export class UpgradeAdapter {
    * var adapter = new UpgradeAdapter();
    * adapter.upgradeNg1Provider('server');
    * adapter.upgradeNg1Provider('login', {asToken: Login});
-   * adapter.addProvider(Example);
    *
    * adapter.bootstrap(document.body, ['myExample']).ready((ref) => {
    *   var example: Example = ref.ng2Injector.get(Example);
@@ -508,7 +507,6 @@ export class UpgradeAdapter {
    * }
    *
    * var adapter = new UpgradeAdapter();
-   * adapter.addProvider(Example);
    *
    * var module = angular.module('myExample', []);
    * module.factory('example', adapter.downgradeNg2Provider(Example));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other... Please describe: Docs

**Details**
The `addProvider` function in the `UpgradeAdapter` was deprecated in this [commit](https://github.com/angular/angular/commit/d21331e902341abe3fdec267d0acae223c801c52#diff-77163e956a7842149f583846c1c01651) and has been removed in final. Given this, the documentation for downgrading ng2 providers for use in ng1 is invalid.
