### PR TITLE
fix(template): template bindings in micro-syntax

### DIFF
--- a/modules/@angular/compiler/src/expression_parser/parser.ts
+++ b/modules/@angular/compiler/src/expression_parser/parser.ts
@@ -693,7 +693,7 @@ export class _ParseAST {
         this.advance();
       }
       let key = this.expectTemplateBindingKey();
-      if (!keyIsVar) {
+      if (key && !keyIsVar) {
         if (prefix == null) {
           prefix = key;
         } else {
@@ -709,11 +709,15 @@ export class _ParseAST {
         } else {
           name = '\$implicit';
         }
-      } else if (this.next !== EOF && !this.peekKeywordLet()) {
-        const start = this.inputIndex;
-        const ast = this.parsePipe();
-        const source = this.input.substring(start - this.offset, this.inputIndex - this.offset);
-        expression = new ASTWithSource(ast, source, this.location, this.errors);
+      } else {
+        const expressionRequired = this.optionalCharacter(chars.$COLON);
+        if (expressionRequired || (this.next !== EOF && !this.peekKeywordLet() &&
+                                   !this.peek(1).isCharacter(chars.$COLON))) {
+          const start = this.inputIndex;
+          const ast = this.parsePipe();
+          const source = this.input.substring(start - this.offset, this.inputIndex - this.offset);
+          expression = new ASTWithSource(ast, source, this.location, this.errors);
+        }
       }
       bindings.push(new TemplateBinding(this.span(start), key, keyIsVar, name, expression));
       if (!this.optionalCharacter(chars.$SEMICOLON)) {

--- a/modules/@angular/compiler/test/expression_parser/parser_spec.ts
+++ b/modules/@angular/compiler/test/expression_parser/parser_spec.ts
@@ -450,13 +450,19 @@ export function main() {
         });
 
         it('should support a prefix', () => {
-          const source = 'let person of people';
-          const prefix = 'ngFor';
-          const bindings = parseTemplateBindings(source, null, prefix);
+          let source = 'let person of people';
+          let prefix = 'ngFor';
+          let bindings = parseTemplateBindings(source, null, prefix);
           expect(keyValues(bindings)).toEqual([
             'ngFor', 'let person=$implicit', 'ngForOf=people in null'
           ]);
           expect(keySpans(source, bindings)).toEqual(['', 'let person ', 'of people']);
+
+          source = 'title: exp';
+          prefix = 'bsPane';
+          bindings = parseTemplateBindings(source, null, prefix);
+          expect(keys(bindings)).toEqual(['bsPane', 'bsPaneTitle']);
+          expect(exprSources(bindings)).toEqual([null, 'exp']);
         });
       });
     });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

1. An unused @Input named exactly like the selector is required on structural directives.
2. An extraneous character followed by a space is required at the beginning for it to work.

See #12194

**What is the new behavior?**

1. Don't require an @Input named as the directive selector.
2. Allow input when no expression is assigned to directive selector itself.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:

This PR could either be merged as it is or wait for a definition on #5894. Issue #5894 list another requirement not solved by this PR, namely optional ":" separator in a few more cases.
