### PR TITLE
fix(http): make normalizeMethodName optimizer-compatible.

### DIFF
--- a/modules/@angular/http/src/http_utils.ts
+++ b/modules/@angular/http/src/http_utils.ts
@@ -11,17 +11,24 @@ import {isString} from '../src/facade/lang';
 import {RequestMethod} from './enums';
 
 export function normalizeMethodName(method: string | RequestMethod): RequestMethod {
-  if (isString(method)) {
-    var originalMethod = method;
-    method = (<string>method)
-                 .replace(
-                     /(\w)(\w*)/g,
-                     (g0: string, g1: string, g2: string) => g1.toUpperCase() + g2.toLowerCase());
-    method = <RequestMethod>(<{[key: string]: any}>RequestMethod)[method];
-    if (typeof method !== 'number')
-      throw new Error(`Invalid request method. The method "${originalMethod}" is not supported.`);
+  if (!isString(method)) return method;
+  switch (method.toUpperCase()) {
+    case 'GET':
+      return RequestMethod.Get;
+    case 'POST':
+      return RequestMethod.Post;
+    case 'PUT':
+      return RequestMethod.Put;
+    case 'DELETE':
+      return RequestMethod.Delete;
+    case 'OPTIONS':
+      return RequestMethod.Options;
+    case 'HEAD':
+      return RequestMethod.Head;
+    case 'PATCH':
+      return RequestMethod.Patch;
   }
-  return <RequestMethod>method;
+  throw new Error(`Invalid request method. The method "${method}" is not supported.`);
 }
 
 export const isSuccess = (status: number): boolean => (status >= 200 && status < 300);


### PR DESCRIPTION
`normalizeMethodName` reflectively accessed the RequestMethod enum. With a smart
optimizer, properties from the enum could be removed or renamed, and so user
code just passing in e.g. 'PATCH' might not work. This change fixes the code to
be more explicit and avoids the optimizer issue.
