### PR TITLE
docs(developer): add linting section and correct command to verify API changes

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -133,7 +133,8 @@ If you happen to modify the public API of Angular, API golden files must be upda
 $ gulp public-api:update
 ```
 
-Note: The command `./test.sh tools` fails when the API doesn't match the golden files.
+Note: The command `gulp public-api:enforce` fails when the API doesn't match the golden files. Make sure to rebuild
+the project before trying to verify after an API change.
 
 ## <a name="clang-format"></a> Formatting your source code
 
@@ -144,6 +145,14 @@ You can automatically format your code by running:
 
 ``` shell
 $ gulp format
+```
+
+## Linting/verifying your source code
+
+You can check that your code is properly formatted and adheres to coding style by running:
+
+``` shell
+$ gulp lint
 ```
 
 ## Publishing your own personal snapshot build


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
-> updated developer docs
```

**What is the current behavior?** (You can also link to an open issue here)
In developer docs (`DEVELOPER.md`) no information is given on how to verify code style/formatting. The description on how to verify API changes contains incorrect (outdated?) information.

**What is the new behavior?**
Added documentation for:
  - linting
  - verifying API changes

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: