### PR TITLE
fix(router): process redirects first

### DIFF
--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -1239,11 +1239,22 @@ function getOutlet(outletMap: RouterOutletMap, route: ActivatedRoute): RouterOut
   return outlet;
 }
 
+const WILDCARD = '**';
+
+/**
+ * Redirects up, wildcards down.
+ */
 export function redirectsFirst(a: Route, b: Route): number {
-  if (a.path === '**' || b.path === '**') {
+  if (a.path === WILDCARD && b.path === WILDCARD) {
     return 0;
   }
-  if (a.redirectTo != null && a.redirectTo == null) {
+  if (a.path === WILDCARD) {
+    return 1;
+  }
+  if (b.path === WILDCARD) {
+    return -1;
+  }
+  if (a.redirectTo != null && b.redirectTo == null) {
     return -1;
   }
   if (b.redirectTo != null && a.redirectTo == null) {

--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -1240,6 +1240,9 @@ function getOutlet(outletMap: RouterOutletMap, route: ActivatedRoute): RouterOut
 }
 
 export function redirectsFirst(a: Route, b: Route): number {
+  if (a.path === '**' || b.path === '**') {
+    return 0;
+  }
   if (a.redirectTo != null && a.redirectTo == null) {
     return -1;
   }

--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -22,7 +22,7 @@ import {mergeMap} from 'rxjs/operator/mergeMap';
 import {reduce} from 'rxjs/operator/reduce';
 
 import {applyRedirects} from './apply_redirects';
-import {ResolveData, Routes, validateConfig} from './config';
+import {ResolveData, Route, Routes, validateConfig} from './config';
 import {createRouterState} from './create_router_state';
 import {createUrlTree} from './create_url_tree';
 import {RouterOutlet} from './directives/router_outlet';
@@ -407,7 +407,7 @@ export class Router {
    */
   resetConfig(config: Routes): void {
     validateConfig(config);
-    this.config = config;
+    this.config = config.sort(redirectsFirst);
   }
 
   /** @docsNotRequired */
@@ -1237,4 +1237,14 @@ function getOutlet(outletMap: RouterOutletMap, route: ActivatedRoute): RouterOut
     }
   }
   return outlet;
+}
+
+export function redirectsFirst(a: Route, b: Route): number {
+  if (a.redirectTo != null && a.redirectTo == null) {
+    return -1;
+  }
+  if (b.redirectTo != null && a.redirectTo == null) {
+    return 1;
+  }
+  return 0;
 }

--- a/modules/@angular/router/src/utils/collection.ts
+++ b/modules/@angular/router/src/utils/collection.ts
@@ -14,7 +14,6 @@ import {every} from 'rxjs/operator/every';
 import * as l from 'rxjs/operator/last';
 import {map} from 'rxjs/operator/map';
 import {mergeAll} from 'rxjs/operator/mergeAll';
-
 import {PRIMARY_OUTLET} from '../shared';
 
 export function shallowEqualArrays(a: any[], b: any[]): boolean {

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -1212,6 +1212,22 @@ describe('Integration', () => {
          expect(location.path()).toEqual('/team/22');
        })));
 
+    it('should work with componentless route',
+       fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+         const fixture = TestBed.createComponent(RootCmp);
+         advance(fixture);
+
+         router.resetConfig([
+           {path: '', children: [{path: 'simple', component: SimpleCmp}]},
+           {path: '', redirectTo: '/simple', pathMatch: 'full'},
+         ]);
+
+         router.initialNavigation();
+         advance(fixture);
+         expect(location.path()).toEqual('/simple');
+         expect(fixture.nativeElement).toHaveText('simple');
+       })));
+
     it('should not break the back button when trigger by location change',
        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
          const fixture = TestBed.createComponent(RootCmp);


### PR DESCRIPTION
Closes #12976

Currently router depends on specific routes order. http://plnkr.co/edit/Ttd5WIBSTbnigNceuBVf?p=preview
For example, the given config does work as expected:
```
 { path: '', redirectTo: '/child', pathMatch: 'full' },
 { path: '', children: [{path: 'child', component: ChildView}] },
```
and the following config doesn't work:
```
 { path: '', children: [{path: 'child', component: ChildView}] },
 { path: '', redirectTo: '/child', pathMatch: 'full' },
```
So we need to sort routes somehow. Maybe introduce a `priority` property.