### PR TITLE
fix(router): routerLinkActive should not throw when not initialized

### DIFF
--- a/modules/@angular/router/src/directives/router_link_active.ts
+++ b/modules/@angular/router/src/directives/router_link_active.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AfterContentInit, ContentChildren, Directive, ElementRef, Input, OnChanges, OnDestroy, QueryList, Renderer} from '@angular/core';
+import {AfterContentInit, ChangeDetectorRef, ContentChildren, Directive, ElementRef, Input, OnChanges, OnDestroy, QueryList, Renderer} from '@angular/core';
 import {Subscription} from 'rxjs/Subscription';
 
 import {NavigationEnd, Router} from '../router';
@@ -82,7 +82,7 @@ import {RouterLink, RouterLinkWithHref} from './router_link';
   exportAs: 'routerLinkActive',
 })
 export class RouterLinkActive implements OnChanges,
-    OnDestroy, AfterContentInit {
+  OnDestroy, AfterContentInit {
   @ContentChildren(RouterLink, {descendants: true}) links: QueryList<RouterLink>;
   @ContentChildren(RouterLinkWithHref, {descendants: true})
   linksWithHrefs: QueryList<RouterLinkWithHref>;
@@ -103,22 +103,18 @@ export class RouterLinkActive implements OnChanges,
   get isActive(): boolean { return this.hasActiveLink(); }
 
   ngAfterContentInit(): void {
-    this.links.changes.subscribe(s => this.update());
-    this.linksWithHrefs.changes.subscribe(s => this.update());
+    this.links.changes.subscribe(_ => this.update());
+    this.linksWithHrefs.changes.subscribe(_ => this.update());
     this.update();
   }
 
   @Input()
   set routerLinkActive(data: string[]|string) {
-    if (Array.isArray(data)) {
-      this.classes = <any>data;
-    } else {
-      this.classes = data.split(' ');
-    }
+    this.classes = (Array.isArray(data) ? data : data.split(' ')).filter(c => !!c);
   }
 
-  ngOnChanges(changes: {}): any { this.update(); }
-  ngOnDestroy(): any { this.subscription.unsubscribe(); }
+  ngOnChanges(changes: {}): void { this.update(); }
+  ngOnDestroy(): void { this.subscription.unsubscribe(); }
 
   private update(): void {
     if (!this.links || !this.linksWithHrefs || !this.router.navigated) return;
@@ -133,11 +129,11 @@ export class RouterLinkActive implements OnChanges,
 
   private isLinkActive(router: Router): (link: (RouterLink|RouterLinkWithHref)) => boolean {
     return (link: RouterLink | RouterLinkWithHref) =>
-               router.isActive(link.urlTree, this.routerLinkActiveOptions.exact);
+      router.isActive(link.urlTree, this.routerLinkActiveOptions.exact);
   }
 
   private hasActiveLink(): boolean {
     return this.links.some(this.isLinkActive(this.router)) ||
-        this.linksWithHrefs.some(this.isLinkActive(this.router));
+      this.linksWithHrefs.some(this.isLinkActive(this.router));
   }
 }

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -2084,6 +2084,8 @@ describe('Integration', () => {
          @Component({
            template: `<a routerLink="/team" routerLinkActive #rla="routerLinkActive"></a>
               <p>{{rla.isActive}}</p>
+              <span *ngIf="rla.isActive"></span>
+              <span [ngClass]="{'highlight': rla.isActive}"></span>
               <router-outlet></router-outlet>`
          })
          class ComponentWithRouterLink {
@@ -2103,15 +2105,15 @@ describe('Integration', () => {
            }
          ]);
 
-         const f = TestBed.createComponent(ComponentWithRouterLink);
+         const fixture = TestBed.createComponent(ComponentWithRouterLink);
          router.navigateByUrl('/team');
-         advance(f);
+         expect(() => advance(fixture)).not.toThrow();
 
-         const paragraph = f.nativeElement.querySelector('p');
+         const paragraph = fixture.nativeElement.querySelector('p');
          expect(paragraph.textContent).toEqual('true');
 
          router.navigateByUrl('/otherteam');
-         advance(f);
+         advance(fixture);
 
          expect(paragraph.textContent).toEqual('false');
        }));

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -262,10 +262,10 @@ export declare class RouterLinkActive implements OnChanges, OnDestroy, AfterCont
     routerLinkActiveOptions: {
         exact: boolean;
     };
-    constructor(router: Router, element: ElementRef, renderer: Renderer);
+    constructor(router: Router, element: ElementRef, renderer: Renderer, cdr: ChangeDetectorRef);
     ngAfterContentInit(): void;
-    ngOnChanges(changes: {}): any;
-    ngOnDestroy(): any;
+    ngOnChanges(changes: {}): void;
+    ngOnDestroy(): void;
 }
 
 /** @stable */

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -264,7 +264,7 @@ export declare class RouterLinkActive implements OnChanges, OnDestroy, AfterCont
     };
     constructor(router: Router, element: ElementRef, renderer: Renderer, cdr: ChangeDetectorRef);
     ngAfterContentInit(): void;
-    ngOnChanges(changes: {}): void;
+    ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
 }
 


### PR DESCRIPTION
Fixes https://github.com/angular/angular/issues/13270

> Also quickly describe what this PR fixes

if we have a template with only interpolation it works fine:
```
<div routerLinkActive="active" #rlaDashboard="routerLinkActive"> 
    <a routerLink="/dashboard">
      Dashboard isActive: {{rlaDashboard.isActive}}
    </a>
  </div>
```

but if we have bindings it fails:
```
<div routerLinkActive="active" #rlaTest="routerLinkActive"> 
    <a routerLink="/test">
    </a>
    <span *ngIf="rlaTest.isActive">DOES NOT WORK </span>
     or
   <span [ngClass]="{'highlight':rlaTest.isActive}">DOES NOT WORK </span>
  </div>
```

[Getter](https://github.com/angular/angular/blob/master/modules/%40angular/router/src/directives/router_link_active.ts#L103) is called before [ContentChildren](https://github.com/angular/angular/blob/master/modules/%40angular/router/src/directives/router_link_active.ts#L105) is initialized thus it failed [here](https://github.com/angular/angular/blob/master/modules/%40angular/router/src/directives/router_link_active.ts#L140) with the error `Cannot read property some of undefined`