### PR TITLE
fix(router): avoid router initialization for non root components

### DIFF
--- a/modules/@angular/router/src/router_module.ts
+++ b/modules/@angular/router/src/router_module.ts
@@ -7,7 +7,7 @@
  */
 
 import {APP_BASE_HREF, HashLocationStrategy, Location, LocationStrategy, PathLocationStrategy, PlatformLocation} from '@angular/common';
-import {ANALYZE_FOR_ENTRY_COMPONENTS, APP_BOOTSTRAP_LISTENER, ApplicationRef, Compiler, Inject, Injector, ModuleWithProviders, NgModule, NgModuleFactoryLoader, OpaqueToken, Optional, Provider, SkipSelf, SystemJsNgModuleLoader} from '@angular/core';
+import {ANALYZE_FOR_ENTRY_COMPONENTS, APP_BOOTSTRAP_LISTENER, ApplicationRef, Compiler, ComponentRef, Inject, Injector, ModuleWithProviders, NgModule, NgModuleFactoryLoader, OpaqueToken, Optional, Provider, SkipSelf, SystemJsNgModuleLoader} from '@angular/core';
 
 import {Route, Routes} from './config';
 import {RouterLink, RouterLinkWithHref} from './directives/router_link';
@@ -262,7 +262,12 @@ export function rootRoute(router: Router): ActivatedRoute {
 
 export function initialRouterNavigation(
     router: Router, ref: ApplicationRef, preloader: RouterPreloader, opts: ExtraOptions) {
-  return () => {
+  return (bootstrappedComponentRef: ComponentRef<any>) => {
+
+    if (bootstrappedComponentRef !== ref.components[0]) {
+      return;
+    }
+
     router.resetRootComponentType(ref.componentTypes[0]);
     preloader.setUpPreloading();
     if (opts.initialNavigation === false) {

--- a/modules/@angular/router/test/router_module.spec.ts
+++ b/modules/@angular/router/test/router_module.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {APP_BASE_HREF} from '@angular/common';
+import {ApplicationRef, Component, NgModule} from '@angular/core';
+import {TestBed, inject} from '@angular/core/testing';
+import {DOCUMENT} from '@angular/platform-browser';
+import {Router, RouterModule, Routes} from '@angular/router';
+
+
+@Component({selector: 'app-root', template: ''})
+export class AppRootComponent {
+}
+
+@Component({selector: 'bootstrappable-component', template: ''})
+export class BootstrappableComponent {
+}
+
+export const appRoutes: Routes = [{path: '**', redirectTo: ''}];
+
+
+@NgModule({
+  imports: [RouterModule.forRoot(appRoutes)],
+  declarations: [AppRootComponent, BootstrappableComponent],
+  entryComponents: [AppRootComponent, BootstrappableComponent],
+  providers: [{provide: APP_BASE_HREF, useValue: '/'}]
+})
+export class RouterInitTestModule {
+}
+
+
+describe('RouterModule', () => {
+  describe('RouterInitializer', () => {
+
+    beforeEach(() => { TestBed.configureTestingModule({imports: [RouterInitTestModule]}); });
+
+    beforeEach(inject([DOCUMENT], function(doc: HTMLDocument) {
+      // create the dom elment for the root component
+      const elRootApp = doc.createElement('app-root');
+      doc.body.appendChild(elRootApp);
+      // create the dom elment for the 2nd bootable component
+      const elBootComp = doc.createElement('bootstrappable-component');
+      doc.body.appendChild(elBootComp);
+    }));
+
+    it('should not init router navigation listeners if a non root component is bootstraped', () => {
+      const appRef: ApplicationRef = TestBed.get(ApplicationRef);
+      const r: Router = TestBed.get(Router);
+
+      // register a spy on a function that is called on each init
+      const spy = spyOn(r, 'resetRootComponentType').and.callThrough();
+
+      // bootstrap the root app
+      appRef.bootstrap(AppRootComponent);
+      // router listener initialization should happen
+      expect(r.resetRootComponentType).toHaveBeenCalled();
+
+      // reset the calls to the spy
+      spy.calls.reset();
+
+      // bootstrap a component that is not the root compnent
+      appRef.bootstrap(BootstrappableComponent);
+      // router listener initialization should not happen
+      expect(r.resetRootComponentType).not.toHaveBeenCalled();
+
+    });
+  });
+
+
+});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?**
If more than one component is bootstrapped the router is initialized more than once. see issues:
- https://github.com/angular/angular/issues/12282
- https://github.com/angular/angular/issues/12218 

**What is the new behavior?**
- if additional components are bootstrapped the router is not initialized again

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:
@vsavkin This pr only solves the mentioned issues. I'm not quite sure. But I think a more general solution would be to make sure the listener for APP_BOOTSTRAP_LISTENER is only called once.
