### PR TITLE
feat(compiler): generate proper reexports in `.ngfactory.ts` file…

### DIFF
--- a/modules/@angular/compiler/src/aot/compiler_factory.ts
+++ b/modules/@angular/compiler/src/aot/compiler_factory.ts
@@ -34,9 +34,10 @@ import {AotCompilerHost} from './compiler_host';
 import {AotCompilerOptions} from './compiler_options';
 import {StaticAndDynamicReflectionCapabilities} from './static_reflection_capabilities';
 import {StaticReflector} from './static_reflector';
-import {StaticSymbolCache} from './static_symbol';
+import {StaticSymbol, StaticSymbolCache} from './static_symbol';
 import {StaticSymbolResolver} from './static_symbol_resolver';
 import {AotSummaryResolver} from './summary_resolver';
+
 
 
 /**
@@ -69,13 +70,19 @@ export function createAotCompiler(compilerHost: AotCompilerHost, options: AotCom
   const resolver = new CompileMetadataResolver(
       new NgModuleResolver(staticReflector), new DirectiveResolver(staticReflector),
       new PipeResolver(staticReflector), summaryResolver, elementSchemaRegistry, normalizer,
-      staticReflector);
+      symbolCache, staticReflector);
   // TODO(vicb): do not pass options.i18nFormat here
+  const importResolver = {
+    getImportAs: (symbol: StaticSymbol) => symbolResolver.getImportAs(symbol),
+    fileNameToModuleName: (fileName: string, containingFilePath: string) =>
+                              compilerHost.fileNameToModuleName(fileName, containingFilePath)
+  };
   const compiler = new AotCompiler(
       compilerHost, resolver, tmplParser, new StyleCompiler(urlResolver),
       new ViewCompiler(config, elementSchemaRegistry),
       new DirectiveWrapperCompiler(config, expressionParser, elementSchemaRegistry, console),
-      new NgModuleCompiler(), new TypeScriptEmitter(compilerHost), summaryResolver, options.locale,
-      options.i18nFormat, new AnimationParser(elementSchemaRegistry), symbolResolver);
+      new NgModuleCompiler(), new TypeScriptEmitter(importResolver), summaryResolver,
+      options.locale, options.i18nFormat, new AnimationParser(elementSchemaRegistry),
+      symbolResolver);
   return {compiler, reflector: staticReflector};
 }

--- a/modules/@angular/compiler/src/aot/compiler_host.ts
+++ b/modules/@angular/compiler/src/aot/compiler_host.ts
@@ -6,19 +6,24 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ImportResolver} from '../output/path_util';
-
 import {StaticSymbol} from './static_symbol';
 import {StaticSymbolResolverHost} from './static_symbol_resolver';
 import {AotSummaryResolverHost} from './summary_resolver';
-import {AotSummarySerializerHost} from './summary_serializer';
 
 /**
  * The host of the AotCompiler disconnects the implementation from TypeScript / other language
  * services and from underlying file systems.
  */
-export interface AotCompilerHost extends StaticSymbolResolverHost, ImportResolver,
-    AotSummaryResolverHost, AotSummarySerializerHost {
+export interface AotCompilerHost extends StaticSymbolResolverHost, AotSummaryResolverHost {
+  /**
+   * Converts a file path to a module name that can be used as an `import.
+   * I.e. `path/to/importedFile.ts` should be imported by `path/to/containingFile.ts`.
+   *
+   * See ImportResolver.
+   */
+  fileNameToModuleName(importedFilePath: string, containingFilePath: string): string
+      /*|null*/;
+
   /**
    * Loads a resource (e.g. html / css)
    */

--- a/modules/@angular/compiler/src/aot/static_reflector.ts
+++ b/modules/@angular/compiler/src/aot/static_reflector.ts
@@ -83,8 +83,11 @@ export class StaticReflector implements ReflectorReader {
       annotations = [];
       const classMetadata = this.getTypeMetadata(type);
       if (classMetadata['extends']) {
-        const parentAnnotations = this.annotations(this.simplify(type, classMetadata['extends']));
-        annotations.push(...parentAnnotations);
+        const parentType = this.simplify(type, classMetadata['extends']);
+        if (parentType instanceof StaticSymbol) {
+          const parentAnnotations = this.annotations(parentType);
+          annotations.push(...parentAnnotations);
+        }
       }
       if (classMetadata['decorators']) {
         const ownAnnotations: any[] = this.simplify(type, classMetadata['decorators']);
@@ -101,10 +104,13 @@ export class StaticReflector implements ReflectorReader {
       const classMetadata = this.getTypeMetadata(type);
       propMetadata = {};
       if (classMetadata['extends']) {
-        const parentPropMetadata = this.propMetadata(this.simplify(type, classMetadata['extends']));
-        Object.keys(parentPropMetadata).forEach((parentProp) => {
-          propMetadata[parentProp] = parentPropMetadata[parentProp];
-        });
+        const parentType = this.simplify(type, classMetadata['extends']);
+        if (parentType instanceof StaticSymbol) {
+          const parentPropMetadata = this.propMetadata(parentType);
+          Object.keys(parentPropMetadata).forEach((parentProp) => {
+            propMetadata[parentProp] = parentPropMetadata[parentProp];
+          });
+        }
       }
 
       const members = classMetadata['members'] || {};
@@ -156,7 +162,10 @@ export class StaticReflector implements ReflectorReader {
             parameters.push(nestedResult);
           });
         } else if (classMetadata['extends']) {
-          parameters = this.parameters(this.simplify(type, classMetadata['extends']));
+          const parentType = this.simplify(type, classMetadata['extends']);
+          if (parentType instanceof StaticSymbol) {
+            parameters = this.parameters(parentType);
+          }
         }
         if (!parameters) {
           parameters = [];
@@ -176,10 +185,13 @@ export class StaticReflector implements ReflectorReader {
       const classMetadata = this.getTypeMetadata(type);
       methodNames = {};
       if (classMetadata['extends']) {
-        const parentMethodNames = this._methodNames(this.simplify(type, classMetadata['extends']));
-        Object.keys(parentMethodNames).forEach((parentProp) => {
-          methodNames[parentProp] = parentMethodNames[parentProp];
-        });
+        const parentType = this.simplify(type, classMetadata['extends']);
+        if (parentType instanceof StaticSymbol) {
+          const parentMethodNames = this._methodNames(parentType);
+          Object.keys(parentMethodNames).forEach((parentProp) => {
+            methodNames[parentProp] = parentMethodNames[parentProp];
+          });
+        }
       }
 
       const members = classMetadata['members'] || {};

--- a/modules/@angular/compiler/src/aot/static_symbol.ts
+++ b/modules/@angular/compiler/src/aot/static_symbol.ts
@@ -12,7 +12,14 @@
  * This token is unique for a filePath and name and can be used as a hash table key.
  */
 export class StaticSymbol {
-  constructor(public filePath: string, public name: string, public members?: string[]) {}
+  constructor(public filePath: string, public name: string, public members: string[]) {}
+
+  assertNoMembers() {
+    if (this.members.length) {
+      throw new Error(
+          `Illegal state: symbol without members expected, but got ${JSON.stringify(this)}.`);
+    }
+  }
 }
 
 /**

--- a/modules/@angular/compiler/src/aot/util.ts
+++ b/modules/@angular/compiler/src/aot/util.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+const STRIP_SRC_FILE_SUFFIXES = /(\.ts|\.d\.ts|\.js|\.jsx|\.tsx)$/;
+
+export function ngfactoryFilePath(filePath: string): string {
+  const urlWithSuffix = splitTypescriptSuffix(filePath);
+  return `${urlWithSuffix[0]}.ngfactory${urlWithSuffix[1]}`;
+}
+
+export function stripNgFactory(filePath: string): string {
+  return filePath.replace(/\.ngfactory\./, '.');
+}
+
+export function splitTypescriptSuffix(path: string): string[] {
+  if (path.endsWith('.d.ts')) {
+    return [path.slice(0, -5), '.ts'];
+  }
+
+  const lastDot = path.lastIndexOf('.');
+
+  if (lastDot !== -1) {
+    return [path.substring(0, lastDot), path.substring(lastDot)];
+  }
+
+  return [path, ''];
+}
+
+export function summaryFileName(fileName: string): string {
+  const fileNameWithoutSuffix = fileName.replace(STRIP_SRC_FILE_SUFFIXES, '');
+  return `${fileNameWithoutSuffix}.ngsummary.json`;
+}

--- a/modules/@angular/compiler/src/directive_wrapper_compiler.ts
+++ b/modules/@angular/compiler/src/directive_wrapper_compiler.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CompileDirectiveMetadata, CompileDirectiveSummary, CompileIdentifierMetadata, identifierModuleUrl, identifierName} from './compile_metadata';
+import {CompileDirectiveMetadata, CompileDirectiveSummary, CompileIdentifierMetadata, dirWrapperClassName, identifierModuleUrl, identifierName} from './compile_metadata';
 import {createCheckBindingField, createCheckBindingStmt} from './compiler_util/binding_util';
 import {EventHandlerVars, convertActionBinding, convertPropertyBinding} from './compiler_util/expression_converter';
 import {triggerAnimation, writeToRenderer} from './compiler_util/render_util';
@@ -52,10 +52,6 @@ const RESET_CHANGES_STMT = o.THIS_EXPR.prop(CHANGES_FIELD_NAME).set(o.literalMap
  */
 @CompilerInjectable()
 export class DirectiveWrapperCompiler {
-  static dirWrapperClassName(id: CompileIdentifierMetadata) {
-    return `Wrapper_${identifierName(id)}`;
-  }
-
   constructor(
       private compilerConfig: CompilerConfig, private _exprParser: Parser,
       private _schemaRegistry: ElementSchemaRegistry, private _console: Console) {}
@@ -149,7 +145,7 @@ class DirectiveWrapperBuilder implements ClassBuilder {
             .toStmt());
 
     return createClassStmt({
-      name: DirectiveWrapperCompiler.dirWrapperClassName(this.dirMeta.type),
+      name: dirWrapperClassName(this.dirMeta.type.reference),
       ctorParams: dirDepParamNames.map((paramName) => new o.FnParam(paramName, o.DYNAMIC_TYPE)),
       builders: [{fields, ctorStmts, methods}, this]
     });

--- a/modules/@angular/compiler/src/i18n/extractor.ts
+++ b/modules/@angular/compiler/src/i18n/extractor.ts
@@ -109,7 +109,7 @@ export class Extractor {
     const resolver = new CompileMetadataResolver(
         new NgModuleResolver(staticReflector), new DirectiveResolver(staticReflector),
         new PipeResolver(staticReflector), summaryResolver, elementSchemaRegistry, normalizer,
-        staticReflector);
+        symbolCache, staticReflector);
 
     // TODO(vicb): implicit tags & attributes
     const messageBundle = new MessageBundle(htmlParser, [], {});

--- a/modules/@angular/compiler/src/ng_module_compiler.ts
+++ b/modules/@angular/compiler/src/ng_module_compiler.ts
@@ -19,9 +19,12 @@ import {LifecycleHooks} from './private_import_core';
 import {NgModuleProviderAnalyzer} from './provider_analyzer';
 import {ProviderAst} from './template_parser/template_ast';
 
+/**
+ * This is currently not read, but will probably be used in the future.
+ * We keep it as we already pass it through all the rigth places...
+ */
 export class ComponentFactoryDependency {
-  constructor(
-      public comp: CompileIdentifierMetadata, public placeholder: CompileIdentifierMetadata) {}
+  constructor(public compType: any) {}
 }
 
 export class NgModuleCompileResult {
@@ -46,13 +49,12 @@ export class NgModuleCompiler {
     const bootstrapComponentFactories: CompileIdentifierMetadata[] = [];
     const entryComponentFactories =
         ngModuleMeta.transitiveModule.entryComponents.map((entryComponent) => {
-          const id: CompileIdentifierMetadata = {reference: null};
           if (ngModuleMeta.bootstrapComponents.some(
-                  (id) => id.reference === entryComponent.reference)) {
-            bootstrapComponentFactories.push(id);
+                  (id) => id.reference === entryComponent.componentType)) {
+            bootstrapComponentFactories.push({reference: entryComponent.componentFactory});
           }
-          deps.push(new ComponentFactoryDependency(entryComponent, id));
-          return id;
+          deps.push(new ComponentFactoryDependency(entryComponent.componentType));
+          return {reference: entryComponent.componentFactory};
         });
     const builder = new _InjectorBuilder(
         ngModuleMeta, entryComponentFactories, bootstrapComponentFactories, sourceSpan);

--- a/modules/@angular/compiler/src/output/js_emitter.ts
+++ b/modules/@angular/compiler/src/output/js_emitter.ts
@@ -7,7 +7,8 @@
  */
 
 
-import {identifierModuleUrl, identifierName} from '../compile_metadata';
+import {StaticSymbol} from '../aot/static_symbol';
+import {CompileIdentifierMetadata} from '../compile_metadata';
 import {isBlank, isPresent} from '../facade/lang';
 
 import {EmitterVisitorContext, OutputEmitter} from './abstract_emitter';
@@ -16,17 +17,17 @@ import * as o from './output_ast';
 import {ImportResolver} from './path_util';
 
 export class JavaScriptEmitter implements OutputEmitter {
-  constructor(private _importGenerator: ImportResolver) {}
-  emitStatements(moduleUrl: string, stmts: o.Statement[], exportedVars: string[]): string {
-    const converter = new JsEmitterVisitor(moduleUrl);
+  constructor(private _importResolver: ImportResolver) {}
+  emitStatements(genFilePath: string, stmts: o.Statement[], exportedVars: string[]): string {
+    const converter = new JsEmitterVisitor(genFilePath, this._importResolver);
     const ctx = EmitterVisitorContext.createRoot(exportedVars);
     converter.visitAllStatements(stmts, ctx);
     const srcParts: string[] = [];
-    converter.importsWithPrefixes.forEach((prefix, importedModuleUrl) => {
+    converter.importsWithPrefixes.forEach((prefix, importedFilePath) => {
       // Note: can't write the real word for import as it screws up system.js auto detection...
       srcParts.push(
           `var ${prefix} = req` +
-          `uire('${this._importGenerator.fileNameToModuleName(importedModuleUrl, moduleUrl)}');`);
+          `uire('${this._importResolver.fileNameToModuleName(importedFilePath, genFilePath)}');`);
     });
     srcParts.push(ctx.toSource());
     return srcParts.join('\n');
@@ -36,20 +37,23 @@ export class JavaScriptEmitter implements OutputEmitter {
 class JsEmitterVisitor extends AbstractJsEmitterVisitor {
   importsWithPrefixes = new Map<string, string>();
 
-  constructor(private _moduleUrl: string) { super(); }
+  constructor(private _genFilePath: string, private _importResolver: ImportResolver) { super(); }
+
+  private _resolveStaticSymbol(value: CompileIdentifierMetadata): StaticSymbol {
+    const reference = value.reference;
+    if (!(reference instanceof StaticSymbol)) {
+      throw new Error(`Internal error: unknown identifier ${JSON.stringify(value)}`);
+    }
+    return this._importResolver.getImportAs(reference) || reference;
+  }
 
   visitExternalExpr(ast: o.ExternalExpr, ctx: EmitterVisitorContext): any {
-    const name = identifierName(ast.value);
-    const moduleUrl = identifierModuleUrl(ast.value);
-    if (isBlank(name)) {
-      console.error('>>>', ast.value);
-      throw new Error(`Internal error: unknown identifier ${ast.value}`);
-    }
-    if (isPresent(moduleUrl) && moduleUrl != this._moduleUrl) {
-      let prefix = this.importsWithPrefixes.get(moduleUrl);
+    const {name, filePath} = this._resolveStaticSymbol(ast.value);
+    if (filePath != this._genFilePath) {
+      let prefix = this.importsWithPrefixes.get(filePath);
       if (isBlank(prefix)) {
         prefix = `import${this.importsWithPrefixes.size}`;
-        this.importsWithPrefixes.set(moduleUrl, prefix);
+        this.importsWithPrefixes.set(filePath, prefix);
       }
       ctx.print(`${prefix}.`);
     }

--- a/modules/@angular/compiler/src/output/path_util.ts
+++ b/modules/@angular/compiler/src/output/path_util.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {StaticSymbol} from '../aot/static_symbol';
+
 /**
  * Interface that defines how import statements should be generated.
  */
@@ -16,4 +18,10 @@ export abstract class ImportResolver {
    */
   abstract fileNameToModuleName(importedFilePath: string, containingFilePath: string): string
       /*|null*/;
+
+  /**
+   * Converts the given StaticSymbol into another StaticSymbol that should be used
+   * to generate the import from.
+   */
+  abstract getImportAs(symbol: StaticSymbol): StaticSymbol /*|null*/;
 }

--- a/modules/@angular/compiler/src/output/ts_emitter.ts
+++ b/modules/@angular/compiler/src/output/ts_emitter.ts
@@ -7,18 +7,22 @@
  */
 
 
-import {CompileIdentifierMetadata, identifierModuleUrl, identifierName} from '../compile_metadata';
+import {StaticSymbol} from '../aot/static_symbol';
+import {CompileIdentifierMetadata} from '../compile_metadata';
 import {isBlank, isPresent} from '../facade/lang';
 
 import {AbstractEmitterVisitor, CATCH_ERROR_VAR, CATCH_STACK_VAR, EmitterVisitorContext, OutputEmitter} from './abstract_emitter';
 import * as o from './output_ast';
 import {ImportResolver} from './path_util';
 
-const _debugModuleUrl = '/debug/lib';
+const _debugFilePath = '/debug/lib';
 
 export function debugOutputAstAsTypeScript(ast: o.Statement | o.Expression | o.Type | any[]):
     string {
-  const converter = new _TsEmitterVisitor(_debugModuleUrl);
+  const converter = new _TsEmitterVisitor(_debugFilePath, {
+    fileNameToModuleName(filePath: string, containingFilePath: string) { return filePath; },
+    getImportAs(symbol: StaticSymbol) { return null; }
+  });
   const ctx = EmitterVisitorContext.createRoot([]);
   const asts: any[] = Array.isArray(ast) ? ast : [ast];
 
@@ -37,17 +41,23 @@ export function debugOutputAstAsTypeScript(ast: o.Statement | o.Expression | o.T
 }
 
 export class TypeScriptEmitter implements OutputEmitter {
-  constructor(private _importGenerator: ImportResolver) {}
-  emitStatements(moduleUrl: string, stmts: o.Statement[], exportedVars: string[]): string {
-    const converter = new _TsEmitterVisitor(moduleUrl);
+  constructor(private _importResolver: ImportResolver) {}
+  emitStatements(genFilePath: string, stmts: o.Statement[], exportedVars: string[]): string {
+    const converter = new _TsEmitterVisitor(genFilePath, this._importResolver);
     const ctx = EmitterVisitorContext.createRoot(exportedVars);
     converter.visitAllStatements(stmts, ctx);
     const srcParts: string[] = [];
-    converter.importsWithPrefixes.forEach((prefix, importedModuleUrl) => {
+    converter.reexports.forEach((reexports, exportedFilePath) => {
+      const reexportsCode =
+          reexports.map(reexport => `${reexport.name} as ${reexport.as}`).join(',');
+      srcParts.push(
+          `export {${reexportsCode}} from '${this._importResolver.fileNameToModuleName(exportedFilePath, genFilePath)}';`);
+    });
+    converter.importsWithPrefixes.forEach((prefix, importedFilePath) => {
       // Note: can't write the real word for import as it screws up system.js auto detection...
       srcParts.push(
           `imp` +
-          `ort * as ${prefix} from '${this._importGenerator.fileNameToModuleName(importedModuleUrl, moduleUrl)}';`);
+          `ort * as ${prefix} from '${this._importResolver.fileNameToModuleName(importedFilePath, genFilePath)}';`);
     });
     srcParts.push(ctx.toSource());
     return srcParts.join('\n');
@@ -55,9 +65,12 @@ export class TypeScriptEmitter implements OutputEmitter {
 }
 
 class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor {
-  constructor(private _moduleUrl: string) { super(false); }
+  constructor(private _genFilePath: string, private _importResolver: ImportResolver) {
+    super(false);
+  }
 
   importsWithPrefixes = new Map<string, string>();
+  reexports = new Map<string, {name: string, as: string}[]>();
 
   visitType(t: o.Type, ctx: EmitterVisitorContext, defaultType: string = 'any') {
     if (isPresent(t)) {
@@ -98,6 +111,19 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
   }
 
   visitDeclareVarStmt(stmt: o.DeclareVarStmt, ctx: EmitterVisitorContext): any {
+    if (ctx.isExportedVar(stmt.name) && stmt.value instanceof o.ExternalExpr && !stmt.type) {
+      // check for a reexport
+      const {name, filePath, members} = this._resolveStaticSymbol(stmt.value.value);
+      if (members.length === 0 && filePath !== this._genFilePath) {
+        let reexports = this.reexports.get(filePath);
+        if (!reexports) {
+          reexports = [];
+          this.reexports.set(filePath, reexports);
+        }
+        reexports.push({name, as: stmt.name});
+        return null;
+      }
+    }
     if (ctx.isExportedVar(stmt.name)) {
       ctx.print(`export `);
     }
@@ -320,25 +346,29 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     }, params, ctx, ',');
   }
 
+  private _resolveStaticSymbol(value: CompileIdentifierMetadata): StaticSymbol {
+    const reference = value.reference;
+    if (!(reference instanceof StaticSymbol)) {
+      throw new Error(`Internal error: unknown identifier ${JSON.stringify(value)}`);
+    }
+    return this._importResolver.getImportAs(reference) || reference;
+  }
+
   private _visitIdentifier(
       value: CompileIdentifierMetadata, typeParams: o.Type[], ctx: EmitterVisitorContext): void {
-    const name = identifierName(value);
-    const moduleUrl = identifierModuleUrl(value);
-    if (isBlank(name)) {
-      throw new Error(`Internal error: unknown identifier ${value}`);
-    }
-    if (isPresent(moduleUrl) && moduleUrl != this._moduleUrl) {
-      let prefix = this.importsWithPrefixes.get(moduleUrl);
+    const {name, filePath, members} = this._resolveStaticSymbol(value);
+    if (filePath != this._genFilePath) {
+      let prefix = this.importsWithPrefixes.get(filePath);
       if (isBlank(prefix)) {
         prefix = `import${this.importsWithPrefixes.size}`;
-        this.importsWithPrefixes.set(moduleUrl, prefix);
+        this.importsWithPrefixes.set(filePath, prefix);
       }
       ctx.print(`${prefix}.`);
     }
-    if (value.reference && value.reference.members && value.reference.members.length) {
-      ctx.print(value.reference.name);
+    if (members.length) {
+      ctx.print(name);
       ctx.print('.');
-      ctx.print(value.reference.members.join('.'));
+      ctx.print(members.join('.'));
     } else {
       ctx.print(name);
     }

--- a/modules/@angular/compiler/src/summary_resolver.ts
+++ b/modules/@angular/compiler/src/summary_resolver.ts
@@ -16,6 +16,9 @@ export interface Summary<T> {
 
 @CompilerInjectable()
 export class SummaryResolver<T> {
+  isLibraryFile(fileName: string): boolean { return false; };
+  getLibraryFileName(fileName: string): string { return null; }
   resolveSummary(reference: T): Summary<T> { return null; };
   getSymbolsOf(filePath: string): T[] { return []; }
+  getImportAs(reference: T): T { return reference; }
 }

--- a/modules/@angular/compiler/src/view_compiler/compile_element.ts
+++ b/modules/@angular/compiler/src/view_compiler/compile_element.ts
@@ -97,12 +97,11 @@ export class CompileElement extends CompileNode {
   }
 
   private _createComponentFactoryResolver() {
-    const entryComponents =
-        this.component.entryComponents.map((entryComponent: CompileIdentifierMetadata) => {
-          const id: CompileIdentifierMetadata = {reference: null};
-          this.view.targetDependencies.push(new ComponentFactoryDependency(entryComponent, id));
-          return id;
-        });
+    const entryComponents = this.component.entryComponents.map((entryComponent) => {
+      this.view.targetDependencies.push(
+          new ComponentFactoryDependency(entryComponent.componentType));
+      return {reference: entryComponent.componentFactory};
+    });
     if (!entryComponents || entryComponents.length === 0) {
       return;
     }
@@ -179,11 +178,11 @@ export class CompileElement extends CompileNode {
           const depsExpr =
               deps.map((dep) => this._getDependency(resolvedProvider.providerType, dep));
           if (isDirectiveWrapper) {
-            const directiveWrapperIdentifier: CompileIdentifierMetadata = {reference: null};
-            this.view.targetDependencies.push(new DirectiveWrapperDependency(
-                provider.useClass, DirectiveWrapperCompiler.dirWrapperClassName(provider.useClass),
-                directiveWrapperIdentifier));
-            return DirectiveWrapperExpressions.create(directiveWrapperIdentifier, depsExpr);
+            const dirMeta =
+                this._directives.find(dir => dir.type.reference === provider.useClass.reference);
+            this.view.targetDependencies.push(
+                new DirectiveWrapperDependency(dirMeta.type.reference));
+            return DirectiveWrapperExpressions.create({reference: dirMeta.wrapperType}, depsExpr);
           } else {
             return o.importExpr(provider.useClass)
                 .instantiate(depsExpr, o.importType(provider.useClass));

--- a/modules/@angular/compiler/src/view_compiler/compile_view.ts
+++ b/modules/@angular/compiler/src/view_compiler/compile_view.ts
@@ -7,7 +7,7 @@
  */
 
 import {AnimationEntryCompileResult} from '../animation/animation_compiler';
-import {CompileDirectiveMetadata, CompileIdentifierMetadata, CompilePipeSummary, tokenName} from '../compile_metadata';
+import {CompileDirectiveMetadata, CompileIdentifierMetadata, CompilePipeSummary, tokenName, viewClassName} from '../compile_metadata';
 import {EventHandlerVars, NameResolver} from '../compiler_util/expression_converter';
 import {createPureProxy} from '../compiler_util/identifier_util';
 import {CompilerConfig} from '../config';
@@ -20,8 +20,8 @@ import {CompileElement, CompileNode} from './compile_element';
 import {CompileMethod} from './compile_method';
 import {CompilePipe} from './compile_pipe';
 import {CompileQuery, addQueryToTokenMap, createQueryList} from './compile_query';
-import {ComponentFactoryDependency, DirectiveWrapperDependency, ViewClassDependency} from './deps';
-import {getPropertyInView, getViewClassName} from './util';
+import {ComponentFactoryDependency, ComponentViewDependency, DirectiveWrapperDependency} from './deps';
+import {getPropertyInView} from './util';
 
 export enum CompileViewRootNodeType {
   Node,
@@ -87,7 +87,7 @@ export class CompileView implements NameResolver {
       public animations: AnimationEntryCompileResult[], public viewIndex: number,
       public declarationElement: CompileElement, public templateVariableBindings: string[][],
       public targetDependencies:
-          Array<ViewClassDependency|ComponentFactoryDependency|DirectiveWrapperDependency>) {
+          Array<ComponentViewDependency|ComponentFactoryDependency|DirectiveWrapperDependency>) {
     this.createMethod = new CompileMethod(this);
     this.animationBindingsMethod = new CompileMethod(this);
     this.injectorGetMethod = new CompileMethod(this);
@@ -103,7 +103,7 @@ export class CompileView implements NameResolver {
     this.detachMethod = new CompileMethod(this);
 
     this.viewType = getViewType(component, viewIndex);
-    this.className = getViewClassName(component, viewIndex);
+    this.className = viewClassName(component.type.reference, viewIndex);
     this.classType = o.expressionType(o.variable(this.className));
     this.classExpr = o.variable(this.className);
     if (this.viewType === ViewType.COMPONENT || this.viewType === ViewType.HOST) {

--- a/modules/@angular/compiler/src/view_compiler/deps.ts
+++ b/modules/@angular/compiler/src/view_compiler/deps.ts
@@ -8,19 +8,26 @@
 
 import {CompileIdentifierMetadata} from '../compile_metadata';
 
-export class ViewClassDependency {
-  constructor(
-      public comp: CompileIdentifierMetadata, public name: string,
-      public placeholder: CompileIdentifierMetadata) {}
+/**
+ * This is currently not read, but will probably be used in the future.
+ * We keep it as we already pass it through all the rigth places...
+ */
+export class ComponentViewDependency {
+  constructor(public compType: any) {}
 }
 
+/**
+ * This is currently not read, but will probably be used in the future.
+ * We keep it as we already pass it through all the rigth places...
+ */
 export class ComponentFactoryDependency {
-  constructor(
-      public comp: CompileIdentifierMetadata, public placeholder: CompileIdentifierMetadata) {}
+  constructor(public compType: any) {}
 }
 
+/**
+ * This is currently not read, but will probably be used in the future.
+ * We keep it as we already pass it through all the rigth places...
+ */
 export class DirectiveWrapperDependency {
-  constructor(
-      public dir: CompileIdentifierMetadata, public name: string,
-      public placeholder: CompileIdentifierMetadata) {}
+  constructor(public dirType: any) {}
 }

--- a/modules/@angular/compiler/src/view_compiler/util.ts
+++ b/modules/@angular/compiler/src/view_compiler/util.ts
@@ -71,12 +71,6 @@ export function injectFromViewParentInjector(
   return viewExpr.callMethod('injectorGet', args);
 }
 
-export function getViewClassName(
-    component: CompileDirectiveSummary | CompileDirectiveMetadata,
-    embeddedTemplateIndex: number): string {
-  return `View_${identifierName(component.type)}${embeddedTemplateIndex}`;
-}
-
 export function getHandleEventMethodName(elementIndex: number): string {
   return `handleEvent_${elementIndex}`;
 }

--- a/modules/@angular/compiler/src/view_compiler/view_compiler.ts
+++ b/modules/@angular/compiler/src/view_compiler/view_compiler.ts
@@ -16,17 +16,17 @@ import {TemplateAst} from '../template_parser/template_ast';
 
 import {CompileElement} from './compile_element';
 import {CompileView} from './compile_view';
-import {ComponentFactoryDependency, DirectiveWrapperDependency, ViewClassDependency} from './deps';
+import {ComponentFactoryDependency, ComponentViewDependency, DirectiveWrapperDependency} from './deps';
 import {bindView} from './view_binder';
 import {buildView, finishView} from './view_builder';
 
-export {ComponentFactoryDependency, DirectiveWrapperDependency, ViewClassDependency} from './deps';
+export {ComponentFactoryDependency, ComponentViewDependency, DirectiveWrapperDependency} from './deps';
 
 export class ViewCompileResult {
   constructor(
       public statements: o.Statement[], public viewClassVar: string,
       public dependencies:
-          Array<ViewClassDependency|ComponentFactoryDependency|DirectiveWrapperDependency>) {}
+          Array<ComponentViewDependency|ComponentFactoryDependency|DirectiveWrapperDependency>) {}
 }
 
 @CompilerInjectable()
@@ -38,7 +38,7 @@ export class ViewCompiler {
       pipes: CompilePipeSummary[],
       compiledAnimations: AnimationEntryCompileResult[]): ViewCompileResult {
     const dependencies:
-        Array<ViewClassDependency|ComponentFactoryDependency|DirectiveWrapperDependency> = [];
+        Array<ComponentViewDependency|ComponentFactoryDependency|DirectiveWrapperDependency> = [];
     const view = new CompileView(
         component, this._genConfig, pipes, styles, compiledAnimations, 0,
         CompileElement.createNull(), [], dependencies);

--- a/modules/@angular/compiler/test/aot/static_reflector_spec.ts
+++ b/modules/@angular/compiler/test/aot/static_reflector_spec.ts
@@ -487,6 +487,8 @@ describe('StaticReflector', () => {
             export class Child extends Parent {}
 
             export class ChildNoDecorators extends Parent {}
+
+            export class ChildInvalidParent extends a.InvalidParent {}
           `
       });
 
@@ -500,6 +502,10 @@ describe('StaticReflector', () => {
       expect(
           reflector.annotations(reflector.getStaticSymbol('/tmp/src/main.ts', 'ChildNoDecorators')))
           .toEqual([new ClassDecorator('parent')]);
+
+      expect(reflector.annotations(
+                 reflector.getStaticSymbol('/tmp/src/main.ts', 'ChildInvalidParent')))
+          .toEqual([]);
     });
 
     it('should inherit parameters', () => {
@@ -520,6 +526,8 @@ describe('StaticReflector', () => {
             export class ChildWithCtor extends Parent {
               constructor(@ParamDecorator('c') c: C) {}
             }
+
+            export class ChildInvalidParent extends a.InvalidParent {}
           `
       });
 
@@ -537,6 +545,10 @@ describe('StaticReflector', () => {
 
       expect(reflector.parameters(reflector.getStaticSymbol('/tmp/src/main.ts', 'ChildWithCtor')))
           .toEqual([[reflector.getStaticSymbol('/tmp/src/main.ts', 'C'), new ParamDecorator('c')]]);
+
+      expect(
+          reflector.parameters(reflector.getStaticSymbol('/tmp/src/main.ts', 'ChildInvalidParent')))
+          .toEqual([]);
     });
 
     it('should inherit property metadata', () => {
@@ -561,6 +573,8 @@ describe('StaticReflector', () => {
               @PropDecorator('c')
               c: C;
             }
+
+            export class ChildInvalidParent extends a.InvalidParent {}
           `
       });
 
@@ -577,6 +591,10 @@ describe('StaticReflector', () => {
             'b': [new PropDecorator('b1'), new PropDecorator('b2')],
             'c': [new PropDecorator('c')]
           });
+
+      expect(reflector.propMetadata(
+                 reflector.getStaticSymbol('/tmp/src/main.ts', 'ChildInvalidParent')))
+          .toEqual({});
     });
 
     it('should inherit lifecycle hooks', () => {
@@ -591,6 +609,8 @@ describe('StaticReflector', () => {
               hook2() {}
               hook3() {}
             }
+
+            export class ChildInvalidParent extends a.InvalidParent {}
           `
       });
 
@@ -606,6 +626,10 @@ describe('StaticReflector', () => {
       expect(hooks(reflector.getStaticSymbol('/tmp/src/main.ts', 'Child'), [
         'hook1', 'hook2', 'hook3'
       ])).toEqual([true, true, true]);
+
+      expect(hooks(reflector.getStaticSymbol('/tmp/src/main.ts', 'ChildInvalidParent'), [
+        'hook1', 'hook2', 'hook3'
+      ])).toEqual([false, false, false]);
     });
   });
 

--- a/modules/@angular/compiler/test/output/output_emitter_util.ts
+++ b/modules/@angular/compiler/test/output/output_emitter_util.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {StaticSymbol} from '@angular/compiler/src/aot/static_symbol';
 import {CompileIdentifierMetadata} from '@angular/compiler/src/compile_metadata';
 import {assetUrl, createIdentifier} from '@angular/compiler/src/identifiers';
 import * as o from '@angular/compiler/src/output/output_ast';
@@ -262,4 +263,5 @@ export class SimpleJsImportGenerator implements ImportResolver {
   fileNameToModuleName(importedUrlStr: string, moduleUrlStr: string): string {
     return importedUrlStr;
   }
+  getImportAs(symbol: StaticSymbol): StaticSymbol { return null; }
 }

--- a/modules/@angular/compiler/test/output/ts_emitter_node_only_spec.ts
+++ b/modules/@angular/compiler/test/output/ts_emitter_node_only_spec.ts
@@ -74,4 +74,5 @@ class StubReflectorHost implements StaticSymbolResolverHost {
 
 class StubImportResolver extends ImportResolver {
   fileNameToModuleName(importedFilePath: string, containingFilePath: string): string { return ''; }
+  getImportAs(symbol: StaticSymbol): StaticSymbol { return null; }
 }

--- a/modules/@angular/core/src/di/opaque_token.ts
+++ b/modules/@angular/core/src/di/opaque_token.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable} from './metadata';
-
 /**
  * Creates a token that can be used in a DI Provider.
  *
@@ -30,7 +28,6 @@ import {Injectable} from './metadata';
  * error messages.
  * @stable
  */
-@Injectable()  // so that metadata is gathered for this class
 export class OpaqueToken {
   constructor(private _desc: string) {}
 

--- a/modules/@angular/core/src/linker/component_factory.ts
+++ b/modules/@angular/core/src/linker/component_factory.ts
@@ -95,9 +95,12 @@ const EMPTY_CONTEXT = new Object();
  * @stable
  */
 export class ComponentFactory<C> {
+  /** @internal */
+  _viewClass: Type<AppView<any>>;
   constructor(
-      public selector: string, private _viewClass: Type<AppView<any>>,
-      private _componentType: Type<any>) {}
+      public selector: string, _viewClass: Type<AppView<any>>, private _componentType: Type<any>) {
+    this._viewClass = _viewClass;
+  }
 
   get componentType(): Type<any> { return this._componentType; }
 

--- a/modules/@angular/core/src/linker/view_utils.ts
+++ b/modules/@angular/core/src/linker/view_utils.ts
@@ -14,9 +14,11 @@ import {isPresent, looseIdentical} from '../facade/lang';
 import {ViewEncapsulation} from '../metadata/view';
 import {RenderComponentType, RenderDebugInfo, Renderer, RootRenderer} from '../render/api';
 import {Sanitizer} from '../security';
+import {Type} from '../type';
 import {VERSION} from '../version';
 import {NgZone} from '../zone/ng_zone';
 
+import {ComponentFactory} from './component_factory';
 import {ExpressionChangedAfterItHasBeenCheckedError} from './errors';
 import {AppView} from './view';
 
@@ -652,3 +654,10 @@ export class InlineArrayDynamic<T> implements InlineArray<T> {
 }
 
 export const EMPTY_INLINE_ARRAY: InlineArray<any> = new InlineArray0();
+
+/**
+ * This is a private API only used by the compiler to read the view class.
+ */
+export function getComponentFactoryViewClass(componentFactory: ComponentFactory<any>): Type<any> {
+  return componentFactory._viewClass;
+}

--- a/modules/@angular/language-service/src/typescript_host.ts
+++ b/modules/@angular/language-service/src/typescript_host.ts
@@ -122,7 +122,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
 
       result = this._resolver = new CompileMetadataResolver(
           moduleResolver, directiveResolver, pipeResolver, new SummaryResolver(),
-          elementSchemaRegistry, directiveNormalizer, this.reflector,
+          elementSchemaRegistry, directiveNormalizer, this._staticSymbolCache, this.reflector,
           (error, type) => this.collectError(error, type && type.filePath));
     }
     return result;
@@ -397,7 +397,8 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
       const summaryResolver = new AotSummaryResolver(
           {
             loadSummary(filePath: string) { return null; },
-            isSourceFile(sourceFilePath: string) { return true; }
+            isSourceFile(sourceFilePath: string) { return true; },
+            getOutputFileName(sourceFilePath: string) { return null; }
           },
           this._staticSymbolCache);
       result = this._staticSymbolResolver = new StaticSymbolResolver(


### PR DESCRIPTION
To merge, this needs cl/142263969, cl/142784802, plus a run of `release_tsc.sh` in G3.

Global presubmit is green (besides flakes).