### PR TITLE
fix(common): capitalize first letter of all words in TitleCasePipe

### DIFF
--- a/modules/@angular/common/src/pipes/case_conversion_pipes.ts
+++ b/modules/@angular/common/src/pipes/case_conversion_pipes.ts
@@ -27,6 +27,17 @@ export class LowerCasePipe implements PipeTransform {
   }
 }
 
+
+/**
+ * Helper method to transform a single word to titlecase.
+ *
+ * @stable
+ */
+function titleCaseWord(word: string) {
+  if (!word) return word;
+  return word[0].toUpperCase() + word.substr(1).toLowerCase();
+}
+
 /**
  * Transforms text to titlecase.
  *
@@ -40,7 +51,7 @@ export class TitleCasePipe implements PipeTransform {
       throw new InvalidPipeArgumentError(TitleCasePipe, value);
     }
 
-    return value[0].toUpperCase() + value.substr(1).toLowerCase();
+    return value.split(/\b/g).map(word => titleCaseWord(word)).join('');
   }
 }
 

--- a/modules/@angular/common/test/pipes/case_conversion_pipes_spec.ts
+++ b/modules/@angular/common/test/pipes/case_conversion_pipes_spec.ts
@@ -32,6 +32,14 @@ export function main() {
 
     it('should return titlecase', () => { expect(pipe.transform('foo')).toEqual('Foo'); });
 
+    it('should return titlecase for subsequent words',
+       () => { expect(pipe.transform('one TWO Three fouR')).toEqual('One Two Three Four'); });
+
+    it('should support empty strings', () => { expect(pipe.transform('')).toEqual(''); });
+
+    it('should persist whitespace',
+       () => { expect(pipe.transform('one   two')).toEqual('One   Two'); });
+
     it('should titlecase when there is a new value', () => {
       expect(pipe.transform('bar')).toEqual('Bar');
       expect(pipe.transform('foo')).toEqual('Foo');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The TitleCasePipe capitalizes the first letter of the value passed in, but fails to capitalize the first letter of the subsequent words.

For example: `{{'one two three' | titlecase}}` produces the output `One two three`.

**What is the new behavior?**

The first letter of every word is capitalized.

Using the same example as above: `{{'one two three' | titlecase}}` produces the output `One Two Three`

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


