### PR TITLE
fix: remove double exports of template_ast

### DIFF
--- a/modules/@angular/compiler/index.ts
+++ b/modules/@angular/compiler/index.ts
@@ -36,7 +36,6 @@ export {NgModuleResolver} from './src/ng_module_resolver';
 export {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from './src/ml_parser/interpolation_config';
 export {ElementSchemaRegistry} from './src/schema/element_schema_registry';
 export * from './src/i18n/index';
-export * from './src/template_parser/template_ast';
 export * from './src/directive_normalizer';
 export * from './src/expression_parser/lexer';
 export * from './src/expression_parser/parser';


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

```
Conflicting namespaces: node_modules/@angular/compiler/index.js re-exports 'TextAst' from both node_modules/@angular/compiler/src/template_parser/template_ast.js (will be ignored) and /Users/jan/Dev/work/gdf-seed/node_modules/@angular/compiler/src/template_parser/template_ast.js
```

**What is the new behavior?**

Does not provide that error.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

Noticed this when running build with rollup.
