### PR TITLE
WIP: fix imports: add explicit /index

### DIFF
--- a/tools/@angular/tsc-wrapped/src/compiler_host.ts
+++ b/tools/@angular/tsc-wrapped/src/compiler_host.ts
@@ -103,7 +103,10 @@ export class TsickleCompilerHost extends DelegatingHost {
         let {output, externs, diagnostics} =
             tsickle.annotate(this.oldProgram, sourceFile, {untyped: true});
         this.diagnostics = diagnostics;
-        return ts.createSourceFile(fileName, output, languageVersion, true);
+        const annotatedSourceFile = ts.createSourceFile(fileName, output, languageVersion, true);
+        let {output: fixedImports} = tsickle.fixIndexImports(this.oldProgram, annotatedSourceFile, this.options, this.delegate);
+
+        return ts.createSourceFile(fileName, fixedImports, languageVersion, true);
       };
 }
 


### PR DESCRIPTION
Along with https://github.com/angular/tsickle/issues/288
this will make our ES6 output consumable by closure.