### PR TITLE
fix(facade): cache original date format string

### DIFF
--- a/modules/@angular/facade/src/intl.ts
+++ b/modules/@angular/facade/src/intl.ts
@@ -187,7 +187,8 @@ function dateFormatter(format: string, date: Date, locale: string): string {
 
   if (fn) return fn(date, locale);
 
-  let parts = DATE_FORMATTER_CACHE.get(format);
+  const cacheKey = format;
+  let parts = DATE_FORMATTER_CACHE.get(cacheKey);
 
   if (!parts) {
     parts = [];
@@ -205,7 +206,7 @@ function dateFormatter(format: string, date: Date, locale: string): string {
       }
     }
 
-    DATE_FORMATTER_CACHE.set(format, parts);
+    DATE_FORMATTER_CACHE.set(cacheKey, parts);
   }
 
   return parts.reduce((text, part) => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

There's a useless cache being maintained in the Intl facade for dates. Its purpose it's to avoid a possibly expensive RegExp operation. Unfortunately the expensive result was being cached in the wrong entry (null).

**What is the new behavior?**

Add to the correct cache entry.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


