### PR TITLE
refactor(compiler): don't print stack trace on template parse errors

### DIFF
--- a/modules/@angular/compiler-cli/src/main.ts
+++ b/modules/@angular/compiler-cli/src/main.ts
@@ -12,12 +12,13 @@
 import 'reflect-metadata';
 
 import * as ts from 'typescript';
-import * as tsc from '@angular/tsc-wrapped';
+import {AngularCompilerOptions, NgcCliOptions, main as tscMain, UserError as tscUserError} from '@angular/tsc-wrapped';
+import {UserError as compilerUserError} from '@angular/compiler';
 
 import {CodeGenerator} from './codegen';
 
 function codegen(
-    ngOptions: tsc.AngularCompilerOptions, cliOptions: tsc.NgcCliOptions, program: ts.Program,
+    ngOptions: AngularCompilerOptions, cliOptions: NgcCliOptions, program: ts.Program,
     host: ts.CompilerHost) {
   return CodeGenerator.create(ngOptions, cliOptions, program, host).codegen();
 }
@@ -25,10 +26,10 @@ function codegen(
 export function main(
     args: any, consoleError: (s: string) => void = console.error): Promise<number> {
   const project = args.p || args.project || '.';
-  const cliOptions = new tsc.NgcCliOptions(args);
+  const cliOptions = new NgcCliOptions(args);
 
-  return tsc.main(project, cliOptions, codegen).then(() => 0).catch(e => {
-    if (e instanceof tsc.UserError) {
+  return tscMain(project, cliOptions, codegen).then(() => 0).catch(e => {
+    if (e instanceof tscUserError || e instanceof compilerUserError) {
       consoleError(e.message);
       return Promise.resolve(1);
     } else {

--- a/modules/@angular/compiler/index.ts
+++ b/modules/@angular/compiler/index.ts
@@ -64,4 +64,5 @@ export * from './src/style_compiler';
 export * from './src/template_parser/template_parser';
 export {ViewCompiler} from './src/view_compiler/view_compiler';
 export {AnimationParser} from './src/animation/animation_parser';
+export {UserError} from './src/util';
 // This file only reexports content of the `src` folder. Keep it that way.

--- a/modules/@angular/compiler/src/directive_normalizer.ts
+++ b/modules/@angular/compiler/src/directive_normalizer.ts
@@ -18,7 +18,7 @@ import {ResourceLoader} from './resource_loader';
 import {extractStyleUrls, isStyleUrlResolvable} from './style_url_resolver';
 import {PreparsedElementType, preparseElement} from './template_parser/template_preparser';
 import {UrlResolver} from './url_resolver';
-import {SyncAsyncResult} from './util';
+import {SyncAsyncResult, UserError} from './util';
 
 export interface PrenormalizedTemplateMetadata {
   componentType: any;
@@ -70,7 +70,7 @@ export class DirectiveNormalizer {
     } else if (prenormData.templateUrl) {
       normalizedTemplateAsync = this.normalizeTemplateAsync(prenormData);
     } else {
-      throw new Error(
+      throw new UserError(
           `No template specified for component ${stringify(prenormData.componentType)}`);
     }
 
@@ -104,7 +104,7 @@ export class DirectiveNormalizer {
         template, stringify(prenomData.componentType), false, interpolationConfig);
     if (rootNodesAndErrors.errors.length > 0) {
       const errorString = rootNodesAndErrors.errors.join('\n');
-      throw new Error(`Template parse errors:\n${errorString}`);
+      throw new UserError(`Template parse errors:\n${errorString}`);
     }
     const templateMetadataStyles = this.normalizeStylesheet(new CompileStylesheetMetadata({
       styles: prenomData.styles,

--- a/modules/@angular/compiler/src/template_parser/template_parser.ts
+++ b/modules/@angular/compiler/src/template_parser/template_parser.ts
@@ -25,7 +25,7 @@ import {ProviderElementContext, ProviderViewContext} from '../provider_analyzer'
 import {ElementSchemaRegistry} from '../schema/element_schema_registry';
 import {CssSelector, SelectorMatcher} from '../selector';
 import {isStyleUrlResolvable} from '../style_url_resolver';
-
+import {UserError} from '../util';
 import {BindingParser, BoundProperty} from './binding_parser';
 import {AttrAst, BoundDirectivePropertyAst, BoundElementPropertyAst, BoundEventAst, BoundTextAst, DirectiveAst, ElementAst, EmbeddedTemplateAst, NgContentAst, PropertyBindingType, ReferenceAst, TemplateAst, TemplateAstVisitor, TextAst, VariableAst, templateVisitAll} from './template_ast';
 import {PreparsedElementType, preparseElement} from './template_preparser';
@@ -102,7 +102,7 @@ export class TemplateParser {
 
     if (errors.length > 0) {
       const errorString = errors.join('\n');
-      throw new Error(`Template parse errors:\n${errorString}`);
+      throw new UserError(`Template parse errors:\n${errorString}`);
     }
 
     return result.templateAst;

--- a/modules/@angular/compiler/src/util.ts
+++ b/modules/@angular/compiler/src/util.ts
@@ -78,3 +78,12 @@ export class SyncAsyncResult<T> {
     }
   }
 }
+
+export class UserError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.message = message;
+    this.name = 'UserError';
+    this.stack = new Error().stack;
+  }
+}

--- a/modules/@angular/compiler/test/directive_normalizer_spec.ts
+++ b/modules/@angular/compiler/test/directive_normalizer_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
+import {UserError} from '@angular/compiler';
 import {CompileDirectiveMetadata, CompileStylesheetMetadata, CompileTemplateMetadata, CompileTypeMetadata} from '@angular/compiler/src/compile_metadata';
 import {CompilerConfig} from '@angular/compiler/src/config';
 import {DirectiveNormalizer} from '@angular/compiler/src/directive_normalizer';
@@ -31,7 +31,7 @@ export function main() {
            expect(() => normalizer.normalizeTemplate({
              componentType: SomeComp,
              moduleUrl: SOME_MODULE_URL,
-           })).toThrowError('No template specified for component SomeComp');
+           })).toThrowError(UserError, 'No template specified for component SomeComp');
          }));
     });
 

--- a/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
+import {UserError} from '@angular/compiler';
 import {CompileAnimationEntryMetadata, CompileDiDependencyMetadata, CompileDirectiveMetadata, CompileDirectiveSummary, CompilePipeMetadata, CompilePipeSummary, CompileProviderMetadata, CompileQueryMetadata, CompileTemplateMetadata, CompileTokenMetadata, CompileTypeMetadata, tokenReference} from '@angular/compiler/src/compile_metadata';
 import {DomElementSchemaRegistry} from '@angular/compiler/src/schema/dom_element_schema_registry';
 import {ElementSchemaRegistry} from '@angular/compiler/src/schema/element_schema_registry';
@@ -368,22 +368,26 @@ export function main() {
             it('should report invalid prefixes', () => {
               expect(() => parse('<p [atTr.foo]>', []))
                   .toThrowError(
+                      UserError,
                       `Template parse errors:\nInvalid property name 'atTr.foo' ("<p [ERROR ->][atTr.foo]>"): TestComp@0:3`);
               expect(() => parse('<p [sTyle.foo]>', []))
                   .toThrowError(
+                      UserError,
                       `Template parse errors:\nInvalid property name 'sTyle.foo' ("<p [ERROR ->][sTyle.foo]>"): TestComp@0:3`);
               expect(() => parse('<p [Class.foo]>', []))
                   .toThrowError(
+                      UserError,
                       `Template parse errors:\nInvalid property name 'Class.foo' ("<p [ERROR ->][Class.foo]>"): TestComp@0:3`);
               expect(() => parse('<p [bar.foo]>', []))
                   .toThrowError(
+                      UserError,
                       `Template parse errors:\nInvalid property name 'bar.foo' ("<p [ERROR ->][bar.foo]>"): TestComp@0:3`);
             });
 
             describe('errors', () => {
               it('should throw error when binding to an unknown property', () => {
                 expect(() => parse('<my-component [invalidProp]="bar"></my-component>', []))
-                    .toThrowError(`Template parse errors:
+                    .toThrowError(UserError, `Template parse errors:
 Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
 1. If 'my-component' is an Angular component and it has 'invalidProp' input, then verify that it is part of this module.
 2. If 'my-component' is a Web Component then add "CUSTOM_ELEMENTS_SCHEMA" to the '@NgModule.schemas' of this component to suppress this message.
@@ -391,7 +395,8 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
               });
 
               it('should throw error when binding to an unknown element w/o bindings', () => {
-                expect(() => parse('<unknown></unknown>', [])).toThrowError(`Template parse errors:
+                expect(() => parse('<unknown></unknown>', []))
+                    .toThrowError(UserError, `Template parse errors:
 'unknown' is not a known element:
 1. If 'unknown' is an Angular component, then verify that it is part of this module.
 2. If 'unknown' is a Web Component then add "CUSTOM_ELEMENTS_SCHEMA" to the '@NgModule.schemas' of this component to suppress this message. ("[ERROR ->]<unknown></unknown>"): TestComp@0:0`);
@@ -400,7 +405,7 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
               it('should throw error when binding to an unknown custom element w/o bindings',
                  () => {
                    expect(() => parse('<un-known></un-known>', []))
-                       .toThrowError(`Template parse errors:
+                       .toThrowError(UserError, `Template parse errors:
 'un-known' is not a known element:
 1. If 'un-known' is an Angular component, then verify that it is part of this module.
 2. If 'un-known' is a Web Component then add "CUSTOM_ELEMENTS_SCHEMA" to the '@NgModule.schemas' of this component to suppress this message. ("[ERROR ->]<un-known></un-known>"): TestComp@0:0`);
@@ -408,13 +413,13 @@ Can't bind to 'invalidProp' since it isn't a known property of 'my-component'.
 
               it('should throw error when binding to an invalid property', () => {
                 expect(() => parse('<my-component [onEvent]="bar"></my-component>', []))
-                    .toThrowError(`Template parse errors:
+                    .toThrowError(UserError, `Template parse errors:
 Binding to property 'onEvent' is disallowed for security reasons ("<my-component [ERROR ->][onEvent]="bar"></my-component>"): TestComp@0:14`);
               });
 
               it('should throw error when binding to an invalid attribute', () => {
                 expect(() => parse('<my-component [attr.onEvent]="bar"></my-component>', []))
-                    .toThrowError(`Template parse errors:
+                    .toThrowError(UserError, `Template parse errors:
 Binding to attribute 'onEvent' is disallowed for security reasons ("<my-component [ERROR ->][attr.onEvent]="bar"></my-component>"): TestComp@0:14`);
               });
             });
@@ -494,6 +499,7 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
 
               expect(() => { parse('<broken></broken>', [dirA]); })
                   .toThrowError(
+                      UserError,
                       `Template parse errors:\nValue of the host property binding "class.foo" needs to be a string representing an expression but got "null" (object) ("[ERROR ->]<broken></broken>"): TestComp@0:0, Directive DirA`);
             });
 
@@ -509,6 +515,7 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
 
               expect(() => { parse('<broken></broken>', [dirA]); })
                   .toThrowError(
+                      UserError,
                       `Template parse errors:\nValue of the host listener "click" needs to be a string representing an expression but got "null" (object) ("[ERROR ->]<broken></broken>"): TestComp@0:0, Directive DirA`);
             });
 
@@ -957,8 +964,8 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
               const dirB = createDir('[dirB]', {providers: [provider1]});
               expect(() => parse('<div dirA dirB>', [dirA, dirB]))
                   .toThrowError(
-                      `Template parse errors:\n` +
-                      `Mixing multi and non multi provider is not possible for token service0 ("[ERROR ->]<div dirA dirB>"): TestComp@0:0`);
+                      UserError, `Template parse errors:\n` +
+                          `Mixing multi and non multi provider is not possible for token service0 ("[ERROR ->]<div dirA dirB>"): TestComp@0:0`);
             });
 
             it('should sort providers by their DI order', () => {
@@ -1051,6 +1058,7 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
               const dirA = createDir('[dirA]', {deps: ['self:provider0']});
               expect(() => parse('<div dirA></div>', [dirA]))
                   .toThrowError(
+                      UserError,
                       'Template parse errors:\nNo provider for provider0 ("[ERROR ->]<div dirA></div>"): TestComp@0:0');
             });
 
@@ -1065,6 +1073,7 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
               const dirA = createDir('[dirA]', {deps: ['host:provider0']});
               expect(() => parse('<div dirA></div>', [dirA]))
                   .toThrowError(
+                      UserError,
                       'Template parse errors:\nNo provider for provider0 ("[ERROR ->]<div dirA></div>"): TestComp@0:0');
             });
 
@@ -1116,23 +1125,26 @@ Binding to attribute 'onEvent' is disallowed for security reasons ("<my-componen
             });
 
             it('should report references with values that dont match a directive as errors', () => {
-              expect(() => parse('<div #a="dirA"></div>', [])).toThrowError(`Template parse errors:
+              expect(() => parse('<div #a="dirA"></div>', []))
+                  .toThrowError(UserError, `Template parse errors:
 There is no directive with "exportAs" set to "dirA" ("<div [ERROR ->]#a="dirA"></div>"): TestComp@0:5`);
             });
 
             it('should report invalid reference names', () => {
-              expect(() => parse('<div #a-b></div>', [])).toThrowError(`Template parse errors:
+              expect(() => parse('<div #a-b></div>', []))
+                  .toThrowError(UserError, `Template parse errors:
 "-" is not allowed in reference names ("<div [ERROR ->]#a-b></div>"): TestComp@0:5`);
             });
 
             it('should report variables as errors', () => {
-              expect(() => parse('<div let-a></div>', [])).toThrowError(`Template parse errors:
+              expect(() => parse('<div let-a></div>', []))
+                  .toThrowError(UserError, `Template parse errors:
 "let-" is only supported on template elements. ("<div [ERROR ->]let-a></div>"): TestComp@0:5`);
             });
 
             it('should report duplicate reference names', () => {
               expect(() => parse('<div #a></div><div #a></div>', []))
-                  .toThrowError(`Template parse errors:
+                  .toThrowError(UserError, `Template parse errors:
 Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>"): TestComp@0:19`);
 
             });
@@ -1488,8 +1500,8 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
           it('should report when ng-content has non WS content', () => {
             expect(() => parse('<ng-content>content</ng-content>', []))
                 .toThrowError(
-                    `Template parse errors:\n` +
-                    `<ng-content> element cannot have content. ("[ERROR ->]<ng-content>content</ng-content>"): TestComp@0:0`);
+                    UserError, `Template parse errors:\n` +
+                        `<ng-content> element cannot have content. ("[ERROR ->]<ng-content>content</ng-content>"): TestComp@0:0`);
           });
 
           it('should treat *attr on a template element as valid',
@@ -1499,19 +1511,20 @@ Reference "#a" is defined several times ("<div #a></div><div [ERROR ->]#a></div>
              () => { expect(() => parse('<template template="ngIf">', [])).not.toThrowError(); });
 
           it('should report when mutliple *attrs are used on the same element', () => {
-            expect(() => parse('<div *ngIf *ngFor>', [])).toThrowError(`Template parse errors:
+            expect(() => parse('<div *ngIf *ngFor>', []))
+                .toThrowError(UserError, `Template parse errors:
 Can't have multiple template bindings on one element. Use only one attribute named 'template' or prefixed with * ("<div *ngIf [ERROR ->]*ngFor>"): TestComp@0:11`);
           });
 
           it('should report when mix of template and *attrs are used on the same element', () => {
             expect(() => parse('<span template="ngIf" *ngFor>', []))
-                .toThrowError(`Template parse errors:
+                .toThrowError(UserError, `Template parse errors:
 Can't have multiple template bindings on one element. Use only one attribute named 'template' or prefixed with * ("<span template="ngIf" [ERROR ->]*ngFor>"): TestComp@0:22`);
           });
 
           it('should report invalid property names', () => {
             expect(() => parse('<div [invalidProp]></div>', []))
-                .toThrowError(`Template parse errors:
+                .toThrowError(UserError, `Template parse errors:
 Can't bind to 'invalidProp' since it isn't a known property of 'div'. ("<div [ERROR ->][invalidProp]></div>"): TestComp@0:5`);
           });
 
@@ -1524,12 +1537,14 @@ Can't bind to 'invalidProp' since it isn't a known property of 'div'. ("<div [ER
                       host: {'[invalidProp]': 'someProp'}
                     })
                     .toSummary();
-            expect(() => parse('<div></div>', [dirA])).toThrowError(`Template parse errors:
+            expect(() => parse('<div></div>', [dirA]))
+                .toThrowError(UserError, `Template parse errors:
 Can't bind to 'invalidProp' since it isn't a known property of 'div'. ("[ERROR ->]<div></div>"): TestComp@0:0, Directive DirA`);
           });
 
           it('should report errors in expressions', () => {
-            expect(() => parse('<div [prop]="a b"></div>', [])).toThrowError(`Template parse errors:
+            expect(() => parse('<div [prop]="a b"></div>', []))
+                .toThrowError(UserError, `Template parse errors:
 Parser Error: Unexpected token 'b' at column 3 in [a b] in TestComp@0:5 ("<div [ERROR ->][prop]="a b"></div>"): TestComp@0:5`);
           });
 
@@ -1567,10 +1582,10 @@ Parser Error: Unexpected token 'b' at column 3 in [a b] in TestComp@0:5 ("<div [
                     .toSummary();
             expect(() => parse('<div>', [dirB, dirA]))
                 .toThrowError(
-                    `Template parse errors:\n` +
-                    `More than one component matched on this element.\n` +
-                    `Make sure that only one component's selector can match a given element.\n` +
-                    `Conflicting components: DirB,DirA ("[ERROR ->]<div>"): TestComp@0:0`);
+                    UserError, `Template parse errors:\n` +
+                        `More than one component matched on this element.\n` +
+                        `Make sure that only one component's selector can match a given element.\n` +
+                        `Conflicting components: DirB,DirA ("[ERROR ->]<div>"): TestComp@0:0`);
           });
 
           it('should not allow components or element bindings nor dom events on explicit embedded templates',
@@ -1585,7 +1600,7 @@ Parser Error: Unexpected token 'b' at column 3 in [a b] in TestComp@0:5 ("<div [
                        })
                        .toSummary();
                expect(() => parse('<template [a]="b" (e)="f"></template>', [dirA]))
-                   .toThrowError(`Template parse errors:
+                   .toThrowError(UserError, `Template parse errors:
 Event binding e not emitted by any directive on an embedded template. Make sure that the event name is spelled correctly and all directives are listed in the "directives" section. ("<template [a]="b" [ERROR ->](e)="f"></template>"): TestComp@0:18
 Components on an embedded template: DirA ("[ERROR ->]<template [a]="b" (e)="f"></template>"): TestComp@0:0
 Property binding a not used by any directive on an embedded template. Make sure that the property name is spelled correctly and all directives are listed in the "directives" section. ("[ERROR ->]<template [a]="b" (e)="f"></template>"): TestComp@0:0`);
@@ -1601,7 +1616,8 @@ Property binding a not used by any directive on an embedded template. Make sure 
                       template: new CompileTemplateMetadata({ngContentSelectors: []})
                     })
                     .toSummary();
-            expect(() => parse('<div *a="b"></div>', [dirA])).toThrowError(`Template parse errors:
+            expect(() => parse('<div *a="b"></div>', [dirA]))
+                .toThrowError(UserError, `Template parse errors:
 Components on an embedded template: DirA ("[ERROR ->]<div *a="b"></div>"): TestComp@0:0
 Property binding a not used by any directive on an embedded template. Make sure that the property name is spelled correctly and all directives are listed in the "directives" section. ("[ERROR ->]<div *a="b"></div>"): TestComp@0:0`);
           });
@@ -1866,7 +1882,7 @@ Property binding a not used by any directive on an embedded template. Make sure 
           });
 
           it('should report pipes as error that have not been defined as dependencies', () => {
-            expect(() => parse('{{a | test}}', [])).toThrowError(`Template parse errors:
+            expect(() => parse('{{a | test}}', [])).toThrowError(UserError, `Template parse errors:
 The pipe 'test' could not be found ("[ERROR ->]{{a | test}}"): TestComp@0:0`);
           });
 

--- a/modules/@angular/upgrade/test/upgrade_spec.ts
+++ b/modules/@angular/upgrade/test/upgrade_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {UserError} from '@angular/compiler';
 import {ChangeDetectorRef, Class, Component, EventEmitter, NO_ERRORS_SCHEMA, NgModule, SimpleChanges, Testability, destroyPlatform, forwardRef} from '@angular/core';
 import {async, fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
@@ -57,7 +58,7 @@ export function main() {
              flushMicrotasks();
            }).toThrowError();
            expect(console.error).toHaveBeenCalled();
-           expect(console.error).toHaveBeenCalledWith(jasmine.any(Error), jasmine.any(String));
+           expect(console.error).toHaveBeenCalledWith(jasmine.any(UserError), jasmine.any(String));
          }));
     });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Stack trace is printed on template parse errors.


**What is the new behavior?**
Error message is printed on template parse errors but not stack trace.
For example:
```
+ ./node_modules/.bin/ngc -p tsconfig-build.json --i18nFile=src/messages.fi.xlf --locale=fi --i18nFormat=xlf
No template specified for component ThirdPartyComponent
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```