### PR TITLE
feat(routerLink) add `extras` input property

### DIFF
--- a/modules/@angular/router/src/directives/router_link.ts
+++ b/modules/@angular/router/src/directives/router_link.ts
@@ -10,10 +10,42 @@ import {LocationStrategy} from '@angular/common';
 import {Directive, HostBinding, HostListener, Input, OnChanges, OnDestroy} from '@angular/core';
 import {Subscription} from 'rxjs/Subscription';
 
-import {NavigationEnd, Router} from '../router';
+import {NavigationEnd, NavigationExtras, Router} from '../router';
 import {ActivatedRoute} from '../router_state';
 import {UrlTree} from '../url_tree';
 
+function mergeNavigationExtras(...extras: NavigationExtras[]): NavigationExtras {
+  const result: NavigationExtras = {};
+  if (extras) {
+    extras.forEach(extra => {
+      if (!extra) {
+        return;
+      }
+      if (extra.relativeTo) {
+        result.relativeTo = extra.relativeTo;
+      }
+      if (extra.queryParams) {
+        result.queryParams = extra.queryParams;
+      }
+      if (extra.preserveQueryParams) {
+        result.preserveQueryParams = extra.preserveQueryParams;
+      }
+      if (extra.fragment) {
+        result.fragment = extra.fragment;
+      }
+      if (extra.preserveFragment) {
+        result.preserveFragment = extra.preserveFragment;
+      }
+      if (extra.replaceUrl) {
+        result.replaceUrl = extra.replaceUrl;
+      }
+      if (extra.skipLocationChange) {
+        result.skipLocationChange = extra.skipLocationChange;
+      }
+    });
+  }
+  return result;
+}
 
 /**
  * @whatItDoes Lets you link to specific parts of your app.
@@ -73,6 +105,13 @@ import {UrlTree} from '../url_tree';
  component</a>
  * ```
  *
+ * And you can pass all settings to `[extras]` property.
+ *
+ * ```
+ * <a [routerLink]="['/user/bob']" [extras]="{ preserveQueryParams: true, fragment: 'education' }"
+ >link to user component</a>
+ * ```
+ *
  * The router link directive always treats the provided input as a delta to the current url.
  *
  * For instance, if the current url is `/user/(box//aux:team)`.
@@ -95,6 +134,7 @@ export class RouterLink {
   @Input() preserveFragment: boolean;
   @Input() skipLocationChange: boolean;
   @Input() replaceUrl: boolean;
+  @Input() extras: NavigationExtras;
   private commands: any[] = [];
 
   constructor(
@@ -117,7 +157,7 @@ export class RouterLink {
   }
 
   get urlTree(): UrlTree {
-    return this.router.createUrlTree(this.commands, {
+    const extras = mergeNavigationExtras(this.extras, {
       relativeTo: this.route,
       queryParams: this.queryParams,
       fragment: this.fragment,
@@ -126,6 +166,7 @@ export class RouterLink {
       skipLocationChange: toBool(this.skipLocationChange),
       replaceUrl: toBool(this.replaceUrl),
     });
+    return this.router.createUrlTree(this.commands, extras);
   }
 }
 
@@ -149,6 +190,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   @Input() preserveFragment: boolean;
   @Input() skipLocationChange: boolean;
   @Input() replaceUrl: boolean;
+  @Input() extras: NavigationExtras;
   private commands: any[] = [];
   private subscription: Subscription;
 
@@ -196,7 +238,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   }
 
   get urlTree(): UrlTree {
-    return this.router.createUrlTree(this.commands, {
+    const extras = mergeNavigationExtras(this.extras, {
       relativeTo: this.route,
       queryParams: this.queryParams,
       fragment: this.fragment,
@@ -205,6 +247,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
       skipLocationChange: toBool(this.skipLocationChange),
       replaceUrl: toBool(this.replaceUrl),
     });
+    return this.router.createUrlTree(this.commands, extras);
   }
 }
 

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -1108,6 +1108,32 @@ describe('Integration', () => {
 
          expect(location.path()).toEqual('/team/22/simple?q=1#f');
        })));
+
+    it('should support extras input',
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = createRoot(router, RootCmp);
+
+         router.resetConfig([{
+           path: 'team/:id',
+           component: TeamCmp,
+           children: [
+             {path: 'link', component: LinkWithNavigationExtras},
+             {path: 'simple', component: SimpleCmp}
+           ]
+         }]);
+
+         router.navigateByUrl('/team/22/link');
+         advance(fixture);
+
+         const native = fixture.nativeElement.querySelector('a');
+         expect(native.getAttribute('href')).toEqual('/team/22/simple?q=1#f');
+         native.click();
+         advance(fixture);
+
+         expect(fixture.nativeElement).toHaveText('team 22 [ simple, right:  ]');
+
+         expect(location.path()).toEqual('/team/22/simple?q=1#f');
+       })));
   });
 
   describe('redirects', () => {
@@ -2412,6 +2438,14 @@ class RelativeLinkCmp {
 class LinkWithQueryParamsAndFragment {
 }
 
+@Component({
+  selector: 'link-cmp',
+  template:
+      `<a [routerLink]="['../simple']" [extras]="{queryParams: {q: '1'}, fragment: 'f'}">link</a>`
+})
+class LinkWithNavigationExtras {
+}
+
 @Component({selector: 'simple-cmp', template: `simple`})
 class SimpleCmp {
 }
@@ -2578,6 +2612,7 @@ function createRoot(router: Router, type: any): ComponentFixture<any> {
     RelativeLinkCmp,
     DummyLinkWithParentCmp,
     LinkWithQueryParamsAndFragment,
+    LinkWithNavigationExtras,
     CollectParamsCmp,
     QueryParamsAndFragmentCmp,
     StringLinkButtonCmp,
@@ -2604,6 +2639,7 @@ function createRoot(router: Router, type: any): ComponentFixture<any> {
     RelativeLinkCmp,
     DummyLinkWithParentCmp,
     LinkWithQueryParamsAndFragment,
+    LinkWithNavigationExtras,
     CollectParamsCmp,
     QueryParamsAndFragmentCmp,
     StringLinkButtonCmp,
@@ -2631,6 +2667,7 @@ function createRoot(router: Router, type: any): ComponentFixture<any> {
     RelativeLinkCmp,
     DummyLinkWithParentCmp,
     LinkWithQueryParamsAndFragment,
+    LinkWithNavigationExtras,
     CollectParamsCmp,
     QueryParamsAndFragmentCmp,
     StringLinkButtonCmp,

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -226,6 +226,7 @@ export declare const ROUTER_INITIALIZER: OpaqueToken;
 
 /** @stable */
 export declare class RouterLink {
+    extras: NavigationExtras;
     fragment: string;
     preserveFragment: boolean;
     preserveQueryParams: boolean;
@@ -257,6 +258,7 @@ export declare class RouterLinkActive implements OnChanges, OnDestroy, AfterCont
 
 /** @stable */
 export declare class RouterLinkWithHref implements OnChanges, OnDestroy {
+    extras: NavigationExtras;
     fragment: string;
     href: string;
     preserveFragment: boolean;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

`routerLink` has many inputs for setting up `NavigationExtras`. 

```html
<a routerLink="/" queryParams="{}" fragment="..." preserveQueryParams preserveFragment skipLocationChange replaceUrl>....</a>
```

it can cause that terrible template... :fearful: 

**What is the new behavior?**

Add new input property, `extras`, which can take `NavigationExtras` directly.

```
// HTML

<a [routerLink]="['/user/alice']" [extras]="myExtras">link to user component</a>
<a [routerLink]="['/user/bob']" [extras]="myExtras">link to user component</a>

// ts

class MyCmp {

  myExtras = { preserveQueryParams: true, fragment: 'education' };
}
```

This is very simple. 

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

