### PR TITLE
fix(router): call data observers when the path changes

### DIFF
--- a/modules/@angular/router/src/router_state.ts
+++ b/modules/@angular/router/src/router_state.ts
@@ -435,10 +435,12 @@ export function advanceActivatedRoute(route: ActivatedRoute): void {
     }
     if (!shallowEqual(route.snapshot.params, route._futureSnapshot.params)) {
       (<any>route.params).next(route._futureSnapshot.params);
-      (<any>route.data).next(route._futureSnapshot.data);
     }
     if (!shallowEqualArrays(route.snapshot.url, route._futureSnapshot.url)) {
       (<any>route.url).next(route._futureSnapshot.url);
+    }
+    if (!equalParamsAndUrlSegments(route.snapshot, route._futureSnapshot)) {
+      (<any>route.data).next(route._futureSnapshot.data);
     }
     route.snapshot = route._futureSnapshot;
   } else {

--- a/modules/@angular/router/test/router_state.spec.ts
+++ b/modules/@angular/router/test/router_state.spec.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot, equalParamsAndUrlSegments} from '../src/router_state';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+
+import {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot, advanceActivatedRoute, equalParamsAndUrlSegments} from '../src/router_state';
 import {Params} from '../src/shared';
 import {UrlSegment} from '../src/url_tree';
 import {TreeNode} from '../src/utils/tree';
@@ -122,6 +124,34 @@ describe('RouterState & Snapshot', () => {
           .toEqual(true);
     });
   });
+
+  describe('advanceActivatedRoute', () => {
+
+    let route: ActivatedRoute;
+
+    beforeEach(() => { route = createActivatedRoute('a'); });
+
+    function createSnapshot(params: Params, url: UrlSegment[]): ActivatedRouteSnapshot {
+      const queryParams = {};
+      const fragment = '';
+      const data = {};
+      return new ActivatedRouteSnapshot(
+          url, params, queryParams, fragment, data, <any>null, <any>null, <any>null, <any>null, -1,
+          null);
+    }
+
+    it('should call change observers', () => {
+      const firstPlace = createSnapshot({a: 1}, []);
+      const secondPlace = createSnapshot({a: 2}, []);
+      route.snapshot = firstPlace;
+      route._futureSnapshot = secondPlace;
+
+      let hasSeenDataChange = false;
+      route.data.forEach((data) => { hasSeenDataChange = true; });
+      advanceActivatedRoute(route);
+      expect(hasSeenDataChange).toEqual(true);
+    });
+  });
 });
 
 function createActivatedRouteSnapshot(cmp: string) {
@@ -132,5 +162,6 @@ function createActivatedRouteSnapshot(cmp: string) {
 
 function createActivatedRoute(cmp: string) {
   return new ActivatedRoute(
-      <any>null, <any>null, <any>null, <any>null, <any>null, <any>null, <any>cmp, <any>null);
+      new BehaviorSubject([new UrlSegment('', {})]), new BehaviorSubject({}), <any>null, <any>null,
+      new BehaviorSubject({}), <any>null, <any>cmp, <any>null);
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
This is a follow up to the first fix for issue #12603 ActivatedRoute.data is still not called when the URL path changes.


**What is the new behavior?**
ActivatedRoute.data is notified on changes to both path and params.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


