### PR TITLE
fix(ngUpgrade): return $injector from AoT bootstrap method

### DIFF
--- a/modules/@angular/upgrade/src/aot/upgrade_module.ts
+++ b/modules/@angular/upgrade/src/aot/upgrade_module.ts
@@ -59,7 +59,7 @@ export class UpgradeModule {
               }
             ]);
 
-    // Bootstrap the angular 1 application inside our zone
-    this.ngZone.run(() => { angular.bootstrap(element, [upgradeModule.name], config); });
+    // Bootstrap the angular 1 application inside our zone - and return the injector
+    return this.ngZone.run(() => angular.bootstrap(element, [upgradeModule.name], config));
   }
 }

--- a/modules/@angular/upgrade/test/aot/integration/injection_spec.ts
+++ b/modules/@angular/upgrade/test/aot/integration/injection_spec.ts
@@ -21,6 +21,22 @@ export function main() {
     beforeEach(() => destroyPlatform());
     afterEach(() => destroyPlatform());
 
+    it('should return the $injector from the bootstrap function', async(() => {
+         // Sample ng1 NgModule for tests
+         @NgModule({imports: [BrowserModule, UpgradeModule]})
+         class Ng2Module {
+           ngDoBootstrap() {}
+         }
+
+         const ng1Module = angular.module('ng1Module', []);
+
+         platformBrowserDynamic().bootstrapModule(Ng2Module).then(ref => {
+           const upgrade = ref.injector.get(UpgradeModule) as UpgradeModule;
+           const $injector = upgrade.bootstrap(html('<div>'), [ng1Module.name]);
+           expect($injector).toBe(upgrade.$injector);
+         });
+       }));
+
     it('should downgrade ng2 service to ng1', async(() => {
          // Tokens used in ng2 to identify services
          const Ng2Service = new OpaqueToken('ng2-service');

--- a/tools/public_api_guard/upgrade/index.d.ts
+++ b/tools/public_api_guard/upgrade/index.d.ts
@@ -40,5 +40,5 @@ export declare class UpgradeModule {
     injector: Injector;
     ngZone: NgZone;
     constructor(injector: Injector, ngZone: NgZone);
-    bootstrap(element: Element, modules?: string[], config?: angular.IAngularBootstrapConfig): void;
+    bootstrap(element: Element, modules?: string[], config?: angular.IAngularBootstrapConfig): any;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The ngUpgrade AoT `boostrap()` function does not return the `$injector`

**What is the new behavior?**

The ngUpgrade AoT `boostrap()` function does return the `$injector`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

cc: @mhevery 
