### PR TITLE
feat(http): add HttpTestingModule

### DIFF
--- a/modules/@angular/http/testing/http_testing_module.ts
+++ b/modules/@angular/http/testing/http_testing_module.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {NgModule} from '@angular/core';
+import {BaseRequestOptions, ConnectionBackend, Http, RequestOptions} from '@angular/http';
+
+import {MockBackend} from './mock_backend';
+
+
+/**
+ * Http setup factory function used for testing.
+ *
+ * @stable
+ */
+export function setupHttpTesting(backend: ConnectionBackend, defaultOptions: RequestOptions) {
+  return new Http(backend, defaultOptions);
+}
+
+/**
+ * @whatItDoes Sets up the http module to be used for testing.
+ *
+ * @howToUse
+ *
+ * ```
+ * beforeEach(() => {
+ *   TestBed.configureTestModule({
+ *     imports: [HttpTestingModule]
+ *   });
+ * });
+ * ```
+ *
+ * @description
+ *
+ * The modules sets up the Http module to be used for testing.
+ * It provides a mock implementation of {@link Http} relying on {@link MockBackend}.
+ *
+ * @stable
+ */
+@NgModule({
+  providers: [
+    MockBackend, BaseRequestOptions,
+    {provide: Http, useFactory: setupHttpTesting, deps: [MockBackend, BaseRequestOptions]}
+  ]
+})
+export class HttpTestingModule {
+}

--- a/modules/@angular/http/testing/index.ts
+++ b/modules/@angular/http/testing/index.ts
@@ -9,6 +9,7 @@
 /**
  * @module
  * @description
- * Entry point for all public APIs of the platform-server/testing package.
+ * Entry point for all public APIs of the http/testing package.
  */
 export * from './mock_backend';
+export * from './http_testing_module';

--- a/tools/public_api_guard/http/typings/testing/testing.d.ts
+++ b/tools/public_api_guard/http/typings/testing/testing.d.ts
@@ -1,3 +1,7 @@
+/** @stable */
+export declare class HttpTestingModule {
+}
+
 /** @experimental */
 export declare class MockBackend implements ConnectionBackend {
     connections: any;
@@ -19,3 +23,6 @@ export declare class MockConnection implements Connection {
     mockError(err?: Error): void;
     mockRespond(res: Response): void;
 }
+
+/** @stable */
+export declare function setupHttpTesting(backend: ConnectionBackend, defaultOptions: RequestOptions): Http;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently, setting up a test of a class that uses the Http service is really verbose

```typescript
beforeEach(() => TestBed.configureTestingModule({
  providers: [
    MockBackend,
    BaseRequestOptions,
    {
      provide: Http,
      useFactory: (backend, defaultOptions) => new Http(backend, defaultOptions),
      deps: [MockBackend, BaseRequestOptions]
    },
    UserService
 ]
}));
```

**What is the new behavior?**

This PR introduces `HttpTestingModule`, a very simple module that can be imported in tests.
We discussed the idea with @robwormald at ngEurope.
This is a naive first try, let me know if the idea still interest the team and how I can improve it if needed.

The PR allows to set up the previous test like:

```typescript
beforeEach(() => TestBed.configureTestingModule({
  imports: [HttpTestingModule],
  providers: [UserService]
}));
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

