### PR TITLE
refactor(compiler): add `span` to `TemplateBinding`

### DIFF
--- a/modules/@angular/compiler/src/expression_parser/ast.ts
+++ b/modules/@angular/compiler/src/expression_parser/ast.ts
@@ -204,7 +204,7 @@ export class ASTWithSource extends AST {
 
 export class TemplateBinding {
   constructor(
-      public key: string, public keyIsVar: boolean, public name: string,
+      public span: ParseSpan, public key: string, public keyIsVar: boolean, public name: string,
       public expression: ASTWithSource) {}
 }
 

--- a/modules/@angular/compiler/src/template_parser/binding_parser.ts
+++ b/modules/@angular/compiler/src/template_parser/binding_parser.ts
@@ -112,9 +112,9 @@ export class BindingParser {
   }
 
   parseInlineTemplateBinding(
-      name: string, value: string, sourceSpan: ParseSourceSpan, targetMatchableAttrs: string[][],
-      targetProps: BoundProperty[], targetVars: VariableAst[]) {
-    const bindings = this._parseTemplateBindings(value, sourceSpan);
+      name: string, prefixToken: string, value: string, sourceSpan: ParseSourceSpan,
+      targetMatchableAttrs: string[][], targetProps: BoundProperty[], targetVars: VariableAst[]) {
+    const bindings = this._parseTemplateBindings(prefixToken, value, sourceSpan);
     for (let i = 0; i < bindings.length; i++) {
       const binding = bindings[i];
       if (binding.keyIsVar) {
@@ -129,11 +129,12 @@ export class BindingParser {
     }
   }
 
-  private _parseTemplateBindings(value: string, sourceSpan: ParseSourceSpan): TemplateBinding[] {
+  private _parseTemplateBindings(prefixToken: string, value: string, sourceSpan: ParseSourceSpan):
+      TemplateBinding[] {
     const sourceInfo = sourceSpan.start.toString();
 
     try {
-      const bindingsResult = this._exprParser.parseTemplateBindings(value, sourceInfo);
+      const bindingsResult = this._exprParser.parseTemplateBindings(prefixToken, value, sourceInfo);
       this._reportExpressionParserErrors(bindingsResult.errors, sourceSpan);
       bindingsResult.templateBindings.forEach((binding) => {
         if (isPresent(binding.expression)) {

--- a/modules/@angular/compiler/src/template_parser/template_parser.ts
+++ b/modules/@angular/compiler/src/template_parser/template_parser.ts
@@ -271,12 +271,13 @@ class TemplateParseVisitor implements html.Visitor {
           isTemplateElement, attr, matchableAttrs, elementOrDirectiveProps, events,
           elementOrDirectiveRefs, elementVars);
 
-      let templateBindingsSource: string;
+      let templateBindingsSource: string|undefined = undefined;
+      let prefixToken: string|undefined = undefined;
       if (this._normalizeAttributeName(attr.name) == TEMPLATE_ATTR) {
         templateBindingsSource = attr.value;
       } else if (attr.name.startsWith(TEMPLATE_ATTR_PREFIX)) {
-        const key = attr.name.substring(TEMPLATE_ATTR_PREFIX.length);  // remove the star
-        templateBindingsSource = (attr.value.length == 0) ? key : key + ' ' + attr.value;
+        templateBindingsSource = attr.value;
+        prefixToken = attr.name.substring(TEMPLATE_ATTR_PREFIX.length);  // remove the star
       }
       const hasTemplateBinding = isPresent(templateBindingsSource);
       if (hasTemplateBinding) {
@@ -287,7 +288,7 @@ class TemplateParseVisitor implements html.Visitor {
         }
         hasInlineTemplates = true;
         this._bindingParser.parseInlineTemplateBinding(
-            attr.name, templateBindingsSource, attr.sourceSpan, templateMatchableAttrs,
+            attr.name, prefixToken, templateBindingsSource, attr.sourceSpan, templateMatchableAttrs,
             templateElementOrDirectiveProps, templateElementVars);
       }
 

--- a/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
@@ -1192,7 +1192,7 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
 
             it('should report an error on variables declared with #', () => {
               expect(() => humanizeTplAst(parse('<div *ngIf="#a=b">', [])))
-                  .toThrowError(/Parser Error: Unexpected token # at column 6/);
+                  .toThrowError(/Parser Error: Unexpected token # at column 1/);
             });
 
             it('should parse variables via let ...', () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Refactoring (no functional changes, no api changes)
```

**What is the current behavior?** (You can also link to an open issue here)

The internal type `TemplateBinding` does have a `span` making it difficult to determine where the expressions are in the source string.

**What is the new behavior?**

The `TemplateBinding` type has a `span`.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:

fix(compiler): corrected error location for implicit templates expressions