### PR TITLE
refactor(BaseError): Don't expect super() to return a new Error object.

### DIFF
--- a/modules/@angular/facade/src/errors.ts
+++ b/modules/@angular/facade/src/errors.ts
@@ -18,9 +18,12 @@ export class BaseError extends Error {
   _nativeError: Error;
 
   constructor(message: string) {
+    super(message);
     // Errors don't use current this, instead they create a new instance.
     // We have to do forward all of our api to the nativeInstance.
-    const nativeError = super(message) as any as Error;
+    // TODO(bradfordcsmith): Remove this hack when
+    //     google/closure-compiler/issues/2102 is fixed.
+    const nativeError = new Error(message) as any as Error;
     this._nativeError = nativeError;
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/angular/angular/issues/12575

**What is the new behavior?**
Just create a new Error() object for delegation instead of expecting `super()` to return one.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Related to https://github.com/angular/angular/issues/12575
