### PR TITLE
refactor(compiler): allows synchronous retrieving of metadata

### DIFF
--- a/modules/@angular/compiler/src/compile_metadata.ts
+++ b/modules/@angular/compiler/src/compile_metadata.ts
@@ -589,7 +589,7 @@ export interface CompileNgModuleDirectiveSummary extends CompileSummary {
   exportedDirectives: CompileIdentifierMetadata[];
   exportedPipes: CompileIdentifierMetadata[];
   exportedModules: CompileNgModuleDirectiveSummary[];
-  loadingPromises: Promise<any>[];
+  directiveLoaders: (() => Promise<void>)[];
 }
 
 export type CompileNgModuleSummary =
@@ -661,7 +661,7 @@ export class CompileNgModuleMetadata implements CompileMetadataWithIdentifier {
       exportedModules: this.exportedModules,
       exportedDirectives: this.exportedDirectives,
       exportedPipes: this.exportedPipes,
-      loadingPromises: this.transitiveModule.loadingPromises
+      directiveLoaders: this.transitiveModule.directiveLoaders
     };
   }
 
@@ -682,7 +682,7 @@ export class CompileNgModuleMetadata implements CompileMetadataWithIdentifier {
       exportedDirectives: this.exportedDirectives,
       exportedPipes: this.exportedPipes,
       exportedModules: this.exportedModules,
-      loadingPromises: this.transitiveModule.loadingPromises
+      directiveLoaders: this.transitiveModule.directiveLoaders
     };
   }
 }
@@ -695,7 +695,7 @@ export class TransitiveCompileNgModuleMetadata {
       public modules: CompileNgModuleInjectorSummary[], public providers: CompileProviderMetadata[],
       public entryComponents: CompileIdentifierMetadata[],
       public directives: CompileIdentifierMetadata[], public pipes: CompileIdentifierMetadata[],
-      public loadingPromises: Promise<any>[]) {
+      public directiveLoaders: (() => Promise<void>)[]) {
     directives.forEach(dir => this.directivesSet.add(dir.reference));
     pipes.forEach(pipe => this.pipesSet.add(pipe.reference));
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Refactoring (no functional changes, no api changes)
```

**What is the current behavior?** (You can also link to an open issue here)

Resolving metadata normalizes the result and normalization requires asynchronous calls. The language service doesn't require normalized metadata and needs to resolve the metadata synchronously.

**What is the new behavior?**

The metadata resolver now has synchronous calls to resolve directives and the code is refactored to first call the synchronous calls then normalize the directives as an optional asynchronous step.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:


Allows non-normalized metadata to be retrieved synchronously.

Related to #7482