### PR TITLE
docs(ContentChild, ViewChildren): fix missing docs on angular.io

### DIFF
--- a/modules/@angular/core/src/metadata/di.ts
+++ b/modules/@angular/core/src/metadata/di.ts
@@ -225,7 +225,33 @@ export const ContentChildren: ContentChildrenDecorator =
  */
 export interface ContentChildDecorator {
   /**
-   * @docsNotRequired
+   * @whatItDoes Configures a content query.
+   *
+   * @howToUse
+   *
+   * {@example core/di/ts/contentChild/content_child_howto.ts region='HowTo'}
+   *
+   * @description
+   *
+   * You can use ContentChild to get the first element or the directive matching the selector from
+   * the content DOM. If the content DOM changes, and a new child matches the selector,
+   * the property will be updated.
+   *
+   * Content queries are set before the `ngAfterContentInit` callback is called.
+   *
+   * **Metadata Properties**:
+   *
+   * * **selector** - the directive type or the name used for querying.
+   * * **read** - read a different token from the queried element.
+   *
+   * Let's look at an example:
+   *
+   * {@example core/di/ts/contentChild/content_child_example.ts region='Component'}
+   *
+   * **npm package**: `@angular/core`
+   *
+   * @stable
+   * @Annotation
    */
   (selector: Type<any>|Function|string, {read}?: {read?: any}): any;
   new (selector: Type<any>|Function|string, {read}?: {read?: any}): ContentChild;
@@ -241,30 +267,7 @@ export interface ContentChildDecorator {
 export type ContentChild = Query;
 
 /**
- * @whatItDoes Configures a content query.
- *
- * @howToUse
- *
- * {@example core/di/ts/contentChild/content_child_howto.ts region='HowTo'}
- *
- * @description
- *
- * You can use ContentChild to get the first element or the directive matching the selector from the
- * content DOM. If the content DOM changes, and a new child matches the selector,
- * the property will be updated.
- *
- * Content queries are set before the `ngAfterContentInit` callback is called.
- *
- * **Metadata Properties**:
- *
- * * **selector** - the directive type or the name used for querying.
- * * **read** - read a different token from the queried element.
- *
- * Let's look at an example:
- *
- * {@example core/di/ts/contentChild/content_child_example.ts region='Component'}
- *
- * **npm package**: `@angular/core`
+ * ContentChild decorator and metadata.
  *
  * @stable
  * @Annotation
@@ -290,8 +293,35 @@ export const ContentChild: ContentChildDecorator = makePropDecorator(
  */
 export interface ViewChildrenDecorator {
   /**
-   * @docsNotRequired
- */ (selector: Type<any>|Function|string, {read}?: {read?: any}): any;
+   * @whatItDoes Configures a view query.
+   *
+   * @howToUse
+   *
+   * {@example core/di/ts/viewChildren/view_children_howto.ts region='HowTo'}
+   *
+   * @description
+   *
+   * You can use ViewChildren to get the {@link QueryList} of elements or directives from the
+   * view DOM. Any time a child element is added, removed, or moved, the query list will be updated,
+   * and the changes observable of the query list will emit a new value.
+   *
+   * View queries are set before the `ngAfterViewInit` callback is called.
+   *
+   * **Metadata Properties**:
+   *
+   * * **selector** - the directive type or the name used for querying.
+   * * **read** - read a different token from the queried elements.
+   *
+   * Let's look at an example:
+   *
+   * {@example core/di/ts/viewChildren/view_children_example.ts region='Component'}
+   *
+   * **npm package**: `@angular/core`
+   *
+   * @stable
+   * @Annotation
+   */
+  (selector: Type<any>|Function|string, {read}?: {read?: any}): any;
   new (selector: Type<any>|Function|string, {read}?: {read?: any}): ViewChildren;
 }
 
@@ -303,30 +333,7 @@ export interface ViewChildrenDecorator {
 export type ViewChildren = Query;
 
 /**
- * @whatItDoes Configures a view query.
- *
- * @howToUse
- *
- * {@example core/di/ts/viewChildren/view_children_howto.ts region='HowTo'}
- *
- * @description
- *
- * You can use ViewChildren to get the {@link QueryList} of elements or directives from the
- * view DOM. Any time a child element is added, removed, or moved, the query list will be updated,
- * and the changes observable of the query list will emit a new value.
- *
- * View queries are set before the `ngAfterViewInit` callback is called.
- *
- * **Metadata Properties**:
- *
- * * **selector** - the directive type or the name used for querying.
- * * **read** - read a different token from the queried elements.
- *
- * Let's look at an example:
- *
- * {@example core/di/ts/viewChildren/view_children_example.ts region='Component'}
- *
- * **npm package**: `@angular/core`
+ * ViewChildren decorator and metadata.
  *
  * @stable
  * @Annotation

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -278,7 +278,7 @@ export declare const ContentChild: ContentChildDecorator;
 
 /** @stable */
 export interface ContentChildDecorator {
-    (selector: Type<any> | Function | string, {read}?: {
+    /** @stable */ (selector: Type<any> | Function | string, {read}?: {
         read?: any;
     }): any;
     new (selector: Type<any> | Function | string, {read}?: {
@@ -979,7 +979,8 @@ export interface ViewChildDecorator {
 export declare const ViewChildren: ViewChildrenDecorator;
 
 /** @stable */
-export interface ViewChildrenDecorator { (selector: Type<any> | Function | string, {read}?: {
+export interface ViewChildrenDecorator {
+    /** @stable */ (selector: Type<any> | Function | string, {read}?: {
         read?: any;
     }): any;
     new (selector: Type<any> | Function | string, {read}?: {


### PR DESCRIPTION
Move the documentations of the ContentChild and ViewChildren decorators
so that they appear correctly on angular.io.

Closes #13625

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

#13625

**What is the new behavior?**

The documentations of ContentChild and ViewChildren appears on angular.io.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

Tested locally by building the angular.io repository. I am not sure how to add tests to verify this fix.
