### PR TITLE
fix(compiler): interpolation expressions report the correct offset

### DIFF
--- a/modules/@angular/compiler/test/expression_parser/parser_spec.ts
+++ b/modules/@angular/compiler/test/expression_parser/parser_spec.ts
@@ -8,7 +8,7 @@
 
 import {ASTWithSource, BindingPipe, Interpolation, ParserError, TemplateBinding} from '@angular/compiler/src/expression_parser/ast';
 import {Lexer} from '@angular/compiler/src/expression_parser/lexer';
-import {Parser, TemplateBindingParseResult} from '@angular/compiler/src/expression_parser/parser';
+import {Parser, SplitInterpolation, TemplateBindingParseResult} from '@angular/compiler/src/expression_parser/parser';
 import {expect} from '@angular/platform-browser/testing/matchers';
 
 import {isBlank, isPresent} from '../../src/facade/lang';
@@ -37,6 +37,10 @@ export function main() {
 
   function parseInterpolation(text: string, location: any = null): ASTWithSource {
     return createParser().parseInterpolation(text, location);
+  }
+
+  function splitInterpolation(text: string, location: any = null): SplitInterpolation {
+    return createParser().splitInterpolation(text, location);
   }
 
   function parseSimpleBinding(text: string, location: any = null): ASTWithSource {
@@ -538,6 +542,19 @@ export function main() {
       it('should be able to recover from a missing selector', () => recover('a.'));
       it('should be able to recover from a missing selector in a array literal',
          () => recover('[[a.], b, c]'));
+    });
+
+    describe('offsets', () => {
+      it('should retain the offsets of an interpolation', () => {
+        const interpolations = splitInterpolation('{{a}}  {{b}}  {{c}}');
+        expect(interpolations.offsets).toEqual([2, 9, 16]);
+      });
+
+      it('should retain the offsets into the expression AST of interpolations', () => {
+        const source = parseInterpolation('{{a}}  {{b}}  {{c}}');
+        const interpolation = source.ast as Interpolation;
+        expect(interpolation.expressions.map(e => e.span.start)).toEqual([2, 9, 16]);
+      });
     });
   });
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

All expression returned by `parseInterpolation()` return overlapping spans for all the expression in an `Interpolation`.

**What is the new behavior?**

The expressions in an `Interpolation` should not overlap and the span should be relative to the  interpolation string parsed instead of the beginning of the expression.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
