### PR TITLE
fix(compiler): don’t throw when using `ANALYZE_FOR_ENTRY_COMPONENTS` …

### DIFF
--- a/modules/@angular/core/src/type.ts
+++ b/modules/@angular/core/src/type.ts
@@ -18,5 +18,8 @@
  */
 export const Type = Function;
 
+export function isType(v: any): v is Type<any> {
+  return typeof v === 'function';
+}
 
 export interface Type<T> extends Function { new (...args: any[]): T; }

--- a/modules/@angular/core/test/linker/regression_integration_spec.ts
+++ b/modules/@angular/core/test/linker/regression_integration_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Injector, OpaqueToken, Pipe, PipeTransform, Provider} from '@angular/core';
+import {ANALYZE_FOR_ENTRY_COMPONENTS, Component, Injector, OpaqueToken, Pipe, PipeTransform, Provider} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/matchers';
 
@@ -119,7 +119,7 @@ function declareTests({useJit}: {useJit: boolean}) {
         expect(injector.get(token)).toEqual(tokenValue);
       });
 
-      it('should support providers with an anonymous function', () => {
+      it('should support providers with an anonymous function as token', () => {
         const token = () => true;
         const tokenValue = 1;
         const injector = createInjector([{provide: token, useValue: tokenValue}]);
@@ -147,6 +147,22 @@ function declareTests({useJit}: {useJit: boolean}) {
         const injector = createInjector([{provide: 'someToken', useValue: data}]);
         expect(injector.get('someToken')).toEqual(data);
       });
+
+      describe('ANALYZE_FOR_ENTRY_COMPONENTS providers', () => {
+
+        it('should support class instances', () => {
+          class SomeObject {
+            someMethod() {}
+          }
+
+          expect(
+              () => createInjector([
+                {provide: ANALYZE_FOR_ENTRY_COMPONENTS, useValue: new SomeObject(), multi: true}
+              ]))
+              .not.toThrow();
+        });
+      });
+
     });
 
     it('should allow logging a previous elements class binding via interpolation', () => {

--- a/modules/@angular/core/test/reflection/reflector_spec.ts
+++ b/modules/@angular/core/test/reflection/reflector_spec.ts
@@ -190,6 +190,8 @@ export function main() {
 
         class ChildNoDecorators extends Parent {}
 
+        class NoDecorators {}
+
         // Check that metadata for Parent was not changed!
         expect(reflector.annotations(Parent)).toEqual([new ClassDecorator({value: 'parent'})]);
 
@@ -199,6 +201,11 @@ export function main() {
 
         expect(reflector.annotations(ChildNoDecorators)).toEqual([new ClassDecorator(
             {value: 'parent'})]);
+
+        expect(reflector.annotations(NoDecorators)).toEqual([]);
+        expect(reflector.annotations(<any>{})).toEqual([]);
+        expect(reflector.annotations(<any>1)).toEqual([]);
+        expect(reflector.annotations(null)).toEqual([]);
       });
 
       it('should inherit parameters', () => {
@@ -226,6 +233,8 @@ export function main() {
           constructor(a: any, b: any, c: any) { super(null, null); }
         }
 
+        class NoDecorators {}
+
         // Check that metadata for Parent was not changed!
         expect(reflector.parameters(Parent)).toEqual([
           [A, new ParamDecorator('a')], [B, new ParamDecorator('b')]
@@ -242,6 +251,11 @@ export function main() {
         expect(reflector.parameters(ChildWithCtorNoDecorator)).toEqual([
           undefined, undefined, undefined
         ]);
+
+        expect(reflector.parameters(NoDecorators)).toEqual([]);
+        expect(reflector.parameters(<any>{})).toEqual([]);
+        expect(reflector.parameters(<any>1)).toEqual([]);
+        expect(reflector.parameters(null)).toEqual([]);
       });
 
       it('should inherit property metadata', () => {
@@ -263,6 +277,8 @@ export function main() {
           c: C;
         }
 
+        class NoDecorators {}
+
         // Check that metadata for Parent was not changed!
         expect(reflector.propMetadata(Parent)).toEqual({
           'a': [new PropDecorator('a')],
@@ -274,6 +290,11 @@ export function main() {
           'b': [new PropDecorator('b1'), new PropDecorator('b2')],
           'c': [new PropDecorator('c')]
         });
+
+        expect(reflector.propMetadata(NoDecorators)).toEqual({});
+        expect(reflector.propMetadata(<any>{})).toEqual({});
+        expect(reflector.propMetadata(<any>1)).toEqual({});
+        expect(reflector.propMetadata(null)).toEqual({});
       });
 
       it('should inherit lifecycle hooks', () => {


### PR DESCRIPTION
…with user classes

Fixed #13565
