### PR TITLE
feat(core): expose destroy() method on ViewRef

### DIFF
--- a/modules/@angular/core/src/linker/view_ref.ts
+++ b/modules/@angular/core/src/linker/view_ref.ts
@@ -18,6 +18,11 @@ import {AppView} from './view';
  * @stable
  */
 export abstract class ViewRef extends ChangeDetectorRef {
+  /**
+   * Destroys the view and all of the data structures associated with it.
+   */
+  abstract destroy(): void;
+
   get destroyed(): boolean { return <boolean>unimplemented(); }
 
   abstract onDestroy(callback: Function): any /** TODO #9100 */;
@@ -81,11 +86,6 @@ export abstract class EmbeddedViewRef<C> extends ViewRef {
   get context(): C { return unimplemented(); }
 
   get rootNodes(): any[] { return <any[]>unimplemented(); };
-
-  /**
-   * Destroys the view and all of the data structures associated with it.
-   */
-  abstract destroy(): void;
 }
 
 export class ViewRef_<C> implements EmbeddedViewRef<C>, ChangeDetectorRef {

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -399,7 +399,6 @@ export declare class ElementRef {
 export declare abstract class EmbeddedViewRef<C> extends ViewRef {
     context: C;
     rootNodes: any[];
-    abstract destroy(): void;
 }
 
 /** @stable */
@@ -1002,6 +1001,7 @@ export declare enum ViewEncapsulation {
 /** @stable */
 export declare abstract class ViewRef extends ChangeDetectorRef {
     destroyed: boolean;
+    abstract destroy(): void;
     abstract onDestroy(callback: Function): any;
 }
 


### PR DESCRIPTION
Discussed in person with @tbosch - the motivation for this change is to make it easier to work with various types of views by providing more uniformity between embedded views and component views. 