### PR TITLE
refactor(compiler): change ngc error handling

### DIFF
--- a/modules/@angular/compiler-cli/src/main.ts
+++ b/modules/@angular/compiler-cli/src/main.ts
@@ -22,7 +22,8 @@ function codegen(
   return CodeGenerator.create(ngOptions, cliOptions, program, host).codegen();
 }
 
-export function main(args: any, consoleError: (s: string) => void = console.error): Promise<number> {
+export function main(
+    args: any, consoleError: (s: string) => void = console.error): Promise<number> {
   const project = args.p || args.project || '.';
   const cliOptions = new tsc.NgcCliOptions(args);
 

--- a/modules/@angular/compiler-cli/src/main.ts
+++ b/modules/@angular/compiler-cli/src/main.ts
@@ -22,14 +22,14 @@ function codegen(
   return CodeGenerator.create(ngOptions, cliOptions, program, host).codegen();
 }
 
-export function main(args: any, consoleError: any): Promise<number> {
+export function main(args: any, consoleError: (s: string) => void = console.error): Promise<number> {
   const project = args.p || args.project || '.';
   const cliOptions = new tsc.NgcCliOptions(args);
 
   return tsc.main(project, cliOptions, codegen).then(() => 0).catch(e => {
     if (e instanceof tsc.UserError) {
       consoleError(e.message);
-      return Promise.resolve(0);
+      return Promise.resolve(1);
     } else {
       consoleError(e.stack);
       consoleError('Compilation failed');
@@ -41,5 +41,5 @@ export function main(args: any, consoleError: any): Promise<number> {
 // CLI entry point
 if (require.main === module) {
   const args = require('minimist')(process.argv.slice(2));
-  main(args, console.error).then((exitCode: number) => process.exit(exitCode));
+  main(args).then((exitCode: number) => process.exit(exitCode));
 }

--- a/modules/@angular/compiler-cli/test/main_spec.ts
+++ b/modules/@angular/compiler-cli/test/main_spec.ts
@@ -44,7 +44,7 @@ describe('compiler-cli', () => {
   it('should compile without errors', (done) => {
     write('test.ts', 'export const A = 1;');
 
-    const mockConsole = {error: {}};
+    const mockConsole = {error: (s: string) => {}};
 
     spyOn(mockConsole, 'error');
 
@@ -58,32 +58,88 @@ describe('compiler-cli', () => {
   });
 
   it('should not print the stack trace if user input file does not exist', (done) => {
-    const mockConsole = {error: {}};
+    const mockConsole = {error: (s: string) => {}};
 
     spyOn(mockConsole, 'error');
 
     main({p: basePath}, mockConsole.error)
         .then((exitCode) => {
-          expect(mockConsole.error).toHaveBeenCalled();
+          expect(mockConsole.error).toHaveBeenCalledWith(`Error File '` + path.join(basePath, 'test.ts') + `' not found.`);
           expect(mockConsole.error).not.toHaveBeenCalledWith('Compilation failed');
-          expect(exitCode).toEqual(0);
+          expect(exitCode).toEqual(1);
           done();
         })
         .catch(e => done.fail(e));
   });
 
   it('should not print the stack trace if user input file is malformed', (done) => {
-    write('test.ts', 'foo bar');
+    write('test.ts', 'foo;');
 
-    const mockConsole = {error: {}};
+    const mockConsole = {error: (s: string) => {}};
 
     spyOn(mockConsole, 'error');
 
     main({p: basePath}, mockConsole.error)
         .then((exitCode) => {
-          expect(mockConsole.error).toHaveBeenCalled();
+          expect(mockConsole.error).toHaveBeenCalledWith('Error at ' + path.join(basePath, 'test.ts') + `:1:1: Cannot find name 'foo'.`);
           expect(mockConsole.error).not.toHaveBeenCalledWith('Compilation failed');
-          expect(exitCode).toEqual(0);
+          expect(exitCode).toEqual(1);
+          done();
+        })
+        .catch(e => done.fail(e));
+  });
+
+  it('should not print the stack trace if cannot find the imported module', (done) => {
+    write('test.ts', "import {MyClass} from './not-exist-deps';");
+
+    const mockConsole = {error: (s: string) => {}};
+
+    spyOn(mockConsole, 'error');
+
+    main({p: basePath}, mockConsole.error)
+        .then((exitCode) => {
+          expect(mockConsole.error).toHaveBeenCalledWith('Error at ' + path.join(basePath, 'test.ts') + `:1:23: Cannot find module './not-exist-deps'.`);
+          expect(mockConsole.error).not.toHaveBeenCalledWith('Compilation failed');
+          expect(exitCode).toEqual(1);
+          done();
+        })
+        .catch(e => done.fail(e));
+  });
+
+  it('should not print the stack trace if cannot import', (done) => {
+    write('empty-deps.ts', 'export const A = 1;');
+    write('test.ts', "import {MyClass} from './empty-deps';");
+
+    const mockConsole = {error: (s: string) => {}};
+
+    spyOn(mockConsole, 'error');
+
+    main({p: basePath}, mockConsole.error)
+        .then((exitCode) => {
+          expect(mockConsole.error).toHaveBeenCalledWith('Error at ' + path.join(basePath, 'test.ts') + `:1:9: Module '"` + path.join(basePath, 'empty-deps') + `"' has no exported member 'MyClass'.`);
+          expect(mockConsole.error).not.toHaveBeenCalledWith('Compilation failed');
+          expect(exitCode).toEqual(1);
+          done();
+        })
+        .catch(e => done.fail(e));
+  });
+
+  it('should not print the stack trace if type mismatches', (done) => {
+    write('empty-deps.ts', 'export const A = "abc";');
+    write('test.ts', `
+      import {A} from './empty-deps';
+      A();
+    `);
+
+    const mockConsole = {error: (s: string) => {}};
+
+    spyOn(mockConsole, 'error');
+
+    main({p: basePath}, mockConsole.error)
+        .then((exitCode) => {
+          expect(mockConsole.error).toHaveBeenCalledWith('Error at ' + path.join(basePath, 'test.ts') + ':3:7: Cannot invoke an expression whose type lacks a call signature.');
+          expect(mockConsole.error).not.toHaveBeenCalledWith('Compilation failed');
+          expect(exitCode).toEqual(1);
           done();
         })
         .catch(e => done.fail(e));
@@ -92,7 +148,7 @@ describe('compiler-cli', () => {
   it('should print the stack trace on compiler internal errors', (done) => {
     write('test.ts', 'export const A = 1;');
 
-    const mockConsole = {error: {}};
+    const mockConsole = {error: (s: string) => {}};
 
     spyOn(mockConsole, 'error');
 

--- a/modules/@angular/compiler-cli/test/main_spec.ts
+++ b/modules/@angular/compiler-cli/test/main_spec.ts
@@ -64,7 +64,9 @@ describe('compiler-cli', () => {
 
     main({p: basePath}, mockConsole.error)
         .then((exitCode) => {
-          expect(mockConsole.error).toHaveBeenCalledWith(`Error File '` + path.join(basePath, 'test.ts') + `' not found.`);
+          expect(mockConsole.error)
+              .toHaveBeenCalledWith(
+                  `Error File '` + path.join(basePath, 'test.ts') + `' not found.`);
           expect(mockConsole.error).not.toHaveBeenCalledWith('Compilation failed');
           expect(exitCode).toEqual(1);
           done();
@@ -81,7 +83,9 @@ describe('compiler-cli', () => {
 
     main({p: basePath}, mockConsole.error)
         .then((exitCode) => {
-          expect(mockConsole.error).toHaveBeenCalledWith('Error at ' + path.join(basePath, 'test.ts') + `:1:1: Cannot find name 'foo'.`);
+          expect(mockConsole.error)
+              .toHaveBeenCalledWith(
+                  'Error at ' + path.join(basePath, 'test.ts') + `:1:1: Cannot find name 'foo'.`);
           expect(mockConsole.error).not.toHaveBeenCalledWith('Compilation failed');
           expect(exitCode).toEqual(1);
           done();
@@ -90,7 +94,7 @@ describe('compiler-cli', () => {
   });
 
   it('should not print the stack trace if cannot find the imported module', (done) => {
-    write('test.ts', "import {MyClass} from './not-exist-deps';");
+    write('test.ts', `import {MyClass} from './not-exist-deps';`);
 
     const mockConsole = {error: (s: string) => {}};
 
@@ -98,7 +102,10 @@ describe('compiler-cli', () => {
 
     main({p: basePath}, mockConsole.error)
         .then((exitCode) => {
-          expect(mockConsole.error).toHaveBeenCalledWith('Error at ' + path.join(basePath, 'test.ts') + `:1:23: Cannot find module './not-exist-deps'.`);
+          expect(mockConsole.error)
+              .toHaveBeenCalledWith(
+                  'Error at ' + path.join(basePath, 'test.ts') +
+                  `:1:23: Cannot find module './not-exist-deps'.`);
           expect(mockConsole.error).not.toHaveBeenCalledWith('Compilation failed');
           expect(exitCode).toEqual(1);
           done();
@@ -108,7 +115,7 @@ describe('compiler-cli', () => {
 
   it('should not print the stack trace if cannot import', (done) => {
     write('empty-deps.ts', 'export const A = 1;');
-    write('test.ts', "import {MyClass} from './empty-deps';");
+    write('test.ts', `import {MyClass} from './empty-deps';`);
 
     const mockConsole = {error: (s: string) => {}};
 
@@ -116,7 +123,10 @@ describe('compiler-cli', () => {
 
     main({p: basePath}, mockConsole.error)
         .then((exitCode) => {
-          expect(mockConsole.error).toHaveBeenCalledWith('Error at ' + path.join(basePath, 'test.ts') + `:1:9: Module '"` + path.join(basePath, 'empty-deps') + `"' has no exported member 'MyClass'.`);
+          expect(mockConsole.error)
+              .toHaveBeenCalledWith(
+                  'Error at ' + path.join(basePath, 'test.ts') + `:1:9: Module '"` +
+                  path.join(basePath, 'empty-deps') + `"' has no exported member 'MyClass'.`);
           expect(mockConsole.error).not.toHaveBeenCalledWith('Compilation failed');
           expect(exitCode).toEqual(1);
           done();
@@ -137,7 +147,10 @@ describe('compiler-cli', () => {
 
     main({p: basePath}, mockConsole.error)
         .then((exitCode) => {
-          expect(mockConsole.error).toHaveBeenCalledWith('Error at ' + path.join(basePath, 'test.ts') + ':3:7: Cannot invoke an expression whose type lacks a call signature.');
+          expect(mockConsole.error)
+              .toHaveBeenCalledWith(
+                  'Error at ' + path.join(basePath, 'test.ts') +
+                  ':3:7: Cannot invoke an expression whose type lacks a call signature.');
           expect(mockConsole.error).not.toHaveBeenCalledWith('Compilation failed');
           expect(exitCode).toEqual(1);
           done();

--- a/modules/@angular/compiler-cli/test/main_spec.ts
+++ b/modules/@angular/compiler-cli/test/main_spec.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {makeTempDir} from '@angular/tsc-wrapped/test/test_support';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {main} from '../src/main';
+import {ReflectionCapabilities, reflector} from './private_import_core';
+
+
+describe('compiler-cli', () => {
+  let basePath: string;
+  let write: (fileName: string, content: string) => void;
+
+  beforeEach(() => {
+    basePath = makeTempDir();
+    write = (fileName: string, content: string) => {
+      fs.writeFileSync(path.join(basePath, fileName), content, {encoding: 'utf-8'});
+    };
+    write('tsconfig.json', `{
+      "compilerOptions": {
+        "experimentalDecorators": true,
+        "types": [],
+        "outDir": "built",
+        "declaration": true,
+        "module": "es2015"
+      },
+      "angularCompilerOptions": {
+        "annotateForClosureCompiler": true
+      },
+      "files": ["test.ts"]
+    }`);
+  });
+
+  // Restore reflector since AoT compiler will update it with a new static reflector
+  afterEach(() => { reflector.updateCapabilities(new ReflectionCapabilities()); });
+
+  it('should compile without errors', (done) => {
+    write('test.ts', 'export const A = 1;');
+
+    const mockConsole = {error: {}};
+
+    spyOn(mockConsole, 'error');
+
+    main({p: basePath}, mockConsole.error)
+        .then((exitCode) => {
+          expect(mockConsole.error).not.toHaveBeenCalled();
+          expect(exitCode).toEqual(0);
+          done();
+        })
+        .catch(e => done.fail(e));
+  });
+
+  it('should not print the stack trace if user input file does not exist', (done) => {
+    const mockConsole = {error: {}};
+
+    spyOn(mockConsole, 'error');
+
+    main({p: basePath}, mockConsole.error)
+        .then((exitCode) => {
+          expect(mockConsole.error).toHaveBeenCalled();
+          expect(mockConsole.error).not.toHaveBeenCalledWith('Compilation failed');
+          expect(exitCode).toEqual(0);
+          done();
+        })
+        .catch(e => done.fail(e));
+  });
+
+  it('should not print the stack trace if user input file is malformed', (done) => {
+    write('test.ts', 'foo bar');
+
+    const mockConsole = {error: {}};
+
+    spyOn(mockConsole, 'error');
+
+    main({p: basePath}, mockConsole.error)
+        .then((exitCode) => {
+          expect(mockConsole.error).toHaveBeenCalled();
+          expect(mockConsole.error).not.toHaveBeenCalledWith('Compilation failed');
+          expect(exitCode).toEqual(0);
+          done();
+        })
+        .catch(e => done.fail(e));
+  });
+
+  it('should print the stack trace on compiler internal errors', (done) => {
+    write('test.ts', 'export const A = 1;');
+
+    const mockConsole = {error: {}};
+
+    spyOn(mockConsole, 'error');
+
+    main({p: 'not-exist'}, mockConsole.error)
+        .then((exitCode) => {
+          expect(mockConsole.error).toHaveBeenCalled();
+          expect(mockConsole.error).toHaveBeenCalledWith('Compilation failed');
+          expect(exitCode).toEqual(1);
+          done();
+        })
+        .catch(e => done.fail(e));
+  });
+});

--- a/modules/@angular/compiler-cli/test/private_import_core.ts
+++ b/modules/@angular/compiler-cli/test/private_import_core.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {__core_private__ as r} from '@angular/core';
+
+export type ReflectionCapabilities = typeof r._ReflectionCapabilities;
+export var ReflectionCapabilities: typeof r.ReflectionCapabilities = r.ReflectionCapabilities;
+export var reflector: typeof r.reflector = r.reflector;

--- a/tools/@angular/tsc-wrapped/index.ts
+++ b/tools/@angular/tsc-wrapped/index.ts
@@ -7,7 +7,7 @@
  */
 
 export {DecoratorDownlevelCompilerHost, MetadataWriterHost} from './src/compiler_host';
-export {CodegenExtension, main} from './src/main';
+export {CodegenExtension, UserError, main} from './src/main';
 
 export {default as AngularCompilerOptions} from './src/options';
 export * from './src/cli_options';

--- a/tools/@angular/tsc-wrapped/src/main.ts
+++ b/tools/@angular/tsc-wrapped/src/main.ts
@@ -16,6 +16,8 @@ import NgOptions from './options';
 import {MetadataWriterHost, DecoratorDownlevelCompilerHost, TsickleCompilerHost} from './compiler_host';
 import {CliOptions} from './cli_options';
 
+export {UserError} from './tsc';
+
 export type CodegenExtension =
     (ngOptions: NgOptions, cliOptions: CliOptions, program: ts.Program, host: ts.CompilerHost) =>
         Promise<void>;

--- a/tools/@angular/tsc-wrapped/src/tsc.ts
+++ b/tools/@angular/tsc-wrapped/src/tsc.ts
@@ -24,6 +24,15 @@ export interface CompilerInterface {
   emit(program: ts.Program): number;
 }
 
+export class UserError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.message = message;
+    this.name = 'UserError';
+    this.stack = new Error().stack;
+  }
+}
+
 const DEBUG = false;
 
 function debug(msg: string, ...o: any[]) {
@@ -48,7 +57,7 @@ export function formatDiagnostics(diags: ts.Diagnostic[]): string {
 
 export function check(diags: ts.Diagnostic[]) {
   if (diags && diags.length && diags[0]) {
-    throw new Error(formatDiagnostics(diags));
+    throw new UserError(formatDiagnostics(diags));
   }
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Refactoring (no functional changes, no api changes)
```

**What is the current behavior?** (You can also link to an open issue here)
ngc prints stack trace on errors.


**What is the new behavior?**
ngc does not print stack trace on user errors.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:


Do not print stack trace for user errors
Print stack trace for compiler internal errors