### PR TITLE
[4.x only] feat(compiler): allow shorthand property names in bindings

### DIFF
--- a/modules/@angular/compiler/src/expression_parser/parser.ts
+++ b/modules/@angular/compiler/src/expression_parser/parser.ts
@@ -609,8 +609,12 @@ export class _ParseAST {
       do {
         const key = this.expectIdentifierOrKeywordOrString();
         keys.push(key);
-        this.expectCharacter(chars.$COLON);
-        values.push(this.parsePipe());
+        if (this.optionalCharacter(chars.$COLON)) {
+          values.push(this.parsePipe());
+        } else {
+          const span = this.span(start);
+          values.push(new PropertyRead(span, new ImplicitReceiver(span), key));
+        }
       } while (this.optionalCharacter(chars.$COMMA));
       this.rbracesExpected--;
       this.expectCharacter(chars.$RBRACE);

--- a/modules/@angular/compiler/test/expression_parser/parser_spec.ts
+++ b/modules/@angular/compiler/test/expression_parser/parser_spec.ts
@@ -285,6 +285,13 @@ export function main() {
         });
       });
 
+      describe('object literals', () => {
+        it('should parse shorthand property name', () => checkBinding('{a}', '{a: a}'));
+
+        it('should parse multiple shorthand property names',
+           () => checkBinding('{a, b, c: d}', '{a: a, b: b, c: d}'));
+      });
+
       it('should store the source in the result',
          () => { expect(parseBinding('someExpr').source).toBe('someExpr'); });
 
@@ -437,7 +444,7 @@ export function main() {
       });
 
       describe('spans', () => {
-        it('should should support let', () => {
+        it('should support let', () => {
           const source = 'let i';
           expect(keySpans(source, parseTemplateBindings(source))).toEqual(['let i']);
         });
@@ -457,6 +464,13 @@ export function main() {
             'ngFor', 'let person=$implicit', 'ngForOf=people in null'
           ]);
           expect(keySpans(source, bindings)).toEqual(['', 'let person ', 'of people']);
+        });
+
+        it('should support shorthand prop names', () => {
+          const source = 'a: a, b, c, d: d';
+          expect(keySpans(source, parseTemplateBindings(source))).toEqual([
+            'a: a', 'b', 'c', 'd: d'
+          ]);
         });
       });
     });

--- a/modules/@angular/compiler/test/integration_spec.ts
+++ b/modules/@angular/compiler/test/integration_spec.ts
@@ -38,11 +38,37 @@ export function main() {
          }));
     });
 
+    it('should support shorthand property names in literal bindings', async(() => {
+         @Component({
+           selector: 'cmp',
+           template: '<div>{{value.prop1}}-{{value.prop2}}-{{value.prop3}}-{{value.prop4}}</div>'
+         })
+         class SomeComponent {
+           @Input() value: any;
+         }
+
+         TestBed.configureTestingModule({
+           declarations: [
+             SomeComponent,
+             TestComponent,
+           ],
+         });
+
+         const template = `<cmp [value]="{prop1: 'value1', prop2, prop3, prop4: prop4}"></cmp>`;
+         fixture = createTestComponent(template);
+         fixture.detectChanges();
+         const div = fixture.debugElement.query(By.css('div')).nativeElement;
+         expect(div).toHaveText('value1-value2-value3-value4');
+       }));
+
   });
 }
 
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {
+  prop2 = 'value2';
+  prop3 = 'value3';
+  prop4 = 'value4';
 }
 
 function createTestComponent(template: string): ComponentFixture<TestComponent> {


### PR DESCRIPTION
Closes #10277