### PR TITLE
feat(i18n): Added MissingTranslationStrategy

### DIFF
--- a/modules/@angular/compiler/src/i18n/i18n_html_parser.ts
+++ b/modules/@angular/compiler/src/i18n/i18n_html_parser.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {MissingTranslationStrategy} from '@angular/core';
+
 import {HtmlParser} from '../ml_parser/html_parser';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../ml_parser/interpolation_config';
 import {ParseTreeResult} from '../ml_parser/parser';
@@ -26,7 +28,9 @@ export class I18NHtmlParser implements HtmlParser {
   // TODO(vicb): remove the interpolationConfig from the Xtb serializer
   constructor(
       private _htmlParser: HtmlParser, private _translations?: string,
-      private _translationsFormat?: string) {}
+      private _translationsFormat?: string,
+      private _missingTranslationStrategy:
+          MissingTranslationStrategy = MissingTranslationStrategy.Error) {}
 
   parse(
       source: string, url: string, parseExpansionForms: boolean = false,
@@ -46,7 +50,8 @@ export class I18NHtmlParser implements HtmlParser {
     }
 
     const serializer = this._createSerializer();
-    const translationBundle = TranslationBundle.load(this._translations, url, serializer);
+    const translationBundle = TranslationBundle.load(
+        this._translations, url, serializer, this._missingTranslationStrategy);
 
     return mergeTranslations(parseResult.rootNodes, translationBundle, interpolationConfig, [], {});
   }

--- a/modules/@angular/compiler/src/i18n/parse_util.ts
+++ b/modules/@angular/compiler/src/i18n/parse_util.ts
@@ -6,11 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ParseError, ParseSourceSpan} from '../parse_util';
+import {ParseError, ParseErrorLevel, ParseSourceSpan} from '../parse_util';
 
 /**
  * An i18n error.
  */
 export class I18nError extends ParseError {
   constructor(span: ParseSourceSpan, msg: string) { super(span, msg); }
+}
+
+export class I18nWarning extends ParseError {
+  constructor(span: ParseSourceSpan, msg: string) { super(span, msg, ParseErrorLevel.WARNING); }
 }

--- a/modules/@angular/compiler/src/jit/compiler_factory.ts
+++ b/modules/@angular/compiler/src/jit/compiler_factory.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {COMPILER_OPTIONS, Compiler, CompilerFactory, CompilerOptions, Inject, OpaqueToken, Optional, PLATFORM_INITIALIZER, PlatformRef, Provider, ReflectiveInjector, TRANSLATIONS, TRANSLATIONS_FORMAT, Type, ViewEncapsulation, createPlatformFactory, isDevMode, platformCore} from '@angular/core';
+import {COMPILER_OPTIONS, Compiler, CompilerFactory, CompilerOptions, Inject, MISSING_TRANSLATION_STRATEGY, MissingTranslationStrategy, OpaqueToken, Optional, PLATFORM_INITIALIZER, PlatformRef, Provider, ReflectiveInjector, TRANSLATIONS, TRANSLATIONS_FORMAT, Type, ViewEncapsulation, createPlatformFactory, isDevMode, platformCore} from '@angular/core';
 
 import {AnimationParser} from '../animation/animation_parser';
 import {CompilerConfig} from '../config';
@@ -60,12 +60,15 @@ export const COMPILER_PROVIDERS: Array<any|Type<any>|{[k: string]: any}|any[]> =
   },
   {
     provide: i18n.I18NHtmlParser,
-    useFactory: (parser: HtmlParser, translations: string, format: string) =>
-                    new i18n.I18NHtmlParser(parser, translations, format),
+    useFactory:
+        (parser: HtmlParser, translations: string, format: string,
+         missingTranslationStrategy: MissingTranslationStrategy) =>
+            new i18n.I18NHtmlParser(parser, translations, format, missingTranslationStrategy),
     deps: [
       baseHtmlParser,
       [new Optional(), new Inject(TRANSLATIONS)],
       [new Optional(), new Inject(TRANSLATIONS_FORMAT)],
+      [new Optional(), new Inject(MISSING_TRANSLATION_STRATEGY)],
     ]
   },
   {

--- a/modules/@angular/compiler/test/i18n/extractor_merger_spec.ts
+++ b/modules/@angular/compiler/test/i18n/extractor_merger_spec.ts
@@ -451,7 +451,7 @@ function fakeTranslate(
     i18nMsgMap[id] = [new i18n.Text(`**${text}**`, null)];
   });
 
-  const translations = new TranslationBundle(i18nMsgMap, digest);
+  const translations = new TranslationBundle(i18nMsgMap, digest, null);
 
   const translatedNodes =
       mergeTranslations(

--- a/modules/@angular/compiler/test/i18n/translation_bundle_spec.ts
+++ b/modules/@angular/compiler/test/i18n/translation_bundle_spec.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {MissingTranslationStrategy} from '@angular/core';
+
 import * as i18n from '../../src/i18n/i18n_ast';
 import {TranslationBundle} from '../../src/i18n/translation_bundle';
 import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_util';
@@ -20,7 +22,7 @@ export function main(): void {
 
     it('should translate a plain message', () => {
       const msgMap = {foo: [new i18n.Text('bar', null)]};
-      const tb = new TranslationBundle(msgMap, (_) => 'foo');
+      const tb = new TranslationBundle(msgMap, (_) => 'foo', null);
       const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
       expect(serializeNodes(tb.get(msg))).toEqual(['bar']);
     });
@@ -35,7 +37,7 @@ export function main(): void {
       const phMap = {
         ph1: '*phContent*',
       };
-      const tb = new TranslationBundle(msgMap, (_) => 'foo');
+      const tb = new TranslationBundle(msgMap, (_) => 'foo', null);
       const msg = new i18n.Message([srcNode], phMap, {}, 'm', 'd', 'i');
       expect(serializeNodes(tb.get(msg))).toEqual(['bar*phContent*']);
     });
@@ -55,7 +57,7 @@ export function main(): void {
       const msg = new i18n.Message([srcNode], {}, {ph1: refMsg}, 'm', 'd', 'i');
       let count = 0;
       const digest = (_: any) => count++ ? 'ref' : 'foo';
-      const tb = new TranslationBundle(msgMap, digest);
+      const tb = new TranslationBundle(msgMap, digest, null);
 
       expect(serializeNodes(tb.get(msg))).toEqual(['--*refMsg*++']);
     });
@@ -68,15 +70,33 @@ export function main(): void {
             new i18n.Placeholder('', 'ph1', span),
           ]
         };
-        const tb = new TranslationBundle(msgMap, (_) => 'foo');
+        const tb = new TranslationBundle(msgMap, (_) => 'foo', null);
         const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
         expect(() => tb.get(msg)).toThrowError(/Unknown placeholder/);
       });
 
       it('should report missing translation', () => {
-        const tb = new TranslationBundle({}, (_) => 'foo');
+        const tb = new TranslationBundle({}, (_) => 'foo', MissingTranslationStrategy.Error);
         const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
         expect(() => tb.get(msg)).toThrowError(/Missing translation for message foo/);
+      });
+
+      it('should report missing translation with MissingTranslationStrategy.Warning', () => {
+        const tb = new TranslationBundle({}, (_) => 'foo', MissingTranslationStrategy.Warning);
+        const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
+        const warn = console.warn;
+        const consoleWarnSpy = spyOn(console, 'warn').and.callThrough();
+
+        expect(() => tb.get(msg)).not.toThrowError();
+        expect(consoleWarnSpy.calls.mostRecent().args[0])
+            .toMatch(/Missing translation for message foo/);
+        console.warn = warn;
+      });
+
+      it('should not report missing translation with MissingTranslationStrategy.Ignore', () => {
+        const tb = new TranslationBundle({}, (_) => 'foo', MissingTranslationStrategy.Ignore);
+        const msg = new i18n.Message([srcNode], {}, {}, 'm', 'd', 'i');
+        expect(() => tb.get(msg)).not.toThrowError();
       });
 
       it('should report missing referenced message', () => {
@@ -87,7 +107,7 @@ export function main(): void {
         const msg = new i18n.Message([srcNode], {}, {ph1: refMsg}, 'm', 'd', 'i');
         let count = 0;
         const digest = (_: any) => count++ ? 'ref' : 'foo';
-        const tb = new TranslationBundle(msgMap, digest);
+        const tb = new TranslationBundle(msgMap, digest, MissingTranslationStrategy.Error);
         expect(() => tb.get(msg)).toThrowError(/Missing translation for message ref/);
       });
 
@@ -101,7 +121,7 @@ export function main(): void {
         const phMap = {
           ph1: '</b>',
         };
-        const tb = new TranslationBundle(msgMap, (_) => 'foo');
+        const tb = new TranslationBundle(msgMap, (_) => 'foo', null);
         const msg = new i18n.Message([srcNode], phMap, {}, 'm', 'd', 'i');
         expect(() => tb.get(msg)).toThrowError(/Unexpected closing tag "b"/);
       });

--- a/modules/@angular/core/src/core.ts
+++ b/modules/@angular/core/src/core.ts
@@ -25,7 +25,7 @@ export {DebugElement, DebugNode, asNativeElements, getDebugNode} from './debug/d
 export {GetTestability, Testability, TestabilityRegistry, setTestabilityGetter} from './testability/testability';
 export * from './change_detection';
 export * from './platform_core_providers';
-export {TRANSLATIONS, TRANSLATIONS_FORMAT, LOCALE_ID} from './i18n/tokens';
+export {TRANSLATIONS, TRANSLATIONS_FORMAT, LOCALE_ID, MISSING_TRANSLATION_STRATEGY, MissingTranslationStrategy} from './i18n/tokens';
 export {ApplicationModule} from './application_module';
 export {wtfCreateScope, wtfLeave, wtfStartTimeRange, wtfEndTimeRange, WtfScopeFn} from './profile/profile';
 export {Type} from './type';

--- a/modules/@angular/core/src/i18n/tokens.ts
+++ b/modules/@angular/core/src/i18n/tokens.ts
@@ -22,3 +22,17 @@ export const TRANSLATIONS = new OpaqueToken('Translations');
  * @experimental i18n support is experimental.
  */
 export const TRANSLATIONS_FORMAT = new OpaqueToken('TranslationsFormat');
+
+/**
+ * @experimental i18n support is experimental.
+ */
+export const MISSING_TRANSLATION_STRATEGY = new OpaqueToken('MissingTranslationStrategy');
+
+/**
+ * @experimental i18n support is experimental.
+ */
+export enum MissingTranslationStrategy {
+  Error,
+  Warning,
+  Ignore,
+}

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -589,6 +589,16 @@ export declare class KeyValueDiffers {
 export declare const LOCALE_ID: OpaqueToken;
 
 /** @experimental */
+export declare const MISSING_TRANSLATION_STRATEGY: OpaqueToken;
+
+/** @experimental */
+export declare enum MissingTranslationStrategy {
+    Error = 0,
+    Warning = 1,
+    Ignore = 2,
+}
+
+/** @experimental */
 export declare class ModuleWithComponentFactories<T> {
     componentFactories: ComponentFactory<any>[];
     ngModuleFactory: NgModuleFactory<T>;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently there's no way to have missing translations without running into template compilation errors. This feature adds a configurable strategy to handle missing translations.


**What is the new behavior?**
The default setting will still throw up during template compilation but a user can now specify MISSING_TRANSLATION_STRATEGY in the compiler providers to control this behaviour. Currently three types are supported:

- **MissingTranslationStrategy.Error (default):** This setting will throw errors during template compilation and the web application will be unavailable on missing translations.
- **MissingTranslationStrategy.Warning:** Providing a MISSING_TRANSLATION_STRATEGY of MissingTranslationStrategy.Warning will log warnings to the console during template compilation on each missing translation.
- **MissingTranslationStrategy.Ignore:** No reporting is done.

For all strategies which don't cause the compiler to die, the original source text will be returned as translated value.

Usage example by extending the example found in the i18n guide on angular.io:

```typescript
import {TRANSLATIONS, TRANSLATIONS_FORMAT, LOCALE_ID, MISSING_TRANSLATION_STRATEGY, MissingTranslationStrategy} from '@angular/core';
export function getTranslationProviders(): Promise<Object[]> {
  // Get the locale id from the global
  const locale = document.locale;
  // return no providers if fail to get translation file for locale
  const noProviders: Object[] = [];
  // No locale or U.S. English: no translation providers
  if (!locale || locale === 'en-US') {
    return Promise.resolve(noProviders);
  }
  // Ex: 'locale/messages.es.xlf`
  const translationFile = `./locale/messages.${locale}.xlf`;
  return getTranslationsWithSystemJs(translationFile)
    .then((translations: string ) => {
      return [
        { provide: TRANSLATIONS, useValue: translations },
        { provide: TRANSLATIONS_FORMAT, useValue: 'xlf' },
        { provide: LOCALE_ID, useValue: locale },
        { provide: MISSING_TRANSLATION_STRATEGY, useValue: MissingTranslationStrategy.Warning}
      ];
    })
    .catch(() => noProviders); // ignore if file not found
}
declare var System: any;
function getTranslationsWithSystemJs(file: string) {
  return System.import(file + '!text'); // relies on text plugin
}
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

