### PR TITLE
refactor(compiler): allow control of StaticSymbol lifetime

### DIFF
--- a/modules/@angular/compiler/src/aot/static_reflector.ts
+++ b/modules/@angular/compiler/src/aot/static_reflector.ts
@@ -45,11 +45,29 @@ export interface StaticReflectorHost {
 }
 
 /**
+ * A cache of static symbol used by the StaticReflector to return the same symbol for the
+ * same symbol values.
+ */
+export class StaticSymbolCache {
+  private cache = new Map<string, StaticSymbol>();
+
+  get(declarationFile: string, name: string, members?: string[]): StaticSymbol {
+    const memberSuffix = members ? `.${ members.join('.')}` : '';
+    const key = `"${declarationFile}".${name}${memberSuffix}`;
+    let result = this.cache.get(key);
+    if (!result) {
+      result = new StaticSymbol(declarationFile, name, members);
+      this.cache.set(key, result);
+    }
+    return result;
+  }
+}
+
+/**
  * A static reflector implements enough of the Reflector API that is necessary to compile
  * templates statically.
  */
 export class StaticReflector implements ReflectorReader {
-  private staticSymbolCache = new Map<string, StaticSymbol>();
   private declarationCache = new Map<string, StaticSymbol>();
   private annotationCache = new Map<StaticSymbol, any[]>();
   private propertyCache = new Map<StaticSymbol, {[key: string]: any}>();
@@ -58,7 +76,11 @@ export class StaticReflector implements ReflectorReader {
   private conversionMap = new Map<StaticSymbol, (context: StaticSymbol, args: any[]) => any>();
   private opaqueToken: StaticSymbol;
 
-  constructor(private host: StaticReflectorHost) { this.initializeConversionMap(); }
+  constructor(
+      private host: StaticReflectorHost,
+      private staticSymbolCache: StaticSymbolCache = new StaticSymbolCache()) {
+    this.initializeConversionMap();
+  }
 
   importUri(typeOrFunc: StaticSymbol): string {
     const staticSymbol = this.findDeclaration(typeOrFunc.filePath, typeOrFunc.name, '');
@@ -225,14 +247,7 @@ export class StaticReflector implements ReflectorReader {
    * @param name the name of the type.
    */
   getStaticSymbol(declarationFile: string, name: string, members?: string[]): StaticSymbol {
-    const memberSuffix = members ? `.${ members.join('.')}` : '';
-    const key = `"${declarationFile}".${name}${memberSuffix}`;
-    let result = this.staticSymbolCache.get(key);
-    if (!result) {
-      result = new StaticSymbol(declarationFile, name, members);
-      this.staticSymbolCache.set(key, result);
-    }
-    return result;
+    return this.staticSymbolCache.get(declarationFile, name, members);
   }
 
   private resolveExportedSymbol(filePath: string, symbolName: string): StaticSymbol {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Refactoring (no functional changes, no api changes)
```

**What is the current behavior?** (You can also link to an open issue here)

The lifetime of a `StaticSymbol` is the same as the `ReflectorHost` that created it.

**What is the new behavior?**

The lifetime of the `StaticSymbol` is the same as the `StaticSymbolCache` that created it. `StaticReflector` now takes an optional`StaticSymbolCache`. If one is not passed to `StaticReflector` will create a new `StaticSymbolCache`.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
