### PR TITLE
refactor(compiler): attribute ast records span of the value

### DIFF
--- a/modules/@angular/compiler/src/ml_parser/ast.ts
+++ b/modules/@angular/compiler/src/ml_parser/ast.ts
@@ -34,7 +34,9 @@ export class ExpansionCase implements Node {
 }
 
 export class Attribute implements Node {
-  constructor(public name: string, public value: string, public sourceSpan: ParseSourceSpan) {}
+  constructor(
+      public name: string, public value: string, public sourceSpan: ParseSourceSpan,
+      public valueSpan?: ParseSourceSpan) {}
   visit(visitor: Visitor, context: any): any { return visitor.visitAttribute(this, context); }
 }
 

--- a/modules/@angular/compiler/src/ml_parser/parser.ts
+++ b/modules/@angular/compiler/src/ml_parser/parser.ts
@@ -331,12 +331,15 @@ class _TreeBuilder {
     const fullName = mergeNsAndName(attrName.parts[0], attrName.parts[1]);
     let end = attrName.sourceSpan.end;
     let value = '';
+    let valueSpan: ParseSourceSpan;
     if (this._peek.type === lex.TokenType.ATTR_VALUE) {
       const valueToken = this._advance();
       value = valueToken.parts[0];
       end = valueToken.sourceSpan.end;
+      valueSpan = valueToken.sourceSpan;
     }
-    return new html.Attribute(fullName, value, new ParseSourceSpan(attrName.sourceSpan.start, end));
+    return new html.Attribute(
+        fullName, value, new ParseSourceSpan(attrName.sourceSpan.start, end), valueSpan);
   }
 
   private _getParentElement(): html.Element {

--- a/modules/@angular/compiler/test/ml_parser/html_parser_spec.ts
+++ b/modules/@angular/compiler/test/ml_parser/html_parser_spec.ts
@@ -376,6 +376,18 @@ export function main() {
                 [html.ExpansionCase, '=0', 2, '=0 {msg}'],
               ]);
         });
+
+        it('should not report a value span for an attribute without a value', () => {
+          const ast = parser.parse('<div bar></div>', 'TestComp');
+          expect((ast.rootNodes[0] as html.Element).attrs[0].valueSpan).toBeUndefined();
+        });
+
+        it('should report a value span for an attibute with a value', () => {
+          const ast = parser.parse('<div bar="12"></div>', 'TestComp');
+          const attr = (ast.rootNodes[0] as html.Element).attrs[0];
+          expect(attr.valueSpan.start.offset).toEqual(9);
+          expect(attr.valueSpan.end.offset).toEqual(13);
+        });
       });
 
       describe('errors', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Refactoring (no functional changes, no api changes)
```

**What is the current behavior?** (You can also link to an open issue here)

The `Attribute` class of the HTML AST does not record where the value is the source. This information is needed in the language service.

**What is the new behavior?**

The `Attribute` class records the span of the value of the attribute if the attribute has a value.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
