### PR TITLE
Fix metadata

### DIFF
--- a/modules/@angular/compiler-cli/package.json
+++ b/modules/@angular/compiler-cli/package.json
@@ -9,7 +9,7 @@
     "ng-xi18n": "./src/extract_i18n.js"
   },
   "dependencies": {
-    "@angular/tsc-wrapped": "^0.4.0",
+    "@angular/tsc-wrapped": "0.4.1",
     "reflect-metadata": "^0.1.2",
     "minimist": "^1.2.0"
   },

--- a/tools/@angular/tsc-wrapped/package.json
+++ b/tools/@angular/tsc-wrapped/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/tsc-wrapped",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Wraps the tsc CLI, allowing extensions.",
   "homepage": "https://github.com/angular/angular/tree/master/tools/tsc-wrapped",
   "bugs": "https://github.com/angular/angular/issues",


### PR DESCRIPTION
We bumped the version number in our metadata. However, we should still produce the old metadata so that authors that stay on an older Angular version can still consume components published with a newer Angular version.

Related to #13057