### PR TITLE
fix(language-service): do not throw for invalid metadata

### DIFF
--- a/modules/@angular/language-service/src/typescript_host.ts
+++ b/modules/@angular/language-service/src/typescript_host.ts
@@ -120,7 +120,8 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
 
       result = this._resolver = new CompileMetadataResolver(
           moduleResolver, directiveResolver, pipeResolver, new SummaryResolver(),
-          elementSchemaRegistry, directiveNormalizer, this.reflector);
+          elementSchemaRegistry, directiveNormalizer, this.reflector,
+          (error, type) => this.collectError(error, type && type.filePath));
     }
     return result;
   }

--- a/modules/@angular/language-service/test/test_utils.ts
+++ b/modules/@angular/language-service/test/test_utils.ts
@@ -91,6 +91,12 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
     }
   }
 
+  addScript(fileName: string, content: string) {
+    this.projectVersion++;
+    this.overrides.set(fileName, content);
+    this.scriptNames.push(fileName);
+  }
+
   getCompilationSettings(): ts.CompilerOptions {
     return {
       target: ts.ScriptTarget.ES5,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

The language service will sometimes throw with invalid metadata.

#13255

**What is the new behavior?**

The language service no longer throws.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:

Fixes #13255