### PR TITLE
build: tslint checks for prohibited jasmine calls

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -138,8 +138,11 @@ gulp.task('check-tests', function() {
       .pipe(ddescribeIit({allowDisabledTests: true}));
 });
 
-// Check the coding standards and programming errors
-gulp.task('lint', ['check-tests', 'format:enforce', 'tools:build'], () => {
+// Check the coding standards and programming errors. Also check for presence
+// of certain jasmine calls (fit, fdescribe). To configure the files scanned by
+// this rule or turn on checks for excluded tests (disabled for now as some have
+// already been comitted) see the docs in ./tslint/prohibitJasmineCallsRule.ts.
+gulp.task('lint', ['format:enforce', 'tools:build'], () => {
   const tslint = require('gulp-tslint');
   // Built-in rules are at
   // https://github.com/palantir/tslint#supported-rules

--- a/tools/tslint/prohibitedJasmineCallsRule.ts
+++ b/tools/tslint/prohibitedJasmineCallsRule.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {RuleWalker} from 'tslint/lib/language/walker';
+import {IOptions, IRuleMetadata, RuleFailure, Utils} from 'tslint/lib/lint';
+import {AbstractRule} from 'tslint/lib/rules';
+import * as ts from 'typescript';
+
+const OPTION_PROHIBIT_EXCLUDUD = 'prohibit-excluded';
+
+const FOCUS_FUNCTIONS = ['fdescribe', 'fit'];
+const EXCLUDE_FUNCTIONS = ['xdescribe', 'xit'];
+
+export class Rule extends AbstractRule {
+  public static metadata: IRuleMetadata = {
+    ruleName: 'prohibited-jasmine-calls',
+    description: 'Checks that focused tests and optionally excluded tests are not present.',
+    optionsDescription: Utils.dedent `
+        The first argument is required. The second is optional.
+        * \`"Regex"\`: Regex to apply to filenames to identify jasmine test files
+        * \`"${OPTION_PROHIBIT_EXCLUDUD}"\`: Checks that excluded tests are not present
+        `,
+    options: {
+      type: 'array',
+      items: {
+        type: 'string',
+        firstItem: 'Regex to apply to filenames to identify jasmine test files',
+        optionalSecondItem: OPTION_PROHIBIT_EXCLUDUD
+      },
+      minLength: 1,
+      maxLength: 2,
+    },
+    optionExamples: ['[true, "*[\.,_]spec.ts", "prohibit-excluded"]'],
+    type: 'functionality'
+  };
+
+  public apply(sourceFile: ts.SourceFile): RuleFailure[] {
+    // the first ruleArgument holds the regex used to identify jasmine test files
+    const options: IOptions = this.getOptions();
+    const ruleArguments: any[] = options.ruleArguments;
+    if (!ruleArguments || ruleArguments.length == 0)
+      throw 'tslint.config should provide config data e.g. unwantedJasmineCalls: [true, "regular' +
+          ' expression to identify test files"]';
+
+    if (new RegExp(ruleArguments[0]).test(sourceFile.fileName)) {
+      const walker = new JasmineTestWalker(sourceFile, options);
+      return this.applyWithWalker(walker);
+    } else {
+      return [];
+    }
+  }
+}
+
+class JasmineTestWalker extends RuleWalker {
+  private prohibitedCalls: string[] = [];
+
+  constructor(sourceFile: ts.SourceFile, options: IOptions) {
+    super(sourceFile, options);
+    this.prohibitedCalls.push.apply(this.prohibitedCalls, FOCUS_FUNCTIONS);
+    if (this.hasOption(OPTION_PROHIBIT_EXCLUDUD)) {
+      this.prohibitedCalls.push.apply(this.prohibitedCalls, EXCLUDE_FUNCTIONS);
+    }
+  }
+
+  protected visitCallExpression(node: ts.CallExpression): void {
+    const functionName: string = node.expression.getText();
+
+    if (this.prohibitedCalls.indexOf(functionName) > -1) {
+      // firstArgument likely to be the test name, output this in error message
+      const firstArgument: string = node.arguments.length > 0 ? node.arguments[0].getText() : '';
+
+      this.addFailure(this.createFailure(
+          node.getStart(), node.getWidth(),
+          `Prohibited function call: ${functionName}(${firstArgument}...`));
+    }
+    super.visitCallExpression(node);
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
       "requireInternalWithUnderscore": true,
       "duplicateModuleImport": true,
       "enforce-copyright-header": true,
+      "prohibitedJasmineCalls": [true, ".*[\\.,_]spec.ts"],
       "no-duplicate-variable": true,
       "semicolon": [true],
       "variable-name": [true, "ban-keywords"]


### PR DESCRIPTION
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?**
Currently when you run gulp lint a call is made to gulp-ddescribe-iit to check that no fdescribe/fit calls have been left in test files. Issue #11800 highlighted that this rule could be added to tslint itself, making the process more robust.

**What is the new behavior?**
-  New rule created for TSLint. 
-  A Regex can be supplied in options to identify the files to apply the rule to, along with a flag to check for excluded tests in future.
-  I don't think ddescribe/iit are supported by jamsine any longer so no checks are performed for them.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:
I have not removed the gulp task to run gulp-ddescribe-iit in isolation, nor the dependency itself. The shrinkwrap readme advises dependencies only be removed on macs, (reshrinkwrap fails when I tried it on windows as well.) I think I probably could manually update package.json, npm-shrinkwrap.json and npm-shrinkwrap.clean.json myself, but airing on the safe side.
