### PR TITLE
build(fsevents+bower) add script to remove mac dependency + run bower after npm install

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -50,6 +50,15 @@ cd angular
 # Add the main Angular repository as an upstream remote to your repository:
 git remote add upstream https://github.com/angular/angular.git
 ```
+## Building on non-Mac Systems
+
+The fsevents package is required when building on Mac, but will cause npm install to fail when building on Windows or Linux. Run this script to remove the dependency:
+```shell
+# Remove Mac specific dependencies
+node remove-mac-dependencies.js
+```
+This changes 2 files, package.json and npm-shrinkwrap.json. Be sure not to commit these changes. For details of Angular 2 package management, see the [shrinkwrap readme](https://github.com/angular/angular/blob/master/npm-shrinkwrap.readme.md).
+
 ## Installing NPM Modules
 
 Next, install the JavaScript modules needed to build and test Angular:
@@ -136,5 +145,3 @@ You can automatically format your code by running:
 ``` shell
 $ gulp format
 ```
-
-

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/angular/angular.git"
   },
   "scripts": {
-    "postinstall": "node tools/npm/copy-npm-shrinkwrap && webdriver-manager update"
+    "postinstall": "node tools/npm/copy-npm-shrinkwrap && webdriver-manager update && node node_modules/bower/bin/bower install"
   },
   "dependencies": {
     "core-js": "^2.4.1",

--- a/remove-mac-dependencies.js
+++ b/remove-mac-dependencies.js
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * The fsevents package is required when building on Mac, but will cause npm install to
+ * fail when building on Windows or Linux. This script removes the dependency.
+ */
+
+fs = require('fs')
+
+transformJSONFile('package.json', function(package) { delete package.devDependencies.fsevents; });
+transformJSONFile(
+    'npm-shrinkwrap.json', function(shrinkwrap) { delete shrinkwrap.dependencies.fsevents });
+
+// tranforms the json in a file and writes contents back to file system
+function transformJSONFile(fileName, objectTransformer) {
+  // logs if the attempt to write the file was a success
+  var logCompletionStatus = function(err) {
+    if (err) {
+      console.log(err);
+      return;
+    }
+
+    console.log(fileName + ' updated');
+  };
+
+  // process the file contents, write it back to the file system
+  var transformDataAndWriteResult = function(err, data) {
+    if (err) {
+      console.log(err);
+      return;
+    }
+
+    var parsedObject = JSON.parse(data);
+    objectTransformer(parsedObject);
+
+    fs.writeFile(fileName, JSON.stringify(parsedObject, null, '  '), logCompletionStatus);
+  };
+
+  fs.readFile(fileName, 'utf8', transformDataAndWriteResult);
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [n/a] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
(from #12443)
There are additional steps required to build angular not included in the developer guide, some of which could be scripted.

a) On Windows / Linux npm install will fail because fsevents requires a mac.

b) On Windows build.sh fails because it tries to create a symlink to the polymer directory and it doesn't exist. This is because the dependency is managed by bower, and bower install is never ran. (The script does not fail on Linux when the directory is missing.)

**What is the new behavior?**
a) Added a script to remove the fsevents dependency which is to be run by developers when not on a mac. Updated dev guide to advise of this. (Better solutions welcome...)
b) Now have bower install run automatically when npm install is ran (using the packages.json postinstall step).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:
