### PR TITLE
fix(compiler): fix transpiled ES5 code

### DIFF
--- a/modules/@angular/compiler/src/jit/compiler.ts
+++ b/modules/@angular/compiler/src/jit/compiler.ts
@@ -213,11 +213,11 @@ export class JitCompiler implements Compiler {
       const compMeta = this._metadataResolver.getDirectiveMetadata(compType);
       assertComponent(compMeta);
 
-      class HostClass {
-        static overriddenName = `${identifierName(compMeta.type)}_Host`;
-      }
+      const hostClass = {
+        overriddenName: `${identifierName(compMeta.type)}_Host`,
+      };
 
-      const hostMeta = createHostComponentMeta(HostClass, compMeta);
+      const hostMeta = createHostComponentMeta(hostClass, compMeta);
       compiledTemplate = new CompiledTemplate(
           true, compMeta.selector, compMeta.type, hostMeta, ngModule, [compMeta.type]);
       this._compiledHostTemplateCache.set(compType, compiledTemplate);


### PR DESCRIPTION
fixes #13301

The inner class would transpile to a nested function declaration which is not
allowed in ES5.

See http://eslint.org/docs/rules/no-inner-declarations