### PR TITLE
refactor(compiler-cli): support extracting the mesage bundle without …

### DIFF
--- a/modules/@angular/compiler-cli/src/extractor.ts
+++ b/modules/@angular/compiler-cli/src/extractor.ts
@@ -31,16 +31,20 @@ export class Extractor {
     // Checks the format and returns the extension
     const ext = this.getExtension(formatName);
 
-    const files = this.program.getSourceFiles().map(
-        sf => this.ngCompilerHost.getCanonicalFileName(sf.fileName));
-
-    const promiseBundle = this.ngExtractor.extract(files);
+    const promiseBundle = this.extractBundle();
 
     return promiseBundle.then(bundle => {
       const content = this.serialize(bundle, ext);
       const dstPath = path.join(this.options.genDir, `messages.${ext}`);
       this.host.writeFile(dstPath, content, false);
     });
+  }
+
+  extractBundle(): Promise<compiler.MessageBundle> {
+    const files = this.program.getSourceFiles().map(
+        sf => this.ngCompilerHost.getCanonicalFileName(sf.fileName));
+
+    return this.ngExtractor.extract(files);
   }
 
   serialize(bundle: compiler.MessageBundle, ext: string): string {


### PR DESCRIPTION
…writing a file

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Refactoring (no functional changes, no api changes)
```

**What is the current behavior?** (You can also link to an open issue here)

The message bundle extractor currently write a file directly.  

**What is the new behavior?**

The call can now get the intermediate bundle and write the file itself.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x No
```
