### PR TITLE
docs(NgModule): Fixed docs for NgModule.entryComponents

### DIFF
--- a/modules/@angular/core/src/metadata/ng_module.ts
+++ b/modules/@angular/core/src/metadata/ng_module.ts
@@ -150,6 +150,8 @@ export interface NgModule {
 
   /**
    * Specifies a list of components that should be compiled when this module is defined.
+   * For each component listed here, Angular will create a {@link ComponentFactory}
+   * and store it in the {@link ComponentFactoryResolver}.
    */
   entryComponents?: Array<Type<any>|any[]>;
 

--- a/modules/@angular/core/src/metadata/ng_module.ts
+++ b/modules/@angular/core/src/metadata/ng_module.ts
@@ -29,7 +29,7 @@ export interface SchemaMetadata { name: string; }
 
 /**
  * Defines a schema that will allow:
- * - any non-angular elements with a `-` in their name,
+ * - any non-Angular elements with a `-` in their name,
  * - any properties on elements with a `-` in their name which is the common rule for custom
  * elements.
  *
@@ -132,9 +132,9 @@ export interface NgModule {
   imports?: Array<Type<any>|ModuleWithProviders|any[]>;
 
   /**
-   * Specifies a list of directives/pipes/module that can be used within the template
-   * of any component that is part of an angular module
-   * that imports this angular module.
+   * Specifies a list of directives/pipes/modules that can be used within the template
+   * of any component that is part of an Angular module
+   * that imports this Angular module.
    *
    * ### Example
    *
@@ -149,10 +149,9 @@ export interface NgModule {
   exports?: Array<Type<any>|any[]>;
 
   /**
-   * Defines the components that should be compiled as well when
-   * this component is defined. For each components listed here,
-   * Angular will create a {@link ComponentFactory ComponentFactory} and store it in the
-   * {@link ComponentFactoryResolver ComponentFactoryResolver}.
+   * Specifies a list of components that should be compiled when this module is defined.
+   * For each component listed here, Angular will create a {@link ComponentFactory ComponentFactory}
+   * and store it in the {@link ComponentFactoryResolver ComponentFactoryResolver}.
    */
   entryComponents?: Array<Type<any>|any[]>;
 
@@ -164,7 +163,7 @@ export interface NgModule {
   bootstrap?: Array<Type<any>|any[]>;
 
   /**
-   * Elements and properties that are not angular Components nor Directives have to be declared in
+   * Elements and properties that are not Angular components nor directives have to be declared in
    * the schema.
    *
    * Available schemas:
@@ -186,7 +185,7 @@ export interface NgModule {
 }
 
 /**
- * NgModule decorator and metadata
+ * NgModule decorator and metadata.
  *
  * @stable
  * @Annotation

--- a/modules/@angular/core/src/metadata/ng_module.ts
+++ b/modules/@angular/core/src/metadata/ng_module.ts
@@ -150,8 +150,6 @@ export interface NgModule {
 
   /**
    * Specifies a list of components that should be compiled when this module is defined.
-   * For each component listed here, Angular will create a {@link ComponentFactory ComponentFactory}
-   * and store it in the {@link ComponentFactoryResolver ComponentFactoryResolver}.
    */
   entryComponents?: Array<Type<any>|any[]>;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Docs fixes (NgModule)
```

**What is the current behavior?** (You can also link to an open issue here)

[Current documentation for the `NgModule` interface](https://angular.io/docs/ts/latest/api/core/index/NgModule-interface.html) states that its `entryComponents` field "Defines the components that should be compiled as well when this component is defined" - this has been copy-pasted from the deprecated `entryComponents` field on the `Component` decorator and is incorrect.

**What is the new behavior?**

The documentation for `entryComponents` has now been corrected to refer to modules instead. Additionally, minor fixes have been made to other pieces of documentation in this file to make the grammar more consistent.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
None
