### PR TITLE
feat(router): register router with ngprobe

### DIFF
--- a/modules/@angular/core/src/application_ref.ts
+++ b/modules/@angular/core/src/application_ref.ts
@@ -61,6 +61,15 @@ export function isDevMode(): boolean {
 }
 
 /**
+ * A token for third-party components that can register themselves with NgProbe.
+ *
+ * @experimental
+ */
+export class NgProbeToken {
+  constructor(public name: string, public token: any) {}
+}
+
+/**
  * Creates a platform.
  * Platforms have to be eagerly created via this function.
  *

--- a/modules/@angular/core/src/core.ts
+++ b/modules/@angular/core/src/core.ts
@@ -14,7 +14,7 @@
 export * from './metadata';
 export * from './util';
 export * from './di';
-export {createPlatform, assertPlatform, destroyPlatform, getPlatform, PlatformRef, ApplicationRef, enableProdMode, isDevMode, createPlatformFactory} from './application_ref';
+export {createPlatform, assertPlatform, destroyPlatform, getPlatform, PlatformRef, ApplicationRef, enableProdMode, isDevMode, createPlatformFactory, NgProbeToken} from './application_ref';
 export {APP_ID, PACKAGE_ROOT_URL, PLATFORM_INITIALIZER, APP_BOOTSTRAP_LISTENER} from './application_tokens';
 export {APP_INITIALIZER, ApplicationInitStatus} from './application_init';
 export * from './zone';

--- a/modules/@angular/platform-browser/src/dom/debug/ng_probe.ts
+++ b/modules/@angular/platform-browser/src/dom/debug/ng_probe.ts
@@ -6,17 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, DebugNode, NgZone, Optional, Provider, RootRenderer, getDebugNode, isDevMode} from '@angular/core';
+import * as core from '@angular/core';
 
 import {StringMapWrapper} from '../../facade/collection';
 import {DebugDomRootRenderer} from '../../private_import_core';
 import {getDOM} from '../dom_adapter';
 import {DomRootRenderer} from '../dom_renderer';
 
-
 const CORE_TOKENS = {
-  'ApplicationRef': ApplicationRef,
-  'NgZone': NgZone
+  'ApplicationRef': core.ApplicationRef,
+  'NgZone': core.NgZone
 };
 
 const INSPECT_GLOBAL_NAME = 'ng.probe';
@@ -27,21 +26,25 @@ const CORE_TOKENS_GLOBAL_NAME = 'ng.coreTokens';
  * null if the given native element does not have an Angular view associated
  * with it.
  */
-export function inspectNativeElement(element: any /** TODO #9100 */): DebugNode {
-  return getDebugNode(element);
+export function inspectNativeElement(element: any /** TODO #9100 */): core.DebugNode {
+  return core.getDebugNode(element);
 }
 
 /**
- * @experimental
+ * Deprecated. Use the one from '@angular/core'.
+ * @deprecated
  */
 export class NgProbeToken {
-  constructor(private name: string, private token: any) {}
+  constructor(public name: string, public token: any) {}
 }
 
+
 export function _createConditionalRootRenderer(
-    rootRenderer: any /** TODO #9100 */, extraTokens: NgProbeToken[]) {
-  if (isDevMode()) {
-    return _createRootRenderer(rootRenderer, extraTokens);
+    rootRenderer: any /** TODO #9100 */, extraTokens: NgProbeToken[],
+    coreTokens: core.NgProbeToken[]) {
+  if (core.isDevMode()) {
+    const tokens = (extraTokens || []).concat(coreTokens || []);
+    return _createRootRenderer(rootRenderer, tokens);
   }
   return rootRenderer;
 }
@@ -61,14 +64,11 @@ function _ngProbeTokensToMap(tokens: NgProbeToken[]): {[name: string]: any} {
 /**
  * Providers which support debugging Angular applications (e.g. via `ng.probe`).
  */
-export const ELEMENT_PROBE_PROVIDERS: Provider[] = [{
-  provide: RootRenderer,
+export const ELEMENT_PROBE_PROVIDERS: core.Provider[] = [{
+  provide: core.RootRenderer,
   useFactory: _createConditionalRootRenderer,
-  deps: [DomRootRenderer, [NgProbeToken, new Optional()]]
-}];
-
-export const ELEMENT_PROBE_PROVIDERS_PROD_MODE: any[] = [{
-  provide: RootRenderer,
-  useFactory: _createRootRenderer,
-  deps: [DomRootRenderer, [NgProbeToken, new Optional()]]
+  deps: [
+    DomRootRenderer, [NgProbeToken, new core.Optional()],
+    [core.NgProbeToken, new core.Optional()]
+  ]
 }];

--- a/modules/@angular/router/src/router_module.ts
+++ b/modules/@angular/router/src/router_module.ts
@@ -7,7 +7,7 @@
  */
 
 import {APP_BASE_HREF, HashLocationStrategy, Location, LocationStrategy, PathLocationStrategy, PlatformLocation} from '@angular/common';
-import {ANALYZE_FOR_ENTRY_COMPONENTS, APP_BOOTSTRAP_LISTENER, ApplicationRef, Compiler, Inject, Injector, ModuleWithProviders, NgModule, NgModuleFactoryLoader, OpaqueToken, Optional, Provider, SkipSelf, SystemJsNgModuleLoader} from '@angular/core';
+import {ANALYZE_FOR_ENTRY_COMPONENTS, APP_BOOTSTRAP_LISTENER, ApplicationRef, Compiler, Inject, Injector, ModuleWithProviders, NgModule, NgModuleFactoryLoader, NgProbeToken, OpaqueToken, Optional, Provider, SkipSelf, SystemJsNgModuleLoader} from '@angular/core';
 
 import {Route, Routes} from './config';
 import {RouterLink, RouterLinkWithHref} from './directives/router_link';
@@ -41,15 +41,6 @@ export const ROUTER_CONFIGURATION = new OpaqueToken('ROUTER_CONFIGURATION');
  */
 export const ROUTER_FORROOT_GUARD = new OpaqueToken('ROUTER_FORROOT_GUARD');
 
-const pathLocationStrategy = {
-  provide: LocationStrategy,
-  useClass: PathLocationStrategy
-};
-const hashLocationStrategy = {
-  provide: LocationStrategy,
-  useClass: HashLocationStrategy
-};
-
 export const ROUTER_PROVIDERS: Provider[] = [
   Location, {provide: UrlSerializer, useClass: DefaultUrlSerializer}, {
     provide: Router,
@@ -63,6 +54,10 @@ export const ROUTER_PROVIDERS: Provider[] = [
   {provide: NgModuleFactoryLoader, useClass: SystemJsNgModuleLoader}, RouterPreloader, NoPreloading,
   PreloadAllModules, {provide: ROUTER_CONFIGURATION, useValue: {enableTracing: false}}
 ];
+
+export function routerNgProbeToken() {
+  return new NgProbeToken('Router', Router);
+}
 
 /**
  * @whatItDoes Adds router directives and providers.
@@ -152,6 +147,7 @@ export class RouterModule {
           useExisting: config && config.preloadingStrategy ? config.preloadingStrategy :
                                                              NoPreloading
         },
+        {provide: NgProbeToken, multi: true, useFactory: routerNgProbeToken},
         provideRouterInitializer()
       ]
     };

--- a/modules/benchmarks/src/tree/ng2_ftl/app.ngfactory.ts
+++ b/modules/benchmarks/src/tree/ng2_ftl/app.ngfactory.ts
@@ -154,7 +154,8 @@ class AppModuleInjector extends import0.NgModuleInjector<import1.AppModule> {
   get _RootRenderer_20(): any {
     if ((this.__RootRenderer_20 == (null as any))) {
       (this.__RootRenderer_20 = import23._createConditionalRootRenderer(
-           this._DomRootRenderer_19, this.parent.get(import23.NgProbeToken, (null as any))));
+           this._DomRootRenderer_19, this.parent.get(import23.NgProbeToken, (null as any)),
+           this.parent.get(import8.NgProbeToken, (null as any))));
     }
     return this.__RootRenderer_20;
   }

--- a/modules/benchmarks/src/tree/ng2_static_ftl/app.ngfactory.ts
+++ b/modules/benchmarks/src/tree/ng2_static_ftl/app.ngfactory.ts
@@ -154,7 +154,8 @@ class AppModuleInjector extends import0.NgModuleInjector<import1.AppModule> {
   get _RootRenderer_20(): any {
     if ((this.__RootRenderer_20 == (null as any))) {
       (this.__RootRenderer_20 = import23._createConditionalRootRenderer(
-           this._DomRootRenderer_19, this.parent.get(import23.NgProbeToken, (null as any))));
+           this._DomRootRenderer_19, this.parent.get(import23.NgProbeToken, (null as any)),
+           this.parent.get(import8.NgProbeToken, (null as any))));
     }
     return this.__RootRenderer_20;
   }

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -600,6 +600,13 @@ export declare abstract class NgModuleRef<T> {
 }
 
 /** @experimental */
+export declare class NgProbeToken {
+    name: string;
+    token: any;
+    constructor(name: string, token: any);
+}
+
+/** @experimental */
 export declare class NgZone {
     hasPendingMacrotasks: boolean;
     hasPendingMicrotasks: boolean;

--- a/tools/public_api_guard/platform-browser/index.d.ts
+++ b/tools/public_api_guard/platform-browser/index.d.ts
@@ -58,8 +58,10 @@ export declare class HammerGestureConfig {
     buildHammer(element: HTMLElement): HammerInstance;
 }
 
-/** @experimental */
+/** @deprecated */
 export declare class NgProbeToken {
+    name: string;
+    token: any;
     constructor(name: string, token: any);
 }
 


### PR DESCRIPTION
When running in the dev mode, the router register itself with ngProbe, so it can be accessed like this: `ng.probe(appElement).injector.get(ng.coreTokens.Router)`