### PR TITLE
fix(compiler-cli): don't unnecessarily throw on StaticSymbols

### DIFF
--- a/modules/@angular/compiler-cli/src/static_reflector.ts
+++ b/modules/@angular/compiler-cli/src/static_reflector.ts
@@ -368,6 +368,9 @@ export class StaticReflector implements ReflectorReader {
           }
           return result;
         }
+        if (expression instanceof StaticSymbol) {
+          return expression;
+        }
         if (expression) {
           if (expression['__symbolic']) {
             let staticSymbol: StaticSymbol;

--- a/modules/@angular/compiler-cli/test/static_reflector_spec.ts
+++ b/modules/@angular/compiler-cli/test/static_reflector_spec.ts
@@ -119,6 +119,11 @@ describe('StaticReflector', () => {
     expect(simplify(noContext, 'some value')).toBe('some value');
   });
 
+  it('should simplify a static symbol into itself', () => {
+    const staticSymbol = new StaticSymbol('', '');
+    expect(simplify(noContext, staticSymbol)).toBe(staticSymbol);
+  });
+
   it('should simplify an array into a copy of the array', () => {
     expect(simplify(noContext, [1, 2, 3])).toEqual([1, 2, 3]);
   });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
#11276 #12097

ngc throws an error when StaticSymbol interface compatible objects are passed to `StaticReflector.parameters` or `StaticReflector.hasLifecycleHook`

**What is the new behavior?**

If the object properly matches the `StaticSymbol` interface, do not throw an error and allow the object to be processed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Closes #11276 #12097
