### PR TITLE
fix(common): add link to trackBy docs

### DIFF
--- a/modules/@angular/common/src/directives/ng_for.ts
+++ b/modules/@angular/common/src/directives/ng_for.ts
@@ -92,7 +92,8 @@ export class NgFor implements DoCheck, OnChanges {
   @Input()
   set ngForTrackBy(fn: TrackByFn) {
     if (typeof fn !== 'function') {
-      throw new Error(`trackBy must be a function, but received ${JSON.stringify(fn)}`);
+      throw new Error(`trackBy must be a function, but received ${JSON.stringify(fn)}.
+      See https://angular.io/docs/ts/latest/api/common/index/NgFor-directive.html#!#change-propagation for more information.`);
     }
     this._trackByFn = fn;
   }


### PR DESCRIPTION
People in gitter still ask why ngFor throws an error for expressions like `*ngFor="let item of items; trackBy: item?.id"` so I added a link to the docs.
Part of this https://github.com/angular/angular/issues/6173