### PR TITLE
Revert a g3 hack to generate valid xmb files

### DIFF
--- a/modules/@angular/compiler/src/i18n/serializers/xmb.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/xmb.ts
@@ -119,11 +119,11 @@ class _Visitor implements i18n.Visitor {
   }
 
   visitPlaceholder(ph: i18n.Placeholder, context?: any): xml.Node[] {
-    return [new xml.Tag(_PLACEHOLDER_TAG, {name: ph.name}, [], false)];
+    return [new xml.Tag(_PLACEHOLDER_TAG, {name: ph.name})];
   }
 
   visitIcuPlaceholder(ph: i18n.IcuPlaceholder, context?: any): xml.Node[] {
-    return [new xml.Tag(_PLACEHOLDER_TAG, {name: ph.name}, [], false)];
+    return [new xml.Tag(_PLACEHOLDER_TAG, {name: ph.name})];
   }
 
   serialize(nodes: i18n.Node[]): xml.Node[] {

--- a/modules/@angular/compiler/src/i18n/serializers/xml_helper.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/xml_helper.ts
@@ -18,8 +18,7 @@ class _Visitor implements IVisitor {
     const strAttrs = this._serializeAttributes(tag.attrs);
 
     if (tag.children.length == 0) {
-      return tag.canSelfClose ? `<${tag.name}${strAttrs}/>` :
-                                `<${tag.name}${strAttrs}></${tag.name}>`;
+      return `<${tag.name}${strAttrs}/>`;
     }
 
     const strChildren = tag.children.map(node => node.visit(this));
@@ -72,8 +71,8 @@ export class Tag implements Node {
   public attrs: {[k: string]: string} = {};
 
   constructor(
-      public name: string, unescapedAttrs: {[k: string]: string} = {}, public children: Node[] = [],
-      public canSelfClose: boolean = true) {
+      public name: string, unescapedAttrs: {[k: string]: string} = {},
+      public children: Node[] = []) {
     Object.keys(unescapedAttrs).forEach((k: string) => {
       this.attrs[k] = _escapeXml(unescapedAttrs[k]);
     });

--- a/modules/@angular/compiler/test/i18n/integration_spec.ts
+++ b/modules/@angular/compiler/test/i18n/integration_spec.ts
@@ -209,7 +209,7 @@ const XMB = `
     </msg>
   <msg id="5868084092545682515">{VAR_SELECT, select, m {male} f {female} }</msg>
   <msg id="4851788426695310455"><ph name="INTERPOLATION"></ph></msg>
-  <msg id="9013357158046221374">sex = <ph name="INTERPOLATION"></ph></msg>
+  <msg id="9013357158046221374">sex = <ph name="INTERPOLATION"></ph>></msg>
   <msg id="8324617391167353662"><ph name="CUSTOM_NAME"></ph></msg>
   <msg id="7685649297917455806">in a translatable section</msg>
   <msg id="2387287228265107305">

--- a/modules/@angular/compiler/test/i18n/integration_spec.ts
+++ b/modules/@angular/compiler/test/i18n/integration_spec.ts
@@ -208,9 +208,9 @@ const XMB = `
         <ph name="ICU"/>
     </msg>
   <msg id="5868084092545682515">{VAR_SELECT, select, m {male} f {female} }</msg>
-  <msg id="4851788426695310455"><ph name="INTERPOLATION"></ph></msg>
-  <msg id="9013357158046221374">sex = <ph name="INTERPOLATION"></ph>></msg>
-  <msg id="8324617391167353662"><ph name="CUSTOM_NAME"></ph></msg>
+  <msg id="4851788426695310455"><ph name="INTERPOLATION"/></msg>
+  <msg id="9013357158046221374">sex = <ph name="INTERPOLATION"/></msg>
+  <msg id="8324617391167353662"><ph name="CUSTOM_NAME"/></msg>
   <msg id="7685649297917455806">in a translatable section</msg>
   <msg id="2387287228265107305">
     <ph name="START_HEADING_LEVEL1"><ex>&lt;h1&gt;</ex></ph>Markers in html comments<ph name="CLOSE_HEADING_LEVEL1"><ex>&lt;/h1&gt;</ex></ph>   

--- a/modules/@angular/compiler/test/i18n/serializers/xmb_spec.ts
+++ b/modules/@angular/compiler/test/i18n/serializers/xmb_spec.ts
@@ -46,7 +46,7 @@ export function main(): void {
 <!ELEMENT ex (#PCDATA)>
 ]>
 <messagebundle>
-  <msg id="7056919470098446707">translatable element <ph name="START_BOLD_TEXT"><ex>&lt;b&gt;</ex></ph>with placeholders<ph name="CLOSE_BOLD_TEXT"><ex>&lt;/b&gt;</ex></ph> <ph name="INTERPOLATION"></ph></msg>
+  <msg id="7056919470098446707">translatable element <ph name="START_BOLD_TEXT"><ex>&lt;b&gt;</ex></ph>with placeholders<ph name="CLOSE_BOLD_TEXT"><ex>&lt;/b&gt;</ex></ph> <ph name="INTERPOLATION"/></msg>
   <msg id="2981514368455622387">{VAR_PLURAL, plural, =0 {<ph name="START_PARAGRAPH"><ex>&lt;p&gt;</ex></ph>test<ph name="CLOSE_PARAGRAPH"><ex>&lt;/p&gt;</ex></ph>} }</msg>
   <msg id="7999024498831672133" desc="d" meaning="m">foo</msg>
   <msg id="i" desc="d" meaning="m">foo</msg>


### PR DESCRIPTION
We first thought that the issue was closed by self-closing `<ph/>`.

Turns out that the issue that TC requires `<ph>` to have child `<ex>` nodes. Then this hack is ineffective.

Will be fixed in TC by b/33583604

