### PR TITLE
fix(closure): quote date pattern aliases

### DIFF
--- a/modules/@angular/facade/src/intl.ts
+++ b/modules/@angular/facade/src/intl.ts
@@ -44,7 +44,7 @@ const DATE_FORMATS_SPLIT =
     /((?:[^yMLdHhmsazZEwGjJ']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|L+|d+|H+|h+|J+|j+|m+|s+|a|z|Z|G+|w+))(.*)/;
 
 const PATTERN_ALIASES: {[format: string]: DateFormatterFn} = {
-  yMMMdjms: datePartGetterFactory(combine([
+  'yMMMdjms': datePartGetterFactory(combine([
     digitCondition('year', 1),
     nameCondition('month', 3),
     digitCondition('day', 1),
@@ -52,23 +52,23 @@ const PATTERN_ALIASES: {[format: string]: DateFormatterFn} = {
     digitCondition('minute', 1),
     digitCondition('second', 1),
   ])),
-  yMdjm: datePartGetterFactory(combine([
+  'yMdjm': datePartGetterFactory(combine([
     digitCondition('year', 1), digitCondition('month', 1), digitCondition('day', 1),
     digitCondition('hour', 1), digitCondition('minute', 1)
   ])),
-  yMMMMEEEEd: datePartGetterFactory(combine([
+  'yMMMMEEEEd': datePartGetterFactory(combine([
     digitCondition('year', 1), nameCondition('month', 4), nameCondition('weekday', 4),
     digitCondition('day', 1)
   ])),
-  yMMMMd: datePartGetterFactory(
+  'yMMMMd': datePartGetterFactory(
       combine([digitCondition('year', 1), nameCondition('month', 4), digitCondition('day', 1)])),
-  yMMMd: datePartGetterFactory(
+  'yMMMd': datePartGetterFactory(
       combine([digitCondition('year', 1), nameCondition('month', 3), digitCondition('day', 1)])),
-  yMd: datePartGetterFactory(
+  'yMd': datePartGetterFactory(
       combine([digitCondition('year', 1), digitCondition('month', 1), digitCondition('day', 1)])),
-  jms: datePartGetterFactory(combine(
+  'jms': datePartGetterFactory(combine(
       [digitCondition('hour', 1), digitCondition('second', 1), digitCondition('minute', 1)])),
-  jm: datePartGetterFactory(combine([digitCondition('hour', 1), digitCondition('minute', 1)]))
+  'jm': datePartGetterFactory(combine([digitCondition('hour', 1), digitCondition('minute', 1)]))
 };
 
 const DATE_FORMATS: {[format: string]: DateFormatterFn} = {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Using a DatePipe alias in a template, like | date:'shortDate' doesn't work after closure compilation.  The output looks like '2016M01' instead of the intended 11/21/2016.

**What is the new behavior?**

The DatePipe works correctly after closure compilation because the alias definitions are not renamed.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


Quota the pattern aliases to prevent closure renaming. These are quoted in DatePipe and also need to be quoted here.