### PR TITLE
fix(security): html5 filesystem url

### DIFF
--- a/modules/@angular/platform-browser/src/security/url_sanitizer.ts
+++ b/modules/@angular/platform-browser/src/security/url_sanitizer.ts
@@ -37,7 +37,7 @@ import {getDOM} from '../dom/dom_adapter';
  *
  * This regular expression was taken from the Closure sanitization library.
  */
-const SAFE_URL_PATTERN = /^(?:(?:https?|mailto|ftp|tel|file):|[^&:/?#]*(?:[/?#]|$))/gi;
+const SAFE_URL_PATTERN = /^(?:(?:https?|mailto|ftp|tel|file|filesystem):|[^&:/?#]*(?:[/?#]|$))/gi;
 
 /* A pattern that matches safe srcset values */
 const SAFE_SRCSET_PATTERN = /^(?:(?:https?|file):|[^&:/?#]*(?:[/?#]|$))/gi;

--- a/modules/@angular/platform-browser/test/security/url_sanitizer_spec.ts
+++ b/modules/@angular/platform-browser/test/security/url_sanitizer_spec.ts
@@ -35,6 +35,8 @@ export function main() {
         'HTTP://abc',
         'https://abc',
         'HTTPS://abc',
+        'filesystem://abc',
+        'FILESYSTEM://abc',
         'ftp://abc',
         'FTP://abc',
         'mailto:me@example.com',


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)
Sanitize fails for urls like : "filesystem://" 


**What is the new behavior?**
Sanitize will allow urls that start like "filesystem://"


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


Allow "filesystem://" as a safe url pattern for html5 filesystem feature