### PR TITLE
fix(enableDebugTools): create AngularTools at ng.tools

### DIFF
--- a/modules/@angular/platform-browser/src/browser/tools/tools.ts
+++ b/modules/@angular/platform-browser/src/browser/tools/tools.ts
@@ -27,7 +27,7 @@ var context = <any>global;
  * @experimental All debugging apis are currently experimental.
  */
 export function enableDebugTools<T>(ref: ComponentRef<T>): ComponentRef<T> {
-  context.ng = new AngularTools(ref);
+  (<any>Object).assign(context.ng, new AngularTools(ref));
   return ref;
 }
 
@@ -37,5 +37,5 @@ export function enableDebugTools<T>(ref: ComponentRef<T>): ComponentRef<T> {
  * @experimental All debugging apis are currently experimental.
  */
 export function disableDebugTools(): void {
-  delete context.ng;
+  delete context.ng.profiler;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

`ng.probe` and `ng.coreTokens` are clobbered when you use `enableDebugTools` because the `AngularTools` class overwrites `context.ng` like this:

``````
```javascript
context.ng = new AngularTools(ref);
```
``````

Source: https://github.com/angular/angular/blob/master/modules/%40angular/platform-browser/src/browser/tools/tools.ts#L30

This means extensions like Augury no longer work because they use `ng.probe`.

More info: https://github.com/angular/angular/issues/12002

**What is the new behavior?**

`AngularTools` is now created at `context.ng.tools` so existing methods and properties on `ng.` are not affected.

This also allows `disableDebugTools` to remove the tools when required.

Unit tests and docs have been modified to incorporate this new location.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Fixes #12002
