### PR TITLE
fix CircleCI breakage, they started giving npm version 4.0.2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   pre:
-    - npm install -g npm
+    - npm install -g npm@3.6.0
 
 test:
   override:


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

CirleCI builds are broken.

**What is the new behavior?**

CircleCI builds work.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
