### PR TITLE
doc: update triage owners for language service and router

### DIFF
--- a/TRIAGE_AND_LABELS.md
+++ b/TRIAGE_AND_LABELS.md
@@ -24,8 +24,9 @@ with it.
 * `comp: forms`: `@kara`
 * `comp: http`: `@jeffbcross`
 * `comp: i18n`: `@vicb`
+* `comp: language service`: `@chuckjaz`
 * `comp: metadata-extractor`: `@chuckjaz`
-* `comp: router`: `@vsavkin`
+* `comp: router`: `@vicb`
 * `comp: testing`: `@juliemr`
 * `comp: upgrade`: `@mhevery`
 * `comp: web-worker`: `@vicb`


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Other... Please describe: docs
```

**What is the current behavior?** (You can also link to an open issue here)

Triage document is slightly out of date.

**What is the new behavior?**

Updated triage document for the new router owner and added a label for the language service.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```