### PR TITLE
feat(core): expose registerChangeDetector on ApplicationRef

### DIFF
--- a/modules/@angular/core/src/application_ref.ts
+++ b/modules/@angular/core/src/application_ref.ts
@@ -378,6 +378,18 @@ export abstract class ApplicationRef {
    * Get a list of components registered to this application.
    */
   get components(): ComponentRef<any>[] { return <ComponentRef<any>[]>unimplemented(); };
+
+  /**
+   * Registers a change detector with the application.
+   * @param changeDetector Reference to the change detector to register.
+   */
+  abstract registerChangeDetector(changeDetector: ChangeDetectorRef): void;
+
+  /**
+   * Unregisters a change detector with the application.
+   * @param changeDetector Reference to the change detector to unregister.
+   */
+  abstract unregisterChangeDetector(changeDetector: ChangeDetectorRef): void;
 }
 
 @Injectable()

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -151,7 +151,9 @@ export declare abstract class ApplicationRef {
     componentTypes: Type<any>[];
     components: ComponentRef<any>[];
     abstract bootstrap<C>(componentFactory: ComponentFactory<C> | Type<C>): ComponentRef<C>;
+    abstract registerChangeDetector(changeDetector: ChangeDetectorRef): void;
     abstract tick(): void;
+    abstract unregisterChangeDetector(changeDetector: ChangeDetectorRef): void;
 }
 
 /** @experimental */


### PR DESCRIPTION
Related to #9293

With these methods, you should have everything you need to dynamically create a component without a ViewContainerRef. 