### PR TITLE
fix(upgrade): detect async downgrade component changes

### DIFF
--- a/modules/@angular/upgrade/test/upgrade_spec.ts
+++ b/modules/@angular/upgrade/test/upgrade_spec.ts
@@ -18,7 +18,89 @@ export function main() {
     beforeEach(() => destroyPlatform());
     afterEach(() => destroyPlatform());
 
-    it('should have angular 1 loaded', () => expect(angular.version.major).toBe(1));
+    describe('(basic use)', () => {
+      it('should have angular 1 loaded', () => expect(angular.version.major).toBe(1));
+
+      it('should instantiate ng2 in ng1 template and project content', async(() => {
+           const ng1Module = angular.module('ng1', []);
+
+           const Ng2 = Component({
+                         selector: 'ng2',
+                         template: `{{ 'NG2' }}(<ng-content></ng-content>)`,
+                       }).Class({constructor: function() {}});
+
+           const Ng2Module = NgModule({declarations: [Ng2], imports: [BrowserModule]}).Class({
+             constructor: function() {}
+           });
+
+           const element =
+               html('<div>{{ \'ng1[\' }}<ng2>~{{ \'ng-content\' }}~</ng2>{{ \']\' }}</div>');
+
+           const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2Module);
+           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+           adapter.bootstrap(element, ['ng1']).ready((ref) => {
+             expect(document.body.textContent).toEqual('ng1[NG2(~ng-content~)]');
+             ref.dispose();
+           });
+         }));
+
+      it('should instantiate ng1 in ng2 template and project content', async(() => {
+           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
+           const ng1Module = angular.module('ng1', []);
+
+           const Ng2 = Component({
+                         selector: 'ng2',
+                         template: `{{ 'ng2(' }}<ng1>{{'transclude'}}</ng1>{{ ')' }}`,
+                       }).Class({constructor: function Ng2() {}});
+
+           const Ng2Module = NgModule({
+                               declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
+                               imports: [BrowserModule],
+                             }).Class({constructor: function Ng2Module() {}});
+
+           ng1Module.directive('ng1', () => {
+             return {transclude: true, template: '{{ "ng1" }}(<ng-transclude></ng-transclude>)'};
+           });
+           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+
+           const element = html('<div>{{\'ng1(\'}}<ng2></ng2>{{\')\'}}</div>');
+
+           adapter.bootstrap(element, ['ng1']).ready((ref) => {
+             expect(document.body.textContent).toEqual('ng1(ng2(ng1(transclude)))');
+             ref.dispose();
+           });
+         }));
+
+      it('supports the compilerOptions argument', async(() => {
+           const platformRef = platformBrowserDynamic();
+           spyOn(platformRef, '_bootstrapModuleWithZone').and.callThrough();
+
+           const ng1Module = angular.module('ng1', []);
+           const Ng2 = Component({
+                         selector: 'ng2',
+                         template: `{{ 'NG2' }}(<ng-content></ng-content>)`
+                       }).Class({constructor: function() {}});
+
+           const element =
+               html('<div>{{ \'ng1[\' }}<ng2>~{{ \'ng-content\' }}~</ng2>{{ \']\' }}</div>');
+
+           const Ng2AppModule =
+               NgModule({
+                 declarations: [Ng2],
+                 imports: [BrowserModule],
+               }).Class({constructor: function Ng2AppModule() {}, ngDoBootstrap: function() {}});
+
+           const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2AppModule, {providers: []});
+           ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
+           adapter.bootstrap(element, ['ng1']).ready((ref) => {
+             expect((platformRef as any)._bootstrapModuleWithZone)
+                 .toHaveBeenCalledWith(
+                     jasmine.any(Function), {providers: []}, jasmine.any(Object),
+                     jasmine.any(Function));
+             ref.dispose();
+           });
+         }));
+    });
 
     describe('bootstrap errors', () => {
       let adapter: UpgradeAdapter;
@@ -51,97 +133,17 @@ export function main() {
          }));
 
       it('should output an error message to the console and re-throw', fakeAsync(() => {
-           let consoleErrorSpy: jasmine.Spy = spyOn(console, 'error');
+           const consoleErrorSpy: jasmine.Spy = spyOn(console, 'error');
            expect(() => {
              adapter.bootstrap(html('<ng2></ng2>'), ['ng1']);
              flushMicrotasks();
            }).toThrowError();
-           let args: any[] = consoleErrorSpy.calls.mostRecent().args;
+           const args: any[] = consoleErrorSpy.calls.mostRecent().args;
            expect(consoleErrorSpy).toHaveBeenCalled();
            expect(args.length).toBeGreaterThan(0);
            expect(args[0]).toEqual(jasmine.any(Error));
          }));
     });
-
-    it('should instantiate ng2 in ng1 template and project content', async(() => {
-         const ng1Module = angular.module('ng1', []);
-
-         const Ng2 = Component({
-                       selector: 'ng2',
-                       template: `{{ 'NG2' }}(<ng-content></ng-content>)`,
-                     }).Class({constructor: function() {}});
-
-         const Ng2Module = NgModule({declarations: [Ng2], imports: [BrowserModule]}).Class({
-           constructor: function() {}
-         });
-
-         const element =
-             html('<div>{{ \'ng1[\' }}<ng2>~{{ \'ng-content\' }}~</ng2>{{ \']\' }}</div>');
-
-         const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2Module);
-         ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-         adapter.bootstrap(element, ['ng1']).ready((ref) => {
-           expect(document.body.textContent).toEqual('ng1[NG2(~ng-content~)]');
-           ref.dispose();
-         });
-       }));
-
-    it('should instantiate ng1 in ng2 template and project content', async(() => {
-         const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-         const ng1Module = angular.module('ng1', []);
-
-         const Ng2 = Component({
-                       selector: 'ng2',
-                       template: `{{ 'ng2(' }}<ng1>{{'transclude'}}</ng1>{{ ')' }}`,
-                     }).Class({constructor: function Ng2() {}});
-
-         const Ng2Module = NgModule({
-                             declarations: [adapter.upgradeNg1Component('ng1'), Ng2],
-                             imports: [BrowserModule],
-                           }).Class({constructor: function Ng2Module() {}});
-
-         ng1Module.directive('ng1', () => {
-           return {transclude: true, template: '{{ "ng1" }}(<ng-transclude></ng-transclude>)'};
-         });
-         ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-
-         const element = html('<div>{{\'ng1(\'}}<ng2></ng2>{{\')\'}}</div>');
-
-         adapter.bootstrap(element, ['ng1']).ready((ref) => {
-           expect(document.body.textContent).toEqual('ng1(ng2(ng1(transclude)))');
-           ref.dispose();
-         });
-       }));
-
-    it('supports the compilerOptions argument', async(() => {
-         const platformRef = platformBrowserDynamic();
-         spyOn(platformRef, '_bootstrapModuleWithZone').and.callThrough();
-
-         const ng1Module = angular.module('ng1', []);
-         const Ng2 = Component({
-                       selector: 'ng2',
-                       template: `{{ 'NG2' }}(<ng-content></ng-content>)`
-                     }).Class({constructor: function() {}});
-
-         const element =
-             html('<div>{{ \'ng1[\' }}<ng2>~{{ \'ng-content\' }}~</ng2>{{ \']\' }}</div>');
-
-         const Ng2AppModule =
-             NgModule({
-               declarations: [Ng2],
-               imports: [BrowserModule],
-             }).Class({constructor: function Ng2AppModule() {}, ngDoBootstrap: function() {}});
-
-         const adapter: UpgradeAdapter = new UpgradeAdapter(Ng2AppModule, {providers: []});
-         ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
-         adapter.bootstrap(element, ['ng1']).ready((ref) => {
-           expect((platformRef as any)._bootstrapModuleWithZone)
-               .toHaveBeenCalledWith(
-                   jasmine.any(Function), {providers: []}, jasmine.any(Object),
-                   jasmine.any(Function));
-           ref.dispose();
-         });
-       }));
 
     describe('scope/component change-detection', () => {
       it('should interleave scope and component expressions', async(() => {
@@ -385,6 +387,31 @@ export function main() {
            ng1Module.directive('ng2', adapter.downgradeNg2Component(Ng2));
            adapter.bootstrap(element, ['ng1']).ready((ref) => {
              expect(document.body.textContent).toEqual('2a(1a)2b(1b)');
+             ref.dispose();
+           });
+         }));
+
+      it('should allow attribute selectors for components in ng2', async(() => {
+           const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => MyNg2Module));
+           const ng1Module = angular.module('myExample', []);
+
+           @Component({selector: '[works]', template: 'works!'})
+           class WorksComponent {
+           }
+
+           @Component({selector: 'root-component', template: 'It <div works></div>'})
+           class RootComponent {
+           }
+
+           @NgModule({imports: [BrowserModule], declarations: [RootComponent, WorksComponent]})
+           class MyNg2Module {
+           }
+
+           ng1Module.directive('rootComponent', adapter.downgradeNg2Component(RootComponent));
+
+           document.body.innerHTML = '<root-component></root-component>';
+           adapter.bootstrap(document.body.firstElementChild, ['myExample']).ready((ref) => {
+             expect(multiTrim(document.body.textContent)).toEqual('It works!');
              ref.dispose();
            });
          }));
@@ -1626,31 +1653,6 @@ export function main() {
            });
          }));
     });
-
-    it('should allow attribute selectors for components in ng2', async(() => {
-         const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => MyNg2Module));
-         const ng1Module = angular.module('myExample', []);
-
-         @Component({selector: '[works]', template: 'works!'})
-         class WorksComponent {
-         }
-
-         @Component({selector: 'root-component', template: 'It <div works></div>'})
-         class RootComponent {
-         }
-
-         @NgModule({imports: [BrowserModule], declarations: [RootComponent, WorksComponent]})
-         class MyNg2Module {
-         }
-
-         ng1Module.directive('rootComponent', adapter.downgradeNg2Component(RootComponent));
-
-         document.body.innerHTML = '<root-component></root-component>';
-         adapter.bootstrap(document.body.firstElementChild, ['myExample']).ready((ref) => {
-           expect(multiTrim(document.body.textContent)).toEqual('It works!');
-           ref.dispose();
-         });
-       }));
 
     describe('examples', () => {
       it('should verify UpgradeAdapter example', async(() => {


### PR DESCRIPTION
This commit effectively reverts 7e0f02f96e59863dff563cb7036c21aa58220a67
as it was an invalid fix for #6385, that created a more significant
bug, which was that changes were not always being detected.

Angular 1 digests should be run inside the ngZone to ensure
that async changes are detected.

We don't know how to fix #6385 without breaking change detection
at this stage. That issue is triggered by async operations, such as
`setTimeout`, being triggered inside scope watcher functions.

One could argue that watcher functions should be pure and not do
work such as triggering async operations. It is possible that the
original use case could be supported by moving the debounce
logic into the watch listener function, which is only called if the
watched value actually changes.

Closes #10660, #12318, #12034

It is possible that this revert could be considered a breaking change since
the previous bug is now apparent again.

The same fix will need to be done on `upgrade/static` as well, once this is approved.