### PR TITLE
fix(router): canDeactivate guards are not triggered for componentless…

### DIFF
--- a/modules/@angular/router/src/config.ts
+++ b/modules/@angular/router/src/config.ts
@@ -8,7 +8,7 @@
 
 import {Type} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
-
+import {PRIMARY_OUTLET} from './shared';
 
 /**
  * @whatItDoes Represents router configuration.
@@ -319,6 +319,10 @@ export function validateConfig(config: Routes): void {
 function validateNode(route: Route): void {
   if (Array.isArray(route)) {
     throw new Error(`Invalid route configuration: Array cannot be specified`);
+  }
+  if (route.component === undefined && (route.outlet && route.outlet !== PRIMARY_OUTLET)) {
+    throw new Error(
+        `Invalid route configuration of route '${route.path}': a componentless route cannot have a named outlet set`);
   }
   if (!!route.redirectTo && !!route.children) {
     throw new Error(

--- a/modules/@angular/router/src/directives/router_outlet.ts
+++ b/modules/@angular/router/src/directives/router_outlet.ts
@@ -12,8 +12,6 @@ import {RouterOutletMap} from '../router_outlet_map';
 import {ActivatedRoute} from '../router_state';
 import {PRIMARY_OUTLET} from '../shared';
 
-
-
 /**
  * @whatItDoes Acts as a placeholder that Angular dynamically fills based on the current router
  * state.
@@ -79,6 +77,10 @@ export class RouterOutlet implements OnDestroy {
       activatedRoute: ActivatedRoute, loadedResolver: ComponentFactoryResolver,
       loadedInjector: Injector, providers: ResolvedReflectiveProvider[],
       outletMap: RouterOutletMap): void {
+    if (this.isActivated) {
+      throw new Error('Cannot activate an already activated outlet');
+    }
+
     this.outletMap = outletMap;
     this._activatedRoute = activatedRoute;
 

--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -21,14 +21,14 @@ import {mergeMap} from 'rxjs/operator/mergeMap';
 import {reduce} from 'rxjs/operator/reduce';
 
 import {applyRedirects} from './apply_redirects';
-import {ResolveData, Routes, validateConfig} from './config';
+import {Data, ResolveData, Routes, validateConfig} from './config';
 import {createRouterState} from './create_router_state';
 import {createUrlTree} from './create_url_tree';
 import {RouterOutlet} from './directives/router_outlet';
 import {recognize} from './recognize';
 import {LoadedRouterConfig, RouterConfigLoader} from './router_config_loader';
 import {RouterOutletMap} from './router_outlet_map';
-import {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot, advanceActivatedRoute, createEmptyState} from './router_state';
+import {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot, advanceActivatedRoute, createEmptyState, inheritedParamsDataResolve} from './router_state';
 import {NavigationCancelingError, PRIMARY_OUTLET, Params} from './shared';
 import {DefaultUrlHandlingStrategy, UrlHandlingStrategy} from './url_handling_strategy';
 import {UrlSerializer, UrlTree, containsTree, createEmptyUrlTree} from './url_tree';
@@ -781,6 +781,7 @@ export class PreActivation {
       } else {
         // we need to set the data
         future.data = curr.data;
+        future._resolvedData = curr._resolvedData;
       }
 
       // If we have a component, we need to go through an outlet.
@@ -881,9 +882,9 @@ export class PreActivation {
 
   private runResolve(future: ActivatedRouteSnapshot): Observable<any> {
     const resolve = future._resolve;
-    return map.call(this.resolveNode(resolve.current, future), (resolvedData: any): any => {
-      resolve.resolvedData = resolvedData;
-      future.data = merge(future.data, resolve.flattenedResolvedData);
+    return map.call(this.resolveNode(resolve, future), (resolvedData: any): any => {
+      future._resolvedData = resolvedData;
+      future.data = merge(future.data, inheritedParamsDataResolve(future).resolve);
       return null;
     });
   }

--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -921,9 +921,7 @@ class ActivateRoutes {
       this.activateRoutes(c, prevChildren[c.value.outlet], outletMap);
       delete prevChildren[c.value.outlet];
     });
-    forEach(
-        prevChildren,
-        (v: any, k: string) => this.deactivateOutletAndItChildren(outletMap._outlets[k]));
+    forEach(prevChildren, (v: any, k: string) => this.deactiveRouteAndItsChildren(v, outletMap));
   }
 
   activateRoutes(
@@ -939,7 +937,7 @@ class ActivateRoutes {
 
       // If we have a normal route, we need to go through an outlet.
       if (future.component) {
-        const outlet = getOutlet(parentOutletMap, futureNode.value);
+        const outlet = getOutlet(parentOutletMap, future);
         this.activateChildRoutes(futureNode, currNode, outlet.outletMap);
 
         // if we have a componentless route, we recurse but keep the same outlet map.
@@ -948,15 +946,7 @@ class ActivateRoutes {
       }
     } else {
       if (curr) {
-        // if we had a normal route, we need to deactivate only that outlet.
-        if (curr.component) {
-          const outlet = getOutlet(parentOutletMap, futureNode.value);
-          this.deactivateOutletAndItChildren(outlet);
-
-          // if we had a componentless route, we need to deactivate everything!
-        } else {
-          this.deactivateOutletMap(parentOutletMap);
-        }
+        this.deactiveRouteAndItsChildren(currNode, parentOutletMap);
       }
 
       // if we have a normal route, we need to advance the route
@@ -998,15 +988,31 @@ class ActivateRoutes {
         outletMap);
   }
 
-  private deactivateOutletAndItChildren(outlet: RouterOutlet): void {
+  private deactiveRouteAndItsChildren(
+      route: TreeNode<ActivatedRoute>, parentOutletMap: RouterOutletMap): void {
+    const prevChildren: {[key: string]: any} = nodeChildrenAsMap(route);
+    let outlet: RouterOutlet = null;
+
+    // getOutlet throws when cannot find the right outlet,
+    // which can happen if an outlet was in an NgIf and was removed
+    try {
+      outlet = getOutlet(parentOutletMap, route.value);
+    } catch (e) {
+      return;
+    }
+    const childOutletMap = outlet.outletMap;
+
+    forEach(prevChildren, (v: any, k: string) => {
+      if (route.value.component) {
+        this.deactiveRouteAndItsChildren(v, childOutletMap);
+      } else {
+        this.deactiveRouteAndItsChildren(v, parentOutletMap);
+      }
+    });
+
     if (outlet && outlet.isActivated) {
-      this.deactivateOutletMap(outlet.outletMap);
       outlet.deactivate();
     }
-  }
-
-  private deactivateOutletMap(outletMap: RouterOutletMap): void {
-    forEach(outletMap._outlets, (v: RouterOutlet) => this.deactivateOutletAndItChildren(v));
   }
 }
 

--- a/modules/@angular/router/test/config.spec.ts
+++ b/modules/@angular/router/test/config.spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {validateConfig} from '../src/config';
+import {PRIMARY_OUTLET} from '../src/shared';
 
 describe('config', () => {
   describe('validateConfig', () => {
@@ -79,6 +80,16 @@ describe('config', () => {
       expect(() => { validateConfig([{path: 'a', pathMatch: 'invalid', component: ComponentB}]); })
           .toThrowError(
               /Invalid configuration of route 'a': pathMatch can only be set to 'prefix' or 'full'/);
+    });
+
+    it('should throw when pathPatch is invalid', () => {
+      expect(() => { validateConfig([{path: 'a', outlet: 'aux', children: []}]); })
+          .toThrowError(
+              /Invalid route configuration of route 'a': a componentless route cannot have a named outlet set/);
+
+      expect(() => validateConfig([{path: 'a', outlet: '', children: []}])).not.toThrow();
+      expect(() => validateConfig([{path: 'a', outlet: PRIMARY_OUTLET, children: []}]))
+          .not.toThrow();
     });
   });
 });

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -695,6 +695,30 @@ describe('Integration', () => {
 
          expect(e).toEqual('error');
        })));
+
+    it('should preserve resolved data',
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = createRoot(router, RootCmp);
+
+         router.resetConfig([{
+           path: 'parent',
+           resolve: {two: 'resolveTwo'},
+           children: [
+             {path: 'child1', component: CollectParamsCmp},
+             {path: 'child2', component: CollectParamsCmp}
+           ]
+         }]);
+
+         let e: any = null;
+         router.navigateByUrl('/parent/child1');
+         advance(fixture);
+
+         router.navigateByUrl('/parent/child2');
+         advance(fixture);
+
+         const cmp = fixture.debugElement.children[1].componentInstance;
+         expect(cmp.route.snapshot.data).toEqual({two: 2});
+       })));
   });
 
   describe('router links', () => {
@@ -2102,9 +2126,9 @@ class CollectParamsCmp {
   private params: any = [];
   private urls: any = [];
 
-  constructor(a: ActivatedRoute) {
-    a.params.forEach(p => this.params.push(p));
-    a.url.forEach(u => this.urls.push(u));
+  constructor(private route: ActivatedRoute) {
+    route.params.forEach(p => this.params.push(p));
+    route.url.forEach(u => this.urls.push(u));
   }
 
   recordedUrls(): string[] {

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -1147,6 +1147,34 @@ describe('Integration', () => {
              ]);
            })));
 
+        it('works with aux routes',
+           fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+             const fixture = createRoot(router, RootCmp);
+
+             router.resetConfig([{
+               path: 'two-outlets',
+               component: TwoOutletsCmp,
+               children: [
+                 {path: 'a', component: BlankCmp}, {
+                   path: 'b',
+                   canDeactivate: ['RecordingDeactivate'],
+                   component: SimpleCmp,
+                   outlet: 'aux'
+                 }
+               ]
+             }]);
+
+             router.navigateByUrl('/two-outlets/(a//aux:b)');
+             advance(fixture);
+             expect(location.path()).toEqual('/two-outlets/(a//aux:b)');
+
+             router.navigate(['two-outlets', {outlets: {aux: null}}]);
+             advance(fixture);
+
+             expect(log).toEqual([['Deactivate', 'b']]);
+             expect(location.path()).toEqual('/two-outlets/(a)');
+           })));
+
         it('works with a nested route',
            fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
              const fixture = createRoot(router, RootCmp);
@@ -2057,6 +2085,14 @@ class TeamCmp {
   }
 }
 
+@Component({
+  selector: 'two-outlets-cmp',
+  template: `[ <router-outlet></router-outlet>, aux: <router-outlet name="aux"></router-outlet> ]`
+})
+class TwoOutletsCmp {
+}
+
+
 @Component({selector: 'user-cmp', template: `user {{name | async}}`})
 class UserCmp {
   name: Observable<string>;
@@ -2159,6 +2195,7 @@ function createRoot(router: Router, type: any): ComponentFixture<any> {
   entryComponents: [
     BlankCmp,
     SimpleCmp,
+    TwoOutletsCmp,
     TeamCmp,
     UserCmp,
     StringLinkCmp,
@@ -2183,6 +2220,7 @@ function createRoot(router: Router, type: any): ComponentFixture<any> {
   exports: [
     BlankCmp,
     SimpleCmp,
+    TwoOutletsCmp,
     TeamCmp,
     UserCmp,
     StringLinkCmp,
@@ -2209,6 +2247,7 @@ function createRoot(router: Router, type: any): ComponentFixture<any> {
     BlankCmp,
     SimpleCmp,
     TeamCmp,
+    TwoOutletsCmp,
     UserCmp,
     StringLinkCmp,
     DummyLinkCmp,

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -531,6 +531,29 @@ describe('Integration', () => {
        expect(fixture.nativeElement).toHaveText('primary [simple] right [user victor]');
      })));
 
+  it('should not deactivate aux routes when navigating from a componentless routes',
+     fakeAsync(inject(
+         [Router, Location, NgModuleFactoryLoader],
+         (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+           const fixture = createRoot(router, TwoOutletsCmp);
+
+           router.resetConfig([
+             {path: 'simple', component: SimpleCmp},
+             {path: 'componentless', children: [{path: 'simple', component: SimpleCmp}]},
+             {path: 'user/:name', outlet: 'aux', component: UserCmp}
+           ]);
+
+           router.navigateByUrl('/componentless/simple(aux:user/victor)');
+           advance(fixture);
+           expect(location.path()).toEqual('/componentless/simple(aux:user/victor)');
+           expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
+
+           router.navigateByUrl('/simple(aux:user/victor)');
+           advance(fixture);
+           expect(location.path()).toEqual('/simple(aux:user/victor)');
+           expect(fixture.nativeElement).toHaveText('[ simple, aux: user victor ]');
+         })));
+
   it('should emit an event when an outlet gets activated', fakeAsync(() => {
        @Component({
          selector: 'container',

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -623,7 +623,8 @@ describe('Integration', () => {
         providers: [
           {provide: 'resolveTwo', useValue: (a: any, b: any) => 2},
           {provide: 'resolveFour', useValue: (a: any, b: any) => 4},
-          {provide: 'resolveSix', useClass: ResolveSix}
+          {provide: 'resolveSix', useClass: ResolveSix},
+          {provide: 'resolveError', useValue: (a: any, b: any) => Promise.reject('error')},
         ]
       });
     });
@@ -671,6 +672,28 @@ describe('Integration', () => {
          expect(rightRecorded).toEqual([
            {one: 1, five: 5, two: 2, six: 6}, {one: 1, five: 5, two: 2, six: 6}
          ]);
+       })));
+
+    it('should handle errors',
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = createRoot(router, RootCmp);
+
+         router.resetConfig(
+             [{path: 'simple', component: SimpleCmp, resolve: {error: 'resolveError'}}]);
+
+         let recordedEvents: any[] = [];
+         router.events.subscribe(e => recordedEvents.push(e));
+
+         let e: any = null;
+         router.navigateByUrl('/simple').catch(error => e = error);
+         advance(fixture);
+
+         expectEvents(recordedEvents, [
+           [NavigationStart, '/simple'], [RoutesRecognized, '/simple'],
+           [NavigationError, '/simple']
+         ]);
+
+         expect(e).toEqual('error');
        })));
   });
 

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -1055,7 +1055,11 @@ describe('Integration', () => {
 
     describe('CanDeactivate', () => {
       describe('should not deactivate a route when CanDeactivate returns false', () => {
+        let log: any;
+
         beforeEach(() => {
+          log = [];
+
           TestBed.configureTestingModule({
             providers: [
               {
@@ -1074,6 +1078,13 @@ describe('Integration', () => {
                 provide: 'CanDeactivateUser',
                 useValue: (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
                   return a.params['name'] === 'victor';
+                }
+              },
+              {
+                provide: 'RecordingDeactivate',
+                useValue: (c: any, a: ActivatedRouteSnapshot, b: RouterStateSnapshot) => {
+                  log.push(['Deactivate', a.routeConfig.path]);
+                  return true;
                 }
               },
             ]
@@ -1103,27 +1114,37 @@ describe('Integration', () => {
              expect(canceledStatus).toEqual(false);
            })));
 
-        it('works (componentless route)',
+        it('works with componentless routes',
            fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
              const fixture = createRoot(router, RootCmp);
 
-             router.resetConfig([{
-               path: 'parent/:id',
-               canDeactivate: ['CanDeactivateParent'],
-               children: [{path: 'simple', component: SimpleCmp}]
-             }]);
+             router.resetConfig([
+               {
+                 path: 'grandparent',
+                 canDeactivate: ['RecordingDeactivate'],
+                 children: [{
+                   path: 'parent',
+                   canDeactivate: ['RecordingDeactivate'],
+                   children: [{
+                     path: 'child',
+                     canDeactivate: ['RecordingDeactivate'],
+                     children: [{path: 'simple', component: SimpleCmp}]
+                   }]
+                 }]
+               },
+               {path: 'simple', component: SimpleCmp}
+             ]);
 
-             router.navigateByUrl('/parent/22/simple');
+             router.navigateByUrl('/grandparent/parent/child/simple');
              advance(fixture);
-             expect(location.path()).toEqual('/parent/22/simple');
+             expect(location.path()).toEqual('/grandparent/parent/child/simple');
 
-             router.navigateByUrl('/parent/33/simple');
+             router.navigateByUrl('/simple');
              advance(fixture);
-             expect(location.path()).toEqual('/parent/33/simple');
 
-             router.navigateByUrl('/parent/44/simple');
-             advance(fixture);
-             expect(location.path()).toEqual('/parent/33/simple');
+             expect(log).toEqual([
+               ['Deactivate', 'child'], ['Deactivate', 'parent'], ['Deactivate', 'grandparent']
+             ]);
            })));
 
         it('works with a nested route',

--- a/modules/@angular/router/test/recognize.spec.ts
+++ b/modules/@angular/router/test/recognize.spec.ts
@@ -219,26 +219,7 @@ describe('recognize', () => {
           [{path: 'a', resolve: {one: 'some-token'}, component: ComponentA}], 'a',
           (s: RouterStateSnapshot) => {
             const r: ActivatedRouteSnapshot = s.firstChild(s.root);
-            expect(r._resolve.current).toEqual({one: 'some-token'});
-          });
-    });
-
-    it('should reuse componentless route\'s resolve', () => {
-      checkRecognize(
-          [{
-            path: 'a',
-            resolve: {one: 'one'},
-            children: [
-              {path: '', resolve: {two: 'two'}, component: ComponentB},
-              {path: '', resolve: {three: 'three'}, component: ComponentC, outlet: 'aux'}
-            ]
-          }],
-          'a', (s: RouterStateSnapshot) => {
-            const a: ActivatedRouteSnapshot = s.firstChild(s.root);
-            const c: ActivatedRouteSnapshot[] = s.children(<any>a);
-
-            expect(c[0]._resolve.parent).toBe(a._resolve);
-            expect(c[1]._resolve.parent).toBe(a._resolve);
+            expect(r._resolve).toEqual({one: 'some-token'});
           });
     });
   });

--- a/modules/@angular/router/test/router.spec.ts
+++ b/modules/@angular/router/test/router.spec.ts
@@ -8,9 +8,10 @@
 
 import {TestBed} from '@angular/core/testing';
 
+import {ResolveData} from '../src/config';
 import {PreActivation, Router} from '../src/router';
 import {RouterOutletMap} from '../src/router_outlet_map';
-import {ActivatedRouteSnapshot, InheritedResolve, RouterStateSnapshot, createEmptyStateSnapshot} from '../src/router_state';
+import {ActivatedRouteSnapshot, RouterStateSnapshot, createEmptyStateSnapshot} from '../src/router_state';
 import {DefaultUrlSerializer} from '../src/url_tree';
 import {TreeNode} from '../src/utils/tree';
 import {RouterTestingModule} from '../testing/router_testing_module';
@@ -39,7 +40,7 @@ describe('Router', () => {
     beforeEach(() => { empty = createEmptyStateSnapshot(serializer.parse('/'), null); });
 
     it('should resolve data', () => {
-      const r = new InheritedResolve(InheritedResolve.empty, {data: 'resolver'});
+      const r = {data: 'resolver'};
       const n = createActivatedRouteSnapshot('a', {resolve: r});
       const s = new RouterStateSnapshot('url', new TreeNode(empty.root, [new TreeNode(n, [])]));
 
@@ -49,10 +50,10 @@ describe('Router', () => {
     });
 
     it('should wait for the parent resolve to complete', () => {
-      const parentResolve = new InheritedResolve(InheritedResolve.empty, {data: 'resolver'});
-      const childResolve = new InheritedResolve(parentResolve, {});
+      const parentResolve = {data: 'resolver'};
+      const childResolve = {};
 
-      const parent = createActivatedRouteSnapshot('a', {resolve: parentResolve});
+      const parent = createActivatedRouteSnapshot(null, {resolve: parentResolve});
       const child = createActivatedRouteSnapshot('b', {resolve: childResolve});
 
       const s = new RouterStateSnapshot(
@@ -66,8 +67,8 @@ describe('Router', () => {
     });
 
     it('should copy over data when creating a snapshot', () => {
-      const r1 = new InheritedResolve(InheritedResolve.empty, {data: 'resolver1'});
-      const r2 = new InheritedResolve(InheritedResolve.empty, {data: 'resolver2'});
+      const r1 = {data: 'resolver1'};
+      const r2 = {data: 'resolver2'};
 
       const n1 = createActivatedRouteSnapshot('a', {resolve: r1});
       const s1 = new RouterStateSnapshot('url', new TreeNode(empty.root, [new TreeNode(n1, [])]));


### PR DESCRIPTION
This PR fixes a few issues with the router.
## Deactivation

Previously we would not trigger the `canDeactivate` guards of componentless routes. This is because we used an outlet map to find the guards, and componentless routes have nothing to do with outlets. This PR changes it. Now we traverse the router tree instead.
## Named outlets and componentless routes

Previously we would allow componentless routes to have named outlets. It never worked properly (it would either silently fail or load components into wrong outlets). This PR makes it an explicit error. 

To see why it has to be an error, let's look at the following example:

```
const routes = [
  {path: 'a', component: A},
  {path: 'b', outlet: 'aux', children: [
    {path: 'b1', component: B1},
    {path: 'b2', outlet: 'aux2, component: B2}
  ]}
]
```

And let's say the template of the root component looks like this:

```
<router-outlet></router-outlet>
<router-outlet name="aux"></router-outlet>
```

When navigating to `/a(aux:b/(b1//aux2:b2))`, where should B1 and B2 be loaded? There is only one 'aux' outlet in the root component. 

In theory we could use some sort of prefix scheme, where you would have to define the root component like this:

```
<router-outlet></router-outlet>
<router-outlet name="aux"></router-outlet>
<router-outlet name="aux_aux2"></router-outlet>
```

This, however, creates a lot of issues (e.g., name collisions). Instead we recommend to create a component with all the right outlets:

```
const routes = [
  {path: 'a', component: A},
  {path: 'b', outlet: 'aux', component: B, children: [
    {path: 'b1', component: B1},
    {path: 'b2', outlet: 'aux2, component: B2}
  ]}
]
```

where the template of B looks like this:

```
<router-outlet></router-outlet>
<router-outlet name="aux2"></router-outlet>
```

Closes #11809
