### PR TITLE
refactor(typescript): remove unused locals and lint more modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -148,14 +148,15 @@ gulp.task('lint', ['check-tests', 'format:enforce', 'tools:build'], () => {
       .src([
         // todo(vicb): add .js files when supported
         // see https://github.com/palantir/tslint/pull/1515
-        'modules/@angular/**/*.ts',
-        'modules/benchpress/**/*.ts',
+        'modules/**/*.ts',
+        'tools/**/*.ts',
         './*.ts',
+        '!**/*.d.ts',
+        '!**/*.ngfactory.ts',
       ])
       .pipe(tslint({
         tslint: require('tslint').default,
         configuration: tslintConfig,
-        rulesDirectory: 'dist/tools/tslint',
         formatter: 'prose',
       }))
       .pipe(tslint.report({emitError: true}));

--- a/modules/@angular/benchpress/src/sample_description.ts
+++ b/modules/@angular/benchpress/src/sample_description.ts
@@ -30,8 +30,9 @@ export class SampleDescription {
                 ],
                 metric.describe()),
     deps: [
-      Metric, Options.SAMPLE_ID, Options.FORCE_GC, Options.USER_AGENT, Validator,
-      Options.DEFAULT_DESCRIPTION, Options.SAMPLE_DESCRIPTION
+      Metric, <OpaqueToken>Options.SAMPLE_ID, <OpaqueToken>Options.FORCE_GC,
+      <OpaqueToken>Options.USER_AGENT, Validator, <OpaqueToken>Options.DEFAULT_DESCRIPTION,
+      <OpaqueToken>Options.SAMPLE_DESCRIPTION
     ]
   }];
   description: {[key: string]: any};

--- a/modules/@angular/benchpress/src/webdriver/ios_driver_extension.ts
+++ b/modules/@angular/benchpress/src/webdriver/ios_driver_extension.ts
@@ -8,7 +8,7 @@
 
 import {Injectable} from '@angular/core';
 
-import {isBlank, isPresent} from '../facade/lang';
+import {isPresent} from '../facade/lang';
 import {WebDriverAdapter} from '../web_driver_adapter';
 import {PerfLogEvent, PerfLogFeatures, WebDriverExtension} from '../web_driver_extension';
 

--- a/modules/@angular/benchpress/test/reporter/console_reporter_spec.ts
+++ b/modules/@angular/benchpress/test/reporter/console_reporter_spec.ts
@@ -10,7 +10,7 @@ import {Provider} from '@angular/core';
 import {describe, expect, it} from '@angular/core/testing/testing_internal';
 
 import {ConsoleReporter, MeasureValues, ReflectiveInjector, SampleDescription} from '../../index';
-import {isBlank, isPresent} from '../../src/facade/lang';
+import {isPresent} from '../../src/facade/lang';
 
 export function main() {
   describe('console reporter', () => {

--- a/modules/@angular/benchpress/test/webdriver/chrome_driver_extension_spec.ts
+++ b/modules/@angular/benchpress/test/webdriver/chrome_driver_extension_spec.ts
@@ -21,8 +21,6 @@ export function main() {
     var extension: ChromeDriverExtension;
 
     var blinkEvents = new TraceEventFactory('blink.console', 'pid0');
-    var v8Events = new TraceEventFactory('v8', 'pid0');
-    var v8EventsOtherProcess = new TraceEventFactory('v8', 'pid1');
     var chromeTimelineEvents =
         new TraceEventFactory('disabled-by-default-devtools.timeline', 'pid0');
     var chrome45TimelineEvents = new TraceEventFactory('devtools.timeline', 'pid0');

--- a/modules/@angular/compiler-cli/integrationtest/src/basic.ts
+++ b/modules/@angular/compiler-cli/integrationtest/src/basic.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgFor, NgIf} from '@angular/common';
 import {Component, Inject, LOCALE_ID, TRANSLATIONS_FORMAT} from '@angular/core';
 
 

--- a/modules/@angular/compiler-cli/integrationtest/src/bootstrap.ts
+++ b/modules/@angular/compiler-cli/integrationtest/src/bootstrap.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {platformBrowser} from '@angular/platform-browser';
 import {BasicComp} from './basic';
 import {MainModuleNgFactory} from './module.ngfactory';
 

--- a/modules/@angular/compiler-cli/integrationtest/src/module_fixtures.ts
+++ b/modules/@angular/compiler-cli/integrationtest/src/module_fixtures.ts
@@ -6,9 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {LowerCasePipe, NgIf} from '@angular/common';
-import {ANALYZE_FOR_ENTRY_COMPONENTS, Component, ComponentFactoryResolver, Directive, Inject, Injectable, Input, ModuleWithProviders, NgModule, OpaqueToken, Pipe} from '@angular/core';
-import {BrowserModule} from '@angular/platform-browser';
+import {ANALYZE_FOR_ENTRY_COMPONENTS, Component, Directive, Injectable, Input, ModuleWithProviders, NgModule, OpaqueToken, Pipe} from '@angular/core';
 
 @Injectable()
 export class SomeService {

--- a/modules/@angular/compiler-cli/integrationtest/src/queries.ts
+++ b/modules/@angular/compiler-cli/integrationtest/src/queries.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgFor} from '@angular/common';
 import {Component, Directive, QueryList, ViewChild, ViewChildren} from '@angular/core';
 
 @Component({selector: 'comp-for-child-query', template: 'child'})

--- a/modules/@angular/compiler-cli/integrationtest/test/query_spec.ts
+++ b/modules/@angular/compiler-cli/integrationtest/test/query_spec.ts
@@ -7,16 +7,13 @@
  */
 
 import './init';
-import {DebugElement, QueryList} from '@angular/core';
-import {By} from '@angular/platform-browser';
+import {QueryList} from '@angular/core';
 import {CompForChildQuery, CompWithChildQuery} from '../src/queries';
 import {createComponent} from './util';
 
 describe('child queries', () => {
   it('should support compiling child queries', () => {
     var childQueryCompFixture = createComponent(CompWithChildQuery);
-    var debugElement = childQueryCompFixture.debugElement;
-    var compWithChildren = debugElement.query(By.directive(CompWithChildQuery));
     expect(childQueryCompFixture.componentInstance.child).toBeDefined();
     expect(childQueryCompFixture.componentInstance.child instanceof CompForChildQuery).toBe(true);
 
@@ -24,8 +21,6 @@ describe('child queries', () => {
 
   it('should support compiling children queries', () => {
     var childQueryCompFixture = createComponent(CompWithChildQuery);
-    var debugElement = childQueryCompFixture.debugElement;
-    var compWithChildren = debugElement.query(By.directive(CompWithChildQuery));
 
     childQueryCompFixture.detectChanges();
 

--- a/modules/@angular/compiler-cli/integrationtest/test/util.ts
+++ b/modules/@angular/compiler-cli/integrationtest/test/util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModuleFactory, NgModuleRef} from '@angular/core';
+import {NgModuleRef} from '@angular/core';
 import {ComponentFixture} from '@angular/core/testing';
 import {platformServer} from '@angular/platform-server';
 

--- a/modules/@angular/compiler-cli/src/extractor.ts
+++ b/modules/@angular/compiler-cli/src/extractor.ts
@@ -18,11 +18,9 @@ import 'reflect-metadata';
 import * as compiler from '@angular/compiler';
 import {Component, NgModule, ViewEncapsulation} from '@angular/core';
 import * as tsc from '@angular/tsc-wrapped';
-import * as path from 'path';
 import * as ts from 'typescript';
 
-import {Console} from './private_import_core';
-import {ReflectorHost, ReflectorHostContext} from './reflector_host';
+import {ReflectorHost} from './reflector_host';
 import {StaticAndDynamicReflectionCapabilities} from './static_reflection_capabilities';
 import {StaticReflector, StaticSymbol} from './static_reflector';
 

--- a/modules/@angular/compiler-cli/src/path_mapped_reflector_host.ts
+++ b/modules/@angular/compiler-cli/src/path_mapped_reflector_host.ts
@@ -7,12 +7,10 @@
  */
 
 import {AngularCompilerOptions, ModuleMetadata} from '@angular/tsc-wrapped';
-import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
 import {ReflectorHost, ReflectorHostContext} from './reflector_host';
-import {StaticSymbol} from './static_reflector';
 
 const EXT = /(\.ts|\.d\.ts|\.js|\.jsx|\.tsx)$/;
 const DTS = /\.d\.ts$/;

--- a/modules/@angular/compiler-cli/src/static_reflector.ts
+++ b/modules/@angular/compiler-cli/src/static_reflector.ts
@@ -255,7 +255,6 @@ export class StaticReflector implements ReflectorReader {
       }
 
       function resolveReferenceValue(staticSymbol: StaticSymbol): any {
-        let result: any = staticSymbol;
         let moduleMetadata = _this.getModuleMetadata(staticSymbol.filePath);
         let declarationValue =
             moduleMetadata ? moduleMetadata['metadata'][staticSymbol.name] : null;
@@ -639,7 +638,6 @@ abstract class BindingScope {
 
   public static build(): BindingScopeBuilder {
     let current = new Map<string, any>();
-    let parent: BindingScope = undefined;
     return {
       define: function(name, value) {
         current.set(name, value);

--- a/modules/@angular/compiler/src/compiler.ts
+++ b/modules/@angular/compiler/src/compiler.ts
@@ -124,11 +124,12 @@ function _initReflector() {
  *
  * @experimental
  */
-export const platformCoreDynamic = createPlatformFactory(platformCore, 'coreDynamic', [
-  {provide: COMPILER_OPTIONS, useValue: {}, multi: true},
-  {provide: CompilerFactory, useClass: RuntimeCompilerFactory},
-  {provide: PLATFORM_INITIALIZER, useValue: _initReflector, multi: true},
-]);
+export const platformCoreDynamic: (extraProviders?: Provider[]) => PlatformRef =
+    createPlatformFactory(platformCore, 'coreDynamic', [
+      {provide: COMPILER_OPTIONS, useValue: {}, multi: true},
+      {provide: CompilerFactory, useClass: RuntimeCompilerFactory},
+      {provide: PLATFORM_INITIALIZER, useValue: _initReflector, multi: true},
+    ]);
 
 function _mergeOptions(optionsArr: CompilerOptions[]): CompilerOptions {
   return {

--- a/modules/@angular/compiler/src/css_parser/css_parser.ts
+++ b/modules/@angular/compiler/src/css_parser/css_parser.ts
@@ -419,7 +419,6 @@ export class CssParser {
 
   /** @internal */
   _parseKeyframeDefinition(delimiters: number): CssKeyframeDefinitionAst {
-    const start = this._getScannerIndex();
     var stepTokens: CssToken[] = [];
     delimiters |= LBRACE_DELIM_FLAG;
     while (!characterContainsDelimiter(this._scanner.peek, delimiters)) {

--- a/modules/@angular/compiler/src/directive_wrapper_compiler.ts
+++ b/modules/@angular/compiler/src/directive_wrapper_compiler.ts
@@ -12,7 +12,7 @@ import {CompileDirectiveMetadata, CompileIdentifierMetadata} from './compile_met
 import {CompilerConfig} from './config';
 import {Identifiers, resolveIdentifier} from './identifiers';
 import * as o from './output/output_ast';
-import {LifecycleHooks, isDefaultChangeDetectionStrategy} from './private_import_core';
+import {LifecycleHooks} from './private_import_core';
 
 export class DirectiveWrapperCompileResult {
   constructor(public statements: o.Statement[], public dirWrapperClassVar: string) {}

--- a/modules/@angular/compiler/src/i18n/serializers/xtb.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/xtb.ts
@@ -179,8 +179,7 @@ class _Visitor implements ml.Visitor {
 
   visitExpansion(expansion: ml.Expansion, context: any): any {
     const strCases = expansion.cases.map(c => c.visit(this, null));
-
-    return `{${expansion.switchValue}, ${expansion.type}, strCases.join(' ')}`;
+    return `{${expansion.switchValue}, ${expansion.type}, ${strCases.join(' ')}}`;
   }
 
   visitExpansionCase(expansionCase: ml.ExpansionCase, context: any): any {

--- a/modules/@angular/compiler/src/identifiers.ts
+++ b/modules/@angular/compiler/src/identifiers.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ANALYZE_FOR_ENTRY_COMPONENTS, AnimationTransitionEvent, ChangeDetectionStrategy, ChangeDetectorRef, ComponentFactory, ComponentFactoryResolver, ElementRef, Injector, LOCALE_ID, NgModuleFactory, QueryList, RenderComponentType, Renderer, SecurityContext, SimpleChange, TRANSLATIONS_FORMAT, TemplateRef, ViewContainerRef, ViewEncapsulation} from '@angular/core';
+import {ANALYZE_FOR_ENTRY_COMPONENTS, ChangeDetectionStrategy, ChangeDetectorRef, ComponentFactory, ComponentFactoryResolver, ElementRef, Injector, LOCALE_ID, NgModuleFactory, QueryList, RenderComponentType, Renderer, SecurityContext, SimpleChange, TRANSLATIONS_FORMAT, TemplateRef, ViewContainerRef, ViewEncapsulation} from '@angular/core';
 
 import {CompileIdentifierMetadata, CompileTokenMetadata} from './compile_metadata';
 import {AnimationGroupPlayer, AnimationKeyframe, AnimationSequencePlayer, AnimationStyles, AnimationTransition, AppElement, AppView, ChangeDetectorStatus, CodegenComponentFactoryResolver, DebugAppView, DebugContext, NgModuleInjector, NoOpAnimationPlayer, StaticNodeDebugInfo, TemplateRef_, UNINITIALIZED, ValueUnwrapper, ViewType, balanceAnimationKeyframes, clearStyles, collectAndResolveStyles, devModeEqual, prepareFinalAnimationStyles, reflector, registerModuleFactory, renderStyles, view_utils} from './private_import_core';

--- a/modules/@angular/compiler/src/offline_compiler.ts
+++ b/modules/@angular/compiler/src/offline_compiler.ts
@@ -12,7 +12,7 @@ import {AnimationCompiler} from './animation/animation_compiler';
 import {AnimationParser} from './animation/animation_parser';
 import {CompileDirectiveMetadata, CompileIdentifierMetadata, CompileNgModuleMetadata, CompilePipeMetadata, CompileProviderMetadata, StaticSymbol, createHostComponentMeta} from './compile_metadata';
 import {DirectiveNormalizer} from './directive_normalizer';
-import {DirectiveWrapperCompileResult, DirectiveWrapperCompiler} from './directive_wrapper_compiler';
+import {DirectiveWrapperCompiler} from './directive_wrapper_compiler';
 import {Identifiers, resolveIdentifier, resolveIdentifierToken} from './identifiers';
 import {CompileMetadataResolver} from './metadata_resolver';
 import {NgModuleCompiler} from './ng_module_compiler';

--- a/modules/@angular/compiler/src/style_url_resolver.ts
+++ b/modules/@angular/compiler/src/style_url_resolver.ts
@@ -9,7 +9,7 @@
 // Some of the code comes from WebComponents.JS
 // https://github.com/webcomponents/webcomponentsjs/blob/master/src/HTMLImports/path.js
 
-import {isBlank, isPresent} from './facade/lang';
+import {isBlank} from './facade/lang';
 
 import {UrlResolver} from './url_resolver';
 

--- a/modules/@angular/compiler/src/view_compiler/compile_element.ts
+++ b/modules/@angular/compiler/src/view_compiler/compile_element.ts
@@ -20,7 +20,7 @@ import {createDiTokenExpression} from '../util';
 import {CompileMethod} from './compile_method';
 import {CompileQuery, addQueryToTokenMap, createQueryList} from './compile_query';
 import {CompileView} from './compile_view';
-import {InjectMethodVars, ViewProperties} from './constants';
+import {InjectMethodVars} from './constants';
 import {ComponentFactoryDependency, DirectiveWrapperDependency, ViewFactoryDependency} from './deps';
 import {getPropertyInView, injectFromViewParentInjector} from './util';
 

--- a/modules/@angular/compiler/src/view_compiler/lifecycle_binder.ts
+++ b/modules/@angular/compiler/src/view_compiler/lifecycle_binder.ts
@@ -9,16 +9,14 @@
 import {CompileDirectiveMetadata, CompilePipeMetadata} from '../compile_metadata';
 import * as o from '../output/output_ast';
 import {LifecycleHooks} from '../private_import_core';
-import {DirectiveAst, ProviderAst} from '../template_parser/template_ast';
+import {ProviderAst} from '../template_parser/template_ast';
 
 import {CompileElement} from './compile_element';
 import {CompileView} from './compile_view';
-import {DetectChangesVars} from './constants';
 
 
 
 var STATE_IS_NEVER_CHECKED = o.THIS_EXPR.prop('numberOfChecks').identical(new o.LiteralExpr(0));
-var NOT_THROW_ON_CHANGES = o.not(DetectChangesVars.throwOnChange);
 
 export function bindDirectiveAfterContentLifecycleCallbacks(
     directiveMeta: CompileDirectiveMetadata, directiveInstance: o.Expression,

--- a/modules/@angular/compiler/src/view_compiler/property_binder.ts
+++ b/modules/@angular/compiler/src/view_compiler/property_binder.ts
@@ -12,9 +12,8 @@ import * as cdAst from '../expression_parser/ast';
 import {isPresent} from '../facade/lang';
 import {Identifiers, resolveIdentifier} from '../identifiers';
 import * as o from '../output/output_ast';
-import {EMPTY_STATE as EMPTY_ANIMATION_STATE, LifecycleHooks, isDefaultChangeDetectionStrategy} from '../private_import_core';
+import {EMPTY_STATE as EMPTY_ANIMATION_STATE, isDefaultChangeDetectionStrategy} from '../private_import_core';
 import {BoundElementPropertyAst, BoundTextAst, DirectiveAst, PropertyBindingType} from '../template_parser/template_ast';
-import {camelCaseToDashCase} from '../util';
 
 import {CompileBinding} from './compile_binding';
 import {CompileElement, CompileNode} from './compile_element';

--- a/modules/@angular/compiler/src/view_compiler/util.ts
+++ b/modules/@angular/compiler/src/view_compiler/util.ts
@@ -7,7 +7,7 @@
  */
 
 
-import {CompileDirectiveMetadata, CompileIdentifierMetadata, CompileTokenMetadata} from '../compile_metadata';
+import {CompileDirectiveMetadata, CompileTokenMetadata} from '../compile_metadata';
 import {isPresent} from '../facade/lang';
 import {Identifiers, resolveIdentifier} from '../identifiers';
 import * as o from '../output/output_ast';

--- a/modules/@angular/compiler/src/view_compiler/view_builder.ts
+++ b/modules/@angular/compiler/src/view_compiler/view_builder.ts
@@ -8,7 +8,7 @@
 
 import {ViewEncapsulation} from '@angular/core';
 
-import {CompileDirectiveMetadata, CompileIdentifierMetadata, CompileTokenMetadata} from '../compile_metadata';
+import {CompileDirectiveMetadata, CompileIdentifierMetadata} from '../compile_metadata';
 import {isPresent} from '../facade/lang';
 import {Identifiers, identifierToken, resolveIdentifier} from '../identifiers';
 import * as o from '../output/output_ast';

--- a/modules/@angular/compiler/test/animation/animation_parser_spec.ts
+++ b/modules/@angular/compiler/test/animation/animation_parser_spec.ts
@@ -293,7 +293,6 @@ export function main() {
 
          var keyframesStep = <AnimationStepAst>ast.steps[0];
          var kf1 = keyframesStep.keyframes[0];
-         var kf2 = keyframesStep.keyframes[1];
 
          expect(flattenStyles(kf1.styles.styles))
              .toEqual({'color': 'red', 'background': FILL_STYLE_FLAG});
@@ -307,8 +306,6 @@ export function main() {
           ]))]);
 
       var keyframesStep = <AnimationStepAst>ast.steps[0];
-      var kf1 = keyframesStep.keyframes[0];
-      var kf2 = keyframesStep.keyframes[1];
       var kf3 = keyframesStep.keyframes[2];
 
       expect(flattenStyles(kf3.styles.styles))
@@ -330,8 +327,6 @@ export function main() {
          var keyframesStep = <AnimationStepAst>ast.steps[0];
          expect(keyframesStep.keyframes.length).toEqual(3);
          var kf1 = keyframesStep.keyframes[0];
-         var kf2 = keyframesStep.keyframes[1];
-         var kf3 = keyframesStep.keyframes[2];
 
          expect(kf1.offset).toEqual(0);
          expect(flattenStyles(kf1.styles.styles)).toEqual({
@@ -360,8 +355,6 @@ export function main() {
 
          var keyframesStep = <AnimationStepAst>ast.steps[0];
          expect(keyframesStep.keyframes.length).toEqual(3);
-         var kf1 = keyframesStep.keyframes[0];
-         var kf2 = keyframesStep.keyframes[1];
          var kf3 = keyframesStep.keyframes[2];
 
          expect(kf3.offset).toEqual(1);

--- a/modules/@angular/compiler/test/css_parser/css_parser_spec.ts
+++ b/modules/@angular/compiler/test/css_parser/css_parser_spec.ts
@@ -68,7 +68,6 @@ export function main() {
 
       var classRule = rule.selectors[0];
       var idRule = rule.selectors[1];
-      var tagRule = rule.selectors[2];
       var attrRule = rule.selectors[3];
       var plusOpRule = rule.selectors[4];
       var starOpRule = rule.selectors[5];

--- a/modules/@angular/compiler/test/css_parser/css_visitor_spec.ts
+++ b/modules/@angular/compiler/test/css_parser/css_visitor_spec.ts
@@ -10,7 +10,6 @@
 import {beforeEach, describe, expect, it} from '../../../core/testing/testing_internal';
 import {CssAst, CssAstVisitor, CssAtRulePredicateAst, CssBlockAst, CssDefinitionAst, CssInlineRuleAst, CssKeyframeDefinitionAst, CssKeyframeRuleAst, CssMediaQueryRuleAst, CssPseudoSelectorAst, CssRuleAst, CssSelectorAst, CssSelectorRuleAst, CssSimpleSelectorAst, CssStyleSheetAst, CssStyleValueAst, CssStylesBlockAst, CssUnknownRuleAst, CssUnknownTokenListAst} from '../../src/css_parser/css_ast';
 import {BlockType, CssParseError, CssParser, CssToken} from '../../src/css_parser/css_parser';
-import {isPresent} from '../../src/facade/lang';
 
 function _assertTokens(tokens: CssToken[], valuesArr: string[]): void {
   expect(tokens.length).toEqual(valuesArr.length);

--- a/modules/@angular/compiler/test/i18n/integration_spec.ts
+++ b/modules/@angular/compiler/test/i18n/integration_spec.ts
@@ -100,33 +100,33 @@ function expectHtml(el: DebugElement, cssSelector: string): any {
   template: `
 <div>
     <h1 i18n>i18n attribute on tags</h1>
-    
+
     <div id="i18n-1"><p i18n>nested</p></div>
-    
+
     <div id="i18n-2"><p i18n="different meaning|">nested</p></div>
-    
+
     <div id="i18n-3"><p i18n><i>with placeholders</i></p></div>
-    
+
     <div>
         <p id="i18n-4" i18n-title title="on not translatable node"></p>
         <p id="i18n-5" i18n i18n-title title="on translatable node"></p>
         <p id="i18n-6" i18n-title title></p>
     </div>
-    
-    <!-- no ph below because the ICU node is the only child of the div, i.e. no text nodes --> 
+
+    <!-- no ph below because the ICU node is the only child of the div, i.e. no text nodes -->
     <div i18n id="i18n-7">{count, plural, =0 {zero} =1 {one} =2 {two} other {<b>many</b>}}</div>
-    
+
     <div i18n id="i18n-8">
         {sex, sex, m {male} f {female}}
     </div>
-    
+
     <div i18n id="i18n-9">{{ "count = " + count }}</div>
     <div i18n id="i18n-10">sex = {{ sex }}</div>
-    <div i18n id="i18n-11">{{ "custom name" //i18n(ph="CUSTOM_NAME") }}</div>    
+    <div i18n id="i18n-11">{{ "custom name" //i18n(ph="CUSTOM_NAME") }}</div>
 </div>
 
 <!-- i18n -->
-    <h1 id="i18n-12" >Markers in html comments</h1>   
+    <h1 id="i18n-12" >Markers in html comments</h1>
     <div id="i18n-13" i18n-title title="in a translatable section"></div>
     <div id="i18n-14">{count, plural, =0 {zero} =1 {one} =2 {two} other {<b>many</b>}}</div>
 <!-- /i18n -->
@@ -166,8 +166,8 @@ const XTB = `
   <translation id="50dac33dc6fc0578884baac79d875785ed77c928">sexe = <ph name="INTERPOLATION"/></translation>
   <translation id="a46f833b1fe6ca49e8b97c18f4b7ea0b930c9383"><ph name="CUSTOM_NAME"/></translation>
   <translation id="2ec983b4893bcd5b24af33bebe3ecba63868453c">dans une section traductible</translation>
-  <translation id="eee74a5be8a75881a4785905bd8302a71f7d9f75">
-    <ph name="START_HEADING_LEVEL1"/>Balises dans les commentaires html<ph name="CLOSE_HEADING_LEVEL1"/>   
+  <translation id="7f6272480ea8e7ffab548da885ab8105ee2caa93">
+    <ph name="START_HEADING_LEVEL1"/>Balises dans les commentaires html<ph name="CLOSE_HEADING_LEVEL1"/>
     <ph name="START_TAG_DIV"/><ph name="CLOSE_TAG_DIV"/>
     <ph name="START_TAG_DIV_1"/><ph name="ICU"/><ph name="CLOSE_TAG_DIV"></ph>
 </translation>
@@ -177,27 +177,38 @@ const XTB = `
 // unused, for reference only
 // can be generated from xmb_spec as follow:
 // `iit('extract xmb', () => { console.log(toXmb(HTML)); });`
+/*
 const XMB = `
 <messagebundle>
   <msg id="3cb04208df1c2f62553ed48e75939cf7107f9dad">i18n attribute on tags</msg>
   <msg id="52895b1221effb3f3585b689f049d2784d714952">nested</msg>
   <msg id="88d5f22050a9df477ee5646153558b3a4862d47e" meaning="different meaning">nested</msg>
-  <msg id="34fec9cc62e28e8aa6ffb306fa8569ef0a8087fe"><ph name="START_ITALIC_TEXT"><ex>&lt;i&gt;</ex></ph>with placeholders<ph name="CLOSE_ITALIC_TEXT"><ex>&lt;/i&gt;</ex></ph></msg>
+  <msg id="34fec9cc62e28e8aa6ffb306fa8569ef0a8087fe"><ph
+name="START_ITALIC_TEXT"><ex>&lt;i&gt;</ex></ph>with placeholders<ph
+name="CLOSE_ITALIC_TEXT"><ex>&lt;/i&gt;</ex></ph></msg>
   <msg id="1fe4616cce80a57c7707bac1c97054aa8e244a67">on not translatable node</msg>
   <msg id="67162b5af5f15fd0eb6480c88688dafdf952b93a">on translatable node</msg>
-  <msg id="dc5536bb9e0e07291c185a0d306601a2ecd4813f">{count, plural, =0 {zero}=1 {one}=2 {two}other {<ph name="START_BOLD_TEXT"><ex>&lt;b&gt;</ex></ph>many<ph name="CLOSE_BOLD_TEXT"><ex>&lt;/b&gt;</ex></ph>}}</msg>
+  <msg id="dc5536bb9e0e07291c185a0d306601a2ecd4813f">{count, plural, =0 {zero} =1 {one} =2 {two}
+other {<ph name="START_BOLD_TEXT"><ex>&lt;b&gt;</ex></ph>many<ph
+name="CLOSE_BOLD_TEXT"><ex>&lt;/b&gt;</ex></ph>} }</msg>
   <msg id="018efa03821ca41e27611e4a584736810d56ed8a">
         <ph name="ICU"/>
     </msg>
-  <msg id="fd3186ad2a9aa801fe072ddb16ca34cd98ae93da">{sex, sex, m {male}f {female}}</msg>
+  <msg id="fd3186ad2a9aa801fe072ddb16ca34cd98ae93da">{sex, sex, m {male} f {female} }</msg>
   <msg id="d9879678f727b244bc7c7e20f22b63d98cb14890"><ph name="INTERPOLATION"/></msg>
   <msg id="50dac33dc6fc0578884baac79d875785ed77c928">sex = <ph name="INTERPOLATION"/></msg>
   <msg id="a46f833b1fe6ca49e8b97c18f4b7ea0b930c9383"><ph name="CUSTOM_NAME"/></msg>
   <msg id="2ec983b4893bcd5b24af33bebe3ecba63868453c">in a translatable section</msg>
-  <msg id="eee74a5be8a75881a4785905bd8302a71f7d9f75">
-    <ph name="START_HEADING_LEVEL1"><ex>&lt;h1&gt;</ex></ph>Markers in html comments<ph name="CLOSE_HEADING_LEVEL1"><ex>&lt;/h1&gt;</ex></ph>   
-    <ph name="START_TAG_DIV"><ex>&lt;div&gt;</ex></ph><ph name="CLOSE_TAG_DIV"><ex>&lt;/div&gt;</ex></ph>
-    <ph name="START_TAG_DIV_1"><ex>&lt;div&gt;</ex></ph><ph name="ICU"/><ph name="CLOSE_TAG_DIV"><ex>&lt;/div&gt;</ex></ph>
+  <msg id="7f6272480ea8e7ffab548da885ab8105ee2caa93">
+    <ph name="START_HEADING_LEVEL1"><ex>&lt;h1&gt;</ex></ph>Markers in html comments<ph
+name="CLOSE_HEADING_LEVEL1"><ex>&lt;/h1&gt;</ex></ph>
+    <ph name="START_TAG_DIV"><ex>&lt;div&gt;</ex></ph><ph
+name="CLOSE_TAG_DIV"><ex>&lt;/div&gt;</ex></ph>
+    <ph name="START_TAG_DIV_1"><ex>&lt;div&gt;</ex></ph><ph name="ICU"/><ph
+name="CLOSE_TAG_DIV"><ex>&lt;/div&gt;</ex></ph>
 </msg>
-  <msg id="93a30c67d4e6c9b37aecfe2ac0f2b5d366d7b520">it <ph name="START_BOLD_TEXT"><ex>&lt;b&gt;</ex></ph>should<ph name="CLOSE_BOLD_TEXT"><ex>&lt;/b&gt;</ex></ph> work</msg>
+  <msg id="93a30c67d4e6c9b37aecfe2ac0f2b5d366d7b520">it <ph
+name="START_BOLD_TEXT"><ex>&lt;b&gt;</ex></ph>should<ph
+name="CLOSE_BOLD_TEXT"><ex>&lt;/b&gt;</ex></ph> work</msg>
 </messagebundle>`;
+*/

--- a/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
@@ -1921,10 +1921,6 @@ class TemplateHumanizer implements TemplateAstVisitor {
   }
 }
 
-function sourceInfo(ast: TemplateAst): string {
-  return `${ast.sourceSpan}: ${ast.sourceSpan.start}`;
-}
-
 function humanizeContentProjection(templateAsts: TemplateAst[]): any[] {
   var humanizer = new TemplateContentProjectionHumanizer();
   templateVisitAll(humanizer, templateAsts);

--- a/modules/@angular/core/src/change_detection/change_detection.ts
+++ b/modules/@angular/core/src/change_detection/change_detection.ts
@@ -7,7 +7,7 @@
  */
 
 import {DefaultIterableDifferFactory} from './differs/default_iterable_differ';
-import {DefaultKeyValueDifferFactory, KeyValueChangeRecord} from './differs/default_keyvalue_differ';
+import {DefaultKeyValueDifferFactory} from './differs/default_keyvalue_differ';
 import {IterableDifferFactory, IterableDiffers} from './differs/iterable_differs';
 import {KeyValueDifferFactory, KeyValueDiffers} from './differs/keyvalue_differs';
 

--- a/modules/@angular/core/src/change_detection/differs/default_keyvalue_differ.ts
+++ b/modules/@angular/core/src/change_detection/differs/default_keyvalue_differ.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {StringMapWrapper} from '../../facade/collection';
 import {isJsObject, looseIdentical, stringify} from '../../facade/lang';
 import {ChangeDetectorRef} from '../change_detector_ref';
 

--- a/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
@@ -7,7 +7,6 @@
  */
 
 import {Optional, Provider, SkipSelf} from '../../di';
-import {ListWrapper} from '../../facade/collection';
 import {isPresent} from '../../facade/lang';
 import {ChangeDetectorRef} from '../change_detector_ref';
 

--- a/modules/@angular/core/src/di/reflective_injector.ts
+++ b/modules/@angular/core/src/di/reflective_injector.ts
@@ -7,7 +7,6 @@
  */
 
 import {unimplemented} from '../facade/errors';
-import {Type} from '../type';
 
 import {Injector, THROW_IF_NOT_FOUND} from './injector';
 import {Self, SkipSelf} from './metadata';

--- a/modules/@angular/core/src/linker/animation_view_context.ts
+++ b/modules/@angular/core/src/linker/animation_view_context.ts
@@ -8,7 +8,6 @@
 import {AnimationGroupPlayer} from '../animation/animation_group_player';
 import {AnimationPlayer} from '../animation/animation_player';
 import {queueAnimation as queueAnimationGlobally} from '../animation/animation_queue';
-import {AnimationTransitionEvent} from '../animation/animation_transition_event';
 import {ViewAnimationMap} from '../animation/view_animation_map';
 
 export class AnimationViewContext {

--- a/modules/@angular/core/src/metadata.ts
+++ b/modules/@angular/core/src/metadata.ts
@@ -11,11 +11,6 @@
  * to be used by the decorator versions of these annotations.
  */
 
-import {Attribute, ContentChild, ContentChildren, Query, ViewChild, ViewChildren} from './metadata/di';
-import {Component, Directive, HostBinding, HostListener, Input, Output, Pipe} from './metadata/directives';
-import {ModuleWithProviders, NgModule, SchemaMetadata} from './metadata/ng_module';
-import {ViewEncapsulation} from './metadata/view';
-
 export {ANALYZE_FOR_ENTRY_COMPONENTS, Attribute, ContentChild, ContentChildDecorator, ContentChildren, ContentChildrenDecorator, Query, ViewChild, ViewChildDecorator, ViewChildren, ViewChildrenDecorator} from './metadata/di';
 export {Component, ComponentDecorator, Directive, DirectiveDecorator, HostBinding, HostListener, Input, Output, Pipe} from './metadata/directives';
 export {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, DoCheck, OnChanges, OnDestroy, OnInit} from './metadata/lifecycle_hooks';

--- a/modules/@angular/core/test/animation/animation_integration_spec.ts
+++ b/modules/@angular/core/test/animation/animation_integration_spec.ts
@@ -217,7 +217,7 @@ function declareTests({useJit}: {useJit: boolean}) {
 
              var message = '';
              try {
-               let fixture = TestBed.createComponent(DummyIfCmp);
+               TestBed.createComponent(DummyIfCmp);
              } catch (e) {
                message = e.message;
              }
@@ -916,7 +916,6 @@ function declareTests({useJit}: {useJit: boolean}) {
              // -1, -2, ~3, ~4, ~0, +9
              var rm0 = driver.log.shift();
              var rm1 = driver.log.shift();
-             var in0 = driver.log.shift();
 
              // we want to assert that the DOM chain is still preserved
              // until the animations are closed
@@ -960,7 +959,6 @@ function declareTests({useJit}: {useJit: boolean}) {
            const driver = TestBed.get(AnimationDriver) as InnerContentTrackingAnimationDriver;
            let fixture = TestBed.createComponent(DummyIfCmp);
            var cmp = fixture.componentInstance;
-           var node = getDOM().querySelector(fixture.nativeElement, '.target');
            cmp.exp = true;
            cmp.exp2 = true;
            fixture.detectChanges();
@@ -1163,7 +1161,6 @@ function declareTests({useJit}: {useJit: boolean}) {
              }
            });
 
-           const driver = TestBed.get(AnimationDriver) as InnerContentTrackingAnimationDriver;
            let fixture = TestBed.createComponent(DummyIfCmp);
            var isAnimationRunning = false;
            var calls = 0;
@@ -1242,7 +1239,6 @@ function declareTests({useJit}: {useJit: boolean}) {
              }
            });
 
-           const driver = TestBed.get(AnimationDriver) as InnerContentTrackingAnimationDriver;
            let fixture = TestBed.createComponent(DummyIfCmp);
            var eventData: AnimationTransitionEvent = null;
            var cmp = fixture.componentInstance;
@@ -1278,7 +1274,6 @@ function declareTests({useJit}: {useJit: boolean}) {
              }
            });
 
-           const driver = TestBed.get(AnimationDriver) as InnerContentTrackingAnimationDriver;
            let fixture = TestBed.createComponent(DummyIfCmp);
            var eventData1: AnimationTransitionEvent = null;
            var eventData2: AnimationTransitionEvent = null;
@@ -1422,7 +1417,6 @@ function declareTests({useJit}: {useJit: boolean}) {
              }
            });
 
-           const driver = TestBed.get(AnimationDriver) as InnerContentTrackingAnimationDriver;
            var ifCalls = 0;
            var loadingCalls = 0;
            let fixture = TestBed.createComponent(DummyIfCmp);
@@ -1554,7 +1548,7 @@ function declareTests({useJit}: {useJit: boolean}) {
 
            var failureMessage = '';
            try {
-             let fixture = TestBed.createComponent(DummyLoadingCmp);
+             TestBed.createComponent(DummyLoadingCmp);
            } catch (e) {
              failureMessage = e.message;
            }
@@ -1569,7 +1563,7 @@ function declareTests({useJit}: {useJit: boolean}) {
 
         var failureMessage = '';
         try {
-          const fixture = TestBed.createComponent(DummyLoadingCmp);
+          TestBed.createComponent(DummyLoadingCmp);
         } catch (e) {
           failureMessage = e.message;
         }
@@ -1611,7 +1605,7 @@ function declareTests({useJit}: {useJit: boolean}) {
 
            var failureMessage = '';
            try {
-             const driver = TestBed.get(AnimationDriver) as MockAnimationDriver;
+             TestBed.get(AnimationDriver);
            } catch (e) {
              failureMessage = e.message;
            }
@@ -1671,7 +1665,6 @@ function declareTests({useJit}: {useJit: boolean}) {
            const driver = TestBed.get(AnimationDriver) as MockAnimationDriver;
            let fixture = TestBed.createComponent(DummyIfCmp);
            var cmp = fixture.componentInstance;
-           var node = getDOM().querySelector(fixture.nativeElement, '.target');
            cmp.exp = 'green';
            fixture.detectChanges();
            flushMicrotasks();
@@ -1727,7 +1720,6 @@ function declareTests({useJit}: {useJit: boolean}) {
            const driver = TestBed.get(AnimationDriver) as MockAnimationDriver;
            let fixture = TestBed.createComponent(DummyIfCmp);
            var cmp = fixture.componentInstance;
-           var node = getDOM().querySelector(fixture.nativeElement, '.target');
            cmp.exp = 'final';
            fixture.detectChanges();
            flushMicrotasks();
@@ -1781,7 +1773,6 @@ function declareTests({useJit}: {useJit: boolean}) {
              }
            });
 
-           const driver = TestBed.get(AnimationDriver) as MockAnimationDriver;
            let fixture = TestBed.createComponent(DummyIfCmp);
            var cmp = fixture.componentInstance;
            var node = getDOM().querySelector(fixture.nativeElement, '.target');
@@ -1840,7 +1831,6 @@ function declareTests({useJit}: {useJit: boolean}) {
            const driver = TestBed.get(AnimationDriver) as MockAnimationDriver;
            let fixture = TestBed.createComponent(DummyIfCmp);
            var cmp = fixture.componentInstance;
-           var node = getDOM().querySelector(fixture.nativeElement, '.target');
 
            cmp.exp = 'a';
            fixture.detectChanges();

--- a/modules/@angular/core/test/animation/animation_style_util_spec.ts
+++ b/modules/@angular/core/test/animation/animation_style_util_spec.ts
@@ -41,7 +41,6 @@ export function main() {
       it('should set all AUTO styles to the null value', () => {
         var styles = {opacity: 0};
         var newStyles = {color: '*', border: '*'};
-        var flag = '*';
         var result = animationUtils.prepareFinalAnimationStyles(styles, newStyles, null);
         expect(result).toEqual({opacity: null, color: null, border: null});
       });

--- a/modules/@angular/core/test/change_detection/differs/default_iterable_differ_spec.ts
+++ b/modules/@angular/core/test/change_detection/differs/default_iterable_differ_spec.ts
@@ -334,7 +334,7 @@ export function main() {
 
              var operations: string[] = [];
              differ.forEachOperation((item: any, prev: number, next: number) => {
-               var value = modifyArrayUsingOperation(startData, endData, prev, next);
+               modifyArrayUsingOperation(startData, endData, prev, next);
                operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
              });
 
@@ -357,7 +357,7 @@ export function main() {
 
              var operations: string[] = [];
              differ.forEachOperation((item: any, prev: number, next: number) => {
-               var value = modifyArrayUsingOperation(startData, endData, prev, next);
+               modifyArrayUsingOperation(startData, endData, prev, next);
                operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
              });
 
@@ -377,7 +377,7 @@ export function main() {
 
           var operations: string[] = [];
           differ.forEachOperation((item: any, prev: number, next: number) => {
-            var value = modifyArrayUsingOperation(startData, endData, prev, next);
+            modifyArrayUsingOperation(startData, endData, prev, next);
             operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
           });
 
@@ -398,7 +398,7 @@ export function main() {
 
           var operations: string[] = [];
           differ.forEachOperation((item: any, prev: number, next: number) => {
-            var value = modifyArrayUsingOperation(startData, endData, prev, next);
+            modifyArrayUsingOperation(startData, endData, prev, next);
             operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
           });
 
@@ -419,7 +419,7 @@ export function main() {
 
           var operations: string[] = [];
           differ.forEachOperation((item: any, prev: number, next: number) => {
-            var value = modifyArrayUsingOperation(startData, endData, prev, next);
+            modifyArrayUsingOperation(startData, endData, prev, next);
             operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
           });
 
@@ -445,7 +445,7 @@ export function main() {
 
              var operations: string[] = [];
              differ.forEachOperation((item: any, prev: number, next: number) => {
-               var value = modifyArrayUsingOperation(startData, endData, prev, next);
+               modifyArrayUsingOperation(startData, endData, prev, next);
                operations.push(stringifyItemChange(item, prev, next, item.previousIndex));
              });
 

--- a/modules/@angular/core/test/fake_async_spec.ts
+++ b/modules/@angular/core/test/fake_async_spec.ts
@@ -187,10 +187,8 @@ export function main() {
          }));
 
       it('should be able to cancel periodic timers from a callback', fakeAsync(() => {
-           var cycles = 0;
-           var id: any /** TODO #9100 */;
-
-           id = setInterval(() => {
+           let cycles = 0;
+           const id = setInterval(() => {
              cycles++;
              clearInterval(id);
            }, 10);
@@ -203,8 +201,8 @@ export function main() {
          }));
 
       it('should clear periodic timers', fakeAsync(() => {
-           var cycles = 0;
-           var id = setInterval(() => { cycles++; }, 10);
+           let cycles = 0;
+           setInterval(() => cycles++, 10);
 
            tick(10);
            expect(cycles).toEqual(1);

--- a/modules/@angular/core/test/linker/change_detection_integration_spec.ts
+++ b/modules/@angular/core/test/linker/change_detection_integration_spec.ts
@@ -8,7 +8,7 @@
 
 import {ElementSchemaRegistry} from '@angular/compiler/src/schema/element_schema_registry';
 import {TEST_COMPILER_PROVIDERS} from '@angular/compiler/testing/test_bindings';
-import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, DebugElement, Directive, DoCheck, Injectable, Input, OnChanges, OnDestroy, OnInit, Output, Pipe, PipeTransform, RenderComponentType, Renderer, RootRenderer, SimpleChange, SimpleChanges, TemplateRef, Type, ViewContainerRef, WrappedValue} from '@angular/core';
+import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, DebugElement, Directive, DoCheck, Injectable, Input, OnChanges, OnDestroy, OnInit, Output, Pipe, PipeTransform, RenderComponentType, Renderer, RootRenderer, SimpleChanges, TemplateRef, Type, ViewContainerRef, WrappedValue} from '@angular/core';
 import {DebugDomRenderer} from '@angular/core/src/debug/debug_renderer';
 import {ComponentFixture, TestBed, fakeAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';

--- a/modules/@angular/core/test/linker/entry_components_integration_spec.ts
+++ b/modules/@angular/core/test/linker/entry_components_integration_spec.ts
@@ -48,7 +48,6 @@ function declareTests({useJit}: {useJit: boolean}) {
       TestBed.configureTestingModule(
           {declarations: [CompWithAnalyzeEntryComponentsProvider, NestedChildComp, ChildComp]});
       let compFixture = TestBed.createComponent(CompWithAnalyzeEntryComponentsProvider);
-      let mainComp: CompWithAnalyzeEntryComponentsProvider = compFixture.componentInstance;
       let cfr: ComponentFactoryResolver =
           compFixture.componentRef.injector.get(ComponentFactoryResolver);
       expect(cfr.resolveComponentFactory(ChildComp).componentType).toBe(ChildComp);

--- a/modules/@angular/core/test/linker/integration_spec.ts
+++ b/modules/@angular/core/test/linker/integration_spec.ts
@@ -254,7 +254,6 @@ function declareTests({useJit}: {useJit: boolean}) {
         TestBed.configureTestingModule({declarations: [MyComp, MyDir]});
         const template = '<p my-dir></p>';
         TestBed.overrideComponent(MyComp, {set: {template}});
-        const fixture = TestBed.createComponent(MyComp);
       });
 
       it('should execute a given directive once, even if specified multiple times', () => {
@@ -298,7 +297,6 @@ function declareTests({useJit}: {useJit: boolean}) {
         TestBed.configureTestingModule({declarations: [MyComp, PrivateImpl, NeedsPublicApi]});
         const template = '<div public-api><div needs-public-api></div></div>';
         TestBed.overrideComponent(MyComp, {set: {template}});
-        const fixture = TestBed.createComponent(MyComp);
       });
 
       it('should support template directives via `<template>` elements.', () => {

--- a/modules/@angular/core/test/linker/view_injector_integration_spec.ts
+++ b/modules/@angular/core/test/linker/view_injector_integration_spec.ts
@@ -366,7 +366,7 @@ export function main() {
         TestBed.configureTestingModule({declarations: [SimpleDirective]});
         TestBed.overrideDirective(SimpleDirective, {set: {providers: [SomeInjectable]}});
 
-        const el = createComponent('<div simpleDirective></div>');
+        createComponent('<div simpleDirective></div>');
 
         expect(created).toBe(true);
       });

--- a/modules/@angular/core/testing/fake_async.ts
+++ b/modules/@angular/core/testing/fake_async.ts
@@ -121,7 +121,6 @@ export function tick(millis: number = 0): void {
  */
 export function discardPeriodicTasks(): void {
   let zoneSpec = _getFakeAsyncZoneSpec();
-  let pendingTimers = zoneSpec.pendingPeriodicTimers;
   zoneSpec.pendingPeriodicTimers.length = 0;
 }
 

--- a/modules/@angular/core/testing/testing_internal.ts
+++ b/modules/@angular/core/testing/testing_internal.ts
@@ -10,7 +10,7 @@ import {AsyncTestCompleter} from './async_test_completer';
 import {StringMapWrapper} from './facade/collection';
 import {global} from './facade/lang';
 import {isPromise} from './private_import_core';
-import {getTestBed, inject} from './test_bed';
+import {getTestBed} from './test_bed';
 
 export {AsyncTestCompleter} from './async_test_completer';
 export {MockAnimationPlayer} from './mock_animation_player';

--- a/modules/@angular/facade/src/collection.ts
+++ b/modules/@angular/facade/src/collection.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {getSymbolIterator, isBlank, isJsObject, isPresent} from './lang';
+import {getSymbolIterator, isJsObject, isPresent} from './lang';
 
 // Safari doesn't implement MapIterator.next(), which is used is Traceur's polyfill of Array.from
 // TODO(mlaval): remove the work around once we have a working polyfill of Array.from

--- a/modules/@angular/facade/src/intl.ts
+++ b/modules/@angular/facade/src/intl.ts
@@ -207,8 +207,6 @@ function dateFormatter(format: string, date: Date, locale: string): string {
   if (datePartsFormatterCache.has(format)) {
     parts = datePartsFormatterCache.get(format);
   } else {
-    const matches = DATE_FORMATS_SPLIT.exec(format);
-
     while (format) {
       match = DATE_FORMATS_SPLIT.exec(format);
       if (match) {

--- a/modules/@angular/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -14,8 +14,8 @@ import {isBlank, isPresent, isPrimitive, looseIdentical} from '../facade/lang';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 
 export const SELECT_MULTIPLE_VALUE_ACCESSOR = {
-  provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => SelectMultipleControlValueAccessor),
+  provide: <OpaqueToken>NG_VALUE_ACCESSOR,
+  useExisting: <Type<any>>forwardRef(() => SelectMultipleControlValueAccessor),
   multi: true
 };
 

--- a/modules/@angular/forms/test/reactive_integration_spec.ts
+++ b/modules/@angular/forms/test/reactive_integration_spec.ts
@@ -1738,7 +1738,6 @@ export function main() {
           }
         });
         const fixture = TestBed.createComponent(FormGroupComp);
-        const myGroup = new FormGroup({person: new FormGroup({})});
         fixture.componentInstance.myGroup = new FormGroup({person: new FormGroup({})});
 
         expect(() => fixture.detectChanges())

--- a/modules/@angular/http/test/backends/xhr_backend_spec.ts
+++ b/modules/@angular/http/test/backends/xhr_backend_spec.ts
@@ -468,7 +468,6 @@ export function main() {
       it('should call error and not complete on 300+ codes',
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
            var nextCalled = false;
-           var errorCalled = false;
            var statusCode = 301;
            var connection = new XHRConnection(
                sampleRequest, new MockBrowserXHR(), new ResponseOptions({status: statusCode}));

--- a/modules/@angular/platform-browser-dynamic/src/platform-browser-dynamic.ts
+++ b/modules/@angular/platform-browser-dynamic/src/platform-browser-dynamic.ts
@@ -23,5 +23,6 @@ export const RESOURCE_CACHE_PROVIDER: Provider[] =
 /**
  * @stable
  */
-export const platformBrowserDynamic = createPlatformFactory(
-    platformCoreDynamic, 'browserDynamic', INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS);
+export const platformBrowserDynamic: (extraProviders?: Provider[]) => PlatformRef =
+    createPlatformFactory(
+        platformCoreDynamic, 'browserDynamic', INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS);

--- a/modules/@angular/platform-browser-dynamic/src/resource_loader/resource_loader_impl.ts
+++ b/modules/@angular/platform-browser-dynamic/src/resource_loader/resource_loader_impl.ts
@@ -8,8 +8,6 @@
 import {ResourceLoader} from '@angular/compiler';
 import {Injectable} from '@angular/core';
 
-import {isPresent} from '../facade/lang';
-
 @Injectable()
 export class ResourceLoaderImpl extends ResourceLoader {
   get(url: string): Promise<string> {

--- a/modules/@angular/platform-browser-dynamic/testing/index.ts
+++ b/modules/@angular/platform-browser-dynamic/testing/index.ts
@@ -19,9 +19,10 @@ export * from './private_export_testing'
 /**
  * @stable
  */
-export const platformBrowserDynamicTesting = createPlatformFactory(
-    platformCoreDynamicTesting, 'browserDynamicTesting',
-    INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS);
+export const platformBrowserDynamicTesting: (extraProviders?: Provider[]) => PlatformRef =
+    createPlatformFactory(
+        platformCoreDynamicTesting, 'browserDynamicTesting',
+        INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS);
 
 /**
  * NgModule for testing.

--- a/modules/@angular/platform-browser/src/browser.ts
+++ b/modules/@angular/platform-browser/src/browser.ts
@@ -46,7 +46,7 @@ export const BROWSER_SANITIZATION_PROVIDERS: Array<any> = [
 /**
  * @stable
  */
-export const platformBrowser =
+export const platformBrowser: (extraProviders?: Provider[]) => PlatformRef =
     createPlatformFactory(platformCore, 'browser', INTERNAL_BROWSER_PLATFORM_PROVIDERS);
 
 export function initDomAdapter() {

--- a/modules/@angular/platform-browser/src/browser/tools/common_tools.ts
+++ b/modules/@angular/platform-browser/src/browser/tools/common_tools.ts
@@ -10,7 +10,7 @@ import {ApplicationRef, ComponentRef} from '@angular/core';
 
 import {getDOM} from '../../dom/dom_adapter';
 import {window} from '../../facade/browser';
-import {NumberWrapper, isPresent} from '../../facade/lang';
+import {isPresent} from '../../facade/lang';
 
 
 export class ChangeDetectionPerfRecord {

--- a/modules/@angular/platform-browser/src/security/url_sanitizer.ts
+++ b/modules/@angular/platform-browser/src/security/url_sanitizer.ts
@@ -39,9 +39,6 @@ import {getDOM} from '../dom/dom_adapter';
  */
 const SAFE_URL_PATTERN = /^(?:(?:https?|mailto|ftp|tel|file):|[^&:/?#]*(?:[/?#]|$))/gi;
 
-/* A pattern that matches safe srcset values */
-const SAFE_SRCSET_PATTERN = /^(?:(?:https?|file):|[^&:/?#]*(?:[/?#]|$))/gi;
-
 /** A pattern that matches safe data URLs. Only matches image, video and audio types. */
 const DATA_URL_PATTERN =
     /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[a-z0-9+\/]+=*$/i;

--- a/modules/@angular/platform-browser/test/testing_public_spec.ts
+++ b/modules/@angular/platform-browser/test/testing_public_spec.ts
@@ -402,7 +402,6 @@ export function main() {
 
     describe('errors', () => {
       var originalJasmineIt: any;
-      var originalJasmineBeforeEach: any;
 
       var patchJasmineIt = () => {
         var resolve: (result: any) => void;
@@ -422,26 +421,6 @@ export function main() {
       };
 
       var restoreJasmineIt = () => { jasmine.getEnv().it = originalJasmineIt; };
-
-      var patchJasmineBeforeEach = () => {
-        var resolve: (result: any) => void;
-        var reject: (error: any) => void;
-        var promise = new Promise((res, rej) => {
-          resolve = res;
-          reject = rej;
-        });
-        originalJasmineBeforeEach = jasmine.getEnv().beforeEach;
-        jasmine.getEnv().beforeEach = (fn: any) => {
-          var done = () => { resolve(null); };
-          (<any>done).fail = (err: any /** TODO #9100 */) => { reject(err); };
-          fn(done);
-          return null;
-        };
-        return promise;
-      };
-
-      var restoreJasmineBeforeEach =
-          () => { jasmine.getEnv().beforeEach = originalJasmineBeforeEach; };
 
       it('should fail when an asynchronous error is thrown', (done: any /** TODO #9100 */) => {
         var itPromise = patchJasmineIt();
@@ -491,7 +470,7 @@ export function main() {
 
         it('should report an error for declared components with templateUrl which never call TestBed.compileComponents',
            () => {
-             var itPromise = patchJasmineIt();
+             patchJasmineIt();
 
              expect(
                  () => it(
@@ -512,7 +491,7 @@ export function main() {
         class ComponentUsingInvalidProperty {
         }
 
-        var itPromise = patchJasmineIt();
+        patchJasmineIt();
 
         expect(
             () =>

--- a/modules/@angular/platform-browser/testing/browser.ts
+++ b/modules/@angular/platform-browser/testing/browser.ts
@@ -24,7 +24,7 @@ const _TEST_BROWSER_PLATFORM_PROVIDERS: Provider[] =
  *
  * @stable
  */
-export const platformBrowserTesting =
+export const platformBrowserTesting: (extraProviders?: Provider[]) => PlatformRef =
     createPlatformFactory(platformCore, 'browserTesting', _TEST_BROWSER_PLATFORM_PROVIDERS);
 
 /**

--- a/modules/@angular/platform-server/src/server.ts
+++ b/modules/@angular/platform-server/src/server.ts
@@ -51,7 +51,7 @@ export class ServerModule {
 /**
  * @experimental
  */
-export const platformServer =
+export const platformServer: (extraProviders?: Provider[]) => PlatformRef =
     createPlatformFactory(platformCore, 'server', INTERNAL_SERVER_PLATFORM_PROVIDERS);
 
 /**
@@ -59,5 +59,5 @@ export const platformServer =
  *
  * @experimental
  */
-export const platformDynamicServer =
+export const platformDynamicServer: (extraProviders?: Provider[]) => PlatformRef =
     createPlatformFactory(platformCoreDynamic, 'serverDynamic', INTERNAL_SERVER_PLATFORM_PROVIDERS);

--- a/modules/@angular/platform-server/testing/server.ts
+++ b/modules/@angular/platform-server/testing/server.ts
@@ -17,8 +17,9 @@ import {INTERNAL_SERVER_PLATFORM_PROVIDERS} from './private_import_platform_serv
  *
  * @experimental API related to bootstrapping are still under review.
  */
-export const platformServerTesting = createPlatformFactory(
-    platformCoreDynamicTesting, 'serverTesting', INTERNAL_SERVER_PLATFORM_PROVIDERS);
+export const platformServerTesting: (extraProviders?: Provider[]) => PlatformRef =
+    createPlatformFactory(
+        platformCoreDynamicTesting, 'serverTesting', INTERNAL_SERVER_PLATFORM_PROVIDERS);
 
 /**
  * NgModule for testing.

--- a/modules/@angular/platform-webworker-dynamic/src/platform-webworker-dynamic.ts
+++ b/modules/@angular/platform-webworker-dynamic/src/platform-webworker-dynamic.ts
@@ -14,9 +14,10 @@ import {ResourceLoaderImpl} from './private_import_platform-browser-dynamic';
 /**
  * @experimental API related to bootstrapping are still under review.
  */
-export const platformWorkerAppDynamic = createPlatformFactory(
-    platformCoreDynamic, 'workerAppDynamic', [{
-      provide: COMPILER_OPTIONS,
-      useValue: {providers: [{provide: ResourceLoader, useClass: ResourceLoaderImpl}]},
-      multi: true
-    }]);
+export const platformWorkerAppDynamic: (extraProviders?: Provider[]) => PlatformRef =
+    createPlatformFactory(
+        platformCoreDynamic, 'workerAppDynamic', [{
+          provide: COMPILER_OPTIONS,
+          useValue: {providers: [{provide: ResourceLoader, useClass: ResourceLoaderImpl}]},
+          multi: true
+        }]);

--- a/modules/@angular/platform-webworker/src/worker_app.ts
+++ b/modules/@angular/platform-webworker/src/worker_app.ts
@@ -25,7 +25,8 @@ import {WorkerDomAdapter} from './web_workers/worker/worker_adapter';
 /**
  * @experimental
  */
-export const platformWorkerApp = createPlatformFactory(platformCore, 'workerApp');
+export const platformWorkerApp: (extraProviders?: Provider[]) => PlatformRef =
+    createPlatformFactory(platformCore, 'workerApp');
 
 export function errorHandler(): ErrorHandler {
   return new ErrorHandler();

--- a/modules/@angular/platform-webworker/src/worker_render.ts
+++ b/modules/@angular/platform-webworker/src/worker_render.ts
@@ -125,7 +125,7 @@ function initWebWorkerRenderPlatform(injector: Injector): () => void {
 /**
  * @experimental WebWorker support is currently experimental.
  */
-export const platformWorkerUi =
+export const platformWorkerUi: (extraProviders?: Provider[]) => PlatformRef =
     createPlatformFactory(platformCore, 'workerUi', _WORKER_UI_PLATFORM_PROVIDERS);
 
 function _exceptionHandler(): ErrorHandler {

--- a/modules/@angular/platform-webworker/test/web_workers/worker/renderer_integration_spec.ts
+++ b/modules/@angular/platform-webworker/test/web_workers/worker/renderer_integration_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ComponentRef, Injectable, Injector} from '@angular/core';
+import {Component, ComponentRef, Injectable} from '@angular/core';
 import {DebugDomRootRenderer} from '@angular/core/src/debug/debug_renderer';
 import {RootRenderer} from '@angular/core/src/render/api';
 import {TestBed} from '@angular/core/testing';
@@ -57,7 +57,6 @@ export function main() {
   }
 
   describe('Web Worker Renderer', () => {
-    var uiInjector: Injector;
     var uiRenderStore: RenderStore;
     var workerRenderStore: RenderStore;
 

--- a/modules/@angular/router/src/router_module.ts
+++ b/modules/@angular/router/src/router_module.ts
@@ -41,15 +41,6 @@ export const ROUTER_CONFIGURATION = new OpaqueToken('ROUTER_CONFIGURATION');
  */
 export const ROUTER_FORROOT_GUARD = new OpaqueToken('ROUTER_FORROOT_GUARD');
 
-const pathLocationStrategy = {
-  provide: LocationStrategy,
-  useClass: PathLocationStrategy
-};
-const hashLocationStrategy = {
-  provide: LocationStrategy,
-  useClass: HashLocationStrategy
-};
-
 export const ROUTER_PROVIDERS: Provider[] = [
   Location, {provide: UrlSerializer, useClass: DefaultUrlSerializer}, {
     provide: Router,

--- a/modules/@angular/router/test/create_router_state.spec.ts
+++ b/modules/@angular/router/test/create_router_state.spec.ts
@@ -74,7 +74,6 @@ describe('create router state', () => {
     const currP = state.firstChild(state.root);
     expect(prevP).toBe(currP);
 
-    const prevC = prevState.children(prevP);
     const currC = state.children(currP);
 
     expect(currP._futureSnapshot.params).toEqual({id: '2', p: '22'});

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -8,7 +8,7 @@
 
 import {CommonModule, Location} from '@angular/common';
 import {Component, NgModule, NgModuleFactoryLoader} from '@angular/core';
-import {ComponentFixture, TestBed, async, fakeAsync, inject, tick} from '@angular/core/testing';
+import {ComponentFixture, TestBed, fakeAsync, inject, tick} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/matchers';
 import {Observable} from 'rxjs/Observable';
 import {of } from 'rxjs/observable/of';

--- a/modules/@angular/upgrade/src/aot/downgrade_component_adapter.ts
+++ b/modules/@angular/upgrade/src/aot/downgrade_component_adapter.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, ComponentFactory, ComponentRef, EventEmitter, Injector, OnChanges, ReflectiveInjector, SimpleChange, SimpleChanges, Type} from '@angular/core';
+import {ChangeDetectorRef, ComponentFactory, ComponentRef, EventEmitter, Injector, OnChanges, ReflectiveInjector, SimpleChange, SimpleChanges} from '@angular/core';
 
 import * as angular from '../angular_js';
 

--- a/modules/@angular/upgrade/src/upgrade_adapter.ts
+++ b/modules/@angular/upgrade/src/upgrade_adapter.ts
@@ -577,6 +577,7 @@ export class UpgradeAdapterRef {
   public ng2Injector: Injector = null;
 
   /* @internal */
+  /* tslint:disable-next-line:no-unused-variable */
   private _bootstrapDone(ngModuleRef: NgModuleRef<any>, ng1Injector: angular.IInjectorService) {
     this.ng2ModuleRef = ngModuleRef;
     this.ng2Injector = ngModuleRef.injector;

--- a/modules/@angular/upgrade/src/upgrade_ng1_adapter.ts
+++ b/modules/@angular/upgrade/src/upgrade_ng1_adapter.ts
@@ -311,7 +311,6 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
       var isOptional = false;
       var startParent = false;
       var searchParents = false;
-      var ch: string;
       if (name.charAt(0) == '?') {
         isOptional = true;
         name = name.substr(1);

--- a/modules/angular1_router/src/ng_outlet.ts
+++ b/modules/angular1_router/src/ng_outlet.ts
@@ -1,5 +1,11 @@
-///<reference path="../typings/angularjs/angular.d.ts"/>
-
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import angular, * as ng from 'angular';
 
 
 /**

--- a/modules/benchmarks/e2e_test/old/compiler_perf.ts
+++ b/modules/benchmarks/e2e_test/old/compiler_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {verifyNoBrowserErrors} from '@angular/testing/src/e2e_util';
 import {runBenchmark} from '@angular/testing/src/perf_util';
 

--- a/modules/benchmarks/e2e_test/old/costs_perf.ts
+++ b/modules/benchmarks/e2e_test/old/costs_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {verifyNoBrowserErrors} from '@angular/testing/src/e2e_util';
 import {runClickBenchmark} from '@angular/testing/src/perf_util';
 

--- a/modules/benchmarks/e2e_test/old/di_perf.ts
+++ b/modules/benchmarks/e2e_test/old/di_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {verifyNoBrowserErrors} from '@angular/testing/src/e2e_util';
 import {runClickBenchmark} from '@angular/testing/src/perf_util';
 

--- a/modules/benchmarks/e2e_test/old/largetable_perf.ts
+++ b/modules/benchmarks/e2e_test/old/largetable_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {verifyNoBrowserErrors} from '@angular/testing/src/e2e_util';
 import {runClickBenchmark} from '@angular/testing/src/perf_util';
 

--- a/modules/benchmarks/e2e_test/old/naive_infinite_scroll_perf.ts
+++ b/modules/benchmarks/e2e_test/old/naive_infinite_scroll_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {verifyNoBrowserErrors} from '@angular/testing/src/e2e_util';
 import {runBenchmark} from '@angular/testing/src/perf_util';
 

--- a/modules/benchmarks/e2e_test/old/naive_infinite_scroll_spec.ts
+++ b/modules/benchmarks/e2e_test/old/naive_infinite_scroll_spec.ts
@@ -1,5 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {verifyNoBrowserErrors} from '@angular/testing/src/e2e_util';
-import {runClickBenchmark} from '@angular/testing/src/perf_util';
 
 describe('ng2 naive infinite scroll benchmark', function() {
 
@@ -43,7 +49,7 @@ describe('ng2 naive infinite scroll benchmark', function() {
       clickFirstOf(`${ stageButtons }:enabled`).then(function() {
         firstTextOf(`${ stageButtons }:enabled`).then(function(text) {
           expect(text).toEqual('Won');
-        })
+        });
       });
     });
 

--- a/modules/benchmarks/e2e_test/old/page_load_perf.ts
+++ b/modules/benchmarks/e2e_test/old/page_load_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {verifyNoBrowserErrors} from 'angular2/src/testing/perf_util';
 
 describe('ng2 largetable benchmark', function() {

--- a/modules/benchmarks/e2e_test/old/selector_perf.ts
+++ b/modules/benchmarks/e2e_test/old/selector_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {verifyNoBrowserErrors} from '@angular/testing/src/e2e_util';
 import {runClickBenchmark} from '@angular/testing/src/perf_util';
 

--- a/modules/benchmarks/e2e_test/old/static_tree_perf.ts
+++ b/modules/benchmarks/e2e_test/old/static_tree_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {verifyNoBrowserErrors} from '@angular/testing/src/e2e_util';
 import {runClickBenchmark} from '@angular/testing/src/perf_util';
 

--- a/modules/benchmarks/src/largeform/ng2/app.ts
+++ b/modules/benchmarks/src/largeform/ng2/app.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {Component, NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {BrowserModule} from '@angular/platform-browser';

--- a/modules/benchmarks/src/largeform/ng2/index.ts
+++ b/modules/benchmarks/src/largeform/ng2/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {enableProdMode} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 

--- a/modules/benchmarks/src/largeform/ng2/index_aot.ts
+++ b/modules/benchmarks/src/largeform/ng2/index_aot.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {enableProdMode} from '@angular/core';
 import {platformBrowser} from '@angular/platform-browser';
 

--- a/modules/benchmarks/src/largeform/ng2/init.ts
+++ b/modules/benchmarks/src/largeform/ng2/init.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {ApplicationRef, NgModuleRef} from '@angular/core';
 
 import {bindAction, getIntParameter, profile} from '../../util';
@@ -19,8 +26,6 @@ export function init(moduleRef: NgModuleRef<AppModule>) {
     app.setCopies(copies);
     appRef.tick();
   }
-
-  function noop() {}
 
   const injector = moduleRef.injector;
   appRef = injector.get(ApplicationRef);

--- a/modules/benchmarks/src/largetable/baseline/index.ts
+++ b/modules/benchmarks/src/largetable/baseline/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {bindAction, profile} from '../../util';
 import {buildTable, emptyTable} from '../util';
 import {TableComponent} from './table';

--- a/modules/benchmarks/src/largetable/baseline/table.ts
+++ b/modules/benchmarks/src/largetable/baseline/table.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {TableCell} from '../util';
 
 export class TableComponent {

--- a/modules/benchmarks/src/largetable/incremental_dom/index.ts
+++ b/modules/benchmarks/src/largetable/incremental_dom/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {bindAction, profile} from '../../util';
 import {buildTable, emptyTable} from '../util';
 import {TableComponent} from './table';

--- a/modules/benchmarks/src/largetable/incremental_dom/table.ts
+++ b/modules/benchmarks/src/largetable/incremental_dom/table.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {TableCell} from '../util';
 const {patch, elementOpen, elementClose, elementOpenStart, elementOpenEnd, attr, text} =
     require('incremental-dom');

--- a/modules/benchmarks/src/largetable/ng2/index.ts
+++ b/modules/benchmarks/src/largetable/ng2/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {enableProdMode} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 

--- a/modules/benchmarks/src/largetable/ng2/index_aot.ts
+++ b/modules/benchmarks/src/largetable/ng2/index_aot.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {enableProdMode} from '@angular/core';
 import {platformBrowser} from '@angular/platform-browser';
 

--- a/modules/benchmarks/src/largetable/ng2/init.ts
+++ b/modules/benchmarks/src/largetable/ng2/init.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {ApplicationRef, NgModuleRef} from '@angular/core';
 
 import {bindAction, profile} from '../../util';

--- a/modules/benchmarks/src/largetable/ng2/table.ts
+++ b/modules/benchmarks/src/largetable/ng2/table.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {Component, Input, NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 

--- a/modules/benchmarks/src/largetable/ng2_switch/index.ts
+++ b/modules/benchmarks/src/largetable/ng2_switch/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {enableProdMode} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 

--- a/modules/benchmarks/src/largetable/ng2_switch/index_aot.ts
+++ b/modules/benchmarks/src/largetable/ng2_switch/index_aot.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {enableProdMode} from '@angular/core';
 import {platformBrowser} from '@angular/platform-browser';
 

--- a/modules/benchmarks/src/largetable/ng2_switch/init.ts
+++ b/modules/benchmarks/src/largetable/ng2_switch/init.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {ApplicationRef, NgModuleRef} from '@angular/core';
 
 import {bindAction, profile} from '../../util';

--- a/modules/benchmarks/src/largetable/ng2_switch/table.ts
+++ b/modules/benchmarks/src/largetable/ng2_switch/table.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {Component, Input, NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 
@@ -8,7 +15,7 @@ import {TableCell, emptyTable} from '../util';
   template: `<table><tbody>
     <tr *ngFor="let row of data; trackBy: trackByIndex">
     <template ngFor [ngForOf]="row" [ngForTrackBy]="trackByIndex" let-cell><ng-container [ngSwitch]="cell.row % 2">
-        <td *ngSwitchCase="0" style="background-color: grey">{{cell.value}}</td><td *ngSwitchDefault>{{cell.value}}</td>    
+        <td *ngSwitchCase="0" style="background-color: grey">{{cell.value}}</td><td *ngSwitchDefault>{{cell.value}}</td>
     </ng-container></template>
     </tr>
   </tbody></table>`

--- a/modules/benchmarks/src/largetable/util.ts
+++ b/modules/benchmarks/src/largetable/util.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {getIntParameter} from '../util';
 
 export class TableCell {

--- a/modules/benchmarks/src/old/compiler/compiler_benchmark.ts
+++ b/modules/benchmarks/src/old/compiler/compiler_benchmark.ts
@@ -1,16 +1,19 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {CompilerConfig, DirectiveResolver} from '@angular/compiler';
+import {Component, ComponentResolver, Directive} from '@angular/core';
+import {ViewMetadata} from '@angular/core/src/metadata/view';
 import {PromiseWrapper} from '@angular/facade/src/async';
 import {Type, print} from '@angular/facade/src/lang';
 import {bootstrap} from '@angular/platform-browser';
 import {BrowserDomAdapter} from '@angular/platform-browser/src/browser/browser_adapter';
 import {DOM} from '@angular/platform-browser/src/dom/dom_adapter';
-
-import {ComponentResolver, Component, Directive, ViewContainerRef,} from '@angular/core';
-
-import {ViewMetadata} from '@angular/core/src/metadata/view';
-
-import {CompilerConfig, DirectiveResolver} from '@angular/compiler';
-
-import {getIntParameter, bindAction} from '@angular/testing/src/benchmark_util';
+import {bindAction, getIntParameter} from '@angular/testing/src/benchmark_util';
 
 function _createBindings(): any[] {
   var multiplyTemplatesBy = getIntParameter('elements');
@@ -56,8 +59,8 @@ function measureWrapper(func, desc) {
 
 
 class MultiplyDirectiveResolver extends DirectiveResolver {
-  _multiplyBy: number;
-  _cache = new Map<Type, ViewMetadata>();
+  private _multiplyBy: number;
+  private _cache = new Map<Type, ViewMetadata>();
 
   constructor(multiple: number, components: Type[]) {
     super();
@@ -65,7 +68,7 @@ class MultiplyDirectiveResolver extends DirectiveResolver {
     components.forEach(c => this._fillCache(c));
   }
 
-  _fillCache(component: Type) {
+  private _fillCache(component: Type) {
     var view = super.resolve(component);
     var multipliedTemplates = new Array(this._multiplyBy);
     for (var i = 0; i < this._multiplyBy; ++i) {

--- a/modules/benchmarks/src/old/compiler/selector_benchmark.ts
+++ b/modules/benchmarks/src/old/compiler/selector_benchmark.ts
@@ -1,5 +1,11 @@
-import {SelectorMatcher} from '@angular/compiler/src/selector';
-import {CssSelector} from '@angular/compiler/src/selector';
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {CssSelector, SelectorMatcher} from '@angular/compiler/src/selector';
 import {Math} from '@angular/facade/lang';
 import {BrowserDomAdapter} from '@angular/platform-browser/src/browser/browser_adapter';
 import {bindAction, getIntParameter} from '@angular/testing/src/benchmark_util';

--- a/modules/benchmarks/src/old/costs/index.ts
+++ b/modules/benchmarks/src/old/costs/index.ts
@@ -1,8 +1,13 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {NgFor, NgIf} from '@angular/common';
 import {Component, Directive, DynamicComponentLoader, ViewContainerRef} from '@angular/core';
 import {ApplicationRef} from '@angular/core/src/application_ref';
-import {ListWrapper} from '@angular/facade/src/lang';
-import {bootstrap} from '@angular/platform-browser';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {bindAction, getIntParameter} from '@angular/testing/src/benchmark_util';

--- a/modules/benchmarks/src/old/di/di_benchmark.ts
+++ b/modules/benchmarks/src/old/di/di_benchmark.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {Injectable, ReflectiveInjector, ReflectiveKey} from '@angular/core';
 import {reflector} from '@angular/core/src/reflection/reflection';
 import {ReflectionCapabilities} from '@angular/core/src/reflection/reflection_capabilities';

--- a/modules/benchmarks/src/old/naive_infinite_scroll/app.ts
+++ b/modules/benchmarks/src/old/naive_infinite_scroll/app.ts
@@ -1,5 +1,12 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {NgFor, NgIf} from '@angular/common';
-import {Component, Directive} from '@angular/core';
+import {Component} from '@angular/core';
 import {TimerWrapper} from '@angular/facade/src/async';
 import {document} from '@angular/facade/src/browser';
 import {isPresent} from '@angular/facade/src/lang';
@@ -66,7 +73,7 @@ export class App {
   }
 
   // Puts a marker indicating that the test is finished.
-  _scheduleFinishedMarker() {
+  private _scheduleFinishedMarker() {
     var existingMarker = this._locateFinishedMarker();
     if (isPresent(existingMarker)) {
       // Nothing to do, the marker is already there
@@ -80,7 +87,7 @@ export class App {
     }, 0);
   }
 
-  _locateFinishedMarker() { return DOM.querySelector(document.body, '#done'); }
+  private _locateFinishedMarker() { return DOM.querySelector(document.body, '#done'); }
 
-  _getScrollDiv() { return DOM.query('body /deep/ #scrollDiv'); }
+  private _getScrollDiv() { return DOM.query('body /deep/ #scrollDiv'); }
 }

--- a/modules/benchmarks/src/old/naive_infinite_scroll/cells.ts
+++ b/modules/benchmarks/src/old/naive_infinite_scroll/cells.ts
@@ -1,5 +1,12 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {NgFor} from '@angular/common';
-import {Component, Directive} from '@angular/core';
+import {Component} from '@angular/core';
 
 import {Account, Company, CustomDate, Offering, Opportunity, STATUS_LIST} from './common';
 
@@ -63,7 +70,7 @@ export class Stage {
       </div>`
 })
 export class StageButtonsComponent extends HasStyle {
-  _offering: Offering;
+  private _offering: Offering;
   stages: Stage[];
 
   get offering(): Offering { return this._offering; }
@@ -78,7 +85,7 @@ export class StageButtonsComponent extends HasStyle {
     this._computeStageButtons();
   }
 
-  _computeStageButtons() {
+  private _computeStageButtons() {
     var disabled = true;
     this.stages = STATUS_LIST
                       .map((status) => {

--- a/modules/benchmarks/src/old/naive_infinite_scroll/common.ts
+++ b/modules/benchmarks/src/old/naive_infinite_scroll/common.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {Math} from '@angular/facade/src/math';
 
 export var ITEMS = 1000;
@@ -52,7 +59,7 @@ export class CustomDate {
 }
 
 export class RawEntity {
-  _data: Map<any, any>;
+  private _data: Map<any, any>;
 
   constructor() { this._data = new Map(); }
 
@@ -93,7 +100,7 @@ export class RawEntity {
     return target.remove(last);
   }
 
-  _resolve(pieces, start) {
+  private _resolve(pieces, start) {
     var cur = start;
     for (var i = 0; i < pieces.length; i++) {
       cur = cur[pieces[i]];

--- a/modules/benchmarks/src/old/naive_infinite_scroll/index.ts
+++ b/modules/benchmarks/src/old/naive_infinite_scroll/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';

--- a/modules/benchmarks/src/old/naive_infinite_scroll/random_data.ts
+++ b/modules/benchmarks/src/old/naive_infinite_scroll/random_data.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {AAT_STATUS_LIST, Account, Company, CustomDate, Offering, Opportunity, STATUS_LIST} from './common';
 
 export function generateOfferings(count: number): Offering[] {

--- a/modules/benchmarks/src/old/naive_infinite_scroll/scroll_area.ts
+++ b/modules/benchmarks/src/old/naive_infinite_scroll/scroll_area.ts
@@ -1,5 +1,12 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {NgFor} from '@angular/common';
-import {Component, Directive} from '@angular/core';
+import {Component} from '@angular/core';
 
 import {HEIGHT, ITEMS, ITEM_HEIGHT, Offering, ROW_WIDTH, VIEW_PORT_HEIGHT, VISIBLE_ITEMS} from './common';
 import {generateOfferings} from './random_data';
@@ -25,7 +32,7 @@ import {ScrollItemComponent} from './scroll_item';
     </div>`
 })
 export class ScrollAreaComponent {
-  _fullList: Offering[];
+  private _fullList: Offering[];
   visibleItems: Offering[];
 
   viewPortHeight: number;

--- a/modules/benchmarks/src/old/naive_infinite_scroll/scroll_item.ts
+++ b/modules/benchmarks/src/old/naive_infinite_scroll/scroll_item.ts
@@ -1,4 +1,11 @@
-import {Component, Directive} from '@angular/core';
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Component} from '@angular/core';
 
 import {AccountCellComponent, CompanyNameComponent, FormattedCellComponent, OfferingNameComponent, OpportunityNameComponent, StageButtonsComponent} from './cells';
 import {AAT_STATUS_WIDTH, ACCOUNT_CELL_WIDTH, BASE_POINTS_WIDTH, BUNDLES_WIDTH, COMPANY_NAME_WIDTH, DUE_DATE_WIDTH, END_DATE_WIDTH, ITEM_HEIGHT, KICKER_POINTS_WIDTH, OFFERING_NAME_WIDTH, OPPORTUNITY_NAME_WIDTH, Offering, STAGE_BUTTONS_WIDTH} from './common';

--- a/modules/benchmarks/src/old/page_load/page_load.ts
+++ b/modules/benchmarks/src/old/page_load/page_load.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {Component, NgModule} from 'angular2/core';

--- a/modules/benchmarks/src/tree/baseline/index.ts
+++ b/modules/benchmarks/src/tree/baseline/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {bindAction, profile} from '../../util';
 import {buildTree, emptyTree} from '../util';
 import {TreeComponent} from './tree';

--- a/modules/benchmarks/src/tree/baseline/tree.ts
+++ b/modules/benchmarks/src/tree/baseline/tree.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {TreeNode} from '../util';
 
 export class TreeComponent {

--- a/modules/benchmarks/src/tree/incremental_dom/index.ts
+++ b/modules/benchmarks/src/tree/incremental_dom/index.ts
@@ -1,7 +1,13 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {bindAction, profile} from '../../util';
 import {buildTree, emptyTree} from '../util';
 import {TreeComponent} from './tree';
-const {patch} = require('incremental-dom');
 
 export function main() {
   var tree: TreeComponent;

--- a/modules/benchmarks/src/tree/incremental_dom/tree.ts
+++ b/modules/benchmarks/src/tree/incremental_dom/tree.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {TreeNode} from '../util';
 const {patch, elementOpen, elementClose, elementOpenStart, elementOpenEnd, text, attr} =
     require('incremental-dom');

--- a/modules/benchmarks/src/tree/ng2/index.ts
+++ b/modules/benchmarks/src/tree/ng2/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {enableProdMode} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 

--- a/modules/benchmarks/src/tree/ng2/index_aot.ts
+++ b/modules/benchmarks/src/tree/ng2/index_aot.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {enableProdMode} from '@angular/core';
 import {platformBrowser} from '@angular/platform-browser';
 

--- a/modules/benchmarks/src/tree/ng2/init.ts
+++ b/modules/benchmarks/src/tree/ng2/init.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {ApplicationRef, NgModuleRef} from '@angular/core';
 
 import {bindAction, profile} from '../../util';

--- a/modules/benchmarks/src/tree/ng2/tree.ts
+++ b/modules/benchmarks/src/tree/ng2/tree.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {Component, NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 

--- a/modules/benchmarks/src/tree/ng2_ftl/ftl_util.ts
+++ b/modules/benchmarks/src/tree/ng2_ftl/ftl_util.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {ComponentFactory, ComponentRef, ElementRef, Injector, TemplateRef, ViewContainerRef, ViewRef} from '@angular/core';
 
 export function unimplemented(): any {

--- a/modules/benchmarks/src/tree/ng2_ftl/index.ts
+++ b/modules/benchmarks/src/tree/ng2_ftl/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {ApplicationRef, enableProdMode} from '@angular/core';
 import {platformBrowser} from '@angular/platform-browser';
 

--- a/modules/benchmarks/src/tree/ng2_ftl/tree.ts
+++ b/modules/benchmarks/src/tree/ng2_ftl/tree.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {TreeNode, emptyTree} from '../util';
 
 export class TreeComponent { data: TreeNode = emptyTree; }

--- a/modules/benchmarks/src/tree/ng2_static/index.ts
+++ b/modules/benchmarks/src/tree/ng2_static/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {ApplicationRef, enableProdMode} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 

--- a/modules/benchmarks/src/tree/ng2_static/tree.ts
+++ b/modules/benchmarks/src/tree/ng2_static/tree.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {Component, Input, NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 

--- a/modules/benchmarks/src/tree/ng2_static_ftl/app.ts
+++ b/modules/benchmarks/src/tree/ng2_static_ftl/app.ts
@@ -1,1 +1,8 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 export class AppModule {}

--- a/modules/benchmarks/src/tree/ng2_static_ftl/ftl_util.ts
+++ b/modules/benchmarks/src/tree/ng2_static_ftl/ftl_util.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 export function createElementAndAppend(parent: any, name: string) {
   const el = document.createElement(name);
   parent.appendChild(el);

--- a/modules/benchmarks/src/tree/ng2_static_ftl/index.ts
+++ b/modules/benchmarks/src/tree/ng2_static_ftl/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {ApplicationRef, enableProdMode} from '@angular/core';
 import {platformBrowser} from '@angular/platform-browser';
 

--- a/modules/benchmarks/src/tree/ng2_static_ftl/tree.ts
+++ b/modules/benchmarks/src/tree/ng2_static_ftl/tree.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {TreeNode, emptyTree} from '../util';
 
 export class TreeRootComponent { data: TreeNode = emptyTree; }

--- a/modules/benchmarks/src/tree/ng2_switch/index.ts
+++ b/modules/benchmarks/src/tree/ng2_switch/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {enableProdMode} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 

--- a/modules/benchmarks/src/tree/ng2_switch/index_aot.ts
+++ b/modules/benchmarks/src/tree/ng2_switch/index_aot.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {enableProdMode} from '@angular/core';
 import {platformBrowser} from '@angular/platform-browser';
 

--- a/modules/benchmarks/src/tree/ng2_switch/init.ts
+++ b/modules/benchmarks/src/tree/ng2_switch/init.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {ApplicationRef, NgModuleRef} from '@angular/core';
 
 import {bindAction, profile} from '../../util';

--- a/modules/benchmarks/src/tree/ng2_switch/tree.ts
+++ b/modules/benchmarks/src/tree/ng2_switch/tree.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {Component, Input, NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 

--- a/modules/benchmarks/src/tree/polymer/index.ts
+++ b/modules/benchmarks/src/tree/polymer/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {bindAction, profile} from '../../util';
 import {buildTree, emptyTree} from '../util';
 

--- a/modules/benchmarks/src/tree/polymer_leaves/index.ts
+++ b/modules/benchmarks/src/tree/polymer_leaves/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {bindAction} from '../../util';
 import {buildTree, flattenTree} from '../util';
 

--- a/modules/benchmarks/src/tree/util.ts
+++ b/modules/benchmarks/src/tree/util.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {getIntParameter} from '../util';
 
 export class TreeNode {

--- a/modules/benchmarks_external/e2e_test/compiler_perf.ts
+++ b/modules/benchmarks_external/e2e_test/compiler_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {runClickBenchmark, verifyNoBrowserErrors} from '@angular/testing/src/perf_util';
 
 describe('ng1.x compiler benchmark', function() {

--- a/modules/benchmarks_external/e2e_test/largetable_perf.ts
+++ b/modules/benchmarks_external/e2e_test/largetable_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {runClickBenchmark, verifyNoBrowserErrors} from '@angular/testing/src/perf_util';
 
 describe('ng1.x largetable benchmark', function() {

--- a/modules/benchmarks_external/e2e_test/naive_infinite_scroll_perf.ts
+++ b/modules/benchmarks_external/e2e_test/naive_infinite_scroll_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {runBenchmark, verifyNoBrowserErrors} from '@angular/testing/src/perf_util';
 
 describe('ng-dart1.x naive infinite scroll benchmark', function() {

--- a/modules/benchmarks_external/e2e_test/polymer_tree_perf.ts
+++ b/modules/benchmarks_external/e2e_test/polymer_tree_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {runClickBenchmark, verifyNoBrowserErrors} from '@angular/testing/src/perf_util';
 
 describe('polymer tree benchmark', function() {

--- a/modules/benchmarks_external/e2e_test/react_tree_perf.ts
+++ b/modules/benchmarks_external/e2e_test/react_tree_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {runClickBenchmark, verifyNoBrowserErrors} from '@angular/testing/src/perf_util';
 
 describe('react tree benchmark', function() {

--- a/modules/benchmarks_external/e2e_test/static_tree_perf.ts
+++ b/modules/benchmarks_external/e2e_test/static_tree_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {runClickBenchmark, verifyNoBrowserErrors} from '@angular/testing/src/perf_util';
 
 describe('ng1.x tree benchmark', function() {

--- a/modules/benchmarks_external/e2e_test/tree_perf.ts
+++ b/modules/benchmarks_external/e2e_test/tree_perf.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {runClickBenchmark, verifyNoBrowserErrors} from '@angular/testing/src/perf_util';
 
 describe('ng1.x tree benchmark', function() {

--- a/modules/benchmarks_external/src/compiler/compiler_benchmark.ts
+++ b/modules/benchmarks_external/src/compiler/compiler_benchmark.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 // compiler benchmark in AngularJS 1.x
 import {getIntParameter, bindAction} from '@angular/testing/src/benchmark_util';
 declare var angular: any;
@@ -31,7 +39,7 @@ angular.module('app', [])
                    return {
                      compile: function($element, $attrs) {
                        var expr = $parse($attrs.attr0);
-                       return function($scope) { $scope.$watch(expr, angular.noop); }
+                       return function($scope) { $scope.$watch(expr, angular.noop); };
                      }
                    };
                  }
@@ -43,7 +51,7 @@ angular.module('app', [])
                    return {
                      compile: function($element, $attrs) {
                        var expr = $parse($attrs.attr1);
-                       return function($scope) { $scope.$watch(expr, angular.noop); }
+                       return function($scope) { $scope.$watch(expr, angular.noop); };
                      }
                    };
                  }
@@ -55,7 +63,7 @@ angular.module('app', [])
                    return {
                      compile: function($element, $attrs) {
                        var expr = $parse($attrs.attr2);
-                       return function($scope) { $scope.$watch(expr, angular.noop); }
+                       return function($scope) { $scope.$watch(expr, angular.noop); };
                      }
                    };
                  }
@@ -67,7 +75,7 @@ angular.module('app', [])
                    return {
                      compile: function($element, $attrs) {
                        var expr = $parse($attrs.attr3);
-                       return function($scope) { $scope.$watch(expr, angular.noop); }
+                       return function($scope) { $scope.$watch(expr, angular.noop); };
                      }
                    };
                  }
@@ -79,7 +87,7 @@ angular.module('app', [])
                    return {
                      compile: function($element, $attrs) {
                        var expr = $parse($attrs.attr4);
-                       return function($scope) { $scope.$watch(expr, angular.noop); }
+                       return function($scope) { $scope.$watch(expr, angular.noop); };
                      }
                    };
                  }

--- a/modules/benchmarks_external/src/largetable/largetable_benchmark.ts
+++ b/modules/benchmarks_external/src/largetable/largetable_benchmark.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {getIntParameter, getStringParameter, bindAction} from '@angular/testing/src/benchmark_util';
 declare var angular: any;
 
@@ -108,4 +115,4 @@ angular.module('app', [])
           }
         }
       };
-    })
+    });

--- a/modules/benchmarks_external/src/static_tree/tree_benchmark.ts
+++ b/modules/benchmarks_external/src/static_tree/tree_benchmark.ts
@@ -1,5 +1,13 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 // static tree benchmark in AngularJS 1.x
-import {getIntParameter, bindAction} from '@angular/testing/src/benchmark_util';
+import {bindAction} from '@angular/testing/src/benchmark_util';
 declare var angular: any;
 
 const MAX_DEPTH = 10;
@@ -11,7 +19,7 @@ export function main() {
 function addTreeDirective(module, level: number) {
   var template;
   if (level <= 0) {
-    template = `<span> {{data.value}}</span>`
+    template = `<span> {{data.value}}</span>`;
   } else {
     template = `<span> {{data.value}} <tree${level-1} data='data.right'></tree${level-1}><tree${level-1} data='data.left'></tree${level-1}></span>`;
   }

--- a/modules/benchmarks_external/src/tree/react/index.ts
+++ b/modules/benchmarks_external/src/tree/react/index.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 // tree benchmark in React
 import {getIntParameter, bindAction} from '@angular/testing/src/benchmark_util';
 import * as React from './react.min';
@@ -11,13 +19,13 @@ var TreeComponent = React.createClass({
     var left = null;
     if (treeNode.left) {
       left = React.createElement(
-          "span", {}, [React.createElement(TreeComponent, {treeNode: treeNode.left}, "")])
+          "span", {}, [React.createElement(TreeComponent, {treeNode: treeNode.left}, "")]);
     }
 
     var right = null;
     if (treeNode.right) {
       right = React.createElement(
-          "span", {}, [React.createElement(TreeComponent, {treeNode: treeNode.right}, "")])
+          "span", {}, [React.createElement(TreeComponent, {treeNode: treeNode.right}, "")]);
     }
 
     var span = React.createElement("span", {}, [" " + treeNode.value, left, right]);

--- a/modules/benchmarks_external/src/tree/tree_benchmark.ts
+++ b/modules/benchmarks_external/src/tree/tree_benchmark.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 // tree benchmark in AngularJS 1.x
 import {getIntParameter, bindAction} from '@angular/testing/src/benchmark_util';
 declare var angular: any;
@@ -24,7 +32,6 @@ angular.module('app', [])
                  '$compile',
                  '$parse',
                  function($compile, $parse) {
-                   var transcludeFn;
                    return {
                      compile: function(element, attrs) {
                        var expr = $parse('!!' + attrs.treeIf);
@@ -49,10 +56,9 @@ angular.module('app', [])
                                                        function(clone) { $element.append(clone); });
                            }
                          });
-                       }
-
+                       };
                      }
-                   }
+                   };
                  }
                ])
     .config([

--- a/modules/e2e_util/perf_util.ts
+++ b/modules/e2e_util/perf_util.ts
@@ -7,7 +7,6 @@
  */
 export {verifyNoBrowserErrors} from './e2e_util';
 
-const yargs = require('yargs');
 const nodeUuid = require('node-uuid');
 import * as fs from 'fs-extra';
 

--- a/modules/payload_tests/hello_world/ts/systemjs/index.ts
+++ b/modules/payload_tests/hello_world/ts/systemjs/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {Component, NgModule} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {BrowserModule} from '@angular/platform-browser';

--- a/modules/payload_tests/hello_world/ts/webpack/index.ts
+++ b/modules/payload_tests/hello_world/ts/webpack/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {Component, NgModule} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {BrowserModule} from '@angular/platform-browser';

--- a/modules/playground/src/animate/app/animate-app.ts
+++ b/modules/playground/src/animate/app/animate-app.ts
@@ -63,12 +63,12 @@ import {Component, animate, keyframes, state, style, transition, trigger} from '
   ]
 })
 export class AnimateApp {
-  public items: any[] /** TODO #9100 */ = [];
-  public _state: any /** TODO #9100 */;
+  public items: number[] = [];
+  private _state: ('start'|'active'|'void'|'default');
 
   public bgStatus = 'focus';
 
-  remove(item: any) {
+  remove(item: number) {
     var index = this.items.indexOf(item);
     if (index >= 0) {
       this.items.splice(index, 1);
@@ -76,7 +76,7 @@ export class AnimateApp {
   }
 
   reorderAndRemove() {
-    this.items = this.items.sort((a: any, b: any) => Math.random() - 0.5);
+    this.items = this.items.sort((a, b) => Math.random() - 0.5);
     this.items.splice(Math.floor(Math.random() * this.items.length), 1);
     this.items.splice(Math.floor(Math.random() * this.items.length), 1);
     this.items[Math.floor(Math.random() * this.items.length)] = 99;

--- a/modules/playground/src/async/index.ts
+++ b/modules/playground/src/async/index.ts
@@ -39,9 +39,9 @@ class AsyncApplication {
   val2: number = 0;
   val3: number = 0;
   val4: number = 0;
-  timeoutId: any /** TODO #9100 */ = null;
-  multiTimeoutId: any /** TODO #9100 */ = null;
-  intervalId: any /** TODO #9100 */ = null;
+  timeoutId: NodeJS.Timer = null;
+  multiTimeoutId: NodeJS.Timer = null;
+  intervalId: NodeJS.Timer = null;
 
   increment(): void { this.val1++; };
 
@@ -57,7 +57,7 @@ class AsyncApplication {
     this.cancelMultiDelayedIncrements();
 
     var self = this;
-    function helper(_i: any /** TODO #9100 */) {
+    function helper(_i: number) {
       if (_i <= 0) {
         self.multiTimeoutId = null;
         return;
@@ -73,7 +73,7 @@ class AsyncApplication {
 
   periodicIncrement(): void {
     this.cancelPeriodicIncrement();
-    this.intervalId = setInterval(() => { this.val4++; }, 2000)
+    this.intervalId = setInterval(() => { this.val4++; }, 2000);
   };
 
   cancelDelayedIncrement(): void {

--- a/modules/playground/src/model_driven_forms/index.ts
+++ b/modules/playground/src/model_driven_forms/index.ts
@@ -48,7 +48,7 @@ function creditCardValidator(c: AbstractControl): {[key: string]: boolean} {
   `
 })
 class ShowError {
-  formDir: any /** TODO #9100 */;
+  formDir: FormGroupDirective;
   controlPath: string;
   errorTypes: string[];
 
@@ -67,9 +67,12 @@ class ShowError {
     return null;
   }
 
-  _errorMessage(code: string): string {
-    var config = {'required': 'is required', 'invalidCreditCard': 'is invalid credit card number'};
-    return (config as any /** TODO #9100 */)[code];
+  private _errorMessage(code: string): string {
+    var config: {[key: string]: string} = {
+      'required': 'is required',
+      'invalidCreditCard': 'is invalid credit card number',
+    };
+    return config[code];
   }
 }
 
@@ -134,7 +137,7 @@ class ShowError {
   `
 })
 class ReactiveForms {
-  form: any /** TODO #9100 */;
+  form: FormGroup;
   countries = ['US', 'Canada'];
 
   constructor(fb: FormBuilder) {

--- a/modules/playground/src/routing/app/data.ts
+++ b/modules/playground/src/routing/app/data.ts
@@ -2121,4 +2121,4 @@ export var data = [
     'subject': 'Fwd: wedding photos',
     'draft': true
   }
-]
+];

--- a/modules/playground/src/routing/app/inbox-detail.ts
+++ b/modules/playground/src/routing/app/inbox-detail.ts
@@ -14,7 +14,6 @@ import {DbService, InboxRecord} from './inbox-app';
 @Component({selector: 'inbox-detail', templateUrl: 'app/inbox-detail.html'})
 export class InboxDetailCmp {
   private record: InboxRecord = new InboxRecord();
-  private ready: boolean = false;
 
   constructor(db: DbService, route: ActivatedRoute) {
     route.params.forEach(

--- a/modules/playground/src/template_driven_forms/index.ts
+++ b/modules/playground/src/template_driven_forms/index.ts
@@ -8,8 +8,8 @@
 
 
 import {Component, Directive, Host, NgModule} from '@angular/core';
-import {isPresent, print} from '@angular/core/src/facade/lang';
-import {FormGroup, FormsModule, NG_VALIDATORS, NgForm} from '@angular/forms';
+import {print} from '@angular/core/src/facade/lang';
+import {FormControl, FormGroup, FormsModule, NG_VALIDATORS, NgForm} from '@angular/forms';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
@@ -33,8 +33,8 @@ class CheckoutModel {
 /**
  * Custom validator.
  */
-function creditCardValidator(c: any /** TODO #9100 */): {[key: string]: boolean} {
-  if (isPresent(c.value) && /^\d{16}$/.test(c.value)) {
+function creditCardValidator(c: FormControl): {[key: string]: boolean} {
+  if (c.value != null && /^\d{16}$/.test(c.value)) {
     return null;
   } else {
     return {'invalidCreditCard': true};
@@ -74,7 +74,7 @@ class CreditCardValidator {
   `
 })
 class ShowError {
-  formDir: any /** TODO #9100 */;
+  formDir: NgForm;
   controlPath: string;
   errorTypes: string[];
 
@@ -83,7 +83,7 @@ class ShowError {
   get errorMessage(): string {
     var form: FormGroup = this.formDir.form;
     var control = form.get(this.controlPath);
-    if (isPresent(control) && control.touched) {
+    if (control != null && control.touched) {
       for (var i = 0; i < this.errorTypes.length; ++i) {
         if (control.hasError(this.errorTypes[i])) {
           return this._errorMessage(this.errorTypes[i]);
@@ -93,9 +93,12 @@ class ShowError {
     return null;
   }
 
-  _errorMessage(code: string): string {
-    var config = {'required': 'is required', 'invalidCreditCard': 'is invalid credit card number'};
-    return (config as any /** TODO #9100 */)[code];
+  private _errorMessage(code: string): string {
+    var config: {[key: string]: string} = {
+      'required': 'is required',
+      'invalidCreditCard': 'is invalid credit card number',
+    };
+    return config[code];
   }
 }
 

--- a/modules/playground/src/todo/app/TodoStore.ts
+++ b/modules/playground/src/todo/app/TodoStore.ts
@@ -20,7 +20,7 @@ export class Todo extends KeyModel {
 
 @Injectable()
 export class TodoFactory {
-  _uid: number = 0;
+  private _uid: number = 0;
 
   nextUid(): number { return ++this._uid; }
 

--- a/modules/playground/src/web_workers/images/services/bitmap.ts
+++ b/modules/playground/src/web_workers/images/services/bitmap.ts
@@ -6,13 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-/// <reference path="../bitmap.d.ts" /> /// <reference path="../b64.d.ts" />
 import {Injectable} from '@angular/core';
-declare var base64js: any /** TODO #9100 */;
-
-// Temporary fix for Typescript issue #4220 (https://github.com/Microsoft/TypeScript/issues/4220)
-// var _ImageData: (width: number, height: number) => void = <any>postMessage;
-var _ImageData: {prototype: ImageData, new (width: number, height: number): ImageData;} = ImageData;
+import * as base64js from 'B64';
 
 // This class is based on the Bitmap examples at:
 // http://www.i-programmer.info/projects/36-web/6234-reading-a-bmp-file-in-javascript.html
@@ -101,7 +96,7 @@ export class BitmapService {
   private _BMPToImageData(bmp: BitmapFile): ImageData {
     var width = bmp.infoHeader.biWidth;
     var height = bmp.infoHeader.biHeight;
-    var imageData = new _ImageData(width, height);
+    var imageData = new ImageData(width, height);
 
     var data = imageData.data;
     var bmpData = bmp.pixels;

--- a/modules/playground/src/web_workers/message_broker/index.ts
+++ b/modules/playground/src/web_workers/message_broker/index.ts
@@ -7,8 +7,7 @@
  */
 
 import {PlatformRef} from '@angular/core';
-import {ClientMessageBrokerFactory, FnArg, PRIMITIVE, UiArguments} from '@angular/platform-webworker';
-import {bootstrapWorkerUi} from '@angular/platform-webworker';
+import {ClientMessageBrokerFactory, FnArg, PRIMITIVE, UiArguments, bootstrapWorkerUi} from '@angular/platform-webworker';
 
 const ECHO_CHANNEL = 'ECHO';
 

--- a/modules/playground/src/web_workers/todo/services/TodoStore.ts
+++ b/modules/playground/src/web_workers/todo/services/TodoStore.ts
@@ -24,7 +24,7 @@ export class Todo extends KeyModel {
 
 @Injectable()
 export class TodoFactory {
-  _uid: number = 0;
+  private _uid: number = 0;
 
   nextUid(): number { return ++this._uid; }
 

--- a/tools/@angular/tsc-wrapped/index.ts
+++ b/tools/@angular/tsc-wrapped/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 export {MetadataWriterHost, TsickleHost} from './src/compiler_host';
 export {CodegenExtension, main} from './src/main';
 

--- a/tools/@angular/tsc-wrapped/src/collector.ts
+++ b/tools/@angular/tsc-wrapped/src/collector.ts
@@ -1,7 +1,14 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import * as ts from 'typescript';
 
 import {Evaluator, errorSymbol, isPrimitive} from './evaluator';
-import {ClassMetadata, ConstructorMetadata, FunctionMetadata, MemberMetadata, MetadataEntry, MetadataError, MetadataMap, MetadataObject, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, VERSION, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSelectExpression, isMethodMetadata} from './schema';
+import {ClassMetadata, ConstructorMetadata, FunctionMetadata, MemberMetadata, MetadataEntry, MetadataError, MetadataMap, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleExportMetadata, ModuleMetadata, VERSION, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSelectExpression, isMethodMetadata} from './schema';
 import {Symbols} from './symbols';
 
 
@@ -54,7 +61,6 @@ export class MetadataCollector {
                 value: evaluator.evaluateNode(returnStatement.expression)
               };
               if (functionDeclaration.parameters.some(p => p.initializer != null)) {
-                const defaults: MetadataValue[] = [];
                 func.defaults = functionDeclaration.parameters.map(
                     p => p.initializer && evaluator.evaluateNode(p.initializer));
               }
@@ -232,7 +238,7 @@ export class MetadataCollector {
               moduleExport.export = exportDeclaration.exportClause.elements.map(
                   element => element.propertyName ?
                       {name: element.propertyName.text, as: element.name.text} :
-                      element.name.text)
+                      element.name.text);
             }
             if (!exports) exports = [];
             exports.push(moduleExport);
@@ -292,7 +298,7 @@ export class MetadataCollector {
                     __symbolic: 'select',
                     expression: recordEntry({__symbolic: 'reference', name: enumName}, node), name
                   }
-                }
+                };
               } else {
                 nextDefaultValue =
                     recordEntry(errorSym('Unsuppported enum member name', member.name), node);
@@ -509,7 +515,7 @@ function validateMetadata(
     const entry = metadata[name];
     try {
       if (isClassMetadata(entry)) {
-        validateClass(entry)
+        validateClass(entry);
       }
     } catch (e) {
       const node = nodeMap.get(entry);

--- a/tools/@angular/tsc-wrapped/src/compiler_host.ts
+++ b/tools/@angular/tsc-wrapped/src/compiler_host.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {writeFileSync} from 'fs';
 import {convertDecorators} from 'tsickle';
 import * as ts from 'typescript';
@@ -69,8 +76,7 @@ const IGNORED_FILES = /\.ngfactory\.js$|\.css\.js$|\.css\.shim\.js$/;
 
 export class MetadataWriterHost extends DelegatingHost {
   private metadataCollector = new MetadataCollector();
-  constructor(
-      delegate: ts.CompilerHost, private program: ts.Program, private ngOptions: NgOptions) {
+  constructor(delegate: ts.CompilerHost, program: ts.Program, private ngOptions: NgOptions) {
     super(delegate);
   }
 
@@ -96,8 +102,7 @@ export class MetadataWriterHost extends DelegatingHost {
           this.delegate.writeFile(fileName, data, writeByteOrderMark, onError, sourceFiles);
 
           // TODO: remove this early return after https://github.com/Microsoft/TypeScript/pull/8412
-          // is
-          // released
+          // is released
           return;
         }
 

--- a/tools/@angular/tsc-wrapped/src/evaluator.ts
+++ b/tools/@angular/tsc-wrapped/src/evaluator.ts
@@ -1,6 +1,13 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import * as ts from 'typescript';
 
-import {MetadataEntry, MetadataError, MetadataGlobalReferenceExpression, MetadataImportedSymbolReferenceExpression, MetadataSymbolicCallExpression, MetadataSymbolicReferenceExpression, MetadataValue, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataImportedSymbolReferenceExpression, isMetadataModuleReferenceExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSpreadExpression} from './schema';
+import {MetadataEntry, MetadataError, MetadataImportedSymbolReferenceExpression, MetadataSymbolicCallExpression, MetadataValue, isMetadataError, isMetadataModuleReferenceExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSpreadExpression} from './schema';
 import {Symbols} from './symbols';
 
 function isMethodCallOf(callExpression: ts.CallExpression, memberName: string): boolean {
@@ -57,7 +64,7 @@ export interface ImportMetadata {
 
 function getSourceFileOfNode(node: ts.Node): ts.SourceFile {
   while (node && node.kind != ts.SyntaxKind.SourceFile) {
-    node = node.parent
+    node = node.parent;
   }
   return <ts.SourceFile>node;
 }
@@ -375,7 +382,7 @@ export class Evaluator {
                         module: left.module,
                         name: qualifiedName.right.text
                       },
-                      node)
+                      node);
                 }
                 // Record a type reference to a declared type as a select.
                 return {__symbolic: 'select', expression: left, member: qualifiedName.right.text};

--- a/tools/@angular/tsc-wrapped/src/main.ts
+++ b/tools/@angular/tsc-wrapped/src/main.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';

--- a/tools/@angular/tsc-wrapped/src/options.ts
+++ b/tools/@angular/tsc-wrapped/src/options.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import * as ts from 'typescript';
 
 interface Options extends ts.CompilerOptions {

--- a/tools/@angular/tsc-wrapped/src/schema.ts
+++ b/tools/@angular/tsc-wrapped/src/schema.ts
@@ -1,3 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 // Metadata Schema
 
 // If you make a backwards incompatible change to the schema, increment the VERSION number.
@@ -88,7 +96,7 @@ export interface MetadataObject { [name: string]: MetadataValue; }
 export interface MetadataArray { [name: number]: MetadataValue; }
 
 export interface MetadataSymbolicExpression {
-  __symbolic: 'binary'|'call'|'index'|'new'|'pre'|'reference'|'select'|'spread'|'if'
+  __symbolic: 'binary'|'call'|'index'|'new'|'pre'|'reference'|'select'|'spread'|'if';
 }
 export function isMetadataSymbolicExpression(value: any): value is MetadataSymbolicExpression {
   if (value) {

--- a/tools/@angular/tsc-wrapped/src/symbols.ts
+++ b/tools/@angular/tsc-wrapped/src/symbols.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import * as ts from 'typescript';
 
 import {MetadataValue} from './schema';

--- a/tools/@angular/tsc-wrapped/src/tsc.ts
+++ b/tools/@angular/tsc-wrapped/src/tsc.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {existsSync} from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';

--- a/tools/@angular/tsc-wrapped/test/collector.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/collector.spec.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import * as ts from 'typescript';
 
 import {MetadataCollector} from '../src/collector';
@@ -542,7 +549,7 @@ describe('Collector', () => {
           arguments: [{providers: [{__symbolic: 'reference', name: 'REQUIRED_VALIDATOR'}]}]
         }]
       }
-    })
+    });
   });
 
   it('should collect an error for a simple function that references a local variable', () => {
@@ -560,7 +567,7 @@ describe('Collector', () => {
           context: {name: 'localSymbol'}
         }
       }
-    })
+    });
   });
 
   describe('in strict mode', () => {
@@ -580,7 +587,7 @@ describe('Collector', () => {
       expect(() => collector.getMetadata(unsupported1, true))
           .toThrowError(/Reference to non-exported class/);
     });
-  })
+  });
 });
 
 // TODO: Do not use \` in a template literal as it confuses clang-format

--- a/tools/@angular/tsc-wrapped/test/evaluator.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/evaluator.spec.ts
@@ -1,4 +1,10 @@
-import * as fs from 'fs';
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import * as ts from 'typescript';
 
 import {Evaluator} from '../src/evaluator';

--- a/tools/@angular/tsc-wrapped/test/symbols.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/symbols.spec.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import * as ts from 'typescript';
 
 import {isMetadataGlobalReferenceExpression} from '../src/schema';
@@ -49,7 +56,7 @@ describe('Symbols', () => {
   it('should be able to find the source files', () => {
     expect(expressions).toBeDefined();
     expect(imports).toBeDefined();
-  })
+  });
 
   it('should be able to create symbols for a source file', () => {
     let symbols = new Symbols(expressions);

--- a/tools/@angular/tsc-wrapped/test/tsc.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/tsc.spec.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import * as ts from 'typescript';
 import {Tsc} from '../src/tsc';
 
@@ -17,7 +24,7 @@ describe('options parsing', () => {
       () => ['tsconfig.json']);
 
   it('should combine all options into ngOptions', () => {
-    const {parsed, ngOptions} = tsc.readConfiguration('projectDir', 'basePath');
+    const {ngOptions} = tsc.readConfiguration('projectDir', 'basePath');
 
     expect(ngOptions).toEqual({
       genDir: 'basePath',

--- a/tools/@angular/tsc-wrapped/test/typescript.mocks.ts
+++ b/tools/@angular/tsc-wrapped/test/typescript.mocks.ts
@@ -1,5 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import * as fs from 'fs';
-import * as path from 'path';
 import * as ts from 'typescript';
 
 export interface Directory { [name: string]: (Directory|string); }
@@ -48,7 +54,7 @@ export class MockNode implements ts.Node {
       public kind: ts.SyntaxKind = ts.SyntaxKind.Identifier, public flags: ts.NodeFlags = 0,
       public pos: number = 0, public end: number = 0) {}
   getSourceFile(): ts.SourceFile { return null; }
-  getChildCount(sourceFile?: ts.SourceFile): number { return 0 }
+  getChildCount(sourceFile?: ts.SourceFile): number { return 0; }
   getChildAt(index: number, sourceFile?: ts.SourceFile): ts.Node { return null; }
   getChildren(sourceFile?: ts.SourceFile): ts.Node[] { return []; }
   getStart(sourceFile?: ts.SourceFile): number { return 0; }
@@ -65,12 +71,12 @@ export class MockNode implements ts.Node {
 
 export class MockIdentifier extends MockNode implements ts.Identifier {
   public text: string;
-  public _primaryExpressionBrand: any;
-  public _memberExpressionBrand: any;
-  public _leftHandSideExpressionBrand: any;
-  public _incrementExpressionBrand: any;
-  public _unaryExpressionBrand: any;
-  public _expressionBrand: any;
+  /* @internal */ public _primaryExpressionBrand: any;
+  /* @internal */ public _memberExpressionBrand: any;
+  /* @internal */ public _leftHandSideExpressionBrand: any;
+  /* @internal */ public _incrementExpressionBrand: any;
+  /* @internal */ public _unaryExpressionBrand: any;
+  /* @internal */ public _expressionBrand: any;
 
   constructor(
       public name: string, kind: ts.SyntaxKind = ts.SyntaxKind.Identifier, flags: ts.NodeFlags = 0,
@@ -81,7 +87,7 @@ export class MockIdentifier extends MockNode implements ts.Identifier {
 }
 
 export class MockVariableDeclaration extends MockNode implements ts.VariableDeclaration {
-  public _declarationBrand: any;
+  /* @internal */ public _declarationBrand: any;
 
   constructor(
       public name: ts.Identifier, kind: ts.SyntaxKind = ts.SyntaxKind.VariableDeclaration,
@@ -131,7 +137,7 @@ export function allChildren<T>(node: ts.Node, cb: (node: ts.Node) => T): T {
       return result;
     }
     return allChildren(child, cb);
-  })
+  });
 }
 
 export function findClass(sourceFile: ts.SourceFile, name: string): ts.ClassDeclaration {

--- a/tools/cjs-jasmine/index-tools.ts
+++ b/tools/cjs-jasmine/index-tools.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 'use strict';
 
 var glob = require('glob');

--- a/tools/cjs-jasmine/index.ts
+++ b/tools/cjs-jasmine/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 'use strict';
 
 var glob = require('glob');

--- a/tools/cjs-jasmine/test-cjs-main.ts
+++ b/tools/cjs-jasmine/test-cjs-main.ts
@@ -1,5 +1,12 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 var testingPlatformServer = require('../../all/@angular/platform-server/testing/server.js');
-var testing = require('../../all/@angular/core/testing');
+var coreTesting = require('../../all/@angular/core/testing');
 
-testing.TestBed.initTestEnvironment(
+coreTesting.TestBed.initTestEnvironment(
     testingPlatformServer.ServerTestingModule, testingPlatformServer.platformServerTesting());

--- a/tools/tsc-watch/index.ts
+++ b/tools/tsc-watch/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {spawn} from 'child_process';
 import {existsSync, mkdirSync, writeFileSync} from 'fs';
 

--- a/tools/tsc-watch/tsc_watch.ts
+++ b/tools/tsc-watch/tsc_watch.ts
@@ -1,7 +1,13 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {spawn} from 'child_process';
 import {platform} from 'os';
 import {normalize} from 'path';
-import {resolve} from 'url';
 
 enum State {
   idle,
@@ -106,8 +112,7 @@ export class TscWatch {
       } else {
         if (this.triggered) {
           this.triggered.then(
-              () => this.triggerCmds(),
-              (e) => {console.log('Error while running commands....', e)});
+              () => this.triggerCmds(), (e) => console.log('Error while running commands....', e));
         } else {
           this.triggerCmds();
         }
@@ -119,9 +124,9 @@ export class TscWatch {
 
   triggerCmds() {
     var cmdPromise: Promise<number> = Promise.resolve(0);
-    this.onChangeCmds.forEach((cmd: string[] | Command) => {cmdPromise = cmdPromise.then(() => {
-                                return this.runCmd(<string[]>cmd);
-                              })});
+    this.onChangeCmds.forEach(
+        (cmd: string[] | Command) => cmdPromise =
+            cmdPromise.then(() => this.runCmd(<string[]>cmd)));
     cmdPromise.then(() => this.triggered = null, (code) => {
       if (this.runOnce) {
         if (typeof code != 'number') {

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -9,6 +9,7 @@
     "outDir": "../dist/tools/",
     "noImplicitAny": true,
     "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
     "paths": {
     },
     "rootDir": ".",

--- a/tools/tslint/duplicateModuleImportRule.ts
+++ b/tools/tslint/duplicateModuleImportRule.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {RuleWalker} from 'tslint/lib/language/walker';
 import {RuleFailure} from 'tslint/lib/lint';
 import {AbstractRule} from 'tslint/lib/rules';
@@ -23,18 +30,6 @@ class ModuleImportWalker extends RuleWalker {
   protected visitImportEqualsDeclaration(node: ts.ImportEqualsDeclaration): void {
     this.visitModuleSpecifier(node.moduleReference);
     super.visitImportEqualsDeclaration(node);
-  }
-
-  private checkTypeAnnotation(location: number, typeAnnotation: ts.TypeNode, name?: ts.Node) {
-    if (typeAnnotation == null) {
-      let ns = '<name missing>';
-      if (name != null && name.kind === ts.SyntaxKind.Identifier) {
-        ns = (<ts.Identifier>name).text;
-      }
-      if (ns.charAt(0) === '_') return;
-      let failure = this.createFailure(location, 1, 'expected parameter ' + ns + ' to have a type');
-      this.addFailure(failure);
-    }
   }
 
   private visitModuleSpecifier(moduleSpecifier: ts.Node) {

--- a/tools/tslint/enforceCopyrightHeaderRule.ts
+++ b/tools/tslint/enforceCopyrightHeaderRule.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {RuleWalker} from 'tslint/lib/language/walker';
 import {RuleFailure} from 'tslint/lib/lint';
 import {AbstractRule} from 'tslint/lib/rules';

--- a/tools/tslint/requireInternalWithUnderscoreRule.ts
+++ b/tools/tslint/requireInternalWithUnderscoreRule.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {RuleWalker} from 'tslint/lib/language/walker';
 import {RuleFailure} from 'tslint/lib/lint';
 import {AbstractRule} from 'tslint/lib/rules';

--- a/tools/typings-test/include-all.ts
+++ b/tools/typings-test/include-all.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import * as compiler from '@angular/compiler';
 import * as compilerTesting from '@angular/compiler/testing';
 import * as coreTesting from '@angular/core';
@@ -28,4 +35,4 @@ export default {
   router,
   routerTesting,
   upgrade
-}
+};

--- a/tslint.json
+++ b/tslint.json
@@ -1,10 +1,19 @@
 {
-    "rules": {
-      "requireInternalWithUnderscore": true,
-      "duplicateModuleImport": true,
-      "enforce-copyright-header": true,
-      "no-duplicate-variable": true,
-      "semicolon": [true],
-      "variable-name": [true, "ban-keywords"]
-    }
+  "rulesDirectory": ["./dist/tools/tslint"],
+  "rules": {
+    "require-internal-with-underscore": true,
+    "duplicate-module-import": true,
+    "enforce-copyright-header": true,
+
+    "no-internal-module": true,
+    "no-namespace": true,
+    "no-reference": true,
+    "typedef-whitespace": [true],
+
+    "no-duplicate-variable": true,
+    "no-unused-variable": true,
+
+    "semicolon": [true],
+    "variable-name": [true, "ban-keywords"]
+  }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
No CI checks exist for unused locals or variables.

**What is the new behavior?**
TypeScript compiler will check for unused locals in some projects.
TSLint is now configured to flag unused variables, and is extended to more projects.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:
Ideally, the Typescript compiler should be used to check for unused locals in all projects, but some of the current projects include generated code, and this PR is already big enough.

P.S.: I might have found a bug with the XTB loading.
