### PR TITLE
docs(examples): fix example path

### DIFF
--- a/modules/@angular/common/src/pipes/case_conversion_pipes.ts
+++ b/modules/@angular/common/src/pipes/case_conversion_pipes.ts
@@ -12,7 +12,7 @@ import {InvalidPipeArgumentError} from './invalid_pipe_argument_error';
 /**
  * Transforms text to lowercase.
  *
- * {@example  core/pipes/ts/lowerupper_pipe/lowerupper_pipe_example.ts region='LowerUpperPipe' }
+ * {@example  common/pipes/ts/lowerupper_pipe.ts region='LowerUpperPipe' }
  *
  * @stable
  */


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```
Docs related change.

**What is the current behavior?** (You can also link to an open issue here)
The angular/angular.io CI is failing when building docs against angular/angular master.

The following error is displayed:
```
./www/docs/ts/latest/api/common/index/LowerCasePipe-pipe.html:78:<div class="code-example"><code-example language="ts" format="">BAD FILENAME: ../../../../../_fragments/_api/core/pipes/ts/lowerupper_pipe/lowerupper_pipe_example-LowerUpperPipe.ts.md   Current path: docs,ts,latest,api,common,index,LowerCasePipe-pipe PathToDocs: ../../../../../</code-example></div></div></div><p class="location-badge">exported from <a href="index.html">@angular/common/index</a>
./www/docs/js/latest/api/common/index/LowerCasePipe-pipe.html:78:<div class="code-example"><code-example language="ts" format="">BAD FILENAME: ../../../../../_fragments/_api/core/pipes/ts/lowerupper_pipe/lowerupper_pipe_example-LowerUpperPipe.ts.md   Current path: docs,js,latest,api,common,index,LowerCasePipe-pipe PathToDocs: ../../../../../</code-example></div></div></div><p class="location-badge">exported from <a href="index.html">@angular/common/index</a>
```

This refers to auto-generated docs from files such as this one

https://github.com/filipesilva/angular/blob/master/modules/%40angular/common/src/pipes/case_conversion_pipes.ts

This line refers to an example that does not exist:
```
{@example  core/pipes/ts/lowerupper_pipe/lowerupper_pipe_example.ts region='LowerUpperPipe' }
```


**What is the new behavior?**

Fixed example reference to the correct example (`common/pipes/ts/lowerupper_pipe.ts`)

https://github.com/filipesilva/angular/blob/master/modules/@angular/examples/common/pipes/ts/lowerupper_pipe.ts

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

/cc @chuckjaz @vicb @wardbell @Foxandxss 