### PR TITLE
fix(compiler): short-circut expressions with an index

### DIFF
--- a/modules/@angular/compiler/src/compiler_util/expression_converter.ts
+++ b/modules/@angular/compiler/src/compiler_util/expression_converter.ts
@@ -284,8 +284,13 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
   }
 
   visitKeyedRead(ast: cdAst.KeyedRead, mode: _Mode): any {
-    return convertToStatementIfNeeded(
-        mode, this.visit(ast.obj, _Mode.Expression).key(this.visit(ast.key, _Mode.Expression)));
+    const leftMostSafe = this.leftMostSafeNode(ast);
+    if (leftMostSafe) {
+      return this.convertSafeAccess(ast, leftMostSafe, mode);
+    } else {
+      return convertToStatementIfNeeded(
+          mode, this.visit(ast.obj, _Mode.Expression).key(this.visit(ast.key, _Mode.Expression)));
+    }
   }
 
   visitKeyedWrite(ast: cdAst.KeyedWrite, mode: _Mode): any {

--- a/modules/@angular/core/test/linker/change_detection_integration_spec.ts
+++ b/modules/@angular/core/test/linker/change_detection_integration_spec.ts
@@ -305,6 +305,12 @@ export function main() {
              expect(renderLog.log).toEqual(['someProp=null']);
            }));
 
+        it('should support short-circuting array index operations', fakeAsync(() => {
+             const ctx = _bindSimpleValue('value?.phones[0]', PersonHolder);
+             ctx.detectChanges(false);
+             expect(renderLog.log).toEqual(['someProp=null']);
+           }));
+
         it('should still throw if right-side would throw', fakeAsync(() => {
              expect(() => {
                const ctx = _bindSimpleValue('value?.address.city', PersonHolder);
@@ -1515,6 +1521,7 @@ class Person {
   age: number;
   name: string;
   address: Address = null;
+  phones: number[];
 
   init(name: string, address: Address = null) {
     this.name = name;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

Using an index operator in an expression will not short-circuit with safe property access.

#13254

**What is the new behavior?**

Index operator now correctly short-circuits. 

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:


Fixes #13254