### PR TITLE
fix(testing): async/fakeAsync/inject/withModule helpers should pass through context to callback functions

### DIFF
--- a/modules/@angular/core/testing/fake_async.ts
+++ b/modules/@angular/core/testing/fake_async.ts
@@ -48,6 +48,7 @@ let _inFakeAsyncCall = false;
  * @experimental
  */
 export function fakeAsync(fn: Function): (...args: any[]) => any {
+  // Not using an arrow function to preserve context passed from call site
   return function(...args: any[]) {
     const proxyZoneSpec = ProxyZoneSpec.assertPresent();
     if (_inFakeAsyncCall) {
@@ -67,7 +68,7 @@ export function fakeAsync(fn: Function): (...args: any[]) => any {
       const lastProxyZoneSpec = proxyZoneSpec.getDelegate();
       proxyZoneSpec.setDelegate(_fakeAsyncTestZoneSpec);
       try {
-        res = fn(...args);
+        res = fn.apply(this, args);
         flushMicrotasks();
       } finally {
         proxyZoneSpec.setDelegate(lastProxyZoneSpec);

--- a/modules/@angular/core/testing/test_bed.ts
+++ b/modules/@angular/core/testing/test_bed.ts
@@ -324,10 +324,10 @@ export class TestBed implements Injector {
     return result === UNDEFINED ? this._compiler.injector.get(token, notFoundValue) : result;
   }
 
-  execute(tokens: any[], fn: Function): any {
+  execute(tokens: any[], fn: Function, context?: any): any {
     this._initIfNeeded();
     const params = tokens.map(t => this.get(t));
-    return fn(...params);
+    return fn.apply(context, params);
   }
 
   overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): void {
@@ -418,13 +418,13 @@ export function inject(tokens: any[], fn: Function): () => any {
       // the injected tokens.
       return testBed.compileComponents().then(() => {
         const completer: AsyncTestCompleter = testBed.get(AsyncTestCompleter);
-        testBed.execute(tokens, fn.bind(this));
+        testBed.execute(tokens, fn, this);
         return completer.promise;
       });
     };
   } else {
     // Not using an arrow function to preserve context passed from call site
-    return function() { return testBed.execute(tokens, fn.bind(this)); };
+    return function() { return testBed.execute(tokens, fn, this); };
   }
 }
 

--- a/tools/public_api_guard/core/testing/index.d.ts
+++ b/tools/public_api_guard/core/testing/index.d.ts
@@ -67,7 +67,7 @@ export declare class TestBed implements Injector {
     }): void;
     configureTestingModule(moduleDef: TestModuleMetadata): void;
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
-    execute(tokens: any[], fn: Function): any;
+    execute(tokens: any[], fn: Function, context?: any): any;
     get(token: any, notFoundValue?: any): any;
     /** @experimental */ initTestEnvironment(ngModule: Type<any>, platform: PlatformRef): void;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): void;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When using async/fakeAsync/inject/withModule test helpers, context (`this`) is not passed through to callback fn. This breaks the usage of Jasmine's variable sharing system.

**What is the new behavior?**
Make sure that context (`this`) that is passed to functions generated by test helpers is passed through to the callback functions. Enables usage of Jasmine's variable sharing system to prevent accidental memory leaks.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

