### PR TITLE
fix(compiler): avoid evaluating arguments to unknown decorators

### DIFF
--- a/modules/@angular/compiler/src/aot/static_reflector.ts
+++ b/modules/@angular/compiler/src/aot/static_reflector.ts
@@ -322,6 +322,7 @@ export class StaticReflector implements ReflectorReader {
             if (value && (depth != 0 || value.__symbolic != 'error')) {
               const parameters: string[] = targetFunction['parameters'];
               const defaults: any[] = targetFunction.defaults;
+              args = args.map(arg => simplifyInContext(context, arg, depth + 1));
               if (defaults && defaults.length > args.length) {
                 args.push(...defaults.slice(args.length).map((value: any) => simplify(value)));
               }
@@ -511,15 +512,15 @@ export class StaticReflector implements ReflectorReader {
                     return context;
                   }
                   const argExpressions: any[] = expression['arguments'] || [];
-                  const args =
-                      argExpressions.map(arg => simplifyInContext(context, arg, depth + 1));
                   let converter = self.conversionMap.get(staticSymbol);
                   if (converter) {
+                    const args =
+                        argExpressions.map(arg => simplifyInContext(context, arg, depth + 1));
                     return converter(context, args);
                   } else {
                     // Determine if the function is one we can simplify.
                     const targetFunction = resolveReferenceValue(staticSymbol);
-                    return simplifyCall(staticSymbol, targetFunction, args);
+                    return simplifyCall(staticSymbol, targetFunction, argExpressions);
                   }
                 }
                 break;

--- a/modules/@angular/compiler/test/aot/static_reflector_spec.ts
+++ b/modules/@angular/compiler/test/aot/static_reflector_spec.ts
@@ -449,6 +449,40 @@ describe('StaticReflector', () => {
     expect(annotations[0].providers[0].useValue.members[0]).toEqual('staticMethod');
   });
 
+  // #13605
+  it('should not throw on unknown decorators', () => {
+    const data = Object.create(DEFAULT_TEST_DATA);
+    const file = '/tmp/src/app.component.ts';
+    data[file] = `
+      import { Component } from '@angular/core';
+
+      export const enum TypeEnum {
+        type
+      }
+
+      export function MyValidationDecorator(p1: any, p2: any): any {
+        return null;
+      }
+
+      export function ValidationFunction(a1: any): any {
+        return null;
+      }
+
+      @Component({
+        selector: 'my-app',
+        template: "<h1>Hello {{name}}</h1>",
+      })
+      export class AppComponent  {
+        name = 'Angular';
+
+        @MyValidationDecorator( TypeEnum.type, ValidationFunction({option: 'value'}))
+        myClassProp: number;
+    }`;
+    init(data);
+    const appComponent = reflector.getStaticSymbol(file, 'AppComponent');
+    expect(() => reflector.propMetadata(appComponent)).not.toThrow();
+  });
+
   describe('inheritance', () => {
     class ClassDecorator {
       constructor(public value: any) {}


### PR DESCRIPTION
Fixes #13605

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

The `ngc` compiler will emit an error if any decorator in a component does not conform to the AOT rules.

**What is the new behavior?**

The `ngc` compiler will only emit an error if a known Angular decorator does not conform to the AOT rules.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
