### PR TITLE
fix(router): fix CanActivate redirect to the root on initial load

### DIFF
--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -757,8 +757,8 @@ export class Router {
           })
           .then(
               () => {
-                this.navigated = true;
                 if (navigationIsSuccessful) {
+                  this.navigated = true;
                   this.routerEvents.next(new NavigationEnd(
                       id, this.serializeUrl(url), this.serializeUrl(this.currentUrlTree)));
                   resolvePromise(true);

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -1442,6 +1442,35 @@ describe('Integration', () => {
 
            })));
       });
+
+      describe('should redirect to / when guard returns false', () => {
+        beforeEach(() => TestBed.configureTestingModule({
+          providers: [{
+            provide: 'returnFalseAndNavigate',
+            useFactory: (router: Router) => () => {
+              router.navigate(['/']);
+              return false;
+            },
+            deps: [Router]
+          }]
+        }));
+
+        it('works', fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
+             router.resetConfig([
+               {
+                 path: '',
+                 component: SimpleCmp,
+               },
+               {path: 'one', component: RouteCmp, canActivate: ['returnFalseAndNavigate']}
+             ]);
+
+             const fixture = TestBed.createComponent(RootCmp);
+             router.navigateByUrl('/one');
+             advance(fixture);
+             expect(location.path()).toEqual('/');
+             expect(fixture.nativeElement).toHaveText('simple');
+           })));
+      });
     });
 
     describe('CanDeactivate', () => {


### PR DESCRIPTION
Closes https://github.com/angular/angular/issues/13530

Description:
The initial navigation is canceled by guard which returns `false`, but `Router.navigated` is set to `true` anyway.
Router initialized with the url equals to `/`, so when the second navigation occurs (`this.router.navigate(['/'])`), router compares [`/` and `/`](https://github.com/angular/angular/blob/master/modules/%40angular/router/src/router.ts#L618), and cancels navigation, because it's not allowed to navigate to the same url again. 
I think we should set `Router.navigated` to `true` only after the first successful navigation.