### PR TITLE
chore(types): exclude @types from build.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -154,11 +154,9 @@ do
   # safely strips 'readonly' specifier from d.ts files to make them compatible with tsc 1.8
   if [ "$(uname)" == "Darwin" ]; then
     find ${DESTDIR} -type f -name '*.d.ts' -print0 | xargs -0 sed -i '' -e 's/\(^ *(static |private )*\)*readonly  */\1/g'
-    find ${DESTDIR} -type f -name '*.d.ts' -print0 | xargs -0 sed -i '' -e 's/\/\/\/ <reference types="node" \/>//g'
     find ${DESTDIR} -type f -name '*.d.ts' -print0 | xargs -0 sed -i '' -E 's/^( +)abstract ([[:alnum:]]+\:)/\1\2/g'
   else
     find ${DESTDIR} -type f -name '*.d.ts' -print0 | xargs -0 sed -i -e 's/\(^ *(static |private )*\)*readonly  */\1/g'
-    find ${DESTDIR} -type f -name '*.d.ts' -print0 | xargs -0 sed -i -e 's/\/\/\/ <reference types="node" \/>//g'
     find ${DESTDIR} -type f -name '*.d.ts' -print0 | xargs -0 sed -i -E 's/^( +)abstract ([[:alnum:]]+\:)/\1\2/g'
   fi
 

--- a/modules/@angular/benchpress/tsconfig-build.json
+++ b/modules/@angular/benchpress/tsconfig-build.json
@@ -14,7 +14,9 @@
         "sourceRoot": ".",
         "outDir": "../../../dist/packages-dist/benchpress",
         "declaration": true,
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
+        "types": []
     },
     "exclude": ["integrationtest"],
     "files": [

--- a/modules/@angular/common/tsconfig-build.json
+++ b/modules/@angular/common/tsconfig-build.json
@@ -15,7 +15,9 @@
     "inlineSources": true,
     "target": "es5",
     "skipLibCheck": true,
-    "lib": [ "es2015", "dom" ]
+    "lib": [ "es2015", "dom" ],
+    // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
+    "types": []
   },
   "files": [
     "index.ts",

--- a/modules/@angular/compiler/tsconfig-build.json
+++ b/modules/@angular/compiler/tsconfig-build.json
@@ -17,7 +17,9 @@
     "inlineSources": true,
     "target": "es5",
     "skipLibCheck": true,
-    "lib": ["es2015", "dom"]
+    "lib": ["es2015", "dom"],
+    // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
+    "types": []
   },
   "files": [
     "index.ts",

--- a/modules/@angular/core/tsconfig-build.json
+++ b/modules/@angular/core/tsconfig-build.json
@@ -15,7 +15,9 @@
     "inlineSources": true,
     "target": "es5",
     "lib": ["es2015", "dom"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
+    "types": []
   },
   "files": [
     "index.ts",

--- a/modules/@angular/forms/tsconfig-build.json
+++ b/modules/@angular/forms/tsconfig-build.json
@@ -20,7 +20,9 @@
     "inlineSources": true,
     "target": "es5",
     "skipLibCheck": true,
-    "lib": ["es2015", "dom"]
+    "lib": ["es2015", "dom"],
+    // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
+    "types": []
   },
   "files": [
     "index.ts",

--- a/modules/@angular/platform-browser-dynamic/tsconfig-build.json
+++ b/modules/@angular/platform-browser-dynamic/tsconfig-build.json
@@ -22,7 +22,9 @@
     "inlineSources": true,
     "target": "es5",
     "skipLibCheck": true,
-    "lib": ["es2015", "dom"]
+    "lib": ["es2015", "dom"],
+    // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
+    "types": []
   },
   "files": [
     "index.ts",

--- a/modules/@angular/platform-browser/tsconfig-build.json
+++ b/modules/@angular/platform-browser/tsconfig-build.json
@@ -16,7 +16,9 @@
     "inlineSources": true,
     "target": "es5",
     "skipLibCheck": true,
-    "lib": ["es2015", "dom"]
+    "lib": ["es2015", "dom"],
+    // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
+    "types": []
   },
   "files": [
     "index.ts",

--- a/modules/@angular/platform-server/tsconfig-build.json
+++ b/modules/@angular/platform-server/tsconfig-build.json
@@ -19,7 +19,9 @@
     "inlineSources": true,
     "target": "es5",
     "skipLibCheck": true,
-    "lib": ["es2015", "dom"]
+    "lib": ["es2015", "dom"],
+    // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
+    "types": []
   },
   "files": [
     "index.ts",

--- a/modules/@angular/platform-webworker-dynamic/tsconfig-build.json
+++ b/modules/@angular/platform-webworker-dynamic/tsconfig-build.json
@@ -20,7 +20,9 @@
     "inlineSources": true,
     "target": "es5",
     "skipLibCheck": true,
-    "lib": ["es2015", "dom"]
+    "lib": ["es2015", "dom"],
+    // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
+    "types": []
   },
   "files": [
     "index.ts",

--- a/modules/@angular/platform-webworker/tsconfig-build.json
+++ b/modules/@angular/platform-webworker/tsconfig-build.json
@@ -17,7 +17,9 @@
     "inlineSources": true,
     "target": "es5",
     "skipLibCheck": true,
-    "lib": ["es2015", "dom"]
+    "lib": ["es2015", "dom"],
+    // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
+    "types": []
   },
   "files": [
     "index.ts",

--- a/modules/@angular/upgrade/tsconfig-build.json
+++ b/modules/@angular/upgrade/tsconfig-build.json
@@ -19,7 +19,9 @@
     "inlineSources": true,
     "target": "es5",
     "skipLibCheck": true,
-    "lib": [ "es2015", "dom" ]
+    "lib": [ "es2015", "dom" ],
+    // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
+    "types": []
   },
   "files": [
     "index.ts",


### PR DESCRIPTION
This would be a lot less ugly on TS 2.1 where we can inherit  configuration from a shared tsconfig.

I noticed it because my ES6 distro has the `/// <reference types="node" />` in a couple files. I could do the regexes on yet another directory but it feels nice to fix it without regex.

Plus when users move to TS 2.1 we'll still have to avoid referencing node typings in our distro, so we wouldn't be able to clean up all the regexes.