### PR TITLE
fix(core): improve error when multiple components match the same element

### DIFF
--- a/modules/@angular/compiler/src/template_parser/template_parser.ts
+++ b/modules/@angular/compiler/src/template_parser/template_parser.ts
@@ -644,7 +644,11 @@ class TemplateParseVisitor implements html.Visitor {
   private _assertOnlyOneComponent(directives: DirectiveAst[], sourceSpan: ParseSourceSpan) {
     const componentTypeNames = this._findComponentDirectiveNames(directives);
     if (componentTypeNames.length > 1) {
-      this._reportError(`More than one component: ${componentTypeNames.join(',')}`, sourceSpan);
+      this._reportError(
+          `More than one component matched on this element.\n` +
+              `Make sure that only one component's selector can match a given element.\n` +
+              `Conflicting components: ${componentTypeNames.join(',')}`,
+          sourceSpan);
     }
   }
 

--- a/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
@@ -1495,8 +1495,12 @@ Parser Error: Unexpected token 'b' at column 3 in [a b] in TestComp@0:5 ("<div [
                   {moduleUrl: someModuleUrl, name: 'DirB', reference: {} as Type<any>}),
               template: new CompileTemplateMetadata({ngContentSelectors: []})
             });
-            expect(() => parse('<div>', [dirB, dirA])).toThrowError(`Template parse errors:
-More than one component: DirB,DirA ("[ERROR ->]<div>"): TestComp@0:0`);
+            expect(() => parse('<div>', [dirB, dirA]))
+                .toThrowError(
+                    `Template parse errors:\n` +
+                    `More than one component matched on this element.\n` +
+                    `Make sure that only one component's selector can match a given element.\n` +
+                    `Conflicting components: DirB,DirA ("[ERROR ->]<div>"): TestComp@0:0`);
           });
 
           it('should not allow components or element bindings nor dom events on explicit embedded templates',


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

See #7067.

**What is the new behavior?**

The error message when multiple components match the same element is a bit more explicit and clear.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

**Other information**:

In order to avoid clang-format reformatting the entire spec file, I had to split the error message up into several string literals.

Closes #7067
