### PR TITLE
fix(compiler): properly shim `:host:before` and `:host(:before)`

### DIFF
--- a/modules/@angular/compiler/src/shadow_css.ts
+++ b/modules/@angular/compiler/src/shadow_css.ts
@@ -381,7 +381,10 @@ export class ShadowCss {
 
     if (_polyfillHostRe.test(selector)) {
       const replaceBy = this.strictStyling ? `[${hostSelector}]` : scopeSelector;
-      return selector.replace(_polyfillHostNoCombinatorRe, (hnc, selector) => selector + replaceBy)
+      return selector
+          .replace(
+              _polyfillHostNoCombinatorRe,
+              (hnc, selector) => selector[0] === ':' ? replaceBy + selector : selector + replaceBy)
           .replace(_polyfillHostRe, replaceBy + ' ');
     }
 

--- a/modules/@angular/compiler/test/shadow_css_spec.ts
+++ b/modules/@angular/compiler/test/shadow_css_spec.ts
@@ -112,10 +112,8 @@ export function main() {
       it('should handle no context',
          () => { expect(s(':host {}', 'a', 'a-host')).toEqual('[a-host] {}'); });
 
-      it('should handle tag selector', () => {
-        expect(s(':host(ul) {}', 'a', 'a-host')).toEqual('ul[a-host] {}');
-
-      });
+      it('should handle tag selector',
+         () => { expect(s(':host(ul) {}', 'a', 'a-host')).toEqual('ul[a-host] {}'); });
 
       it('should handle class selector',
          () => { expect(s(':host(.x) {}', 'a', 'a-host')).toEqual('.x[a-host] {}'); });
@@ -140,6 +138,11 @@ export function main() {
       it('should handle multiple attribute selectors', () => {
         expect(s(':host([a="b"],[c=d]) {}', 'a', 'a-host'))
             .toEqual('[a="b"][a-host], [c="d"][a-host] {}');
+      });
+
+      it('should handle pseudo selector', () => {
+        expect(s(':host(:before) {}', 'a', 'a-host')).toEqual('[a-host]:before {}');
+        expect(s(':host:before {}', 'a', 'a-host')).toEqual('[a-host]:before {}');
       });
     });
 


### PR DESCRIPTION
fixes #12165
