### PR TITLE
feat(router): add paramsFromRoot getter to ActivatedRoute

### DIFF
--- a/modules/@angular/router/rollup.config.js
+++ b/modules/@angular/router/rollup.config.js
@@ -18,6 +18,7 @@ export default {
 
     'rxjs/BehaviorSubject': 'Rx',
     'rxjs/Observable': 'Rx',
+    'rxjs/Rx': 'Rx',
     'rxjs/Subject': 'Rx',
     'rxjs/Subscription': 'Rx',
     'rxjs/util/EmptyError': 'Rx',
@@ -27,6 +28,9 @@ export default {
     'rxjs/observable/forkJoin': 'Rx.Observable',
     'rxjs/observable/of': 'Rx.Observable',
 
+    'rxjs/add/observable/combineLatest': 'Rx.Observable',
+
+    'rxjs/operator/concatMap': 'Rx.Observable.prototype',
     'rxjs/operator/toPromise': 'Rx.Observable.prototype',
     'rxjs/operator/map': 'Rx.Observable.prototype',
     'rxjs/operator/mergeAll': 'Rx.Observable.prototype',
@@ -37,7 +41,9 @@ export default {
     'rxjs/operator/first': 'Rx.Observable.prototype',
     'rxjs/operator/catch': 'Rx.Observable.prototype',
     'rxjs/operator/last': 'Rx.Observable.prototype',
-    'rxjs/operator/filter': 'Rx.Observable.prototype'
+    'rxjs/operator/filter': 'Rx.Observable.prototype',
+
+    'rxjs/add/operator/map': 'Rx.Observable.prototype'
   },
   plugins: []
 };

--- a/modules/@angular/router/src/router_state.ts
+++ b/modules/@angular/router/src/router_state.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import 'rxjs/add/observable/combineLatest';
+import 'rxjs/add/operator/map';
+
 import {Type} from '@angular/core';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {Observable} from 'rxjs/Observable';
@@ -195,6 +198,22 @@ export class ActivatedRoute {
    * The path from the root of the router state tree to this route.
    */
   get pathFromRoot(): ActivatedRoute[] { return this._routerState.pathFromRoot(this); }
+
+  /**
+   * All the parameters combined from the root of the router state tree to this route.
+   */
+  get paramsFromRoot(): Observable<Params> {
+    return Observable.combineLatest(this.pathFromRoot.map((v: ActivatedRoute) => v.params))
+        .map(
+            (params: Params[]) => params.reduce(
+                (pre: Params, cur: Params) => {
+                  for (let key of Object.keys(cur)) {
+                    pre[key] = cur[key];
+                  }
+                  return pre;
+                },
+                {} as Params));
+  }
 
   /**
    * @docsNotRequired

--- a/modules/@angular/router/test/router_state.spec.ts
+++ b/modules/@angular/router/test/router_state.spec.ts
@@ -6,6 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/toPromise';
+
+import {Observable} from 'rxjs/Observable';
+
 import {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot, equalParamsAndUrlSegments} from '../src/router_state';
 import {Params} from '../src/shared';
 import {UrlSegment} from '../src/url_tree';
@@ -96,6 +101,43 @@ describe('RouterState & Snapshot', () => {
     });
   });
 
+  describe('RouterState with Params', () => {
+    let state: RouterState;
+    let a: ActivatedRoute;
+    let b: ActivatedRoute;
+    let c: ActivatedRoute;
+
+    beforeEach(() => {
+      a = createActivatedRouteWithParams('a', {
+        'param1': 'a',
+        'param2': 'b',
+      });
+      b = createActivatedRouteWithParams('b', {
+        'param3': 'c',
+        'param4': 'd',
+      });
+      c = createActivatedRouteWithParams('c', {
+        'param5': 'e',
+        'param6': 'f',
+      });
+
+      const root = new TreeNode(a, [new TreeNode(b, [new TreeNode(c, [])])]);
+
+      state = new RouterState(root, <any>null);
+    });
+
+    it('should return params from root', () => {
+      return c.paramsFromRoot.toPromise().then((params) => {
+        expect(params['param1']).toBe('a');
+        expect(params['param2']).toBe('b');
+        expect(params['param3']).toBe('c');
+        expect(params['param4']).toBe('d');
+        expect(params['param5']).toBe('e');
+        expect(params['param6']).toBe('f');
+      });
+    });
+  });
+
   describe('equalParamsAndUrlSegments', () => {
     function createSnapshot(params: Params, url: UrlSegment[]): ActivatedRouteSnapshot {
       return new ActivatedRouteSnapshot(
@@ -133,4 +175,10 @@ function createActivatedRouteSnapshot(cmp: string) {
 function createActivatedRoute(cmp: string) {
   return new ActivatedRoute(
       <any>null, <any>null, <any>null, <any>null, <any>null, <any>null, <any>cmp, <any>null);
+}
+
+function createActivatedRouteWithParams(cmp: string, params: Params) {
+  return new ActivatedRoute(
+      <any>null, Observable.of(params), <any>null, <any>null, <any>null, <any>null, <any>cmp,
+      <any>null);
 }

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -7,6 +7,7 @@ export declare class ActivatedRoute {
     fragment: Observable<string>;
     outlet: string;
     params: Observable<Params>;
+    paramsFromRoot: Observable<Params>;
     parent: ActivatedRoute;
     pathFromRoot: ActivatedRoute[];
     queryParams: Observable<Params>;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) - as in jsdoc. Let me know if there is other documentation I need to update.

**What kind of change does this PR introduce?** (check one with "x")

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Components would need to manually traverse the tree.

**What is the new behavior?**
Components can now be incognizant of the router configuration.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

This helps the components consuming ActivatedRoute finding all the parameters defined in the
route, decoupling them from the knowledge of how nested routers are configured.
