### PR TITLE
fix(language-service): update to use `CompilerHost` from compiler-cli

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -145,6 +145,11 @@ do
     $TSC -p ${SRCDIR}/tsconfig-testing.json
   fi
 
+  if [[ -e ${SRCDIR}/tsconfig-2015.json ]]; then
+    echo "======      COMPILING ESM: ${TSC} -p ${SRCDIR}/tsconfig-2015.json"
+    ${TSC} -p ${SRCDIR}/tsconfig-2015.json
+  fi
+
   echo "======      TSC 1.8 d.ts compat for ${DESTDIR}   ====="
   # safely strips 'readonly' specifier from d.ts files to make them compatible with tsc 1.8
   if [ "$(uname)" == "Darwin" ]; then

--- a/modules/@angular/compiler-cli/tsconfig-2015.json
+++ b/modules/@angular/compiler-cli/tsconfig-2015.json
@@ -1,0 +1,34 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "declaration": true,
+        "experimentalDecorators": true,
+        "noImplicitAny": true,
+        "module": "es2015",
+        "moduleResolution": "node",
+        "outDir": "../../../dist/packages-dist/esm/compiler-cli",
+        "paths": {
+          "@angular/core": ["../../../dist/packages-dist/core"],
+          "@angular/common": ["../../../dist/packages-dist/common"],
+          "@angular/compiler": ["../../../dist/packages-dist/compiler"],
+          "@angular/platform-server": ["../../../dist/packages-dist/platform-server"],
+          "@angular/platform-browser": ["../../../dist/packages-dist/platform-browser"],
+          "@angular/tsc-wrapped": ["../../../dist/tools/@angular/tsc-wrapped"]
+        },
+        "rootDir": ".",
+        "sourceMap": true,
+        "inlineSources": true,
+        "target": "es5",
+        "lib": ["es6", "dom"],
+        "skipLibCheck": true
+    },
+    "exclude": ["integrationtest"],
+    "files": [
+        "index.ts",
+        "src/main.ts",
+        "src/extract_i18n.ts",
+        "../../../node_modules/@types/node/index.d.ts",
+        "../../../node_modules/@types/jasmine/index.d.ts",
+        "../../../node_modules/zone.js/dist/zone.js.d.ts"
+    ]
+}

--- a/modules/@angular/language-service/rollup.config.js
+++ b/modules/@angular/language-service/rollup.config.js
@@ -18,7 +18,7 @@ var locations = {
   'tsc-wrapped': normalize('../../../dist/tools/@angular') + '/',
 };
 
-var esm_suffixes = {};
+var esm_suffixes = {'compiler-cli': esm};
 
 function normalize(fileName) {
   return path.resolve(__dirname, fileName);

--- a/modules/@angular/language-service/src/diagnostics.ts
+++ b/modules/@angular/language-service/src/diagnostics.ts
@@ -55,12 +55,14 @@ export function getDeclarationDiagnostics(
 
   let directives: Set<StaticSymbol>|undefined = undefined;
   for (const declaration of declarations) {
-    let report = (message: string) => {
-      results.push(
-          <Diagnostic>{kind: DiagnosticKind.Error, span: declaration.declarationSpan, message});
+    const report = (message: string, span?: Span) => {
+      results.push(<Diagnostic>{
+        kind: DiagnosticKind.Error,
+        span: span || declaration.declarationSpan, message
+      });
     };
-    if (declaration.error) {
-      report(declaration.error);
+    for (const error of declaration.errors) {
+      report(error.message, error.span);
     }
     if (declaration.metadata) {
       if (declaration.metadata.isComponent) {

--- a/modules/@angular/language-service/src/reflector_host.ts
+++ b/modules/@angular/language-service/src/reflector_host.ts
@@ -6,28 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {StaticReflectorHost, StaticSymbol} from '@angular/compiler';
-import {MetadataCollector} from '@angular/tsc-wrapped/src/collector';
-import {ModuleMetadata} from '@angular/tsc-wrapped/src/schema';
-import * as path from 'path';
+import {AngularCompilerOptions, AotCompilerHost, CompilerHost, ModuleResolutionHostAdapter} from '@angular/compiler-cli';
 import * as ts from 'typescript';
 
-const EXT = /(\.ts|\.d\.ts|\.js|\.jsx|\.tsx)$/;
-const DTS = /\.d\.ts$/;
-
-let serialNumber = 0;
-
 class ReflectorModuleModuleResolutionHost implements ts.ModuleResolutionHost {
-  private forceExists: string[] = [];
-
   constructor(private host: ts.LanguageServiceHost) {
     if (host.directoryExists)
       this.directoryExists = directoryName => this.host.directoryExists(directoryName);
   }
 
-  fileExists(fileName: string): boolean {
-    return !!this.host.getScriptSnapshot(fileName) || this.forceExists.indexOf(fileName) >= 0;
-  }
+  fileExists(fileName: string): boolean { return !!this.host.getScriptSnapshot(fileName); }
 
   readFile(fileName: string): string {
     let snapshot = this.host.getScriptSnapshot(fileName);
@@ -37,122 +25,19 @@ class ReflectorModuleModuleResolutionHost implements ts.ModuleResolutionHost {
   }
 
   directoryExists: (directoryName: string) => boolean;
-
-  forceExist(fileName: string): void { this.forceExists.push(fileName); }
 }
 
-export class ReflectorHost implements StaticReflectorHost {
-  private metadataCollector: MetadataCollector;
-  private moduleResolverHost: ReflectorModuleModuleResolutionHost;
-  private _typeChecker: ts.TypeChecker;
-  private metadataCache = new Map<string, MetadataCacheEntry>();
-
+export class ReflectorHost extends CompilerHost {
   constructor(
-      private getProgram: () => ts.Program, private serviceHost: ts.LanguageServiceHost,
-      private options: ts.CompilerOptions, private basePath: string) {
-    this.moduleResolverHost = new ReflectorModuleModuleResolutionHost(serviceHost);
-    this.metadataCollector = new MetadataCollector();
+      private getProgram: () => ts.Program, serviceHost: ts.LanguageServiceHost,
+      options: AngularCompilerOptions) {
+    super(
+        null, options,
+        new ModuleResolutionHostAdapter(new ReflectorModuleModuleResolutionHost(serviceHost)));
   }
 
-  getCanonicalFileName(fileName: string): string { return fileName; }
-
-  private get program() { return this.getProgram(); }
-
-  public moduleNameToFileName(moduleName: string, containingFile: string) {
-    if (!containingFile || !containingFile.length) {
-      if (moduleName.indexOf('.') === 0) {
-        throw new Error('Resolution of relative paths requires a containing file.');
-      }
-      // Any containing file gives the same result for absolute imports
-      containingFile = this.getCanonicalFileName(path.join(this.basePath, 'index.ts'));
-    }
-    moduleName = moduleName.replace(EXT, '');
-    const resolved =
-        ts.resolveModuleName(moduleName, containingFile, this.options, this.moduleResolverHost)
-            .resolvedModule;
-    return resolved ? resolved.resolvedFileName : null;
-  };
-
-  /**
-   * We want a moduleId that will appear in import statements in the generated code.
-   * These need to be in a form that system.js can load, so absolute file paths don't work.
-   * Relativize the paths by checking candidate prefixes of the absolute path, to see if
-   * they are resolvable by the moduleResolution strategy from the CompilerHost.
-   */
-  fileNameToModuleName(importedFile: string, containingFile: string) {
-    // TODO(tbosch): if a file does not yet exist (because we compile it later),
-    // we still need to create it so that the `resolve` method works!
-    if (!this.moduleResolverHost.fileExists(importedFile)) {
-      this.moduleResolverHost.forceExist(importedFile);
-    }
-
-    const parts = importedFile.replace(EXT, '').split(path.sep).filter(p => !!p);
-
-    for (let index = parts.length - 1; index >= 0; index--) {
-      let candidate = parts.slice(index, parts.length).join(path.sep);
-      if (this.moduleNameToFileName('.' + path.sep + candidate, containingFile) === importedFile) {
-        return `./${candidate}`;
-      }
-      if (this.moduleNameToFileName(candidate, containingFile) === importedFile) {
-        return candidate;
-      }
-    }
-    throw new Error(
-        `Unable to find any resolvable import for ${importedFile} relative to ${containingFile}`);
+  protected get program() { return this.getProgram(); }
+  protected set program(value: ts.Program) {
+    // Discard the result set by ancestor constructor
   }
-
-  private get typeChecker(): ts.TypeChecker {
-    let result = this._typeChecker;
-    if (!result) {
-      result = this._typeChecker = this.program.getTypeChecker();
-    }
-    return result;
-  }
-
-  private typeCache = new Map<string, StaticSymbol>();
-
-  // TODO(alexeagle): take a statictype
-  getMetadataFor(filePath: string): ModuleMetadata[] {
-    if (!this.moduleResolverHost.fileExists(filePath)) {
-      throw new Error(`No such file '${filePath}'`);
-    }
-    if (DTS.test(filePath)) {
-      const metadataPath = filePath.replace(DTS, '.metadata.json');
-      if (this.moduleResolverHost.fileExists(metadataPath)) {
-        return this.readMetadata(metadataPath);
-      }
-    }
-
-    let sf = this.program.getSourceFile(filePath);
-    if (!sf) {
-      throw new Error(`Source file ${filePath} not present in program.`);
-    }
-
-    const entry = this.metadataCache.get(sf.path);
-    const version = this.serviceHost.getScriptVersion(sf.path);
-    if (entry && entry.version == version) {
-      if (!entry.content) return undefined;
-      return [entry.content];
-    }
-    const metadata = this.metadataCollector.getMetadata(sf);
-    this.metadataCache.set(sf.path, {version, content: metadata});
-    if (metadata) return [metadata];
-  }
-
-  readMetadata(filePath: string) {
-    try {
-      const text = this.moduleResolverHost.readFile(filePath);
-      const result = JSON.parse(text);
-      if (!Array.isArray(result)) return [result];
-      return result;
-    } catch (e) {
-      console.error(`Failed to read JSON file ${filePath}`);
-      throw e;
-    }
-  }
-}
-
-interface MetadataCacheEntry {
-  version: string;
-  content: ModuleMetadata;
 }

--- a/modules/@angular/language-service/src/types.ts
+++ b/modules/@angular/language-service/src/types.ts
@@ -88,6 +88,25 @@ export interface TemplateSource {
 export type TemplateSources = TemplateSource[] /* | undefined */;
 
 /**
+ * Error information found getting declaration information
+ *
+ * A host type; see `LanagueServiceHost`.
+ *
+ * @experimental
+ */
+export interface DeclarationError {
+  /**
+   * The span of the error in the declaration's module.
+   */
+  readonly span: Span;
+
+  /**
+   * The message to display describing the error.
+   */
+  readonly message: string;
+}
+
+/**
  * Information about the component declarations.
  *
  * A file might contain a declaration without a template because the file contains only
@@ -117,11 +136,10 @@ export interface Declaration {
    */
   readonly metadata?: CompileDirectiveMetadata;
 
-
   /**
    * Error reported trying to get the metadata.
    */
-  readonly error?: string;
+  readonly errors: DeclarationError[];
 }
 
 /**

--- a/modules/@angular/language-service/test/completions_spec.ts
+++ b/modules/@angular/language-service/test/completions_spec.ts
@@ -166,6 +166,7 @@ export class MyComponent {
     const originalContent = mockHost.getFileContent(fileName);
     const newContent = originalContent + code;
     mockHost.override(fileName, originalContent + code);
+    ngHost.updateAnalyzedModules();
     try {
       cb(fileName, newContent);
     } finally {

--- a/modules/@angular/language-service/test/diagnostics_spec.ts
+++ b/modules/@angular/language-service/test/diagnostics_spec.ts
@@ -120,6 +120,7 @@ describe('diagnostics', () => {
       const originalContent = mockHost.getFileContent(fileName);
       const newContent = originalContent + code;
       mockHost.override(fileName, originalContent + code);
+      ngHost.updateAnalyzedModules();
       try {
         cb(fileName, newContent);
       } finally {

--- a/modules/@angular/language-service/tsconfig-build.json
+++ b/modules/@angular/language-service/tsconfig-build.json
@@ -15,6 +15,7 @@
       "@angular/common": ["../../../dist/packages-dist/common"],
       "@angular/compiler": ["../../../dist/packages-dist/compiler"],
       "@angular/compiler/*": ["../../../dist/packages-dist/compiler/*"],
+      "@angular/compiler-cli": ["../../../dist/packages-dist/compiler-cli"],
       "@angular/platform-server": ["../../../dist/packages-dist/platform-server"],
       "@angular/platform-browser": ["../../../dist/packages-dist/platform-browser"],
       "@angular/tsc-wrapped": ["../../../dist/tools/@angular/tsc-wrapped"],


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

The language service used its own `StaticReflectorHost` which didn't have the auto-upgrade of metadata so it only worked for  2.3.0 projects.

**What is the new behavior?**

Use the compiler host from `compiler-cli` which includes the auto-upgrade of metadata allowing it to work on all 2.x.x projects.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
