### PR TITLE
docs(router): attribute notation for string paths

### DIFF
--- a/modules/@angular/router/src/directives/router_link_active.ts
+++ b/modules/@angular/router/src/directives/router_link_active.ts
@@ -20,7 +20,7 @@ import {RouterLink, RouterLinkWithHref} from './router_link';
  * @howToUse
  *
  * ```
- * <a [routerLink]='/user/bob' routerLinkActive='active-link'>Bob</a>
+ * <a routerLink="/user/bob" routerLinkActive="active-link">Bob</a>
  * ```
  *
  * @description
@@ -31,7 +31,7 @@ import {RouterLink, RouterLinkWithHref} from './router_link';
  * Consider the following example:
  *
  * ```
- * <a [routerLink]="/user/bob" routerLinkActive="active-link">Bob</a>
+ * <a routerLink="/user/bob" routerLinkActive="active-link">Bob</a>
  * ```
  *
  * When the url is either '/user' or '/user/bob', the active-link class will
@@ -40,15 +40,15 @@ import {RouterLink, RouterLinkWithHref} from './router_link';
  * You can set more than one class, as follows:
  *
  * ```
- * <a [routerLink]="/user/bob" routerLinkActive="class1 class2">Bob</a>
- * <a [routerLink]="/user/bob" [routerLinkActive]="['class1', 'class2']">Bob</a>
+ * <a routerLink="/user/bob" routerLinkActive="class1 class2">Bob</a>
+ * <a routerLink="/user/bob" [routerLinkActive]="['class1', 'class2']">Bob</a>
  * ```
  *
  * You can configure RouterLinkActive by passing `exact: true`. This will add the classes
  * only when the url matches the link exactly.
  *
  * ```
- * <a [routerLink]="/user/bob" routerLinkActive="active-link" [routerLinkActiveOptions]="{exact:
+ * <a routerLink="/user/bob" routerLinkActive="active-link" [routerLinkActiveOptions]="{exact:
  * true}">Bob</a>
  * ```
  *
@@ -56,8 +56,8 @@ import {RouterLink, RouterLinkWithHref} from './router_link';
  *
  * ```
  * <div routerLinkActive="active-link" [routerLinkActiveOptions]="{exact: true}">
- *   <a [routerLink]="/user/jim">Jim</a>
- *   <a [routerLink]="/user/bob">Bob</a>
+ *   <a routerLink="/user/jim">Jim</a>
+ *   <a routerLink="/user/bob">Bob</a>
  * </div>
  * ```
  *


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- _not required_: Tests for the changes have been added (for bug fixes / features)
- _not required_: Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Docs
```

**What is the current behavior?** (You can also link to an open issue here)
Wrong code in docs

**What is the new behavior?**
Correct code in docs :+1:

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Either bind an expression or use the attribute notation.
The mixed way `[routerLink]="/path"` won't work.
Prefer the attribute notation for string-only paths
