### PR TITLE
fix(platform_browser): doesn't throw error in disableDebugTools

### DIFF
--- a/modules/@angular/platform-browser/src/browser/tools/tools.ts
+++ b/modules/@angular/platform-browser/src/browser/tools/tools.ts
@@ -37,5 +37,7 @@ export function enableDebugTools<T>(ref: ComponentRef<T>): ComponentRef<T> {
  * @experimental All debugging apis are currently experimental.
  */
 export function disableDebugTools(): void {
-  delete context.ng.profiler;
+  if (context.ng) {
+    delete context.ng.profiler;
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/angular/angular/issues/12915