### PR TITLE
[4.x only] refactor(core): strong type keyvalue differs

### DIFF
--- a/modules/@angular/common/src/common.ts
+++ b/modules/@angular/common/src/common.ts
@@ -17,4 +17,3 @@ export {CommonModule} from './common_module';
 export {NgClass, NgFor, NgIf, NgPlural, NgPluralCase, NgStyle, NgSwitch, NgSwitchCase, NgSwitchDefault, NgTemplateOutlet} from './directives/index';
 export {AsyncPipe, DatePipe, I18nPluralPipe, I18nSelectPipe, JsonPipe, LowerCasePipe, CurrencyPipe, DecimalPipe, PercentPipe, SlicePipe, UpperCasePipe, TitleCasePipe} from './pipes/index';
 export {VERSION} from './version';
-export {Version} from '@angular/core';

--- a/modules/@angular/common/src/directives/ng_class.ts
+++ b/modules/@angular/common/src/directives/ng_class.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CollectionChangeRecord, Directive, DoCheck, ElementRef, Input, IterableDiffer, IterableDiffers, KeyValueChangeRecord, KeyValueDiffer, KeyValueDiffers, Renderer} from '@angular/core';
+import {Directive, DoCheck, ElementRef, Input, IterableChanges, IterableDiffer, IterableDiffers, KeyValueChanges, KeyValueDiffer, KeyValueDiffers, Renderer} from '@angular/core';
 
 import {isListLikeIterable} from '../facade/collection';
 import {isPresent, stringify} from '../facade/lang';
@@ -41,8 +41,8 @@ import {isPresent, stringify} from '../facade/lang';
  */
 @Directive({selector: '[ngClass]'})
 export class NgClass implements DoCheck {
-  private _iterableDiffer: IterableDiffer;
-  private _keyValueDiffer: KeyValueDiffer;
+  private _iterableDiffer: IterableDiffer<string>;
+  private _keyValueDiffer: KeyValueDiffer<string, any>;
   private _initialClasses: string[] = [];
   private _rawClass: string[]|Set<string>|{[klass: string]: any};
 
@@ -78,39 +78,35 @@ export class NgClass implements DoCheck {
 
   ngDoCheck(): void {
     if (this._iterableDiffer) {
-      const changes = this._iterableDiffer.diff(this._rawClass);
-      if (changes) {
-        this._applyIterableChanges(changes);
+      const iterableChanges = this._iterableDiffer.diff(this._rawClass as string[]);
+      if (iterableChanges) {
+        this._applyIterableChanges(iterableChanges);
       }
     } else if (this._keyValueDiffer) {
-      const changes = this._keyValueDiffer.diff(this._rawClass);
-      if (changes) {
-        this._applyKeyValueChanges(changes);
+      const keyValueChanges = this._keyValueDiffer.diff(this._rawClass as{[k: string]: any});
+      if (keyValueChanges) {
+        this._applyKeyValueChanges(keyValueChanges);
       }
     }
   }
 
-  private _cleanupClasses(rawClassVal: string[]|Set<string>|{[klass: string]: any}): void {
+  private _cleanupClasses(rawClassVal: string[]|{[klass: string]: any}): void {
     this._applyClasses(rawClassVal, true);
     this._applyInitialClasses(false);
   }
 
-  private _applyKeyValueChanges(changes: any): void {
-    changes.forEachAddedItem(
-        (record: KeyValueChangeRecord) => this._toggleClass(record.key, record.currentValue));
-
-    changes.forEachChangedItem(
-        (record: KeyValueChangeRecord) => this._toggleClass(record.key, record.currentValue));
-
-    changes.forEachRemovedItem((record: KeyValueChangeRecord) => {
+  private _applyKeyValueChanges(changes: KeyValueChanges<string, any>): void {
+    changes.forEachAddedItem((record) => this._toggleClass(record.key, record.currentValue));
+    changes.forEachChangedItem((record) => this._toggleClass(record.key, record.currentValue));
+    changes.forEachRemovedItem((record) => {
       if (record.previousValue) {
         this._toggleClass(record.key, false);
       }
     });
   }
 
-  private _applyIterableChanges(changes: any): void {
-    changes.forEachAddedItem((record: CollectionChangeRecord) => {
+  private _applyIterableChanges(changes: IterableChanges<string>): void {
+    changes.forEachAddedItem((record) => {
       if (typeof record.item === 'string') {
         this._toggleClass(record.item, true);
       } else {
@@ -119,8 +115,7 @@ export class NgClass implements DoCheck {
       }
     });
 
-    changes.forEachRemovedItem(
-        (record: CollectionChangeRecord) => this._toggleClass(record.item, false));
+    changes.forEachRemovedItem((record) => this._toggleClass(record.item, false));
   }
 
   private _applyInitialClasses(isCleanup: boolean) {
@@ -128,7 +123,7 @@ export class NgClass implements DoCheck {
   }
 
   private _applyClasses(
-      rawClassVal: string[]|Set<string>|{[key: string]: any}, isCleanup: boolean) {
+      rawClassVal: string[]|Set<string>|{[klass: string]: any}, isCleanup: boolean) {
     if (rawClassVal) {
       if (Array.isArray(rawClassVal) || rawClassVal instanceof Set) {
         (<any>rawClassVal).forEach((klass: string) => this._toggleClass(klass, !isCleanup));
@@ -140,11 +135,11 @@ export class NgClass implements DoCheck {
     }
   }
 
-  private _toggleClass(klass: string, enabled: boolean): void {
+  private _toggleClass(klass: string, enabled: any): void {
     klass = klass.trim();
     if (klass) {
       klass.split(/\s+/g).forEach(
-          klass => { this._renderer.setElementClass(this._ngEl.nativeElement, klass, enabled); });
+          klass => { this._renderer.setElementClass(this._ngEl.nativeElement, klass, !!enabled); });
     }
   }
 }

--- a/modules/@angular/common/src/directives/ng_for.ts
+++ b/modules/@angular/common/src/directives/ng_for.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, CollectionChangeRecord, DefaultIterableDiffer, Directive, DoCheck, EmbeddedViewRef, Input, IterableDiffer, IterableDiffers, OnChanges, SimpleChanges, TemplateRef, TrackByFn, ViewContainerRef, isDevMode} from '@angular/core';
+import {ChangeDetectorRef, Directive, DoCheck, EmbeddedViewRef, Input, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDiffers, OnChanges, SimpleChanges, TemplateRef, TrackByFn, ViewContainerRef, isDevMode} from '@angular/core';
 
 import {getTypeNameForDebugging} from '../facade/lang';
 
@@ -104,7 +104,7 @@ export class NgFor implements DoCheck, OnChanges {
 
   get ngForTrackBy(): TrackByFn { return this._trackByFn; }
 
-  private _differ: IterableDiffer = null;
+  private _differ: IterableDiffer<any> = null;
   private _trackByFn: TrackByFn;
 
   constructor(
@@ -140,10 +140,10 @@ export class NgFor implements DoCheck, OnChanges {
     }
   }
 
-  private _applyChanges(changes: DefaultIterableDiffer) {
+  private _applyChanges(changes: IterableChanges<any>) {
     const insertTuples: RecordViewTuple[] = [];
     changes.forEachOperation(
-        (item: CollectionChangeRecord, adjustedPreviousIndex: number, currentIndex: number) => {
+        (item: IterableChangeRecord<any>, adjustedPreviousIndex: number, currentIndex: number) => {
           if (item.previousIndex == null) {
             const view = this._viewContainer.createEmbeddedView(
                 this._template, new NgForRow(null, null, null), currentIndex);
@@ -175,7 +175,7 @@ export class NgFor implements DoCheck, OnChanges {
     });
   }
 
-  private _perViewChange(view: EmbeddedViewRef<NgForRow>, record: CollectionChangeRecord) {
+  private _perViewChange(view: EmbeddedViewRef<NgForRow>, record: IterableChangeRecord<any>) {
     view.context.$implicit = record.item;
   }
 }

--- a/modules/@angular/common/src/directives/ng_style.ts
+++ b/modules/@angular/common/src/directives/ng_style.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, DoCheck, ElementRef, Input, KeyValueChangeRecord, KeyValueDiffer, KeyValueDiffers, Renderer} from '@angular/core';
+import {Directive, DoCheck, ElementRef, Input, KeyValueChanges, KeyValueDiffer, KeyValueDiffers, Renderer} from '@angular/core';
 
 /**
  * @ngModule CommonModule
@@ -33,7 +33,7 @@ import {Directive, DoCheck, ElementRef, Input, KeyValueChangeRecord, KeyValueDif
 @Directive({selector: '[ngStyle]'})
 export class NgStyle implements DoCheck {
   private _ngStyle: {[key: string]: string};
-  private _differ: KeyValueDiffer;
+  private _differ: KeyValueDiffer<string, string|number>;
 
   constructor(
       private _differs: KeyValueDiffers, private _ngEl: ElementRef, private _renderer: Renderer) {}
@@ -55,20 +55,16 @@ export class NgStyle implements DoCheck {
     }
   }
 
-  private _applyChanges(changes: any): void {
-    changes.forEachRemovedItem((record: KeyValueChangeRecord) => this._setStyle(record.key, null));
-
-    changes.forEachAddedItem(
-        (record: KeyValueChangeRecord) => this._setStyle(record.key, record.currentValue));
-
-    changes.forEachChangedItem(
-        (record: KeyValueChangeRecord) => this._setStyle(record.key, record.currentValue));
+  private _applyChanges(changes: KeyValueChanges<string, string|number>): void {
+    changes.forEachRemovedItem((record) => this._setStyle(record.key, null));
+    changes.forEachAddedItem((record) => this._setStyle(record.key, record.currentValue));
+    changes.forEachChangedItem((record) => this._setStyle(record.key, record.currentValue));
   }
 
-  private _setStyle(nameAndUnit: string, value: string): void {
+  private _setStyle(nameAndUnit: string, value: string|number): void {
     const [name, unit] = nameAndUnit.split('.');
-    value = value && unit ? `${value}${unit}` : value;
+    value = value != null && unit ? `${value}${unit}` : value;
 
-    this._renderer.setElementStyle(this._ngEl.nativeElement, name, value);
+    this._renderer.setElementStyle(this._ngEl.nativeElement, name, value as string);
   }
 }

--- a/modules/@angular/core/src/change_detection.ts
+++ b/modules/@angular/core/src/change_detection.ts
@@ -12,4 +12,4 @@
  * Change detection enables data binding in Angular.
  */
 
-export {ChangeDetectionStrategy, ChangeDetectorRef, CollectionChangeRecord, DefaultIterableDiffer, IterableDiffer, IterableDifferFactory, IterableDiffers, KeyValueChangeRecord, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers, PipeTransform, SimpleChange, SimpleChanges, TrackByFn, WrappedValue} from './change_detection/change_detection';
+export {ChangeDetectionStrategy, ChangeDetectorRef, CollectionChangeRecord, DefaultIterableDiffer, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers, PipeTransform, SimpleChange, SimpleChanges, TrackByFn, WrappedValue} from './change_detection/change_detection';

--- a/modules/@angular/core/src/change_detection/change_detection.ts
+++ b/modules/@angular/core/src/change_detection/change_detection.ts
@@ -7,7 +7,7 @@
  */
 
 import {DefaultIterableDifferFactory} from './differs/default_iterable_differ';
-import {DefaultKeyValueDifferFactory, KeyValueChangeRecord} from './differs/default_keyvalue_differ';
+import {DefaultKeyValueDifferFactory} from './differs/default_keyvalue_differ';
 import {IterableDifferFactory, IterableDiffers} from './differs/iterable_differs';
 import {KeyValueDifferFactory, KeyValueDiffers} from './differs/keyvalue_differs';
 
@@ -15,11 +15,11 @@ export {SimpleChanges} from '../metadata/lifecycle_hooks';
 export {SimpleChange, ValueUnwrapper, WrappedValue, devModeEqual, looseIdentical} from './change_detection_util';
 export {ChangeDetectorRef} from './change_detector_ref';
 export {ChangeDetectionStrategy, ChangeDetectorStatus, isDefaultChangeDetectionStrategy} from './constants';
-export {CollectionChangeRecord, DefaultIterableDifferFactory} from './differs/default_iterable_differ';
+export {DefaultIterableDifferFactory} from './differs/default_iterable_differ';
 export {DefaultIterableDiffer} from './differs/default_iterable_differ';
-export {DefaultKeyValueDifferFactory, KeyValueChangeRecord} from './differs/default_keyvalue_differ';
-export {IterableDiffer, IterableDifferFactory, IterableDiffers, TrackByFn} from './differs/iterable_differs';
-export {KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers} from './differs/keyvalue_differs';
+export {DefaultKeyValueDifferFactory} from './differs/default_keyvalue_differ';
+export {CollectionChangeRecord, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, TrackByFn} from './differs/iterable_differs';
+export {KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers} from './differs/keyvalue_differs';
 export {PipeTransform} from './pipe_transform';
 
 
@@ -27,12 +27,12 @@ export {PipeTransform} from './pipe_transform';
 /**
  * Structural diffing for `Object`s and `Map`s.
  */
-export const keyValDiff: KeyValueDifferFactory[] = [new DefaultKeyValueDifferFactory()];
+const keyValDiff: KeyValueDifferFactory[] = [new DefaultKeyValueDifferFactory()];
 
 /**
  * Structural diffing for `Iterable` types such as `Array`s.
  */
-export const iterableDiff: IterableDifferFactory[] = [new DefaultIterableDifferFactory()];
+const iterableDiff: IterableDifferFactory[] = [new DefaultIterableDifferFactory()];
 
 export const defaultIterableDiffers = new IterableDiffers(iterableDiff);
 

--- a/modules/@angular/core/test/change_detection/differs/default_keyvalue_differ_spec.ts
+++ b/modules/@angular/core/test/change_detection/differs/default_keyvalue_differ_spec.ts
@@ -14,11 +14,11 @@ import {kvChangesAsString} from '../../change_detection/util';
 export function main() {
   describe('keyvalue differ', function() {
     describe('DefaultKeyValueDiffer', function() {
-      let differ: DefaultKeyValueDiffer;
+      let differ: DefaultKeyValueDiffer<any, any>;
       let m: Map<any, any>;
 
       beforeEach(() => {
-        differ = new DefaultKeyValueDiffer();
+        differ = new DefaultKeyValueDiffer<string, any>();
         m = new Map();
       });
 

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -201,14 +201,8 @@ export interface ClassProvider {
     useClass: Type<any>;
 }
 
-/** @stable */
-export declare class CollectionChangeRecord {
-    currentIndex: number;
-    item: any;
-    previousIndex: number;
-    trackById: any;
-    constructor(item: any, trackById: any);
-    toString(): string;
+/** @deprecated */
+export interface CollectionChangeRecord<V> extends IterableChangeRecord<V> {
 }
 
 /** @stable */
@@ -354,21 +348,21 @@ export declare class DebugNode {
     constructor(nativeNode: any, parent: DebugNode, _debugInfo: RenderDebugInfo);
 }
 
-/** @stable */
-export declare class DefaultIterableDiffer implements IterableDiffer {
+/** @deprecated */
+export declare class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChanges<V> {
     collection: any;
     isDirty: boolean;
     length: number;
     constructor(_trackByFn?: TrackByFn);
-    check(collection: any): boolean;
-    diff(collection: any): DefaultIterableDiffer;
-    forEachAddedItem(fn: Function): void;
-    forEachIdentityChange(fn: Function): void;
-    forEachItem(fn: Function): void;
-    forEachMovedItem(fn: Function): void;
-    forEachOperation(fn: (item: CollectionChangeRecord, previousIndex: number, currentIndex: number) => void): void;
-    forEachPreviousItem(fn: Function): void;
-    forEachRemovedItem(fn: Function): void;
+    check(collection: V[] | Set<V>[] | any): boolean;
+    diff(collection: V[] | Set<V>[] | any): DefaultIterableDiffer<V>;
+    forEachAddedItem(fn: (record: IterableChangeRecord_<V>) => void): void;
+    forEachIdentityChange(fn: (record: IterableChangeRecord_<V>) => void): void;
+    forEachItem(fn: (record: IterableChangeRecord_<V>) => void): void;
+    forEachMovedItem(fn: (record: IterableChangeRecord_<V>) => void): void;
+    forEachOperation(fn: (item: IterableChangeRecord_<V>, previousIndex: number, currentIndex: number) => void): void;
+    forEachPreviousItem(fn: (record: IterableChangeRecord_<V>) => void): void;
+    forEachRemovedItem(fn: (record: IterableChangeRecord_<V>) => void): void;
     onDestroy(): void;
     toString(): string;
 }
@@ -507,20 +501,38 @@ export declare const Input: InputDecorator;
 export declare function isDevMode(): boolean;
 
 /** @stable */
-export interface IterableDiffer {
-    diff(object: any): any;
-    onDestroy(): any;
+export interface IterableChangeRecord<V> {
+    currentIndex: number;
+    item: V;
+    previousIndex: number;
+    trackById: any;
+}
+
+/** @stable */
+export interface IterableChanges<V> {
+    forEachAddedItem(fn: (record: IterableChangeRecord<V>) => void): void;
+    forEachIdentityChange(fn: (record: IterableChangeRecord<V>) => void): void;
+    forEachItem(fn: (record: IterableChangeRecord<V>) => void): void;
+    forEachMovedItem(fn: (record: IterableChangeRecord<V>) => void): void;
+    forEachOperation(fn: (record: IterableChangeRecord<V>, previousIndex: number, currentIndex: number) => void): void;
+    forEachPreviousItem(fn: (record: IterableChangeRecord<V>) => void): void;
+    forEachRemovedItem(fn: (record: IterableChangeRecord<V>) => void): void;
+}
+
+/** @stable */
+export interface IterableDiffer<V> {
+    diff(object: V[] | Set<V> | any): IterableChanges<V>;
 }
 
 /** @stable */
 export interface IterableDifferFactory {
-    create(cdRef: ChangeDetectorRef, trackByFn?: TrackByFn): IterableDiffer;
+    create<V>(cdRef: ChangeDetectorRef, trackByFn?: TrackByFn): IterableDiffer<V>;
     supports(objects: any): boolean;
 }
 
 /** @stable */
 export declare class IterableDiffers {
-    factories: IterableDifferFactory[];
+    /** @deprecated */ factories: IterableDifferFactory[];
     constructor(factories: IterableDifferFactory[]);
     find(iterable: any): IterableDifferFactory;
     static create(factories: IterableDifferFactory[], parent?: IterableDiffers): IterableDiffers;
@@ -531,33 +543,42 @@ export declare class IterableDiffers {
 export declare function keyframes(steps: AnimationStyleMetadata[]): AnimationKeyframesSequenceMetadata;
 
 /** @stable */
-export declare class KeyValueChangeRecord {
-    currentValue: any;
-    key: any;
-    previousValue: any;
-    constructor(key: any);
-    toString(): string;
+export interface KeyValueChangeRecord<K, V> {
+    currentValue: V;
+    key: K;
+    previousValue: V;
 }
 
 /** @stable */
-export interface KeyValueDiffer {
-    diff(object: any): any;
-    onDestroy(): any;
+export interface KeyValueChanges<K, V> {
+    forEachAddedItem(fn: (r: KeyValueChangeRecord<K, V>) => void): void;
+    forEachChangedItem(fn: (r: KeyValueChangeRecord<K, V>) => void): void;
+    forEachItem(fn: (r: KeyValueChangeRecord<K, V>) => void): void;
+    forEachPreviousItem(fn: (r: KeyValueChangeRecord<K, V>) => void): void;
+    forEachRemovedItem(fn: (r: KeyValueChangeRecord<K, V>) => void): void;
+}
+
+/** @stable */
+export interface KeyValueDiffer<K, V> {
+    diff(object: Map<K, V>): KeyValueChanges<K, V>;
+    diff(object: {
+        [key: string]: V;
+    }): KeyValueChanges<string, V>;
 }
 
 /** @stable */
 export interface KeyValueDifferFactory {
-    create(cdRef: ChangeDetectorRef): KeyValueDiffer;
+    create<K, V>(cdRef: ChangeDetectorRef): KeyValueDiffer<K, V>;
     supports(objects: any): boolean;
 }
 
 /** @stable */
 export declare class KeyValueDiffers {
-    factories: KeyValueDifferFactory[];
+    /** @deprecated */ factories: KeyValueDifferFactory[];
     constructor(factories: KeyValueDifferFactory[]);
-    find(kv: Object): KeyValueDifferFactory;
-    static create(factories: KeyValueDifferFactory[], parent?: KeyValueDiffers): KeyValueDiffers;
-    static extend(factories: KeyValueDifferFactory[]): Provider;
+    find(kv: any): KeyValueDifferFactory;
+    static create<S>(factories: KeyValueDifferFactory[], parent?: KeyValueDiffers): KeyValueDiffers;
+    static extend<S>(factories: KeyValueDifferFactory[]): Provider;
 }
 
 /** @experimental */


### PR DESCRIPTION
refactor(core): Add type information to  differs

BREAKING CHANGE:

- `CollectionChangeRecord` is renamed to `IterableChangeRecord`.
  `CollectionChangeRecord` is aliased to `IterableChangeRecord` and is 
  marked as `@deprecated`. It will be removed in `v5.x.x`.
- `IterableChangeRecord` is now an interface and parameterized on `<V>`.
  This should not be an issue unless your code does 
  `new IterableChangeRecord` which it should not have a reason to do.
- `KeyValueChangeRecord` is now an interface and parameterized on `<V>`.
  This should not be an issue unless your code does 
  `new IterableChangeRecord` which it should not have a reason to do.
- Deprecate unused `onDestroy` method on the `KeyValueDiffer` and 
  `IterableDiffer`.
- More restrictive type on `NgClass#ngClass` and `NgStyle#ngStyle`.
- Deprecate `DefaultIterableDiffer` as it is private class which 
  was erroneously exposed.
- Deprecate `KeyValueDiffers#factories` as it is private field which 
  was erroneously exposed.
- Deprecate `IterableDiffers#factories` as it is private field which 
  was erroneously exposed.



Original PR #12570