### PR TITLE
fix(platform-browser-dynamic): mark platformBrowserDynamic as stable API

### DIFF
--- a/modules/@angular/platform-browser-dynamic/src/platform-browser-dynamic.ts
+++ b/modules/@angular/platform-browser-dynamic/src/platform-browser-dynamic.ts
@@ -21,7 +21,7 @@ export const RESOURCE_CACHE_PROVIDER: Provider[] =
     [{provide: ResourceLoader, useClass: CachedResourceLoader}];
 
 /**
- * @experimental API related to bootstrapping are still under review.
+ * @stable
  */
 export const platformBrowserDynamic = createPlatformFactory(
     platformCoreDynamic, 'browserDynamic', INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS);

--- a/tools/public_api_guard/platform-browser-dynamic/index.d.ts
+++ b/tools/public_api_guard/platform-browser-dynamic/index.d.ts
@@ -1,4 +1,4 @@
-/** @experimental */
+/** @stable */
 export declare const platformBrowserDynamic: (extraProviders?: Provider[]) => PlatformRef;
 
 /** @experimental */


### PR DESCRIPTION
 Everyone building Angular apps need to use this api to bootstrap or AoT compile, so it can't be experimental.
