### PR TITLE
fix(router): eager loading with loadChildren in aot

### DIFF
--- a/modules/@angular/router/src/config.ts
+++ b/modules/@angular/router/src/config.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Type} from '@angular/core';
+import {NgModuleFactory, Type} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {PRIMARY_OUTLET} from './shared';
 import {UrlSegment, UrlSegmentGroup} from './url_tree';
@@ -310,7 +310,8 @@ export type ResolveData = {
  * See {@link Routes} for more details.
  * @stable
  */
-export type LoadChildrenCallback = () => Type<any>| Promise<Type<any>>| Observable<Type<any>>;
+export type LoadChildrenCallback = () =>
+    Type<any>| NgModuleFactory<any>| Promise<Type<any>>| Observable<Type<any>>;
 
 /**
  * @whatItDoes The type of `loadChildren`.

--- a/modules/@angular/router/src/utils/collection.ts
+++ b/modules/@angular/router/src/utils/collection.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {NgModuleFactory} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {fromPromise} from 'rxjs/observable/fromPromise';
 import {of } from 'rxjs/observable/of';
@@ -126,7 +127,8 @@ export function andObservables(observables: Observable<Observable<any>>): Observ
   return every.call(merged$, (result: any) => result === true);
 }
 
-export function wrapIntoObservable<T>(value: T | Promise<T>| Observable<T>): Observable<T> {
+export function wrapIntoObservable<T>(value: T | NgModuleFactory<T>| Promise<T>| Observable<T>):
+    Observable<T> {
   if (value instanceof Observable) {
     return value;
   }

--- a/tools/public_api_guard/router/index.d.ts
+++ b/tools/public_api_guard/router/index.d.ts
@@ -85,7 +85,7 @@ export interface ExtraOptions {
 export declare type LoadChildren = string | LoadChildrenCallback;
 
 /** @stable */
-export declare type LoadChildrenCallback = () => Type<any> | Promise<Type<any>> | Observable<Type<any>>;
+export declare type LoadChildrenCallback = () => Type<any> | NgModuleFactory<any> | Promise<Type<any>> | Observable<Type<any>>;
 
 /** @stable */
 export declare class NavigationCancel {


### PR DESCRIPTION
Closes #11075

Description:
Runtime compiler is not available after aot compilation, so we need to return `NgModuleFactory` instead of just `NgModule`, because we cannot compile it at runtime.
```
import { Routes, RouterModule, PreloadAllModules } from '@angular/router';
import { HomeComponent } from './home/home.component';
import { ProfileModuleNgFactory } from '../compiled/src/app/profile.module.ngfactory';

export function loadProfileModule() {
	return ProfileModuleNgFactory;
}

export const routes: Routes = [
	{ path: '', component: HomeComponent, pathMatch: 'full' },
	{ path: 'profile', loadChildren: loadProfileModule}
];

export const routing = RouterModule.forRoot(routes);
```
instead of
```
import { Routes, RouterModule, PreloadAllModules } from '@angular/router';
import { HomeComponent } from './home/home.component';
import { ProfileModule } from './profile/profile.module';

export function loadProfileModule() {
	return ProfileModule;
}

export const routes: Routes = [
	{ path: '', component: HomeComponent, pathMatch: 'full' },
	{ path: 'profile', loadChildren: loadProfileModule}
];

export const routing = RouterModule.forRoot(routes);
```