### PR TITLE
fix(animations): ensure unit-less destination state style values are auto suffixed with `px`

### DIFF
--- a/modules/@angular/core/test/animation/animation_integration_spec.ts
+++ b/modules/@angular/core/test/animation/animation_integration_spec.ts
@@ -52,7 +52,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                    'myAnimation',
                    [transition(
                        'void => *',
-                       [style({'opacity': 0}), animate(500, style({'opacity': 1}))])])]
+                       [style({'opacity': '0'}), animate(500, style({'opacity': '1'}))])])]
              }
            });
 
@@ -68,8 +68,8 @@ function declareTests({useJit}: {useJit: boolean}) {
 
            var keyframes2 = driver.log[0]['keyframeLookup'];
            expect(keyframes2.length).toEqual(2);
-           expect(keyframes2[0]).toEqual([0, {'opacity': 0}]);
-           expect(keyframes2[1]).toEqual([1, {'opacity': 1}]);
+           expect(keyframes2[0]).toEqual([0, {'opacity': '0'}]);
+           expect(keyframes2[1]).toEqual([1, {'opacity': '1'}]);
          }));
 
       it('should trigger a state change animation from state => void', fakeAsync(() => {
@@ -82,7 +82,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                    'myAnimation',
                    [transition(
                        '* => void',
-                       [style({'opacity': 1}), animate(500, style({'opacity': 0}))])])]
+                       [style({'opacity': '1'}), animate(500, style({'opacity': '0'}))])])]
              }
            });
 
@@ -102,8 +102,8 @@ function declareTests({useJit}: {useJit: boolean}) {
 
            var keyframes2 = driver.log[0]['keyframeLookup'];
            expect(keyframes2.length).toEqual(2);
-           expect(keyframes2[0]).toEqual([0, {'opacity': 1}]);
-           expect(keyframes2[1]).toEqual([1, {'opacity': 0}]);
+           expect(keyframes2[0]).toEqual([0, {'opacity': '1'}]);
+           expect(keyframes2[1]).toEqual([1, {'opacity': '0'}]);
          }));
 
       it('should animate the element when the expression changes between states', fakeAsync(() => {
@@ -154,10 +154,12 @@ function declareTests({useJit}: {useJit: boolean}) {
                   <div *ngIf="exp" [@myAnimation]="exp"></div>
                 `,
                  animations: [trigger(
-                     'myAnimation',
-                     [transition(
-                         ':enter',
-                         [style({'opacity': 0}), animate('500ms', style({opacity: 1}))])])]
+                     'myAnimation', [transition(
+                                        ':enter',
+                                        [
+                                          style({'opacity': '0'}),
+                                          animate('500ms', style({'opacity': '1'}))
+                                        ])])]
                }
              });
 
@@ -181,7 +183,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                 `,
                  animations: [trigger(
                      'myAnimation',
-                     [transition(':leave', [animate('999ms', style({opacity: 0}))])])]
+                     [transition(':leave', [animate('999ms', style({'opacity': '0'}))])])]
                }
              });
 
@@ -211,7 +213,8 @@ function declareTests({useJit}: {useJit: boolean}) {
                 `,
                  animations: [trigger(
                      'myAnimation',
-                     [transition(':dont_leave_me', [animate('444ms', style({opacity: 0}))])])]
+                     [transition(
+                         ':dont_leave_me', [animate('444ms', style({'opacity': '0'}))])])]
                }
              });
 
@@ -277,11 +280,11 @@ function declareTests({useJit}: {useJit: boolean}) {
                   style({'background': 'red'}),
                   style({'width': '100px'}),
                   style({'background': 'gold'}),
-                  style({'height': 111}),
+                  style({'height': '111px'}),
                   animate('999ms', style({'width': '200px', 'background': 'blue'})),
                   style({'opacity': '1'}),
-                  style({'border-width': '100px'}),
-                  animate('999ms', style({'opacity': '0', 'height': '200px', 'border-width': '10px'}))
+                  style({'borderWidth': '100px'}),
+                  animate('999ms', style({'opacity': '0', 'height': '200px', 'borderWidth': '10px'}))
                 ])
               ])
             ]
@@ -303,7 +306,7 @@ function declareTests({useJit}: {useJit: boolean}) {
            expect(animation1['delay']).toEqual(0);
            expect(animation1['easing']).toEqual(null);
            expect(animation1['startingStyles'])
-               .toEqual({'background': 'gold', 'width': '100px', 'height': 111});
+               .toEqual({'background': 'gold', 'width': '100px', 'height': '111px'});
 
            var keyframes1 = animation1['keyframeLookup'];
            expect(keyframes1[0]).toEqual([0, {'background': 'gold', 'width': '100px'}]);
@@ -313,14 +316,14 @@ function declareTests({useJit}: {useJit: boolean}) {
            expect(animation2['duration']).toEqual(999);
            expect(animation2['delay']).toEqual(0);
            expect(animation2['easing']).toEqual(null);
-           expect(animation2['startingStyles']).toEqual({'opacity': '1', 'border-width': '100px'});
+           expect(animation2['startingStyles']).toEqual({'opacity': '1', 'borderWidth': '100px'});
 
            var keyframes2 = animation2['keyframeLookup'];
            expect(keyframes2[0]).toEqual([
-             0, {'opacity': '1', 'height': 111, 'border-width': '100px'}
+             0, {'opacity': '1', 'height': '111px', 'borderWidth': '100px'}
            ]);
            expect(keyframes2[1]).toEqual([
-             1, {'opacity': '0', 'height': '200px', 'border-width': '10px'}
+             1, {'opacity': '0', 'height': '200px', 'borderWidth': '10px'}
            ]);
          }));
 
@@ -496,13 +499,14 @@ function declareTests({useJit}: {useJit: boolean}) {
               `,
                  animations: [trigger(
                      'myAnimation',
-                     [transition('void => *', [animate(
-                                                  1000, keyframes([
-                                                    style([{'width': 0, offset: 0}]),
-                                                    style([{'width': 100, offset: 0.25}]),
-                                                    style([{'width': 200, offset: 0.75}]),
-                                                    style([{'width': 300, offset: 1}])
-                                                  ]))])])]
+                     [transition(
+                         'void => *',
+                         [animate(1000, keyframes([
+                                    style([{'width': '0px', offset: 0}]),
+                                    style([{'width': '100px', offset: 0.25}]),
+                                    style([{'width': '200px', offset: 0.75}]),
+                                    style([{'width': '300px', offset: 1}])
+                                  ]))])])]
                }
              });
 
@@ -515,10 +519,10 @@ function declareTests({useJit}: {useJit: boolean}) {
 
              var kf = driver.log[0]['keyframeLookup'];
              expect(kf.length).toEqual(4);
-             expect(kf[0]).toEqual([0, {'width': 0}]);
-             expect(kf[1]).toEqual([0.25, {'width': 100}]);
-             expect(kf[2]).toEqual([0.75, {'width': 200}]);
-             expect(kf[3]).toEqual([1, {'width': 300}]);
+             expect(kf[0]).toEqual([0, {'width': '0px'}]);
+             expect(kf[1]).toEqual([0.25, {'width': '100px'}]);
+             expect(kf[2]).toEqual([0.75, {'width': '200px'}]);
+             expect(kf[3]).toEqual([1, {'width': '300px'}]);
            }));
 
         it('should fetch any keyframe styles that are not defined in the first keyframe from the previous entries or getCompuedStyle',
@@ -535,7 +539,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                     animate(1000, style({'color': 'silver'})),
                     animate(1000, keyframes([
                       style([{'color': 'gold', offset: 0.25}]),
-                      style([{'color': 'bronze', 'background-color': 'teal', offset: 0.50}]),
+                      style([{'color': 'bronze', 'backgroundColor': 'teal', offset: 0.50}]),
                       style([{'color': 'platinum', offset: 0.75}]),
                       style([{'color': 'diamond', offset: 1}])
                     ]))
@@ -554,11 +558,11 @@ function declareTests({useJit}: {useJit: boolean}) {
 
              var kf = driver.log[1]['keyframeLookup'];
              expect(kf.length).toEqual(5);
-             expect(kf[0]).toEqual([0, {'color': 'silver', 'background-color': AUTO_STYLE}]);
+             expect(kf[0]).toEqual([0, {'color': 'silver', 'backgroundColor': AUTO_STYLE}]);
              expect(kf[1]).toEqual([0.25, {'color': 'gold'}]);
-             expect(kf[2]).toEqual([0.50, {'color': 'bronze', 'background-color': 'teal'}]);
+             expect(kf[2]).toEqual([0.50, {'color': 'bronze', 'backgroundColor': 'teal'}]);
              expect(kf[3]).toEqual([0.75, {'color': 'platinum'}]);
-             expect(kf[4]).toEqual([1, {'color': 'diamond', 'background-color': 'teal'}]);
+             expect(kf[4]).toEqual([1, {'color': 'diamond', 'backgroundColor': 'teal'}]);
            }));
       });
 
@@ -573,7 +577,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                    'myAnimation',
                    [transition(
                        '* => *',
-                       [style({'opacity': 0}), animate(500, style({'opacity': 1}))])])]
+                       [style({'opacity': '0'}), animate(500, style({'opacity': '1'}))])])]
              }
            });
 
@@ -607,7 +611,7 @@ function declareTests({useJit}: {useJit: boolean}) {
             animations: [
               trigger('myAnimation', [
                 transition('void => *', [
-                  style({'background': 'red', 'opacity': 0.5}),
+                  style({'background': 'red', 'opacity': '0.5'}),
                   animate(500, style({'background': 'black'})),
                   group([
                     animate(500, style({'background': 'black'})),
@@ -714,7 +718,7 @@ function declareTests({useJit}: {useJit: boolean}) {
             `,
                animations: [trigger(
                    'myAnimation',
-                   [transition('* => void', [animate(1000, style({'opacity': 0}))])])]
+                   [transition('* => void', [animate(1000, style({'opacity': '0'}))])])]
              }
            });
 
@@ -750,8 +754,8 @@ function declareTests({useJit}: {useJit: boolean}) {
                    [trigger('myAnimation', [transition(
                                                '* => *',
                                                [
-                                                 animate(1000, style({'opacity': 0})),
-                                                 animate(1000, style({'opacity': 1}))
+                                                 animate(1000, style({'opacity': '0'})),
+                                                 animate(1000, style({'opacity': '1'}))
                                                ])])]
              }
            });
@@ -766,12 +770,12 @@ function declareTests({useJit}: {useJit: boolean}) {
            var animation1 = driver.log[0];
            var keyframes1 = animation1['keyframeLookup'];
            expect(keyframes1[0]).toEqual([0, {'opacity': AUTO_STYLE}]);
-           expect(keyframes1[1]).toEqual([1, {'opacity': 0}]);
+           expect(keyframes1[1]).toEqual([1, {'opacity': '0'}]);
 
            var animation2 = driver.log[1];
            var keyframes2 = animation2['keyframeLookup'];
-           expect(keyframes2[0]).toEqual([0, {'opacity': 0}]);
-           expect(keyframes2[1]).toEqual([1, {'opacity': 1}]);
+           expect(keyframes2[0]).toEqual([0, {'opacity': '0'}]);
+           expect(keyframes2[1]).toEqual([1, {'opacity': '1'}]);
          }));
 
       it('should perform two transitions in parallel if defined in different state triggers',
@@ -783,9 +787,10 @@ function declareTests({useJit}: {useJit: boolean}) {
             `,
                animations: [
                  trigger(
-                     'one', [transition(
-                                'state1 => state2',
-                                [style({'opacity': 0}), animate(1000, style({'opacity': 1}))])]),
+                     'one',
+                     [transition(
+                         'state1 => state2',
+                         [style({'opacity': '0'}), animate(1000, style({'opacity': '1'}))])]),
                  trigger(
                      'two',
                      [transition(
@@ -1629,8 +1634,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                animations: [trigger(
                    'status',
                    [
-                     state('final', style({'top': '100px'})),
-                     transition('* => final', [animate(1000)])
+                     state('final', style({'top': 100})), transition('* => final', [animate(1000)])
                    ])]
              }
            });
@@ -1877,7 +1881,7 @@ function declareTests({useJit}: {useJit: boolean}) {
                animations: [trigger(
                    'status',
                    [
-                     state('void', style({'height': '100px', 'opacity': 0})),
+                     state('void', style({'height': '100px', 'opacity': '0'})),
                      state('final', style({'height': '333px', 'width': '200px'})),
                      transition('void => final', [animate(1000)])
                    ])]
@@ -1895,7 +1899,7 @@ function declareTests({useJit}: {useJit: boolean}) {
            var animation = driver.log.pop();
            var kf = animation['keyframeLookup'];
 
-           expect(kf[0]).toEqual([0, {'height': '100px', 'opacity': 0, 'width': AUTO_STYLE}]);
+           expect(kf[0]).toEqual([0, {'height': '100px', 'opacity': '0', 'width': AUTO_STYLE}]);
 
            expect(kf[1]).toEqual([1, {'height': '333px', 'opacity': AUTO_STYLE, 'width': '200px'}]);
          });

--- a/modules/@angular/core/test/linker/integration_spec.ts
+++ b/modules/@angular/core/test/linker/integration_spec.ts
@@ -124,6 +124,50 @@ function declareTests({useJit}: {useJit: boolean}) {
             .toEqual('');
       });
 
+      it('should auto suffix dimensional string-based style values with `px` that do not already contain a unit suffix',
+         () => {
+           TestBed.configureTestingModule({declarations: [MyComp]});
+           const template = '<div [style.height]="ctxProp" [style.zIndex]="ctxProp"></div>';
+           TestBed.overrideComponent(MyComp, {set: {template}});
+           const fixture = TestBed.createComponent(MyComp);
+
+           var node = fixture.debugElement.children[0].nativeElement;
+
+           fixture.componentInstance.ctxProp = '10';
+           fixture.detectChanges();
+           expect(getDOM().getStyle(node, 'height')).toEqual('10px');
+           expect(getDOM().getStyle(node, 'zIndex')).toEqual('10');
+
+           fixture.componentInstance.ctxProp = '20em';
+           fixture.detectChanges();
+           expect(getDOM().getStyle(node, 'height')).toEqual('20em');
+           expect(getDOM().getStyle(node, 'zIndex')).not.toEqual('20em');
+
+           fixture.componentInstance.ctxProp = '0';
+           fixture.detectChanges();
+           expect(getDOM().getStyle(node, 'height')).toEqual('0px');
+           expect(getDOM().getStyle(node, 'zIndex')).toEqual('0');
+         });
+
+      it('should auto suffix dimensional numeric style values with `px`', () => {
+        TestBed.configureTestingModule({declarations: [MyComp]});
+        const template = '<div [style.height]="ctxNumProp" [style.zIndex]="ctxNumProp"></div>';
+        TestBed.overrideComponent(MyComp, {set: {template}});
+        const fixture = TestBed.createComponent(MyComp);
+
+        var node = fixture.debugElement.children[0].nativeElement;
+
+        fixture.componentInstance.ctxNumProp = 10;
+        fixture.detectChanges();
+        expect(getDOM().getStyle(node, 'height')).toEqual('10px');
+        expect(getDOM().getStyle(node, 'zIndex')).toEqual('10');
+
+        fixture.componentInstance.ctxNumProp = 0;
+        fixture.detectChanges();
+        expect(getDOM().getStyle(node, 'height')).toEqual('0px');
+        expect(getDOM().getStyle(node, 'zIndex')).toEqual('0');
+      });
+
       it('should consume binding to property names where attr name and property name do not match',
          () => {
            TestBed.configureTestingModule({declarations: [MyComp]});

--- a/modules/@angular/platform-browser/src/dom/web_animations_driver.ts
+++ b/modules/@angular/platform-browser/src/dom/web_animations_driver.ts
@@ -6,13 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AUTO_STYLE} from '@angular/core';
-
 import {isPresent} from '../facade/lang';
 import {AnimationKeyframe, AnimationStyles} from '../private_import_core';
 
 import {AnimationDriver} from './animation_driver';
-import {dashCaseToCamelCase} from './util';
 import {WebAnimationsPlayer} from './web_animations_player';
 
 export class WebAnimationsDriver implements AnimationDriver {
@@ -22,13 +19,13 @@ export class WebAnimationsDriver implements AnimationDriver {
     var formattedSteps: {[key: string]: string | number}[] = [];
     var startingStyleLookup: {[key: string]: string | number} = {};
     if (isPresent(startingStyles) && startingStyles.styles.length > 0) {
-      startingStyleLookup = _populateStyles(element, startingStyles, {});
+      startingStyleLookup = _flattenStyles(startingStyles, {});
       startingStyleLookup['offset'] = 0;
       formattedSteps.push(startingStyleLookup);
     }
 
     keyframes.forEach((keyframe: AnimationKeyframe) => {
-      let data = _populateStyles(element, keyframe.styles, startingStyleLookup);
+      let data = _flattenStyles(keyframe.styles, startingStyleLookup);
       data['offset'] = keyframe.offset;
       formattedSteps.push(data);
     });
@@ -59,85 +56,15 @@ export class WebAnimationsDriver implements AnimationDriver {
   }
 }
 
-function _populateStyles(
-    element: any, styles: AnimationStyles,
-    defaultStyles: {[key: string]: string | number}): {[key: string]: string | number} {
+function _flattenStyles(styles: AnimationStyles, defaultStyles: {[key: string]: string | number}):
+    {[key: string]: string | number} {
   var data: {[key: string]: string | number} = {};
-  styles.styles.forEach((entry) => {
-    Object.keys(entry).forEach(prop => {
-      const val = entry[prop];
-      var formattedProp = dashCaseToCamelCase(prop);
-      data[formattedProp] =
-          val == AUTO_STYLE ? val : val.toString() + _resolveStyleUnit(val, prop, formattedProp);
-    });
-  });
+  styles.styles.forEach(
+      (entry) => { Object.keys(entry).forEach(prop => { data[prop] = entry[prop]; }); });
   Object.keys(defaultStyles).forEach(prop => {
     if (!isPresent(data[prop])) {
       data[prop] = defaultStyles[prop];
     }
   });
   return data;
-}
-
-function _resolveStyleUnit(
-    val: string | number, userProvidedProp: string, formattedProp: string): string {
-  var unit = '';
-  if (_isPixelDimensionStyle(formattedProp) && val != 0 && val != '0') {
-    if (typeof val === 'number') {
-      unit = 'px';
-    } else if (_findDimensionalSuffix(val.toString()).length == 0) {
-      throw new Error('Please provide a CSS unit value for ' + userProvidedProp + ':' + val);
-    }
-  }
-  return unit;
-}
-
-const _$0 = 48;
-const _$9 = 57;
-const _$PERIOD = 46;
-
-function _findDimensionalSuffix(value: string): string {
-  for (var i = 0; i < value.length; i++) {
-    var c = value.charCodeAt(i);
-    if ((c >= _$0 && c <= _$9) || c == _$PERIOD) continue;
-    return value.substring(i, value.length);
-  }
-  return '';
-}
-
-function _isPixelDimensionStyle(prop: string): boolean {
-  switch (prop) {
-    case 'width':
-    case 'height':
-    case 'minWidth':
-    case 'minHeight':
-    case 'maxWidth':
-    case 'maxHeight':
-    case 'left':
-    case 'top':
-    case 'bottom':
-    case 'right':
-    case 'fontSize':
-    case 'outlineWidth':
-    case 'outlineOffset':
-    case 'paddingTop':
-    case 'paddingLeft':
-    case 'paddingBottom':
-    case 'paddingRight':
-    case 'marginTop':
-    case 'marginLeft':
-    case 'marginBottom':
-    case 'marginRight':
-    case 'borderRadius':
-    case 'borderWidth':
-    case 'borderTopWidth':
-    case 'borderLeftWidth':
-    case 'borderRightWidth':
-    case 'borderBottomWidth':
-    case 'textIndent':
-      return true;
-
-    default:
-      return false;
-  }
 }

--- a/modules/@angular/platform-browser/test/dom/web_animations_driver_spec.ts
+++ b/modules/@angular/platform-browser/test/dom/web_animations_driver_spec.ts
@@ -45,46 +45,6 @@ export function main() {
       elm = el('<div></div>');
     });
 
-    it('should convert all styles to camelcase', () => {
-      var startingStyles = _makeStyles({'border-top-right': '40px'});
-      var styles = [
-        _makeKeyframe(0, {'max-width': '100px', 'height': '200px'}),
-        _makeKeyframe(1, {'font-size': '555px'})
-      ];
-
-      var player = driver.animate(elm, startingStyles, styles, 0, 0, 'linear');
-      var details = _formatOptions(player);
-      var startKeyframe = details['keyframes'][0];
-      var firstKeyframe = details['keyframes'][1];
-      var lastKeyframe = details['keyframes'][2];
-
-      expect(startKeyframe['borderTopRight']).toEqual('40px');
-
-      expect(firstKeyframe['maxWidth']).toEqual('100px');
-      expect(firstKeyframe['max-width']).toBeFalsy();
-      expect(firstKeyframe['height']).toEqual('200px');
-
-      expect(lastKeyframe['fontSize']).toEqual('555px');
-      expect(lastKeyframe['font-size']).toBeFalsy();
-    });
-
-    it('should auto prefix numeric properties with a `px` value', () => {
-      var startingStyles = _makeStyles({'borderTopWidth': 40});
-      var styles = [_makeKeyframe(0, {'font-size': 100}), _makeKeyframe(1, {'height': '555em'})];
-
-      var player = driver.animate(elm, startingStyles, styles, 0, 0, 'linear');
-      var details = _formatOptions(player);
-      var startKeyframe = details['keyframes'][0];
-      var firstKeyframe = details['keyframes'][1];
-      var lastKeyframe = details['keyframes'][2];
-
-      expect(startKeyframe['borderTopWidth']).toEqual('40px');
-
-      expect(firstKeyframe['fontSize']).toEqual('100px');
-
-      expect(lastKeyframe['height']).toEqual('555em');
-    });
-
     it('should use a fill mode of `both`', () => {
       var startingStyles = _makeStyles({});
       var styles = [_makeKeyframe(0, {'color': 'green'}), _makeKeyframe(1, {'color': 'red'})];


### PR DESCRIPTION
Prior to this fix any styling numeric or unit-less style
values (that exist amoung `state()` styles within an animation
trigger) are not suffixed with `px` for the DOM platform. This
fix ensures that this works now.

Closes #11582