### PR TITLE
fix(decorators): don't require reflect-metadata when annotations present

### DIFF
--- a/modules/@angular/core/src/util/decorators.ts
+++ b/modules/@angular/core/src/util/decorators.ts
@@ -262,13 +262,13 @@ export function makeDecorator(
   const metaCtor = makeMetadataCtor([props]);
 
   function DecoratorFactory(objOrType: any): (cls: any) => any {
-    if (!(Reflect && Reflect.getMetadata)) {
-      throw 'reflect-metadata shim is required when using class decorators';
-    }
-
     if (this instanceof DecoratorFactory) {
       metaCtor.call(this, objOrType);
       return this;
+    }
+
+    if (!(Reflect && Reflect.getMetadata)) {
+      throw 'reflect-metadata shim is required when using class decorators';
     }
 
     const annotationInstance = new (<any>DecoratorFactory)(objOrType);


### PR DESCRIPTION
Fixes #10857