### PR TITLE
refactor(upgrade): allow Closure advanced optimizations in `UpgradeComponent`

### DIFF
--- a/modules/@angular/upgrade/src/aot/upgrade_component.ts
+++ b/modules/@angular/upgrade/src/aot/upgrade_component.ts
@@ -167,10 +167,12 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
       });
     }
 
-    this.callLifecycleHook('$onInit', this.controllerInstance);
+    if (this.controllerInstance && isFunction(this.controllerInstance.$onInit)) {
+      this.controllerInstance.$onInit();
+    }
 
     if (this.controllerInstance && isFunction(this.controllerInstance.$doCheck)) {
-      const callDoCheck = () => this.callLifecycleHook('$doCheck', this.controllerInstance);
+      const callDoCheck = () => this.controllerInstance.$doCheck();
 
       this.$componentScope.$parent.$watch(callDoCheck);
       callDoCheck();
@@ -200,7 +202,9 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
       postLink(this.$componentScope, this.$element, attrs, requiredControllers, transcludeFn);
     }
 
-    this.callLifecycleHook('$postLink', this.controllerInstance);
+    if (this.controllerInstance && isFunction(this.controllerInstance.$postLink)) {
+      this.controllerInstance.$postLink();
+    }
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -208,7 +212,9 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     Object.keys(changes).forEach(
         propName => this.bindingDestination[propName] = changes[propName].currentValue);
 
-    this.callLifecycleHook('$onChanges', this.bindingDestination, changes);
+    if (isFunction(this.bindingDestination.$onChanges)) {
+      this.bindingDestination.$onChanges(changes);
+    }
   }
 
   ngDoCheck() {
@@ -231,14 +237,10 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.callLifecycleHook('$onDestroy', this.controllerInstance);
-    this.$componentScope.$destroy();
-  }
-
-  private callLifecycleHook(method: LifecycleHook, context: IBindingDestination, arg?: any) {
-    if (context && isFunction(context[method])) {
-      context[method](arg);
+    if (this.controllerInstance && isFunction(this.controllerInstance.$onDestroy)) {
+      this.controllerInstance.$onDestroy();
     }
+    this.$componentScope.$destroy();
   }
 
   private getDirective(name: string): angular.IDirective {


### PR DESCRIPTION
Get rid of the dynamic invocation style used in `callLifecycleHook()`, which would break under Closure Compiler's advanced optimizations. Related to https://github.com/angular/angular/pull/13020#discussion_r93492935.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
