### PR TITLE
feat(language-service): warn when a method isn't called in an event

### DIFF
--- a/modules/@angular/language-service/src/diagnostics.ts
+++ b/modules/@angular/language-service/src/diagnostics.ts
@@ -208,12 +208,13 @@ class ExpressionDiagnosticsVisitor extends TemplateAstChildVisitor {
   private diagnoseExpression(ast: AST, offset: number, includeEvent: boolean) {
     const scope = this.getExpressionScope(this.path, includeEvent);
     this.diagnostics.push(
-        ...getExpressionDiagnostics(scope, ast, this.info.template.query)
-            .map(d => ({
-                   span: offsetSpan(d.ast.span, offset + this.info.template.span.start),
-                   kind: d.kind,
-                   message: d.message
-                 })));
+        ...getExpressionDiagnostics(scope, ast, this.info.template.query, {
+          event: includeEvent
+        }).map(d => ({
+                 span: offsetSpan(d.ast.span, offset + this.info.template.span.start),
+                 kind: d.kind,
+                 message: d.message
+               })));
   }
 
   private push(ast: TemplateAst) { this.path.push(ast); }

--- a/modules/@angular/language-service/test/diagnostics_spec.ts
+++ b/modules/@angular/language-service/test/diagnostics_spec.ts
@@ -130,6 +130,17 @@ describe('diagnostics', () => {
       });
     });
 
+    it('should report a warning if an event results in a callable expression', () => {
+      const code =
+          ` @Component({template: \`<div (click)="onClick"></div>\`}) export class MyComponent { onClick() { } }`;
+      addCode(code, (fileName, content) => {
+        const diagnostics = ngService.getDiagnostics(fileName);
+        includeDiagnostic(
+            diagnostics, 'Unexpected callable expression. Expected a method call', 'onClick',
+            content);
+      });
+    });
+
     function addCode(code: string, cb: (fileName: string, content?: string) => void) {
       const fileName = '/app/app.component.ts';
       const originalContent = mockHost.getFileContent(fileName);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Feature
```

**What is the current behavior?** (You can also link to an open issue here)

A diagnostic is not reported if a event expression is refers to a method instead of calling it. This is a common mistake that could be caught by the language service.

#13435

**What is the new behavior?**

A diagnostic warning is emitted when an event binding results in a callable expression.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:

Closes 13435