### PR TITLE
fix(http): preserve header case when copying headers

### DIFF
--- a/modules/@angular/http/src/headers.ts
+++ b/modules/@angular/http/src/headers.ts
@@ -49,7 +49,7 @@ export class Headers {
     }
 
     if (headers instanceof Headers) {
-      headers._headers.forEach((values: string[], name: string) => {
+      headers.forEach((values: string[], name: string) => {
         values.forEach(value => this.append(name, value));
       });
       return;

--- a/modules/@angular/http/test/backends/xhr_backend_spec.ts
+++ b/modules/@angular/http/test/backends/xhr_backend_spec.ts
@@ -233,9 +233,9 @@ export function main() {
         var connection = new XHRConnection(
             new Request(base.merge(new RequestOptions({headers: headers}))), new MockBrowserXHR());
         connection.response.subscribe();
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('content-type', 'text/xml');
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('breaking-bad', '<3');
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('x-multi', 'a,b');
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('Content-Type', 'text/xml');
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('Breaking-Bad', '<3');
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('X-Multi', 'a,b');
       });
 
       it('should skip content type detection if custom content type header is set', () => {
@@ -246,7 +246,8 @@ export function main() {
             new Request(base.merge(new RequestOptions({body: body, headers: headers}))),
             new MockBrowserXHR());
         connection.response.subscribe();
-        expect(setRequestHeaderSpy).toHaveBeenCalledWith('content-type', 'text/plain');
+        expect(setRequestHeaderSpy).toHaveBeenCalledWith('Content-Type', 'text/plain');
+        expect(setRequestHeaderSpy).not.toHaveBeenCalledWith('Content-Type', 'application/json');
         expect(setRequestHeaderSpy).not.toHaveBeenCalledWith('content-type', 'application/json');
       });
 
@@ -355,7 +356,7 @@ export function main() {
                  new MockBrowserXHR());
              connection.response.subscribe();
              expect(sendSpy).toHaveBeenCalledWith(body);
-             expect(setRequestHeaderSpy).toHaveBeenCalledWith('content-type', 'text/css');
+             expect(setRequestHeaderSpy).toHaveBeenCalledWith('Content-Type', 'text/css');
            });
 
         it('should use array buffer body to the request', () => {
@@ -386,7 +387,7 @@ export function main() {
                  new MockBrowserXHR());
              connection.response.subscribe();
              expect(sendSpy).toHaveBeenCalledWith(body);
-             expect(setRequestHeaderSpy).toHaveBeenCalledWith('content-type', 'text/css');
+             expect(setRequestHeaderSpy).toHaveBeenCalledWith('Content-Type', 'text/css');
            });
       }
 

--- a/modules/@angular/http/test/headers_spec.ts
+++ b/modules/@angular/http/test/headers_spec.ts
@@ -76,6 +76,13 @@ export function main() {
         expect(JSON.stringify(headers)).toEqual('{"fOo":["bat"]}');
       });
 
+      it('should preserve cases after cloning', () => {
+        const headers = new Headers();
+        headers.set('fOo', 'baz');
+        headers.set('foo', 'bat');
+        expect(JSON.stringify(new Headers(headers))).toEqual('{"fOo":["bat"]}');
+      });
+
       it('should convert input array to string', () => {
         const headers = new Headers();
         headers.set('foo', ['bar', 'baz']);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

#12106 attempted to preserve the case of HTTP headers added to the `Headers` object.

It failed, because `StaticRequest` copies the headers (https://github.com/angular/angular/blob/69f006cd89b5fc08ed87655368eef50ebcc0e75a/modules/%40angular/http/src/static_request.ts#L97) and that copy ignores the saved case (https://github.com/angular/angular/blob/69f006cd89b5fc08ed87655368eef50ebcc0e75a/modules/@angular/http/src/headers.ts#L52).

**What is the new behavior?**

Copying headers preserves their case.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


