### PR TITLE
fix(common): update DatePipe to allow closure compilation

### DIFF
--- a/modules/@angular/facade/src/intl.ts
+++ b/modules/@angular/facade/src/intl.ts
@@ -44,6 +44,7 @@ const DATE_FORMATS_SPLIT =
     /((?:[^yMLdHhmsazZEwGjJ']+)|(?:'(?:[^']|'')*')|(?:E+|y+|M+|L+|d+|H+|h+|J+|j+|m+|s+|a|z|Z|G+|w+))(.*)/;
 
 const PATTERN_ALIASES: {[format: string]: DateFormatterFn} = {
+  // Keys are quoted so they do not get renamed during closure compilation.
   'yMMMdjms': datePartGetterFactory(combine([
     digitCondition('year', 1),
     nameCondition('month', 3),
@@ -72,48 +73,50 @@ const PATTERN_ALIASES: {[format: string]: DateFormatterFn} = {
 };
 
 const DATE_FORMATS: {[format: string]: DateFormatterFn} = {
-  yyyy: datePartGetterFactory(digitCondition('year', 4)),
-  yy: datePartGetterFactory(digitCondition('year', 2)),
-  y: datePartGetterFactory(digitCondition('year', 1)),
-  MMMM: datePartGetterFactory(nameCondition('month', 4)),
-  MMM: datePartGetterFactory(nameCondition('month', 3)),
-  MM: datePartGetterFactory(digitCondition('month', 2)),
-  M: datePartGetterFactory(digitCondition('month', 1)),
-  LLLL: datePartGetterFactory(nameCondition('month', 4)),
-  L: datePartGetterFactory(nameCondition('month', 1)),
-  dd: datePartGetterFactory(digitCondition('day', 2)),
-  d: datePartGetterFactory(digitCondition('day', 1)),
-  HH: digitModifier(
+  // Keys are quoted so they do not get renamed.
+  'yyyy': datePartGetterFactory(digitCondition('year', 4)),
+  'yy': datePartGetterFactory(digitCondition('year', 2)),
+  'y': datePartGetterFactory(digitCondition('year', 1)),
+  'MMMM': datePartGetterFactory(nameCondition('month', 4)),
+  'MMM': datePartGetterFactory(nameCondition('month', 3)),
+  'MM': datePartGetterFactory(digitCondition('month', 2)),
+  'M': datePartGetterFactory(digitCondition('month', 1)),
+  'LLLL': datePartGetterFactory(nameCondition('month', 4)),
+  'L': datePartGetterFactory(nameCondition('month', 1)),
+  'dd': datePartGetterFactory(digitCondition('day', 2)),
+  'd': datePartGetterFactory(digitCondition('day', 1)),
+  'HH': digitModifier(
       hourExtractor(datePartGetterFactory(hour12Modify(digitCondition('hour', 2), false)))),
-  H: hourExtractor(datePartGetterFactory(hour12Modify(digitCondition('hour', 1), false))),
-  hh: digitModifier(
+  'H': hourExtractor(datePartGetterFactory(hour12Modify(digitCondition('hour', 1), false))),
+  'hh': digitModifier(
       hourExtractor(datePartGetterFactory(hour12Modify(digitCondition('hour', 2), true)))),
-  h: hourExtractor(datePartGetterFactory(hour12Modify(digitCondition('hour', 1), true))),
-  jj: datePartGetterFactory(digitCondition('hour', 2)),
-  j: datePartGetterFactory(digitCondition('hour', 1)),
-  mm: digitModifier(datePartGetterFactory(digitCondition('minute', 2))),
-  m: datePartGetterFactory(digitCondition('minute', 1)),
-  ss: digitModifier(datePartGetterFactory(digitCondition('second', 2))),
-  s: datePartGetterFactory(digitCondition('second', 1)),
+  'h': hourExtractor(datePartGetterFactory(hour12Modify(digitCondition('hour', 1), true))),
+  'jj': datePartGetterFactory(digitCondition('hour', 2)),
+  'j': datePartGetterFactory(digitCondition('hour', 1)),
+  'mm': digitModifier(datePartGetterFactory(digitCondition('minute', 2))),
+  'm': datePartGetterFactory(digitCondition('minute', 1)),
+  'ss': digitModifier(datePartGetterFactory(digitCondition('second', 2))),
+  's': datePartGetterFactory(digitCondition('second', 1)),
   // while ISO 8601 requires fractions to be prefixed with `.` or `,`
   // we can be just safely rely on using `sss` since we currently don't support single or two digit
   // fractions
-  sss: datePartGetterFactory(digitCondition('second', 3)),
-  EEEE: datePartGetterFactory(nameCondition('weekday', 4)),
-  EEE: datePartGetterFactory(nameCondition('weekday', 3)),
-  EE: datePartGetterFactory(nameCondition('weekday', 2)),
-  E: datePartGetterFactory(nameCondition('weekday', 1)),
-  a: hourClockExtractor(datePartGetterFactory(hour12Modify(digitCondition('hour', 1), true))),
-  Z: timeZoneGetter('short'),
-  z: timeZoneGetter('long'),
-  ww: datePartGetterFactory({}),  // Week of year, padded (00-53). Week 01 is the week with the
-                                  // first Thursday of the year. not support ?
-  w: datePartGetterFactory({}),   // Week of year (0-53). Week 1 is the week with the first Thursday
+  'sss': datePartGetterFactory(digitCondition('second', 3)),
+  'EEEE': datePartGetterFactory(nameCondition('weekday', 4)),
+  'EEE': datePartGetterFactory(nameCondition('weekday', 3)),
+  'EE': datePartGetterFactory(nameCondition('weekday', 2)),
+  'E': datePartGetterFactory(nameCondition('weekday', 1)),
+  'a': hourClockExtractor(datePartGetterFactory(hour12Modify(digitCondition('hour', 1), true))),
+  'Z': timeZoneGetter('short'),
+  'z': timeZoneGetter('long'),
+  'ww': datePartGetterFactory({}),  // Week of year, padded (00-53). Week 01 is the week with the
+                                    // first Thursday of the year. not support ?
+  'w':
+      datePartGetterFactory({}),  // Week of year (0-53). Week 1 is the week with the first Thursday
                                   // of the year not support ?
-  G: datePartGetterFactory(nameCondition('era', 1)),
-  GG: datePartGetterFactory(nameCondition('era', 2)),
-  GGG: datePartGetterFactory(nameCondition('era', 3)),
-  GGGG: datePartGetterFactory(nameCondition('era', 4))
+  'G': datePartGetterFactory(nameCondition('era', 1)),
+  'GG': datePartGetterFactory(nameCondition('era', 2)),
+  'GGG': datePartGetterFactory(nameCondition('era', 3)),
+  'GGGG': datePartGetterFactory(nameCondition('era', 4))
 };
 
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)


Using a DatePipe custom format in a template, like | date:'yyMMdd' doesn't work after closure compilation.

**What is the new behavior?**


DatePipe with custom formats work correctly after closure compilation because the format strings are not renamed.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


Quote the date formats to prevent closure renaming.  These are specified as strings in templates using DatePipes and also need to be quoted here.

This is a followup from https://github.com/angular/angular/pull/13012.