### PR TITLE
[2.4] fix(http):  MockConnection.mockError() accept a Response object

### DIFF
--- a/modules/@angular/http/testing/mock_backend.ts
+++ b/modules/@angular/http/testing/mock_backend.ts
@@ -82,7 +82,6 @@ export class MockConnection implements Connection {
     // }
   }
 
-  // TODO(jeffbcross): consider using Response type
   /**
    * Emits the provided error object as an error to the {@link Response} {@link EventEmitter}
    * returned
@@ -98,7 +97,7 @@ export class MockConnection implements Connection {
    * ```
    *
    */
-  mockError(err?: Error) {
+  mockError(err?: Error|Response) {
     // Matches ResourceLoader semantics
     this.readyState = ReadyState.Done;
     this.response.error(err);

--- a/tools/public_api_guard/http/testing/index.d.ts
+++ b/tools/public_api_guard/http/testing/index.d.ts
@@ -16,6 +16,6 @@ export declare class MockConnection implements Connection {
     response: ReplaySubject<Response>;
     constructor(req: Request);
     mockDownload(res: Response): void;
-    mockError(err?: Error): void;
+    mockError(err?: Error | Response): void;
     mockRespond(res: Response): void;
 }


### PR DESCRIPTION
Fixes https://github.com/angular/angular/issues/7135