### PR TITLE
build: update the package list of the symlinks scripts for Windows

### DIFF
--- a/scripts/windows/packages.txt
+++ b/scripts/windows/packages.txt
@@ -5,7 +5,6 @@ compiler/testing
 core/src
 core/testing
 forms/src
-http/src
 platform-browser/src
 platform-browser/testing
 platform-browser-dynamic/src


### PR DESCRIPTION
http doesn't use facade anymore