### PR TITLE
fix(Common): allow null/undefined values for `NgForTrackBy`

### DIFF
--- a/modules/@angular/common/src/directives/ng_for.ts
+++ b/modules/@angular/common/src/directives/ng_for.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef, CollectionChangeRecord, DefaultIterableDiffer, Directive, DoCheck, EmbeddedViewRef, Input, IterableDiffer, IterableDiffers, OnChanges, SimpleChanges, TemplateRef, TrackByFn, ViewContainerRef} from '@angular/core';
+import {ChangeDetectorRef, CollectionChangeRecord, DefaultIterableDiffer, Directive, DoCheck, EmbeddedViewRef, Input, IterableDiffer, IterableDiffers, OnChanges, SimpleChanges, TemplateRef, TrackByFn, ViewContainerRef, isDevMode} from '@angular/core';
 
 import {getTypeNameForDebugging} from '../facade/lang';
 
@@ -91,9 +91,13 @@ export class NgFor implements DoCheck, OnChanges {
   @Input() ngForOf: any;
   @Input()
   set ngForTrackBy(fn: TrackByFn) {
-    if (typeof fn !== 'function') {
-      throw new Error(`trackBy must be a function, but received ${JSON.stringify(fn)}.
-      See https://angular.io/docs/ts/latest/api/common/index/NgFor-directive.html#!#change-propagation for more information.`);
+    if (isDevMode() && fn != null && typeof fn !== 'function') {
+      // TODO(vicb): use a log service once there is a public one available
+      if (<any>console && <any>console.warn) {
+        console.warn(
+            `trackBy must be a function, but received ${JSON.stringify(fn)}. ` +
+            `See https://angular.io/docs/ts/latest/api/common/index/NgFor-directive.html#!#change-propagation for more information.`);
+      }
     }
     this._trackByFn = fn;
   }

--- a/modules/@angular/common/test/directives/ng_for_spec.ts
+++ b/modules/@angular/common/test/directives/ng_for_spec.ts
@@ -294,14 +294,25 @@ export function main() {
        }));
 
     describe('track by', () => {
-      it('should throw if trackBy is not a function', async(() => {
+      it('should console.warn if trackBy is not a function', async(() => {
+           // TODO(vicb): expect a warning message when we have a proper log service
            const template =
-               `<template ngFor let-item [ngForOf]="items" [ngForTrackBy]="item?.id"></template>`;
+               `<template ngFor let-item [ngForOf]="items" [ngForTrackBy]="value"></template>`;
            fixture = createTestComponent(template);
+           fixture.componentInstance.value = 0;
+           fixture.detectChanges();
+         }));
 
-           getComponent().items = [{id: 1}, {id: 2}];
-           expect(() => fixture.detectChanges())
-               .toThrowError(/trackBy must be a function, but received null/);
+      it('should track by identity when trackBy is to `null` or `undefined`', async(() => {
+           // TODO(vicb): expect no warning message when we have a proper log service
+           const template =
+               `<template ngFor let-item [ngForOf]="items" [ngForTrackBy]="value">{{ item }}</template>`;
+           fixture = createTestComponent(template);
+           fixture.componentInstance.items = ['a', 'b', 'c'];
+           fixture.componentInstance.value = null;
+           detectChangesAndExpectText('abc');
+           fixture.componentInstance.value = undefined;
+           detectChangesAndExpectText('abc');
          }));
 
       it('should set the context to the component instance', async(() => {
@@ -343,6 +354,7 @@ export function main() {
            getComponent().items = [{'id': 'a', 'color': 'red'}];
            detectChangesAndExpectText('red');
          }));
+
       it('should move items around and keep them updated ', async(() => {
            const template =
                `<div><template ngFor let-item [ngForOf]="items" [ngForTrackBy]="trackById">{{item['color']}}</template></div>`;
@@ -378,6 +390,7 @@ class Foo {
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {
   @ContentChild(TemplateRef) contentTpl: TemplateRef<Object>;
+  value: any;
   items: any[] = [1, 2];
   trackById(index: number, item: any): string { return item['id']; }
   trackByIndex(index: number, item: any): number { return index; }

--- a/modules/@angular/compiler-cli/src/codegen.ts
+++ b/modules/@angular/compiler-cli/src/codegen.ts
@@ -11,7 +11,6 @@
  * Intended to be used in a build step.
  */
 import * as compiler from '@angular/compiler';
-import {ViewEncapsulation} from '@angular/core';
 import {AngularCompilerOptions, NgcCliOptions} from '@angular/tsc-wrapped';
 import {readFileSync} from 'fs';
 import * as path from 'path';
@@ -19,7 +18,6 @@ import * as ts from 'typescript';
 
 import {CompilerHost, CompilerHostContext, ModuleResolutionHostAdapter} from './compiler_host';
 import {PathMappedCompilerHost} from './path_mapped_compiler_host';
-import {Console} from './private_import_core';
 
 const GENERATED_META_FILES = /\.json$/;
 

--- a/modules/@angular/compiler/src/directive_wrapper_compiler.ts
+++ b/modules/@angular/compiler/src/directive_wrapper_compiler.ts
@@ -18,7 +18,7 @@ import {DEFAULT_INTERPOLATION_CONFIG} from './ml_parser/interpolation_config';
 import {ClassBuilder, createClassStmt} from './output/class_builder';
 import * as o from './output/output_ast';
 import {ParseError, ParseErrorLevel, ParseLocation, ParseSourceFile, ParseSourceSpan} from './parse_util';
-import {Console, LifecycleHooks, isDefaultChangeDetectionStrategy} from './private_import_core';
+import {Console, LifecycleHooks} from './private_import_core';
 import {ElementSchemaRegistry} from './schema/element_schema_registry';
 import {BindingParser} from './template_parser/binding_parser';
 import {BoundElementPropertyAst, BoundEventAst} from './template_parser/template_ast';

--- a/modules/@angular/compiler/test/selector_spec.ts
+++ b/modules/@angular/compiler/test/selector_spec.ts
@@ -7,7 +7,6 @@
  */
 
 import {CssSelector, SelectorMatcher} from '@angular/compiler/src/selector';
-import {createElementCssSelector} from '@angular/compiler/src/template_parser/template_parser';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {el} from '@angular/platform-browser/testing/browser_util';
 

--- a/modules/@angular/language-service/test/completions_spec.ts
+++ b/modules/@angular/language-service/test/completions_spec.ts
@@ -10,17 +10,16 @@ import 'reflect-metadata';
 import * as ts from 'typescript';
 
 import {createLanguageService} from '../src/language_service';
-import {Completions, Diagnostic, Diagnostics} from '../src/types';
+import {Completions} from '../src/types';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {toh} from './test_data';
-import {MockTypescriptHost, includeDiagnostic, noDiagnostics} from './test_utils';
+import {MockTypescriptHost} from './test_utils';
 
 describe('completions', () => {
   let documentRegistry = ts.createDocumentRegistry();
   let mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh);
   let service = ts.createLanguageService(mockHost, documentRegistry);
-  let program = service.getProgram();
   let ngHost = new TypeScriptServiceHost(mockHost, service);
   let ngService = createLanguageService(ngHost);
   ngHost.setSite(ngService);

--- a/modules/@angular/language-service/test/definitions_spec.ts
+++ b/modules/@angular/language-service/test/definitions_spec.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 
 import {createLanguageService} from '../src/language_service';
-import {Completions, Diagnostic, Diagnostics, Span} from '../src/types';
+import {Span} from '../src/types';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {toh} from './test_data';
@@ -20,7 +20,6 @@ describe('definitions', () => {
   let documentRegistry = ts.createDocumentRegistry();
   let mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh);
   let service = ts.createLanguageService(mockHost, documentRegistry);
-  let program = service.getProgram();
   let ngHost = new TypeScriptServiceHost(mockHost, service);
   let ngService = createLanguageService(ngHost);
   ngHost.setSite(ngService);

--- a/modules/@angular/language-service/test/diagnostics_spec.ts
+++ b/modules/@angular/language-service/test/diagnostics_spec.ts
@@ -9,7 +9,7 @@
 import * as ts from 'typescript';
 
 import {createLanguageService} from '../src/language_service';
-import {Completions, Diagnostic, Diagnostics} from '../src/types';
+import {Diagnostics} from '../src/types';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {toh} from './test_data';
@@ -19,7 +19,6 @@ describe('diagnostics', () => {
   let documentRegistry = ts.createDocumentRegistry();
   let mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh);
   let service = ts.createLanguageService(mockHost, documentRegistry);
-  let program = service.getProgram();
   let ngHost = new TypeScriptServiceHost(mockHost, service);
   let ngService = createLanguageService(ngHost);
   ngHost.setSite(ngService);

--- a/modules/@angular/language-service/test/hover_spec.ts
+++ b/modules/@angular/language-service/test/hover_spec.ts
@@ -11,17 +11,16 @@ import 'reflect-metadata';
 import * as ts from 'typescript';
 
 import {createLanguageService} from '../src/language_service';
-import {Hover, HoverTextSection} from '../src/types';
+import {Hover} from '../src/types';
 import {TypeScriptServiceHost} from '../src/typescript_host';
 
 import {toh} from './test_data';
-import {MockTypescriptHost, includeDiagnostic, noDiagnostics} from './test_utils';
+import {MockTypescriptHost} from './test_utils';
 
 describe('hover', () => {
   let documentRegistry = ts.createDocumentRegistry();
   let mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh);
   let service = ts.createLanguageService(mockHost, documentRegistry);
-  let program = service.getProgram();
   let ngHost = new TypeScriptServiceHost(mockHost, service);
   let ngService = createLanguageService(ngHost);
   ngHost.setSite(ngService);


### PR DESCRIPTION
Reverts a breaking change introduced in 2.4.1 by #13420
fixes #13641
