### PR TITLE
fix(router): do not require the creation of empty-path routes when no…

### DIFF
--- a/modules/@angular/router/src/apply_redirects.ts
+++ b/modules/@angular/router/src/apply_redirects.ts
@@ -146,11 +146,20 @@ class ApplyRedirects {
     const first$ = first.call(concattedProcessedRoutes$, (s: any) => !!s);
     return _catch.call(first$, (e: any, _: any): Observable<UrlSegmentGroup> => {
       if (e instanceof EmptyError) {
-        throw new NoMatch(segmentGroup);
+        if (this.noLeftoversInUrl(segmentGroup, segments, outlet)) {
+          return of (new UrlSegmentGroup([], {}));
+        } else {
+          throw new NoMatch(segmentGroup);
+        }
       } else {
         throw e;
       }
     });
+  }
+
+  private noLeftoversInUrl(segmentGroup: UrlSegmentGroup, segments: UrlSegment[], outlet: string):
+      boolean {
+    return segments.length === 0 && !segmentGroup.children[outlet];
   }
 
   private expandSegmentAgainstRoute(

--- a/modules/@angular/router/src/config.ts
+++ b/modules/@angular/router/src/config.ts
@@ -8,7 +8,8 @@
 
 import {Type} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
-import {PRIMARY_OUTLET} from './shared';
+import {PRIMARY_OUTLET, Params} from './shared';
+import {UrlSegment, UrlSegmentGroup} from './url_tree';
 
 /**
  * @whatItDoes Represents router configuration.
@@ -260,6 +261,41 @@ import {PRIMARY_OUTLET} from './shared';
 export type Routes = Route[];
 
 /**
+ * @whatItDoes Represents the results of the URL matching.
+ *
+ * * `consumed` is an array of the consumed URL segments.
+ * * `posParams` is a map of positional parameters.
+ *
+ * @experimental
+ */
+export type UrlMatchResult = {
+  consumed: UrlSegment[]; posParams?: {[name: string]: UrlSegment};
+};
+
+/**
+ * @whatItDoes A function matching URLs
+ *
+ * @description
+ *
+ * A custom URL matcher can be provided when a combination of `path` and `pathMatch` isn't
+ * expressive enough.
+ *
+ * For instance, the following matcher matches html files.
+ *
+ * ```
+ * function htmlFiles(url: UrlSegment[]) {
+ *  return url.length === 1 && url[0].path.endsWith('.html') ? ({consumed: url}) : null;
+ * }
+ *
+ * const routes = [{ matcher: htmlFiles, component: HtmlCmp }];
+ * ```
+ *
+ * @experimental
+ */
+export type UrlMatcher = (segments: UrlSegment[], group: UrlSegmentGroup, route: Route) =>
+    UrlMatchResult;
+
+/**
  * @whatItDoes Represents the static data associated with a particular route.
  * See {@link Routes} for more details.
  * @stable
@@ -269,7 +305,7 @@ export type Data = {
 };
 
 /**
- *  @whatItDoes Represents the resolved data associated with a particular route.
+ * @whatItDoes Represents the resolved data associated with a particular route.
  * See {@link Routes} for more details.
  * @stable
  */
@@ -299,6 +335,7 @@ export type LoadChildren = string | LoadChildrenCallback;
 export interface Route {
   path?: string;
   pathMatch?: string;
+  matcher?: UrlMatcher;
   component?: Type<any>;
   redirectTo?: string;
   outlet?: string;
@@ -339,6 +376,10 @@ function validateNode(route: Route): void {
   if (!!route.redirectTo && !!route.component) {
     throw new Error(
         `Invalid configuration of route '${route.path}': redirectTo and component cannot be used together`);
+  }
+  if (!!route.path && !!route.matcher) {
+    throw new Error(
+        `Invalid configuration of route '${route.path}': path and matcher cannot be used together`);
   }
   if (route.redirectTo === undefined && !route.component && !route.children &&
       !route.loadChildren) {

--- a/modules/@angular/router/src/recognize.ts
+++ b/modules/@angular/router/src/recognize.ts
@@ -90,7 +90,16 @@ class Recognizer {
         if (!(e instanceof NoMatch)) throw e;
       }
     }
-    throw new NoMatch();
+    if (this.noLeftoversInUrl(segmentGroup, segments, outlet)) {
+      return [];
+    } else {
+      throw new NoMatch();
+    }
+  }
+
+  private noLeftoversInUrl(segmentGroup: UrlSegmentGroup, segments: UrlSegment[], outlet: string):
+      boolean {
+    return segments.length === 0 && !segmentGroup.children[outlet];
   }
 
   processSegmentAgainstRoute(

--- a/modules/@angular/router/src/shared.ts
+++ b/modules/@angular/router/src/shared.ts
@@ -6,6 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+
+import {Route, UrlMatchResult} from './config';
+import {UrlSegment, UrlSegmentGroup} from './url_tree';
+
+
 /**
  * @whatItDoes Name of the primary outlet.
  *
@@ -29,4 +34,36 @@ export class NavigationCancelingError extends Error {
     this.stack = (<any>new Error(message)).stack;
   }
   toString(): string { return this.message; }
+}
+
+export function defaultUrlMatcher(
+    segments: UrlSegment[], segmentGroup: UrlSegmentGroup, route: Route): UrlMatchResult {
+  const path = route.path;
+  const parts = path.split('/');
+  const posParams: {[key: string]: UrlSegment} = {};
+  const consumed: UrlSegment[] = [];
+
+  let currentIndex = 0;
+
+  for (let i = 0; i < parts.length; ++i) {
+    if (currentIndex >= segments.length) return null;
+    const current = segments[currentIndex];
+
+    const p = parts[i];
+    const isPosParam = p.startsWith(':');
+
+    if (!isPosParam && p !== current.path) return null;
+    if (isPosParam) {
+      posParams[p.substring(1)] = current;
+    }
+    consumed.push(current);
+    currentIndex++;
+  }
+
+  if (route.pathMatch === 'full' &&
+      (segmentGroup.hasChildren() || currentIndex < segments.length)) {
+    return null;
+  } else {
+    return {consumed, posParams};
+  }
 }

--- a/modules/@angular/router/test/apply_redirects.spec.ts
+++ b/modules/@angular/router/test/apply_redirects.spec.ts
@@ -515,6 +515,37 @@ describe('applyRedirects', () => {
       });
     });
   });
+
+  describe('empty URL leftovers', () => {
+    it('should not error when no children matching and no url is left', () => {
+      checkRedirect(
+          [{path: 'a', component: ComponentA, children: [{path: 'b', component: ComponentB}]}],
+          '/a', (t: UrlTree) => { compareTrees(t, tree('a')); });
+    });
+
+    it('should not error when no children matching and no url is left (aux routes)', () => {
+      checkRedirect(
+          [{
+            path: 'a',
+            component: ComponentA,
+            children: [
+              {path: 'b', component: ComponentB},
+              {path: '', redirectTo: 'c', outlet: 'aux'},
+              {path: 'c', component: ComponentC, outlet: 'aux'},
+            ]
+          }],
+          '/a', (t: UrlTree) => { compareTrees(t, tree('a/(aux:c)')); });
+    });
+
+    it('should error when no children matching and some url is left', () => {
+      applyRedirects(
+          null, null, tree('/a/c'),
+          [{path: 'a', component: ComponentA, children: [{path: 'b', component: ComponentB}]}])
+          .subscribe(
+              (_) => { throw 'Should not be reached'; },
+              e => { expect(e.message).toEqual('Cannot match any routes. URL Segment: \'a/c\''); });
+    });
+  });
 });
 
 function checkRedirect(config: Routes, url: string, callback: any): void {

--- a/modules/@angular/router/test/apply_redirects.spec.ts
+++ b/modules/@angular/router/test/apply_redirects.spec.ts
@@ -546,6 +546,26 @@ describe('applyRedirects', () => {
               e => { expect(e.message).toEqual('Cannot match any routes. URL Segment: \'a/c\''); });
     });
   });
+
+  describe('custom path matchers', () => {
+    it('should use custom path matcher', () => {
+      const matcher = (s: any, g: any, r: any) => {
+        if (s[0].path === 'a') {
+          return {consumed: s.slice(0, 2), posParams: {id: s[1]}};
+        } else {
+          return null;
+        }
+      };
+
+      checkRedirect(
+          [{
+            matcher: matcher,
+            component: ComponentA,
+            children: [{path: 'b', component: ComponentB}]
+          }],
+          '/a/1/b', (t: UrlTree) => { compareTrees(t, tree('a/1/b')); });
+    });
+  });
 });
 
 function checkRedirect(config: Routes, url: string, callback: any): void {

--- a/modules/@angular/router/test/config.spec.ts
+++ b/modules/@angular/router/test/config.spec.ts
@@ -51,7 +51,14 @@ describe('config', () => {
               `Invalid configuration of route 'a': redirectTo and component cannot be used together`);
     });
 
-    it('should throw when path is missing', () => {
+
+    it('should throw when path and mathcer are used together', () => {
+      expect(() => { validateConfig([{path: 'a', matcher: <any>'someFunc', children: []}]); })
+          .toThrowError(
+              `Invalid configuration of route 'a': path and matcher cannot be used together`);
+    });
+
+    it('should throw when path and matcher are missing', () => {
       expect(() => {
         validateConfig([{component: null, redirectTo: 'b'}]);
       }).toThrowError(`Invalid route configuration: routes must have path specified`);

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -675,7 +675,7 @@ describe('Integration', () => {
        expect(cmp.activations.length).toEqual(1);
        expect(cmp.activations[0] instanceof BlankCmp).toBe(true);
 
-       router.navigateByUrl('/simple').catch(e => console.log(e));
+       router.navigateByUrl('/simple');
        advance(fixture);
 
        expect(cmp.activations.length).toEqual(2);

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -22,11 +22,8 @@ import {RouterTestingModule, SpyNgModuleFactoryLoader} from '../testing';
 describe('Integration', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule.withRoutes(
-            [{path: '', component: BlankCmp}, {path: 'simple', component: SimpleCmp}]),
-        TestModule
-      ]
+      imports:
+          [RouterTestingModule.withRoutes([{path: 'simple', component: SimpleCmp}]), TestModule]
     });
   });
 
@@ -108,6 +105,29 @@ describe('Integration', () => {
          ]);
        })));
   });
+
+  it('should not error when no url left and no children are matching',
+     fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+       const fixture = createRoot(router, RootCmp);
+
+       router.resetConfig([{
+         path: 'team/:id',
+         component: TeamCmp,
+         children: [{path: 'simple', component: SimpleCmp}]
+       }]);
+
+       router.navigateByUrl('/team/33/simple');
+       advance(fixture);
+
+       expect(location.path()).toEqual('/team/33/simple');
+       expect(fixture.nativeElement).toHaveText('team 33 [ simple, right:  ]');
+
+       router.navigateByUrl('/team/33');
+       advance(fixture);
+
+       expect(location.path()).toEqual('/team/33');
+       expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
+     })));
 
   it('should work when an outlet is in an ngIf',
      fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
@@ -655,13 +675,13 @@ describe('Integration', () => {
        expect(cmp.activations.length).toEqual(1);
        expect(cmp.activations[0] instanceof BlankCmp).toBe(true);
 
-       router.navigateByUrl('/simple');
+       router.navigateByUrl('/simple').catch(e => console.log(e));
        advance(fixture);
 
        expect(cmp.activations.length).toEqual(2);
        expect(cmp.activations[1] instanceof SimpleCmp).toBe(true);
-       expect(cmp.deactivations.length).toEqual(2);
-       expect(cmp.deactivations[1] instanceof BlankCmp).toBe(true);
+       expect(cmp.deactivations.length).toEqual(1);
+       expect(cmp.deactivations[0] instanceof BlankCmp).toBe(true);
      }));
 
   it('should update url and router state before activating components',

--- a/modules/@angular/router/test/recognize.spec.ts
+++ b/modules/@angular/router/test/recognize.spec.ts
@@ -636,6 +636,30 @@ describe('recognize', () => {
     });
   });
 
+  describe('custom path matchers', () => {
+    it('should use custom path matcher', () => {
+      const matcher = (s: any, g: any, r: any) => {
+        if (s[0].path === 'a') {
+          return {consumed: s.slice(0, 2), posParams: {id: s[1]}};
+        } else {
+          return null;
+        }
+      };
+
+      checkRecognize(
+          [{
+            matcher: matcher,
+            component: ComponentA,
+            children: [{path: 'b', component: ComponentB}]
+          }],
+          '/a/1;p=99/b', (s: RouterStateSnapshot) => {
+            const a = s.root.firstChild;
+            checkActivatedRoute(a, 'a/1', {id: '1', p: '99'}, ComponentA);
+            checkActivatedRoute(a.firstChild, 'b', {}, ComponentB);
+          });
+    });
+  });
+
   describe('query parameters', () => {
     it('should support query params', () => {
       const config = [{path: 'a', component: ComponentA}];

--- a/modules/@angular/router/test/recognize.spec.ts
+++ b/modules/@angular/router/test/recognize.spec.ts
@@ -608,6 +608,34 @@ describe('recognize', () => {
     });
   });
 
+  describe('empty URL leftovers', () => {
+    it('should not throw when no children matching', () => {
+      checkRecognize(
+          [{path: 'a', component: ComponentA, children: [{path: 'b', component: ComponentB}]}],
+          '/a', (s: RouterStateSnapshot) => {
+            const a = s.firstChild(s.root);
+            checkActivatedRoute(a, 'a', {}, ComponentA);
+          });
+    });
+
+    it('should not throw when no children matching (aux routes)', () => {
+      checkRecognize(
+          [{
+            path: 'a',
+            component: ComponentA,
+            children: [
+              {path: 'b', component: ComponentB},
+              {path: '', component: ComponentC, outlet: 'aux'},
+            ]
+          }],
+          '/a', (s: RouterStateSnapshot) => {
+            const a = s.firstChild(s.root);
+            checkActivatedRoute(a, 'a', {}, ComponentA);
+            checkActivatedRoute(a.children[0], '', {}, ComponentC, 'aux');
+          });
+    });
+  });
+
   describe('query parameters', () => {
     it('should support query params', () => {
       const config = [{path: 'a', component: ComponentA}];

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -187,6 +187,7 @@ export interface Route {
     component?: Type<any>;
     data?: Data;
     loadChildren?: LoadChildren;
+    matcher?: UrlMatcher;
     outlet?: string;
     path?: string;
     pathMatch?: string;


### PR DESCRIPTION
# Two Changes

## Relax Matching

Previously having this configuration

```
{ path: 'parent', component: Parent, children: [
  { path: 'child', component: Child }
] }
```

the following url would not match '/parent'. You would have to create a bogus empty-path route, so the configuration looks like this:

```
{ path: 'parent', component: Parent, children: [
  { path: '', component: Blank },
  { path: 'child', component: Child }
] }
```

Now it is no longer required.

## Custom Matching

We are adding support for doing custom url matching.

```
function endsWithHtml(url: UrlSegment[], group: UrlSegmentGroup, route: Route) {
  return url.length === 1 && url[0].path.endsWith(".htmlk") ? ({consumed: url}) : null;
}
{ matcher: endsWithHtml, component: HtmlCmp }
``` 