### PR TITLE
fix(testing): improve misleading error message when don't call compileComponents

### DIFF
--- a/modules/@angular/core/testing/test_bed.ts
+++ b/modules/@angular/core/testing/test_bed.ts
@@ -267,7 +267,7 @@ export class TestBed implements Injector {
       } catch (e) {
         if (e.compType) {
           throw new Error(
-              `This test module uses the component ${stringify(e.compType)} which is using a "templateUrl", but they were never compiled. ` +
+              `This test module uses the component ${stringify(e.compType)} which is using a "templateUrl" or "styleUrls", but they were never compiled. ` +
               `Please call "TestBed.compileComponents" before your test.`);
         } else {
           throw e;

--- a/modules/@angular/platform-browser/test/testing_public_spec.ts
+++ b/modules/@angular/platform-browser/test/testing_public_spec.ts
@@ -503,7 +503,7 @@ export function main() {
                                            {declarations: [CompWithUrlTemplate]},
                                            () => TestBed.createComponent(CompWithUrlTemplate))))
                  .toThrowError(
-                     `This test module uses the component ${stringify(CompWithUrlTemplate)} which is using a "templateUrl", but they were never compiled. ` +
+                     `This test module uses the component ${stringify(CompWithUrlTemplate)} which is using a "templateUrl" or "styleUrls", but they were never compiled. ` +
                      `Please call "TestBed.compileComponents" before your test.`);
 
              restoreJasmineIt();


### PR DESCRIPTION
Closes https://github.com/angular/angular/issues/11301