### PR TITLE
fix(tools): harden colletor against invalid asts

### DIFF
--- a/tools/@angular/tsc-wrapped/src/collector.ts
+++ b/tools/@angular/tsc-wrapped/src/collector.ts
@@ -205,12 +205,14 @@ export class MetadataCollector {
       switch (node.kind) {
         case ts.SyntaxKind.ClassDeclaration:
           const classDeclaration = <ts.ClassDeclaration>node;
-          const className = classDeclaration.name.text;
-          if (node.flags & ts.NodeFlags.Export) {
-            locals.define(className, {__symbolic: 'reference', name: className});
-          } else {
-            locals.define(
-                className, errorSym('Reference to non-exported class', node, {className}));
+          if (classDeclaration.name) {
+            const className = classDeclaration.name.text;
+            if (node.flags & ts.NodeFlags.Export) {
+              locals.define(className, {__symbolic: 'reference', name: className});
+            } else {
+              locals.define(
+                  className, errorSym('Reference to non-exported class', node, {className}));
+            }
           }
           break;
         case ts.SyntaxKind.FunctionDeclaration:
@@ -218,9 +220,12 @@ export class MetadataCollector {
             // Report references to this function as an error.
             const functionDeclaration = <ts.FunctionDeclaration>node;
             const nameNode = functionDeclaration.name;
-            locals.define(
-                nameNode.text,
-                errorSym('Reference to a non-exported function', nameNode, {name: nameNode.text}));
+            if (nameNode && nameNode.text) {
+              locals.define(
+                  nameNode.text,
+                  errorSym(
+                      'Reference to a non-exported function', nameNode, {name: nameNode.text}));
+            }
           }
           break;
       }
@@ -248,11 +253,13 @@ export class MetadataCollector {
           break;
         case ts.SyntaxKind.ClassDeclaration:
           const classDeclaration = <ts.ClassDeclaration>node;
-          const className = classDeclaration.name.text;
-          if (node.flags & ts.NodeFlags.Export) {
-            if (classDeclaration.decorators) {
-              if (!metadata) metadata = {};
-              metadata[className] = classMetadataOf(classDeclaration);
+          if (classDeclaration.name) {
+            const className = classDeclaration.name.text;
+            if (node.flags & ts.NodeFlags.Export) {
+              if (classDeclaration.decorators) {
+                if (!metadata) metadata = {};
+                metadata[className] = classMetadataOf(classDeclaration);
+              }
             }
           }
           // Otherwise don't record metadata for the class.

--- a/tools/@angular/tsc-wrapped/test/collector.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/collector.spec.ts
@@ -15,7 +15,7 @@ import {Directory, Host, expectValidSources} from './typescript.mocks';
 
 describe('Collector', () => {
   let documentRegistry = ts.createDocumentRegistry();
-  let host: ts.LanguageServiceHost;
+  let host: Host;
   let service: ts.LanguageService;
   let program: ts.Program;
   let collector: MetadataCollector;
@@ -589,6 +589,28 @@ describe('Collector', () => {
           .toThrowError(/Reference to non-exported class/);
     });
   });
+
+  describe('with invalid input', () => {
+    it('should not throw with a class with no name', () => {
+      const fileName = '/invalid-class.ts';
+      override(fileName, 'export class');
+      let invalidClass = program.getSourceFile(fileName);
+      expect(() => collector.getMetadata(invalidClass)).not.toThrow();
+    });
+
+    it('should not throw with a function with no name', () => {
+      const fileName = '/invalid-function.ts';
+      override(fileName, 'export function');
+      let invalidFunction = program.getSourceFile(fileName);
+      expect(() => collector.getMetadata(invalidFunction)).not.toThrow();
+    });
+  });
+
+  function override(fileName: string, content: string) {
+    host.overrideFile(fileName, content);
+    host.addFile(fileName);
+    program = service.getProgram();
+  }
 });
 
 // TODO: Do not use \` in a template literal as it confuses clang-format


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

If the collector is requested to produce metadata for invalid TypeScript it will sometimes throw.

**What is the new behavior?**

The collector will no longer throw on invalid files.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
