### PR TITLE
fix(language-service): avoid throwing for invalid class declarations

### DIFF
--- a/modules/@angular/language-service/src/typescript_host.ts
+++ b/modules/@angular/language-service/src/typescript_host.ts
@@ -325,7 +325,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
       case this.ts.SyntaxKind.StringLiteral:
         let [declaration, decorator] = this.getTemplateClassDeclFromNode(node);
         let queryCache: SymbolQuery|undefined = undefined;
-        if (declaration) {
+        if (declaration && declaration.name) {
           const sourceFile = this.getSourceFile(fileName);
           return this.getSourceFromDeclaration(
               fileName, version, this.stringOf(node), shrink(spanOf(node)),

--- a/modules/@angular/language-service/test/diagnostics_spec.ts
+++ b/modules/@angular/language-service/test/diagnostics_spec.ts
@@ -115,6 +115,12 @@ describe('diagnostics', () => {
       });
     });
 
+    it('should not throw for an invalid class', () => {
+      const code = ` @Component({template: ''}) class`;
+      addCode(
+          code, fileName => { expect(() => ngService.getDiagnostics(fileName)).not.toThrow(); });
+    });
+
     function addCode(code: string, cb: (fileName: string, content?: string) => void) {
       const fileName = '/app/app.component.ts';
       const originalContent = mockHost.getFileContent(fileName);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

Language service diagnostics throws when a file has an invalid class.

#13253

**What is the new behavior?**

The language service no longer throws.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:


Fixes #13253