### PR TITLE
build: ensure necessary symlinks created on windows

### DIFF
--- a/scripts/windows/create-symlinks.sh
+++ b/scripts/windows/create-symlinks.sh
@@ -2,9 +2,9 @@
 
 cd `dirname $0`
 
-while read RAW_PACKAGE
+while read RAW_PACKAGE || [[ -n "$RAW_PACKAGE" ]]
 do
-  PACKAGE=${RAW_PACKAGE: : -1}
+  PACKAGE=${RAW_PACKAGE%$'\r'}
   DESTDIR=./../../modules/\@angular/${PACKAGE}
   mv ${DESTDIR}/facade ${DESTDIR}/facade.old
   cmd <<< "mklink \"..\\..\\modules\\\@angular\\"${PACKAGE}"\\facade\" \"..\\..\\facade\\src\\\""

--- a/scripts/windows/packages.txt
+++ b/scripts/windows/packages.txt
@@ -1,3 +1,4 @@
+benchpress/src
 common/src
 compiler/src
 compiler/testing

--- a/scripts/windows/remove-symlinks.sh
+++ b/scripts/windows/remove-symlinks.sh
@@ -2,9 +2,9 @@
 
 cd `dirname $0`
 
-while read RAW_PACKAGE
+while read RAW_PACKAGE || [[ -n "$RAW_PACKAGE" ]]
 do
-  PACKAGE=${RAW_PACKAGE: : -1}
+  PACKAGE=${RAW_PACKAGE%$'\r'}
   DESTDIR=./../../modules/\@angular/${PACKAGE}
   rm ${DESTDIR}/facade
   mv ${DESTDIR}/facade.old ${DESTDIR}/facade


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [n/a ] Tests for the changes have been added (for bug fixes / features)
- [ n/a] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Symlinks on windows where not all created because one was missing from packages.txt (#12420) and the bash scripts ignored the last line of packages.txt as it didn't end in a newline (#12422).

**What is the new behavior?**
The last line of packages.txt is always read.
The missing symlink location is present in packages.txt

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
N/A

**Other information**:
