### PR TITLE
fix(router): don't use factory provider for router

### DIFF
--- a/modules/@angular/router/src/index.ts
+++ b/modules/@angular/router/src/index.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-
 export {Data, LoadChildren, LoadChildrenCallback, ResolveData, Route, Routes} from './config';
 export {RouterLink, RouterLinkWithHref} from './directives/router_link';
 export {RouterLinkActive} from './directives/router_link_active';
@@ -14,9 +13,9 @@ export {RouterOutlet} from './directives/router_outlet';
 export {Event, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, RouteConfigLoadEnd, RouteConfigLoadStart, RoutesRecognized} from './events';
 export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, Resolve} from './interfaces';
 export {DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
-export {NavigationExtras, Router} from './router';
+export {ExtraOptions, NavigationExtras, ROUTER_CONFIGURATION, Router} from './router';
 export {ROUTES} from './router_config_loader';
-export {ExtraOptions, ROUTER_CONFIGURATION, ROUTER_INITIALIZER, RouterModule, provideRoutes} from './router_module';
+export {ROUTER_INITIALIZER, RouterModule, provideRoutes} from './router_module';
 export {RouterOutletMap} from './router_outlet_map';
 export {NoPreloading, PreloadAllModules, PreloadingStrategy, RouterPreloader} from './router_preloader';
 export {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot} from './router_state';
@@ -24,5 +23,4 @@ export {PRIMARY_OUTLET, Params} from './shared';
 export {UrlHandlingStrategy} from './url_handling_strategy';
 export {DefaultUrlSerializer, UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
 export {VERSION} from './version';
-
 export * from './private_export'

--- a/modules/@angular/router/testing/router_testing_module.ts
+++ b/modules/@angular/router/testing/router_testing_module.ts
@@ -8,12 +8,9 @@
 
 import {Location, LocationStrategy} from '@angular/common';
 import {MockLocationStrategy, SpyLocation} from '@angular/common/testing';
-import {Compiler, Injectable, Injector, ModuleWithProviders, NgModule, NgModuleFactory, NgModuleFactoryLoader, Optional} from '@angular/core';
+import {Compiler, Injectable, Injector, ModuleWithProviders, NgModule, NgModuleFactory, NgModuleFactoryLoader} from '@angular/core';
 import {NoPreloading, PreloadingStrategy, Route, Router, RouterModule, RouterOutletMap, Routes, UrlHandlingStrategy, UrlSerializer, provideRoutes} from '@angular/router';
-
-import {ROUTER_PROVIDERS, ROUTES, flatten} from './private_import_router';
-
-
+import {ROUTER_PROVIDERS} from './private_import_router';
 
 /**
  * @whatItDoes Allows to simulate the loading of ng modules in tests.
@@ -81,14 +78,15 @@ export class SpyNgModuleFactoryLoader implements NgModuleFactoryLoader {
 /**
  * Router setup factory function used for testing.
  *
- * @stable
+ * @deprecated use RouterTestingModule instead
  */
 export function setupTestingRouter(
     urlSerializer: UrlSerializer, outletMap: RouterOutletMap, location: Location,
     loader: NgModuleFactoryLoader, compiler: Compiler, injector: Injector, routes: Route[][],
     urlHandlingStrategy?: UrlHandlingStrategy) {
   const router = new Router(
-      null, urlSerializer, outletMap, location, injector, loader, compiler, flatten(routes));
+      urlSerializer, outletMap, location, injector, loader, compiler, routes, null,
+      urlHandlingStrategy);
   if (urlHandlingStrategy) {
     router.urlHandlingStrategy = urlHandlingStrategy;
   }
@@ -123,17 +121,13 @@ export function setupTestingRouter(
 @NgModule({
   exports: [RouterModule],
   providers: [
-    ROUTER_PROVIDERS, {provide: Location, useClass: SpyLocation},
+    Router,
+    ROUTER_PROVIDERS,
+    provideRoutes([]),
+    {provide: Location, useClass: SpyLocation},
     {provide: LocationStrategy, useClass: MockLocationStrategy},
-    {provide: NgModuleFactoryLoader, useClass: SpyNgModuleFactoryLoader}, {
-      provide: Router,
-      useFactory: setupTestingRouter,
-      deps: [
-        UrlSerializer, RouterOutletMap, Location, NgModuleFactoryLoader, Compiler, Injector, ROUTES,
-        [UrlHandlingStrategy, new Optional()]
-      ]
-    },
-    {provide: PreloadingStrategy, useExisting: NoPreloading}, provideRoutes([])
+    {provide: NgModuleFactoryLoader, useClass: SpyNgModuleFactoryLoader},
+    {provide: PreloadingStrategy, useExisting: NoPreloading},
   ]
 })
 export class RouterTestingModule {

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -223,7 +223,7 @@ export declare class Router {
     readonly routerState: RouterState;
     readonly url: string;
     urlHandlingStrategy: UrlHandlingStrategy;
-    constructor(rootComponentType: Type<any>, urlSerializer: UrlSerializer, outletMap: RouterOutletMap, location: Location, injector: Injector, loader: NgModuleFactoryLoader, compiler: Compiler, config: Routes);
+    constructor(urlSerializer: UrlSerializer, outletMap: RouterOutletMap, location: Location, injector: Injector, loader: NgModuleFactoryLoader, compiler: Compiler, routes: Routes[], opts: any, urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy);
     createUrlTree(commands: any[], {relativeTo, queryParams, fragment, preserveQueryParams, queryParamsHandling, preserveFragment}?: NavigationExtras): UrlTree;
     dispose(): void;
     initialNavigation(): void;


### PR DESCRIPTION
Closes #12014

Reason:
Angular doesn't call lifecycle hooks on providers created using 'useFactory'.