### PR TITLE
Fix(http): invalidStateError response body

### DIFF
--- a/modules/@angular/http/src/backends/xhr_backend.ts
+++ b/modules/@angular/http/src/backends/xhr_backend.ts
@@ -59,7 +59,7 @@ export class XHRConnection implements Connection {
           // responseText is the old-school way of retrieving response (supported by IE8 & 9)
           // response/responseType properties were introduced in ResourceLoader Level2 spec
           // (supported by IE10)
-          body = _xhr.response == null ? _xhr.responseText : _xhr.response;
+          body = (typeof _xhr.response === 'undefined') ? _xhr.responseText : _xhr.response;
 
           // Implicitly strip a potential XSSI prefix.
           if (typeof body === 'string') {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The var body take the responseText value when the _xhr.response value is null but defined. When the response value is defined the responseText value thrown always an invalidStateError exception.

**What is the new behavior?**

The var body take the responseText value only when the _xhr.response is undefined.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


Check on null value failed with last version of Firefox (50.0).
Check on undefined type instead null value.