### PR TITLE
fix(compiler-cli): fix paths in source maps to be relative

### DIFF
--- a/modules/@angular/compiler-cli/tsconfig-build.json
+++ b/modules/@angular/compiler-cli/tsconfig-build.json
@@ -1,11 +1,11 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "target": "es5",
-        "lib": ["es6", "dom"],
-        "noImplicitAny": true,
-        "sourceMap": true,
         "baseUrl": ".",
+        "declaration": true,
+        "experimentalDecorators": true,
+        "noImplicitAny": true,
+        "module": "commonjs",
+        "outDir": "../../../dist/packages-dist/compiler-cli",
         "paths": {
           "@angular/core": ["../../../dist/packages-dist/core"],
           "@angular/common": ["../../../dist/packages-dist/common"],
@@ -14,11 +14,11 @@
           "@angular/platform-browser": ["../../../dist/packages-dist/platform-browser"],
           "@angular/tsc-wrapped": ["../../../dist/tools/@angular/tsc-wrapped"]
         },
-        "experimentalDecorators": true,
         "rootDir": ".",
-        "sourceRoot": ".",
-        "outDir": "../../../dist/packages-dist/compiler-cli",
-        "declaration": true,
+        "sourceMap": true,
+        "inlineSources": true,
+        "target": "es5",
+        "lib": ["es6", "dom"],
         "skipLibCheck": true
     },
     "exclude": ["integrationtest"],


### PR DESCRIPTION
The change looks bigger than it really is because I reordered the properties to match other tsconfigs we have.

The only real change is removal of sourceRoot property.

Fixes #13040