### PR TITLE
fix: allow for null values in HTML select options bound with ngValue

### DIFF
--- a/modules/@angular/forms/src/directives/select_control_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/select_control_value_accessor.ts
@@ -116,8 +116,8 @@ export class SelectControlValueAccessor implements ControlValueAccessor {
 
   /** @internal */
   _getOptionValue(valueString: string): any {
-    let value = this._optionMap.get(_extractId(valueString));
-    return isPresent(value) ? value : valueString;
+    let key: string = _extractId(valueString);
+    return this._optionMap.has(key) ? this._optionMap.get(key) : valueString;
   }
 }
 

--- a/modules/@angular/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -122,8 +122,8 @@ export class SelectMultipleControlValueAccessor implements ControlValueAccessor 
 
   /** @internal */
   _getOptionValue(valueString: string): any {
-    let opt = this._optionMap.get(_extractId(valueString));
-    return isPresent(opt) ? opt._value : valueString;
+    let key: string = _extractId(valueString);
+    return this._optionMap.has(key) ? this._optionMap.get(key)._value : valueString;
   }
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Issue described here: #10349.

Using a value of "null" on a select option like so:

``` html
<option [ngValue]="null">[Unassigned]</option>
```

The value bound by ngModel is the string "{0: null}" instead of the object null.

**What is the new behavior?**
ngModel now binds the object "null" to the model.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

This corrects the case of <option [ngValue]="null"> binding a string like "{0: null}" to the model instead of an actual null object.

Closes #10349
