### PR TITLE
chore(benchpress): fix the license

### DIFF
--- a/modules/@angular/benchpress/README.md
+++ b/modules/@angular/benchpress/README.md
@@ -5,7 +5,7 @@ See [here for an example project](https://github.com/angular/benchpress-tree).
 
 The sources for this package are in the main [Angular2](https://github.com/angular/angular) repo. Please file issues and pull requests against that repo.
 
-License: Apache MIT 2.0
+License: MIT
 
 # Why?
 


### PR DESCRIPTION
It's not Apache MIT 2.0, that's a mishmash of Apache 2.0 and MIT
