### PR TITLE
refactor(ngUpgrade): Small cleanup with Testability API and resumeBootstrap

### DIFF
--- a/modules/@angular/upgrade/src/aot/upgrade_module.ts
+++ b/modules/@angular/upgrade/src/aot/upgrade_module.ts
@@ -166,16 +166,14 @@ export class UpgradeModule {
                     (testabilityDelegate: angular.ITestabilityService) => {
                       const originalWhenStable: Function = testabilityDelegate.whenStable;
                       const injector = this.injector;
-                      // Cannot use arrow function below because we need to grab the context
+                      // Cannot use arrow function below because we need the context
                       const newWhenStable = function(callback: Function) {
-                        const whenStableContext: any = this;
                         originalWhenStable.call(this, function() {
                           const ng2Testability: Testability = injector.get(Testability);
                           if (ng2Testability.isStable()) {
                             callback.apply(this, arguments);
                           } else {
-                            ng2Testability.whenStable(
-                                newWhenStable.bind(whenStableContext, callback));
+                            ng2Testability.whenStable(newWhenStable.bind(this, callback));
                           }
                         });
                       };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

See "Other Information"

**What is the new behavior?**

See "Other Information"

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:

* With non-static ngUpgrade apps, callbacks to `whenStable` were being invoked with the wrong
  context
* With non-static ngUpgrade apps, `resumeBootstrap` was being run outside the NgZone
* Remove redundent `whenStableContext` variable

Neither of the first two problems were actually causing bugs (as far as I know), but they *might*
have caused problems in the future,

Inspired by https://github.com/angular/angular/pull/12910, but for non-static apps.