### PR TITLE
fix(interfaces): Make ResponseOptionsArgs an interface

### DIFF
--- a/modules/@angular/http/src/interfaces.ts
+++ b/modules/@angular/http/src/interfaces.ts
@@ -68,7 +68,7 @@ export interface RequestArgs extends RequestOptionsArgs { url: string; }
  *
  * @experimental
  */
-export interface ResponseOptionsArgs = {
+export interface ResponseOptionsArgs {
   body?: string | Object | FormData | ArrayBuffer | Blob; status?: number; statusText?: string;
   headers?: Headers;
   type?: ResponseType;

--- a/modules/@angular/http/src/interfaces.ts
+++ b/modules/@angular/http/src/interfaces.ts
@@ -68,7 +68,7 @@ export interface RequestArgs extends RequestOptionsArgs { url: string; }
  *
  * @experimental
  */
-export type ResponseOptionsArgs = {
+export interface ResponseOptionsArgs = {
   body?: string | Object | FormData | ArrayBuffer | Blob; status?: number; statusText?: string;
   headers?: Headers;
   type?: ResponseType;

--- a/modules/@angular/http/src/interfaces.ts
+++ b/modules/@angular/http/src/interfaces.ts
@@ -69,8 +69,10 @@ export interface RequestArgs extends RequestOptionsArgs { url: string; }
  * @experimental
  */
 export interface ResponseOptionsArgs {
-  body?: string | Object | FormData | ArrayBuffer | Blob; status?: number; statusText?: string;
+  body?: string|Object|FormData|ArrayBuffer|Blob;
+  status?: number;
+  statusText?: string;
   headers?: Headers;
   type?: ResponseType;
   url?: string;
-};
+}


### PR DESCRIPTION
fix(interfaces): Make ResponseOptionsArgs an interface

As per the [Typescript Language Spec](https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#3.10) having it as an interface means extends, and implements keywords cannot be used. It is unclear why this was declared as a type in the first place

**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Is a type definition

**What is the new behavior?**
Is an interface. Allowing for extends, implements etc.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X ] No
```