### PR TITLE
Support TypeScript plugin extensibility model for Language Service features

### DIFF
--- a/modules/@angular/compiler/src/aot/static_reflector.ts
+++ b/modules/@angular/compiler/src/aot/static_reflector.ts
@@ -84,7 +84,7 @@ export class StaticReflector implements ReflectorReader {
       const classMetadata = this.getTypeMetadata(type);
       if (classMetadata['extends']) {
         const parentType = this.simplify(type, classMetadata['extends']);
-        if (parentType instanceof StaticSymbol) {
+        if (parentType && (parentType instanceof StaticSymbol)) {
           const parentAnnotations = this.annotations(parentType);
           annotations.push(...parentAnnotations);
         }

--- a/modules/@angular/language-service/index.ts
+++ b/modules/@angular/language-service/index.ts
@@ -11,11 +11,8 @@
  * @description
  * Entry point for all public APIs of the language service package.
  */
-import {LanguageServicePlugin} from './src/ts_plugin';
-
 export {createLanguageService} from './src/language_service';
+export {create} from './src/ts_plugin';
 export {Completion, Completions, Declaration, Declarations, Definition, Diagnostic, Diagnostics, Hover, HoverTextSection, LanguageService, LanguageServiceHost, Location, Span, TemplateSource, TemplateSources} from './src/types';
 export {TypeScriptServiceHost, createLanguageServiceFromTypescript} from './src/typescript_host';
 export {VERSION} from './src/version';
-
-export default LanguageServicePlugin;

--- a/modules/@angular/language-service/src/language_service.ts
+++ b/modules/@angular/language-service/src/language_service.ts
@@ -107,8 +107,9 @@ class LanguageServiceImpl implements LanguageService {
   getTemplateAst(template: TemplateSource, contextFile: string): AstResult {
     let result: AstResult;
     try {
-      const {metadata} =
+      const resolvedMetadata =
           this.metadataResolver.getNonNormalizedDirectiveMetadata(template.type as any);
+      const metadata = resolvedMetadata && resolvedMetadata.metadata;
       if (metadata) {
         const rawHtmlParser = new HtmlParser();
         const htmlParser = new I18NHtmlParser(rawHtmlParser);
@@ -124,9 +125,10 @@ class LanguageServiceImpl implements LanguageService {
           ngModule = findSuitableDefaultModule(analyzedModules);
         }
         if (ngModule) {
-          const directives = ngModule.transitiveModule.directives.map(
-              d => this.host.resolver.getNonNormalizedDirectiveMetadata(d.reference)
-                       .metadata.toSummary());
+          const resolvedDirectives = ngModule.transitiveModule.directives.map(
+              d => this.host.resolver.getNonNormalizedDirectiveMetadata(d.reference));
+          const directives =
+              resolvedDirectives.filter(d => d !== null).map(d => d.metadata.toSummary());
           const pipes = ngModule.transitiveModule.pipes.map(
               p => this.host.resolver.getOrLoadPipeMetadata(p.reference).toSummary());
           const schemas = ngModule.schemas;

--- a/modules/@angular/language-service/test/test_utils.ts
+++ b/modules/@angular/language-service/test/test_utils.ts
@@ -71,12 +71,13 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
   private projectVersion = 0;
 
   constructor(private scriptNames: string[], private data: MockData) {
-    let angularIndex = module.filename.indexOf('@angular');
+    const moduleFilename = module.filename.replace(/\\/g, '/');
+    let angularIndex = moduleFilename.indexOf('@angular');
     if (angularIndex >= 0)
-      this.angularPath = module.filename.substr(0, angularIndex).replace('/all/', '/all/@angular/');
-    let distIndex = module.filename.indexOf('/dist/all');
+      this.angularPath = moduleFilename.substr(0, angularIndex).replace('/all/', '/all/@angular/');
+    let distIndex = moduleFilename.indexOf('/dist/all');
     if (distIndex >= 0)
-      this.nodeModulesPath = path.join(module.filename.substr(0, distIndex), 'node_modules');
+      this.nodeModulesPath = path.join(moduleFilename.substr(0, distIndex), 'node_modules');
   }
 
   override(fileName: string, content: string) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features) (n/a)
- [x] Docs have been added / updated (for bug fixes / features) (n/a)

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
No language service for the new TypeScript plugin model exists

**What is the new behavior?**
A language service for the new TypeScript plugin model exists


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:

Commits in this PR:
* **Add some null checking**: Additional diagnostics
* **Avoid crashing in certain situations**: Null checks were missing in a few places
* **Port ts2.1 compat fixes from Chuck**: Patches from @chuckjaz to make things cross-compatible with TS2.0 and TS2.1
* **Support new plugin model from TypeScript**: New proxy LS plugin model
* **'create' method from LS module**: Expose the plugin factory function from the language-service module

When the corresponding PR Microsoft/TypeScript#12231 goes in, the following workflow will be enabled:
 * Clone `angular/quickstart`
 * Add `"plugins": [{ "name": "@angular/language-service" }, }]` to `tsconfig.json`
 * `npm install --save-dev @angular/language-service`
 * :tada: Completions, go-to-def, diagnostics, and hover info appear in VS Code and other tsserver-based plugins
