### PR TITLE
build: fix publish-build-artifacts branch detection

### DIFF
--- a/scripts/publish/publish-build-artifacts.sh
+++ b/scripts/publish/publish-build-artifacts.sh
@@ -97,7 +97,7 @@ function publishPackages {
 }
 
 # See DEVELOPER.md for help
-BRANCH=`git rev-parse --abbrev-ref HEAD`
+BRANCH=${TRAVIS_BRANCH:-$(git symbolic-ref --short HEAD)}
 if [ $# -gt 0 ]; then
   ORG=$1
   publishPackages "ssh"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The changes introduced in https://github.com/angular/angular/pull/13529 pass locally but fail on travis.

More specifically, branch detection in `BRANCH=`git rev-parse --abbrev-ref HEAD` results in `BRANCH=HEAD` instead of `BRANCH=master` in https://travis-ci.org/angular/angular/jobs/185615697#L2214, which breaks the publishing process further down the script execution.


**What is the new behavior?**
This PR introduces an alternative mechanism for determining the current branch: 
```
BRANCH=${TRAVIS_BRANCH:-$(git symbolic-ref --short HEAD)}
```
It will first check for `TRAVIS_BRANCH` and if not present, determine the branch via a newer git mechanism.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

/cc @chuckjaz 