### PR TITLE
fix(compiler): make ngOnChange argument optional

### DIFF
--- a/modules/@angular/compiler/src/directive_wrapper_compiler.ts
+++ b/modules/@angular/compiler/src/directive_wrapper_compiler.ts
@@ -166,9 +166,13 @@ function addNgDoCheckMethod(builder: DirectiveWrapperBuilder) {
   if (builder.genChanges) {
     const onChangesStmts: o.Statement[] = [];
     if (builder.ngOnChanges) {
-      onChangesStmts.push(o.THIS_EXPR.prop(CONTEXT_FIELD_NAME)
-                              .callMethod('ngOnChanges', [o.THIS_EXPR.prop(CHANGES_FIELD_NAME)])
-                              .toStmt());
+      onChangesStmts.push(
+          o.THIS_EXPR.prop(CONTEXT_FIELD_NAME)
+              .prop('ngOnChanges')
+              .callMethod(
+                  'call',
+                  [o.THIS_EXPR.prop(CONTEXT_FIELD_NAME), o.THIS_EXPR.prop(CHANGES_FIELD_NAME)])
+              .toStmt());
     }
     if (builder.compilerConfig.logBindingUpdate) {
       onChangesStmts.push(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Original Issue: https://github.com/angular/angular/issues/11062

a `changes` argument of the `ngOnChanges` method is non-optional. At AoT compilation, generated code requires one argument to the method always. it's not convenient.

``` ts
this._MyComponent_5_4.ngOnChanges(changes);
```

**What is the new behavior?**

It can be optional.

``` ts
this._MyComponent_5_4.ngOnChanges.call(this._MyComponent_5_4, changes);
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
