### PR TITLE
feat(forms): update validity on touched

### DIFF
--- a/modules/@angular/forms/src/directives/shared.ts
+++ b/modules/@angular/forms/src/directives/shared.ts
@@ -47,7 +47,10 @@ export function setUpControl(control: FormControl, dir: NgControl): void {
   });
 
   // touched
-  dir.valueAccessor.registerOnTouched(() => control.markAsTouched());
+  dir.valueAccessor.registerOnTouched(() => {
+    control.updateValueAndValidity();
+    control.markAsTouched();
+  });
 
   control.registerOnChange((newValue: any, emitModelEvent: boolean) => {
     // control -> view


### PR DESCRIPTION
closes #7113

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

I'm not sure if adding tests or changing the docs is necessary for this change, let me know.


**What kind of change does this PR introduce?**
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**
https://github.com/angular/angular/issues/7113
The current behavior is that validators are only called when form values change.



**What is the new behavior?**
Validators are called onTouched (onBlur).



**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No


**Other information**:
Running validators onTouched (onBlur), allows a validators that only run once the user has moved on to the next input.

For example:
```typescript
export function trim(control: AbstractControl): {[key: string]: any} {
	if (control.touched && String(control.value).match(/^\s+|\s+$/)) {
		control.setValue(String(control.value).replace(/^\s+|\s+$/, ''));
		control.markAsUntouched();
	}
	return null;
}
```