### PR TITLE
fix(forms): allow optional fields with pattern and minlength validators

### DIFF
--- a/modules/@angular/forms/test/template_integration_spec.ts
+++ b/modules/@angular/forms/test/template_integration_spec.ts
@@ -22,7 +22,7 @@ export function main() {
           StandaloneNgModel, NgModelForm, NgModelGroupForm, NgModelValidBinding, NgModelNgIfForm,
           NgModelRadioForm, NgModelSelectForm, NgNoFormComp, InvalidNgModelNoName,
           NgModelOptionsStandalone, NgModelCustomComp, NgModelCustomWrapper,
-          NgModelValidationBindings
+          NgModelValidationBindings, NgModelMultipleValidators
         ],
         imports: [FormsModule]
       });
@@ -728,6 +728,50 @@ export function main() {
            expect(form.valid).toEqual(true);
          }));
 
+      it('should support optional fields with pattern validator', fakeAsync(() => {
+           const fixture = TestBed.createComponent(NgModelMultipleValidators);
+           fixture.componentInstance.required = false;
+           fixture.componentInstance.pattern = '[a-z]+';
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           const input = fixture.debugElement.query(By.css('input'));
+
+           input.nativeElement.value = '';
+           dispatchEvent(input.nativeElement, 'input');
+           fixture.detectChanges();
+           expect(form.valid).toBeTruthy();
+
+           input.nativeElement.value = '1';
+           dispatchEvent(input.nativeElement, 'input');
+           fixture.detectChanges();
+           expect(form.valid).toBeFalsy();
+           expect(form.control.hasError('pattern', ['tovalidate'])).toBeTruthy();
+         }));
+
+      it('should support optional fields with minlength validator', fakeAsync(() => {
+           const fixture = TestBed.createComponent(NgModelMultipleValidators);
+           fixture.componentInstance.required = false;
+           fixture.componentInstance.minLen = 2;
+           fixture.detectChanges();
+           tick();
+
+           const form = fixture.debugElement.children[0].injector.get(NgForm);
+           const input = fixture.debugElement.query(By.css('input'));
+
+           input.nativeElement.value = '';
+           dispatchEvent(input.nativeElement, 'input');
+           fixture.detectChanges();
+           expect(form.valid).toBeTruthy();
+
+           input.nativeElement.value = '1';
+           dispatchEvent(input.nativeElement, 'input');
+           fixture.detectChanges();
+           expect(form.valid).toBeFalsy();
+           expect(form.control.hasError('minlength', ['tovalidate'])).toBeTruthy();
+         }));
+
       it('changes on bound properties should change the validation state of the form',
          fakeAsync(() => {
            const fixture = TestBed.createComponent(NgModelValidationBindings);
@@ -1034,6 +1078,20 @@ class NgModelValidationBindings {
   required: boolean;
   minLen: number;
   maxLen: number;
+  pattern: string;
+}
+
+@Component({
+  selector: 'ng-model-multiple-validators',
+  template: `
+    <form>
+      <input name="tovalidate" ngModel  [required]="required" [minlength]="minLen" [pattern]="pattern">
+    </form>
+  `
+})
+class NgModelMultipleValidators {
+  required: boolean;
+  minLen: number;
   pattern: string;
 }
 

--- a/modules/@angular/forms/test/validators_spec.ts
+++ b/modules/@angular/forms/test/validators_spec.ts
@@ -44,33 +44,24 @@ export function main() {
          () => { expect(Validators.required(new FormControl(null))).toEqual({'required': true}); });
 
       it('should not error on a non-empty string',
-         () => { expect(Validators.required(new FormControl('not empty'))).toEqual(null); });
+         () => { expect(Validators.required(new FormControl('not empty'))).toBeNull(); });
 
       it('should accept zero as valid',
-         () => { expect(Validators.required(new FormControl(0))).toEqual(null); });
+         () => { expect(Validators.required(new FormControl(0))).toBeNull(); });
     });
 
     describe('minLength', () => {
-      it('should error on an empty string', () => {
-        expect(Validators.minLength(2)(new FormControl(''))).toEqual({
-          'minlength': {'requiredLength': 2, 'actualLength': 0}
-        });
-      });
+      it('should not error on an empty string',
+         () => { expect(Validators.minLength(2)(new FormControl(''))).toBeNull(); });
 
-      it('should error on null', () => {
-        expect(Validators.minLength(2)(new FormControl(null))).toEqual({
-          'minlength': {'requiredLength': 2, 'actualLength': 0}
-        });
-      });
+      it('should not error on null',
+         () => { expect(Validators.minLength(2)(new FormControl(null))).toBeNull(); });
 
-      it('should error on undefined', () => {
-        expect(Validators.minLength(2)(new FormControl(null))).toEqual({
-          'minlength': {'requiredLength': 2, 'actualLength': 0}
-        });
-      });
+      it('should not error on undefined',
+         () => { expect(Validators.minLength(2)(new FormControl(null))).toBeNull(); });
 
       it('should not error on valid strings',
-         () => { expect(Validators.minLength(2)(new FormControl('aa'))).toEqual(null); });
+         () => { expect(Validators.minLength(2)(new FormControl('aa'))).toBeNull(); });
 
       it('should error on short strings', () => {
         expect(Validators.minLength(2)(new FormControl('a'))).toEqual({
@@ -81,13 +72,13 @@ export function main() {
 
     describe('maxLength', () => {
       it('should not error on an empty string',
-         () => { expect(Validators.maxLength(2)(new FormControl(''))).toEqual(null); });
+         () => { expect(Validators.maxLength(2)(new FormControl(''))).toBeNull(); });
 
       it('should not error on null',
-         () => { expect(Validators.maxLength(2)(new FormControl(null))).toEqual(null); });
+         () => { expect(Validators.maxLength(2)(new FormControl(null))).toBeNull(); });
 
       it('should not error on valid strings',
-         () => { expect(Validators.maxLength(2)(new FormControl('aa'))).toEqual(null); });
+         () => { expect(Validators.maxLength(2)(new FormControl('aa'))).toBeNull(); });
 
       it('should error on long strings', () => {
         expect(Validators.maxLength(2)(new FormControl('aaa'))).toEqual({
@@ -98,27 +89,23 @@ export function main() {
 
     describe('pattern', () => {
       it('should not error on an empty string',
-         () => { expect(Validators.pattern('[a-zA-Z ]*')(new FormControl(''))).toEqual(null); });
+         () => { expect(Validators.pattern('[a-zA-Z ]+')(new FormControl(''))).toBeNull(); });
 
       it('should not error on null',
-         () => { expect(Validators.pattern('[a-zA-Z ]*')(new FormControl(null))).toEqual(null); });
+         () => { expect(Validators.pattern('[a-zA-Z ]+')(new FormControl(null))).toBeNull(); });
+
+      it('should not error on undefined',
+         () => { expect(Validators.pattern('[a-zA-Z ]+')(new FormControl(null))).toBeNull(); });
 
       it('should not error on null value and "null" pattern',
-         () => { expect(Validators.pattern('null')(new FormControl(null))).toEqual(null); });
+         () => { expect(Validators.pattern('null')(new FormControl(null))).toBeNull(); });
 
-      it('should not error on valid strings', () => {
-        expect(Validators.pattern('[a-zA-Z ]*')(new FormControl('aaAA'))).toEqual(null);
-      });
+      it('should not error on valid strings',
+         () => { expect(Validators.pattern('[a-zA-Z ]*')(new FormControl('aaAA'))).toBeNull(); });
 
       it('should error on failure to match string', () => {
         expect(Validators.pattern('[a-zA-Z ]*')(new FormControl('aaa0'))).toEqual({
           'pattern': {'requiredPattern': '^[a-zA-Z ]*$', 'actualValue': 'aaa0'}
-        });
-      });
-
-      it('should error on failure to match empty string', () => {
-        expect(Validators.pattern('[a-zA-Z]+')(new FormControl(''))).toEqual({
-          'pattern': {'requiredPattern': '^[a-zA-Z]+$', 'actualValue': ''}
         });
       });
     });
@@ -139,7 +126,7 @@ export function main() {
 
       it('should return null when no errors', () => {
         var c = Validators.compose([Validators.nullValidator, Validators.nullValidator]);
-        expect(c(new FormControl(''))).toEqual(null);
+        expect(c(new FormControl(''))).toBeNull();
       });
 
       it('should ignore nulls', () => {
@@ -166,7 +153,7 @@ export function main() {
       }
 
       it('should return null when given null',
-         () => { expect(Validators.composeAsync(null)).toEqual(null); });
+         () => { expect(Validators.composeAsync(null)).toBeNull(); });
 
       it('should collect errors from all the validators', fakeAsync(() => {
            var c = Validators.composeAsync([
@@ -199,7 +186,7 @@ export function main() {
            (<Promise<any>>c(new FormControl('expected'))).then(v => value = v);
            tick(1);
 
-           expect(value).toEqual(null);
+           expect(value).toBeNull();
          }));
 
       it('should ignore nulls', fakeAsync(() => {


### PR DESCRIPTION
@vsavkin @vicb a [comment from a user](https://github.com/angular/angular/pull/11450#issuecomment-252175182) made me realize that I might have screwed up royally with my 2 previous PRs (#11450 and #12091)!

It _might_ be that the idea of `pattern`  and `minlength` validators is that they should be combined with the `required` validator to get proper validation on empty fields. Those validators alone should allow empty values so we can have optional fields.

In my self-defense I can only say that we didn't have any test for this use case so I've added one.

PTAL as my previous PRs (#11450 and #12091) might be a regression (fortunately #12091 didn't make it into any release and  #11450 is very easy to work-around).
