### PR TITLE
feat(forms): API to add multipe controls at once

### DIFF
--- a/modules/@angular/forms/src/model.ts
+++ b/modules/@angular/forms/src/model.ts
@@ -873,6 +873,13 @@ export class FormGroup extends AbstractControl {
   }
 
   /**
+   * Add multiple controls to this group.
+   */
+  addControls(controlMap: {[name: string]: AbstractControl}): void {
+    Object.keys(controlMap).forEach((name) => this.addControl(name, controlMap[name]));
+  }
+
+  /**
    * Remove a control from this group.
    */
   removeControl(name: string): void {

--- a/modules/@angular/forms/test/form_group_spec.ts
+++ b/modules/@angular/forms/test/form_group_spec.ts
@@ -74,6 +74,21 @@ export function main() {
         expect(g.valid).toBe(false);
       });
 
+      it('should update value and validity when multiple controls are added', () => {
+        const g = new FormGroup({'one': new FormControl('1')});
+        expect(g.value).toEqual({'one': '1'});
+        expect(g.valid).toBe(true);
+
+        const gs = {
+          'two': new FormControl('2', Validators.minLength(10)),
+          'three': new FormControl('3', Validators.minLength(10))
+        };
+        g.addControls(gs);
+
+        expect(g.value).toEqual({'one': '1', 'two': '2', 'three': '3'});
+        expect(g.valid).toBe(false);
+      });
+
       it('should update value and validity when control is removed', () => {
         const g = new FormGroup(
             {'one': new FormControl('1'), 'two': new FormControl('2', Validators.minLength(10))});

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -268,6 +268,9 @@ export declare class FormGroup extends AbstractControl {
         [key: string]: AbstractControl;
     }, validator?: ValidatorFn, asyncValidator?: AsyncValidatorFn);
     addControl(name: string, control: AbstractControl): void;
+    addControls(controlMap: {
+        [name: string]: AbstractControl;
+    }): void;
     contains(controlName: string): boolean;
     getRawValue(): Object;
     patchValue(value: {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
#12747


**What is the new behavior?**
#12747


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


Using forms the user should be able to conveniently add multiple controls.
Therefore, `addControls` was added to `FormGroup`, `FormGroupDirective` and `NgForm`.

Close #12747