### PR TITLE
fix(compiler): narrow the span reported for invalid pipes

### DIFF
--- a/modules/@angular/compiler/src/expression_parser/parser.ts
+++ b/modules/@angular/compiler/src/expression_parser/parser.ts
@@ -344,7 +344,7 @@ export class _ParseAST {
         while (this.optionalCharacter(chars.$COLON)) {
           args.push(this.parseExpression());
         }
-        result = new BindingPipe(this.span(result.span.start - this.offset), result, name, args);
+        result = new BindingPipe(this.span(result.span.start), result, name, args);
       } while (this.optionalOperator('|'));
     }
 

--- a/modules/@angular/compiler/src/template_parser/binding_parser.ts
+++ b/modules/@angular/compiler/src/template_parser/binding_parser.ts
@@ -377,9 +377,12 @@ export class BindingParser {
     if (isPresent(ast)) {
       const collector = new PipeCollector();
       ast.visit(collector);
-      collector.pipes.forEach((pipeName) => {
+      collector.pipes.forEach((ast, pipeName) => {
         if (!this.pipesByName.has(pipeName)) {
-          this._reportError(`The pipe '${pipeName}' could not be found`, sourceSpan);
+          this._reportError(
+              `The pipe '${pipeName}' could not be found`,
+              new ParseSourceSpan(
+                  sourceSpan.start.moveBy(ast.span.start), sourceSpan.start.moveBy(ast.span.end)));
         }
       });
     }
@@ -402,9 +405,9 @@ export class BindingParser {
 }
 
 export class PipeCollector extends RecursiveAstVisitor {
-  pipes = new Set<string>();
+  pipes = new Map<string, BindingPipe>();
   visitPipe(ast: BindingPipe, context: any): any {
-    this.pipes.add(ast.name);
+    this.pipes.set(ast.name, ast);
     ast.exp.visit(this);
     this.visitAll(ast.args, context);
     return null;

--- a/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
@@ -1839,7 +1839,7 @@ Property binding a not used by any directive on an embedded template. Make sure 
 
       it('should report pipes as error that have not been defined as dependencies', () => {
         expect(() => parse('{{a | test}}', [])).toThrowError(`Template parse errors:
-The pipe 'test' could not be found ("[ERROR ->]{{a | test}}"): TestComp@0:0`);
+The pipe 'test' could not be found ("{{[ERROR ->]a | test}}"): TestComp@0:2`);
       });
 
     });

--- a/modules/@angular/language-service/test/diagnostics_spec.ts
+++ b/modules/@angular/language-service/test/diagnostics_spec.ts
@@ -130,6 +130,18 @@ describe('diagnostics', () => {
       });
     });
 
+    // Issue #13326
+    it('should report a narrow span for invalid pipes', () => {
+      const code =
+          ` @Component({template: '<p> Using an invalid pipe {{data | dat}} </p>'}) export class MyComponent { data = 'some data'; }`;
+      addCode(code, fileName => {
+        const diagnostic =
+            ngService.getDiagnostics(fileName).filter(d => d.message.indexOf('pipe') > 0)[0];
+        expect(diagnostic).not.toBeUndefined();
+        expect(diagnostic.span.end - diagnostic.span.start).toBeLessThan(11);
+      });
+    });
+
     function addCode(code: string, cb: (fileName: string, content?: string) => void) {
       const fileName = '/app/app.component.ts';
       const originalContent = mockHost.getFileContent(fileName);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

The span of a pipe error is reported as the entire expression or interpolation. 

**What is the new behavior?**

The span is now reported as the span of the pipe expression.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:

Fix #13326