### PR TITLE
fix(router): do not create new module on every navigation

### DIFF
--- a/modules/@angular/router/src/router_config_loader.ts
+++ b/modules/@angular/router/src/router_config_loader.ts
@@ -16,6 +16,18 @@ import {mergeMap} from 'rxjs/operator/mergeMap';
 import {LoadChildren, Route} from './config';
 import {flatten, wrapIntoObservable} from './utils/collection';
 
+export class InjectorWrapper implements Injector {
+  constructor(private inj1: Injector, private inj2: Injector) {}
+
+  get(token: any, notFoundValue?: any): any {
+    const result = this.inj1.get(token, null);
+    if (result === null) {
+      return this.inj2.get(token);
+    }
+    return result;
+  }
+}
+
 /**
  * @experimental
  */
@@ -33,7 +45,7 @@ export class RouterConfigLoader {
   load(parentInjector: Injector, loadChildren: LoadChildren): Observable<LoadedRouterConfig> {
     return map.call(this.loadModuleFactory(loadChildren), (r: NgModuleFactory<any>) => {
       const ref = r.create(parentInjector);
-      const injectorFactory = (parent: Injector) => r.create(parent).injector;
+      const injectorFactory = (parent: Injector) => new InjectorWrapper(ref.injector, parent);
       return new LoadedRouterConfig(
           flatten(ref.injector.get(ROUTES)), ref.injector, ref.componentFactoryResolver,
           injectorFactory);

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -2035,6 +2035,48 @@ describe('Integration', () => {
              expect(fixture.nativeElement).toHaveText('lazy-loaded-parent [lazy-loaded-child]');
            })));
 
+    it('should instantiate lazy loaded module only once',
+       fakeAsync(inject(
+           [Router, Location, NgModuleFactoryLoader],
+           (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+             let instantiatedTimes: number = 0;
+             @Component({
+               selector: 'lazy',
+               template: 'lazy-loaded-parent [<router-outlet></router-outlet>]'
+             })
+             class ParentLazyLoadedComponent {
+             }
+
+             @Component({selector: 'lazy', template: 'lazy-loaded-child'})
+             class ChildLazyLoadedComponent {
+             }
+
+             @NgModule({
+               declarations: [ParentLazyLoadedComponent, ChildLazyLoadedComponent],
+               imports: [RouterModule.forChild([{
+                 path: 'loaded',
+                 component: ParentLazyLoadedComponent,
+                 children: [{path: 'child', component: ChildLazyLoadedComponent}]
+               }])]
+             })
+             class LoadedModule {
+               constructor() { instantiatedTimes++; }
+             }
+
+             loader.stubbedModules = {expected: LoadedModule};
+
+             const fixture = createRoot(router, RootCmp);
+
+             router.resetConfig([{path: 'lazy', loadChildren: 'expected'}]);
+
+             router.navigateByUrl('/lazy/loaded/child');
+             advance(fixture);
+
+             expect(location.path()).toEqual('/lazy/loaded/child');
+             expect(fixture.nativeElement).toHaveText('lazy-loaded-parent [lazy-loaded-child]');
+             expect(instantiatedTimes).toEqual(1);
+           })));
+
     it('throws an error when forRoot() is used in a lazy context',
        fakeAsync(inject(
            [Router, Location, NgModuleFactoryLoader],


### PR DESCRIPTION
Closes https://github.com/angular/angular/issues/12869 and https://github.com/angular/angular/issues/12889 https://github.com/angular/angular/issues/13885 https://github.com/angular/angular/issues/13870

Repro: http://plnkr.co/edit/Yox9H7vPEfpTEQEzuBmb?p=preview
Every time u click on a button a new module is being created.

Description:
The origin of the issue is [here](https://github.com/angular/angular/blob/master/modules/%40angular/router/src/router.ts#L1130). During each navigation we call [injectorFactory](https://github.com/angular/angular/blob/master/modules/%40angular/router/src/router_config_loader.ts#L36) function which creates a new module every time. 

There're 2 injectors:app injector and one from lazy loaded module. And our goal is to merge them without re-creating a new module every time. Afaik currently there's no api for it so I created a wrapper around 2 injectors.