### PR TITLE
docs(changelog): fix mentions, backticks and a misplaced line ending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,10 @@ Note: 2.1.0-rc.0 release also contains all the changes present in the 2.0.2 rele
 * **compiler:** support `[attr="value with space"]` ([bd012ef](https://github.com/angular/angular/commit/bd012ef)), closes [#6249](https://github.com/angular/angular/issues/6249)
 * **compiler:** support quoted attribute values ([7395400](https://github.com/angular/angular/commit/7395400)), closes [#6085](https://github.com/angular/angular/issues/6085)
 * **compiler:** fix `<x>` ctype names ([7578d85](https://github.com/angular/angular/commit/7578d85)), closes [#12000](https://github.com/angular/angular/issues/12000)
-* **compiler-cli:** allow ReflectorHost passed as argument to CodeGenerator#create ([#11951](https://github.com/angular/angular/issues/11951)) ([826c98e](https://github.com/angular/angular/co
+* **compiler-cli:** allow ReflectorHost passed as argument to CodeGenerator#create ([#11951](https://github.com/angular/angular/issues/11951)) ([826c98e](https://github.com/angular/angular/commit/826c98e))
 * **forms:** properly validate empty strings with patterns ([#11450](https://github.com/angular/angular/issues/11450)) ([e00de0c](https://github.com/angular/angular/commit/e00de0c))
 * **http:** preserve case of the first init, `set()` or `append()` ([#12023](https://github.com/angular/angular/issues/12023)) ([adb17fe](https://github.com/angular/angular/commit/adb17fe)), closes [#11624](https://github.com/angular/angular/issues/11624)
 * **http:** remove url params if provided value is null or undefined ([#11990](https://github.com/angular/angular/issues/11990)) ([9cc0a4e](https://github.com/angular/angular/commit/9cc0a4e))
-mmit/826c98e))
 * **router:** do not reset the router state when updating the component ([#11867](https://github.com/angular/angular/issues/11867)) ([cf750e1](https://github.com/angular/angular/commit/cf750e1))
 * **upgrade:** bind optional properties when upgrading from ng1 ([#11411](https://github.com/angular/angular/issues/11411)) ([0851238](https://github.com/angular/angular/commit/0851238)), closes [#10181](https://github.com/angular/angular/issues/10181)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * **compiler-cli:** allow ReflectorHost passed as argument to CodeGenerator#create ([#11951](https://github.com/angular/angular/issues/11951)) ([1564042](https://github.com/angular/angular/commit/1564042))
 * **compiler:** fix `:host(tag)` and `:host-context(tag)` ([a6bb84e](https://github.com/angular/angular/commit/a6bb84e)), closes [#11972](https://github.com/angular/angular/issues/11972)
 * **compiler:** fix attribute selectors in :host and :host-context ([#12056](https://github.com/angular/angular/issues/12056)) ([a633596](https://github.com/angular/angular/commit/a633596)), closes [#11917](https://github.com/angular/angular/issues/11917)
-* **compiler:** support `[@page](https://github.com/page)` and `[@document](https://github.com/document)` CSS rules ([#11878](https://github.com/angular/angular/issues/11878)) ([9316f95](https://github.com/angular/angular/commit/9316f95)), closes [#11860](https://github.com/angular/angular/issues/11860)
+* **compiler:** support `@page` and `@document` CSS rules ([#11878](https://github.com/angular/angular/issues/11878)) ([9316f95](https://github.com/angular/angular/commit/9316f95)), closes [#11860](https://github.com/angular/angular/issues/11860)
 * **compiler:** support `[attr="value with space"]` ([6c4ec05](https://github.com/angular/angular/commit/6c4ec05)), closes [#6249](https://github.com/angular/angular/issues/6249)
 * **compiler:** support quoted attribute values ([83d94b7](https://github.com/angular/angular/commit/83d94b7)), closes [#6085](https://github.com/angular/angular/issues/6085)
 * **upgrade:** bind optional properties when upgrading from ng1 ([#11411](https://github.com/angular/angular/issues/11411)) ([42b4b6d](https://github.com/angular/angular/commit/42b4b6d)), closes [#10181](https://github.com/angular/angular/issues/10181)
@@ -22,7 +22,7 @@
 
 ### Features
 
-* **animations:** provide aliases for :enter and :leave transitions ([#11991](https://github.com/angular/angular/issues/11991)) ([e884f48](https://github.com/angular/angular/commit/e884f48))
+* **animations:** provide aliases for `:enter` and `:leave` transitions ([#11991](https://github.com/angular/angular/issues/11991)) ([e884f48](https://github.com/angular/angular/commit/e884f48))
 
 
 <a name="2.1.0-beta.0"></a>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The changelog is incorrectly linking to GitHub repositories and missing a few backticks. It also has a misplaced line ending.

**What is the new behavior?**
The mentions are removed, backticks have been added to annotate keywords, and the line ending has been moved to the correct line.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
