### PR TITLE
fix(language-service): correctly type undefined

### DIFF
--- a/modules/@angular/language-service/src/expressions.ts
+++ b/modules/@angular/language-service/src/expressions.ts
@@ -201,22 +201,25 @@ class AstType implements ExpressionVisitor {
 
   visitBinary(ast: Binary): Symbol {
     // Treat undefined and null as other.
-    function normalize(kind: BuiltinType): BuiltinType {
+    function normalize(kind: BuiltinType, other: BuiltinType): BuiltinType {
       switch (kind) {
         case BuiltinType.Undefined:
         case BuiltinType.Null:
-          return BuiltinType.Other;
+          return normalize(other, BuiltinType.Other);
       }
       return kind;
     }
 
     const leftType = this.getType(ast.left);
     const rightType = this.getType(ast.right);
-    const leftKind = normalize(this.query.getTypeKind(leftType));
-    const rightKind = normalize(this.query.getTypeKind(rightType));
+    const leftRawKind = this.query.getTypeKind(leftType);
+    const rightRawKind = this.query.getTypeKind(rightType);
+    const leftKind = normalize(leftRawKind, rightRawKind);
+    const rightKind = normalize(rightRawKind, leftRawKind);
 
     // The following swtich implements operator typing similar to the
     // type production tables in the TypeScript specification.
+    // https://github.com/Microsoft/TypeScript/blob/v1.8.10/doc/spec.md#4.19
     const operKind = leftKind << 8 | rightKind;
     switch (ast.operation) {
       case '*':
@@ -403,6 +406,8 @@ class AstType implements ExpressionVisitor {
         return this.query.getBuiltinType(BuiltinType.Boolean);
       case null:
         return this.query.getBuiltinType(BuiltinType.Null);
+      case undefined:
+        return this.query.getBuiltinType(BuiltinType.Undefined);
       default:
         switch (typeof ast.value) {
           case 'string':

--- a/modules/@angular/language-service/test/diagnostics_spec.ts
+++ b/modules/@angular/language-service/test/diagnostics_spec.ts
@@ -130,6 +130,16 @@ describe('diagnostics', () => {
       });
     });
 
+    // #13412
+    it('should not report an error for using undefined', () => {
+      const code =
+          ` @Component({template: \`<div *ngIf="something === undefined"></div>\`}) export class MyComponent { something = 'foo'; }})`;
+      addCode(code, fileName => {
+        const diagnostics = ngService.getDiagnostics(fileName);
+        onlyModuleDiagnostics(diagnostics);
+      });
+    });
+
     function addCode(code: string, cb: (fileName: string, content?: string) => void) {
       const fileName = '/app/app.component.ts';
       const originalContent = mockHost.getFileContent(fileName);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

`undefined` is not correctly recognized as a primitive value. Also, the type of operators using `null` and `undefined` are incorrect.

**What is the new behavior?**

`undefined` is not recognized and it and `null` are correctly typed in expressions.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:

Fixes #13412