### PR TITLE
Metadata format 3

### DIFF
--- a/modules/@angular/compiler-cli/src/compiler_host.ts
+++ b/modules/@angular/compiler-cli/src/compiler_host.ts
@@ -177,28 +177,28 @@ export class CompilerHost implements AotCompilerHost {
           (Array.isArray(metadataOrMetadatas) ? metadataOrMetadatas : [metadataOrMetadatas]) :
           [];
       const v1Metadata = metadatas.find((m: any) => m['version'] === 1);
-      let v2Metadata = metadatas.find((m: any) => m['version'] === 2);
-      if (!v2Metadata && v1Metadata) {
-        // patch up v1 to v2 by merging the metadata with metadata collected from the d.ts file
+      let v3Metadata = metadatas.find((m: any) => m['version'] === 3);
+      if (!v3Metadata && v1Metadata) {
+        // patch up v1 to v3 by merging the metadata with metadata collected from the d.ts file
         // as the only difference between the versions is whether all exports are contained in
         // the metadata and the `extends` clause.
-        v2Metadata = {'__symbolic': 'module', 'version': 2, 'metadata': {}};
+        v3Metadata = {'__symbolic': 'module', 'version': 3, 'metadata': {}};
         if (v1Metadata.exports) {
-          v2Metadata.exports = v1Metadata.exports;
+          v3Metadata.exports = v1Metadata.exports;
         }
         for (let prop in v1Metadata.metadata) {
-          v2Metadata.metadata[prop] = v1Metadata.metadata[prop];
+          v3Metadata.metadata[prop] = v1Metadata.metadata[prop];
         }
         const sourceText = this.context.readFile(dtsFilePath);
         const exports = this.metadataCollector.getMetadata(this.getSourceFile(dtsFilePath));
         if (exports) {
           for (let prop in exports.metadata) {
-            if (!v2Metadata.metadata[prop]) {
-              v2Metadata.metadata[prop] = exports.metadata[prop];
+            if (!v3Metadata.metadata[prop]) {
+              v3Metadata.metadata[prop] = exports.metadata[prop];
             }
           }
         }
-        metadatas.push(v2Metadata);
+        metadatas.push(v3Metadata);
       }
       this.resolverCache.set(filePath, metadatas);
       return metadatas;

--- a/modules/@angular/compiler-cli/test/aot_host_spec.ts
+++ b/modules/@angular/compiler-cli/test/aot_host_spec.ts
@@ -166,11 +166,11 @@ describe('CompilerHost', () => {
     expect(hostNestedGenDir.getMetadataFor('node_modules/@angular/missing.d.ts')).toBeUndefined();
   });
 
-  it('should add missing v2 metadata from v1 metadata and .d.ts files', () => {
+  it('should add missing v3 metadata from v1 metadata and .d.ts files', () => {
     expect(hostNestedGenDir.getMetadataFor('metadata_versions/v1.d.ts')).toEqual([
       {__symbolic: 'module', version: 1, metadata: {foo: {__symbolic: 'class'}}}, {
         __symbolic: 'module',
-        version: 2,
+        version: 3,
         metadata: {
           foo: {__symbolic: 'class'},
           Bar: {__symbolic: 'class', members: {ngOnInit: [{__symbolic: 'method'}]}},

--- a/modules/@angular/compiler/src/aot/static_reflector.ts
+++ b/modules/@angular/compiler/src/aot/static_reflector.ts
@@ -10,7 +10,7 @@ import {Attribute, Component, ContentChild, ContentChildren, Directive, Host, Ho
 import {ReflectorReader} from '../private_import_core';
 import {StaticSymbol} from './static_symbol';
 
-const SUPPORTED_SCHEMA_VERSION = 2;
+const SUPPORTED_SCHEMA_VERSION = 3;
 const ANGULAR_IMPORT_LOCATIONS = {
   coreDecorators: '@angular/core/src/metadata',
   diDecorators: '@angular/core/src/di/metadata',
@@ -751,10 +751,10 @@ export class StaticReflector implements ReflectorReader {
             {__symbolic: 'module', version: SUPPORTED_SCHEMA_VERSION, module: module, metadata: {}};
       }
       if (moduleMetadata['version'] != SUPPORTED_SCHEMA_VERSION) {
-        this.reportError(
-            new Error(
-                `Metadata version mismatch for module ${module}, found version ${moduleMetadata['version']}, expected ${SUPPORTED_SCHEMA_VERSION}`),
-            null);
+        const errorMessage = moduleMetadata['version'] == 2 ?
+            `Unsupported metadata version ${moduleMetadata['version']} for module ${module}. This module should be compiled with a newer version of ngc` :
+            `Metadata version mismatch for module ${module}, found version ${moduleMetadata['version']}, expected ${SUPPORTED_SCHEMA_VERSION}`;
+        this.reportError(new Error(errorMessage), null);
       }
       this.metadataCache.set(module, moduleMetadata);
     }

--- a/modules/@angular/compiler/test/aot/static_reflector_spec.ts
+++ b/modules/@angular/compiler/test/aot/static_reflector_spec.ts
@@ -80,7 +80,13 @@ describe('StaticReflector', () => {
   it('should throw an exception for unsupported metadata versions', () => {
     expect(() => reflector.findDeclaration('src/version-error', 'e'))
         .toThrow(new Error(
-            'Metadata version mismatch for module /tmp/src/version-error.d.ts, found version 100, expected 2'));
+            'Metadata version mismatch for module /tmp/src/version-error.d.ts, found version 100, expected 3'));
+  });
+
+  it('should throw an exception for version 2 metadata', () => {
+    expect(() => reflector.findDeclaration('src/version-2-error', 'e'))
+        .toThrowError(
+            'Unsupported metadata version 2 for module /tmp/src/version-2-error.d.ts. This module should be compiled with a newer version of ngc');
   });
 
   it('should get and empty annotation list for an unknown class', () => {
@@ -378,7 +384,7 @@ describe('StaticReflector', () => {
     const metadata = reflector.getModuleMetadata('/tmp/src/custom-decorator-reference.ts');
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 2,
+      version: 3,
       metadata: {
         Foo: {
           __symbolic: 'class',
@@ -769,7 +775,7 @@ export class MockStaticReflectorHost implements StaticReflectorHost {
 const DEFAULT_TEST_DATA: {[key: string]: any} = {
       '/tmp/@angular/common/src/forms-deprecated/directives.d.ts': [{
         '__symbolic': 'module',
-        'version': 2,
+        'version': 3,
         'metadata': {
           'FORM_DIRECTIVES': [
             {
@@ -782,7 +788,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
       }],
       '/tmp/@angular/common/src/directives/ng_for.d.ts': {
         '__symbolic': 'module',
-        'version': 2,
+        'version': 3,
         'metadata': {
           'NgFor': {
             '__symbolic': 'class',
@@ -835,16 +841,16 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
         }
       },
       '/tmp/@angular/core/src/linker/view_container_ref.d.ts':
-          {version: 2, 'metadata': {'ViewContainerRef': {'__symbolic': 'class'}}},
+          {version: 3, 'metadata': {'ViewContainerRef': {'__symbolic': 'class'}}},
       '/tmp/@angular/core/src/linker/template_ref.d.ts':
-          {version: 2, 'module': './template_ref', 'metadata': {'TemplateRef': {'__symbolic': 'class'}}},
+          {version: 3, 'module': './template_ref', 'metadata': {'TemplateRef': {'__symbolic': 'class'}}},
       '/tmp/@angular/core/src/change_detection/differs/iterable_differs.d.ts':
-          {version: 2, 'metadata': {'IterableDiffers': {'__symbolic': 'class'}}},
+          {version: 3, 'metadata': {'IterableDiffers': {'__symbolic': 'class'}}},
       '/tmp/@angular/core/src/change_detection/change_detector_ref.d.ts':
-          {version: 2, 'metadata': {'ChangeDetectorRef': {'__symbolic': 'class'}}},
+          {version: 3, 'metadata': {'ChangeDetectorRef': {'__symbolic': 'class'}}},
       '/tmp/src/app/hero-detail.component.d.ts': {
         '__symbolic': 'module',
-        'version': 2,
+        'version': 3,
         'metadata': {
           'HeroDetailComponent': {
             '__symbolic': 'class',
@@ -995,11 +1001,12 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
           }
         }
       },
-      '/src/extern.d.ts': {'__symbolic': 'module', 'version': 2, metadata: {s: 's'}},
+      '/src/extern.d.ts': {'__symbolic': 'module', 'version': 3, metadata: {s: 's'}},
       '/tmp/src/version-error.d.ts': {'__symbolic': 'module', 'version': 100, metadata: {e: 's'}},
+      '/tmp/src/version-2-error.d.ts': {'__symbolic': 'module', 'version': 2, metadata: {e: 's'}},
       '/tmp/src/error-reporting.d.ts': {
         __symbolic: 'module',
-        version: 2,
+        version: 3,
         metadata: {
           SomeClass: {
             __symbolic: 'class',
@@ -1029,7 +1036,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
       },
       '/tmp/src/error-references.d.ts': {
         __symbolic: 'module',
-        version: 2,
+        version: 3,
         metadata: {
           Link1: {
             __symbolic: 'reference',
@@ -1051,7 +1058,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
       },
       '/tmp/src/function-declaration.d.ts': {
         __symbolic: 'module',
-        version: 2,
+        version: 3,
         metadata: {
           one: {
             __symbolic: 'function',
@@ -1080,7 +1087,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
       },
       '/tmp/src/function-reference.ts': {
         __symbolic: 'module',
-        version: 2,
+        version: 3,
         metadata: {
           one: {
             __symbolic: 'call',
@@ -1122,7 +1129,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
       },
       '/tmp/src/function-recursive.d.ts': {
         __symbolic: 'modules',
-        version: 2,
+        version: 3,
         metadata: {
           recursive: {
             __symbolic: 'function',
@@ -1182,7 +1189,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
       },
       '/tmp/src/spread.ts': {
         __symbolic: 'module',
-        version: 2,
+        version: 3,
         metadata: {
           spread: [0, {__symbolic: 'spread', expression: [1, 2, 3, 4]}, 5]
         }
@@ -1332,7 +1339,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
       `,
       '/tmp/src/reexport/reexport.d.ts': {
         __symbolic: 'module',
-        version: 2,
+        version: 3,
         metadata: {},
         exports: [
           {from: './src/origin1', export: ['One', 'Two', {name: 'Three', as: 'Four'}]},
@@ -1341,7 +1348,7 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
       },
       '/tmp/src/reexport/src/origin1.d.ts': {
         __symbolic: 'module',
-        version: 2,
+        version: 3,
         metadata: {
           One: {__symbolic: 'class'},
           Two: {__symbolic: 'class'},
@@ -1350,26 +1357,26 @@ const DEFAULT_TEST_DATA: {[key: string]: any} = {
       },
       '/tmp/src/reexport/src/origin5.d.ts': {
         __symbolic: 'module',
-        version: 2,
+        version: 3,
         metadata: {
           Five: {__symbolic: 'class'},
         },
       },
       '/tmp/src/reexport/src/origin30.d.ts': {
         __symbolic: 'module',
-        version: 2,
+        version: 3,
         metadata: {
           Thirty: {__symbolic: 'class'},
         },
       },
       '/tmp/src/reexport/src/originNone.d.ts': {
         __symbolic: 'module',
-        version: 2,
+        version: 3,
         metadata: {},
       },
       '/tmp/src/reexport/src/reexport2.d.ts': {
         __symbolic: 'module',
-        version: 2,
+        version: 3,
         metadata: {},
         exports: [{from: './originNone'}, {from: './origin30'}]
       }

--- a/tools/@angular/tsc-wrapped/src/collector.ts
+++ b/tools/@angular/tsc-wrapped/src/collector.ts
@@ -18,6 +18,11 @@ import {Symbols} from './symbols';
  */
 export class CollectorOptions {
   /**
+   * Version of the metadata to collect.
+   */
+  version?: number;
+
+  /**
    * Collect a hidden field "$quoted$" in objects literals that record when the key was quoted in
    * the source.
    */
@@ -412,7 +417,10 @@ export class MetadataCollector {
       else if (strict) {
         validateMetadata(sourceFile, nodeMap, metadata);
       }
-      const result: ModuleMetadata = {__symbolic: 'module', version: VERSION, metadata};
+      const result: ModuleMetadata = {
+        __symbolic: 'module',
+        version: this.options.version || VERSION, metadata
+      };
       if (exports) result.exports = exports;
       return result;
     }

--- a/tools/@angular/tsc-wrapped/src/schema.ts
+++ b/tools/@angular/tsc-wrapped/src/schema.ts
@@ -15,7 +15,7 @@
 // semantics of the file in an array. For example, when generating a version 2 file, if version 1
 // can accurately represent the metadata, generate both version 1 and version 2 in an array.
 
-export const VERSION = 2;
+export const VERSION = 3;
 
 export type MetadataEntry = ClassMetadata | FunctionMetadata | MetadataValue;
 

--- a/tools/@angular/tsc-wrapped/test/collector.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/collector.spec.ts
@@ -66,7 +66,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 2,
+      version: 3,
       metadata: {
         HeroDetailComponent: {
           __symbolic: 'class',
@@ -107,7 +107,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 2,
+      version: 3,
       metadata: {
         AppComponent: {
           __symbolic: 'class',
@@ -161,7 +161,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 2,
+      version: 3,
       metadata: {
         HEROES: [
           {'id': 11, 'name': 'Mr. Nice', '$quoted$': ['id', 'name']},
@@ -240,7 +240,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(unsupported1);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 2,
+      version: 3,
       metadata: {
         a: {__symbolic: 'error', message: 'Destructuring not supported', line: 1, character: 16},
         b: {__symbolic: 'error', message: 'Destructuring not supported', line: 1, character: 19},
@@ -282,7 +282,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(sourceFile);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 2,
+      version: 3,
       metadata: {
         SimpleClass: {__symbolic: 'class'},
         AbstractClass: {__symbolic: 'class'},
@@ -296,7 +296,7 @@ describe('Collector', () => {
     const metadata = collector.getMetadata(exportedFunctions);
     expect(metadata).toEqual({
       __symbolic: 'module',
-      version: 2,
+      version: 3,
       metadata: {
         one: {
           __symbolic: 'function',


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** 

Various errors in the collection of version 2 format requires a version format change to fix.

**What is the new behavior?**

The updates the metadata format produced by the collector and required by the static reflector to version 3.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:

Version 1 is still supported and is auto-upgraded to format 3 by the `CompilerHost` in the `compiler-cli`.

