### PR TITLE
Fixes angular/universal/issues/597

### DIFF
--- a/modules/@angular/core/src/linker/view_utils.ts
+++ b/modules/@angular/core/src/linker/view_utils.ts
@@ -20,7 +20,7 @@ import {ExpressionChangedAfterItHasBeenCheckedError} from './errors';
 @Injectable()
 export class ViewUtils {
   sanitizer: Sanitizer;
-  private _nextCompTypeId: number = 0;
+  private static _nextCompTypeId: number = 0;
 
   constructor(
       private _renderer: RootRenderer, @Inject(APP_ID) private _appId: string,
@@ -36,7 +36,7 @@ export class ViewUtils {
       templateUrl: string, slotCount: number, encapsulation: ViewEncapsulation,
       styles: Array<string|any[]>, animations: {[key: string]: Function}): RenderComponentType {
     return new RenderComponentType(
-        `${this._appId}-${this._nextCompTypeId++}`, templateUrl, slotCount, encapsulation, styles,
+        `${this._appId}-${ViewUtils._nextCompTypeId++}`, templateUrl, slotCount, encapsulation, styles,
         animations);
   }
 

--- a/modules/@angular/core/src/linker/view_utils.ts
+++ b/modules/@angular/core/src/linker/view_utils.ts
@@ -37,7 +37,7 @@ export class ViewUtils {
       styles: Array<string|any[]>, animations: {[key: string]: Function}): RenderComponentType {
     return new RenderComponentType(
         `${this._appId}-${ViewUtils._nextCompTypeId++}`, templateUrl, slotCount, encapsulation,
-      styles, animations);
+        styles, animations);
   }
 
   /** @internal */

--- a/modules/@angular/core/src/linker/view_utils.ts
+++ b/modules/@angular/core/src/linker/view_utils.ts
@@ -36,8 +36,8 @@ export class ViewUtils {
       templateUrl: string, slotCount: number, encapsulation: ViewEncapsulation,
       styles: Array<string|any[]>, animations: {[key: string]: Function}): RenderComponentType {
     return new RenderComponentType(
-        `${this._appId}-${ViewUtils._nextCompTypeId++}`, templateUrl, slotCount, encapsulation, styles,
-        animations);
+        `${this._appId}-${ViewUtils._nextCompTypeId++}`, templateUrl, slotCount, encapsulation,
+      styles, animations);
   }
 
   /** @internal */


### PR DESCRIPTION
- **I'm submitting a ...**
- [x] bug report
- [ ] feature request
- [ ] support request => Please do not submit support request here, see note at the top of this template.
- **What modules are related to this Issue?**
- [ ] express-engine
- [ ] grunt-prerender
- [ ] gulp-prerender
- [ ] hapi-engine
- [ ] universal-next
- [x] universal
- [ ] webpack-prerender
- **Do you want to request a _feature_ or report a _bug_?**
  Report a _bug_
- **What is the current behavior?**
  There is an app with bootstrapped module _Main_ and two routes: _A_ and _B_.
  After server rendering there is a bunch of style tags in the head of a document. All of them belong to _Main_ and first hitted route, let it be _A_. And it's prefect, since I have all styles for that page. But when I try to hit route _B_ I see only styles from _Main_ component but no styles for _B_ component.
  If I restart server and hit route with _B_ component first, I see _Main_ and _B_ styles. But if I try to go to route _A_ I will see only _Main_ component's styles in my document and no styles for _A_ component.

[Example](https://github.com/ServerSideRender/angular-universal)
- **If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem** by creating a github repo.
- Remove javascript bundle from any Angular Universal App with at least 2 routes.
- Start server.
- Make a request to one route, check styles.
- Make a request to another route, check styles. 
  Some components' styles are missed on this step. 
- **What is the expected behavior?**
  Every response should provide all classes for components presented on the page for current route. 
- **Please tell us about your environment:**
- Angular version: 2.0.0 / 2.1.0
- Browser: [all]
- Language: [TypeScript]
- OS:  [Mac OS X]
- Platform: [NodeJs]

This will fix an issue of Angular Universal with styles being rendered with wrong ids and not rendered at all.

https://github.com/angular/universal/issues/597
