### PR TITLE
fix(router): RouterLink mirrors input `target` as attribute

### DIFF
--- a/modules/@angular/router/src/directives/router_link.ts
+++ b/modules/@angular/router/src/directives/router_link.ts
@@ -139,7 +139,7 @@ export class RouterLink {
  */
 @Directive({selector: 'a[routerLink]'})
 export class RouterLinkWithHref implements OnChanges, OnDestroy {
-  @Input() target: string;
+  @HostBinding('attr.target') @Input() target: string;
   @Input() queryParams: {[k: string]: any};
   @Input() fragment: string;
   @Input() preserveQueryParams: boolean;

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -998,6 +998,7 @@ describe('Integration', () => {
 
          const native = fixture.nativeElement.querySelector('a');
          expect(native.getAttribute('href')).toEqual('/team/33/simple');
+         expect(native.getAttribute('target')).toEqual('_self');
          native.click();
          advance(fixture);
 
@@ -2710,7 +2711,8 @@ function expectEvents(events: Event[], pairs: any[]) {
   }
 }
 
-@Component({selector: 'link-cmp', template: `<a routerLink="/team/33/simple">link</a>`})
+@Component(
+    {selector: 'link-cmp', template: `<a routerLink="/team/33/simple" [target]="'_self'">link</a>`})
 class StringLinkCmp {
 }
 


### PR DESCRIPTION
Closes #13837

Description:
When we use input binding 
```
<a [routerLink]="['/child']" [target]="'_blank'">Failing 1</a>
``` 
the actual dom element doesn't have `target` attribute this is why the link doesn't open in a new tab.