### PR TITLE
refactor(http): use Http.request for all http shorthand methods

### DIFF
--- a/modules/@angular/http/src/http.ts
+++ b/modules/@angular/http/src/http.ts
@@ -8,9 +8,7 @@
 
 import {Injectable} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
-
 import {isPresent, isString} from '../src/facade/lang';
-
 import {BaseRequestOptions, RequestOptions} from './base_request_options';
 import {RequestMethod} from './enums';
 import {ConnectionBackend, RequestOptionsArgs} from './interfaces';
@@ -24,7 +22,7 @@ function httpRequest(backend: ConnectionBackend, request: Request): Observable<R
 function mergeOptions(
     defaultOpts: BaseRequestOptions, providedOpts: RequestOptionsArgs, method: RequestMethod,
     url: string): RequestOptions {
-  var newOptions = defaultOpts;
+  const newOptions = defaultOpts;
   if (isPresent(providedOpts)) {
     // Hack so Dart can used named parameters
     return newOptions.merge(new RequestOptions({
@@ -115,7 +113,7 @@ export class Http {
    * of {@link BaseRequestOptions} before performing the request.
    */
   request(url: string|Request, options?: RequestOptionsArgs): Observable<Response> {
-    var responseObservable: any;
+    let responseObservable: any;
     if (isString(url)) {
       responseObservable = httpRequest(
           this._backend,
@@ -132,8 +130,7 @@ export class Http {
    * Performs a request with `get` http method.
    */
   get(url: string, options?: RequestOptionsArgs): Observable<Response> {
-    return httpRequest(
-        this._backend,
+    return this.request(
         new Request(mergeOptions(this._defaultOptions, options, RequestMethod.Get, url)));
   }
 
@@ -141,28 +138,25 @@ export class Http {
    * Performs a request with `post` http method.
    */
   post(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
-    return httpRequest(
-        this._backend, new Request(mergeOptions(
-                           this._defaultOptions.merge(new RequestOptions({body: body})), options,
-                           RequestMethod.Post, url)));
+    return this.request(new Request(mergeOptions(
+        this._defaultOptions.merge(new RequestOptions({body: body})), options, RequestMethod.Post,
+        url)));
   }
 
   /**
    * Performs a request with `put` http method.
    */
   put(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
-    return httpRequest(
-        this._backend, new Request(mergeOptions(
-                           this._defaultOptions.merge(new RequestOptions({body: body})), options,
-                           RequestMethod.Put, url)));
+    return this.request(new Request(mergeOptions(
+        this._defaultOptions.merge(new RequestOptions({body: body})), options, RequestMethod.Put,
+        url)));
   }
 
   /**
    * Performs a request with `delete` http method.
    */
   delete (url: string, options?: RequestOptionsArgs): Observable<Response> {
-    return httpRequest(
-        this._backend,
+    return this.request(
         new Request(mergeOptions(this._defaultOptions, options, RequestMethod.Delete, url)));
   }
 
@@ -170,18 +164,16 @@ export class Http {
    * Performs a request with `patch` http method.
    */
   patch(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
-    return httpRequest(
-        this._backend, new Request(mergeOptions(
-                           this._defaultOptions.merge(new RequestOptions({body: body})), options,
-                           RequestMethod.Patch, url)));
+    return this.request(new Request(mergeOptions(
+        this._defaultOptions.merge(new RequestOptions({body: body})), options, RequestMethod.Patch,
+        url)));
   }
 
   /**
    * Performs a request with `head` http method.
    */
   head(url: string, options?: RequestOptionsArgs): Observable<Response> {
-    return httpRequest(
-        this._backend,
+    return this.request(
         new Request(mergeOptions(this._defaultOptions, options, RequestMethod.Head, url)));
   }
 
@@ -189,8 +181,7 @@ export class Http {
    * Performs a request with `options` http method.
    */
   options(url: string, options?: RequestOptionsArgs): Observable<Response> {
-    return httpRequest(
-        this._backend,
+    return this.request(
         new Request(mergeOptions(this._defaultOptions, options, RequestMethod.Options, url)));
   }
 }
@@ -220,7 +211,7 @@ export class Jsonp extends Http {
    * [Security Guide](http://g.co/ng/security).
    */
   request(url: string|Request, options?: RequestOptionsArgs): Observable<Response> {
-    var responseObservable: any;
+    let responseObservable: any;
     if (isString(url)) {
       url =
           new Request(mergeOptions(this._defaultOptions, options, RequestMethod.Get, <string>url));

--- a/modules/@angular/http/test/http_spec.ts
+++ b/modules/@angular/http/test/http_spec.ts
@@ -72,12 +72,13 @@ export function main() {
   });
 
   describe('http', () => {
-    var url = 'http://foo.bar';
-    var http: Http;
-    var injector: Injector;
-    var backend: MockBackend;
-    var baseResponse: Response;
-    var jsonp: Jsonp;
+    let url = 'http://foo.bar';
+    let http: Http;
+    let injector: Injector;
+    let backend: MockBackend;
+    let baseResponse: Response;
+    let jsonp: Jsonp;
+
     beforeEach(() => {
       injector = ReflectiveInjector.resolveAndCreate([
         BaseRequestOptions, MockBackend, {
@@ -99,6 +100,7 @@ export function main() {
       jsonp = injector.get(Jsonp);
       backend = injector.get(MockBackend);
       baseResponse = new Response(new ResponseOptions({body: 'base response'}));
+      spyOn(Http.prototype, 'request').and.callThrough();
     });
 
     afterEach(() => backend.verifyNoPendingRequests());
@@ -149,7 +151,7 @@ export function main() {
                expect(c.request.method).toEqual(RequestMethod.Post);
                c.mockRespond(baseResponse);
              });
-             let requestOptions = new RequestOptions({method: RequestMethod.Post});
+             const requestOptions = new RequestOptions({method: RequestMethod.Post});
              http.request('http://basic.connection', requestOptions).subscribe((res: Response) => {
                expect(res.text()).toBe('base response');
                async.done();
@@ -192,7 +194,7 @@ export function main() {
            }));
 
         it('should throw if url is not a string or Request', () => {
-          var req = <Request>{};
+          const req = <Request>{};
           expect(() => http.request(req))
               .toThrowError('First argument must be a url string or Request instance.');
         });
@@ -204,9 +206,11 @@ export function main() {
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
              backend.connections.subscribe((c: MockConnection) => {
                expect(c.request.method).toBe(RequestMethod.Get);
+               expect(http.request).toHaveBeenCalled();
                backend.resolveAllConnections();
                async.done();
              });
+             expect(http.request).not.toHaveBeenCalled();
              http.get(url).subscribe((res: Response) => {});
            }));
       });
@@ -217,16 +221,18 @@ export function main() {
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
              backend.connections.subscribe((c: MockConnection) => {
                expect(c.request.method).toBe(RequestMethod.Post);
+               expect(http.request).toHaveBeenCalled();
                backend.resolveAllConnections();
                async.done();
              });
+             expect(http.request).not.toHaveBeenCalled();
              http.post(url, 'post me').subscribe((res: Response) => {});
            }));
 
 
         it('should attach the provided body to the request',
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-             var body = 'this is my post body';
+             const body = 'this is my post body';
              backend.connections.subscribe((c: MockConnection) => {
                expect(c.request.text()).toBe(body);
                backend.resolveAllConnections();
@@ -242,15 +248,17 @@ export function main() {
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
              backend.connections.subscribe((c: MockConnection) => {
                expect(c.request.method).toBe(RequestMethod.Put);
+               expect(http.request).toHaveBeenCalled();
                backend.resolveAllConnections();
                async.done();
              });
+             expect(http.request).not.toHaveBeenCalled();
              http.put(url, 'put me').subscribe((res: Response) => {});
            }));
 
         it('should attach the provided body to the request',
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-             var body = 'this is my put body';
+             const body = 'this is my put body';
              backend.connections.subscribe((c: MockConnection) => {
                expect(c.request.text()).toBe(body);
                backend.resolveAllConnections();
@@ -266,9 +274,11 @@ export function main() {
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
              backend.connections.subscribe((c: MockConnection) => {
                expect(c.request.method).toBe(RequestMethod.Delete);
+               expect(http.request).toHaveBeenCalled();
                backend.resolveAllConnections();
                async.done();
              });
+             expect(http.request).not.toHaveBeenCalled();
              http.delete(url).subscribe((res: Response) => {});
            }));
       });
@@ -279,15 +289,17 @@ export function main() {
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
              backend.connections.subscribe((c: MockConnection) => {
                expect(c.request.method).toBe(RequestMethod.Patch);
+               expect(http.request).toHaveBeenCalled();
                backend.resolveAllConnections();
                async.done();
              });
+             expect(http.request).not.toHaveBeenCalled();
              http.patch(url, 'this is my patch body').subscribe((res: Response) => {});
            }));
 
         it('should attach the provided body to the request',
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
-             var body = 'this is my patch body';
+             const body = 'this is my patch body';
              backend.connections.subscribe((c: MockConnection) => {
                expect(c.request.text()).toBe(body);
                backend.resolveAllConnections();
@@ -303,9 +315,11 @@ export function main() {
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
              backend.connections.subscribe((c: MockConnection) => {
                expect(c.request.method).toBe(RequestMethod.Head);
+               expect(http.request).toHaveBeenCalled();
                backend.resolveAllConnections();
                async.done();
              });
+             expect(http.request).not.toHaveBeenCalled();
              http.head(url).subscribe((res: Response) => {});
            }));
       });
@@ -316,9 +330,11 @@ export function main() {
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
              backend.connections.subscribe((c: MockConnection) => {
                expect(c.request.method).toBe(RequestMethod.Options);
+               expect(http.request).toHaveBeenCalled();
                backend.resolveAllConnections();
                async.done();
              });
+             expect(http.request).not.toHaveBeenCalled();
              http.options(url).subscribe((res: Response) => {});
            }));
       });


### PR DESCRIPTION
Closes https://github.com/angular/angular/issues/11670
