### PR TITLE
fix(compiler-cli): avoid handling functions in loadChildren as lazy load routes paths

### DIFF
--- a/modules/@angular/compiler-cli/src/ngtools_impl.ts
+++ b/modules/@angular/compiler-cli/src/ngtools_impl.ts
@@ -192,7 +192,7 @@ function _collectRoutes(
  */
 function _collectLoadChildren(routes: Route[]): string[] {
   return routes.reduce((m, r) => {
-    if (r.loadChildren) {
+    if (r.loadChildren && typeof r.loadChildren === 'string') {
       return m.concat(r.loadChildren);
     } else if (Array.isArray(r)) {
       return m.concat(_collectLoadChildren(r));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
N/A for the private API //  CC @hansl 
- [ ] Docs have been added / updated (for bug fixes / features)
N/A

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

If you use an official tool that uses the Angular Compiler CLI private API, like Angular CLI (or @ng-tools Webpack plugin), and you have some route code like:

```
import { NonLazyLoadedModule } from './non-lazy-loaded/non-lazy-loaded.module';

export function getNonLazyLoadedModule() { return NonLazyLoadedModule; }

export const routes = [
  { path: '/some-path', loadChildren: getNonLazyLoadedModule }
];
```

Building this (for example `ng build` using Angular CLI beta.24) shows a build error:

> ERROR in entry.split is not a function

And it also shows in the browser.

**What is the new behavior?**

No build error in console or browser in that case. Build just succeeds and browser functionality shows no error. Loading modules (lazy or not) works as expected.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

<strike>If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...</strike>


**Other information**:

The core problem in the previous case is that the compiler CLI internal API treats the function `getNonLazyLoadedModule()` as a lazy loading string  
(like `'./non-lazy-loaded/non-lazy-loaded.module#NonLazyLoadedModule'`).

It passes the output as the `entry` argument to `RouteDef.fromString(entry: string)`, where the error `entry.split is not a function` happens.

@hansl would be an ideal reviewer for this, having created the private API.

Fixes https://github.com/angular/angular-cli/issues/3204