### PR TITLE
fix(upgrade): fix `registerForNg1Tests`

### DIFF
--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -24,17 +24,25 @@ module.exports = function(config) {
       'node_modules/core-js/client/core.js',
       // include Angular v1 for upgrade module testing
       'node_modules/angular/angular.js',
+      'node_modules/angular-mocks/angular-mocks.js',
 
-      'node_modules/zone.js/dist/zone.js', 'node_modules/zone.js/dist/long-stack-trace-zone.js',
-      'node_modules/zone.js/dist/proxy.js', 'node_modules/zone.js/dist/sync-test.js',
-      'node_modules/zone.js/dist/jasmine-patch.js', 'node_modules/zone.js/dist/async-test.js',
+      'node_modules/zone.js/dist/zone.js',
+      'node_modules/zone.js/dist/long-stack-trace-zone.js',
+      'node_modules/zone.js/dist/proxy.js',
+      'node_modules/zone.js/dist/sync-test.js',
+      'node_modules/zone.js/dist/jasmine-patch.js',
+      'node_modules/zone.js/dist/async-test.js',
       'node_modules/zone.js/dist/fake-async-test.js',
 
       // Including systemjs because it defines `__eval`, which produces correct stack traces.
-      'shims_for_IE.js', 'node_modules/systemjs/dist/system.src.js',
+      'shims_for_IE.js',
+      'node_modules/systemjs/dist/system.src.js',
       {pattern: 'node_modules/rxjs/**', included: false, watched: false, served: true},
-      'node_modules/reflect-metadata/Reflect.js', 'tools/build/file2modulename.js', 'test-main.js',
-      {pattern: 'dist/all/empty.*', included: false, watched: false}, {
+      'node_modules/reflect-metadata/Reflect.js',
+      'tools/build/file2modulename.js',
+      'test-main.js',
+      {pattern: 'dist/all/empty.*', included: false, watched: false},
+      {
         pattern: 'modules/@angular/platform-browser/test/static_assets/**',
         included: false,
         watched: false

--- a/modules/@angular/upgrade/src/upgrade_adapter.ts
+++ b/modules/@angular/upgrade/src/upgrade_adapter.ts
@@ -320,7 +320,7 @@ export class UpgradeAdapter {
     windowNgMock.module(this.ng1Module.name);
     const upgrade = new UpgradeAdapterRef();
     this.ng2BootstrapDeferred.promise.then(
-        () => { (<any>upgrade)._bootstrapDone(this.moduleRef, upgrade.ng1Injector); }, onError);
+        (ng1Injector) => { (<any>upgrade)._bootstrapDone(this.moduleRef, ng1Injector); }, onError);
     return upgrade;
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

When trying the example in for `UpgradeAdapter#registerForNg1Tests`, it crashes with the following exception:

```js
Unhandled Promise rejection: Cannot read property 'get' of null ; Zone: ProxyZone ; Task: Promise.then ; Value: TypeError: Cannot read property 'get' of null
    at UpgradeAdapterRef._bootstrapDone (base/dist/all/@angular/upgrade/src/upgrade_adapter.js:697)
    at base/dist/all/@angular/upgrade/src/upgrade_adapter.js:315
    at ZoneDelegate.invoke (zone.js:229)
    at ProxyZoneSpec.onInvoke (proxy.js:79)
    at ZoneDelegate.invoke (zone.js:228)
    at Zone.run (zone.js:113)
    at zone.js:509
    at ZoneDelegate.invokeTask (zone.js:262)
    at ProxyZoneSpec.onInvokeTask (proxy.js:103)
    at ZoneDelegate.invokeTask (zone.js:261)
    at Zone.runTask (zone.js:151)
    at drainMicroTaskQueue (zone.js:405)
    at XMLHttpRequest.ZoneTask.invoke (zone.js:336) TypeError: Cannot read property 'get' of null
    at UpgradeAdapterRef._bootstrapDone (http://localhost:9878/base/dist/all/@angular/upgrade/src/upgrade_adapter.js:697:40)
    at http://localhost:9878/base/dist/all/@angular/upgrade/src/upgrade_adapter.js:315:70
    at ZoneDelegate.invoke (http://localhost:9878/base/node_modules/zone.js/dist/zone.js:229:26)
    at ProxyZoneSpec.onInvoke (http://localhost:9878/base/node_modules/zone.js/dist/proxy.js:79:39)
    at ZoneDelegate.invoke (http://localhost:9878/base/node_modules/zone.js/dist/zone.js:228:32)
    at Zone.run (http://localhost:9878/base/node_modules/zone.js/dist/zone.js:113:43)
    at http://localhost:9878/base/node_modules/zone.js/dist/zone.js:509:57
    at ZoneDelegate.invokeTask (http://localhost:9878/base/node_modules/zone.js/dist/zone.js:262:35)
    at ProxyZoneSpec.onInvokeTask (http://localhost:9878/base/node_modules/zone.js/dist/proxy.js:103:39)
    at ZoneDelegate.invokeTask (http://localhost:9878/base/node_modules/zone.js/dist/zone.js:261:40)
    at Zone.runTask (http://localhost:9878/base/node_modules/zone.js/dist/zone.js:151:47)
    at drainMicroTaskQueue (http://localhost:9878/base/node_modules/zone.js/dist/zone.js:405:35)
    at XMLHttpRequest.ZoneTask.invoke (http://localhost:9878/base/node_modules/zone.js/dist/zone.js:336:25)
```

This is because `upgrade.ng1Injector` passed to `_bootstrapDone` in `registerForNg1Tests` is null.

**What is the new behavior?**

`UpgradeAdapter#registerForNg1Tests` doesn't throw the above exception anymore.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:


Fix an issue in `registerForNg1Tests`, where it passes a `null` as
`ng1Injector` to `_bootstrapDone`. This causes a "TypeError: Cannot
read property 'get' of null" to be thrown from `_bootstrapDone`.