### PR TITLE
fix(core): ViewContainerRef.indexOf doesn't throw error when empty

### DIFF
--- a/modules/@angular/core/src/linker/view_container_ref.ts
+++ b/modules/@angular/core/src/linker/view_container_ref.ts
@@ -187,7 +187,8 @@ export class ViewContainerRef_ implements ViewContainerRef {
   }
 
   indexOf(viewRef: ViewRef): number {
-    return this._element.nestedViews.indexOf((<ViewRef_<any>>viewRef).internalView);
+    return this.length ? this._element.nestedViews.indexOf((<ViewRef_<any>>viewRef).internalView) :
+                         -1;
   }
 
   /** @internal */
@@ -214,7 +215,7 @@ export class ViewContainerRef_ implements ViewContainerRef {
     return wtfLeave(s, view.ref);
   }
 
-  clear() {
+  clear(): void {
     for (let i = this.length - 1; i >= 0; i--) {
       this.remove(i);
     }


### PR DESCRIPTION
Fixes https://github.com/angular/angular/issues/13207