### PR TITLE
fix (forms): clear selected options when model is not an array

### DIFF
--- a/modules/@angular/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -66,11 +66,15 @@ export class SelectMultipleControlValueAccessor implements ControlValueAccessor 
 
   writeValue(value: any): void {
     this.value = value;
-    if (value == null) return;
-    const values: Array<any> = <Array<any>>value;
-    // convert values to ids
-    const ids = values.map((v) => this._getOptionId(v));
-    this._optionMap.forEach((opt, o) => { opt._setSelected(ids.indexOf(o.toString()) > -1); });
+    let optionSelectedStateSetter: (opt: NgSelectMultipleOption, o: any) => void;
+    if (Array.isArray(value)) {
+      // convert values to ids
+      const ids = value.map((v) => this._getOptionId(v));
+      optionSelectedStateSetter = (opt, o) => { opt._setSelected(ids.indexOf(o.toString()) > -1); };
+    } else {
+      optionSelectedStateSetter = (opt, o) => { opt._setSelected(false); };
+    }
+    this._optionMap.forEach(optionSelectedStateSetter);
   }
 
   registerOnChange(fn: (value: any) => any): void {

--- a/modules/@angular/forms/test/template_integration_spec.ts
+++ b/modules/@angular/forms/test/template_integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, Directive, Input, forwardRef} from '@angular/core';
-import {TestBed, async, fakeAsync, tick} from '@angular/core/testing';
+import {ComponentFixture, TestBed, async, fakeAsync, tick} from '@angular/core/testing';
 import {AbstractControl, ControlValueAccessor, FormsModule, NG_ASYNC_VALIDATORS, NG_VALUE_ACCESSOR, NgForm, Validator} from '@angular/forms';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
@@ -23,7 +23,7 @@ export function main() {
           NgModelRadioForm, NgModelRangeForm, NgModelSelectForm, NgNoFormComp, InvalidNgModelNoName,
           NgModelOptionsStandalone, NgModelCustomComp, NgModelCustomWrapper,
           NgModelValidationBindings, NgModelMultipleValidators, NgAsyncValidator,
-          NgModelAsyncValidation, NgModelSelectWithNullForm
+          NgModelAsyncValidation, NgModelSelectMultipleForm, NgModelSelectWithNullForm
         ],
         imports: [FormsModule]
       });
@@ -723,6 +723,65 @@ export function main() {
          }));
     });
 
+    describe('select multiple controls', () => {
+      let fixture: ComponentFixture<NgModelSelectMultipleForm>;
+      let comp: NgModelSelectMultipleForm;
+
+      beforeEach(() => {
+        fixture = TestBed.createComponent(NgModelSelectMultipleForm);
+        comp = fixture.componentInstance;
+        comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'Buffalo'}];
+      });
+
+      const setSelectedCities = (selectedCities: any): void => {
+        comp.selectedCities = selectedCities;
+        fixture.detectChanges();
+        tick();
+      };
+
+      const assertOptionElementSelectedState = (selectedStates: boolean[]): void => {
+        const options = fixture.debugElement.queryAll(By.css('option'));
+        if (options.length !== selectedStates.length) {
+          throw 'the selected state values to assert does not match the number of options';
+        }
+        for (let i = 0; i < selectedStates.length; i++) {
+          expect(options[i].nativeElement.selected).toBe(selectedStates[i]);
+        }
+      };
+
+      const testNewModelValueUnselectsAllOptions = (modelValue: any): void => {
+        setSelectedCities([comp.cities[1]]);
+        assertOptionElementSelectedState([false, true, false]);
+
+        setSelectedCities(modelValue);
+
+        const select = fixture.debugElement.query(By.css('select'));
+        expect(select.nativeElement.value).toEqual('');
+        assertOptionElementSelectedState([false, false, false]);
+      };
+
+      it('should support setting value to null and undefined', fakeAsync(() => {
+           testNewModelValueUnselectsAllOptions(null);
+           testNewModelValueUnselectsAllOptions(undefined);
+         }));
+
+      it('should clear all selected option elements when value of wrong type supplied',
+         fakeAsync(() => { testNewModelValueUnselectsAllOptions(''); }));
+
+      it('should set option elements to selected that are present in model', fakeAsync(() => {
+           setSelectedCities([comp.cities[0], comp.cities[2]]);
+           assertOptionElementSelectedState([true, false, true]);
+         }));
+
+      it('should clear selected option elements since removed from model', fakeAsync(() => {
+           const selectedCities: [{'name:string': string}] = <[{'name:string': string}]>[];
+           selectedCities.push.apply(selectedCities, comp.cities);
+           setSelectedCities(selectedCities);
+           setSelectedCities([comp.cities[1]]);
+           assertOptionElementSelectedState([false, true, false]);
+         }));
+    });
+
     describe('custom value accessors', () => {
       it('should support standard writing to view and model', async(() => {
            const fixture = TestBed.createComponent(NgModelCustomWrapper);
@@ -1133,6 +1192,19 @@ class NgModelSelectForm {
 })
 class NgModelSelectWithNullForm {
   selectedCity: {[k: string]: string} = {};
+  cities: any[] = [];
+}
+
+@Component({
+  selector: 'ng-model-select-multiple-form',
+  template: `
+    <select multiple [(ngModel)]="selectedCities">
+      <option *ngFor="let c of cities" [ngValue]="c"> {{c.name}} </option>
+    </select>
+  `
+})
+class NgModelSelectMultipleForm {
+  selectedCities: any[];
   cities: any[] = [];
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
1. For a select[multiple] with NgModel, the expected model type is an Array. Currently if you set it to a different type of object (ignoring null/undefined for the moment), you get an error. NgModel does not throw such an error when you use an invalid model value with other input controls, eg input[type=number].
   The repro in Issue #11926 includes the use of ngModel on a select element, where ngModel is not explicitly bound. This result in an initial model value for the select of an empty string. (I'm going to raise a separate issue about this ngModel behavior, which I suspect is related to one time string initialization.)
2. When you set the model value to null or undefined, the currently selected option elements stay selected. NgModel used with other input controls clears the selection when these values are passed in.

**What is the new behavior?**
1. If a select[multiple] is bound to an invalid value, the currently selected option elements are cleared and no error is raised.
2. If you set the model to null or undefined, the currently selected option elements are cleared.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No - (Well, changes what happens when the model is set to null / undefined - but I doubt anyone desires the old behavior.)
```
