### PR TITLE
feat(router): add UrlSegment[] to CanLoad interface

### DIFF
--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -255,7 +255,7 @@ class ApplyRedirects {
     if (!matched) return noMatch(rawSegmentGroup);
 
     const rawSlicedSegments = segments.slice(lastChild);
-    const childConfig$ = this.getChildConfig(ngModule, route);
+    const childConfig$ = this.getChildConfig(ngModule, route, segments);
 
     return childConfig$.pipe(mergeMap((routerConfig: LoadedRouterConfig) => {
       const childModule = routerConfig.module;
@@ -282,7 +282,8 @@ class ApplyRedirects {
     }));
   }
 
-  private getChildConfig(ngModule: NgModuleRef<any>, route: Route): Observable<LoadedRouterConfig> {
+  private getChildConfig(ngModule: NgModuleRef<any>, route: Route, segments: UrlSegment[]):
+      Observable<LoadedRouterConfig> {
     if (route.children) {
       // The children belong to the same module
       return of (new LoadedRouterConfig(route.children, ngModule));
@@ -294,16 +295,17 @@ class ApplyRedirects {
         return of (route._loadedConfig);
       }
 
-      return runCanLoadGuard(ngModule.injector, route).pipe(mergeMap((shouldLoad: boolean) => {
-        if (shouldLoad) {
-          return this.configLoader.load(ngModule.injector, route)
-              .pipe(map((cfg: LoadedRouterConfig) => {
-                route._loadedConfig = cfg;
-                return cfg;
-              }));
-        }
-        return canLoadFails(route);
-      }));
+      return runCanLoadGuard(ngModule.injector, route, segments)
+          .pipe(mergeMap((shouldLoad: boolean) => {
+            if (shouldLoad) {
+              return this.configLoader.load(ngModule.injector, route)
+                  .pipe(map((cfg: LoadedRouterConfig) => {
+                    route._loadedConfig = cfg;
+                    return cfg;
+                  }));
+            }
+            return canLoadFails(route);
+          }));
     }
 
     return of (new LoadedRouterConfig([], ngModule));
@@ -399,13 +401,15 @@ class ApplyRedirects {
   }
 }
 
-function runCanLoadGuard(moduleInjector: Injector, route: Route): Observable<boolean> {
+function runCanLoadGuard(
+    moduleInjector: Injector, route: Route, segments: UrlSegment[]): Observable<boolean> {
   const canLoad = route.canLoad;
   if (!canLoad || canLoad.length === 0) return of (true);
 
   const obs = from(canLoad).pipe(map((injectionToken: any) => {
     const guard = moduleInjector.get(injectionToken);
-    return wrapIntoObservable(guard.canLoad ? guard.canLoad(route) : guard(route));
+    return wrapIntoObservable(
+        guard.canLoad ? guard.canLoad(route, segments) : guard(route, segments));
   }));
 
   return andObservables(obs);

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -10,6 +10,7 @@ import {Observable} from 'rxjs';
 
 import {Route} from './config';
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
+import {UrlSegment} from './url_tree';
 
 
 /**
@@ -320,7 +321,7 @@ export interface Resolve<T> {
  * ```
  * class UserToken {}
  * class Permissions {
- *   canLoadChildren(user: UserToken, id: string): boolean {
+ *   canLoadChildren(user: UserToken, id: string, segments: UrlSegment[]): boolean {
  *     return true;
  *   }
  * }
@@ -329,8 +330,8 @@ export interface Resolve<T> {
  * class CanLoadTeamSection implements CanLoad {
  *   constructor(private permissions: Permissions, private currentUser: UserToken) {}
  *
- *   canLoad(route: Route): Observable<boolean>|Promise<boolean>|boolean {
- *     return this.permissions.canLoadChildren(this.currentUser, route);
+ *   canLoad(route: Route, segments: UrlSegment[]): Observable<boolean>|Promise<boolean>|boolean {
+ *     return this.permissions.canLoadChildren(this.currentUser, route, segments);
  *   }
  * }
  *
@@ -367,7 +368,7 @@ export interface Resolve<T> {
  *   providers: [
  *     {
  *       provide: 'canLoadTeamSection',
- *       useValue: (route: Route) => true
+ *       useValue: (route: Route, segments: UrlSegment[]) => true
  *     }
  *   ]
  * })
@@ -376,4 +377,6 @@ export interface Resolve<T> {
  *
  * @stable
  */
-export interface CanLoad { canLoad(route: Route): Observable<boolean>|Promise<boolean>|boolean; }
+export interface CanLoad {
+  canLoad(route: Route, segments: UrlSegment[]): Observable<boolean>|Promise<boolean>|boolean;
+}

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -72,7 +72,7 @@ export interface CanDeactivate<T> {
 
 /** @stable */
 export interface CanLoad {
-    canLoad(route: Route): Observable<boolean> | Promise<boolean> | boolean;
+    canLoad(route: Route, segments: UrlSegment[]): Observable<boolean> | Promise<boolean> | boolean;
 }
 
 /** @experimental */


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The `Route` object as passed to implementations of `CanLoad` which only provides minimal information on the page which should be navigated to. (see #12411)

**What is the new behavior?**

Additionally to `Route` an `UrlSegment[]` is passed to implementations of `CanLoad` as a second parameter. It contains the array of path elements the user tried to navigate to before `canLoad` is evaluated.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:


CanLoad now defines UrlSegment[] as a second parameter of the function.
Users can store the initial url segments and refer to them later, e.g. to go
back to the original url after authentication via router.navigate(urlSegments).
Existing code still works as before because the second function parameter
does not have to be defined.

Closes #12411