### PR TITLE
feat(router): attach 'router-link-active' class automatically

### DIFF
--- a/modules/@angular/router/src/directives/router_link.ts
+++ b/modules/@angular/router/src/directives/router_link.ts
@@ -93,11 +93,7 @@ export class RouterLink {
 
   @Input()
   set routerLink(data: any[]|string) {
-    if (Array.isArray(data)) {
-      this.commands = data;
-    } else {
-      this.commands = [data];
-    }
+    this.commands = Array.isArray(data) ? data : [data];
   }
 
   @HostListener('click', [])
@@ -158,15 +154,11 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
 
   @Input()
   set routerLink(data: any[]|string) {
-    if (Array.isArray(data)) {
-      this.commands = data;
-    } else {
-      this.commands = [data];
-    }
+    this.commands = Array.isArray(data) ? data : [data];
   }
 
-  ngOnChanges(changes: {}): any { this.updateTargetUrlAndHref(); }
-  ngOnDestroy(): any { this.subscription.unsubscribe(); }
+  ngOnChanges(changes: {}): void { this.updateTargetUrlAndHref(); }
+  ngOnDestroy(): void { this.subscription.unsubscribe(); }
 
   @HostListener('click', ['$event.button', '$event.ctrlKey', '$event.metaKey'])
   onClick(button: number, ctrlKey: boolean, metaKey: boolean): boolean {

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -238,7 +238,8 @@ export declare abstract class RouteReuseStrategy {
 }
 
 /** @stable */
-export declare class RouterLink {
+export declare class RouterLink implements OnChanges, OnDestroy {
+    active: boolean;
     fragment: string;
     preserveFragment: boolean;
     preserveQueryParams: boolean;
@@ -250,6 +251,8 @@ export declare class RouterLink {
     skipLocationChange: boolean;
     urlTree: UrlTree;
     constructor(router: Router, route: ActivatedRoute);
+    ngOnChanges(changes: {}): void;
+    ngOnDestroy(): void;
     onClick(): boolean;
 }
 
@@ -270,6 +273,7 @@ export declare class RouterLinkActive implements OnChanges, OnDestroy, AfterCont
 
 /** @stable */
 export declare class RouterLinkWithHref implements OnChanges, OnDestroy {
+    active: boolean;
     fragment: string;
     href: string;
     preserveFragment: boolean;

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -283,8 +283,8 @@ export declare class RouterLinkWithHref implements OnChanges, OnDestroy {
     target: string;
     urlTree: UrlTree;
     constructor(router: Router, route: ActivatedRoute, locationStrategy: LocationStrategy);
-    ngOnChanges(changes: {}): any;
-    ngOnDestroy(): any;
+    ngOnChanges(changes: {}): void;
+    ngOnDestroy(): void;
     onClick(button: number, ctrlKey: boolean, metaKey: boolean): boolean;
 }
 


### PR DESCRIPTION
Original motivation is here https://github.com/angular/angular/issues/13098#issuecomment-264320857

Fixes https://github.com/angular/angular/issues/9426 / https://github.com/angular/angular/issues/13098 / https://github.com/angular/angular/issues/13075

This also makes redundant https://github.com/angular/angular/pull/13273

With just a few lines (we can extract common code into parent class so it will be even less) we can make `RouterLinkActive` absolutely redundant with all its issues. So my question is: why do we need `RouterLinkActive` in the first place?

I know we can't remove `RouterLinkActive` now (or I can? http://prnt.sc/dhazum 4.0 beta next week). But I can:
1) Extract common code into parent class.
2) Automatically attach `router-link-active` (as described in the original issue https://github.com/angular/angular/issues/9426) with the following semantics:
```
// new feature without routerLinkActive 
<a routerLink=""></a>// => class="router-link-active"

// no changes with routerLinkActive and its value
<a routerLink="" routerLinkActive="my-active-link"></a> // => class="my-active-link"
```
and in ng3 we will completely remove `RouterLinkActive` from the code base.

@vicb what do u think?
