### PR TITLE
feat(compiler.umd): allow root path declaration for Component styleUrls

### DIFF
--- a/modules/@angular/compiler/src/directive_normalizer.ts
+++ b/modules/@angular/compiler/src/directive_normalizer.ts
@@ -40,6 +40,8 @@ export class DirectiveNormalizer {
   }
 
   private _fetch(url: string): Promise<string> {
+    // remove the `~` to allow the url to be processed as a root url
+    if (url[0] == '~') url = url.substring(1, url.length);
     var result = this._resourceLoaderCache.get(url);
     if (!result) {
       result = this._resourceLoader.get(url);
@@ -172,8 +174,11 @@ export class DirectiveNormalizer {
   }
 
   normalizeStylesheet(stylesheet: CompileStylesheetMetadata): CompileStylesheetMetadata {
-    var allStyleUrls = stylesheet.styleUrls.filter(isStyleUrlResolvable)
-                           .map(url => this._urlResolver.resolve(stylesheet.moduleUrl, url));
+    var allStyleUrls = stylesheet.styleUrls.filter(isStyleUrlResolvable).map(url => {
+      // remove the `~` to allow the url to be processed as a root url
+      if (url[0] == '~') url = url.substring(1, url.length);
+      return this._urlResolver.resolve(stylesheet.moduleUrl, url);
+    });
 
     var allStyles = stylesheet.styles.map(style => {
       var styleWithImports = extractStyleUrls(this._urlResolver, stylesheet.moduleUrl, style);

--- a/modules/@angular/compiler/src/style_url_resolver.ts
+++ b/modules/@angular/compiler/src/style_url_resolver.ts
@@ -18,7 +18,12 @@ export class StyleWithImports {
 }
 
 export function isStyleUrlResolvable(url: string): boolean {
-  if (isBlank(url) || url.length === 0 || url[0] == '/') return false;
+  // resolve a url beginning with `~`
+  // it will be removed by directive_normalizer.ts to be treated as a root url
+  if (url !== null && url[0] == '~')
+    url = url.substring(1, url.length);
+  else if (isBlank(url) || url.length === 0 || url[0] == '/')
+    return false;
   const schemeMatch = url.match(_urlWithSchemaRe);
   return schemeMatch === null || schemeMatch[1] == 'package' || schemeMatch[1] == 'asset';
 }

--- a/modules/@angular/compiler/test/style_url_resolver_spec.ts
+++ b/modules/@angular/compiler/test/style_url_resolver_spec.ts
@@ -106,6 +106,9 @@ export function main() {
       expect(isStyleUrlResolvable('/otherurl')).toBe(false);
       expect(isStyleUrlResolvable('//otherurl')).toBe(false);
     });
+
+    it('should resolve urls starting with `~` to a root relative path',
+       () => { expect(isStyleUrlResolvable('~/someStyleUrl.css')).toBe(true); });
   });
 }
 

--- a/tools/cjs-jasmine/test-cjs-main.ts
+++ b/tools/cjs-jasmine/test-cjs-main.ts
@@ -7,7 +7,7 @@
  */
 
 var testingPlatformServer = require('../../all/@angular/platform-server/testing/server.js');
-var testing = require('../../all/@angular/core/testing');
+var testingJasmine = require('../../all/@angular/core/testing');
 
-testing.TestBed.initTestEnvironment(
+testingJasmine.TestBed.initTestEnvironment(
     testingPlatformServer.ServerTestingModule, testingPlatformServer.platformServerTesting());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
Need to add a note to https://angular.io/docs/ts/latest/guide/component-styles.html in the note that begins with "The URL is relative to the application root". The new note should read:

> The URL is relative to the application root which is usually the location of the index.html web page that hosts the application. The style file URL is not relative to the component file. That's why the example URL begins app/. See Appendix 2 to specify a URL relative to the component file. Prefix the URL with a `~` to make it relative to the web root (i.e. `~/path/to/styles.css`)

**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Resolves this issue: https://github.com/angular/angular/issues/4974
Also corrects a bug with cjs-jasmine that causes a duplicate var declaration in some environments.


**What is the new behavior?**
Component styleUrls can now be prefixed with a `~` to make the URL relative to the web root.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

