### PR TITLE
docs(ViewChildren, ContentChild): refactor the comments according to decorator API guide

### DIFF
--- a/modules/@angular/core/src/metadata/di.ts
+++ b/modules/@angular/core/src/metadata/di.ts
@@ -294,8 +294,35 @@ export const ContentChild: ContentChildDecorator = makePropDecorator(
  */
 export interface ViewChildrenDecorator {
   /**
-   * @docsNotRequired
- */ (selector: Type<any>|Function|string, {read}?: {read?: any}): any;
+   * @whatItDoes Configures a view query.
+   *
+   * @howToUse
+   *
+   * {@example core/di/ts/viewChildren/view_children_howto.ts region='HowTo'}
+   *
+   * @description
+   *
+   * You can use ViewChildren to get the {@link QueryList} of elements or directives from the
+   * view DOM. Any time a child element is added, removed, or moved, the query list will be updated,
+   * and the changes observable of the query list will emit a new value.
+   *
+   * View queries are set before the `ngAfterViewInit` callback is called.
+   *
+   * **Metadata Properties**:
+   *
+   * * **selector** - the directive type or the name used for querying.
+   * * **read** - read a different token from the queried elements.
+   *
+   * Let's look at an example:
+   *
+   * {@example core/di/ts/viewChildren/view_children_example.ts region='Component'}
+   *
+   * **npm package**: `@angular/core`
+   *
+   * @stable
+   * @Annotation
+   */
+  (selector: Type<any>|Function|string, {read}?: {read?: any}): any;
   new (selector: Type<any>|Function|string, {read}?: {read?: any}): ViewChildren;
 }
 
@@ -307,30 +334,7 @@ export interface ViewChildrenDecorator {
 export type ViewChildren = Query;
 
 /**
- * @whatItDoes Configures a view query.
- *
- * @howToUse
- *
- * {@example core/di/ts/viewChildren/view_children_howto.ts region='HowTo'}
- *
- * @description
- *
- * You can use ViewChildren to get the {@link QueryList} of elements or directives from the
- * view DOM. Any time a child element is added, removed, or moved, the query list will be updated,
- * and the changes observable of the query list will emit a new value.
- *
- * View queries are set before the `ngAfterViewInit` callback is called.
- *
- * **Metadata Properties**:
- *
- * * **selector** - the directive type or the name used for querying.
- * * **read** - read a different token from the queried elements.
- *
- * Let's look at an example:
- *
- * {@example core/di/ts/viewChildren/view_children_example.ts region='Component'}
- *
- * **npm package**: `@angular/core`
+ * ViewChildren decorator and metadata.
  *
  * @stable
  * @Annotation

--- a/modules/@angular/core/src/metadata/di.ts
+++ b/modules/@angular/core/src/metadata/di.ts
@@ -220,12 +220,39 @@ export const ContentChildren: ContentChildrenDecorator =
 /**
  * Type of the ContentChild decorator / constructor function.
  *
+ * See {@link ContentChild}.
  *
  * @stable
  */
 export interface ContentChildDecorator {
   /**
-   * @docsNotRequired
+   * @whatItDoes Configures a content query.
+   *
+   * @howToUse
+   *
+   * {@example core/di/ts/contentChild/content_child_howto.ts region='HowTo'}
+   *
+   * @description
+   *
+   * You can use ContentChild to get the first element or the directive matching the selector from the
+   * content DOM. If the content DOM changes, and a new child matches the selector,
+   * the property will be updated.
+   *
+   * Content queries are set before the `ngAfterContentInit` callback is called.
+   *
+   * **Metadata Properties**:
+   *
+   * * **selector** - the directive type or the name used for querying.
+   * * **read** - read a different token from the queried element.
+   *
+   * Let's look at an example:
+   *
+   * {@example core/di/ts/contentChild/content_child_example.ts region='Component'}
+   *
+   * **npm package**: `@angular/core`
+   *
+   * @stable
+   * @Annotation
    */
   (selector: Type<any>|Function|string, {read}?: {read?: any}): any;
   new (selector: Type<any>|Function|string, {read}?: {read?: any}): ContentChild;
@@ -241,33 +268,10 @@ export interface ContentChildDecorator {
 export type ContentChild = Query;
 
 /**
- * @whatItDoes Configures a content query.
+ * ContentChild decorator and metadata.
  *
- * @howToUse
- *
- * {@example core/di/ts/contentChild/content_child_howto.ts region='HowTo'}
- *
- * @description
- *
- * You can use ContentChild to get the first element or the directive matching the selector from the
- * content DOM. If the content DOM changes, and a new child matches the selector,
- * the property will be updated.
- *
- * Content queries are set before the `ngAfterContentInit` callback is called.
- *
- * **Metadata Properties**:
- *
- * * **selector** - the directive type or the name used for querying.
- * * **read** - read a different token from the queried element.
- *
- * Let's look at an example:
- *
- * {@example core/di/ts/contentChild/content_child_example.ts region='Component'}
- *
- * **npm package**: `@angular/core`
- *
- * @stable
- * @Annotation
+ *  @stable
+ *  @Annotation
  */
 export const ContentChild: ContentChildDecorator = makePropDecorator(
     'ContentChild',

--- a/modules/@angular/core/src/metadata/di.ts
+++ b/modules/@angular/core/src/metadata/di.ts
@@ -234,8 +234,8 @@ export interface ContentChildDecorator {
    *
    * @description
    *
-   * You can use ContentChild to get the first element or the directive matching the selector from the
-   * content DOM. If the content DOM changes, and a new child matches the selector,
+   * You can use ContentChild to get the first element or the directive matching the selector from
+   * the content DOM. If the content DOM changes, and a new child matches the selector,
    * the property will be updated.
    *
    * Content queries are set before the `ngAfterContentInit` callback is called.

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -277,7 +277,7 @@ export declare const ContentChild: ContentChildDecorator;
 
 /** @stable */
 export interface ContentChildDecorator {
-    (selector: Type<any> | Function | string, {read}?: {
+    /** @stable */ (selector: Type<any> | Function | string, {read}?: {
         read?: any;
     }): any;
     new (selector: Type<any> | Function | string, {read}?: {

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -978,7 +978,8 @@ export interface ViewChildDecorator {
 export declare const ViewChildren: ViewChildrenDecorator;
 
 /** @stable */
-export interface ViewChildrenDecorator { (selector: Type<any> | Function | string, {read}?: {
+export interface ViewChildrenDecorator {
+    /** @stable */ (selector: Type<any> | Function | string, {read}?: {
         read?: any;
     }): any;
     new (selector: Type<any> | Function | string, {read}?: {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)




**What is the current behavior?** (You can also link to an open issue here)
In manual site(angular.io), the document of ContentChild API is broken.
-> https://angular.io/docs/ts/latest/api/core/index/ContentChild-decorator.html

Here is the sample of expected result 
-> https://angular.io/docs/ts/latest/api/core/index/ContentChildren-decorator.html

**What is the new behavior?**
I have made changes to the documentation according to the decorator API guide.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```