### PR TITLE
refactor(compiler): module collector is reusable

### DIFF
--- a/modules/@angular/compiler-cli/src/static_reflector.ts
+++ b/modules/@angular/compiler-cli/src/static_reflector.ts
@@ -44,6 +44,8 @@ export interface StaticReflectorHost {
     animationMetadata: string,
     provider: string
   };
+
+  getCanonicalFileName(fileName: string): string;
 }
 
 /**

--- a/modules/@angular/compiler-cli/test/static_reflector_spec.ts
+++ b/modules/@angular/compiler-cli/test/static_reflector_spec.ts
@@ -450,6 +450,9 @@ class MockReflectorHost implements StaticReflectorHost {
       provider: 'angular2/src/core/di/provider'
     };
   }
+
+  getCanonicalFileName(fileName: string): string { return fileName; }
+
   getStaticSymbol(declarationFile: string, name: string, members?: string[]): StaticSymbol {
     var cacheKey = `${declarationFile}:${name}${members?'.'+members.join('.'):''}`;
     var result = this.staticTypeCache.get(cacheKey);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Refactoring (no functional changes, no api changes)
```

**What is the current behavior?** (You can also link to an open issue here)

Module collection is private behavior of the `CodeGenerator` class.

**What is the new behavior?**

Split module collection into a separate class so it can be used by the language service.
Fixed `CodeGenerator` to refer to the `StaticReflectorHost` abstraction instead of a concrete implementation.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
