### PR TITLE
perf(EventManager): Event subscription speedup using Plugin cache

### DIFF
--- a/modules/@angular/platform-browser/src/dom/events/event_manager.ts
+++ b/modules/@angular/platform-browser/src/dom/events/event_manager.ts
@@ -20,7 +20,8 @@ export const EVENT_MANAGER_PLUGINS: OpaqueToken = new OpaqueToken('EventManagerP
 @Injectable()
 export class EventManager {
   private _plugins: EventManagerPlugin[];
-  private _eventNameToPlugin: Map<string, EventManagerPlugin> = new Map<string, EventManagerPlugin>();
+  private _eventNameToPlugin: Map<string, EventManagerPlugin> = 
+      new Map<string, EventManagerPlugin>();
 
   constructor(@Inject(EVENT_MANAGER_PLUGINS) plugins: EventManagerPlugin[], private _zone: NgZone) {
     plugins.forEach(p => p.manager = this);

--- a/modules/@angular/platform-browser/src/dom/events/event_manager.ts
+++ b/modules/@angular/platform-browser/src/dom/events/event_manager.ts
@@ -41,13 +41,13 @@ export class EventManager {
 
   /** @internal */
   _findPluginFor(eventName: string): EventManagerPlugin {
-    const plugin = _eventNameToPlugin.get(eventName);
+    const plugin = this._eventNameToPlugin.get(eventName);
     if (plugin != null) return plugin;
     const plugins = this._plugins;
     for (let i = 0; i < plugins.length; i++) {
       plugin = plugins[i];
       if (plugin.supports(eventName)) {
-        _eventNameToPlugin.set(eventName, plugin);
+        this._eventNameToPlugin.set(eventName, plugin);
         return plugin;
       }
     }

--- a/modules/@angular/platform-browser/src/dom/events/event_manager.ts
+++ b/modules/@angular/platform-browser/src/dom/events/event_manager.ts
@@ -20,6 +20,7 @@ export const EVENT_MANAGER_PLUGINS: OpaqueToken = new OpaqueToken('EventManagerP
 @Injectable()
 export class EventManager {
   private _plugins: EventManagerPlugin[];
+  private _eventNameToPlugin: Map<string, EventManagerPlugin> = new Map<string, EventManagerPlugin>();
 
   constructor(@Inject(EVENT_MANAGER_PLUGINS) plugins: EventManagerPlugin[], private _zone: NgZone) {
     plugins.forEach(p => p.manager = this);
@@ -40,10 +41,13 @@ export class EventManager {
 
   /** @internal */
   _findPluginFor(eventName: string): EventManagerPlugin {
+    const plugin = _eventNameToPlugin.get(eventName);
+    if (plugin != null) return plugin;
     const plugins = this._plugins;
     for (let i = 0; i < plugins.length; i++) {
-      const plugin = plugins[i];
+      plugin = plugins[i];
       if (plugin.supports(eventName)) {
+        _eventNameToPlugin.set(eventName, plugin);
         return plugin;
       }
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Refactoring (no functional changes, no api changes)
```

**What is the current behavior?** (You can also link to an open issue here)
On every event subscription, event manager searches all plugins.
Dom events plugin is last in list of plugins, therefore each subscription goes through .supports(eventName) calls unnecessarily after the first lookup. This change caches them to efficiently bypass the search.

**What is the new behavior?**
Once we know which plugin serves an event type, it is cached.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
