### PR TITLE
refactor(routerLinkActive): optimised routerLinkActive active check code

### DIFF
--- a/modules/@angular/router/src/directives/router_link_active.ts
+++ b/modules/@angular/router/src/directives/router_link_active.ts
@@ -109,17 +109,18 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
   private update(): void {
     if (!this.links || !this.linksWithHrefs || !this.router.navigated) return;
 
-    const isActiveLinks = this.reduceList(this.links);
-    const isActiveLinksWithHrefs = this.reduceList(this.linksWithHrefs);
+    const isActive = this.hasActiveLink();
     this.classes.forEach(
-        c => this.renderer.setElementClass(
-            this.element.nativeElement, c, isActiveLinks || isActiveLinksWithHrefs));
+        c => this.renderer.setElementClass(this.element.nativeElement, c, isActive));
   }
 
-  private reduceList(q: QueryList<any>): boolean {
-    return q.reduce(
-        (res: boolean, link: any) =>
-            res || this.router.isActive(link.urlTree, this.routerLinkActiveOptions.exact),
-        false);
+  private isLinkActive(router: Router): (link: (RouterLink|RouterLinkWithHref)) => boolean {
+    return (link: RouterLink | RouterLinkWithHref) =>
+               router.isActive(link.urlTree, this.routerLinkActiveOptions.exact);
+  }
+
+  private hasActiveLink(): boolean {
+    return this.links.some(this.isLinkActive(this.router)) ||
+        this.linksWithHrefs.some(this.isLinkActive(this.router));
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] **N/A** Tests for the changes have been added (for bug fixes / features)
- [ ] **N/A** Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The RouterLinkActive directive currently iterates over the whole list of links, even is it has found an active link. This iteration is not necessary in this case. Furthermore it checks both RouterLinks and RouterLinkWithHrefs even if there is a RouterLink that is active.

**What is the new behavior?**

The iteration now breaks on finding an active RouterLink/RouterLinkWithHref saving iteration, and also doesn't check both arrays if the first array has an active link.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Modify routerLinkActive to optimise performance by removing unnecessary iteration. By replacing Array.reduce with Array.some, the loop will break when it finds an active link. Useful if used on the parent of a large group of routerLinks. Furthermore, if a RouterLink is active it will not check the RouterLinkWithHrefs.

Notes: 
- I have not added tests for this case as it is not relied upon behaviour and is purely an implementation detail.
- I have replaced a usage of Array#reduce with Array#some and have made sure that browser support for the method is high as it is part of the core-js ES6 polyfill.
