### PR TITLE
fix(ngUpgrade): make AoT ngUpgrade work with the testability API and resumeBootstrap()

### DIFF
--- a/modules/@angular/upgrade/src/aot/constants.ts
+++ b/modules/@angular/upgrade/src/aot/constants.ts
@@ -13,6 +13,9 @@ export const $INJECTOR = '$injector';
 export const $PARSE = '$parse';
 export const $ROOT_SCOPE = '$rootScope';
 export const $SCOPE = '$scope';
+export const $PROVIDE = '$provide';
+export const $DELEGATE = '$delegate';
+export const $$TESTABILITY = '$$testability';
 
 export const $COMPILE = '$compile';
 export const $TEMPLATE_CACHE = '$templateCache';

--- a/modules/@angular/upgrade/test/aot/integration/testability_spec.ts
+++ b/modules/@angular/upgrade/test/aot/integration/testability_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {NgModule, Testability, destroyPlatform} from '@angular/core';
+import {NgZone} from '@angular/core/src/zone/ng_zone';
 import {fakeAsync, tick} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
@@ -28,7 +29,11 @@ export function main() {
 
     it('should handle deferred bootstrap', fakeAsync(() => {
          let applicationRunning = false;
-         const ng1Module = angular.module('ng1', []).run(() => { applicationRunning = true; });
+         let stayedInTheZone: boolean;
+         const ng1Module = angular.module('ng1', []).run(() => {
+           applicationRunning = true;
+           stayedInTheZone = NgZone.isInAngularZone();
+         });
 
          const element = html('<div></div>');
          window.name = 'NG_DEFER_BOOTSTRAP!' + window.name;
@@ -40,6 +45,7 @@ export function main() {
          expect(applicationRunning).toEqual(false);
          tick(100);
          expect(applicationRunning).toEqual(true);
+         expect(stayedInTheZone).toEqual(true);
        }));
 
     it('should wait for ng2 testability', fakeAsync(() => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

In apps using `ngUpgrade` and AoT compilation, `resumeBootstrap` causes `config` and `run` blocks to be run outside `NgZone`, which in turn causes problems with change detection.  Additionally, the testability APIs of ng1 and ng2 were not hooked together properly.

**What is the new behavior?**

`resumeBootstrap` is patched to always run inside the `NgZone`, ng1 testability API is decorated to wait on the ng2 API.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

I have no idea why the second test in `modules/@angular/upgrade/test/aot/integration/testability_spec.ts` was passing but I verified using a sample app that the decoration of the ng1 testability API was nessisary