### PR TITLE
feat(ngModel):handle ime events

### DIFF
--- a/modules/@angular/forms/src/directives/ng_model.ts
+++ b/modules/@angular/forms/src/directives/ng_model.ts
@@ -115,7 +115,7 @@ export class NgModel extends NgControl implements OnChanges,
   _control = new FormControl();
   /** @internal */
   _registered = false;
-  _composing = false;
+  private _composing = false;
   viewModel: any;
 
   @Input() name: string;
@@ -125,13 +125,13 @@ export class NgModel extends NgControl implements OnChanges,
 
   @Output('ngModelChange') update = new EventEmitter();
 
-  @HostListener('compositionstart', ['$event'])
-  public compositionStart(): void {
+  @HostListener('compositionstart')
+  compositionStart(): void {
     this._composing = true;
   }
 
-  @HostListener('compositionend', ['$event'])
-  public compositionEnd(): void {
+  @HostListener('compositionend')
+  compositionEnd(): void {
     this._composing = false;
     this.update.emit(this.viewModel);
   }

--- a/modules/@angular/forms/src/directives/ng_model.ts
+++ b/modules/@angular/forms/src/directives/ng_model.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges, forwardRef} from '@angular/core';
+import {Directive, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges, forwardRef, HostListener} from '@angular/core';
 
 import {EventEmitter} from '../facade/async';
 import {FormControl} from '../model';
@@ -115,6 +115,7 @@ export class NgModel extends NgControl implements OnChanges,
   _control = new FormControl();
   /** @internal */
   _registered = false;
+  _composing = false;
   viewModel: any;
 
   @Input() name: string;
@@ -123,6 +124,17 @@ export class NgModel extends NgControl implements OnChanges,
   @Input('ngModelOptions') options: {name?: string, standalone?: boolean};
 
   @Output('ngModelChange') update = new EventEmitter();
+
+  @HostListener('compositionstart', ['$event'])
+  public compositionStart(): void {
+    this._composing = true;
+  }
+
+  @HostListener('compositionend', ['$event'])
+  public compositionEnd(): void {
+    this._composing = false;
+    this.update.emit(this.viewModel);
+  }
 
   constructor(@Optional() @Host() parent: ControlContainer,
               @Optional() @Self() @Inject(NG_VALIDATORS) validators: Array<Validator|ValidatorFn>,
@@ -167,7 +179,7 @@ export class NgModel extends NgControl implements OnChanges,
 
               viewToModelUpdate(newValue: any): void {
                 this.viewModel = newValue;
-                this.update.emit(newValue);
+                !this._composing && this.update.emit(newValue);
               }
 
               private _setUpControl(): void {

--- a/modules/@angular/forms/src/directives/ng_model.ts
+++ b/modules/@angular/forms/src/directives/ng_model.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges, forwardRef, HostListener} from '@angular/core';
+import {Directive, Host, HostListener, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges, forwardRef} from '@angular/core';
 
 import {EventEmitter} from '../facade/async';
 import {FormControl} from '../model';
@@ -126,9 +126,7 @@ export class NgModel extends NgControl implements OnChanges,
   @Output('ngModelChange') update = new EventEmitter();
 
   @HostListener('compositionstart')
-  compositionStart(): void {
-    this._composing = true;
-  }
+  compositionStart(): void { this._composing = true; }
 
   @HostListener('compositionend')
   compositionEnd(): void {

--- a/modules/@angular/forms/test/template_integration_spec.ts
+++ b/modules/@angular/forms/test/template_integration_spec.ts
@@ -64,6 +64,39 @@ export function main() {
            expect(fixture.componentInstance.name).toEqual('updatedValue');
          }));
 
+      it('should ngModel hold ime events until compositionend', fakeAsync(() => {
+           const fixture = TestBed.createComponent(StandaloneNgModel);
+           // model -> view
+           const inputEl = fixture.debugElement.query(By.css('input'));
+           const inputNativeEl = inputEl.nativeElement;
+
+           fixture.componentInstance.name = 'oldValue';
+
+           fixture.detectChanges();
+           tick();
+
+           expect(inputNativeEl.value).toEqual('oldValue');
+           // view -> model
+           inputEl.triggerEventHandler('compositionstart', null);
+
+           inputNativeEl.value = 'updatedValue';
+           dispatchEvent(inputNativeEl, 'input');
+           tick();
+
+           // should ngModel not update when compositionstart
+
+           expect(fixture.componentInstance.name).toEqual('oldValue');
+
+           inputEl.triggerEventHandler('compositionend', null);
+
+           fixture.detectChanges();
+           tick();
+
+           // should ngModel update when compositionend
+
+           expect(fixture.componentInstance.name).toEqual('updatedValue');
+         }));
+
       it('should support ngModel registration with a parent form', fakeAsync(() => {
            const fixture = TestBed.createComponent(NgModelForm);
            fixture.componentInstance.name = 'Nancy';

--- a/tools/public_api_guard/forms/index.d.ts
+++ b/tools/public_api_guard/forms/index.d.ts
@@ -426,6 +426,8 @@ export declare class NgModel extends NgControl implements OnChanges, OnDestroy {
     validator: ValidatorFn;
     viewModel: any;
     constructor(parent: ControlContainer, validators: Array<Validator | ValidatorFn>, asyncValidators: Array<Validator | AsyncValidatorFn>, valueAccessors: ControlValueAccessor[]);
+    compositionEnd(): void;
+    compositionStart(): void;
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     viewToModelUpdate(newValue: any): void;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

IME events are not handled in appropriate way, the value bind to ngModel will be updated intermediately when users are inputting text buffer in Chinese|Korea|Japanese typing mode.

**What is the new behavior?**

In composition mode, users are still inputting intermediate text buffer,hold the input value until composition is done.
More about composition events: https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent.

The same feature can be found in angularjs code [here](https://github.com/angular/angular.js/blob/a24777a2c4ad2ac087d9e3aa278fa2e61e8cc740/src/ng/directive/input.js#L1243)


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

