### PR TITLE
#13491 fix(router): fire only one location change event when use hash strategy 

### DIFF
--- a/modules/@angular/common/src/location/hash_location_strategy.ts
+++ b/modules/@angular/common/src/location/hash_location_strategy.ts
@@ -7,14 +7,9 @@
  */
 
 import {Inject, Injectable, Optional} from '@angular/core';
-
-import {isPresent} from '../facade/lang';
-
 import {Location} from './location';
 import {APP_BASE_HREF, LocationStrategy} from './location_strategy';
 import {LocationChangeListener, PlatformLocation} from './platform_location';
-
-
 
 /**
  * @whatItDoes Use URL hash for storing application location data.
@@ -40,7 +35,7 @@ export class HashLocationStrategy extends LocationStrategy {
       private _platformLocation: PlatformLocation,
       @Optional() @Inject(APP_BASE_HREF) _baseHref?: string) {
     super();
-    if (isPresent(_baseHref)) {
+    if (_baseHref != null) {
       this._baseHref = _baseHref;
     }
   }
@@ -56,8 +51,9 @@ export class HashLocationStrategy extends LocationStrategy {
     // the hash value is always prefixed with a `#`
     // and if it is empty then it will stay empty
     let path = this._platformLocation.hash;
-    if (!isPresent(path)) path = '#';
-
+    if (path == null) {
+      path = '#';
+    }
     return path.length > 0 ? path.substring(1) : path;
   }
 
@@ -66,7 +62,7 @@ export class HashLocationStrategy extends LocationStrategy {
     return url.length > 0 ? ('#' + url) : url;
   }
 
-  pushState(state: any, title: string, path: string, queryParams: string) {
+  pushState(state: any, title: string, path: string, queryParams: string): void {
     let url = this.prepareExternalUrl(path + Location.normalizeQueryParams(queryParams));
     if (url.length == 0) {
       url = this._platformLocation.pathname;
@@ -74,9 +70,9 @@ export class HashLocationStrategy extends LocationStrategy {
     this._platformLocation.pushState(state, title, url);
   }
 
-  replaceState(state: any, title: string, path: string, queryParams: string) {
+  replaceState(state: any, title: string, path: string, queryParams: string): void {
     let url = this.prepareExternalUrl(path + Location.normalizeQueryParams(queryParams));
-    if (url.length == 0) {
+    if (url.length === 0) {
       url = this._platformLocation.pathname;
     }
     this._platformLocation.replaceState(state, title, url);

--- a/modules/@angular/common/src/location/hash_location_strategy.ts
+++ b/modules/@angular/common/src/location/hash_location_strategy.ts
@@ -41,7 +41,7 @@ export class HashLocationStrategy extends LocationStrategy {
   }
 
   onPopState(fn: LocationChangeListener): void {
-    this._platformLocation.onPopState(fn);
+    // this._platformLocation.onPopState(fn);
     this._platformLocation.onHashChange(fn);
   }
 


### PR DESCRIPTION
Closes https://github.com/angular/angular/issues/13491

Description of the issue:
Using `HashLocationStrategy` when we click on the link
```
<a href="#/page2">Page 2</a>
```
it fires 2 browser events: `popstate` and `hashchange`. Router is subscribed to these events [here](https://github.com/angular/angular/blob/master/modules/%40angular/router/src/router.ts#L375). Each event schedules navigation. But navigation triggered by `popstate` (has id 3 on the screenshot) is canceled by the router and only navigation triggered by `hashchange` (id 4) succeeded. http://prntscr.com/djwhqg 

When router cancels navigation it resets url to the previous state. This is the origin of the https://github.com/angular/angular/issues/13491. So to fix this we need to avoid canceled navigation by only firing one 'hashchange' event.