### PR TITLE
fix(platform-browser): Make different SafeValue types incompatible values in TypeScript

### DIFF
--- a/aio/src/app/shared/toc.service.spec.ts
+++ b/aio/src/app/shared/toc.service.spec.ts
@@ -11,6 +11,7 @@ describe('TocService', () => {
   let scrollSpyService: MockScrollSpyService;
   let tocService: TocService;
   let lastTocList: TocItem[];
+  let sanitizer: DomSanitizer;
 
   // call TocService.genToc
   function callGenToc(html = '', docId = 'fizz/buzz'): HTMLDivElement {
@@ -18,6 +19,10 @@ describe('TocService', () => {
     el.innerHTML = html;
     tocService.genToc(el, docId);
     return el;
+  }
+
+  function createTocItem(title: string, level = 'h2', href = '', content = title) {
+    return {title, href, level, content: sanitizer.bypassSecurityTrustHtml(content)};
   }
 
   beforeEach(() => {
@@ -30,6 +35,7 @@ describe('TocService', () => {
     scrollSpyService = injector.get(ScrollSpyService);
     tocService = injector.get(TocService);
     tocService.tocList.subscribe(tocList => lastTocList = tocList);
+    sanitizer = injector.get(DomSanitizer);
   });
 
   describe('tocList', () => {
@@ -368,9 +374,5 @@ class MockScrollSpyService {
       unspy: jasmine.createSpy('unspy'),
     };
   }
-}
-
-function createTocItem(title: string, level = 'h2', href = '', content = title) {
-  return { title, href, level, content };
 }
 

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -9,7 +9,7 @@
 import {Component, Directive, HostBinding, Input, NO_ERRORS_SCHEMA, ɵivyEnabled as ivyEnabled} from '@angular/core';
 import {ComponentFixture, TestBed, getTestBed} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
-import {DomSanitizer} from '@angular/platform-browser/src/security/dom_sanitization_service';
+import {DomSanitizer} from '@angular/platform-browser/src/security/dom_sanitization';
 import {fixmeIvy} from '@angular/private/testing';
 
 {

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -21,7 +21,7 @@ import {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 import {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HammerGestureConfig, HammerGesturesPlugin} from './dom/events/hammer_gestures';
 import {KeyEventsPlugin} from './dom/events/key_events';
 import {DomSharedStylesHost, SharedStylesHost} from './dom/shared_styles_host';
-import {DomSanitizer, DomSanitizerImpl} from './security/dom_sanitization_service';
+import {DomSanitizer, DomSanitizerImpl} from './security/dom_sanitization';
 
 export const INTERNAL_BROWSER_PLATFORM_PROVIDERS: StaticProvider[] = [
   {provide: PLATFORM_ID, useValue: PLATFORM_BROWSER_ID},

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -15,7 +15,7 @@ export {By} from './dom/debug/by';
 export {DOCUMENT} from './dom/dom_tokens';
 export {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 export {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HammerGestureConfig, HammerLoader} from './dom/events/hammer_gestures';
-export {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl, SafeValue} from './security/dom_sanitization_service';
+export {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl, SafeValue} from './security/dom_sanitization';
 
 export * from './private_export';
 export {VERSION} from './version';

--- a/packages/platform-browser/src/private_export.ts
+++ b/packages/platform-browser/src/private_export.ts
@@ -19,4 +19,4 @@ export {DomEventsPlugin as ɵDomEventsPlugin} from './dom/events/dom_events';
 export {HammerGesturesPlugin as ɵHammerGesturesPlugin} from './dom/events/hammer_gestures';
 export {KeyEventsPlugin as ɵKeyEventsPlugin} from './dom/events/key_events';
 export {DomSharedStylesHost as ɵDomSharedStylesHost, SharedStylesHost as ɵSharedStylesHost} from './dom/shared_styles_host';
-export {DomSanitizerImpl as ɵDomSanitizerImpl} from './security/dom_sanitization_service';
+export {DomSanitizerImpl as ɵDomSanitizerImpl} from './security/dom_sanitization';

--- a/packages/platform-browser/test/security/dom_sanitization_spec.ts
+++ b/packages/platform-browser/test/security/dom_sanitization_spec.ts
@@ -8,7 +8,7 @@
 
 import {SecurityContext} from '@angular/core';
 import * as t from '@angular/core/testing/src/testing_internal';
-import {DomSanitizerImpl} from '@angular/platform-browser/src/security/dom_sanitization_service';
+import {DomSanitizerImpl} from '@angular/platform-browser/src/security/dom_sanitization';
 
 {
   t.describe('DOM Sanitization Service', () => {

--- a/tools/public_api_guard/platform-browser/platform-browser.d.ts
+++ b/tools/public_api_guard/platform-browser/platform-browser.d.ts
@@ -93,21 +93,27 @@ export declare type MetaDefinition = {
 export declare const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef;
 
 export interface SafeHtml extends SafeValue {
+    readonly kind: SecurityContext.HTML;
 }
 
-export interface SafeResourceUrl extends SafeValue {
+export interface SafeResourceUrl extends SafeUrl {
+    readonly kind: SecurityContext.RESOURCE_URL;
 }
 
 export interface SafeScript extends SafeValue {
+    readonly kind: SecurityContext.SCRIPT;
 }
 
 export interface SafeStyle extends SafeValue {
+    readonly kind: SecurityContext.STYLE;
 }
 
 export interface SafeUrl extends SafeValue {
+    readonly kind: SecurityContext.URL | SecurityContext.RESOURCE_URL;
 }
 
 export interface SafeValue {
+    readonly kind: SecurityContext;
 }
 
 export declare type StateKey<T> = string & {


### PR DESCRIPTION
Previously, because all `SafeValue`s were empty marker interfaces, users could
accidentally assign safe values into each other:

```
let myUrl: SafeUrl = ...;
let myHtml: SafeHtml = myUrl;
```

While this would fail at runtime (safety is enforced based on the values,
independent of TypeScript types), this can lead to very confusing code that
seems to pass around values of one type, which actually is of another type.

This change adds a `readonly kind` field that makes sure such accidental
assignments are compile time errors.
