### PR TITLE
docs(developer): add description of `npm-run` to run locally installed `npm` scripts

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -71,7 +71,13 @@ particular `gulp` and `protractor` commands. If you prefer, you can drop this pa
 Since global installs can become stale, and required versions can vary by project, we avoid their
 use in these instructions.
 
-*Option 2*: defining a bash alias like `alias nbin='PATH=$(npm bin):$PATH'` as detailed in this
+*Option 2*: globally installing the package `npm-run` by running `npm install -g npm-run`
+(you might need to prefix this command with `sudo`). You will then be able to run locally installed
+package scripts by invoking: e.g., `npm-run gulp build`
+(see [npm-run project page](https://github.com/timoxley/npm-run) for more details).
+
+
+*Option 3*: defining a bash alias like `alias nbin='PATH=$(npm bin):$PATH'` as detailed in this
 [Stackoverflow answer](http://stackoverflow.com/questions/9679932/how-to-use-package-installed-locally-in-node-modules/15157360#15157360) and used like this: e.g., `nbin gulp build`.
 
 ## Installing Bower Modules


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: improve docs
```

**What is the current behavior?** (You can also link to an open issue here)
A description for a convenient common option to run locally installed `npm` scripts via `npm-run` is missing. Instead, a manual workaround which involves more complicated setup steps is described.


**What is the new behavior?**
Adds a description on how to run locally installed `npm` scripts via `npm-run`. 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: