### PR TITLE
fix(CurrencyPipe): should accept `null` input on currencyCode

### DIFF
--- a/modules/@angular/common/src/pipes/number_pipe.ts
+++ b/modules/@angular/common/src/pipes/number_pipe.ts
@@ -7,13 +7,12 @@
  */
 
 import {Inject, LOCALE_ID, Pipe, PipeTransform, Type} from '@angular/core';
-
 import {NumberFormatStyle, NumberFormatter} from '../facade/intl';
 import {NumberWrapper, isBlank, isPresent} from '../facade/lang';
-
 import {InvalidPipeArgumentError} from './invalid_pipe_argument_error';
 
 const _NUMBER_FORMAT_REGEXP = /^(\d+)?\.((\d+)(-(\d+))?)?$/;
+const DEFAULT_CODE: string = 'USD';
 
 function formatNumber(
     pipe: Type<any>, locale: string, value: number | string, style: NumberFormatStyle,
@@ -155,8 +154,9 @@ export class CurrencyPipe implements PipeTransform {
   constructor(@Inject(LOCALE_ID) private _locale: string) {}
 
   transform(
-      value: any, currencyCode: string = 'USD', symbolDisplay: boolean = false,
+      value: any, currencyCode?: string, symbolDisplay: boolean = false,
       digits: string = null): string {
+    currencyCode = currencyCode || DEFAULT_CODE;
     return formatNumber(
         CurrencyPipe, this._locale, value, NumberFormatStyle.Currency, digits, currencyCode,
         symbolDisplay);

--- a/modules/@angular/common/test/pipes/number_pipe_spec.ts
+++ b/modules/@angular/common/test/pipes/number_pipe_spec.ts
@@ -66,7 +66,7 @@ export function main() {
 
       describe('transform', () => {
         it('should return correct value for numbers', () => {
-          // In old Chrome, default formatiing for USD is different
+          // In old Chrome, default formatting for USD is different
           if (browserDetection.isOldChrome) {
             expect(normalize(pipe.transform(123))).toEqual('USD123');
           } else {
@@ -76,8 +76,14 @@ export function main() {
           expect(normalize(pipe.transform(5.1234, 'USD', false, '.0-3'))).toEqual('USD5.123');
         });
 
+        it('should not throw for undefined currencyCode',
+           () => expect(() => pipe.transform(12, undefined)).not.toThrowError());
+
+        it('should not throw for null currencyCode',
+           () => expect(() => pipe.transform(12, null)).not.toThrowError());
+
         it('should not support other objects',
-           () => { expect(() => pipe.transform(new Object())).toThrowError(); });
+           () => expect(() => pipe.transform({})).toThrowError());
       });
     });
   });


### PR DESCRIPTION
Fixes https://github.com/angular/angular/issues/7917
