### PR TITLE
fix(language-service): remove incompletely used parameter from `creat…

### DIFF
--- a/modules/@angular/language-service/src/ts_plugin.ts
+++ b/modules/@angular/language-service/src/ts_plugin.ts
@@ -19,7 +19,6 @@ import {TypeScriptServiceHost} from './typescript_host';
  * @experimental
  */
 export class LanguageServicePlugin {
-  private ts: typeof ts;
   private serviceHost: TypeScriptServiceHost;
   private service: LanguageService;
   private host: ts.LanguageServiceHost;
@@ -27,12 +26,11 @@ export class LanguageServicePlugin {
   static 'extension-kind' = 'language-service';
 
   constructor(config: {
-    ts: typeof ts; host: ts.LanguageServiceHost; service: ts.LanguageService;
+    host: ts.LanguageServiceHost; service: ts.LanguageService;
     registry?: ts.DocumentRegistry, args?: any
   }) {
-    this.ts = config.ts;
     this.host = config.host;
-    this.serviceHost = new TypeScriptServiceHost(this.ts, config.host, config.service);
+    this.serviceHost = new TypeScriptServiceHost(config.host, config.service);
     this.service = createLanguageService(this.serviceHost);
     this.serviceHost.setSite(this.service);
   }
@@ -51,7 +49,7 @@ export class LanguageServicePlugin {
           start: error.span.start,
           length: error.span.end - error.span.start,
           messageText: error.message,
-          category: this.ts.DiagnosticCategory.Error,
+          category: ts.DiagnosticCategory.Error,
           code: 0
         });
       }

--- a/modules/@angular/language-service/test/completions_spec.ts
+++ b/modules/@angular/language-service/test/completions_spec.ts
@@ -21,7 +21,7 @@ describe('completions', () => {
   let mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh);
   let service = ts.createLanguageService(mockHost, documentRegistry);
   let program = service.getProgram();
-  let ngHost = new TypeScriptServiceHost(ts, mockHost, service);
+  let ngHost = new TypeScriptServiceHost(mockHost, service);
   let ngService = createLanguageService(ngHost);
   ngHost.setSite(ngService);
 

--- a/modules/@angular/language-service/test/definitions_spec.ts
+++ b/modules/@angular/language-service/test/definitions_spec.ts
@@ -21,7 +21,7 @@ describe('definitions', () => {
   let mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh);
   let service = ts.createLanguageService(mockHost, documentRegistry);
   let program = service.getProgram();
-  let ngHost = new TypeScriptServiceHost(ts, mockHost, service);
+  let ngHost = new TypeScriptServiceHost(mockHost, service);
   let ngService = createLanguageService(ngHost);
   ngHost.setSite(ngService);
 

--- a/modules/@angular/language-service/test/diagnostics_spec.ts
+++ b/modules/@angular/language-service/test/diagnostics_spec.ts
@@ -20,7 +20,7 @@ describe('diagnostics', () => {
   let mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh);
   let service = ts.createLanguageService(mockHost, documentRegistry);
   let program = service.getProgram();
-  let ngHost = new TypeScriptServiceHost(ts, mockHost, service);
+  let ngHost = new TypeScriptServiceHost(mockHost, service);
   let ngService = createLanguageService(ngHost);
   ngHost.setSite(ngService);
 

--- a/modules/@angular/language-service/test/hover_spec.ts
+++ b/modules/@angular/language-service/test/hover_spec.ts
@@ -22,7 +22,7 @@ describe('hover', () => {
   let mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh);
   let service = ts.createLanguageService(mockHost, documentRegistry);
   let program = service.getProgram();
-  let ngHost = new TypeScriptServiceHost(ts, mockHost, service);
+  let ngHost = new TypeScriptServiceHost(mockHost, service);
   let ngService = createLanguageService(ngHost);
   ngHost.setSite(ngService);
 

--- a/modules/@angular/language-service/test/template_references_spec.ts
+++ b/modules/@angular/language-service/test/template_references_spec.ts
@@ -20,7 +20,7 @@ describe('references', () => {
   let mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh);
   let service = ts.createLanguageService(mockHost, documentRegistry);
   let program = service.getProgram();
-  let ngHost = new TypeScriptServiceHost(ts, mockHost, service);
+  let ngHost = new TypeScriptServiceHost(mockHost, service);
   let ngService = createLanguageService(ngHost);
   ngHost.setSite(ngService);
 

--- a/modules/@angular/language-service/test/ts_plugin_spec.ts
+++ b/modules/@angular/language-service/test/ts_plugin_spec.ts
@@ -29,8 +29,7 @@ describe('plugin', () => {
     }
   });
 
-  let plugin =
-      new LanguageServicePlugin({ts: ts, host: mockHost, service, registry: documentRegistry});
+  let plugin = new LanguageServicePlugin({host: mockHost, service, registry: documentRegistry});
 
   it('should not report template errors on tour of heroes', () => {
     for (let source of program.getSourceFiles()) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

`createLanguageServiceFromTypescript()` takes a `typescript` parameter that it doesn't completely use as some places it uses this parameter and in other places it uses the imported TypeScript.

**What is the new behavior?**

`createLanguageServiceFromTypescript()` no longer takes the typescript module as a parameter and will always use the imported version.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:

…eLanguageServiceFromTypescript()`

Fixes #13277