### PR TITLE
docs(upgrade): rename undeclared `Ng2` to `Ng2Component`

### DIFF
--- a/modules/@angular/upgrade/src/upgrade_adapter.ts
+++ b/modules/@angular/upgrade/src/upgrade_adapter.ts
@@ -60,7 +60,7 @@ var upgradeCount: number = 0;
  * ```
  * var adapter = new UpgradeAdapter(forwardRef(() => MyNg2Module));
  * var module = angular.module('myExample', []);
- * module.directive('ng2Comp', adapter.downgradeNg2Component(Ng2));
+ * module.directive('ng2Comp', adapter.downgradeNg2Component(Ng2Component));
  *
  * module.directive('ng1Hello', function() {
  *   return {
@@ -237,17 +237,17 @@ export class UpgradeAdapter {
    *   };
    * });
    *
-   * module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+   * module.directive('ng2', adapter.downgradeNg2Component(Ng2Component));
    *
    * @Component({
    *   selector: 'ng2',
    *   template: 'ng2 template: <greet salutation="Hello" [name]="world">text</greet>'
    * })
-   * class Ng2 {
+   * class Ng2Component {
    * }
    *
    * @NgModule({
-   *   declarations: [Ng2, adapter.upgradeNg1Component('greet')],
+   *   declarations: [Ng2Component, adapter.upgradeNg1Component('greet')],
    *   imports: [BrowserModule]
    * })
    * class MyNg2Module {}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Docs

**Details**:
In the example, the code references the variable `Ng2` which is never defined. It can be inferred the author intended this to be `Ng2Component` variable.

Additionally, later on in the component it references `Ng2`. I went ahead and updated this to
`Ng2Component` too for consistency and naming best practices.
