### PR TITLE
feat(i18n): add support for gettext file format

### DIFF
--- a/modules/@angular/compiler-cli/integrationtest/test/i18n_spec.ts
+++ b/modules/@angular/compiler-cli/integrationtest/test/i18n_spec.ts
@@ -58,6 +58,23 @@ const EXPECTED_XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 </xliff>
 `;
 
+const EXPECTED_GETTEXT = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Project-Id-Version: \\n"
+
+#. desc
+#: 76e1eccb1b772fa9f294ef9c146ea6d0efa8a2d4
+msgctxt "meaning"
+msgid "translate me"
+msgstr ""
+
+#: 65cc4ab3b4c438e07c89be2b677d08369fb62da2
+msgid "Welcome"
+msgstr ""
+`;
+
 describe('template i18n extraction output', () => {
   const outDir = '';
 
@@ -73,6 +90,13 @@ describe('template i18n extraction output', () => {
     expect(fs.existsSync(xlfOutput)).toBeTruthy();
     const xlf = fs.readFileSync(xlfOutput, {encoding: 'utf-8'});
     expect(xlf).toEqual(EXPECTED_XLIFF);
+  });
+
+  it('should extract i18n messages as gettext', () => {
+    const potOutput = path.join(outDir, 'messages.pot');
+    expect(fs.existsSync(potOutput)).toBeTruthy();
+    const pot = fs.readFileSync(potOutput, {encoding: 'utf-8'});
+    expect(pot).toEqual(EXPECTED_GETTEXT);
   });
 
 });

--- a/modules/@angular/compiler-cli/src/extract_i18n.ts
+++ b/modules/@angular/compiler-cli/src/extract_i18n.ts
@@ -40,6 +40,12 @@ function extract(
     const format = (cliOptions.i18nFormat || 'xlf').toLowerCase();
 
     switch (format) {
+      case 'gettext':
+      case 'pot':
+      case 'po':
+        ext = 'pot';
+        serializer = new compiler.Gettext(htmlParser, compiler.DEFAULT_INTERPOLATION_CONFIG);
+        break;
       case 'xmb':
         ext = 'xmb';
         serializer = new compiler.Xmb();

--- a/modules/@angular/compiler/src/i18n/i18n_html_parser.ts
+++ b/modules/@angular/compiler/src/i18n/i18n_html_parser.ts
@@ -12,6 +12,7 @@ import {ParseTreeResult} from '../ml_parser/parser';
 
 import {mergeTranslations} from './extractor_merger';
 import {MessageBundle} from './message_bundle';
+import {Gettext} from './serializers/gettext';
 import {Serializer} from './serializers/serializer';
 import {Xliff} from './serializers/xliff';
 import {Xmb} from './serializers/xmb';
@@ -59,6 +60,10 @@ export class I18NHtmlParser implements HtmlParser {
     const format = (this._translationsFormat || 'xlf').toLowerCase();
 
     switch (format) {
+      case 'gettext':
+      case 'pot':
+      case 'po':
+        return new Gettext(this._htmlParser, interpolationConfig);
       case 'xmb':
         return new Xmb();
       case 'xtb':

--- a/modules/@angular/compiler/src/i18n/index.ts
+++ b/modules/@angular/compiler/src/i18n/index.ts
@@ -8,6 +8,7 @@
 
 export {I18NHtmlParser} from './i18n_html_parser';
 export {MessageBundle} from './message_bundle';
+export {Gettext} from './serializers/gettext';
 export {Serializer} from './serializers/serializer';
 export {Xliff} from './serializers/xliff';
 export {Xmb} from './serializers/xmb';

--- a/modules/@angular/compiler/src/i18n/serializers/gettext.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/gettext.ts
@@ -1,0 +1,184 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ml from '../../ml_parser/ast';
+import {HtmlParser} from '../../ml_parser/html_parser';
+import {InterpolationConfig} from '../../ml_parser/interpolation_config';
+import {ParseError} from '../../parse_util';
+import * as i18n from '../i18n_ast';
+import {MessageBundle} from '../message_bundle';
+
+import {Serializer} from './serializer';
+
+
+
+// https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html
+export class Gettext implements Serializer {
+  constructor(private _htmlParser: HtmlParser, private _interpolationConfig: InterpolationConfig) {}
+
+  write(messageMap: {[id: string]: i18n.Message}): string {
+    const visitor = new _WriteVisitor();
+
+    const entries: PoEntry[] = [];
+
+    Object.keys(messageMap).forEach(id => {
+      const message = messageMap[id];
+
+      // TODO(alfaproject): add file references (#: <file-name>:<line number>)
+      const entry: PoEntry = {
+        comments: [],
+        references: [id],
+        msgctxt: message.meaning,
+        msgid: visitor.serialize(message.nodes)
+      };
+
+      if (message.description) {
+        entry.comments.push(message.description);
+      }
+
+      entries.push(entry);
+    });
+
+    return entries.reduce(
+        (template, entry) => template + entry.comments.map(comment => '\n#. ' + comment).join('') +
+            entry.references.map(reference => '\n#: ' + reference).join('') +
+            (entry.msgctxt ? `\nmsgctxt "${entry.msgctxt.replace(/"/g, '\\"')}"` : '') + `
+msgid "${entry.msgid.replace(/"/g, '\\"')}"
+msgstr ""
+`,
+        `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Project-Id-Version: \\n"
+`);
+  }
+
+  load(content: string, url: string, messageBundle: MessageBundle): {[id: string]: ml.Node[]} {
+    const messageMap: {[id: string]: ml.Node[]} = {};
+    const parseErrors: ParseError[] = [];
+
+    // Parse the content
+    let isMsgIdParsed: boolean;
+    let message: PoEntry;
+    const lines = content.split('\n');
+    lines.forEach((line, lineIndex) => {
+      line = line.trim();
+
+      // New message
+      if (lineIndex === 0 || line.length === 0) {
+        if (message) {
+          // Convert the string message to html ast
+          const res = this._htmlParser.parse(message.msgstr, url, true, this._interpolationConfig);
+
+          // TODO(alfaproject): map error message back to the original message in gettext
+          parseErrors.push(...res.errors);
+
+          // TODO(alfaproject): make sure we are extracting the id from the right reference
+          const id = message.references[0];
+          if (id) {
+            messageMap[id] = res.rootNodes;
+          }
+        }
+
+        // Start a new message
+        message = {
+          comments: [],
+          references: [],
+          msgid: '',
+        };
+        isMsgIdParsed = false;
+        return;
+      }
+
+      // Parse current line
+      const firstToken = line.substr(0, line.indexOf(' '));
+      switch (firstToken) {
+        case '#.':
+          message.comments.push(line.substr(3));
+          return;
+        case '#:':
+          message.references.push(line.substr(3));
+          return;
+        case 'msgctxt':
+          message.msgctxt = line.substr(9, line.length - 10).replace(/\\"/g, '"');
+          return;
+        case 'msgid':
+          message.msgid = line.substr(7, line.length - 8).replace(/\\"/g, '"');
+          return;
+        case 'msgstr':
+          isMsgIdParsed = true;
+          message.msgstr = line.substr(8, line.length - 9).replace(/\\"/g, '"');
+          return;
+      }
+
+      if (line[0] === '"') {
+        line = line.substr(1, line.length - 2).replace(/\\"/g, '"');
+        if (isMsgIdParsed) {
+          message.msgstr += line;
+        } else {
+          message.msgid += line;
+        }
+      }
+    });
+
+    if (parseErrors.length) {
+      throw new Error(`gettext parse errors:\n${parseErrors.join('\n')}`);
+    }
+
+    return messageMap;
+  }
+}
+
+interface PoEntry {
+  comments: string[];
+  references: string[];
+  msgctxt?: string;
+  msgid: string;
+  msgstr?: string;
+}
+
+class _WriteVisitor implements i18n.Visitor {
+  visitText(text: i18n.Text, context?: any): string { return text.value; }
+
+  visitContainer(container: i18n.Container, context?: any): string {
+    return container.children.map(child => child.visit(this)).join('');
+  }
+
+  visitIcu(icu: i18n.Icu, context?: any): string {
+    // TODO(alfaproject): investigate the possibility of using gettext plural for basic ICU plural
+    const cases = Object.keys(icu.cases).map((k: string) => `${k} {${icu.cases[k].visit(this)}}`);
+    return `{${icu.expression}, ${icu.type}, ${cases.join(', ')}}`;
+  }
+
+  visitTagPlaceholder(ph: i18n.TagPlaceholder, context?: any): string {
+    let startTag = '<' + ph.tag;
+
+    startTag += Object.keys(ph.attrs).reduce(
+        (attributes, attrName) => `${attributes} ${attrName}="${ph.attrs[attrName]}"`, '');
+
+    startTag += '>';
+
+    if (ph.isVoid) {
+      // void tags have no children nor closing tags
+      return startTag;
+    }
+
+    const closeTag = '</' + ph.tag + '>';
+
+    return startTag + ph.children.map(child => child.visit(this)).join('') + closeTag;
+  }
+
+  visitPlaceholder(ph: i18n.Placeholder, context?: any): string { return '{{' + ph.value + '}}'; }
+
+  visitIcuPlaceholder(ph: i18n.IcuPlaceholder, context?: any): string {
+    return '{{' + ph.value.visit(this) + '}}';
+  }
+
+  serialize(nodes: i18n.Node[]): string { return nodes.map(node => node.visit(this)).join(''); }
+}

--- a/modules/@angular/compiler/test/i18n/serializers/gettext_spec.ts
+++ b/modules/@angular/compiler/test/i18n/serializers/gettext_spec.ts
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Gettext} from '@angular/compiler/src/i18n/serializers/gettext';
+import {beforeEach, describe, expect, it} from '@angular/core/testing/testing_internal';
+import {MessageBundle} from '../../../src/i18n/message_bundle';
+import {HtmlParser} from '../../../src/ml_parser/html_parser';
+import {DEFAULT_INTERPOLATION_CONFIG} from '../../../src/ml_parser/interpolation_config';
+import {serializeNodes} from '../../ml_parser/ast_serializer_spec';
+
+const HTML = `
+<p i18n-title title="translatable attribute">not translatable</p>
+<p i18n>translatable element <b>with placeholders</b> {{ interpolation}}</p>
+<p i18n="m|d">foo</p>
+<p i18n="ph names"><br><img><div></div></p>
+<p i18n>'single' & "double" quotes</p>
+<p i18n><b class=one>first</b> <b class=two>second</b> <b class="one two">third</b></p>
+<!-- i18n -->{ count, plural, =0 {<p>test</p>}}<!-- /i18n -->
+<p i18n>{ count, plural, =0 { { sex, gender, other {<p>deeply nested</p>}} }}</p>
+`;
+
+const TEMPLATE_POT = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Project-Id-Version: \\n"
+
+#: 983775b9a51ce14b036be72d4cfd65d68d64e231
+msgid "translatable attribute"
+msgstr ""
+
+#: ec1d033f2436133c14ab038286c4f5df4697484a
+msgid "translatable element <b>with placeholders</b> {{ interpolation}}"
+msgstr ""
+
+#. d
+#: db3e0a6a5a96481f60aec61d98c3eecddef5ac23
+msgctxt "m"
+msgid "foo"
+msgstr ""
+
+#. ph names
+#: d7fa2d59aaedcaa5309f13028c59af8c85b8c49d
+msgid "<br><img><div></div>"
+msgstr ""
+
+#: e0a80bce57d61503935b2fa6a42f21ac96d692b1
+msgid "'single' & \\"double\\" quotes"
+msgstr ""
+
+#: bf77d9a5b50dc8bc3ff70158e69ece119522fb7e
+msgid "<b class=\\"one\\">first</b> <b class=\\"two\\">second</b> <b class=\\"one two\\">third</b>"
+msgstr ""
+
+#: e2ccf3d131b15f54aa1fcf1314b1ca77c14bfcc2
+msgid "{ count, plural, =0 {<p>test</p>}}"
+msgstr ""
+
+#: 83dd87699b8c1779dd72277ef6e2d46ca58be042
+msgid "{ count, plural, =0 {{ sex, gender, other {<p>deeply nested</p>}} }}"
+msgstr ""
+`;
+
+const LOCALE_PO = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Project-Id-Version: \\n"
+
+#: 983775b9a51ce14b036be72d4cfd65d68d64e231
+msgid "translatable attribute"
+msgstr "etubirtta elbatalsnart"
+
+#: ec1d033f2436133c14ab038286c4f5df4697484a
+msgid "translatable element <b>with placeholders</b> {{ interpolation}}"
+msgstr "{{ interpolation}} footnemele elbatalsnart <b>sredlohecalp htiw</b>"
+
+#. d
+#: db3e0a6a5a96481f60aec61d98c3eecddef5ac23
+msgctxt "m"
+msgid "foo"
+msgstr "oof"
+
+#. ph names
+#: d7fa2d59aaedcaa5309f13028c59af8c85b8c49d
+msgid "<br><img><div></div>"
+msgstr "<div></div><img><br>"
+
+#: e0a80bce57d61503935b2fa6a42f21ac96d692b1
+msgid "'single' & \\"double\\" quotes"
+msgstr "\\"double\\" and 'single' quotes"
+
+#: bf77d9a5b50dc8bc3ff70158e69ece119522fb7e
+msgid ""
+"<b class=\\"one\\">first</b> <b class=\\"two\\">second</b> <b class=\\"one "
+"two\\">third</b>"
+msgstr ""
+"<b class=\\"one two\\">third</b> <b class=\\"two\\">second</b> <b "
+"class=\\"one\\">first</b>"
+
+#: e2ccf3d131b15f54aa1fcf1314b1ca77c14bfcc2
+msgid "{ count, plural, =0 {<p>test</p>}}"
+msgstr "{ count, plural, =0 {<p>tset</p>}}"
+
+#: 83dd87699b8c1779dd72277ef6e2d46ca58be042
+msgid "{ count, plural, =0 {{ sex, gender, other {<p>deeply nested</p>}} }}"
+msgstr "{ count, plural, =0 {{ sex, gender, other {<p>detsen ylpeed</p>}} }}"
+`;
+
+export function main(): void {
+  let serializer: Gettext;
+  let htmlParser: HtmlParser;
+
+  function toGettext(html: string): string {
+    let catalog = new MessageBundle(new HtmlParser, [], {});
+    catalog.updateFromTemplate(html, '', DEFAULT_INTERPOLATION_CONFIG);
+    return catalog.write(serializer);
+  }
+
+  function loadAsText(template: string, gettext: string): {[id: string]: string} {
+    let messageBundle = new MessageBundle(htmlParser, [], {});
+    messageBundle.updateFromTemplate(template, 'url', DEFAULT_INTERPOLATION_CONFIG);
+
+    const asAst = serializer.load(gettext, 'url', messageBundle);
+    let asText: {[id: string]: string} = {};
+    Object.keys(asAst).forEach(id => { asText[id] = serializeNodes(asAst[id]).join(''); });
+
+    return asText;
+  }
+
+  describe('gettext serializer', () => {
+    beforeEach(() => {
+      htmlParser = new HtmlParser();
+      serializer = new Gettext(htmlParser, DEFAULT_INTERPOLATION_CONFIG);
+    });
+
+    it('should write a valid gettext file',
+       () => { expect(toGettext(HTML)).toEqual(TEMPLATE_POT); });
+
+    it('should load gettext files', () => {
+      expect(loadAsText(HTML, LOCALE_PO)).toEqual({
+        '983775b9a51ce14b036be72d4cfd65d68d64e231': 'etubirtta elbatalsnart',
+        'ec1d033f2436133c14ab038286c4f5df4697484a':
+            '{{ interpolation}} footnemele elbatalsnart <b>sredlohecalp htiw</b>',
+        'db3e0a6a5a96481f60aec61d98c3eecddef5ac23': 'oof',
+        'd7fa2d59aaedcaa5309f13028c59af8c85b8c49d': '<div></div><img/><br/>',
+        'e0a80bce57d61503935b2fa6a42f21ac96d692b1': '"double" and \'single\' quotes',
+        'bf77d9a5b50dc8bc3ff70158e69ece119522fb7e':
+            '<b class="one two">third</b> <b class="two">second</b> <b class="one">first</b>',
+        'e2ccf3d131b15f54aa1fcf1314b1ca77c14bfcc2': '{ count, plural, =0 {<p>tset</p>}}',
+        '83dd87699b8c1779dd72277ef6e2d46ca58be042':
+            '{ count, plural, =0 {{ sex, gender, other {<p>detsen ylpeed</p>}} }}',
+      });
+    });
+  });
+}

--- a/scripts/ci-lite/offline_compiler_test.sh
+++ b/scripts/ci-lite/offline_compiler_test.sh
@@ -41,6 +41,7 @@ cp -v package.json $TMP
   ./node_modules/.bin/ngc --i18nFile=src/messages.fi.xlf --locale=fi --i18nFormat=xlf
   ./node_modules/.bin/ng-xi18n --i18nFormat=xlf
   ./node_modules/.bin/ng-xi18n --i18nFormat=xmb
+  ./node_modules/.bin/ng-xi18n --i18nFormat=pot
 
   ./node_modules/.bin/jasmine init
   # Run compiler-cli integration tests in node


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?**
There is no support for gettext (PO/POT files).
Related ticket: #9104

**What is the new behavior?**
There is some basic support for gettext.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:
`gettext` is a widely used format, and our company has been using it for years. Pretty much all of our tooling is built around it.

I'm starting this PR to tackle the lack of `gettext` support. I'm also starting it early in development, so if anyone else wants to give some feedback or help, then by all means.

The plan is to add acceptable support for serialization and deserialization of PO/POT files. I'm going to try to avoid 3rd party libraries and just assume that all files thrown at this are generated by us or civilized tools.
