### PR TITLE
Change router-outlet name type

### DIFF
--- a/modules/@angular/router/src/directives/router_outlet.ts
+++ b/modules/@angular/router/src/directives/router_outlet.ts
@@ -51,8 +51,9 @@ export class RouterOutlet implements OnDestroy {
 
   constructor(
       private parentOutletMap: RouterOutletMap, private location: ViewContainerRef,
-      private resolver: ComponentFactoryResolver, name: string) {
-    parentOutletMap.registerOutlet(name ? name : PRIMARY_OUTLET, this);
+      private resolver: ComponentFactoryResolver) {
+    this.name = getName();
+    parentOutletMap.registerOutlet(this.name ? this.name : PRIMARY_OUTLET, this);
   }
 
   ngOnDestroy(): void { this.parentOutletMap.removeOutlet(this.name ? this.name : PRIMARY_OUTLET); }
@@ -99,5 +100,9 @@ export class RouterOutlet implements OnDestroy {
     this.activated.changeDetectorRef.detectChanges();
 
     this.activateEvents.emit(this.activated.instance);
+  }
+  
+  getName() {
+    return this.name;
   }
 }

--- a/modules/@angular/router/src/directives/router_outlet.ts
+++ b/modules/@angular/router/src/directives/router_outlet.ts
@@ -102,7 +102,7 @@ export class RouterOutlet implements OnDestroy {
     this.activateEvents.emit(this.activated.instance);
   }
   
-  getName() {
+  getName(): void {
     return this.name;
   }
 }

--- a/modules/@angular/router/src/directives/router_outlet.ts
+++ b/modules/@angular/router/src/directives/router_outlet.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Attribute, ComponentFactory, ComponentFactoryResolver, ComponentRef, Directive, EventEmitter, Injector, Input, OnDestroy, Output, ReflectiveInjector, ResolvedReflectiveProvider, ViewContainerRef} from '@angular/core';
+import {Attribute, ComponentFactory, ComponentFactoryResolver, ComponentRef, Directive, EventEmitter, Injector, OnDestroy, Output, ReflectiveInjector, ResolvedReflectiveProvider, ViewContainerRef} from '@angular/core';
 
 import {RouterOutletMap} from '../router_outlet_map';
 import {ActivatedRoute} from '../router_state';
@@ -51,7 +51,7 @@ export class RouterOutlet implements OnDestroy {
 
   constructor(
       private parentOutletMap: RouterOutletMap, private location: ViewContainerRef,
-      private resolver: ComponentFactoryResolver, name: string) {
+      private resolver: ComponentFactoryResolver, @Attribute('name') private name: string)) {
     parentOutletMap.registerOutlet(name ? name : PRIMARY_OUTLET, this);
   }
 

--- a/modules/@angular/router/src/directives/router_outlet.ts
+++ b/modules/@angular/router/src/directives/router_outlet.ts
@@ -52,7 +52,6 @@ export class RouterOutlet implements OnDestroy {
   constructor(
       private parentOutletMap: RouterOutletMap, private location: ViewContainerRef,
       private resolver: ComponentFactoryResolver) {
-    this.name = getName();
     parentOutletMap.registerOutlet(this.name ? this.name : PRIMARY_OUTLET, this);
   }
 
@@ -100,9 +99,5 @@ export class RouterOutlet implements OnDestroy {
     this.activated.changeDetectorRef.detectChanges();
 
     this.activateEvents.emit(this.activated.instance);
-  }
-  
-  getName(): void {
-    return this.name;
   }
 }

--- a/modules/@angular/router/src/directives/router_outlet.ts
+++ b/modules/@angular/router/src/directives/router_outlet.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Attribute, ComponentFactory, ComponentFactoryResolver, ComponentRef, Directive, EventEmitter, Injector, OnDestroy, Output, ReflectiveInjector, ResolvedReflectiveProvider, ViewContainerRef} from '@angular/core';
+import {Attribute, ComponentFactory, ComponentFactoryResolver, ComponentRef, Directive, EventEmitter, Injector, Input, OnDestroy, Output, ReflectiveInjector, ResolvedReflectiveProvider, ViewContainerRef} from '@angular/core';
 
 import {RouterOutletMap} from '../router_outlet_map';
 import {ActivatedRoute} from '../router_state';
@@ -45,12 +45,13 @@ export class RouterOutlet implements OnDestroy {
   private _activatedRoute: ActivatedRoute;
   public outletMap: RouterOutletMap;
 
+  @Input() name: string;
   @Output('activate') activateEvents = new EventEmitter<any>();
   @Output('deactivate') deactivateEvents = new EventEmitter<any>();
 
   constructor(
       private parentOutletMap: RouterOutletMap, private location: ViewContainerRef,
-      private resolver: ComponentFactoryResolver, @Attribute('name') private name: string) {
+      private resolver: ComponentFactoryResolver, name: string) {
     parentOutletMap.registerOutlet(name ? name : PRIMARY_OUTLET, this);
   }
 

--- a/modules/@angular/router/src/directives/router_outlet.ts
+++ b/modules/@angular/router/src/directives/router_outlet.ts
@@ -45,7 +45,6 @@ export class RouterOutlet implements OnDestroy {
   private _activatedRoute: ActivatedRoute;
   public outletMap: RouterOutletMap;
 
-  @Input() name: string;
   @Output('activate') activateEvents = new EventEmitter<any>();
   @Output('deactivate') deactivateEvents = new EventEmitter<any>();
 

--- a/modules/@angular/router/src/directives/router_outlet.ts
+++ b/modules/@angular/router/src/directives/router_outlet.ts
@@ -51,7 +51,7 @@ export class RouterOutlet implements OnDestroy {
 
   constructor(
       private parentOutletMap: RouterOutletMap, private location: ViewContainerRef,
-      private resolver: ComponentFactoryResolver, @Attribute('name') private name: string)) {
+      private resolver: ComponentFactoryResolver, @Attribute('name') private name: string) {
     parentOutletMap.registerOutlet(name ? name : PRIMARY_OUTLET, this);
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[X] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
users can only bind a string to the name attribute
`<router-outlet name='profile'></router-outlet>
`

**What is the new behavior?**
users can bind name as a property
`<router-outlet [name]=list.name></router-outlet>
`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
