### PR TITLE
fix(language-service): support TypeScript 2.1

### DIFF
--- a/modules/@angular/compiler-cli/integrationtest/third_party_src/tsconfig-build.json
+++ b/modules/@angular/compiler-cli/integrationtest/third_party_src/tsconfig-build.json
@@ -15,6 +15,8 @@
     "declaration": true,
     "lib": ["es6", "dom"],
     "baseUrl": ".",
-    "outDir": "../node_modules/third_party"
-  }
+    "outDir": "../node_modules/third_party",
+     // Prevent scanning up the directory tree for types
+    "typeRoots": ["node_modules/@types"]
+ }
 }

--- a/modules/@angular/compiler-cli/integrationtest/tsconfig-build.json
+++ b/modules/@angular/compiler-cli/integrationtest/tsconfig-build.json
@@ -14,7 +14,9 @@
     "rootDir": "",
     "declaration": true,
     "lib": ["es6", "dom"],
-    "baseUrl": "."
+    "baseUrl": ".",
+    // Prevent scanning up the directory tree for types
+    "typeRoots": ["node_modules/@types"]
   },
 
   "files": [

--- a/scripts/ci-lite/offline_compiler_test.sh
+++ b/scripts/ci-lite/offline_compiler_test.sh
@@ -6,9 +6,10 @@ LINKABLE_PKGS=(
   $(pwd)/dist/packages-dist/{common,forms,core,compiler,compiler-cli,platform-{browser,server},platform-browser-dynamic,router}
   $(pwd)/dist/tools/@angular/tsc-wrapped
 )
+TYPESCRIPT_2_0=typescript@2.0.2
+TYPESCRIPT_2_1=typescript@2.1.4
 PKGS=(
   reflect-metadata@0.1.8
-  typescript@2.0.2
   zone.js@0.6.25
   rxjs@5.0.1
   @types/{node@6.0.38,jasmine@2.2.33}
@@ -30,7 +31,7 @@ cp -v package.json $TMP
 (
   cd $TMP
   set -ex -o pipefail
-  npm install ${PKGS[*]}
+  npm install ${PKGS[*]} $TYPESCRIPT_2_0
   # TODO(alexeagle): allow this to be npm link instead
   npm install ${LINKABLE_PKGS[*]}
 
@@ -61,4 +62,22 @@ cp -v package.json $TMP
   # Compile again with a differently named tsconfig file
   mv tsconfig-build.json othername.json
   ./node_modules/.bin/ngc -p othername.json
+)
+
+# Repeat selected parts of the above with TypeScript 2.1
+readonly TMP_2_1=$TMPDIR/e2e_test.$(date +%s)
+mkdir -p $TMP_2_1
+cp -R -v modules/@angular/compiler-cli/integrationtest/* $TMP_2_1
+cp -R -v modules/benchmarks $TMP_2_1
+cp -v package.json $TMP_2_1
+(
+  cd $TMP_2_1
+  set -ex -o pipefail
+
+  npm install ${PKGS[*]} $TYPESCRIPT_2_1
+  npm install ${LINKABLE_PKGS[*]}
+
+  ./node_modules/.bin/tsc --version
+  node ./node_modules/@angular/tsc-wrapped/src/main -p third_party_src/tsconfig-build.json
+  ./node_modules/.bin/ngc -p tsconfig-build.json --i18nFile=src/messages.fi.xlf --locale=fi --i18nFormat=xlf
 )

--- a/tools/@angular/tsc-wrapped/src/compiler_host.ts
+++ b/tools/@angular/tsc-wrapped/src/compiler_host.ts
@@ -119,9 +119,19 @@ export class MetadataWriterHost extends DelegatingHost {
     // released
     if (/*DTS*/ /\.js$/.test(emitFilePath)) {
       const path = emitFilePath.replace(/*DTS*/ /\.js$/, '.metadata.json');
+
+      // Beginning with 2.1, TypeScript transforms the source tree before emitting it.
+      // We need the original, unmodified, tree which might be several levels back
+      // depending on the number of transforms performed. All SourceFile's prior to 2.1
+      // will appear to be the original source since they didn't include an original field.
+      let collectableFile = sourceFile;
+      while ((collectableFile as any).original) {
+        collectableFile = (collectableFile as any).original;
+      }
+
       const metadata =
-          this.metadataCollector.getMetadata(sourceFile, !!this.ngOptions.strictMetadataEmit);
-      const metadata1 = this.metadataCollector1.getMetadata(sourceFile, false);
+          this.metadataCollector.getMetadata(collectableFile, !!this.ngOptions.strictMetadataEmit);
+      const metadata1 = this.metadataCollector1.getMetadata(collectableFile, false);
       const metadatas: ModuleMetadata[] = [metadata, metadata1].filter(e => !!e);
       if (metadatas.length) {
         const metadataText = JSON.stringify(metadatas);

--- a/tools/@angular/tsc-wrapped/src/evaluator.ts
+++ b/tools/@angular/tsc-wrapped/src/evaluator.ts
@@ -12,6 +12,10 @@ import {CollectorOptions} from './collector';
 import {MetadataEntry, MetadataError, MetadataGlobalReferenceExpression, MetadataImportedSymbolReferenceExpression, MetadataSymbolicCallExpression, MetadataSymbolicReferenceExpression, MetadataValue, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataImportedSymbolReferenceExpression, isMetadataModuleReferenceExpression, isMetadataSymbolicReferenceExpression, isMetadataSymbolicSpreadExpression} from './schema';
 import {Symbols} from './symbols';
 
+// In TypeScript 2.1 the spread element kind was renamed.
+const spreadElementSyntaxKind: ts.SyntaxKind =
+    (ts.SyntaxKind as any).SpreadElement || (ts.SyntaxKind as any).SpreadElementExpression;
+
 function isMethodCallOf(callExpression: ts.CallExpression, memberName: string): boolean {
   const expression = callExpression.expression;
   if (expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
@@ -282,9 +286,8 @@ export class Evaluator {
         });
         if (error) return error;
         return arr;
-      case ts.SyntaxKind.SpreadElementExpression:
-        let spread = <ts.SpreadElementExpression>node;
-        let spreadExpression = this.evaluateNode(spread.expression);
+      case spreadElementSyntaxKind:
+        let spreadExpression = this.evaluateNode((node as any).expression);
         return recordEntry({__symbolic: 'spread', expression: spreadExpression}, node);
       case ts.SyntaxKind.CallExpression:
         const callExpression = <ts.CallExpression>node;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

The metadata collector and the language service assume TypeScript 2.0.

**What is the new behavior?**

The metadata collector and language service will work with 2.0 and 2.1.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
