### PR TITLE
fix(compiler-cli): add support for more than 2 levels of nested lazy routes

### DIFF
--- a/modules/@angular/compiler-cli/integrationtest/ngtools_src/feature/lazy-feature-nested.module.ts
+++ b/modules/@angular/compiler-cli/integrationtest/ngtools_src/feature/lazy-feature-nested.module.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, NgModule} from '@angular/core';
+import {RouterModule} from '@angular/router';
+
+@Component({selector: 'lazy-feature-comp', template: 'lazy feature, nested!'})
+export class LazyFeatureNestedComponent {
+}
+
+@NgModule({
+  imports: [RouterModule.forChild([
+    {path: '', component: LazyFeatureNestedComponent, pathMatch: 'full'},
+  ])],
+  declarations: [LazyFeatureNestedComponent]
+})
+export class LazyFeatureNestedModule {
+}

--- a/modules/@angular/compiler-cli/integrationtest/ngtools_src/feature/lazy-feature.module.ts
+++ b/modules/@angular/compiler-cli/integrationtest/ngtools_src/feature/lazy-feature.module.ts
@@ -16,7 +16,10 @@ export class LazyFeatureComponent {
 @NgModule({
   imports: [RouterModule.forChild([
     {path: '', component: LazyFeatureComponent, pathMatch: 'full'},
-    {path: 'feature', loadChildren: './feature.module#FeatureModule'}
+    {path: 'feature', loadChildren: './feature.module#FeatureModule'}, {
+      path: 'nested-feature',
+      loadChildren: './lazy-feature-nested.module#LazyFeatureNestedModule'
+    }
   ])],
   declarations: [LazyFeatureComponent]
 })

--- a/modules/@angular/compiler-cli/integrationtest/test/test_ngtools_api.ts
+++ b/modules/@angular/compiler-cli/integrationtest/test/test_ngtools_api.ts
@@ -191,6 +191,8 @@ function lazyRoutesTest() {
     './lazy.module#LazyModule': 'lazy.module.ts',
     './feature/feature.module#FeatureModule': 'feature/feature.module.ts',
     './feature/lazy-feature.module#LazyFeatureModule': 'feature/lazy-feature.module.ts',
+    './feature.module#FeatureModule': 'feature/feature.module.ts',
+    './lazy-feature-nested.module#LazyFeatureNestedModule': 'feature/lazy-feature-nested.module.ts',
     'feature2/feature2.module#Feature2Module': 'feature2/feature2.module.ts',
     './default.module': 'feature2/default.module.ts',
     'feature/feature.module#FeatureModule': 'feature/feature.module.ts'

--- a/modules/@angular/compiler-cli/src/ngtools_impl.ts
+++ b/modules/@angular/compiler-cli/src/ngtools_impl.ts
@@ -192,7 +192,7 @@ function _collectRoutes(
  */
 function _collectLoadChildren(routes: Route[]): string[] {
   return routes.reduce((m, r) => {
-    if (r.loadChildren) {
+    if (r.loadChildren && typeof r.loadChildren === 'string') {
       return m.concat(r.loadChildren);
     } else if (Array.isArray(r)) {
       return m.concat(_collectLoadChildren(r));

--- a/modules/@angular/compiler-cli/src/ngtools_impl.ts
+++ b/modules/@angular/compiler-cli/src/ngtools_impl.ts
@@ -15,8 +15,6 @@
 import {AotCompilerHost, StaticReflector, StaticSymbol} from '@angular/compiler';
 import {NgModule} from '@angular/core';
 
-
-
 // We cannot depend directly to @angular/router.
 type Route = any;
 const ROUTER_MODULE_PATH = '@angular/router/src/router_config_loader';
@@ -63,29 +61,37 @@ export function listLazyRoutesOfModule(
   const className = entryRouteDef.className;
 
   // List loadChildren of this single module.
-  const staticSymbol = reflector.findDeclaration(modulePath, className, containingFile);
+  const appStaticSymbol = reflector.findDeclaration(modulePath, className, containingFile);
   const ROUTES = reflector.findDeclaration(ROUTER_MODULE_PATH, ROUTER_ROUTES_SYMBOL_NAME);
   const lazyRoutes: LazyRoute[] =
-      _extractLazyRoutesFromStaticModule(staticSymbol, reflector, host, ROUTES);
-  const routes: LazyRouteMap = {};
+      _extractLazyRoutesFromStaticModule(appStaticSymbol, reflector, host, ROUTES);
 
-  lazyRoutes.forEach((lazyRoute: LazyRoute) => {
-    const route: string = lazyRoute.routeDef.toString();
-    _assertRoute(routes, lazyRoute);
-    routes[route] = lazyRoute;
+  const allLazyRoutes = lazyRoutes.reduce(
+      function includeLazyRouteAndSubRoutes(allRoutes: LazyRouteMap, lazyRoute: LazyRoute):
+          LazyRouteMap {
+            const route: string = lazyRoute.routeDef.toString();
+            _assertRoute(allRoutes, lazyRoute);
+            allRoutes[route] = lazyRoute;
 
-    const lazyModuleSymbol = reflector.findDeclaration(
-        lazyRoute.absoluteFilePath, lazyRoute.routeDef.className || 'default');
-    const subRoutes = _extractLazyRoutesFromStaticModule(lazyModuleSymbol, reflector, host, ROUTES);
+            // StaticReflector does not support discovering annotations like `NgModule` on default
+            // exports
+            // Which means: if a default export NgModule was lazy-loaded, we can discover it, but,
+            //  we cannot parse its routes to see if they have loadChildren or not.
+            if (!lazyRoute.routeDef.className) {
+              return allRoutes;
+            }
 
-    // Populate the map using the routes we just found.
-    subRoutes.forEach(subRoute => {
-      _assertRoute(routes, subRoute);
-      routes[subRoute.routeDef.toString()] = subRoute;
-    });
-  });
+            const lazyModuleSymbol = reflector.findDeclaration(
+                lazyRoute.absoluteFilePath, lazyRoute.routeDef.className || 'default');
 
-  return routes;
+            const subRoutes =
+                _extractLazyRoutesFromStaticModule(lazyModuleSymbol, reflector, host, ROUTES);
+
+            return subRoutes.reduce(includeLazyRouteAndSubRoutes, allRoutes);
+          },
+      {});
+
+  return allLazyRoutes;
 }
 
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

If you have more than 3 levels of nested lazy routes, like: `{app-root}/lazy-loaded-module-1/lazy-loaded-module-2/lazy-loaded-module-3`

Where `lazy-loaded-module-3` is lazy loaded from `lazy-loaded-module-2`,
and `lazy-loaded-module-2` is lazy loaded from module `lazy-loaded-module-1`,
and `lazy-loaded-module-1` is lazy loaded from `AppModule`

You get only 2 chunk bundles created in addition to the main bundle, when you build your project using Angular CLI or @ng-tools Webpack plugin.

You'll be able to browse to `{app-root}/lazy-loaded-module-1/lazy-loaded-module-2/` but get a router error in browser for `{app-root}/lazy-loaded-module-1/lazy-loaded-module-2/lazy-loaded-module-3`, because no bundle was generated for it.

**What is the new behavior?**

- Your build will include the same number of chunks as your lazy modules, plus the main chunk of course.

- Your browser will be able to go to any level of nested lazy-loaded modules you declared.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

<strike>If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...</strike>


**Other information**:

This PR includes work from PR #13676, and superseeds it.

The PR can be tested on this sample repository https://github.com/meligy/routing-angular-cli  
The test path in this sample is `/lazy/deep/third/`. The UI walks you level by level as well.

@hansl would be the best person to review this as he wrote the original implementation.

Fixes angular/angular-cli#3663