### PR TITLE
refactor(compiler): Remove duplicate export

### DIFF
--- a/modules/@angular/compiler/index.ts
+++ b/modules/@angular/compiler/index.ts
@@ -36,7 +36,6 @@ export {NgModuleResolver} from './src/ng_module_resolver';
 export {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from './src/ml_parser/interpolation_config';
 export {ElementSchemaRegistry} from './src/schema/element_schema_registry';
 export * from './src/i18n/index';
-export * from './src/template_parser/template_ast';
 export * from './src/directive_normalizer';
 export * from './src/expression_parser/lexer';
 export * from './src/expression_parser/parser';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The `./src/template_parser/template_ast` is exported twice in `@angular/compiler/index.ts`

**What is the new behavior?**
The `./src/template_parser/template_ast` is exported only once in `@angular/compiler/index.ts`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Remove duplicate export of `./src/template_parser/template_ast`.

It is causing problems when web-packing angular with `wepack@2.1.0-beta.25`
