### PR TITLE
fix(UrlSearchParams): change a behavior when a param value is null or undefined

### DIFF
--- a/modules/@angular/http/src/url_search_params.ts
+++ b/modules/@angular/http/src/url_search_params.ts
@@ -102,6 +102,10 @@ export class URLSearchParams {
   getAll(param: string): string[] { return this.paramsMap.get(param) || []; }
 
   set(param: string, val: string) {
+    if (val === void 0 || val === null) {
+      this.delete(param);
+      return;
+    }
     const list = this.paramsMap.get(param) || [];
     list.length = 0;
     list.push(val);
@@ -124,6 +128,7 @@ export class URLSearchParams {
   }
 
   append(param: string, val: string): void {
+    if (val === void 0 || val === null) return;
     const list = this.paramsMap.get(param) || [];
     list.push(val);
     this.paramsMap.set(param, list);

--- a/modules/@angular/http/test/url_search_params_spec.ts
+++ b/modules/@angular/http/test/url_search_params_spec.ts
@@ -149,5 +149,23 @@ export function main() {
       expect(paramsC.toString()).toEqual('a=2&q=4%2B&c=8');
     });
 
+    it('should remove the parameter when set to undefined or null', () => {
+      const params = new URLSearchParams('q=Q');
+      params.set('q', undefined);
+      expect(params.has('q')).toBe(false);
+      expect(params.toString()).toEqual('');
+      params.set('q', null);
+      expect(params.has('q')).toBe(false);
+      expect(params.toString()).toEqual('');
+    });
+
+    it('should ignore the value when append undefined or null', () => {
+      const params = new URLSearchParams('q=Q');
+      params.append('q', undefined);
+      expect(params.toString()).toEqual('q=Q');
+      params.append('q', null);
+      expect(params.toString()).toEqual('q=Q');
+    });
+
   });
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
- [x] Bugfix

**What is the current behavior?**
Right now `search.set('foo', undefined)` leads to `?foo=undefined`. You can check such cases before `set` invocation, but that would be error prone. So right now almost every `reset form` action potentially leads to errors.

**What is the new behavior?**
`search.set('foo', undefined)` and  `search.set('foo', null)` WILL NOT store values in the map and the result query string WILL NOT contain `foo`. If there is already a param with the same key, it will be deleted. Also `search.has('foo')` will be falsy, because this and only this way stringification is fully reversible.

BUT: `.set('foo', '')` -> `foo=`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

Right now FF and Chrome has experimental builtin object URLSearchParams, which behaves differently (the behavior is the same as BEFORE this commit):

```
var s = new URLSearchParams('q=qq'); s.set('foo', undefined); console.log(s.toString());
// q=qq&foo=undefined
```

But I consider this is a bug. Because if it's not, the `toString` isn't a reversible process.
