### PR TITLE
fix(router): correctly export filter operator in es5

### DIFF
--- a/modules/@angular/router/rollup.config.js
+++ b/modules/@angular/router/rollup.config.js
@@ -37,6 +37,7 @@ export default {
     'rxjs/operator/first': 'Rx.Observable.prototype',
     'rxjs/operator/catch': 'Rx.Observable.prototype',
     'rxjs/operator/last': 'Rx.Observable.prototype',
+    'rxjs/operator/filter': 'Rx.Observable.prototype'
   },
   plugins: []
 };


### PR DESCRIPTION
closes #12266 
