### PR TITLE
fix(compiler): support inert script tags in templates

### DIFF
--- a/modules/@angular/compiler/src/template_parser/template_parser.ts
+++ b/modules/@angular/compiler/src/template_parser/template_parser.ts
@@ -332,9 +332,9 @@ class TemplateParseVisitor implements html.Visitor {
   visitElement(element: html.Element, parent: ElementContext): any {
     const nodeName = element.name;
     const preparsedElement = preparseElement(element);
-    if (preparsedElement.type === PreparsedElementType.SCRIPT ||
+    if (preparsedElement.type === PreparsedElementType.JAVASCRIPT ||
         preparsedElement.type === PreparsedElementType.STYLE) {
-      // Skipping <script> for security reasons
+      // Skipping <script> containing JS for security reasons
       // Skipping <style> as we already processed them
       // in the StyleCompiler
       return null;
@@ -1068,7 +1068,7 @@ class TemplateParseVisitor implements html.Visitor {
 class NonBindableVisitor implements html.Visitor {
   visitElement(ast: html.Element, parent: ElementContext): ElementAst {
     const preparsedElement = preparseElement(ast);
-    if (preparsedElement.type === PreparsedElementType.SCRIPT ||
+    if (preparsedElement.type === PreparsedElementType.JAVASCRIPT ||
         preparsedElement.type === PreparsedElementType.STYLE ||
         preparsedElement.type === PreparsedElementType.STYLESHEET) {
       // Skipping <script> for security reasons

--- a/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
@@ -1414,9 +1414,16 @@ Property binding a not used by any directive on an embedded template. Make sure 
         });
 
         describe('ignore elements', () => {
-          it('should ignore <script> elements', () => {
-            expect(humanizeTplAst(parse('<script></script>a', []))).toEqual([[TextAst, 'a']]);
-
+          it('should ignore <script> elements with JS content', () => {
+            expect(humanizeTplAst(parse('<script></script>a', []))).toEqual([
+              [TextAst, 'a'],
+            ]);
+            expect(humanizeTplAst(parse('<script type="application/ld+json"></script>a', [])))
+                .toEqual([
+                  [ElementAst, 'script'],
+                  [AttrAst, 'type', 'application/ld+json'],
+                  [TextAst, 'a'],
+                ]);
           });
 
           it('should ignore <style> elements', () => {
@@ -1429,8 +1436,10 @@ Property binding a not used by any directive on an embedded template. Make sure 
                () => {
                  expect(humanizeTplAst(parse('<link rel="stylesheet" href="http://someurl">a', [])))
                      .toEqual([
-                       [ElementAst, 'link'], [AttrAst, 'rel', 'stylesheet'],
-                       [AttrAst, 'href', 'http://someurl'], [TextAst, 'a']
+                       [ElementAst, 'link'],
+                       [AttrAst, 'rel', 'stylesheet'],
+                       [AttrAst, 'href', 'http://someurl'],
+                       [TextAst, 'a'],
                      ]);
                });
 

--- a/modules/@angular/compiler/test/template_parser/template_preparser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser/template_preparser_spec.ts
@@ -11,39 +11,61 @@ import {Element} from '../../src/ml_parser/ast';
 import {HtmlParser} from '../../src/ml_parser/html_parser';
 import {PreparsedElement, PreparsedElementType, preparseElement} from '../../src/template_parser/template_preparser';
 
+// see https://html.spec.whatwg.org/multipage/scripting.html#javascript-mime-type
+const JS_MIME_TYPES = [
+  'application/ecmascript',
+  'application/javascript',
+  'application/x-ecmascript',
+  'application/x-javascript',
+  'text/ecmascript',
+  'text/javascript',
+  'text/javascript1.0',
+  'text/javascript1.1',
+  'text/javascript1.2',
+  'text/javascript1.3',
+  'text/javascript1.4',
+  'text/javascript1.5',
+  'text/jscript',
+  'text/livescript',
+  'text/x-ecmascript',
+  'text/x-javascript',
+];
+
 export function main() {
   describe('preparseElement', () => {
-    var htmlParser: HtmlParser;
+    let htmlParser: HtmlParser;
+
     beforeEach(inject([HtmlParser], (_htmlParser: HtmlParser) => { htmlParser = _htmlParser; }));
 
     function preparse(html: string): PreparsedElement {
       return preparseElement(htmlParser.parse(html, 'TestComp').rootNodes[0] as Element);
     }
 
-    it('should detect script elements', inject([HtmlParser], (htmlParser: HtmlParser) => {
-         expect(preparse('<script>').type).toBe(PreparsedElementType.SCRIPT);
-       }));
+    it('should detect javascript elements', () => {
+      expect(preparse('<script>').type).toBe(PreparsedElementType.JAVASCRIPT);
+      JS_MIME_TYPES.forEach(type => {
+        expect(preparse(`<script type="${type}">`).type).toBe(PreparsedElementType.JAVASCRIPT);
+      });
+      expect(preparse('<script type="application/ld+json">').type).toBe(PreparsedElementType.OTHER);
+    });
 
-    it('should detect style elements', inject([HtmlParser], (htmlParser: HtmlParser) => {
-         expect(preparse('<style>').type).toBe(PreparsedElementType.STYLE);
-       }));
+    it('should detect style elements',
+       () => { expect(preparse('<style>').type).toBe(PreparsedElementType.STYLE); });
 
-    it('should detect stylesheet elements', inject([HtmlParser], (htmlParser: HtmlParser) => {
-         expect(preparse('<link rel="stylesheet">').type).toBe(PreparsedElementType.STYLESHEET);
-         expect(preparse('<link rel="stylesheet" href="someUrl">').hrefAttr).toEqual('someUrl');
-         expect(preparse('<link rel="someRel">').type).toBe(PreparsedElementType.OTHER);
-       }));
+    it('should detect stylesheet elements', () => {
+      expect(preparse('<link rel="stylesheet">').type).toBe(PreparsedElementType.STYLESHEET);
+      expect(preparse('<link rel="stylesheet" href="someUrl">').hrefAttr).toEqual('someUrl');
+      expect(preparse('<link rel="someRel">').type).toBe(PreparsedElementType.OTHER);
+    });
 
-    it('should detect ng-content elements', inject([HtmlParser], (htmlParser: HtmlParser) => {
-         expect(preparse('<ng-content>').type).toBe(PreparsedElementType.NG_CONTENT);
-       }));
+    it('should detect ng-content elements',
+       () => { expect(preparse('<ng-content>').type).toBe(PreparsedElementType.NG_CONTENT); });
 
-    it('should normalize ng-content.select attribute',
-       inject([HtmlParser], (htmlParser: HtmlParser) => {
-         expect(preparse('<ng-content>').selectAttr).toEqual('*');
-         expect(preparse('<ng-content select>').selectAttr).toEqual('*');
-         expect(preparse('<ng-content select="*">').selectAttr).toEqual('*');
-       }));
+    it('should normalize ng-content.select attribute', () => {
+      expect(preparse('<ng-content>').selectAttr).toEqual('*');
+      expect(preparse('<ng-content select>').selectAttr).toEqual('*');
+      expect(preparse('<ng-content select="*">').selectAttr).toEqual('*');
+    });
 
     it('should extract ngProjectAs value', () => {
       expect(preparse('<p ngProjectAs="el[attr].class"></p>').projectAs).toEqual('el[attr].class');


### PR DESCRIPTION
fixes #9695

/cc @mprobst @rjamet for security

The former behavior was to remove all `script` tags from the template. After this PR, only `script` tags containing javascript are removed, other inert tags are left untouched. One of the use case is JSON-LD as described in the original issue
