### PR TITLE
fix(router): ensure preactivation orders guards correctly (#12377)

### DIFF
--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -727,7 +727,9 @@ export class PreActivation {
     // reusing the node
     if (curr && future._routeConfig === curr._routeConfig) {
       if (!shallowEqual(future.params, curr.params)) {
-        this.checks.push(new CanDeactivate(outlet.component, curr), new CanActivate(futurePath));
+        // we're moving top-down, so deactivations should always be added onto the front
+        this.checks.unshift(new CanDeactivate(outlet.component, curr));
+        this.checks.push(new CanActivate(futurePath));
       } else {
         // we need to set the data
         future.data = curr.data;
@@ -768,8 +770,8 @@ export class PreActivation {
 
   private deactivateOutletAndItChildren(route: ActivatedRouteSnapshot, outlet: RouterOutlet): void {
     if (outlet && outlet.isActivated) {
+      this.checks.unshift(new CanDeactivate(outlet.component, route));
       this.deactivateOutletMap(outlet.outletMap);
-      this.checks.push(new CanDeactivate(outlet.component, route));
     }
   }
 

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -1331,16 +1331,13 @@ describe('Integration', () => {
             provide: token,
             useFactory: (logger: Logger) => () => (logger.add(token), true),
             deps: [Logger]
-          }
-        }
+          };
+        };
         TestBed.configureTestingModule({
           providers: [
-            Logger,
-            provideTokenLogger('canActivateChild_parent'),
-            provideTokenLogger('canActivate_team'),
-            provideTokenLogger('canDeactivate_team'),
-            provideTokenLogger('canActivate_summary'),
-            provideTokenLogger('canDeactivate_summary'),
+            Logger, provideTokenLogger('canActivateChild_parent'),
+            provideTokenLogger('canActivate_team'), provideTokenLogger('canDeactivate_team'),
+            provideTokenLogger('canActivate_summary'), provideTokenLogger('canDeactivate_summary'),
             provideTokenLogger('canActivate_roster')
           ]
         });
@@ -1385,7 +1382,8 @@ describe('Integration', () => {
                  canActivate: ['canActivate_team'],
                  canDeactivate: ['canDeactivate_team'],
                  component: TeamCmp,
-                 children: [{
+                 children: [
+                   {
                      path: 'summary',
                      canActivate: ['canActivate_summary'],
                      canDeactivate: ['canDeactivate_summary'],
@@ -1396,7 +1394,8 @@ describe('Integration', () => {
                      canActivate: ['canActivate_roster'],
                      canDeactivate: ['canDeactivate_NEVER'],
                      component: BlankCmp
-                   }]
+                   }
+                 ]
                }]);
 
                router.navigateByUrl('/team/22/summary');
@@ -1408,7 +1407,8 @@ describe('Integration', () => {
                expect(logger.logs).toEqual([
                  'canActivate_team', 'canActivate_summary',
 
-                 'canDeactivate_summary', 'canDeactivate_team', 'canActivate_team', 'canActivate_roster'
+                 'canDeactivate_summary', 'canDeactivate_team', 'canActivate_team',
+                 'canActivate_roster'
                ]);
              })));
     });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)  _N/A -- fix brings behavior in line with the existing docs._

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
#12377

**What is the new behavior?**
Reused nodes add their guards to the to-check list in a manner that maintains the overall order of (deactivations leaf-to-root, then activations root-to-leaf).

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes (sort-of??)
[ ] No
```

If anyone was dependent on the existing (_incorrect_ and _undocumented_) ordering, they could use guards to trigger a singular service which would enforce their desired behavior upon the operations, or for certain setups they may be able to restructure the route hierarchy to execute in the way they desire.

IMO, it seems highly unlikely anyone would be super dependent on the existing behavior though, because it is incongruous and defies the inherent hierarchy of the route configuration.

**Other information**:

Fixes #12377