### PR TITLE
fix(forms): ensure select[multiple] retains selections

### DIFF
--- a/modules/@angular/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/modules/@angular/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -95,6 +95,7 @@ export class SelectMultipleControlValueAccessor implements ControlValueAccessor 
           }
         }
       }
+      this.value = selected;
       fn(selected);
     };
   }

--- a/modules/@angular/forms/test/template_integration_spec.ts
+++ b/modules/@angular/forms/test/template_integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, Directive, Input, forwardRef} from '@angular/core';
-import {TestBed, async, fakeAsync, tick} from '@angular/core/testing';
+import {ComponentFixture, TestBed, async, fakeAsync, tick} from '@angular/core/testing';
 import {AbstractControl, ControlValueAccessor, FormsModule, NG_ASYNC_VALIDATORS, NG_VALUE_ACCESSOR, NgForm, Validator} from '@angular/forms';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
@@ -23,7 +23,7 @@ export function main() {
           NgModelRadioForm, NgModelRangeForm, NgModelSelectForm, NgNoFormComp, InvalidNgModelNoName,
           NgModelOptionsStandalone, NgModelCustomComp, NgModelCustomWrapper,
           NgModelValidationBindings, NgModelMultipleValidators, NgAsyncValidator,
-          NgModelAsyncValidation, NgModelSelectWithNullForm
+          NgModelAsyncValidation, NgModelSelectMultipleForm, NgModelSelectWithNullForm
         ],
         imports: [FormsModule]
       });
@@ -723,6 +723,70 @@ export function main() {
          }));
     });
 
+    describe('select multiple controls', () => {
+      let fixture: ComponentFixture<NgModelSelectMultipleForm>;
+      let comp: NgModelSelectMultipleForm;
+
+      beforeEach(() => {
+        fixture = TestBed.createComponent(NgModelSelectMultipleForm);
+        comp = fixture.componentInstance;
+        comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'Buffalo'}];
+      });
+
+      const detectChangesAndTick = (): void => {
+        fixture.detectChanges();
+        tick();
+      };
+
+      const setSelectedCities = (selectedCities: any): void => {
+        comp.selectedCities = selectedCities;
+        detectChangesAndTick();
+      };
+
+      const selectOptionViaUI = (valueString: string): void => {
+        const select = fixture.debugElement.query(By.css('select'));
+        select.nativeElement.value = valueString;
+        dispatchEvent(select.nativeElement, 'change');
+        detectChangesAndTick();
+      };
+
+      const assertOptionElementSelectedState = (selectedStates: boolean[]): void => {
+        const options = fixture.debugElement.queryAll(By.css('option'));
+        if (options.length !== selectedStates.length) {
+          throw 'the selected state values to assert does not match the number of options';
+        }
+        for (let i = 0; i < selectedStates.length; i++) {
+          expect(options[i].nativeElement.selected).toBe(selectedStates[i]);
+        }
+      };
+
+      it('should reflect state of model after option selected and new options subsequently added',
+         fakeAsync(() => {
+           setSelectedCities([]);
+
+           selectOptionViaUI('1: Object');
+           assertOptionElementSelectedState([false, true, false]);
+
+           comp.cities.push({'name': 'Chicago'});
+           detectChangesAndTick();
+
+           assertOptionElementSelectedState([false, true, false, false]);
+         }));
+
+      it('should reflect state of model after option selected and then other options removed',
+         fakeAsync(() => {
+           setSelectedCities([]);
+
+           selectOptionViaUI('1: Object');
+           assertOptionElementSelectedState([false, true, false]);
+
+           comp.cities.pop();
+           detectChangesAndTick();
+
+           assertOptionElementSelectedState([false, true]);
+         }));
+    });
+
     describe('custom value accessors', () => {
       it('should support standard writing to view and model', async(() => {
            const fixture = TestBed.createComponent(NgModelCustomWrapper);
@@ -1133,6 +1197,19 @@ class NgModelSelectForm {
 })
 class NgModelSelectWithNullForm {
   selectedCity: {[k: string]: string} = {};
+  cities: any[] = [];
+}
+
+@Component({
+  selector: 'ng-model-select-multiple-form',
+  template: `
+    <select multiple [(ngModel)]="selectedCities">
+      <option *ngFor="let c of cities" [ngValue]="c"> {{c.name}} </option>
+    </select>
+  `
+})
+class NgModelSelectMultipleForm {
+  selectedCities: any[];
   cities: any[] = [];
 }
 


### PR DESCRIPTION
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** 
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** 
Closes #12527. The original repro had quite a lot going on, [here is a more distilled version](https://plnkr.co/edit/Sfkzy2IqXRszv7LBwjKL?p=preview)  Select a few options, then push or pop from the options list. 

If you bound an array to select[multiple] via ngModel and subsequently changed the options to select from, the UI would drop any selections that the user had made since. 

After options change SelectMultipleControlValueAccessor will read the model again and set the state of the options. The problem was that it didn't keep a reference to the latest model.

**What is the new behavior?**
SelectMultipleControlValueAccessor  maintains an up to date reference to the model. You can now add and remove items from the options and currently selected items will remain selected. Items in the model array that didn't have matching options in the select list will also cause their corresponding options to become selected once added.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

Whoever looks at this could look at #12519 again too. Ill need to do a little bit of refactoring to the tests when the last one is committed, if they both are accepted that is :P