### PR TITLE
refactor(compiler-cli): refactor compiler host parameters

### DIFF
--- a/modules/@angular/compiler-cli/index.ts
+++ b/modules/@angular/compiler-cli/index.ts
@@ -8,7 +8,7 @@
 
 export {AotCompilerHost, AotCompilerHost as StaticReflectorHost, StaticReflector, StaticSymbol} from '@angular/compiler';
 export {CodeGenerator} from './src/codegen';
-export {CompilerHost, CompilerHostContext, NodeCompilerHostContext} from './src/compiler_host';
+export {CompilerHost, CompilerHostContext, ModuleResolutionHostAdapter, NodeCompilerHostContext} from './src/compiler_host';
 export {Extractor} from './src/extractor';
 
 export * from '@angular/tsc-wrapped';

--- a/modules/@angular/compiler-cli/src/codegen.ts
+++ b/modules/@angular/compiler-cli/src/codegen.ts
@@ -17,7 +17,7 @@ import {readFileSync} from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
-import {CompilerHost, CompilerHostContext} from './compiler_host';
+import {CompilerHost, CompilerHostContext, ModuleResolutionHostAdapter} from './compiler_host';
 import {PathMappedCompilerHost} from './path_mapped_compiler_host';
 import {Console} from './private_import_core';
 
@@ -82,9 +82,9 @@ export class CodeGenerator {
       ngCompilerHost?: CompilerHost): CodeGenerator {
     if (!ngCompilerHost) {
       const usePathMapping = !!options.rootDirs && options.rootDirs.length > 0;
-      ngCompilerHost = usePathMapping ?
-          new PathMappedCompilerHost(program, tsCompilerHost, options, compilerHostContext) :
-          new CompilerHost(program, tsCompilerHost, options, compilerHostContext);
+      const context = compilerHostContext || new ModuleResolutionHostAdapter(tsCompilerHost);
+      ngCompilerHost = usePathMapping ? new PathMappedCompilerHost(program, options, context) :
+                                        new CompilerHost(program, options, context);
     }
     const transFile = cliOptions.i18nFile;
     const locale = cliOptions.locale;

--- a/modules/@angular/compiler-cli/src/extractor.ts
+++ b/modules/@angular/compiler-cli/src/extractor.ts
@@ -18,7 +18,7 @@ import * as tsc from '@angular/tsc-wrapped';
 import * as ts from 'typescript';
 
 import {excludeFilePattern} from './codegen';
-import {CompilerHost} from './compiler_host';
+import {CompilerHost, ModuleResolutionHostAdapter} from './compiler_host';
 
 export class Extractor {
   constructor(
@@ -32,8 +32,10 @@ export class Extractor {
 
   static create(
       options: tsc.AngularCompilerOptions, translationsFormat: string, program: ts.Program,
-      tsCompilerHost: ts.CompilerHost, ngCompilerHost?: CompilerHost): Extractor {
-    if (!ngCompilerHost) ngCompilerHost = new CompilerHost(program, tsCompilerHost, options);
+      moduleResolverHost: ts.ModuleResolutionHost, ngCompilerHost?: CompilerHost): Extractor {
+    if (!ngCompilerHost)
+      ngCompilerHost =
+          new CompilerHost(program, options, new ModuleResolutionHostAdapter(moduleResolverHost));
     const {extractor: ngExtractor} = compiler.Extractor.create(
         ngCompilerHost, {excludeFilePattern: excludeFilePattern(options)});
     return new Extractor(ngExtractor, ngCompilerHost, program);

--- a/modules/@angular/compiler-cli/src/path_mapped_compiler_host.ts
+++ b/modules/@angular/compiler-cli/src/path_mapped_compiler_host.ts
@@ -25,10 +25,8 @@ const DTS = /\.d\.ts$/;
  * loader what to do.
  */
 export class PathMappedCompilerHost extends CompilerHost {
-  constructor(
-      program: ts.Program, compilerHost: ts.CompilerHost, options: AngularCompilerOptions,
-      context?: CompilerHostContext) {
-    super(program, compilerHost, options, context);
+  constructor(program: ts.Program, options: AngularCompilerOptions, context: CompilerHostContext) {
+    super(program, options, context);
   }
 
   getCanonicalFileName(fileName: string): string {
@@ -119,7 +117,7 @@ export class PathMappedCompilerHost extends CompilerHost {
   getMetadataFor(filePath: string): ModuleMetadata[] {
     for (const root of this.options.rootDirs || []) {
       const rootedPath = path.join(root, filePath);
-      if (!this.compilerHost.fileExists(rootedPath)) {
+      if (!this.context.fileExists(rootedPath)) {
         // If the file doesn't exists then we cannot return metadata for the file.
         // This will occur if the user refernced a declared module for which no file
         // exists for the module (i.e. jQuery or angularjs).

--- a/modules/@angular/compiler-cli/test/aot_host_spec.ts
+++ b/modules/@angular/compiler-cli/test/aot_host_spec.ts
@@ -14,14 +14,13 @@ import {Directory, Entry, MockAotContext, MockCompilerHost} from './mocks';
 
 describe('CompilerHost', () => {
   let context: MockAotContext;
-  let host: ts.CompilerHost;
   let program: ts.Program;
   let hostNestedGenDir: CompilerHost;
   let hostSiblingGenDir: CompilerHost;
 
   beforeEach(() => {
     context = new MockAotContext('/tmp/src', clone(FILES));
-    host = new MockCompilerHost(context);
+    const host = new MockCompilerHost(context);
     program = ts.createProgram(
         ['main.ts'], {
           module: ts.ModuleKind.CommonJS,
@@ -33,7 +32,7 @@ describe('CompilerHost', () => {
       throw new Error('Expected no errors');
     }
     hostNestedGenDir = new CompilerHost(
-        program, host, {
+        program, {
           genDir: '/tmp/project/src/gen/',
           basePath: '/tmp/project/src',
           skipMetadataEmit: false,
@@ -43,7 +42,7 @@ describe('CompilerHost', () => {
         },
         context);
     hostSiblingGenDir = new CompilerHost(
-        program, host, {
+        program, {
           genDir: '/tmp/project/gen',
           basePath: '/tmp/project/src/',
           skipMetadataEmit: false,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Refactoring (no functional changes, no api changes)
```

**What is the current behavior?** (You can also link to an open issue here)

The `CompilerHost` requires a TypeScript `CompilerHost` but the dependency can be reduced to a `ModuleResolverHost`. 

**What is the new behavior?**

Making this change allows the `language-service` tp reuse the `CompilerHost` instead of using its own.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
