### PR TITLE
feat(platform-browser): use attachShadow if createShadowRoot not available

### DIFF
--- a/modules/@angular/platform-browser/src/dom/dom_renderer.ts
+++ b/modules/@angular/platform-browser/src/dom/dom_renderer.ts
@@ -15,7 +15,6 @@ import {AnimationDriver} from './animation_driver';
 import {DOCUMENT} from './dom_tokens';
 import {EventManager} from './events/event_manager';
 import {DomSharedStylesHost} from './shared_styles_host';
-import {camelCaseToDashCase} from './util';
 
 export const NAMESPACE_URIS: {[ns: string]: string} = {
   'xlink': 'http://www.w3.org/1999/xlink',
@@ -66,10 +65,15 @@ export const DIRECT_DOM_RENDERER: DirectRenderer = {
   parentElement(node: Node): Element{return node.parentNode as Element;}
 };
 
+function attachShadow() {
+  return (<any>document.body).attachShadow.call(this, {mode: 'open'});
+}
+
 export class DomRenderer implements Renderer {
   private _contentAttr: string;
   private _hostAttr: string;
   private _styles: string[];
+  private _createShadowRoot: Function = (<any>document.body).createShadowRoot || attachShadow;
 
   directRenderer: DirectRenderer = DIRECT_DOM_RENDERER;
 
@@ -126,7 +130,7 @@ export class DomRenderer implements Renderer {
   createViewRoot(hostElement: Element): Element|DocumentFragment {
     let nodesParent: Element|DocumentFragment;
     if (this.componentProto.encapsulation === ViewEncapsulation.Native) {
-      nodesParent = (hostElement as any).createShadowRoot();
+      nodesParent = this._createShadowRoot.call(hostElement);
       this._rootRenderer.sharedStylesHost.addHost(nodesParent);
       for (let i = 0; i < this._styles.length; i++) {
         const styleEl = document.createElement('style');


### PR DESCRIPTION
Fixes https://github.com/angular/angular/issues/7856

Also note that `createShadowRoot` and `attachShadow` are not fully interchangeable. 
`createShadowRoot` uses `<content>` element for content projection but it was deprecated in favor of `<slot>` element. Thus [this](https://github.com/angular/angular/blob/master/modules/%40angular/core/test/linker/projection_integration_spec.ts#L369) test will fails with `attachShadow`. Currently we can't even use  `<slot>` element in Angular (throws unknown element exception).