### PR TITLE
feat(tools): allow disabling annotation lowering

### DIFF
--- a/tools/@angular/tsc-wrapped/src/options.ts
+++ b/tools/@angular/tsc-wrapped/src/options.ts
@@ -29,6 +29,9 @@ interface Options extends ts.CompilerOptions {
   // Default is true.
   generateCodeForLibraries?: boolean;
 
+  // Modify how angular annotations are emitted to improve tree-shaking.
+  annotationsAs?: string; /* 'decorator'|'static field' */
+
   // Print extra information while running the compiler
   trace: boolean;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Feature
```

**What is the current behavior?** (You can also link to an open issue here)

By default, `ngc` converts decorators to static fields. This add considerable overhead to `ngc` over just using `tsc`. This transformation is only useful if the result will tree-shaken.

**What is the new behavior?**

Converting decorators to static fields now an emit option of the compiler. To enable converting annotations to static fields include:

```json
"angularCompilerOptions": {
  "annotationsAs": "static fields"
}
```

The valid values for `annotationsAs` are `static fields` and `decorators`. The default value of this option is `decorators`.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
