### PR TITLE
docs(reset): change semi-colon to colon in code example

### DIFF
--- a/modules/@angular/forms/src/model.ts
+++ b/modules/@angular/forms/src/model.ts
@@ -983,7 +983,7 @@ export class FormGroup extends AbstractControl {
    * ### Example
    *
    * ```ts
-   * this.form.reset({first: 'name', last; 'last name'});
+   * this.form.reset({first: 'name', last: 'last name'});
    *
    * console.log(this.form.value);  // {first: 'name', last: 'last name'}
    * ```


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```

documentation change to fix typo

**What is the current behavior?** (You can also link to an open issue here)

https://github.com/angular/angular/issues/12531

**What is the new behavior?**

The typo is the first code example for reset has been fixed.  It now has a colon instead of a semi-colon for the last property in the json object

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

The first code example for the reset function was invalid as it has a semi-colon instead of a colon for the last property in the json object.  Change the semi-colon to a colon.

Closes https://github.com/angular/angular/issues/12531
