### PR TITLE
test(upgrade): fix failing test in browsers which do not support RAF

### DIFF
--- a/modules/@angular/upgrade/test/upgrade_spec.ts
+++ b/modules/@angular/upgrade/test/upgrade_spec.ts
@@ -1023,6 +1023,13 @@ export function main() {
              expect($onDestroySpy).toHaveBeenCalled();
 
              ref.dispose();
+
+             // Needed for browser which don't support RAF and use a 16.6 setTimeout instead in
+             // ng1's AnimateRunner.
+             // This setTimeout remains at the end of the test and needs to be discarded.
+             if (!(global as any /** TODO #9100 */)['requestAnimationFrame']) {
+               tick(20);
+             }
            });
          }));
 


### PR DESCRIPTION
This particular is failing in browsers which do not support RAF: IE9, Android <= 4.3

For a cleaner fix, I've tried to use `$timeout.flush()` from ng1 instead of `tick(20)`, but I couldn't make it work. 
When adding `angular-mock.js` to Karma's configuration, it doesn't patch $timeout and .flush() is not available.