### PR TITLE
feat(core): allow to bootstrap multiple components with different sel…

### DIFF
--- a/modules/@angular/compiler/src/url_resolver.ts
+++ b/modules/@angular/compiler/src/url_resolver.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, PACKAGE_ROOT_URL} from '@angular/core';
+import {Inject, Injectable, PACKAGE_ROOT_URL, Provider} from '@angular/core';
 
 import {isBlank, isPresent} from './facade/lang';
 
@@ -24,7 +24,7 @@ export function createOfflineCompileUrlResolver(): UrlResolver {
 /**
  * A default provider for {@link PACKAGE_ROOT_URL} that maps to '/'.
  */
-export var DEFAULT_PACKAGE_URL_PROVIDER = {
+export const DEFAULT_PACKAGE_URL_PROVIDER: Provider = {
   provide: PACKAGE_ROOT_URL,
   useValue: '/'
 };

--- a/modules/@angular/core/src/application_tokens.ts
+++ b/modules/@angular/core/src/application_tokens.ts
@@ -19,7 +19,7 @@ import {OpaqueToken} from './di';
  * using this token.
  * @experimental
  */
-export const APP_ID: any = new OpaqueToken('AppId');
+export const APP_ID: OpaqueToken = new OpaqueToken('AppId');
 
 export function _appIdRandomProviderFactory() {
   return `${_randomChar()}${_randomChar()}${_randomChar()}`;
@@ -43,7 +43,7 @@ function _randomChar(): string {
  * A function that will be executed when a platform is initialized.
  * @experimental
  */
-export const PLATFORM_INITIALIZER: any = new OpaqueToken('Platform Initializer');
+export const PLATFORM_INITIALIZER: OpaqueToken = new OpaqueToken('Platform Initializer');
 
 /**
  * All callbacks provided via this token will be called for every component that is bootstrapped.
@@ -53,10 +53,18 @@ export const PLATFORM_INITIALIZER: any = new OpaqueToken('Platform Initializer')
  *
  * @experimental
  */
-export const APP_BOOTSTRAP_LISTENER = new OpaqueToken('appBootstrapListener');
+export const APP_BOOTSTRAP_LISTENER: OpaqueToken = new OpaqueToken('appBootstrapListener');
 
 /**
  * A token which indicates the root directory of the application
  * @experimental
  */
-export const PACKAGE_ROOT_URL: any = new OpaqueToken('Application Packages Root URL');
+export const PACKAGE_ROOT_URL: OpaqueToken = new OpaqueToken('Application Packages Root URL');
+
+/**
+ * A token which can be used to provide components to bootstrap. Useful when there are multiple
+ * applications on the same page.
+ *
+ * @experimental
+ */
+export const BOOTSTRAP_COMPONENTS: OpaqueToken = new OpaqueToken('Bootstrap Components');

--- a/modules/@angular/core/src/core.ts
+++ b/modules/@angular/core/src/core.ts
@@ -14,8 +14,8 @@
 export * from './metadata';
 export * from './util';
 export * from './di';
-export {createPlatform, assertPlatform, destroyPlatform, getPlatform, PlatformRef, ApplicationRef, enableProdMode, isDevMode, createPlatformFactory, NgProbeToken} from './application_ref';
-export {APP_ID, PACKAGE_ROOT_URL, PLATFORM_INITIALIZER, APP_BOOTSTRAP_LISTENER} from './application_tokens';
+export {createPlatform, assertPlatform, destroyPlatform, getPlatform, PlatformRef, ApplicationRef, enableProdMode, isDevMode, createPlatformFactory, NgProbeToken, BootstrapComponent} from './application_ref';
+export {APP_ID, PACKAGE_ROOT_URL, PLATFORM_INITIALIZER, APP_BOOTSTRAP_LISTENER, BOOTSTRAP_COMPONENTS} from './application_tokens';
 export {APP_INITIALIZER, ApplicationInitStatus} from './application_init';
 export * from './zone';
 export * from './render';

--- a/modules/@angular/core/test/application_ref_spec.ts
+++ b/modules/@angular/core/test/application_ref_spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, CompilerFactory, Component, NgModule, PlatformRef, Type, ViewChild, ViewContainerRef} from '@angular/core';
+import {platformCoreDynamic} from '@angular/compiler';
+import {APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, BOOTSTRAP_COMPONENTS, CompilerFactory, Component, NgModule, PlatformRef, Type, ViewChild, ViewContainerRef, createPlatformFactory} from '@angular/core';
 import {ApplicationRef, ApplicationRef_} from '@angular/core/src/application_ref';
 import {ErrorHandler} from '@angular/core/src/error_handler';
 import {ComponentRef} from '@angular/core/src/linker/component_factory';
@@ -30,7 +31,9 @@ export function main() {
     beforeEach(() => {
       fakeDoc = getDOM().createHtmlDocument();
       const el = getDOM().createElement('comp', fakeDoc);
+      const customEl = getDOM().createElement('custom-comp', fakeDoc);
       getDOM().appendChild(fakeDoc.body, el);
+      getDOM().appendChild(fakeDoc.body, customEl);
       mockConsole = new MockConsole();
     });
 
@@ -202,7 +205,21 @@ export function main() {
                });
          }));
 
-      it('should error if neither `ngDoBootstrap` nor @NgModule.bootstrap was specified',
+      // it('should auto bootstrap components provided via BOOTSTRAP_COMPONENTS', async(() => {
+      //      const components = [
+      //        {type: SomeComponent, selector: 'comp'},
+      //        {type: SomeComponent, selector: 'custom-comp'}
+      //      ];
+      //      const providers = [{provide: BOOTSTRAP_COMPONENTS, useValue: components}];
+      //      const platform =
+      //          createPlatformFactory(platformCoreDynamic, 'bootstrapTest', providers)();
+      //      platform.bootstrapModule(createModule({ngDoBootstrap: false})).then((moduleRef) => {
+      //        const appRef: ApplicationRef = moduleRef.injector.get(ApplicationRef);
+      //        expect(appRef.componentTypes).toEqual([SomeComponent, SomeComponent]);
+      //      });
+      //    }));
+
+      it('should error if neither `ngDoBootstrap`, nor @NgModule.bootstrap, nor BOOTSTRAP_COMPONENTS was specified',
          async(() => {
            defaultPlatform.bootstrapModule(createModule({ngDoBootstrap: false}))
                .then(() => expect(false).toBe(true), (e) => {

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -130,7 +130,7 @@ export declare abstract class AnimationWithStepsMetadata extends AnimationMetada
 export declare const APP_BOOTSTRAP_LISTENER: OpaqueToken;
 
 /** @experimental */
-export declare const APP_ID: any;
+export declare const APP_ID: OpaqueToken;
 
 /** @experimental */
 export declare const APP_INITIALIZER: any;
@@ -168,6 +168,15 @@ export declare const Attribute: AttributeDecorator;
 
 /** @experimental */
 export declare const AUTO_STYLE: string;
+
+/** @experimental */
+export declare const BOOTSTRAP_COMPONENTS: OpaqueToken;
+
+/** @experimental */
+export interface BootstrapComponent {
+    selector: string;
+    type: Type<any>;
+}
 
 /** @stable */
 export declare enum ChangeDetectionStrategy {
@@ -666,7 +675,7 @@ export interface OptionalDecorator {
 export declare const Output: OutputDecorator;
 
 /** @experimental */
-export declare const PACKAGE_ROOT_URL: any;
+export declare const PACKAGE_ROOT_URL: OpaqueToken;
 
 /** @stable */
 export declare const Pipe: PipeDecorator;
@@ -677,7 +686,7 @@ export interface PipeTransform {
 }
 
 /** @experimental */
-export declare const PLATFORM_INITIALIZER: any;
+export declare const PLATFORM_INITIALIZER: OpaqueToken;
 
 /** @experimental */
 export declare const platformCore: (extraProviders?: Provider[]) => PlatformRef;


### PR DESCRIPTION
Fixes https://github.com/angular/angular/issues/7136

I need help with unit test. For test case I need to create a new PlatformRef (with providers) but I can't do it because there's already `defaultPlatform` present and I cannot destroy  `defaultPlatform` because it's already marked as destroyed (wtf) and `defaultPlatform.destroy()` throws an error.