### PR TITLE
fix(forms): properly validate blank strings with minlength

### DIFF
--- a/modules/@angular/forms/src/validators.ts
+++ b/modules/@angular/forms/src/validators.ts
@@ -70,10 +70,9 @@ export class Validators {
    */
   static minLength(minLength: number): ValidatorFn {
     return (control: AbstractControl): {[key: string]: any} => {
-      if (isPresent(Validators.required(control))) return null;
-      var v: string = control.value;
-      return v.length < minLength ?
-          {'minlength': {'requiredLength': minLength, 'actualLength': v.length}} :
+      const length = typeof control.value === 'string' ? control.value.length : 0;
+      return length < minLength ?
+          {'minlength': {'requiredLength': minLength, 'actualLength': length}} :
           null;
     };
   }
@@ -83,10 +82,9 @@ export class Validators {
    */
   static maxLength(maxLength: number): ValidatorFn {
     return (control: AbstractControl): {[key: string]: any} => {
-      if (isPresent(Validators.required(control))) return null;
-      var v: string = control.value;
-      return v.length > maxLength ?
-          {'maxlength': {'requiredLength': maxLength, 'actualLength': v.length}} :
+      const length = typeof control.value === 'string' ? control.value.length : 0;
+      return length > maxLength ?
+          {'maxlength': {'requiredLength': maxLength, 'actualLength': length}} :
           null;
     };
   }

--- a/modules/@angular/forms/test/validators_spec.ts
+++ b/modules/@angular/forms/test/validators_spec.ts
@@ -51,11 +51,23 @@ export function main() {
     });
 
     describe('minLength', () => {
-      it('should not error on an empty string',
-         () => { expect(Validators.minLength(2)(new FormControl(''))).toEqual(null); });
+      it('should error on an empty string', () => {
+        expect(Validators.minLength(2)(new FormControl(''))).toEqual({
+          'minlength': {'requiredLength': 2, 'actualLength': 0}
+        });
+      });
 
-      it('should not error on null',
-         () => { expect(Validators.minLength(2)(new FormControl(null))).toEqual(null); });
+      it('should error on null', () => {
+        expect(Validators.minLength(2)(new FormControl(null))).toEqual({
+          'minlength': {'requiredLength': 2, 'actualLength': 0}
+        });
+      });
+
+      it('should error on undefined', () => {
+        expect(Validators.minLength(2)(new FormControl(null))).toEqual({
+          'minlength': {'requiredLength': 2, 'actualLength': 0}
+        });
+      });
 
       it('should not error on valid strings',
          () => { expect(Validators.minLength(2)(new FormControl('aa'))).toEqual(null); });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x ] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

Blank values (`null`, `undefined`, `""`) would be marked as valid given `<input [(ngModel)]="name" [minlength]="2">`: https://plnkr.co/edit/tpl:AvJOMERrnz94ekVua0u5?p=preview

**What is the new behavior?**

Blank values (`null`, `undefined`, `""`) are properly recognized as invalid given `<input [(ngModel)]="name" [minlength]="2">

**Does this PR introduce a breaking change?** (check one with "x")

```
[n] No
```

**Other information**:

@kara @vsavkin this one is very similar to #11450
