### PR TITLE
fix(upgrade): add default stacktrace when not supported

### DIFF
--- a/modules/@angular/upgrade/src/util.ts
+++ b/modules/@angular/upgrade/src/util.ts
@@ -8,11 +8,13 @@
 
 export function onError(e: any) {
   // TODO: (misko): We seem to not have a stack trace here!
+  // IE9 doesn't support stacktrace
+  const stack: any = e.stack || 'No stack trace available in this browser.';
   if (console.error) {
-    console.error(e, e.stack);
+    console.error(e, stack);
   } else {
     // tslint:disable-next-line:no-console
-    console.log(e, e.stack);
+    console.log(e, stack);
   }
   throw e;
 }

--- a/modules/@angular/upgrade/test/upgrade_spec.ts
+++ b/modules/@angular/upgrade/test/upgrade_spec.ts
@@ -60,6 +60,17 @@ export function main() {
            expect(consoleErrorSpy).toHaveBeenCalled();
            expect(args.length).toBeGreaterThan(0);
            expect(args[0]).toEqual(jasmine.any(Error));
+           let supportsStacktrace = false;
+           try {
+             throw new Error();
+           } catch(e) {
+             supportsStacktrace = !!e.stack
+           }
+           if (supportsStacktrace) {
+             expect(args[1]).not.toEqual('No stack trace available in this browser.');
+           } else {
+             expect(args[1]).toEqual('No stack trace available in this browser.');
+           }
          }));
     });
 


### PR DESCRIPTION
One upgrade test is failing in IE9 because this browser doesn't support stacktrace.

The test is:
```
it('should output an error message to the console and re-throw', fakeAsync(() => {
           spyOn(console, 'error');
           expect(() => {
             adapter.bootstrap(html('<ng2></ng2>'), ['ng1']);
             flushMicrotasks();
           }).toThrowError();
           expect(console.error).toHaveBeenCalled();
           expect(console.error).toHaveBeenCalledWith(jasmine.any(Error), jasmine.any(String));
         }));
```

The proposal is to set a default message in that case.