### PR TITLE
refactor(build): fix build location of compiler-cli esm module

### DIFF
--- a/modules/@angular/compiler-cli/tsconfig-2015.json
+++ b/modules/@angular/compiler-cli/tsconfig-2015.json
@@ -6,7 +6,7 @@
         "noImplicitAny": true,
         "module": "es2015",
         "moduleResolution": "node",
-        "outDir": "../../../dist/packages-dist/esm/compiler-cli",
+        "outDir": "../../../dist/esm/compiler-cli",
         "paths": {
           "@angular/core": ["../../../dist/packages-dist/core"],
           "@angular/common": ["../../../dist/packages-dist/common"],

--- a/modules/@angular/language-service/rollup.config.js
+++ b/modules/@angular/language-service/rollup.config.js
@@ -16,9 +16,10 @@ var esm = 'esm/';
 
 var locations = {
   'tsc-wrapped': normalize('../../../dist/tools/@angular') + '/',
+  'compiler-cli': normalize('../../../dist/esm') + '/'
 };
 
-var esm_suffixes = {'compiler-cli': esm};
+var esm_suffixes = {};
 
 function normalize(fileName) {
   return path.resolve(__dirname, fileName);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Refactoring (no functional changes, no api changes)
```

**What is the current behavior?** (You can also link to an open issue here)

The compiler-cli esm module is build in the package-dist directory causing its build artifact to be published.

**What is the new behavior?**

The compiler-cli esm module is no longer built in the package-dist directory as the result is published as part of the language-service module

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
