### PR TITLE
fix(tools): fix error when running test.sh

### DIFF
--- a/modules/tsconfig.json
+++ b/modules/tsconfig.json
@@ -20,7 +20,8 @@
     "lib": ["es5", "dom", "es2015.promise", "es2015.collection", "es2015.iterable"],
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
-    "target": "es5"
+    "target": "es5",
+    "types": ["angularjs"]
   },
   "exclude": [
     "angular1_router",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

Running `./test.sh node` produces an error in `@angular/examples/upgrade/static/ts/module.ts`. 

The example requires the `angularjs` type description which is not provided by `tsconfig.json` in the `modules` directory.

**What is the new behavior?**

Running `./test.sh` no longer produces an error in the upgrade example because it is excluded from the build.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
