### PR TITLE
fix(core): do not rethrow an error from ErrorHandler

### DIFF
--- a/packages/core/src/error_handler.ts
+++ b/packages/core/src/error_handler.ts
@@ -41,12 +41,7 @@ export class ErrorHandler {
    */
   _console: Console = console;
 
-  /**
-   * @internal
-   */
-  rethrowError: boolean;
-
-  constructor(rethrowError: boolean = true) { this.rethrowError = rethrowError; }
+  constructor(private rethrowError: boolean = false) {}
 
   handleError(error: any): void {
     this._console.error(`EXCEPTION: ${this._extractMessage(error)}`);
@@ -71,8 +66,6 @@ export class ErrorHandler {
       }
     }
 
-    // We rethrow exceptions, so operations like 'bootstrap' will result in an error
-    // when an error happens. If we do not rethrow, bootstrap will always succeed.
     if (this.rethrowError) throw error;
   }
 


### PR DESCRIPTION
Closes https://github.com/angular/angular/issues/13159 and https://github.com/angular/angular/issues/8993

Issue description:
The origin of the issue is [this line](https://github.com/angular/angular/blob/master/modules/%40angular/core/src/error_handler.ts#L73). After rethrowing we are getting unsubscribed and do not receive further errors. According to the comment this is required to fail on bootstrap error but I think this is outdated because there're several [tests](https://github.com/angular/angular/blob/master/modules/%40angular/core/test/application_ref_spec.ts#L149) to ensure that bootstrap will fail even if ErrorHandler is not rethrowing the error.

If we still need to rethrow on bootstrap then another solution would be to set `rethrowError` to false after bootstrap.