### PR TITLE
fix(router): correctly export concatMap operator in es5

### DIFF
--- a/modules/@angular/router/rollup.config.js
+++ b/modules/@angular/router/rollup.config.js
@@ -37,7 +37,8 @@ export default {
     'rxjs/operator/first': 'Rx.Observable.prototype',
     'rxjs/operator/catch': 'Rx.Observable.prototype',
     'rxjs/operator/last': 'Rx.Observable.prototype',
-    'rxjs/operator/filter': 'Rx.Observable.prototype'
+    'rxjs/operator/filter': 'Rx.Observable.prototype',
+    'rxjs/operator/concatMap': 'Rx.Observable.prototype'
   },
   plugins: []
 };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

`EXCEPTION: rxjs_operator_concatMap is undefined`

**What is the new behavior?**

Fix it

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
