### PR TITLE
docs(developer): add anchor to source code formatting

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -126,7 +126,7 @@ $ gulp public-api:update
 
 Note: The command `./test.sh tools` fails when the API doesn't match the golden files.
 
-## Formatting your source code
+## <a name="clang-format"></a> Formatting your source code
 
 Angular uses [clang-format](http://clang.llvm.org/docs/ClangFormat.html) to format the source code. If the source code
 is not properly formatted, the CI will fail and the PR can not be merged.


### PR DESCRIPTION
In [CONTRIBUTING.md](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#rules) has reference to [DEVELOPER.md](https://github.com/angular/angular/blob/master/DEVELOPER.md#clang-format) but `#clang-format` anchor is not present