### PR TITLE
fix(build): move fsevents into optionalDependencies

### DIFF
--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -1,2136 +1,1335 @@
 {
   "name": "angular-srcs",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-beta.3",
   "dependencies": {
     "@types/angularjs": {
-      "version": "1.5.13-alpha"
+      "version": "1.5.13-alpha",
+      "dev": true
     },
     "@types/base64-js": {
-      "version": "1.2.5"
+      "version": "1.2.5",
+      "dev": true
     },
     "@types/fs-extra": {
-      "version": "0.0.22-alpha"
+      "version": "0.0.22-alpha",
+      "dev": true
     },
     "@types/hammerjs": {
-      "version": "2.0.33"
+      "version": "2.0.34",
+      "dev": true
     },
     "@types/jasmine": {
-      "version": "2.2.22-alpha"
+      "version": "2.5.40",
+      "dev": true
     },
     "@types/jquery": {
-      "version": "1.10.21-alpha"
+      "version": "2.0.39",
+      "dev": true
     },
     "@types/node": {
-      "version": "4.0.22-alpha"
+      "version": "4.2.0",
+      "dev": true
     },
     "@types/q": {
-      "version": "0.0.32"
+      "version": "0.0.32",
+      "dev": true
     },
     "@types/selenium-webdriver": {
-      "version": "2.53.35"
+      "version": "2.53.39",
+      "dev": true
     },
     "@types/systemjs": {
-      "version": "0.19.32"
+      "version": "0.19.33",
+      "dev": true
     },
     "accepts": {
       "version": "1.2.13",
-      "dependencies": {
-        "mime-db": {
-          "version": "1.20.0"
-        },
-        "mime-types": {
-          "version": "2.1.8"
-        }
-      }
+      "dev": true
     },
     "acorn": {
-      "version": "1.2.2"
+      "version": "1.2.2",
+      "dev": true
     },
     "add-stream": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "adm-zip": {
-      "version": "0.4.7"
+      "version": "0.4.7",
+      "dev": true
     },
     "after": {
-      "version": "0.8.1"
+      "version": "0.8.2",
+      "dev": true
     },
     "agent-base": {
       "version": "2.0.1",
+      "dev": true,
       "dependencies": {
         "semver": {
-          "version": "5.0.3"
+          "version": "5.0.3",
+          "dev": true
         }
       }
     },
     "align-text": {
-      "version": "0.1.3",
+      "version": "0.1.4",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "angular": {
+      "version": "1.6.1",
+      "dev": true
+    },
+    "angular-animate": {
+      "version": "1.6.1",
+      "dev": true
+    },
+    "angular-mocks": {
+      "version": "1.6.1",
+      "dev": true
+    },
+    "ansi-align": {
+      "version": "1.1.0",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "dev": true
+    },
+    "any-promise": {
+      "version": "0.1.0",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "1.3.0",
+      "dev": true
+    },
+    "archiver": {
+      "version": "1.0.1",
+      "dev": true,
       "dependencies": {
-        "kind-of": {
-          "version": "2.0.1"
+        "async": {
+          "version": "2.1.4",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.1",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "dev": true
         }
       }
     },
-    "amdefine": {
-      "version": "1.0.1"
-    },
-    "angular": {
-      "version": "1.5.0"
-    },
-    "angular-animate": {
-      "version": "1.5.0"
-    },
-    "angular-mocks": {
-      "version": "1.5.0"
-    },
-    "ansi-align": {
-      "version": "1.1.0"
-    },
-    "ansi-green": {
-      "version": "0.1.1"
-    },
-    "ansi-regex": {
-      "version": "2.0.0"
-    },
-    "ansi-styles": {
-      "version": "2.2.1"
-    },
-    "ansi-wrap": {
-      "version": "0.1.0"
-    },
-    "any-promise": {
-      "version": "0.1.0"
-    },
-    "anymatch": {
-      "version": "1.3.0"
-    },
-    "archiver": {
-      "version": "0.14.4",
+    "archiver-utils": {
+      "version": "1.3.0",
+      "dev": true,
       "dependencies": {
-        "async": {
-          "version": "0.9.2"
-        },
         "glob": {
-          "version": "4.3.5",
-          "dependencies": {
-            "minimatch": {
-              "version": "2.0.10"
-            }
-          }
+          "version": "7.1.1",
+          "dev": true
         },
-        "lodash": {
-          "version": "3.2.0"
+        "graceful-fs": {
+          "version": "4.1.11",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
         },
         "readable-stream": {
-          "version": "1.0.33"
+          "version": "2.2.2",
+          "dev": true
         }
       }
     },
     "archy": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "arr-diff": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "arr-flatten": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "array-differ": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "dev": true
     },
     "array-ify": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "array-slice": {
-      "version": "0.2.3"
+      "version": "0.2.3",
+      "dev": true
     },
     "array-union": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "array-uniq": {
-      "version": "1.0.2"
+      "version": "1.0.3",
+      "dev": true
     },
     "array-unique": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "dev": true
     },
     "arraybuffer.slice": {
-      "version": "0.0.6"
+      "version": "0.0.6",
+      "dev": true
     },
     "arrify": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "asap": {
-      "version": "2.0.3"
+      "version": "2.0.5",
+      "dev": true
     },
     "asn1": {
-      "version": "0.2.3"
+      "version": "0.1.11",
+      "dev": true
     },
     "assert": {
-      "version": "1.4.1"
+      "version": "1.4.1",
+      "dev": true
     },
     "assert-plus": {
-      "version": "0.1.5"
+      "version": "0.1.5",
+      "dev": true
+    },
+    "ast-types": {
+      "version": "0.9.2",
+      "dev": true
     },
     "async": {
-      "version": "0.2.10"
+      "version": "1.5.2",
+      "dev": true
     },
     "async-each": {
-      "version": "0.1.6"
+      "version": "1.0.1",
+      "dev": true
     },
     "asynckit": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "dev": true
     },
     "aws-sign2": {
-      "version": "0.6.0"
+      "version": "0.5.0",
+      "dev": true
     },
     "aws4": {
-      "version": "1.5.0"
+      "version": "1.5.0",
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.20.0",
+      "dev": true,
       "dependencies": {
-        "esutils": {
-          "version": "2.0.2"
-        },
         "js-tokens": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "dev": true
         }
       }
     },
     "backo2": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "balanced-match": {
-      "version": "0.4.2"
+      "version": "0.4.2",
+      "dev": true
     },
     "base62": {
-      "version": "0.1.1"
-    },
-    "Base64": {
-      "version": "0.2.1"
+      "version": "1.1.2",
+      "dev": true
     },
     "base64-arraybuffer": {
-      "version": "0.1.2"
+      "version": "0.1.5",
+      "dev": true
     },
     "base64-js": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "dev": true
     },
     "base64-url": {
-      "version": "1.2.1"
+      "version": "1.3.3",
+      "dev": true
     },
     "base64id": {
-      "version": "0.1.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "basic-auth": {
-      "version": "1.0.3"
+      "version": "1.0.4",
+      "dev": true
     },
     "basic-auth-connect": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "batch": {
-      "version": "0.5.2"
+      "version": "0.5.3",
+      "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true,
+      "optional": true
     },
     "beeper": {
-      "version": "1.1.0"
-    },
-    "benchmark": {
-      "version": "1.0.0"
+      "version": "1.1.1",
+      "dev": true
     },
     "better-assert": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "big.js": {
-      "version": "3.1.3"
+      "version": "3.1.3",
+      "dev": true
     },
     "binary": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "dev": true
     },
     "binary-extensions": {
-      "version": "1.4.0"
+      "version": "1.8.0",
+      "dev": true
     },
     "bl": {
-      "version": "0.9.4",
+      "version": "1.2.0",
+      "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "1.0.33"
+          "version": "2.2.2",
+          "dev": true
         }
       }
     },
     "blob": {
-      "version": "0.0.4"
+      "version": "0.0.4",
+      "dev": true
     },
     "bluebird": {
-      "version": "2.10.2"
+      "version": "2.11.0",
+      "dev": true
     },
     "body-parser": {
-      "version": "1.13.3"
+      "version": "1.13.3",
+      "dev": true
     },
     "boom": {
-      "version": "2.10.1"
+      "version": "2.10.1",
+      "dev": true
     },
     "bower": {
-      "version": "1.7.2",
-      "dependencies": {
-        "abbrev": {
-          "version": "1.0.7"
-        },
-        "archy": {
-          "version": "1.0.0"
-        },
-        "bower-config": {
-          "version": "1.3.0",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.2"
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.10"
-                },
-                "wordwrap": {
-                  "version": "0.0.3"
-                }
-              }
-            },
-            "osenv": {
-              "version": "0.1.3",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "untildify": {
-              "version": "2.1.0",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1"
-                }
-              }
-            }
-          }
-        },
-        "bower-endpoint-parser": {
-          "version": "0.2.2"
-        },
-        "bower-json": {
-          "version": "0.4.0",
-          "dependencies": {
-            "deep-extend": {
-              "version": "0.2.11"
-            },
-            "graceful-fs": {
-              "version": "2.0.3"
-            },
-            "intersect": {
-              "version": "0.0.3"
-            }
-          }
-        },
-        "bower-logger": {
-          "version": "0.2.2"
-        },
-        "bower-registry-client": {
-          "version": "1.0.0",
-          "dependencies": {
-            "async": {
-              "version": "0.2.10"
-            },
-            "graceful-fs": {
-              "version": "4.1.2"
-            },
-            "mkdirp": {
-              "version": "0.3.5"
-            },
-            "request-replay": {
-              "version": "0.2.0"
-            }
-          }
-        },
-        "cardinal": {
-          "version": "0.4.4",
-          "dependencies": {
-            "ansicolors": {
-              "version": "0.2.1"
-            },
-            "redeyed": {
-              "version": "0.4.4",
-              "dependencies": {
-                "esprima": {
-                  "version": "1.0.4"
-                }
-              }
-            }
-          }
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.4"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0"
-            }
-          }
-        },
-        "chmodr": {
-          "version": "1.0.2"
-        },
-        "configstore": {
-          "version": "0.3.2",
-          "dependencies": {
-            "js-yaml": {
-              "version": "3.4.6",
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.3",
-                  "dependencies": {
-                    "lodash": {
-                      "version": "3.10.1"
-                    },
-                    "sprintf-js": {
-                      "version": "1.0.3"
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "2.7.1"
-                },
-                "inherit": {
-                  "version": "2.2.2"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.1.1"
-            },
-            "osenv": {
-              "version": "0.1.3",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "uuid": {
-              "version": "2.0.1"
-            },
-            "xdg-basedir": {
-              "version": "1.0.1"
-            }
-          }
-        },
-        "decompress-zip": {
-          "version": "0.1.0",
-          "dependencies": {
-            "binary": {
-              "version": "0.3.0",
-              "dependencies": {
-                "buffers": {
-                  "version": "0.1.1"
-                },
-                "chainsaw": {
-                  "version": "0.1.0",
-                  "dependencies": {
-                    "traverse": {
-                      "version": "0.3.9"
-                    }
-                  }
-                }
-              }
-            },
-            "mkpath": {
-              "version": "0.1.0"
-            },
-            "readable-stream": {
-              "version": "1.1.13",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2"
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                },
-                "isarray": {
-                  "version": "0.0.1"
-                },
-                "string_decoder": {
-                  "version": "0.10.31"
-                }
-              }
-            },
-            "touch": {
-              "version": "0.0.3",
-              "dependencies": {
-                "nopt": {
-                  "version": "1.0.10"
-                }
-              }
-            }
-          }
-        },
-        "destroy": {
-          "version": "1.0.3"
-        },
-        "fs-write-stream-atomic": {
-          "version": "1.0.5",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.2"
-            },
-            "imurmurhash": {
-              "version": "0.1.4"
-            }
-          }
-        },
-        "fstream": {
-          "version": "1.0.8",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.2"
-            },
-            "inherits": {
-              "version": "2.0.1"
-            }
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.3",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1"
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "github": {
-          "version": "0.2.4",
-          "dependencies": {
-            "mime": {
-              "version": "1.3.4"
-            }
-          }
-        },
-        "glob": {
-          "version": "4.5.3",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1"
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "3.0.8"
-        },
-        "handlebars": {
-          "version": "2.0.0",
-          "dependencies": {
-            "optimist": {
-              "version": "0.3.7",
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3"
-                }
-              }
-            },
-            "uglify-js": {
-              "version": "2.3.6",
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10"
-                },
-                "source-map": {
-                  "version": "0.1.43",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "inquirer": {
-          "version": "0.10.0",
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "1.1.0"
-            },
-            "ansi-regex": {
-              "version": "2.0.0"
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "dependencies": {
-                "restore-cursor": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "exit-hook": {
-                      "version": "1.1.1"
-                    },
-                    "onetime": {
-                      "version": "1.1.0"
-                    }
-                  }
-                }
-              }
-            },
-            "cli-width": {
-              "version": "1.1.0"
-            },
-            "figures": {
-              "version": "1.4.0"
-            },
-            "lodash": {
-              "version": "3.10.1"
-            },
-            "readline2": {
-              "version": "1.0.1",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "mute-stream": {
-                  "version": "0.0.5"
-                }
-              }
-            },
-            "run-async": {
-              "version": "0.1.0",
-              "dependencies": {
-                "once": {
-                  "version": "1.3.3",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "rx-lite": {
-              "version": "3.1.2"
-            },
-            "strip-ansi": {
-              "version": "3.0.0"
-            },
-            "through": {
-              "version": "2.3.8"
-            }
-          }
-        },
-        "insight": {
-          "version": "0.7.0",
-          "dependencies": {
-            "async": {
-              "version": "1.5.0"
-            },
-            "configstore": {
-              "version": "1.4.0",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.2"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1"
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "uuid": {
-                  "version": "2.0.1"
-                },
-                "write-file-atomic": {
-                  "version": "1.1.4",
-                  "dependencies": {
-                    "imurmurhash": {
-                      "version": "0.1.4"
-                    },
-                    "slide": {
-                      "version": "1.1.6"
-                    }
-                  }
-                },
-                "xdg-basedir": {
-                  "version": "2.0.0",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash.debounce": {
-              "version": "3.1.1",
-              "dependencies": {
-                "lodash._getnative": {
-                  "version": "3.9.1"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.0.1"
-            },
-            "os-name": {
-              "version": "1.0.3",
-              "dependencies": {
-                "osx-release": {
-                  "version": "1.1.0",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "1.2.0"
-                    }
-                  }
-                },
-                "win-release": {
-                  "version": "1.1.1",
-                  "dependencies": {
-                    "semver": {
-                      "version": "5.1.0"
-                    }
-                  }
-                }
-              }
-            },
-            "tough-cookie": {
-              "version": "2.2.1"
-            }
-          }
-        },
-        "is-root": {
-          "version": "1.0.0"
-        },
-        "junk": {
-          "version": "1.0.2"
-        },
-        "lockfile": {
-          "version": "1.0.1"
-        },
-        "lru-cache": {
-          "version": "2.7.3"
-        },
-        "md5-hex": {
-          "version": "1.2.0",
-          "dependencies": {
-            "md5-o-matic": {
-              "version": "0.1.1"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8"
-            }
-          }
-        },
-        "mout": {
-          "version": "0.11.1"
-        },
-        "nopt": {
-          "version": "3.0.6"
-        },
-        "opn": {
-          "version": "1.0.2"
-        },
-        "p-throttler": {
-          "version": "0.1.1",
-          "dependencies": {
-            "q": {
-              "version": "0.9.7"
-            }
-          }
-        },
-        "promptly": {
-          "version": "0.2.0",
-          "dependencies": {
-            "read": {
-              "version": "1.0.7",
-              "dependencies": {
-                "mute-stream": {
-                  "version": "0.0.5"
-                }
-              }
-            }
-          }
-        },
-        "q": {
-          "version": "1.4.1"
-        },
-        "request": {
-          "version": "2.53.0",
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.5.0"
-            },
-            "bl": {
-              "version": "0.9.4",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    }
-                  }
-                }
-              }
-            },
-            "caseless": {
-              "version": "0.9.0"
-            },
-            "combined-stream": {
-              "version": "0.0.7",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "0.0.5"
-                }
-              }
-            },
-            "forever-agent": {
-              "version": "0.5.2"
-            },
-            "form-data": {
-              "version": "0.2.0",
-              "dependencies": {
-                "async": {
-                  "version": "0.9.2"
-                }
-              }
-            },
-            "hawk": {
-              "version": "2.3.1",
-              "dependencies": {
-                "boom": {
-                  "version": "2.10.1"
-                },
-                "cryptiles": {
-                  "version": "2.0.5"
-                },
-                "hoek": {
-                  "version": "2.16.3"
-                },
-                "sntp": {
-                  "version": "1.0.9"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "0.10.1",
-              "dependencies": {
-                "asn1": {
-                  "version": "0.1.11"
-                },
-                "assert-plus": {
-                  "version": "0.1.5"
-                },
-                "ctype": {
-                  "version": "0.5.3"
-                }
-              }
-            },
-            "isstream": {
-              "version": "0.1.2"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1"
-            },
-            "mime-types": {
-              "version": "2.0.14",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.12.0"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.7"
-            },
-            "oauth-sign": {
-              "version": "0.6.0"
-            },
-            "qs": {
-              "version": "2.3.3"
-            },
-            "stringstream": {
-              "version": "0.0.5"
-            },
-            "tough-cookie": {
-              "version": "2.2.1"
-            },
-            "tunnel-agent": {
-              "version": "0.4.2"
-            }
-          }
-        },
-        "request-progress": {
-          "version": "0.3.1",
-          "dependencies": {
-            "throttleit": {
-              "version": "0.0.2"
-            }
-          }
-        },
-        "retry": {
-          "version": "0.6.1"
-        },
-        "rimraf": {
-          "version": "2.5.0",
-          "dependencies": {
-            "glob": {
-              "version": "6.0.3",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.2",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "semver": {
-          "version": "2.3.2"
-        },
-        "shell-quote": {
-          "version": "1.4.3",
-          "dependencies": {
-            "array-filter": {
-              "version": "0.0.1"
-            },
-            "array-map": {
-              "version": "0.0.0"
-            },
-            "array-reduce": {
-              "version": "0.0.0"
-            },
-            "jsonify": {
-              "version": "0.0.0"
-            }
-          }
-        },
-        "stringify-object": {
-          "version": "1.0.1"
-        },
-        "tar-fs": {
-          "version": "1.9.0",
-          "dependencies": {
-            "pump": {
-              "version": "1.0.1",
-              "dependencies": {
-                "end-of-stream": {
-                  "version": "1.1.0"
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "tar-stream": {
-              "version": "1.3.1",
-              "dependencies": {
-                "bl": {
-                  "version": "1.0.0"
-                },
-                "end-of-stream": {
-                  "version": "1.1.0",
-                  "dependencies": {
-                    "once": {
-                      "version": "1.3.3",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.0.5",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1"
-                }
-              }
-            }
-          }
-        },
-        "tmp": {
-          "version": "0.0.24"
-        },
-        "update-notifier": {
-          "version": "0.6.0",
-          "dependencies": {
-            "configstore": {
-              "version": "1.4.0",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.2"
-                },
-                "object-assign": {
-                  "version": "4.0.1"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1"
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "uuid": {
-                  "version": "2.0.1"
-                },
-                "write-file-atomic": {
-                  "version": "1.1.4",
-                  "dependencies": {
-                    "imurmurhash": {
-                      "version": "0.1.4"
-                    },
-                    "slide": {
-                      "version": "1.1.6"
-                    }
-                  }
-                },
-                "xdg-basedir": {
-                  "version": "2.0.0",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "is-npm": {
-              "version": "1.0.0"
-            },
-            "latest-version": {
-              "version": "2.0.0",
-              "dependencies": {
-                "package-json": {
-                  "version": "2.3.0",
-                  "dependencies": {
-                    "got": {
-                      "version": "5.3.0",
-                      "dependencies": {
-                        "create-error-class": {
-                          "version": "2.0.1",
-                          "dependencies": {
-                            "capture-stack-trace": {
-                              "version": "1.0.0"
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.4.2",
-                          "dependencies": {
-                            "end-of-stream": {
-                              "version": "1.0.0",
-                              "dependencies": {
-                                "once": {
-                                  "version": "1.3.3",
-                                  "dependencies": {
-                                    "wrappy": {
-                                      "version": "1.0.1"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "readable-stream": {
-                              "version": "2.0.5",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1"
-                                },
-                                "process-nextick-args": {
-                                  "version": "1.0.6"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31"
-                                },
-                                "util-deprecate": {
-                                  "version": "1.0.2"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "is-plain-obj": {
-                          "version": "1.1.0"
-                        },
-                        "is-redirect": {
-                          "version": "1.0.0"
-                        },
-                        "is-stream": {
-                          "version": "1.0.1"
-                        },
-                        "lowercase-keys": {
-                          "version": "1.0.0"
-                        },
-                        "node-status-codes": {
-                          "version": "1.0.0"
-                        },
-                        "object-assign": {
-                          "version": "4.0.1"
-                        },
-                        "parse-json": {
-                          "version": "2.2.0",
-                          "dependencies": {
-                            "error-ex": {
-                              "version": "1.3.0",
-                              "dependencies": {
-                                "is-arrayish": {
-                                  "version": "0.2.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.1"
-                            }
-                          }
-                        },
-                        "read-all-stream": {
-                          "version": "3.0.1",
-                          "dependencies": {
-                            "pinkie-promise": {
-                              "version": "1.0.0",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "1.0.0"
-                                }
-                              }
-                            },
-                            "readable-stream": {
-                              "version": "2.0.5",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1"
-                                },
-                                "process-nextick-args": {
-                                  "version": "1.0.6"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31"
-                                },
-                                "util-deprecate": {
-                                  "version": "1.0.2"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "timed-out": {
-                          "version": "2.0.0"
-                        },
-                        "unzip-response": {
-                          "version": "1.0.0"
-                        },
-                        "url-parse-lax": {
-                          "version": "1.0.0",
-                          "dependencies": {
-                            "prepend-http": {
-                              "version": "1.0.3"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "rc": {
-                      "version": "1.1.6",
-                      "dependencies": {
-                        "deep-extend": {
-                          "version": "0.4.0"
-                        },
-                        "ini": {
-                          "version": "1.3.4"
-                        },
-                        "minimist": {
-                          "version": "1.2.0"
-                        },
-                        "strip-json-comments": {
-                          "version": "1.0.4"
-                        }
-                      }
-                    },
-                    "registry-url": {
-                      "version": "3.0.3"
-                    },
-                    "semver": {
-                      "version": "5.1.0"
-                    }
-                  }
-                }
-              }
-            },
-            "repeating": {
-              "version": "2.0.0",
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "semver-diff": {
-              "version": "2.1.0",
-              "dependencies": {
-                "semver": {
-                  "version": "5.1.0"
-                }
-              }
-            },
-            "string-length": {
-              "version": "1.0.1",
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "user-home": {
-          "version": "1.1.1"
-        },
-        "which": {
-          "version": "1.2.1",
-          "dependencies": {
-            "is-absolute": {
-              "version": "0.1.7",
-              "dependencies": {
-                "is-relative": {
-                  "version": "0.1.3"
-                }
-              }
-            }
-          }
-        }
-      }
+      "version": "1.8.0",
+      "dev": true
     },
     "boxen": {
       "version": "0.6.0",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.6",
+      "dev": true
+    },
+    "braces": {
+      "version": "1.8.5",
+      "dev": true
+    },
+    "browserify-aes": {
+      "version": "0.4.0",
+      "dev": true
+    },
+    "browserify-zlib": {
+      "version": "0.1.4",
+      "dev": true,
       "dependencies": {
-        "camelcase": {
-          "version": "2.1.1"
+        "pako": {
+          "version": "0.2.9",
+          "dev": true
         }
       }
     },
-    "brace-expansion": {
-      "version": "1.1.6"
-    },
-    "braces": {
-      "version": "1.8.3"
-    },
-    "browserify-zlib": {
-      "version": "0.1.4"
-    },
     "browserstack": {
-      "version": "1.2.0"
+      "version": "1.3.1",
+      "dev": true
     },
     "browserstacktunnel-wrapper": {
-      "version": "1.4.2"
+      "version": "1.4.2",
+      "dev": true
     },
     "buffer": {
       "version": "4.9.1",
+      "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "dev": true
         }
       }
     },
     "buffer-crc32": {
-      "version": "0.2.5"
+      "version": "0.2.13",
+      "dev": true
     },
     "buffer-shims": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "buffers": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "dev": true
     },
     "builtin-modules": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "dev": true
     },
     "bytes": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "callsite": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "camelcase": {
-      "version": "2.0.1"
+      "version": "2.1.1",
+      "dev": true
     },
     "camelcase-keys": {
-      "version": "2.0.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "capture-stack-trace": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "caseless": {
-      "version": "0.11.0"
+      "version": "0.9.0",
+      "dev": true
     },
     "center-align": {
-      "version": "0.1.2"
+      "version": "0.1.3",
+      "dev": true
     },
     "chainsaw": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "chalk": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "dev": true
     },
     "chokidar": {
-      "version": "1.4.2"
+      "version": "1.6.1",
+      "dev": true
     },
     "clang-format": {
-      "version": "1.0.41",
+      "version": "1.0.46",
+      "dev": true,
       "dependencies": {
-        "async": {
-          "version": "1.5.2"
-        },
         "glob": {
-          "version": "7.0.3"
+          "version": "7.1.1",
+          "dev": true
         }
       }
     },
     "cldr": {
       "version": "3.5.2",
-      "dependencies": {
-        "uglify-js": {
-          "version": "1.3.3"
-        },
-        "underscore": {
-          "version": "1.3.3"
-        }
-      }
+      "dev": true
     },
     "cli-boxes": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "cli-color": {
       "version": "1.1.0",
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0"
-        }
-      }
+      "dev": true
     },
     "cliui": {
-      "version": "3.1.0",
+      "version": "2.1.0",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0"
-        },
-        "strip-ansi": {
-          "version": "3.0.0"
+        "wordwrap": {
+          "version": "0.0.2",
+          "dev": true
         }
       }
     },
     "clone": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "clone-stats": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true
     },
     "code-point-at": {
-      "version": "1.0.0"
+      "version": "1.1.0",
+      "dev": true
     },
     "colors": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "dev": true
     },
     "combined-stream": {
-      "version": "1.0.5"
+      "version": "0.0.7",
+      "dev": true
     },
     "commander": {
-      "version": "2.9.0"
+      "version": "2.6.0",
+      "dev": true
+    },
+    "commoner": {
+      "version": "0.10.8",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "dev": true
+        }
+      }
     },
     "compare-func": {
-      "version": "1.3.2"
+      "version": "1.3.2",
+      "dev": true
     },
     "component-bind": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "component-emitter": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "dev": true
     },
     "component-inherit": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "dev": true
     },
     "compress-commons": {
-      "version": "0.2.9",
+      "version": "1.1.0",
+      "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "1.0.33"
+          "version": "2.2.2",
+          "dev": true
         }
       }
     },
     "compressible": {
-      "version": "2.0.6",
+      "version": "2.0.9",
+      "dev": true
+    },
+    "compression": {
+      "version": "1.5.2",
+      "dev": true,
       "dependencies": {
-        "mime-db": {
-          "version": "1.20.0"
+        "vary": {
+          "version": "1.0.1",
+          "dev": true
         }
       }
     },
-    "compression": {
-      "version": "1.5.2"
-    },
     "concat-map": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "dev": true
+        }
+      }
     },
     "configstore": {
       "version": "2.1.0",
+      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.11"
+          "version": "4.1.11",
+          "dev": true
         }
       }
     },
     "connect": {
-      "version": "3.4.0"
+      "version": "2.30.2",
+      "dev": true
     },
     "connect-livereload": {
-      "version": "0.5.4"
+      "version": "0.5.4",
+      "dev": true
     },
     "connect-timeout": {
-      "version": "1.6.2"
+      "version": "1.6.2",
+      "dev": true
     },
     "console-browserify": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dev": true
     },
     "constants-browserify": {
-      "version": "0.0.1"
+      "version": "1.0.0",
+      "dev": true
     },
     "content-type": {
-      "version": "1.0.1"
+      "version": "1.0.2",
+      "dev": true
     },
     "conventional-changelog": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dev": true
     },
     "conventional-changelog-angular": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "dev": true
     },
     "conventional-changelog-atom": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "conventional-changelog-codemirror": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "conventional-changelog-core": {
       "version": "1.5.0",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "lodash": {
-          "version": "4.14.2"
-        },
-        "readable-stream": {
-          "version": "2.0.6"
-        },
-        "through2": {
-          "version": "2.0.1"
-        }
-      }
+      "dev": true
     },
     "conventional-changelog-ember": {
-      "version": "0.2.2"
+      "version": "0.2.2",
+      "dev": true
     },
     "conventional-changelog-eslint": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "conventional-changelog-express": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "conventional-changelog-jquery": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "conventional-changelog-jscs": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "conventional-changelog-jshint": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "conventional-changelog-writer": {
       "version": "1.4.1",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "lodash": {
-          "version": "4.14.2"
-        },
-        "readable-stream": {
-          "version": "2.0.6"
-        },
-        "through2": {
-          "version": "2.0.1"
-        }
-      }
+      "dev": true
     },
     "conventional-commits-filter": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "conventional-commits-parser": {
-      "version": "1.2.3",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "lodash": {
-          "version": "4.14.2"
-        },
-        "readable-stream": {
-          "version": "2.0.6"
-        },
-        "through2": {
-          "version": "2.0.1"
-        }
-      }
+      "version": "1.3.0",
+      "dev": true
     },
     "cookie": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "dev": true
     },
     "cookie-parser": {
-      "version": "1.3.5"
+      "version": "1.3.5",
+      "dev": true
     },
     "cookie-signature": {
-      "version": "1.0.6"
+      "version": "1.0.6",
+      "dev": true
     },
     "core-js": {
       "version": "2.4.1"
     },
     "core-util-is": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "cors": {
-      "version": "2.7.1"
+      "version": "2.8.1",
+      "dev": true
     },
     "crc": {
-      "version": "3.3.0"
+      "version": "3.4.4",
+      "dev": true
     },
     "crc32-stream": {
-      "version": "0.3.4",
+      "version": "1.0.1",
+      "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "1.0.33"
+          "version": "2.2.2",
+          "dev": true
         }
       }
     },
     "create-error-class": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "dev": true
     },
     "cryptiles": {
-      "version": "2.0.5"
+      "version": "2.0.5",
+      "dev": true
     },
     "crypto-browserify": {
-      "version": "3.2.8"
+      "version": "3.3.0",
+      "dev": true
     },
     "csrf": {
-      "version": "3.0.0"
+      "version": "3.0.4",
+      "dev": true
     },
     "csurf": {
-      "version": "1.8.3"
+      "version": "1.8.3",
+      "dev": true
     },
     "ctype": {
-      "version": "0.5.3"
+      "version": "0.5.3",
+      "dev": true
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "dev": true
     },
     "custom-event": {
-      "version": "1.0.0"
+      "version": "1.0.1",
+      "dev": true
     },
     "d": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "dev": true
     },
     "dargs": {
-      "version": "4.1.0"
+      "version": "4.1.0",
+      "dev": true
     },
     "dashdash": {
-      "version": "1.14.0",
+      "version": "1.14.1",
+      "dev": true,
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "dev": true
         }
       }
     },
     "date-now": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "dev": true
     },
     "dateformat": {
-      "version": "1.0.12"
+      "version": "1.0.12",
+      "dev": true
     },
     "debug": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "dev": true
     },
     "decamelize": {
-      "version": "1.1.2"
+      "version": "1.2.0",
+      "dev": true
     },
     "deep-extend": {
-      "version": "0.4.1"
+      "version": "0.4.1",
+      "dev": true
     },
     "defaults": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "dev": true
+    },
+    "defined": {
+      "version": "1.0.0",
+      "dev": true
     },
     "del": {
-      "version": "2.2.2"
+      "version": "2.2.2",
+      "dev": true
     },
     "delayed-stream": {
-      "version": "1.0.0"
+      "version": "0.0.5",
+      "dev": true
     },
     "depd": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "deprecated": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true
     },
     "destroy": {
-      "version": "1.0.3"
+      "version": "1.0.4",
+      "dev": true
+    },
+    "detect-file": {
+      "version": "0.1.0",
+      "dev": true
+    },
+    "detective": {
+      "version": "4.3.2",
+      "dev": true,
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "dev": true
+        }
+      }
     },
     "di": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true
     },
     "diff": {
-      "version": "2.2.1"
+      "version": "2.2.3",
+      "dev": true
     },
     "doctrine": {
-      "version": "0.7.2"
+      "version": "0.7.2",
+      "dev": true,
+      "dependencies": {
+        "esutils": {
+          "version": "1.1.6",
+          "dev": true
+        }
+      }
     },
     "dom-serialize": {
-      "version": "2.2.1"
+      "version": "2.2.1",
+      "dev": true
     },
     "domain-browser": {
-      "version": "1.1.7"
+      "version": "1.1.7",
+      "dev": true
     },
     "dot-prop": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "duplexer": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "dev": true
     },
     "duplexer2": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "dev": true
+        }
+      }
     },
     "ecc-jsbn": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "dev": true,
+      "optional": true
     },
     "ee-first": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "dev": true
     },
     "end-of-stream": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dev": true,
+      "dependencies": {
+        "once": {
+          "version": "1.3.3",
+          "dev": true
+        }
+      }
     },
     "engine.io": {
-      "version": "1.6.9",
+      "version": "1.8.2",
+      "dev": true,
       "dependencies": {
         "accepts": {
-          "version": "1.1.4"
+          "version": "1.3.3",
+          "dev": true
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.3.3",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "dev": true
         },
         "negotiator": {
-          "version": "0.4.9"
-        },
-        "ws": {
-          "version": "1.0.1"
+          "version": "0.6.1",
+          "dev": true
         }
       }
     },
     "engine.io-client": {
-      "version": "1.6.9",
+      "version": "1.8.2",
+      "dev": true,
       "dependencies": {
-        "ws": {
-          "version": "1.0.1"
+        "component-emitter": {
+          "version": "1.2.1",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.3.3",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "dev": true
         }
       }
     },
     "engine.io-parser": {
-      "version": "1.2.4",
-      "dependencies": {
-        "has-binary": {
-          "version": "0.1.6"
-        }
-      }
+      "version": "1.3.2",
+      "dev": true
     },
     "enhanced-resolve": {
       "version": "0.9.1",
+      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2"
+          "version": "4.1.11",
+          "dev": true
         },
         "memory-fs": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "dev": true
         }
       }
     },
     "ent": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "dev": true
     },
     "envify": {
-      "version": "3.4.0"
+      "version": "3.4.1",
+      "dev": true
     },
     "errno": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "dev": true
     },
     "error-ex": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "dev": true
     },
     "errorhandler": {
-      "version": "1.4.2"
+      "version": "1.4.3",
+      "dev": true,
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.3",
+          "dev": true
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "dev": true
+        }
+      }
     },
     "es5-ext": {
-      "version": "0.10.11"
+      "version": "0.10.12",
+      "dev": true
     },
     "es6-iterator": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "es6-module-loader": {
-      "version": "0.17.9"
+      "version": "0.17.11",
+      "dev": true
     },
     "es6-symbol": {
-      "version": "3.0.2"
+      "version": "3.1.0",
+      "dev": true
     },
     "es6-weak-map": {
       "version": "0.1.4",
+      "dev": true,
       "dependencies": {
         "es6-iterator": {
-          "version": "0.1.3"
+          "version": "0.1.3",
+          "dev": true
         },
         "es6-symbol": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "dev": true
         }
       }
     },
     "escape-html": {
-      "version": "1.0.2"
+      "version": "1.0.3",
+      "dev": true
     },
     "escape-string-regexp": {
-      "version": "1.0.4"
+      "version": "1.0.5",
+      "dev": true
     },
-    "esprima": {
-      "version": "2.7.1"
+    "esprima-fb": {
+      "version": "15001.1.0-dev-harmony-fb",
+      "dev": true
     },
     "estree-walker": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "dev": true
     },
     "esutils": {
-      "version": "1.1.6"
+      "version": "2.0.2",
+      "dev": true
     },
     "etag": {
-      "version": "1.7.0"
+      "version": "1.7.0",
+      "dev": true
     },
     "event-emitter": {
-      "version": "0.3.4"
+      "version": "0.3.4",
+      "dev": true
     },
     "event-stream": {
-      "version": "3.3.2",
+      "version": "3.3.4",
+      "dev": true,
       "dependencies": {
         "split": {
-          "version": "0.3.3"
+          "version": "0.3.3",
+          "dev": true
         }
       }
     },
     "eventemitter3": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "dev": true
     },
     "events": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "exit": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "dev": true
     },
     "expand-braces": {
       "version": "0.1.2",
+      "dev": true,
       "dependencies": {
         "braces": {
-          "version": "0.1.5"
+          "version": "0.1.5",
+          "dev": true
         },
         "expand-range": {
-          "version": "0.1.1"
+          "version": "0.1.1",
+          "dev": true
         },
         "is-number": {
-          "version": "0.1.1"
+          "version": "0.1.1",
+          "dev": true
         },
         "repeat-string": {
-          "version": "0.2.2"
+          "version": "0.2.2",
+          "dev": true
         }
       }
     },
     "expand-brackets": {
-      "version": "0.1.4"
+      "version": "0.1.5",
+      "dev": true
     },
     "expand-range": {
-      "version": "1.8.1"
+      "version": "1.8.2",
+      "dev": true
+    },
+    "expand-tilde": {
+      "version": "1.2.2",
+      "dev": true
     },
     "express-session": {
-      "version": "1.11.3"
-    },
-    "extend": {
-      "version": "3.0.0"
-    },
-    "extglob": {
-      "version": "0.3.1"
-    },
-    "extsprintf": {
-      "version": "1.0.2"
-    },
-    "fancy-log": {
-      "version": "1.1.0",
+      "version": "1.11.3",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0"
+        "base64-url": {
+          "version": "1.2.1",
+          "dev": true
         },
-        "ansi-styles": {
-          "version": "2.1.0"
+        "crc": {
+          "version": "3.3.0",
+          "dev": true
         },
-        "chalk": {
-          "version": "1.1.1"
-        },
-        "has-ansi": {
-          "version": "2.0.0"
-        },
-        "strip-ansi": {
-          "version": "3.0.0"
-        },
-        "supports-color": {
-          "version": "2.0.0"
+        "uid-safe": {
+          "version": "2.0.0",
+          "dev": true
         }
       }
     },
+    "extend": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "fancy-log": {
+      "version": "1.3.0",
+      "dev": true
+    },
     "faye-websocket": {
-      "version": "0.10.0"
+      "version": "0.10.0",
+      "dev": true
     },
     "fbjs": {
-      "version": "0.6.0",
+      "version": "0.6.1",
+      "dev": true,
       "dependencies": {
         "core-js": {
-          "version": "1.2.6"
+          "version": "1.2.7",
+          "dev": true
         }
       }
     },
     "filename-regex": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "fill-range": {
-      "version": "2.2.3"
+      "version": "2.2.3",
+      "dev": true
     },
     "filled-array": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dev": true
     },
     "finalhandler": {
-      "version": "0.4.0"
-    },
-    "find-index": {
-      "version": "0.1.1"
-    },
-    "find-up": {
-      "version": "1.1.0"
-    },
-    "findup-sync": {
-      "version": "0.3.0",
+      "version": "0.4.0",
+      "dev": true,
       "dependencies": {
-        "glob": {
-          "version": "5.0.15"
+        "escape-html": {
+          "version": "1.0.2",
+          "dev": true
         }
       }
     },
+    "find-index": {
+      "version": "0.1.1",
+      "dev": true
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "dev": true
+    },
+    "findup-sync": {
+      "version": "0.4.3",
+      "dev": true
+    },
+    "fined": {
+      "version": "1.0.2",
+      "dev": true
+    },
     "firefox-profile": {
-      "version": "0.3.11",
+      "version": "0.3.13",
+      "dev": true,
       "dependencies": {
-        "async": {
-          "version": "0.9.2"
-        },
         "fs-extra": {
-          "version": "0.16.5"
+          "version": "0.28.0",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "dev": true
         },
         "lodash": {
-          "version": "3.5.0"
+          "version": "4.11.2",
+          "dev": true
         }
       }
     },
     "first-chunk-stream": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "flagged-respawn": {
-      "version": "0.3.1"
+      "version": "0.3.2",
+      "dev": true
     },
     "for-in": {
-      "version": "0.1.4"
+      "version": "0.1.6",
+      "dev": true
     },
     "for-own": {
-      "version": "0.1.3"
+      "version": "0.1.4",
+      "dev": true
     },
     "forever-agent": {
-      "version": "0.6.1"
+      "version": "0.6.1",
+      "dev": true
     },
     "form-data": {
-      "version": "2.1.2",
+      "version": "0.2.0",
+      "dev": true,
       "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "dev": true
+        },
         "mime-db": {
-          "version": "1.24.0"
+          "version": "1.12.0",
+          "dev": true
         },
         "mime-types": {
-          "version": "2.1.12"
+          "version": "2.0.14",
+          "dev": true
         }
       }
     },
     "fresh": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "dev": true
     },
     "from": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "dev": true
     },
     "fs-access": {
-      "version": "1.0.0"
+      "version": "1.0.1",
+      "dev": true
+    },
+    "fs-exists-sync": {
+      "version": "0.1.0",
+      "dev": true
     },
     "fs-extra": {
-      "version": "0.26.3",
+      "version": "0.26.7",
+      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2"
+          "version": "4.1.11",
+          "dev": true
         }
       }
     },
     "fs-promise": {
-      "version": "0.3.1"
+      "version": "0.3.1",
+      "dev": true
     },
     "fs.realpath": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "fsevents": {
-      "version": "1.0.14",
+      "version": "1.0.17",
+      "optional": true,
       "dependencies": {
         "abbrev": {
-          "version": "1.0.9"
+          "version": "1.0.9",
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.0.0"
         },
         "ansi-styles": {
-          "version": "2.2.1"
+          "version": "2.2.1",
+          "optional": true
         },
         "aproba": {
-          "version": "1.0.4"
+          "version": "1.0.4",
+          "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.2"
+          "version": "1.1.2",
+          "optional": true
         },
         "asn1": {
-          "version": "0.2.3"
+          "version": "0.2.3",
+          "optional": true
         },
         "assert-plus": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "optional": true
         },
-        "async": {
-          "version": "1.5.2"
+        "asynckit": {
+          "version": "0.4.0",
+          "optional": true
         },
         "aws-sign2": {
-          "version": "0.6.0"
+          "version": "0.6.0",
+          "optional": true
         },
         "aws4": {
-          "version": "1.4.1"
+          "version": "1.5.0",
+          "optional": true
         },
-        "bl": {
-          "version": "1.1.2",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.6"
-            }
-          }
+        "balanced-match": {
+          "version": "0.4.2"
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.0",
+          "optional": true
         },
         "block-stream": {
           "version": "0.0.9"
@@ -2138,23 +1337,38 @@
         "boom": {
           "version": "2.10.1"
         },
+        "brace-expansion": {
+          "version": "1.1.6"
+        },
         "buffer-shims": {
           "version": "1.0.0"
         },
         "caseless": {
-          "version": "0.11.0"
+          "version": "0.11.0",
+          "optional": true
         },
         "chalk": {
-          "version": "1.1.3"
+          "version": "1.1.3",
+          "optional": true,
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "optional": true
+            }
+          }
         },
         "code-point-at": {
-          "version": "1.0.0"
+          "version": "1.1.0"
         },
         "combined-stream": {
           "version": "1.0.5"
         },
         "commander": {
-          "version": "2.9.0"
+          "version": "2.9.0",
+          "optional": true
+        },
+        "concat-map": {
+          "version": "0.0.1"
         },
         "console-control-strings": {
           "version": "1.1.0"
@@ -2163,45 +1377,56 @@
           "version": "1.0.2"
         },
         "cryptiles": {
-          "version": "2.0.5"
+          "version": "2.0.5",
+          "optional": true
         },
         "dashdash": {
-          "version": "1.14.0",
+          "version": "1.14.1",
+          "optional": true,
           "dependencies": {
             "assert-plus": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "optional": true
             }
           }
         },
         "debug": {
-          "version": "2.2.0"
+          "version": "2.2.0",
+          "optional": true
         },
         "deep-extend": {
-          "version": "0.4.1"
+          "version": "0.4.1",
+          "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0"
         },
         "delegates": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "optional": true
         },
         "ecc-jsbn": {
-          "version": "0.1.1"
+          "version": "0.1.1",
+          "optional": true
         },
         "escape-string-regexp": {
-          "version": "1.0.5"
+          "version": "1.0.5",
+          "optional": true
         },
         "extend": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "optional": true
         },
         "extsprintf": {
           "version": "1.0.2"
         },
         "forever-agent": {
-          "version": "0.6.1"
+          "version": "0.6.1",
+          "optional": true
         },
         "form-data": {
-          "version": "1.0.0-rc4"
+          "version": "2.1.2",
+          "optional": true
         },
         "fs.realpath": {
           "version": "1.0.0"
@@ -2210,105 +1435,128 @@
           "version": "1.0.10"
         },
         "fstream-ignore": {
-          "version": "1.0.5"
+          "version": "1.0.5",
+          "optional": true
         },
         "gauge": {
-          "version": "2.6.0"
+          "version": "2.7.2",
+          "optional": true
         },
         "generate-function": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "optional": true
         },
         "generate-object-property": {
-          "version": "1.2.0"
+          "version": "1.2.0",
+          "optional": true
         },
         "getpass": {
           "version": "0.1.6",
+          "optional": true,
           "dependencies": {
             "assert-plus": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "optional": true
             }
           }
         },
         "glob": {
-          "version": "7.0.5"
+          "version": "7.1.1"
         },
         "graceful-fs": {
-          "version": "4.1.4"
+          "version": "4.1.11"
         },
         "graceful-readlink": {
-          "version": "1.0.1"
+          "version": "1.0.1",
+          "optional": true
         },
         "har-validator": {
-          "version": "2.0.6"
+          "version": "2.0.6",
+          "optional": true
         },
         "has-ansi": {
-          "version": "2.0.0"
-        },
-        "has-color": {
-          "version": "0.1.7"
+          "version": "2.0.0",
+          "optional": true
         },
         "has-unicode": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "optional": true
         },
         "hawk": {
-          "version": "3.1.3"
+          "version": "3.1.3",
+          "optional": true
         },
         "hoek": {
           "version": "2.16.3"
         },
         "http-signature": {
-          "version": "1.1.1"
+          "version": "1.1.1",
+          "optional": true
         },
         "inflight": {
-          "version": "1.0.5"
+          "version": "1.0.6"
         },
         "inherits": {
-          "version": "2.0.1"
+          "version": "2.0.3"
         },
         "ini": {
-          "version": "1.3.4"
+          "version": "1.3.4",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0"
         },
         "is-my-json-valid": {
-          "version": "2.13.1"
+          "version": "2.15.0",
+          "optional": true
         },
         "is-property": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "optional": true
         },
         "is-typedarray": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "optional": true
         },
         "isarray": {
           "version": "1.0.0"
         },
         "isstream": {
-          "version": "0.1.2"
+          "version": "0.1.2",
+          "optional": true
         },
         "jodid25519": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "optional": true
         },
         "jsbn": {
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "optional": true
         },
         "json-schema": {
-          "version": "0.2.2"
+          "version": "0.2.3",
+          "optional": true
         },
         "json-stringify-safe": {
-          "version": "5.0.1"
+          "version": "5.0.1",
+          "optional": true
         },
         "jsonpointer": {
-          "version": "2.0.0"
+          "version": "4.0.1",
+          "optional": true
         },
         "jsprim": {
-          "version": "1.3.0"
+          "version": "1.3.1",
+          "optional": true
         },
         "mime-db": {
-          "version": "1.23.0"
+          "version": "1.25.0"
         },
         "mime-types": {
-          "version": "2.1.11"
+          "version": "2.1.13"
+        },
+        "minimatch": {
+          "version": "3.0.3"
         },
         "minimist": {
           "version": "0.0.8"
@@ -2317,84 +1565,101 @@
           "version": "0.5.1"
         },
         "ms": {
-          "version": "0.7.1"
-        },
-        "nan": {
-          "version": "2.4.0"
+          "version": "0.7.1",
+          "optional": true
         },
         "node-pre-gyp": {
-          "version": "0.6.29"
-        },
-        "node-uuid": {
-          "version": "1.4.7"
+          "version": "0.6.32",
+          "optional": true
         },
         "nopt": {
-          "version": "3.0.6"
+          "version": "3.0.6",
+          "optional": true
         },
         "npmlog": {
-          "version": "3.1.2"
+          "version": "4.0.2",
+          "optional": true
         },
         "number-is-nan": {
-          "version": "1.0.0"
+          "version": "1.0.1"
         },
         "oauth-sign": {
-          "version": "0.8.2"
+          "version": "0.8.2",
+          "optional": true
         },
         "object-assign": {
-          "version": "4.1.0"
+          "version": "4.1.0",
+          "optional": true
         },
         "once": {
-          "version": "1.3.3"
+          "version": "1.4.0"
         },
         "path-is-absolute": {
-          "version": "1.0.0"
+          "version": "1.0.1"
         },
         "pinkie": {
-          "version": "2.0.4"
+          "version": "2.0.4",
+          "optional": true
         },
         "pinkie-promise": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7"
         },
+        "punycode": {
+          "version": "1.4.1",
+          "optional": true
+        },
         "qs": {
-          "version": "6.2.0"
+          "version": "6.3.0",
+          "optional": true
         },
         "rc": {
           "version": "1.1.6",
+          "optional": true,
           "dependencies": {
             "minimist": {
-              "version": "1.2.0"
+              "version": "1.2.0",
+              "optional": true
             }
           }
         },
         "readable-stream": {
-          "version": "2.1.4"
+          "version": "2.2.2",
+          "optional": true
         },
         "request": {
-          "version": "2.73.0"
+          "version": "2.79.0",
+          "optional": true
         },
         "rimraf": {
-          "version": "2.5.3"
+          "version": "2.5.4"
         },
         "semver": {
-          "version": "5.2.0"
+          "version": "5.3.0",
+          "optional": true
         },
         "set-blocking": {
-          "version": "2.0.0"
+          "version": "2.0.0",
+          "optional": true
         },
         "signal-exit": {
-          "version": "3.0.0"
+          "version": "3.0.2",
+          "optional": true
         },
         "sntp": {
-          "version": "1.0.9"
+          "version": "1.0.9",
+          "optional": true
         },
         "sshpk": {
-          "version": "1.8.3",
+          "version": "1.10.1",
+          "optional": true,
           "dependencies": {
             "assert-plus": {
-              "version": "1.0.0"
+              "version": "1.0.0",
+              "optional": true
             }
           }
         },
@@ -2402,972 +1667,1242 @@
           "version": "0.10.31"
         },
         "string-width": {
-          "version": "1.0.1"
+          "version": "1.0.2"
         },
         "stringstream": {
-          "version": "0.0.5"
+          "version": "0.0.5",
+          "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1"
         },
         "strip-json-comments": {
-          "version": "1.0.4"
+          "version": "1.0.4",
+          "optional": true
         },
         "supports-color": {
-          "version": "2.0.0"
+          "version": "0.2.0",
+          "optional": true
         },
         "tar": {
           "version": "2.2.1"
         },
         "tar-pack": {
-          "version": "3.1.4"
+          "version": "3.3.0",
+          "optional": true,
+          "dependencies": {
+            "once": {
+              "version": "1.3.3",
+              "optional": true
+            },
+            "readable-stream": {
+              "version": "2.1.5",
+              "optional": true
+            }
+          }
         },
         "tough-cookie": {
-          "version": "2.2.2"
+          "version": "2.3.2",
+          "optional": true
         },
         "tunnel-agent": {
-          "version": "0.4.3"
+          "version": "0.4.3",
+          "optional": true
         },
         "tweetnacl": {
-          "version": "0.13.3"
+          "version": "0.14.5",
+          "optional": true
         },
         "uid-number": {
-          "version": "0.0.6"
+          "version": "0.0.6",
+          "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2"
         },
+        "uuid": {
+          "version": "3.0.1",
+          "optional": true
+        },
         "verror": {
-          "version": "1.3.6"
+          "version": "1.3.6",
+          "optional": true
         },
         "wide-align": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "optional": true
         },
         "wrappy": {
           "version": "1.0.2"
         },
         "xtend": {
-          "version": "4.0.1"
+          "version": "4.0.1",
+          "optional": true
         }
       }
     },
     "fstream": {
-      "version": "0.1.31"
+      "version": "0.1.31",
+      "dev": true
     },
     "fx-runner": {
       "version": "0.0.7",
+      "dev": true,
       "dependencies": {
-        "commander": {
-          "version": "2.6.0"
-        },
         "lodash": {
-          "version": "2.4.1"
+          "version": "2.4.1",
+          "dev": true
         },
         "when": {
-          "version": "3.6.4"
+          "version": "3.6.4",
+          "dev": true
         }
       }
     },
     "gaze": {
-      "version": "0.5.2"
+      "version": "0.5.2",
+      "dev": true
     },
     "generate-function": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "generate-object-property": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "dev": true
     },
     "get-pkg-repo": {
-      "version": "1.2.1",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "readable-stream": {
-          "version": "2.0.6"
-        },
-        "through2": {
-          "version": "2.0.1"
-        }
-      }
+      "version": "1.3.0",
+      "dev": true
     },
     "get-stdin": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "dev": true
     },
     "getpass": {
       "version": "0.1.6",
+      "dev": true,
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "dev": true
         }
       }
     },
     "git-raw-commits": {
       "version": "1.1.2",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "lodash.template": {
-          "version": "4.3.0"
-        },
-        "lodash.templatesettings": {
-          "version": "4.1.0"
-        },
-        "readable-stream": {
-          "version": "2.0.6"
-        },
-        "through2": {
-          "version": "2.0.1"
-        }
-      }
+      "dev": true
     },
     "git-remote-origin-url": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "git-semver-tags": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "dev": true
     },
     "gitconfiglocal": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "github-url-from-git": {
-      "version": "1.4.0"
+      "version": "1.5.0",
+      "dev": true
     },
     "glob": {
       "version": "4.5.3",
+      "dev": true,
       "dependencies": {
         "minimatch": {
-          "version": "2.0.10"
+          "version": "2.0.10",
+          "dev": true
         }
       }
     },
     "glob-base": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "dev": true
     },
     "glob-parent": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "glob-stream": {
       "version": "3.1.18",
+      "dev": true,
       "dependencies": {
         "minimatch": {
-          "version": "2.0.10"
+          "version": "2.0.10",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.6.5",
+          "dev": true
         }
       }
     },
     "glob-watcher": {
-      "version": "0.0.6"
+      "version": "0.0.6",
+      "dev": true
     },
     "glob2base": {
-      "version": "0.0.12"
+      "version": "0.0.12",
+      "dev": true
+    },
+    "global-modules": {
+      "version": "0.2.3",
+      "dev": true
+    },
+    "global-prefix": {
+      "version": "0.1.5",
+      "dev": true
     },
     "globby": {
       "version": "5.0.0",
+      "dev": true,
       "dependencies": {
         "glob": {
-          "version": "7.1.1"
+          "version": "7.1.1",
+          "dev": true
         }
       }
     },
     "globule": {
       "version": "0.1.0",
+      "dev": true,
       "dependencies": {
         "glob": {
-          "version": "3.1.21"
+          "version": "3.1.21",
+          "dev": true
         },
         "graceful-fs": {
-          "version": "1.2.3"
+          "version": "1.2.3",
+          "dev": true
         },
         "inherits": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "dev": true
         },
         "lodash": {
-          "version": "1.0.2"
+          "version": "1.0.2",
+          "dev": true
         },
         "minimatch": {
           "version": "0.2.14",
-          "dependencies": {
-            "lru-cache": {
-              "version": "2.7.3"
-            },
-            "sigmund": {
-              "version": "1.0.1"
-            }
-          }
+          "dev": true
         }
       }
     },
     "glogg": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "got": {
       "version": "5.7.1",
+      "dev": true,
       "dependencies": {
         "duplexer2": {
-          "version": "0.1.4"
+          "version": "0.1.4",
+          "dev": true
         },
         "isarray": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "dev": true
         },
         "readable-stream": {
-          "version": "2.2.2"
+          "version": "2.2.2",
+          "dev": true
         }
       }
     },
     "graceful-fs": {
-      "version": "3.0.8"
+      "version": "3.0.11",
+      "dev": true
     },
     "graceful-readlink": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "gulp": {
-      "version": "3.9.0",
+      "version": "3.9.1",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0"
-        },
-        "ansi-styles": {
-          "version": "2.1.0"
-        },
-        "chalk": {
-          "version": "1.1.1"
-        },
-        "has-ansi": {
-          "version": "2.0.0"
-        },
         "semver": {
-          "version": "4.3.6"
-        },
-        "strip-ansi": {
-          "version": "3.0.0"
-        },
-        "supports-color": {
-          "version": "2.0.0"
+          "version": "4.3.6",
+          "dev": true
         }
       }
     },
     "gulp-clang-format": {
       "version": "1.0.23",
+      "dev": true,
       "dependencies": {
-        "duplexer2": {
-          "version": "0.1.4"
-        },
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "readable-stream": {
-          "version": "2.1.4",
-          "dependencies": {
-            "buffer-shims": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "stream-combiner2": {
-          "version": "1.1.1"
+        "through2": {
+          "version": "0.6.5",
+          "dev": true
         }
       }
     },
     "gulp-connect": {
       "version": "2.3.1",
-      "dependencies": {
-        "connect": {
-          "version": "2.30.2"
-        }
-      }
+      "dev": true
     },
     "gulp-conventional-changelog": {
       "version": "1.1.0",
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.5.1"
-        },
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "readable-stream": {
-          "version": "2.0.6"
-        },
-        "through2": {
-          "version": "2.0.1"
-        }
-      }
+      "dev": true
     },
     "gulp-diff": {
       "version": "1.0.0",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "readable-stream": {
-          "version": "2.0.6"
-        },
-        "through2": {
-          "version": "2.0.1"
-        }
-      }
+      "dev": true
     },
     "gulp-tslint": {
-      "version": "7.0.1"
+      "version": "7.0.1",
+      "dev": true
     },
     "gulp-util": {
-      "version": "3.0.7",
+      "version": "3.0.8",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0"
+        "dateformat": {
+          "version": "2.0.0",
+          "dev": true
         },
-        "ansi-styles": {
-          "version": "2.1.0"
+        "lodash.template": {
+          "version": "3.6.2",
+          "dev": true
         },
-        "chalk": {
-          "version": "1.1.1"
-        },
-        "has-ansi": {
-          "version": "2.0.0"
+        "lodash.templatesettings": {
+          "version": "3.1.1",
+          "dev": true
         },
         "object-assign": {
-          "version": "3.0.0"
-        },
-        "readable-stream": {
-          "version": "2.0.5"
-        },
-        "strip-ansi": {
-          "version": "3.0.0"
-        },
-        "supports-color": {
-          "version": "2.0.0"
-        },
-        "through2": {
-          "version": "2.0.0"
-        },
-        "vinyl": {
-          "version": "0.5.3"
+          "version": "3.0.0",
+          "dev": true
         }
       }
     },
     "gulplog": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "hammerjs": {
-      "version": "2.0.8"
+      "version": "2.0.8",
+      "dev": true
     },
     "handlebars": {
-      "version": "4.0.5",
+      "version": "4.0.6",
+      "dev": true,
       "dependencies": {
-        "async": {
-          "version": "1.5.2"
+        "camelcase": {
+          "version": "1.2.1",
+          "dev": true,
+          "optional": true
         },
         "source-map": {
           "version": "0.4.4",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.7.5",
+          "dev": true,
+          "optional": true,
           "dependencies": {
-            "amdefine": {
-              "version": "1.0.1"
+            "async": {
+              "version": "0.2.10",
+              "dev": true,
+              "optional": true
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "dev": true,
+              "optional": true
             }
           }
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "dev": true,
+          "optional": true
         }
       }
     },
     "har-validator": {
-      "version": "2.0.6",
+      "version": "1.8.0",
+      "dev": true,
       "dependencies": {
-        "is-my-json-valid": {
-          "version": "2.15.0"
-        },
-        "jsonpointer": {
-          "version": "4.0.0"
+        "commander": {
+          "version": "2.9.0",
+          "dev": true
         }
       }
     },
     "has-ansi": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "has-binary": {
-      "version": "0.1.7"
+      "version": "0.1.7",
+      "dev": true
     },
     "has-cors": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dev": true
     },
     "has-flag": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "has-gulplog": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "hashish": {
-      "version": "0.0.4"
+      "version": "0.0.4",
+      "dev": true
     },
     "hawk": {
-      "version": "3.1.3"
+      "version": "2.3.1",
+      "dev": true
     },
     "hoek": {
-      "version": "2.16.3"
+      "version": "2.16.3",
+      "dev": true
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "dev": true
     },
     "hosted-git-info": {
-      "version": "2.1.4"
-    },
-    "http-browserify": {
-      "version": "1.7.0"
+      "version": "2.1.5",
+      "dev": true
     },
     "http-errors": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "dev": true
     },
     "http-proxy": {
-      "version": "1.13.3"
+      "version": "1.16.2",
+      "dev": true
     },
     "http-signature": {
-      "version": "1.1.1",
+      "version": "0.10.1",
+      "dev": true
+    },
+    "https-browserify": {
+      "version": "0.0.1",
+      "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.11",
+      "dev": true
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "dev": true
+    },
+    "incremental-dom": {
+      "version": "0.4.1",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.4",
+      "dev": true
+    },
+    "interpret": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "is-absolute": {
+      "version": "0.2.6",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.4",
+      "dev": true
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "is-dotfile": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "dev": true
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.15.0",
+      "dev": true
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "dev": true
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "is-relative": {
+      "version": "0.2.1",
+      "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "dev": true
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "dev": true
+    },
+    "is-text-path": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "is-unc-path": {
+      "version": "0.1.2",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "0.2.0",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "dev": true
+    },
+    "isbinaryfile": {
+      "version": "3.0.2",
+      "dev": true
+    },
+    "isexe": {
+      "version": "1.1.2",
+      "dev": true
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "dev": true,
       "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0"
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
         }
       }
     },
-    "https-browserify": {
-      "version": "0.0.0"
-    },
-    "https-proxy-agent": {
-      "version": "1.0.0"
-    },
-    "iconv-lite": {
-      "version": "0.4.11"
-    },
-    "ieee754": {
-      "version": "1.1.8"
-    },
-    "imurmurhash": {
-      "version": "0.1.4"
-    },
-    "incremental-dom": {
-      "version": "0.4.1"
-    },
-    "indent-string": {
-      "version": "2.1.0"
-    },
-    "indexof": {
-      "version": "0.0.1"
-    },
-    "inflight": {
-      "version": "1.0.5"
-    },
-    "inherits": {
-      "version": "2.0.1"
-    },
-    "ini": {
-      "version": "1.3.4"
-    },
-    "interpret": {
-      "version": "0.6.6"
-    },
-    "invert-kv": {
-      "version": "1.0.0"
-    },
-    "is-arrayish": {
-      "version": "0.2.1"
-    },
-    "is-binary-path": {
-      "version": "1.0.1"
-    },
-    "is-buffer": {
-      "version": "1.1.0"
-    },
-    "is-builtin-module": {
-      "version": "1.0.0"
-    },
-    "is-dotfile": {
-      "version": "1.0.2"
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3"
-    },
-    "is-extendable": {
-      "version": "0.1.1"
-    },
-    "is-extglob": {
-      "version": "1.0.0"
-    },
-    "is-finite": {
-      "version": "1.0.1"
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0"
-    },
-    "is-glob": {
-      "version": "2.0.1"
-    },
-    "is-my-json-valid": {
-      "version": "2.12.3"
-    },
-    "is-npm": {
-      "version": "1.0.0"
-    },
-    "is-number": {
-      "version": "2.1.0"
-    },
-    "is-obj": {
-      "version": "1.0.1"
-    },
-    "is-path-cwd": {
-      "version": "1.0.0"
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.0"
-    },
-    "is-path-inside": {
-      "version": "1.0.0"
-    },
-    "is-primitive": {
-      "version": "2.0.0"
-    },
-    "is-property": {
-      "version": "1.0.2"
-    },
-    "is-redirect": {
-      "version": "1.0.0"
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0"
-    },
-    "is-stream": {
-      "version": "1.1.0"
-    },
-    "is-subset": {
-      "version": "0.1.1"
-    },
-    "is-text-path": {
-      "version": "1.0.1"
-    },
-    "is-typedarray": {
-      "version": "1.0.0"
-    },
-    "is-utf8": {
-      "version": "0.2.1"
-    },
-    "isarray": {
-      "version": "0.0.1"
-    },
-    "isbinaryfile": {
-      "version": "3.0.0"
-    },
-    "isexe": {
-      "version": "1.1.2"
-    },
-    "isobject": {
-      "version": "2.0.0"
-    },
     "isstream": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "dev": true
     },
     "jasmine": {
-      "version": "2.4.1",
+      "version": "2.5.3",
+      "dev": true,
       "dependencies": {
         "glob": {
-          "version": "3.2.11"
-        },
-        "jasmine-core": {
-          "version": "2.4.1"
-        },
-        "minimatch": {
-          "version": "0.3.0"
+          "version": "7.1.1",
+          "dev": true
         }
       }
     },
     "jasmine-core": {
-      "version": "2.3.4"
+      "version": "2.5.2",
+      "dev": true
     },
     "jasminewd2": {
-      "version": "0.0.10"
+      "version": "0.0.10",
+      "dev": true
     },
     "jetpack-id": {
-      "version": "0.0.4"
+      "version": "1.0.0",
+      "dev": true
     },
     "jetpack-validation": {
       "version": "0.0.4",
+      "dev": true,
       "dependencies": {
+        "jetpack-id": {
+          "version": "0.0.4",
+          "dev": true
+        },
         "resolve": {
-          "version": "0.7.4"
+          "version": "0.7.4",
+          "dev": true
         },
         "semver": {
-          "version": "2.3.2"
+          "version": "2.3.2",
+          "dev": true
         }
       }
     },
     "jodid25519": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true,
+      "optional": true
     },
     "jpm": {
       "version": "1.0.0",
+      "dev": true,
       "dependencies": {
-        "async": {
-          "version": "0.9.2"
+        "archiver": {
+          "version": "0.14.4",
+          "dev": true,
+          "dependencies": {
+            "lodash": {
+              "version": "3.2.0",
+              "dev": true
+            }
+          }
         },
-        "commander": {
-          "version": "2.6.0"
+        "async": {
+          "version": "0.9.2",
+          "dev": true
+        },
+        "bl": {
+          "version": "0.9.5",
+          "dev": true
+        },
+        "compress-commons": {
+          "version": "0.2.9",
+          "dev": true
+        },
+        "crc32-stream": {
+          "version": "0.3.4",
+          "dev": true
         },
         "firefox-profile": {
           "version": "0.3.9",
+          "dev": true,
           "dependencies": {
             "lodash": {
-              "version": "3.5.0"
+              "version": "3.5.0",
+              "dev": true
             }
           }
         },
         "fs-extra": {
-          "version": "0.16.4"
+          "version": "0.16.4",
+          "dev": true
+        },
+        "glob": {
+          "version": "4.3.5",
+          "dev": true
+        },
+        "jetpack-id": {
+          "version": "0.0.4",
+          "dev": true
+        },
+        "lazystream": {
+          "version": "0.1.0",
+          "dev": true
         },
         "lodash": {
-          "version": "3.3.1"
+          "version": "3.3.1",
+          "dev": true
         },
         "minimatch": {
-          "version": "2.0.4"
-        },
-        "open": {
-          "version": "0.0.5"
+          "version": "2.0.4",
+          "dev": true
         },
         "semver": {
-          "version": "4.3.3"
+          "version": "4.3.3",
+          "dev": true
+        },
+        "tar-stream": {
+          "version": "1.1.5",
+          "dev": true
+        },
+        "zip-stream": {
+          "version": "0.5.2",
+          "dev": true,
+          "dependencies": {
+            "lodash": {
+              "version": "3.2.0",
+              "dev": true
+            }
+          }
         }
       }
     },
     "jpm-core": {
-      "version": "0.0.9"
+      "version": "0.0.9",
+      "dev": true
     },
     "js-tokens": {
-      "version": "1.0.2"
+      "version": "3.0.0",
+      "dev": true
     },
     "jsbn": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true,
+      "optional": true
     },
     "json-schema": {
-      "version": "0.2.3"
+      "version": "0.2.3",
+      "dev": true
     },
     "json-stringify-safe": {
-      "version": "5.0.1"
+      "version": "5.0.1",
+      "dev": true
     },
     "json3": {
-      "version": "3.2.6"
+      "version": "3.3.2",
+      "dev": true
     },
     "json5": {
-      "version": "0.4.0"
+      "version": "0.5.1",
+      "dev": true
     },
     "jsonfile": {
-      "version": "2.2.3"
+      "version": "2.4.0",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "jsonparse": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "dev": true
     },
     "jsonpointer": {
-      "version": "2.0.0"
+      "version": "4.0.1",
+      "dev": true
     },
     "JSONStream": {
-      "version": "1.0.7"
+      "version": "1.3.0",
+      "dev": true
     },
     "jsontoxml": {
-      "version": "0.0.11"
+      "version": "0.0.11",
+      "dev": true
     },
     "jsprim": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "dev": true
     },
     "jstransform": {
-      "version": "10.1.0",
+      "version": "11.0.3",
+      "dev": true,
       "dependencies": {
-        "esprima-fb": {
-          "version": "13001.1001.0-dev-harmony-fb"
+        "object-assign": {
+          "version": "2.1.1",
+          "dev": true
         },
         "source-map": {
-          "version": "0.1.31",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.1"
-            }
-          }
+          "version": "0.4.4",
+          "dev": true
         }
       }
     },
     "jszip": {
-      "version": "2.5.0"
+      "version": "2.6.1",
+      "dev": true
     },
     "karma": {
-      "version": "0.13.20",
+      "version": "0.13.22",
+      "dev": true,
       "dependencies": {
-        "batch": {
-          "version": "0.5.3"
+        "connect": {
+          "version": "3.5.0",
+          "dev": true
+        },
+        "finalhandler": {
+          "version": "0.5.0",
+          "dev": true
         },
         "glob": {
-          "version": "7.0.3"
+          "version": "7.1.1",
+          "dev": true
         },
         "graceful-fs": {
-          "version": "4.1.4"
+          "version": "4.1.11",
+          "dev": true
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "dev": true
         },
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.6",
+          "dev": true
         }
       }
     },
     "karma-browserstack-launcher": {
-      "version": "0.1.9"
+      "version": "0.1.11",
+      "dev": true
     },
     "karma-chrome-launcher": {
-      "version": "0.2.2"
+      "version": "0.2.3",
+      "dev": true
     },
     "karma-jasmine": {
-      "version": "0.3.6"
+      "version": "0.3.8",
+      "dev": true
     },
     "karma-sauce-launcher": {
-      "version": "0.3.0"
+      "version": "0.3.1",
+      "dev": true
     },
     "karma-sourcemap-loader": {
-      "version": "0.3.6"
+      "version": "0.3.7",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "dev": true
+        }
+      }
     },
     "kind-of": {
-      "version": "3.0.2"
+      "version": "3.1.0",
+      "dev": true
     },
     "klaw": {
-      "version": "1.1.3"
+      "version": "1.3.1",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "latest-version": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "lazy-cache": {
-      "version": "0.2.7"
+      "version": "1.0.4",
+      "dev": true
     },
     "lazy-req": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dev": true
     },
     "lazystream": {
-      "version": "0.1.0",
+      "version": "1.0.0",
+      "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "1.0.33"
+          "version": "2.2.2",
+          "dev": true
         }
       }
     },
     "lcid": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "liftoff": {
-      "version": "2.2.0",
-      "dependencies": {
-        "extend": {
-          "version": "2.0.1"
-        },
-        "findup-sync": {
-          "version": "0.3.0"
-        },
-        "glob": {
-          "version": "5.0.15"
-        }
-      }
+      "version": "2.3.0",
+      "dev": true
     },
     "livereload-js": {
-      "version": "2.2.2"
+      "version": "2.2.2",
+      "dev": true
     },
     "load-json-file": {
       "version": "1.1.0",
+      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2"
+          "version": "4.1.11",
+          "dev": true
         }
       }
     },
     "loader-utils": {
-      "version": "0.2.12"
+      "version": "0.2.16",
+      "dev": true
     },
     "lodash": {
-      "version": "3.10.1"
+      "version": "4.17.4",
+      "dev": true
     },
     "lodash._basecopy": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "lodash._basetostring": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "lodash._basevalues": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "lodash._getnative": {
-      "version": "3.9.1"
+      "version": "3.9.1",
+      "dev": true
     },
     "lodash._isiterateecall": {
-      "version": "3.0.9"
+      "version": "3.0.9",
+      "dev": true
     },
     "lodash._reescape": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "lodash._reevaluate": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "lodash._reinterpolate": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "dev": true
+    },
+    "lodash.assignwith": {
+      "version": "4.2.0",
+      "dev": true
     },
     "lodash.escape": {
-      "version": "3.0.0"
+      "version": "3.2.0",
+      "dev": true
     },
     "lodash.isarguments": {
-      "version": "3.0.4"
+      "version": "3.1.0",
+      "dev": true
     },
     "lodash.isarray": {
-      "version": "3.0.4"
+      "version": "3.0.4",
+      "dev": true
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "dev": true
     },
     "lodash.keys": {
-      "version": "3.1.2"
+      "version": "3.1.2",
+      "dev": true
+    },
+    "lodash.mapvalues": {
+      "version": "4.6.0",
+      "dev": true
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "dev": true
     },
     "lodash.restparam": {
-      "version": "3.6.1"
+      "version": "3.6.1",
+      "dev": true
     },
     "lodash.template": {
-      "version": "3.6.2"
+      "version": "4.4.0",
+      "dev": true
     },
     "lodash.templatesettings": {
-      "version": "3.1.0"
+      "version": "4.1.0",
+      "dev": true
     },
     "log4js": {
-      "version": "0.6.36",
+      "version": "0.6.38",
+      "dev": true,
       "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34"
-        },
         "semver": {
-          "version": "4.3.6"
+          "version": "4.3.6",
+          "dev": true
         }
       }
     },
     "longest": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "loose-envify": {
-      "version": "1.1.0"
+      "version": "1.3.1",
+      "dev": true
     },
     "loud-rejection": {
-      "version": "1.2.0"
+      "version": "1.6.0",
+      "dev": true
     },
     "lowercase-keys": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "lru-cache": {
-      "version": "2.7.3"
+      "version": "2.5.0",
+      "dev": true
     },
     "lru-queue": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "madge": {
       "version": "0.5.0",
+      "dev": true,
       "dependencies": {
         "amdetective": {
           "version": "0.0.2",
+          "dev": true,
           "dependencies": {
             "esprima": {
-              "version": "1.2.2"
+              "version": "1.2.2",
+              "dev": true
             }
           }
         },
         "coffee-script": {
-          "version": "1.3.3"
+          "version": "1.3.3",
+          "dev": true
         },
         "colors": {
-          "version": "0.6.0-1"
+          "version": "0.6.0-1",
+          "dev": true
         },
         "commander": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "dev": true
         },
         "commondir": {
-          "version": "0.0.1"
+          "version": "0.0.1",
+          "dev": true
         },
         "detective": {
-          "version": "0.1.1"
+          "version": "0.1.1",
+          "dev": true
         },
         "detective-es6": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "dev": true
         },
         "graphviz": {
           "version": "0.0.7",
+          "dev": true,
           "dependencies": {
             "temp": {
-              "version": "0.4.0"
+              "version": "0.4.0",
+              "dev": true
             }
           }
         },
         "react-tools": {
           "version": "0.12.1",
+          "dev": true,
           "dependencies": {
             "commoner": {
               "version": "0.10.1",
+              "dev": true,
               "dependencies": {
                 "commander": {
-                  "version": "2.5.1"
+                  "version": "2.5.1",
+                  "dev": true
                 },
                 "glob": {
                   "version": "4.2.2",
+                  "dev": true,
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
+                      "dev": true,
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1"
+                          "version": "1.0.1",
+                          "dev": true
                         }
                       }
                     },
                     "inherits": {
-                      "version": "2.0.1"
+                      "version": "2.0.1",
+                      "dev": true
                     },
                     "minimatch": {
                       "version": "1.0.0",
+                      "dev": true,
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.5.0"
+                          "version": "2.5.0",
+                          "dev": true
                         },
                         "sigmund": {
-                          "version": "1.0.0"
+                          "version": "1.0.0",
+                          "dev": true
                         }
                       }
                     },
                     "once": {
                       "version": "1.3.1",
+                      "dev": true,
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1"
+                          "version": "1.0.1",
+                          "dev": true
                         }
                       }
                     }
                   }
                 },
                 "graceful-fs": {
-                  "version": "3.0.5"
+                  "version": "3.0.5",
+                  "dev": true
                 },
                 "iconv-lite": {
-                  "version": "0.4.5"
+                  "version": "0.4.5",
+                  "dev": true
                 },
                 "install": {
-                  "version": "0.1.8"
+                  "version": "0.1.8",
+                  "dev": true
                 },
                 "mkdirp": {
                   "version": "0.5.0",
+                  "dev": true,
                   "dependencies": {
                     "minimist": {
-                      "version": "0.0.8"
+                      "version": "0.0.8",
+                      "dev": true
                     }
                   }
                 },
                 "private": {
-                  "version": "0.1.6"
+                  "version": "0.1.6",
+                  "dev": true
                 },
                 "q": {
-                  "version": "1.1.2"
+                  "version": "1.1.2",
+                  "dev": true
                 },
                 "recast": {
                   "version": "0.9.11",
+                  "dev": true,
                   "dependencies": {
                     "ast-types": {
-                      "version": "0.6.7"
+                      "version": "0.6.7",
+                      "dev": true
                     },
                     "esprima-fb": {
-                      "version": "8001.1001.0-dev-harmony-fb"
+                      "version": "8001.1001.0-dev-harmony-fb",
+                      "dev": true
                     },
                     "source-map": {
                       "version": "0.1.41",
+                      "dev": true,
                       "dependencies": {
                         "amdefine": {
-                          "version": "0.1.0"
+                          "version": "0.1.0",
+                          "dev": true
                         }
                       }
                     }
@@ -3377,18 +2912,23 @@
             },
             "jstransform": {
               "version": "8.2.0",
+              "dev": true,
               "dependencies": {
                 "base62": {
-                  "version": "0.1.1"
+                  "version": "0.1.1",
+                  "dev": true
                 },
                 "esprima-fb": {
-                  "version": "8001.1001.0-dev-harmony-fb"
+                  "version": "8001.1001.0-dev-harmony-fb",
+                  "dev": true
                 },
                 "source-map": {
                   "version": "0.1.31",
+                  "dev": true,
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.0"
+                      "version": "0.1.0",
+                      "dev": true
                     }
                   }
                 }
@@ -3397,1419 +2937,1826 @@
           }
         },
         "resolve": {
-          "version": "0.2.3"
+          "version": "0.2.3",
+          "dev": true
         },
         "uglify-js": {
-          "version": "1.2.6"
+          "version": "1.2.6",
+          "dev": true
         },
         "walkdir": {
-          "version": "0.0.5"
+          "version": "0.0.5",
+          "dev": true
         }
       }
     },
     "magic-string": {
-      "version": "0.16.0"
+      "version": "0.16.0",
+      "dev": true
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "dev": true
     },
     "map-obj": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "map-stream": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "match-stream": {
       "version": "0.0.2",
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.33"
-        }
-      }
+      "dev": true
     },
     "media-typer": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "dev": true
     },
     "memoizeasync": {
       "version": "0.8.0",
+      "dev": true,
       "dependencies": {
-        "lru-cache": {
-          "version": "2.5.0"
-        },
         "passerror": {
-          "version": "0.0.2"
+          "version": "0.0.2",
+          "dev": true
         }
       }
     },
     "memoizee": {
-      "version": "0.3.10"
+      "version": "0.3.10",
+      "dev": true
     },
     "memory-fs": {
       "version": "0.3.0",
+      "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "2.0.5"
+          "version": "2.2.2",
+          "dev": true
         }
       }
     },
     "meow": {
-      "version": "3.6.0"
+      "version": "3.7.0",
+      "dev": true
     },
     "method-override": {
-      "version": "2.3.5"
+      "version": "2.3.7",
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "dev": true
+        }
+      }
     },
     "methods": {
-      "version": "1.1.1"
+      "version": "1.1.2",
+      "dev": true
     },
     "micromatch": {
-      "version": "2.3.7"
+      "version": "2.3.11",
+      "dev": true
     },
     "mime": {
-      "version": "1.3.4"
+      "version": "1.3.4",
+      "dev": true
     },
     "mime-db": {
-      "version": "1.12.0"
+      "version": "1.26.0",
+      "dev": true
     },
     "mime-types": {
-      "version": "2.0.14"
+      "version": "2.1.14",
+      "dev": true
     },
     "minimatch": {
-      "version": "3.0.3"
+      "version": "3.0.3",
+      "dev": true
     },
     "minimist": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
+      "dev": true,
       "dependencies": {
         "minimist": {
-          "version": "0.0.8"
+          "version": "0.0.8",
+          "dev": true
         }
       }
     },
     "modify-values": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "morgan": {
-      "version": "1.6.1"
+      "version": "1.6.1",
+      "dev": true
     },
     "mozilla-toolkit-versioning": {
-      "version": "0.0.2"
+      "version": "0.0.2",
+      "dev": true
     },
     "mozilla-version-comparator": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "ms": {
-      "version": "0.7.1"
+      "version": "0.7.1",
+      "dev": true
     },
     "multiparty": {
-      "version": "3.3.2"
+      "version": "3.3.2",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "dev": true
+        }
+      }
     },
     "multipipe": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "dev": true
     },
     "mute-stream": {
-      "version": "0.0.5"
+      "version": "0.0.7",
+      "dev": true
     },
     "nan": {
-      "version": "2.4.0"
+      "version": "2.5.0"
+    },
+    "natives": {
+      "version": "1.1.0",
+      "dev": true
     },
     "negotiator": {
-      "version": "0.5.3"
+      "version": "0.5.3",
+      "dev": true
     },
     "next-tick": {
-      "version": "0.2.2"
+      "version": "0.2.2",
+      "dev": true
     },
     "node-int64": {
-      "version": "0.3.3"
+      "version": "0.3.3",
+      "dev": true
     },
     "node-libs-browser": {
-      "version": "0.6.0"
+      "version": "0.7.0",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "dev": true
+        }
+      }
     },
     "node-source-walk": {
-      "version": "1.4.2"
+      "version": "1.4.2",
+      "dev": true
     },
     "node-status-codes": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "node-uuid": {
-      "version": "1.4.7"
+      "version": "1.4.7",
+      "dev": true
     },
     "node-watch": {
-      "version": "0.3.4"
+      "version": "0.3.4",
+      "dev": true
     },
     "normalize-package-data": {
-      "version": "2.3.5"
+      "version": "2.3.5",
+      "dev": true
     },
     "normalize-path": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "dev": true
     },
     "null-check": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "number-is-nan": {
-      "version": "1.0.0"
+      "version": "1.0.1",
+      "dev": true
     },
     "oauth-sign": {
-      "version": "0.8.2"
+      "version": "0.6.0",
+      "dev": true
     },
     "object-assign": {
-      "version": "4.0.1"
+      "version": "4.1.0",
+      "dev": true
     },
     "object-component": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "dev": true
     },
     "object.omit": {
-      "version": "2.0.0"
+      "version": "2.0.1",
+      "dev": true
     },
     "on-finished": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "dev": true
     },
     "on-headers": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "once": {
-      "version": "1.3.3"
+      "version": "1.4.0",
+      "dev": true
+    },
+    "open": {
+      "version": "0.0.5",
+      "dev": true
     },
     "optimist": {
       "version": "0.6.1",
+      "dev": true,
       "dependencies": {
         "minimist": {
-          "version": "0.0.10"
+          "version": "0.0.10",
+          "dev": true
         }
       }
     },
     "options": {
-      "version": "0.0.6"
+      "version": "0.0.6",
+      "dev": true
     },
     "orchestrator": {
-      "version": "0.3.7",
+      "version": "0.3.8",
+      "dev": true,
       "dependencies": {
         "end-of-stream": {
-          "version": "0.1.5"
+          "version": "0.1.5",
+          "dev": true
+        },
+        "once": {
+          "version": "1.3.3",
+          "dev": true
         }
       }
     },
     "ordered-read-streams": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "os-browserify": {
-      "version": "0.1.2"
+      "version": "0.2.1",
+      "dev": true
     },
     "os-homedir": {
-      "version": "1.0.1"
+      "version": "1.0.2",
+      "dev": true
     },
     "os-locale": {
-      "version": "1.4.0"
+      "version": "1.4.0",
+      "dev": true
     },
     "os-tmpdir": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "osenv": {
-      "version": "0.1.3"
+      "version": "0.1.4",
+      "dev": true
     },
     "over": {
-      "version": "0.0.5"
+      "version": "0.0.5",
+      "dev": true
     },
     "package-json": {
-      "version": "2.4.0"
+      "version": "2.4.0",
+      "dev": true
     },
     "pako": {
-      "version": "0.2.8"
+      "version": "1.0.4",
+      "dev": true
+    },
+    "parse-filepath": {
+      "version": "1.0.1",
+      "dev": true
     },
     "parse-github-repo-url": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "dev": true
     },
     "parse-glob": {
-      "version": "3.0.4"
+      "version": "3.0.4",
+      "dev": true
     },
     "parse-json": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "dev": true
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "dev": true
     },
     "parse5": {
-      "version": "2.2.1"
+      "version": "2.2.3",
+      "dev": true
     },
     "parsejson": {
-      "version": "0.0.1"
+      "version": "0.0.3",
+      "dev": true
     },
     "parseqs": {
-      "version": "0.0.2"
+      "version": "0.0.5",
+      "dev": true
     },
     "parseuri": {
-      "version": "0.0.4"
+      "version": "0.0.5",
+      "dev": true
     },
     "parseurl": {
-      "version": "1.3.0"
+      "version": "1.3.1",
+      "dev": true
     },
     "passerror": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true
     },
     "path-browserify": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dev": true
     },
     "path-exists": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "path-is-absolute": {
-      "version": "1.0.0"
+      "version": "1.0.1",
+      "dev": true
     },
     "path-is-inside": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "dev": true
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "dev": true
     },
     "path-type": {
       "version": "1.1.0",
+      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2"
+          "version": "4.1.11",
+          "dev": true
         }
       }
     },
     "pause": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "pause-stream": {
-      "version": "0.0.11"
+      "version": "0.0.11",
+      "dev": true
     },
     "pbkdf2-compat": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "dev": true
     },
     "pegjs": {
-      "version": "0.9.0"
+      "version": "0.9.0",
+      "dev": true
     },
     "pify": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "dev": true
     },
     "pinkie": {
-      "version": "2.0.1"
+      "version": "2.0.4",
+      "dev": true
     },
     "pinkie-promise": {
-      "version": "2.0.0"
+      "version": "2.0.1",
+      "dev": true
     },
     "pkginfo": {
-      "version": "0.3.1"
+      "version": "0.3.1",
+      "dev": true
     },
     "prepend-http": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "dev": true
     },
     "preserve": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "dev": true
     },
     "pretty-hrtime": {
-      "version": "1.0.1"
+      "version": "1.0.3",
+      "dev": true
+    },
+    "private": {
+      "version": "0.1.6",
+      "dev": true
     },
     "process": {
-      "version": "0.11.9"
+      "version": "0.11.9",
+      "dev": true
     },
     "process-nextick-args": {
-      "version": "1.0.6"
+      "version": "1.0.7",
+      "dev": true
     },
     "promise": {
-      "version": "7.1.1"
+      "version": "7.1.1",
+      "dev": true
     },
     "promzard": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "dev": true
     },
     "protractor": {
-      "version": "4.0.11",
+      "version": "4.0.14",
+      "dev": true,
       "dependencies": {
-        "@types/jasmine": {
-          "version": "2.5.37"
-        },
         "@types/node": {
-          "version": "6.0.46"
+          "version": "6.0.60",
+          "dev": true
+        },
+        "@types/selenium-webdriver": {
+          "version": "2.53.37",
+          "dev": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.9.0",
+          "dev": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.1.2",
+          "dev": true
         },
         "glob": {
-          "version": "7.1.1"
+          "version": "7.1.1",
+          "dev": true
         },
-        "mime-db": {
-          "version": "1.24.0"
+        "har-validator": {
+          "version": "2.0.6",
+          "dev": true
         },
-        "mime-types": {
-          "version": "2.1.12"
+        "hawk": {
+          "version": "3.1.3",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "dev": true
+        },
+        "jasmine": {
+          "version": "2.4.1",
+          "dev": true,
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "dev": true
+            }
+          }
+        },
+        "jasmine-core": {
+          "version": "2.4.1",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "dev": true
         },
         "qs": {
-          "version": "6.3.0"
+          "version": "6.3.0",
+          "dev": true
         },
         "request": {
-          "version": "2.78.0"
+          "version": "2.79.0",
+          "dev": true
         },
-        "rimraf": {
-          "version": "2.5.4"
-        },
-        "saucelabs": {
-          "version": "1.3.0"
-        },
-        "semver": {
-          "version": "5.3.0"
-        },
-        "tough-cookie": {
-          "version": "2.3.2"
+        "uuid": {
+          "version": "3.0.1",
+          "dev": true
         },
         "webdriver-manager": {
-          "version": "10.2.8"
+          "version": "10.3.0",
+          "dev": true
         }
       }
     },
     "prr": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dev": true
     },
     "pullstream": {
       "version": "0.4.1",
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.33"
-        }
-      }
+      "dev": true
     },
     "punycode": {
-      "version": "1.4.1"
+      "version": "1.4.1",
+      "dev": true
     },
     "q": {
-      "version": "1.4.1"
+      "version": "1.4.1",
+      "dev": true
     },
     "qs": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "querystring": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "dev": true
     },
     "querystring-es3": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "dev": true
+    },
+    "random-bytes": {
+      "version": "1.0.0",
+      "dev": true
     },
     "randomatic": {
-      "version": "1.1.5"
+      "version": "1.1.6",
+      "dev": true
     },
     "range-parser": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "dev": true
     },
     "raw-body": {
-      "version": "2.1.5",
+      "version": "2.1.7",
+      "dev": true,
       "dependencies": {
         "bytes": {
-          "version": "2.2.0"
+          "version": "2.4.0",
+          "dev": true
         },
         "iconv-lite": {
-          "version": "0.4.13"
+          "version": "0.4.13",
+          "dev": true
         }
       }
     },
     "rc": {
-      "version": "1.1.6"
+      "version": "1.1.6",
+      "dev": true
     },
     "react": {
-      "version": "0.14.5"
+      "version": "0.14.8",
+      "dev": true
     },
     "read": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "dev": true
     },
     "read-all-stream": {
       "version": "3.1.0",
+      "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "dev": true
         },
         "readable-stream": {
-          "version": "2.2.2"
+          "version": "2.2.2",
+          "dev": true
         }
       }
     },
     "read-pkg": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dev": true
     },
     "read-pkg-up": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "readable-stream": {
-      "version": "1.1.13"
+      "version": "1.0.34",
+      "dev": true
     },
     "readdirp": {
-      "version": "2.0.0",
+      "version": "2.1.0",
+      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2"
+          "version": "4.1.11",
+          "dev": true
         },
-        "minimatch": {
-          "version": "2.0.10"
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
         },
         "readable-stream": {
-          "version": "2.0.5"
+          "version": "2.2.2",
+          "dev": true
+        }
+      }
+    },
+    "recast": {
+      "version": "0.11.18",
+      "dev": true,
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "dev": true
         }
       }
     },
     "rechoir": {
-      "version": "0.6.2"
+      "version": "0.6.2",
+      "dev": true
     },
     "redent": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "reflect-metadata": {
-      "version": "0.1.3"
+      "version": "0.1.9"
     },
     "regex-cache": {
-      "version": "0.4.2"
+      "version": "0.4.3",
+      "dev": true
     },
     "registry-auth-token": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "dev": true
     },
     "registry-url": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "dev": true
     },
     "repeat-element": {
-      "version": "1.1.2"
+      "version": "1.1.2",
+      "dev": true
     },
     "repeat-string": {
-      "version": "1.5.2"
+      "version": "1.6.1",
+      "dev": true
     },
     "repeating": {
-      "version": "2.0.0"
+      "version": "2.0.1",
+      "dev": true
     },
     "replace-ext": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true
     },
     "request": {
-      "version": "2.51.0",
+      "version": "2.55.0",
+      "dev": true,
       "dependencies": {
-        "asn1": {
-          "version": "0.1.11"
+        "bl": {
+          "version": "0.9.5",
+          "dev": true
         },
-        "async": {
-          "version": "0.9.2"
-        },
-        "aws-sign2": {
-          "version": "0.5.0"
-        },
-        "boom": {
-          "version": "0.4.2"
-        },
-        "caseless": {
-          "version": "0.8.0"
-        },
-        "combined-stream": {
-          "version": "0.0.7"
-        },
-        "cryptiles": {
-          "version": "0.2.2"
-        },
-        "delayed-stream": {
-          "version": "0.0.5"
-        },
-        "forever-agent": {
-          "version": "0.5.2"
-        },
-        "form-data": {
-          "version": "0.2.0",
-          "dependencies": {
-            "mime-types": {
-              "version": "2.0.14"
-            }
-          }
-        },
-        "hawk": {
-          "version": "1.1.1"
-        },
-        "hoek": {
-          "version": "0.9.1"
-        },
-        "http-signature": {
-          "version": "0.10.1"
+        "mime-db": {
+          "version": "1.12.0",
+          "dev": true
         },
         "mime-types": {
-          "version": "1.0.2"
-        },
-        "oauth-sign": {
-          "version": "0.5.0"
+          "version": "2.0.14",
+          "dev": true
         },
         "qs": {
-          "version": "2.3.3"
-        },
-        "sntp": {
-          "version": "0.2.4"
+          "version": "2.4.2",
+          "dev": true
         }
       }
     },
     "requires-port": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "resolve": {
-      "version": "1.1.6"
+      "version": "1.2.0",
+      "dev": true
+    },
+    "resolve-dir": {
+      "version": "0.1.1",
+      "dev": true
     },
     "response-time": {
-      "version": "2.3.1"
+      "version": "2.3.2",
+      "dev": true,
+      "dependencies": {
+        "depd": {
+          "version": "1.1.0",
+          "dev": true
+        }
+      }
     },
     "rewire": {
-      "version": "2.5.1"
+      "version": "2.5.2",
+      "dev": true
     },
     "right-align": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "dev": true
     },
     "rimraf": {
-      "version": "2.5.0",
+      "version": "2.5.4",
+      "dev": true,
       "dependencies": {
         "glob": {
-          "version": "6.0.3"
+          "version": "7.1.1",
+          "dev": true
         }
       }
     },
     "ripemd160": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "dev": true
     },
     "rndm": {
-      "version": "1.1.1"
+      "version": "1.2.0",
+      "dev": true
     },
     "rollup": {
-      "version": "0.26.3",
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0"
-        },
-        "ansi-styles": {
-          "version": "2.2.1"
-        },
-        "chalk": {
-          "version": "1.1.3"
-        },
-        "has-ansi": {
-          "version": "2.0.0"
-        },
-        "source-map": {
-          "version": "0.1.32",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.1"
-            }
-          }
-        },
-        "source-map-support": {
-          "version": "0.4.0"
-        },
-        "strip-ansi": {
-          "version": "3.0.1"
-        },
-        "supports-color": {
-          "version": "2.0.0"
-        }
-      }
+      "version": "0.26.7",
+      "dev": true
     },
     "rollup-plugin-commonjs": {
       "version": "5.0.5",
+      "dev": true,
       "dependencies": {
         "acorn": {
-          "version": "4.0.3"
-        },
-        "resolve": {
-          "version": "1.1.7"
+          "version": "4.0.4",
+          "dev": true
         }
       }
     },
     "rollup-pluginutils": {
-      "version": "1.5.2"
+      "version": "1.5.2",
+      "dev": true
     },
     "rxjs": {
-      "version": "5.0.1"
+      "version": "5.0.3"
     },
     "sauce-connect-launcher": {
       "version": "0.13.0",
+      "dev": true,
       "dependencies": {
         "async": {
-          "version": "1.4.0"
+          "version": "1.4.0",
+          "dev": true
         },
         "glob": {
-          "version": "5.0.15"
+          "version": "5.0.15",
+          "dev": true
         },
         "lodash": {
-          "version": "3.10.1"
+          "version": "3.10.1",
+          "dev": true
         },
         "rimraf": {
-          "version": "2.4.3"
+          "version": "2.4.3",
+          "dev": true
         }
       }
     },
     "saucelabs": {
-      "version": "1.0.1"
+      "version": "1.3.0",
+      "dev": true
     },
     "sax": {
-      "version": "1.1.4"
-    },
-    "scmp": {
-      "version": "1.0.0"
+      "version": "1.2.1",
+      "dev": true
     },
     "selenium-webdriver": {
       "version": "2.53.3",
+      "dev": true,
       "dependencies": {
         "adm-zip": {
-          "version": "0.4.4"
+          "version": "0.4.4",
+          "dev": true
         },
         "sax": {
-          "version": "0.6.1"
+          "version": "0.6.1",
+          "dev": true
         },
         "tmp": {
-          "version": "0.0.24"
+          "version": "0.0.24",
+          "dev": true
         },
         "xml2js": {
-          "version": "0.4.4"
+          "version": "0.4.4",
+          "dev": true
         }
       }
     },
     "semver": {
-      "version": "5.1.0"
+      "version": "5.3.0",
+      "dev": true
     },
     "semver-diff": {
-      "version": "2.1.0"
-    },
-    "semver-utils": {
-      "version": "1.1.1"
+      "version": "2.1.0",
+      "dev": true
     },
     "send": {
-      "version": "0.13.0"
+      "version": "0.13.2",
+      "dev": true,
+      "dependencies": {
+        "depd": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.2.1",
+          "dev": true
+        }
+      }
     },
     "seq": {
       "version": "0.3.5",
+      "dev": true,
       "dependencies": {
         "chainsaw": {
-          "version": "0.0.9"
+          "version": "0.0.9",
+          "dev": true
         }
       }
     },
     "sequencify": {
-      "version": "0.0.7"
+      "version": "0.0.7",
+      "dev": true
     },
     "serve-favicon": {
-      "version": "2.3.0"
-    },
-    "serve-index": {
-      "version": "1.7.2",
+      "version": "2.3.2",
+      "dev": true,
       "dependencies": {
-        "mime-db": {
-          "version": "1.20.0"
-        },
-        "mime-types": {
-          "version": "2.1.8"
+        "ms": {
+          "version": "0.7.2",
+          "dev": true
         }
       }
     },
+    "serve-index": {
+      "version": "1.7.3",
+      "dev": true
+    },
     "serve-static": {
-      "version": "1.10.0"
+      "version": "1.10.3",
+      "dev": true
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "dev": true
     },
     "setimmediate": {
-      "version": "1.0.4"
+      "version": "1.0.5",
+      "dev": true
     },
     "sha.js": {
-      "version": "2.2.6"
+      "version": "2.2.6",
+      "dev": true
     },
     "sigmund": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "signal-exit": {
-      "version": "2.1.2"
+      "version": "3.0.2",
+      "dev": true
     },
     "slice-stream": {
       "version": "1.0.0",
+      "dev": true
+    },
+    "slide": {
+      "version": "1.1.6",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "dev": true
+    },
+    "socket.io": {
+      "version": "1.7.2",
+      "dev": true,
       "dependencies": {
-        "readable-stream": {
-          "version": "1.0.33"
+        "debug": {
+          "version": "2.3.3",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "dev": true
         }
       }
     },
-    "slide": {
-      "version": "1.1.6"
-    },
-    "sntp": {
-      "version": "1.0.9"
-    },
-    "socket.io": {
-      "version": "1.4.6"
-    },
     "socket.io-adapter": {
-      "version": "0.4.0",
+      "version": "0.5.0",
+      "dev": true,
       "dependencies": {
-        "socket.io-parser": {
-          "version": "2.2.2",
-          "dependencies": {
-            "debug": {
-              "version": "0.7.4"
-            }
-          }
+        "debug": {
+          "version": "2.3.3",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "dev": true
         }
       }
     },
     "socket.io-client": {
-      "version": "1.4.6",
+      "version": "1.7.2",
+      "dev": true,
       "dependencies": {
         "component-emitter": {
-          "version": "1.2.0"
+          "version": "1.2.1",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.3.3",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "dev": true
         }
       }
     },
     "socket.io-parser": {
-      "version": "2.2.6",
-      "dependencies": {
-        "json3": {
-          "version": "3.3.2"
-        }
-      }
+      "version": "2.3.1",
+      "dev": true
     },
     "source-list-map": {
-      "version": "0.1.5"
+      "version": "0.1.8",
+      "dev": true
     },
     "source-map": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "dev": true
     },
     "source-map-support": {
-      "version": "0.4.2",
+      "version": "0.4.9",
+      "dev": true,
       "dependencies": {
         "source-map": {
-          "version": "0.1.32",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.1"
-            }
-          }
+          "version": "0.5.6",
+          "dev": true
         }
       }
     },
     "sparkles": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "spdx-correct": {
-      "version": "1.0.2"
-    },
-    "spdx-exceptions": {
-      "version": "1.0.4"
+      "version": "1.0.2",
+      "dev": true
     },
     "spdx-expression-parse": {
-      "version": "1.0.2"
+      "version": "1.0.4",
+      "dev": true
     },
     "spdx-license-ids": {
-      "version": "1.1.0"
+      "version": "1.2.2",
+      "dev": true
     },
     "split": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "split2": {
-      "version": "2.1.0",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0"
-        },
-        "readable-stream": {
-          "version": "2.0.6"
-        },
-        "through2": {
-          "version": "2.0.1"
-        }
-      }
+      "version": "2.1.1",
+      "dev": true
     },
     "sprintf-js": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "dev": true
     },
     "sshpk": {
-      "version": "1.10.1",
+      "version": "1.10.2",
+      "dev": true,
       "dependencies": {
+        "asn1": {
+          "version": "0.2.3",
+          "dev": true
+        },
         "assert-plus": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "dev": true
         }
       }
     },
     "statuses": {
-      "version": "1.2.1"
+      "version": "1.3.1",
+      "dev": true
     },
     "stream-browserify": {
-      "version": "1.0.0"
-    },
-    "stream-combiner": {
-      "version": "0.0.4"
-    },
-    "stream-consume": {
-      "version": "0.1.0"
-    },
-    "stream-counter": {
-      "version": "0.2.0"
-    },
-    "stream-equal": {
-      "version": "0.1.6"
-    },
-    "string_decoder": {
-      "version": "0.10.31"
-    },
-    "string-width": {
-      "version": "1.0.1",
+      "version": "2.0.1",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0"
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
         },
-        "strip-ansi": {
-          "version": "3.0.0"
+        "readable-stream": {
+          "version": "2.2.2",
+          "dev": true
         }
       }
     },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "dev": true
+    },
+    "stream-combiner2": {
+      "version": "1.1.1",
+      "dev": true,
+      "dependencies": {
+        "duplexer2": {
+          "version": "0.1.4",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "dev": true
+        }
+      }
+    },
+    "stream-consume": {
+      "version": "0.1.0",
+      "dev": true
+    },
+    "stream-counter": {
+      "version": "0.2.0",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "dev": true
+        }
+      }
+    },
+    "stream-equal": {
+      "version": "0.1.6",
+      "dev": true
+    },
+    "stream-http": {
+      "version": "2.6.1",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "dev": true
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "dev": true
+    },
     "stringstream": {
-      "version": "0.0.5"
+      "version": "0.0.5",
+      "dev": true
     },
     "strip-ansi": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "strip-bom": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "strip-indent": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "strip-json-comments": {
-      "version": "1.0.4"
-    },
-    "success-symbol": {
-      "version": "0.1.0"
+      "version": "1.0.4",
+      "dev": true
     },
     "supports-color": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "symbol-observable": {
       "version": "1.0.4"
     },
     "systemjs": {
-      "version": "0.18.10"
+      "version": "0.18.10",
+      "dev": true
     },
     "tapable": {
-      "version": "0.1.10"
+      "version": "0.1.10",
+      "dev": true
     },
     "tar-stream": {
-      "version": "1.1.5",
+      "version": "1.5.2",
+      "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "1.0.33"
+          "version": "2.2.2",
+          "dev": true
         }
       }
     },
     "text-extensions": {
-      "version": "1.3.3"
+      "version": "1.4.0",
+      "dev": true
     },
     "through": {
-      "version": "2.3.8"
+      "version": "2.3.8",
+      "dev": true
     },
     "through2": {
-      "version": "0.6.5",
+      "version": "2.0.3",
+      "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "1.0.34"
+          "version": "2.2.2",
+          "dev": true
         }
       }
     },
     "tildify": {
-      "version": "1.1.2"
+      "version": "1.2.0",
+      "dev": true
+    },
+    "time-stamp": {
+      "version": "1.0.1",
+      "dev": true
     },
     "timed-out": {
-      "version": "3.0.0"
+      "version": "3.1.3",
+      "dev": true
     },
     "timers-browserify": {
-      "version": "1.4.2"
+      "version": "2.0.2",
+      "dev": true
     },
     "timers-ext": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "tiny-lr": {
       "version": "0.2.1",
+      "dev": true,
       "dependencies": {
         "body-parser": {
           "version": "1.14.2",
+          "dev": true,
           "dependencies": {
             "qs": {
-              "version": "5.2.0"
+              "version": "5.2.0",
+              "dev": true
             }
           }
         },
         "bytes": {
-          "version": "2.2.0"
+          "version": "2.2.0",
+          "dev": true
         },
         "depd": {
-          "version": "1.1.0"
+          "version": "1.1.0",
+          "dev": true
         },
         "iconv-lite": {
-          "version": "0.4.13"
+          "version": "0.4.13",
+          "dev": true
         },
         "qs": {
-          "version": "5.1.0"
+          "version": "5.1.0",
+          "dev": true
         }
       }
     },
     "tmp": {
-      "version": "0.0.25"
+      "version": "0.0.25",
+      "dev": true
     },
     "to-array": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "dev": true
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "dev": true
     },
     "tough-cookie": {
-      "version": "2.2.1"
+      "version": "2.3.2",
+      "dev": true
     },
     "traverse": {
-      "version": "0.3.9"
+      "version": "0.3.9",
+      "dev": true
     },
     "trim-newlines": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "trim-off-newlines": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "ts-api-guardian": {
       "version": "0.1.4",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0"
-        },
-        "ansi-styles": {
-          "version": "2.2.1"
-        },
-        "chalk": {
-          "version": "1.1.3"
-        },
-        "diff": {
-          "version": "2.2.3"
-        },
-        "has-ansi": {
-          "version": "2.0.0"
-        },
-        "strip-ansi": {
-          "version": "3.0.1"
-        },
-        "supports-color": {
-          "version": "2.0.0"
-        },
         "typescript": {
-          "version": "1.7.3"
+          "version": "1.7.3",
+          "dev": true
         }
       }
     },
     "tsickle": {
-      "version": "0.2.2",
+      "version": "0.2.4",
+      "dev": true,
       "dependencies": {
         "source-map": {
-          "version": "0.5.6"
+          "version": "0.5.6",
+          "dev": true
         }
       }
     },
     "tslint": {
-      "version": "4.1.1",
+      "version": "4.3.1",
+      "dev": true,
       "dependencies": {
         "diff": {
-          "version": "3.1.0"
+          "version": "3.2.0",
+          "dev": true
+        },
+        "findup-sync": {
+          "version": "0.3.0",
+          "dev": true,
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "dev": true
+            }
+          }
         },
         "glob": {
-          "version": "7.1.1"
+          "version": "7.1.1",
+          "dev": true
         },
-        "resolve": {
-          "version": "1.2.0"
+        "underscore.string": {
+          "version": "3.3.4",
+          "dev": true
         }
       }
     },
     "tslint-eslint-rules": {
-      "version": "3.1.0",
-      "dependencies": {
-        "diff": {
-          "version": "3.1.0"
-        },
-        "glob": {
-          "version": "7.1.1"
-        },
-        "resolve": {
-          "version": "1.1.7"
-        },
-        "tslint": {
-          "version": "4.0.2"
-        }
-      }
+      "version": "3.2.3",
+      "dev": true
+    },
+    "tsscmp": {
+      "version": "1.0.5",
+      "dev": true
     },
     "tty-browserify": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dev": true
     },
     "tunnel-agent": {
-      "version": "0.4.2"
+      "version": "0.4.3",
+      "dev": true
     },
     "tweetnacl": {
-      "version": "0.14.3"
+      "version": "0.14.5",
+      "dev": true,
+      "optional": true
     },
     "type-is": {
-      "version": "1.6.10",
-      "dependencies": {
-        "mime-db": {
-          "version": "1.20.0"
-        },
-        "mime-types": {
-          "version": "2.1.8"
-        }
-      }
+      "version": "1.6.14",
+      "dev": true
     },
     "typedarray": {
-      "version": "0.0.6"
+      "version": "0.0.6",
+      "dev": true
     },
     "typescript": {
-      "version": "2.0.2"
+      "version": "2.1.5",
+      "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.10"
+      "version": "0.7.12",
+      "dev": true
     },
     "uglify-js": {
-      "version": "2.7.0",
+      "version": "1.3.3",
+      "dev": true
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "uid-safe": {
+      "version": "2.1.3",
+      "dev": true
+    },
+    "ultron": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.3.3",
+      "dev": true
+    },
+    "underscore.string": {
+      "version": "3.0.3",
+      "dev": true
+    },
+    "unicoderegexp": {
+      "version": "0.4.1",
+      "dev": true
+    },
+    "unique-stream": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "universal-analytics": {
+      "version": "0.3.11",
+      "dev": true,
       "dependencies": {
-        "camelcase": {
-          "version": "1.2.1"
-        },
-        "cliui": {
-          "version": "2.1.0"
-        },
-        "source-map": {
-          "version": "0.5.6"
-        },
-        "window-size": {
-          "version": "0.1.0"
-        },
-        "wordwrap": {
-          "version": "0.0.2"
-        },
-        "yargs": {
-          "version": "3.10.0"
+        "async": {
+          "version": "0.2.10",
+          "dev": true
         }
       }
     },
-    "uglify-to-browserify": {
-      "version": "1.0.2"
-    },
-    "uid-safe": {
-      "version": "2.0.0"
-    },
-    "ultron": {
-      "version": "1.0.2"
-    },
-    "underscore": {
-      "version": "1.8.3"
-    },
-    "underscore.string": {
-      "version": "3.3.4"
-    },
-    "unicoderegexp": {
-      "version": "0.4.1"
-    },
-    "unique-stream": {
-      "version": "1.0.0"
-    },
-    "universal-analytics": {
-      "version": "0.3.10"
-    },
     "unpipe": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "unzip": {
       "version": "0.1.11",
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.33"
-        }
-      }
+      "dev": true
     },
     "unzip-response": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "update-notifier": {
-      "version": "1.0.3"
+      "version": "1.0.3",
+      "dev": true
     },
     "url": {
-      "version": "0.10.3",
+      "version": "0.11.0",
+      "dev": true,
       "dependencies": {
         "punycode": {
-          "version": "1.3.2"
+          "version": "1.3.2",
+          "dev": true
         }
       }
     },
     "url-parse-lax": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "user-home": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "useragent": {
-      "version": "2.1.9",
+      "version": "2.1.10",
+      "dev": true,
       "dependencies": {
         "lru-cache": {
-          "version": "2.2.4"
+          "version": "2.2.4",
+          "dev": true
         }
       }
     },
-    "utf8": {
-      "version": "2.1.0"
-    },
     "util": {
-      "version": "0.10.3"
+      "version": "0.10.3",
+      "dev": true,
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "dev": true
+        }
+      }
     },
     "util-deprecate": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "utils-merge": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "uuid": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "dev": true
     },
     "v8flags": {
-      "version": "2.0.11"
+      "version": "2.0.11",
+      "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "vargs": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     },
     "vary": {
-      "version": "1.0.1"
+      "version": "1.1.0",
+      "dev": true
     },
     "verror": {
-      "version": "1.3.6"
+      "version": "1.3.6",
+      "dev": true
     },
     "vhost": {
-      "version": "3.0.2"
+      "version": "3.0.2",
+      "dev": true
+    },
+    "vinyl": {
+      "version": "0.5.3",
+      "dev": true
     },
     "vinyl-fs": {
       "version": "0.3.14",
+      "dev": true,
       "dependencies": {
         "clone": {
-          "version": "0.2.0"
+          "version": "0.2.0",
+          "dev": true
         },
         "strip-bom": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.6.5",
+          "dev": true
         },
         "vinyl": {
-          "version": "0.4.6"
+          "version": "0.4.6",
+          "dev": true
         }
       }
     },
     "vlq": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "dev": true
     },
     "vm-browserify": {
-      "version": "0.0.4"
+      "version": "0.0.4",
+      "dev": true
     },
     "void-elements": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "dev": true
     },
     "vrsource-tslint-rules": {
-      "version": "4.0.0"
+      "version": "4.0.1",
+      "dev": true
     },
     "watchpack": {
       "version": "0.2.9",
+      "dev": true,
       "dependencies": {
         "async": {
-          "version": "0.9.2"
+          "version": "0.9.2",
+          "dev": true
         },
         "graceful-fs": {
-          "version": "4.1.2"
+          "version": "4.1.11",
+          "dev": true
         }
       }
     },
     "wd": {
       "version": "0.3.12",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0"
-        },
-        "ansi-styles": {
-          "version": "2.1.0"
-        },
-        "asn1": {
-          "version": "0.1.11"
-        },
-        "async": {
-          "version": "1.0.0"
-        },
-        "aws-sign2": {
-          "version": "0.5.0"
-        },
-        "caseless": {
-          "version": "0.9.0"
-        },
-        "chalk": {
-          "version": "1.1.1"
-        },
-        "combined-stream": {
-          "version": "0.0.7"
-        },
-        "delayed-stream": {
-          "version": "0.0.5"
-        },
-        "form-data": {
-          "version": "0.2.0",
+        "archiver": {
+          "version": "0.14.4",
+          "dev": true,
           "dependencies": {
             "async": {
-              "version": "0.9.2"
+              "version": "0.9.2",
+              "dev": true
+            },
+            "lodash": {
+              "version": "3.2.0",
+              "dev": true
             }
           }
         },
-        "har-validator": {
-          "version": "1.8.0"
+        "async": {
+          "version": "1.0.0",
+          "dev": true
         },
-        "has-ansi": {
-          "version": "2.0.0"
+        "bl": {
+          "version": "0.9.5",
+          "dev": true
         },
-        "hawk": {
-          "version": "2.3.1"
+        "compress-commons": {
+          "version": "0.2.9",
+          "dev": true
         },
-        "http-signature": {
-          "version": "0.10.1"
+        "crc32-stream": {
+          "version": "0.3.4",
+          "dev": true
+        },
+        "glob": {
+          "version": "4.3.5",
+          "dev": true
+        },
+        "lazystream": {
+          "version": "0.1.0",
+          "dev": true
         },
         "lodash": {
-          "version": "3.9.3"
+          "version": "3.9.3",
+          "dev": true
         },
-        "oauth-sign": {
-          "version": "0.6.0"
+        "minimatch": {
+          "version": "2.0.10",
+          "dev": true
         },
-        "qs": {
-          "version": "2.4.2"
+        "tar-stream": {
+          "version": "1.1.5",
+          "dev": true
         },
-        "request": {
-          "version": "2.55.0"
-        },
-        "strip-ansi": {
-          "version": "3.0.0"
-        },
-        "supports-color": {
-          "version": "2.0.0"
-        },
-        "underscore.string": {
-          "version": "3.0.3"
+        "zip-stream": {
+          "version": "0.5.2",
+          "dev": true,
+          "dependencies": {
+            "lodash": {
+              "version": "3.2.0",
+              "dev": true
+            }
+          }
         }
       }
     },
     "webpack": {
-      "version": "1.12.9",
+      "version": "1.14.0",
+      "dev": true,
       "dependencies": {
-        "async": {
-          "version": "1.5.0"
+        "acorn": {
+          "version": "3.3.0",
+          "dev": true
         },
         "camelcase": {
-          "version": "1.2.1"
+          "version": "1.2.1",
+          "dev": true
         },
-        "cliui": {
-          "version": "2.1.0"
+        "interpret": {
+          "version": "0.6.6",
+          "dev": true
         },
         "source-map": {
-          "version": "0.5.3"
+          "version": "0.5.6",
+          "dev": true
         },
         "supports-color": {
-          "version": "3.1.2"
+          "version": "3.2.3",
+          "dev": true
         },
         "uglify-js": {
-          "version": "2.6.1",
+          "version": "2.7.5",
+          "dev": true,
           "dependencies": {
             "async": {
-              "version": "0.2.10"
+              "version": "0.2.10",
+              "dev": true
             }
           }
         },
-        "window-size": {
-          "version": "0.1.0"
-        },
-        "wordwrap": {
-          "version": "0.0.2"
-        },
         "yargs": {
-          "version": "3.10.0"
+          "version": "3.10.0",
+          "dev": true
         }
       }
     },
     "webpack-core": {
-      "version": "0.6.8",
+      "version": "0.6.9",
+      "dev": true,
       "dependencies": {
         "source-map": {
-          "version": "0.4.4"
+          "version": "0.4.4",
+          "dev": true
         }
       }
     },
     "websocket-driver": {
-      "version": "0.6.3"
+      "version": "0.6.5",
+      "dev": true
     },
     "websocket-extensions": {
-      "version": "0.1.1"
+      "version": "0.1.1",
+      "dev": true
     },
     "whatwg-fetch": {
-      "version": "0.9.0"
+      "version": "0.9.0",
+      "dev": true
     },
     "when": {
-      "version": "3.7.2"
+      "version": "3.7.2",
+      "dev": true
     },
     "which": {
-      "version": "1.2.10"
+      "version": "1.2.12",
+      "dev": true
     },
     "widest-line": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "window-size": {
-      "version": "0.1.4"
+      "version": "0.1.0",
+      "dev": true
     },
     "winreg": {
-      "version": "0.0.12"
+      "version": "0.0.12",
+      "dev": true
     },
     "wordwrap": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "dev": true
     },
     "wrap-ansi": {
-      "version": "1.0.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "wrappy": {
-      "version": "1.0.1"
+      "version": "1.0.2",
+      "dev": true
     },
     "wrench": {
-      "version": "1.5.8"
+      "version": "1.5.9",
+      "dev": true
     },
     "write-file-atomic": {
-      "version": "1.2.0",
+      "version": "1.3.1",
+      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.11"
+          "version": "4.1.11",
+          "dev": true
         }
       }
     },
     "ws": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
+    },
+    "wtf-8": {
+      "version": "1.0.0",
+      "dev": true
     },
     "xdg-basedir": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "xml2js": {
-      "version": "0.4.15"
+      "version": "0.4.17",
+      "dev": true
     },
     "xmlbuilder": {
-      "version": "8.2.2"
+      "version": "4.2.1",
+      "dev": true
     },
     "xmldom": {
-      "version": "0.1.19"
+      "version": "0.1.19",
+      "dev": true
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.1"
+      "version": "1.5.3",
+      "dev": true
     },
     "xpath": {
-      "version": "0.0.7"
+      "version": "0.0.7",
+      "dev": true
     },
     "xtend": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "dev": true
     },
     "y18n": {
-      "version": "3.2.0"
+      "version": "3.2.1",
+      "dev": true
     },
     "yargs": {
-      "version": "3.31.0"
+      "version": "3.32.0",
+      "dev": true,
+      "dependencies": {
+        "cliui": {
+          "version": "3.2.0",
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.4",
+          "dev": true
+        }
+      }
     },
     "yeast": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "dev": true
     },
     "zip-dir": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "zip-stream": {
-      "version": "0.5.2",
+      "version": "1.1.1",
+      "dev": true,
       "dependencies": {
-        "lodash": {
-          "version": "3.2.0"
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
         },
         "readable-stream": {
-          "version": "1.0.33"
+          "version": "2.2.2",
+          "dev": true
         }
       }
     },
     "zone.js": {
-      "version": "0.7.2"
+      "version": "0.7.5"
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,3307 +1,1903 @@
 {
   "name": "angular-srcs",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-beta.3",
   "dependencies": {
     "@types/angularjs": {
       "version": "1.5.13-alpha",
-      "from": "@types/angularjs@latest",
-      "resolved": "https://registry.npmjs.org/@types/angularjs/-/angularjs-1.5.13-alpha.tgz"
+      "from": "@types/angularjs@>=1.5.13-alpha <2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/angularjs/-/angularjs-1.5.13-alpha.tgz",
+      "dev": true
     },
     "@types/base64-js": {
       "version": "1.2.5",
-      "from": "@types/base64-js@latest",
-      "resolved": "https://registry.npmjs.org/@types/base64-js/-/base64-js-1.2.5.tgz"
+      "from": "@types/base64-js@>=1.2.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/base64-js/-/base64-js-1.2.5.tgz",
+      "dev": true
     },
     "@types/fs-extra": {
       "version": "0.0.22-alpha",
-      "from": "@types/fs-extra@latest",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-0.0.22-alpha.tgz"
+      "from": "@types/fs-extra@0.0.22-alpha",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-0.0.22-alpha.tgz",
+      "dev": true
     },
     "@types/hammerjs": {
-      "version": "2.0.33",
-      "from": "@types/hammerjs@latest",
-      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.33.tgz"
+      "version": "2.0.34",
+      "from": "@types/hammerjs@>=2.0.33 <3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.34.tgz",
+      "dev": true
     },
     "@types/jasmine": {
-      "version": "2.2.22-alpha",
-      "from": "@types/jasmine@latest",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.2.22-alpha.tgz"
+      "version": "2.5.40",
+      "from": "@types/jasmine@>=2.2.22-alpha <3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.5.40.tgz",
+      "dev": true
     },
     "@types/jquery": {
-      "version": "1.10.21-alpha",
+      "version": "2.0.39",
       "from": "@types/jquery@*",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-1.10.21-alpha.tgz"
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.39.tgz",
+      "dev": true
     },
     "@types/node": {
-      "version": "4.0.22-alpha",
-      "from": "@types/node@latest",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-4.0.22-alpha.tgz"
+      "version": "4.2.0",
+      "from": "@types/node@>=4.0.22-alpha <5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.0.tgz",
+      "dev": true
     },
     "@types/q": {
       "version": "0.0.32",
       "from": "@types/q@>=0.0.32 <0.0.33",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz"
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+      "dev": true
     },
     "@types/selenium-webdriver": {
-      "version": "2.53.35",
-      "from": "@types/selenium-webdriver@latest",
-      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.35.tgz"
+      "version": "2.53.39",
+      "from": "@types/selenium-webdriver@>=2.53.35 <3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.39.tgz",
+      "dev": true
     },
     "@types/systemjs": {
-      "version": "0.19.32",
-      "from": "@types/systemjs@latest",
-      "resolved": "https://registry.npmjs.org/@types/systemjs/-/systemjs-0.19.32.tgz"
+      "version": "0.19.33",
+      "from": "@types/systemjs@>=0.19.32 <0.20.0",
+      "resolved": "https://registry.npmjs.org/@types/systemjs/-/systemjs-0.19.33.tgz",
+      "dev": true
     },
     "accepts": {
       "version": "1.2.13",
       "from": "accepts@>=1.2.12 <1.3.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-      "dependencies": {
-        "mime-db": {
-          "version": "1.20.0",
-          "from": "mime-db@1.20.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
-        },
-        "mime-types": {
-          "version": "2.1.8",
-          "from": "mime-types@2.1.8",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz"
-        }
-      }
+      "dev": true
     },
     "acorn": {
       "version": "1.2.2",
       "from": "acorn@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+      "dev": true
     },
     "add-stream": {
       "version": "1.0.0",
       "from": "add-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+      "dev": true
     },
     "adm-zip": {
       "version": "0.4.7",
       "from": "adm-zip@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
+      "dev": true
     },
     "after": {
-      "version": "0.8.1",
-      "from": "after@0.8.1",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+      "version": "0.8.2",
+      "from": "after@0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "dev": true
     },
     "agent-base": {
       "version": "2.0.1",
       "from": "agent-base@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
+      "dev": true,
       "dependencies": {
         "semver": {
           "version": "5.0.3",
           "from": "semver@>=5.0.1 <5.1.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "dev": true
         }
       }
     },
     "align-text": {
-      "version": "0.1.3",
-      "from": "align-text@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-      "dependencies": {
-        "kind-of": {
-          "version": "2.0.1",
-          "from": "kind-of@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz"
-        }
-      }
+      "version": "0.1.4",
+      "from": "align-text@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
-      "from": "amdefine@1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+      "from": "amdefine@>=0.0.4",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "dev": true
     },
     "angular": {
-      "version": "1.5.0",
-      "from": "angular@1.5.0",
-      "resolved": "https://registry.npmjs.org/angular/-/angular-1.5.0.tgz"
+      "version": "1.6.1",
+      "from": "angular@>=1.5.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.6.1.tgz",
+      "dev": true
     },
     "angular-animate": {
-      "version": "1.5.0",
-      "from": "angular-animate@1.5.0",
-      "resolved": "https://registry.npmjs.org/angular-animate/-/angular-animate-1.5.0.tgz"
+      "version": "1.6.1",
+      "from": "angular-animate@>=1.5.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/angular-animate/-/angular-animate-1.6.1.tgz",
+      "dev": true
     },
     "angular-mocks": {
-      "version": "1.5.0",
-      "from": "angular-mocks@1.5.0",
-      "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.5.0.tgz"
+      "version": "1.6.1",
+      "from": "angular-mocks@>=1.5.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.6.1.tgz",
+      "dev": true
     },
     "ansi-align": {
       "version": "1.1.0",
       "from": "ansi-align@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz"
-    },
-    "ansi-green": {
-      "version": "0.1.1",
-      "from": "ansi-green@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+      "dev": true
     },
     "ansi-regex": {
-      "version": "2.0.0",
+      "version": "2.1.1",
       "from": "ansi-regex@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
       "from": "ansi-styles@>=2.2.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-    },
-    "ansi-wrap": {
-      "version": "0.1.0",
-      "from": "ansi-wrap@0.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "dev": true
     },
     "any-promise": {
       "version": "0.1.0",
       "from": "any-promise@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz",
+      "dev": true
     },
     "anymatch": {
       "version": "1.3.0",
       "from": "anymatch@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+      "dev": true
     },
     "archiver": {
-      "version": "0.14.4",
-      "from": "archiver@>=0.14.3 <0.15.0",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.14.4.tgz",
+      "version": "1.0.1",
+      "from": "archiver@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.0.1.tgz",
+      "dev": true,
       "dependencies": {
         "async": {
-          "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+          "version": "2.1.4",
+          "from": "async@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+          "dev": true
         },
         "glob": {
-          "version": "4.3.5",
-          "from": "glob@>=4.3.0 <4.4.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-          "dependencies": {
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
-            }
-          }
+          "version": "7.1.1",
+          "from": "glob@>=7.0.0 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "dev": true
         },
-        "lodash": {
-          "version": "3.2.0",
-          "from": "lodash@>=3.2.0 <3.3.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
         },
         "readable-stream": {
-          "version": "1.0.33",
-          "from": "readable-stream@>=1.0.26 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
+        }
+      }
+    },
+    "archiver-utils": {
+      "version": "1.3.0",
+      "from": "archiver-utils@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1",
+          "from": "glob@>=7.0.0 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "from": "graceful-fs@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
         }
       }
     },
     "archy": {
       "version": "1.0.0",
       "from": "archy@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "dev": true
     },
     "arr-diff": {
       "version": "2.0.0",
       "from": "arr-diff@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "dev": true
     },
     "arr-flatten": {
       "version": "1.0.1",
       "from": "arr-flatten@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+      "dev": true
     },
     "array-differ": {
       "version": "1.0.0",
       "from": "array-differ@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "from": "array-find-index@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "dev": true
     },
     "array-ify": {
       "version": "1.0.0",
       "from": "array-ify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "dev": true
     },
     "array-slice": {
       "version": "0.2.3",
       "from": "array-slice@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+      "dev": true
     },
     "array-union": {
       "version": "1.0.2",
       "from": "array-union@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "dev": true
     },
     "array-uniq": {
-      "version": "1.0.2",
-      "from": "array-uniq@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+      "version": "1.0.3",
+      "from": "array-uniq@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "dev": true
     },
     "array-unique": {
       "version": "0.2.1",
       "from": "array-unique@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "dev": true
     },
     "arraybuffer.slice": {
       "version": "0.0.6",
       "from": "arraybuffer.slice@0.0.6",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+      "dev": true
     },
     "arrify": {
       "version": "1.0.1",
       "from": "arrify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "dev": true
     },
     "asap": {
-      "version": "2.0.3",
+      "version": "2.0.5",
       "from": "asap@>=2.0.3 <2.1.0",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+      "dev": true
     },
     "asn1": {
-      "version": "0.2.3",
-      "from": "asn1@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+      "version": "0.1.11",
+      "from": "asn1@0.1.11",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+      "dev": true
     },
     "assert": {
       "version": "1.4.1",
       "from": "assert@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "dev": true
     },
     "assert-plus": {
       "version": "0.1.5",
       "from": "assert-plus@>=0.1.5 <0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+      "dev": true
+    },
+    "ast-types": {
+      "version": "0.9.2",
+      "from": "ast-types@0.9.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.2.tgz",
+      "dev": true
     },
     "async": {
-      "version": "0.2.10",
-      "from": "async@>=0.2.6 <0.3.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+      "version": "1.5.2",
+      "from": "async@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "dev": true
     },
     "async-each": {
-      "version": "0.1.6",
-      "from": "async-each@>=0.1.6 <0.2.0",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+      "version": "1.0.1",
+      "from": "async-each@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
       "from": "asynckit@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "dev": true
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "from": "aws-sign2@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+      "version": "0.5.0",
+      "from": "aws-sign2@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+      "dev": true
     },
     "aws4": {
       "version": "1.5.0",
       "from": "aws4@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.20.0",
       "from": "babel-code-frame@>=6.20.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.20.0.tgz",
+      "dev": true,
       "dependencies": {
-        "esutils": {
-          "version": "2.0.2",
-          "from": "esutils@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-        },
         "js-tokens": {
           "version": "2.0.0",
           "from": "js-tokens@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
+          "dev": true
         }
       }
     },
     "backo2": {
       "version": "1.0.2",
       "from": "backo2@1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "dev": true
     },
     "balanced-match": {
       "version": "0.4.2",
       "from": "balanced-match@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "dev": true
     },
     "base62": {
-      "version": "0.1.1",
-      "from": "base62@0.1.1",
-      "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
-    },
-    "Base64": {
-      "version": "0.2.1",
-      "from": "Base64@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+      "version": "1.1.2",
+      "from": "base62@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/base62/-/base62-1.1.2.tgz",
+      "dev": true
     },
     "base64-arraybuffer": {
-      "version": "0.1.2",
-      "from": "base64-arraybuffer@0.1.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+      "version": "0.1.5",
+      "from": "base64-arraybuffer@0.1.5",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "dev": true
     },
     "base64-js": {
       "version": "1.2.0",
-      "from": "base64-js@latest",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
+      "from": "base64-js@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+      "dev": true
     },
     "base64-url": {
-      "version": "1.2.1",
-      "from": "base64-url@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+      "version": "1.3.3",
+      "from": "base64-url@1.3.3",
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.3.tgz",
+      "dev": true
     },
     "base64id": {
-      "version": "0.1.0",
-      "from": "base64id@0.1.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
+      "version": "1.0.0",
+      "from": "base64id@1.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+      "dev": true
     },
     "basic-auth": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "from": "basic-auth@>=1.0.3 <1.1.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz",
+      "dev": true
     },
     "basic-auth-connect": {
       "version": "1.0.0",
       "from": "basic-auth-connect@1.0.0",
-      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
+      "dev": true
     },
     "batch": {
-      "version": "0.5.2",
-      "from": "batch@0.5.2",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz"
+      "version": "0.5.3",
+      "from": "batch@0.5.3",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.0",
       "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+      "dev": true,
+      "optional": true
     },
     "beeper": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "from": "beeper@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
-    },
-    "benchmark": {
-      "version": "1.0.0",
-      "from": "benchmark@1.0.0",
-      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+      "dev": true
     },
     "better-assert": {
       "version": "1.0.2",
       "from": "better-assert@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "dev": true
     },
     "big.js": {
       "version": "3.1.3",
-      "from": "big.js@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+      "from": "big.js@>=3.1.3 <4.0.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+      "dev": true
     },
     "binary": {
       "version": "0.3.0",
       "from": "binary@>=0.3.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "dev": true
     },
     "binary-extensions": {
-      "version": "1.4.0",
+      "version": "1.8.0",
       "from": "binary-extensions@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
+      "dev": true
     },
     "bl": {
-      "version": "0.9.4",
-      "from": "bl@>=0.9.0 <0.10.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+      "version": "1.2.0",
+      "from": "bl@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.0.tgz",
+      "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "1.0.33",
-          "from": "readable-stream@>=1.0.26 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.5 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
         }
       }
     },
     "blob": {
       "version": "0.0.4",
       "from": "blob@0.0.4",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "dev": true
     },
     "bluebird": {
-      "version": "2.10.2",
+      "version": "2.11.0",
       "from": "bluebird@>=2.9.27 <3.0.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "dev": true
     },
     "body-parser": {
       "version": "1.13.3",
       "from": "body-parser@>=1.13.3 <1.14.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz"
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
+      "dev": true
     },
     "boom": {
       "version": "2.10.1",
       "from": "boom@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "dev": true
     },
     "bower": {
-      "version": "1.7.2",
+      "version": "1.8.0",
       "from": "bower@>=1.3.12 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.7.2.tgz",
-      "dependencies": {
-        "abbrev": {
-          "version": "1.0.7",
-          "from": "abbrev@>=1.0.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-        },
-        "archy": {
-          "version": "1.0.0",
-          "from": "archy@1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
-        },
-        "bower-config": {
-          "version": "1.3.0",
-          "from": "bower-config@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.3.0.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.2",
-              "from": "graceful-fs@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "from": "optimist@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                },
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                }
-              }
-            },
-            "osenv": {
-              "version": "0.1.3",
-              "from": "osenv@>=0.1.3 <0.2.0",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                }
-              }
-            },
-            "untildify": {
-              "version": "2.1.0",
-              "from": "untildify@2.1.0",
-              "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "bower-endpoint-parser": {
-          "version": "0.2.2",
-          "from": "bower-endpoint-parser@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
-        },
-        "bower-json": {
-          "version": "0.4.0",
-          "from": "bower-json@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
-          "dependencies": {
-            "deep-extend": {
-              "version": "0.2.11",
-              "from": "deep-extend@>=0.2.5 <0.3.0",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
-            },
-            "graceful-fs": {
-              "version": "2.0.3",
-              "from": "graceful-fs@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-            },
-            "intersect": {
-              "version": "0.0.3",
-              "from": "intersect@>=0.0.3 <0.1.0",
-              "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
-            }
-          }
-        },
-        "bower-logger": {
-          "version": "0.2.2",
-          "from": "bower-logger@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
-        },
-        "bower-registry-client": {
-          "version": "1.0.0",
-          "from": "bower-registry-client@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-1.0.0.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.2.10",
-              "from": "async@>=0.2.8 <0.3.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-            },
-            "graceful-fs": {
-              "version": "4.1.2",
-              "from": "graceful-fs@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "mkdirp": {
-              "version": "0.3.5",
-              "from": "mkdirp@>=0.3.5 <0.4.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
-            },
-            "request-replay": {
-              "version": "0.2.0",
-              "from": "request-replay@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
-            }
-          }
-        },
-        "cardinal": {
-          "version": "0.4.4",
-          "from": "cardinal@0.4.4",
-          "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
-          "dependencies": {
-            "ansicolors": {
-              "version": "0.2.1",
-              "from": "ansicolors@>=0.2.1 <0.3.0",
-              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
-            },
-            "redeyed": {
-              "version": "0.4.4",
-              "from": "redeyed@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
-              "dependencies": {
-                "esprima": {
-                  "version": "1.0.4",
-                  "from": "esprima@>=1.0.4 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-                }
-              }
-            }
-          }
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.4",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "chmodr": {
-          "version": "1.0.2",
-          "from": "chmodr@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz"
-        },
-        "configstore": {
-          "version": "0.3.2",
-          "from": "configstore@>=0.3.2 <0.4.0",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
-          "dependencies": {
-            "js-yaml": {
-              "version": "3.4.6",
-              "from": "js-yaml@>=3.1.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.3",
-                  "from": "argparse@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
-                  "dependencies": {
-                    "lodash": {
-                      "version": "3.10.1",
-                      "from": "lodash@>=3.2.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                    },
-                    "sprintf-js": {
-                      "version": "1.0.3",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "2.7.1",
-                  "from": "esprima@>=2.6.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
-                },
-                "inherit": {
-                  "version": "2.2.2",
-                  "from": "inherit@>=2.2.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.2.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.1.1",
-              "from": "object-assign@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-            },
-            "osenv": {
-              "version": "0.1.3",
-              "from": "osenv@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                }
-              }
-            },
-            "uuid": {
-              "version": "2.0.1",
-              "from": "uuid@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
-            },
-            "xdg-basedir": {
-              "version": "1.0.1",
-              "from": "xdg-basedir@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
-            }
-          }
-        },
-        "decompress-zip": {
-          "version": "0.1.0",
-          "from": "decompress-zip@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
-          "dependencies": {
-            "binary": {
-              "version": "0.3.0",
-              "from": "binary@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-              "dependencies": {
-                "buffers": {
-                  "version": "0.1.1",
-                  "from": "buffers@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
-                },
-                "chainsaw": {
-                  "version": "0.1.0",
-                  "from": "chainsaw@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-                  "dependencies": {
-                    "traverse": {
-                      "version": "0.3.9",
-                      "from": "traverse@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "mkpath": {
-              "version": "0.1.0",
-              "from": "mkpath@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
-            },
-            "readable-stream": {
-              "version": "1.1.13",
-              "from": "readable-stream@>=1.1.8 <2.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                }
-              }
-            },
-            "touch": {
-              "version": "0.0.3",
-              "from": "touch@0.0.3",
-              "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
-              "dependencies": {
-                "nopt": {
-                  "version": "1.0.10",
-                  "from": "nopt@>=1.0.10 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
-                }
-              }
-            }
-          }
-        },
-        "destroy": {
-          "version": "1.0.3",
-          "from": "destroy@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
-        },
-        "fs-write-stream-atomic": {
-          "version": "1.0.5",
-          "from": "fs-write-stream-atomic@1.0.5",
-          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.5.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.2",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "from": "imurmurhash@>=0.1.4 <0.2.0",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-            }
-          }
-        },
-        "fstream": {
-          "version": "1.0.8",
-          "from": "fstream@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.2",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            }
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.3",
-          "from": "fstream-ignore@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "from": "minimatch@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "github": {
-          "version": "0.2.4",
-          "from": "github@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
-          "dependencies": {
-            "mime": {
-              "version": "1.3.4",
-              "from": "mime@>=1.2.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-            }
-          }
-        },
-        "glob": {
-          "version": "4.5.3",
-          "from": "glob@>=4.3.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "3.0.8",
-          "from": "graceful-fs@>=3.0.5 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-        },
-        "handlebars": {
-          "version": "2.0.0",
-          "from": "handlebars@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
-          "dependencies": {
-            "optimist": {
-              "version": "0.3.7",
-              "from": "optimist@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                }
-              }
-            },
-            "uglify-js": {
-              "version": "2.3.6",
-              "from": "uglify-js@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                },
-                "source-map": {
-                  "version": "0.1.43",
-                  "from": "source-map@>=0.1.7 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "inquirer": {
-          "version": "0.10.0",
-          "from": "inquirer@0.10.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.10.0.tgz",
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "1.1.0",
-              "from": "ansi-escapes@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.0.tgz"
-            },
-            "ansi-regex": {
-              "version": "2.0.0",
-              "from": "ansi-regex@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "from": "cli-cursor@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-              "dependencies": {
-                "restore-cursor": {
-                  "version": "1.0.1",
-                  "from": "restore-cursor@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                  "dependencies": {
-                    "exit-hook": {
-                      "version": "1.1.1",
-                      "from": "exit-hook@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
-                    },
-                    "onetime": {
-                      "version": "1.1.0",
-                      "from": "onetime@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "cli-width": {
-              "version": "1.1.0",
-              "from": "cli-width@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz"
-            },
-            "figures": {
-              "version": "1.4.0",
-              "from": "figures@>=1.3.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "from": "lodash@>=3.3.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-            },
-            "readline2": {
-              "version": "1.0.1",
-              "from": "readline2@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "from": "code-point-at@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                },
-                "mute-stream": {
-                  "version": "0.0.5",
-                  "from": "mute-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-                }
-              }
-            },
-            "run-async": {
-              "version": "0.1.0",
-              "from": "run-async@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-              "dependencies": {
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "rx-lite": {
-              "version": "3.1.2",
-              "from": "rx-lite@>=3.1.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-            },
-            "through": {
-              "version": "2.3.8",
-              "from": "through@>=2.3.6 <3.0.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            }
-          }
-        },
-        "insight": {
-          "version": "0.7.0",
-          "from": "insight@>=0.7.0 <0.8.0",
-          "resolved": "https://registry.npmjs.org/insight/-/insight-0.7.0.tgz",
-          "dependencies": {
-            "async": {
-              "version": "1.5.0",
-              "from": "async@>=1.4.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-            },
-            "configstore": {
-              "version": "1.4.0",
-              "from": "configstore@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "from": "osenv@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    }
-                  }
-                },
-                "uuid": {
-                  "version": "2.0.1",
-                  "from": "uuid@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
-                },
-                "write-file-atomic": {
-                  "version": "1.1.4",
-                  "from": "write-file-atomic@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-                  "dependencies": {
-                    "imurmurhash": {
-                      "version": "0.1.4",
-                      "from": "imurmurhash@>=0.1.4 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-                    },
-                    "slide": {
-                      "version": "1.1.6",
-                      "from": "slide@>=1.1.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-                    }
-                  }
-                },
-                "xdg-basedir": {
-                  "version": "2.0.0",
-                  "from": "xdg-basedir@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash.debounce": {
-              "version": "3.1.1",
-              "from": "lodash.debounce@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
-              "dependencies": {
-                "lodash._getnative": {
-                  "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-            },
-            "os-name": {
-              "version": "1.0.3",
-              "from": "os-name@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
-              "dependencies": {
-                "osx-release": {
-                  "version": "1.1.0",
-                  "from": "osx-release@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "1.2.0",
-                      "from": "minimist@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                    }
-                  }
-                },
-                "win-release": {
-                  "version": "1.1.1",
-                  "from": "win-release@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
-                  "dependencies": {
-                    "semver": {
-                      "version": "5.1.0",
-                      "from": "semver@>=5.0.1 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "tough-cookie": {
-              "version": "2.2.1",
-              "from": "tough-cookie@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-            }
-          }
-        },
-        "is-root": {
-          "version": "1.0.0",
-          "from": "is-root@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
-        },
-        "junk": {
-          "version": "1.0.2",
-          "from": "junk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.2.tgz"
-        },
-        "lockfile": {
-          "version": "1.0.1",
-          "from": "lockfile@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "from": "lru-cache@>=2.5.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-        },
-        "md5-hex": {
-          "version": "1.2.0",
-          "from": "md5-hex@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.2.0.tgz",
-          "dependencies": {
-            "md5-o-matic": {
-              "version": "0.1.1",
-              "from": "md5-o-matic@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "from": "mkdirp@0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "mout": {
-          "version": "0.11.1",
-          "from": "mout@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz"
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "from": "nopt@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
-        },
-        "opn": {
-          "version": "1.0.2",
-          "from": "opn@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
-        },
-        "p-throttler": {
-          "version": "0.1.1",
-          "from": "p-throttler@0.1.1",
-          "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.1.tgz",
-          "dependencies": {
-            "q": {
-              "version": "0.9.7",
-              "from": "q@>=0.9.2 <0.10.0",
-              "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
-            }
-          }
-        },
-        "promptly": {
-          "version": "0.2.0",
-          "from": "promptly@0.2.0",
-          "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
-          "dependencies": {
-            "read": {
-              "version": "1.0.7",
-              "from": "read@>=1.0.4 <1.1.0",
-              "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-              "dependencies": {
-                "mute-stream": {
-                  "version": "0.0.5",
-                  "from": "mute-stream@>=0.0.4 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "q": {
-          "version": "1.4.1",
-          "from": "q@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
-        },
-        "request": {
-          "version": "2.53.0",
-          "from": "request@2.53.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-            },
-            "bl": {
-              "version": "0.9.4",
-              "from": "bl@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "caseless": {
-              "version": "0.9.0",
-              "from": "caseless@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
-            },
-            "combined-stream": {
-              "version": "0.0.7",
-              "from": "combined-stream@>=0.0.5 <0.1.0",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                }
-              }
-            },
-            "forever-agent": {
-              "version": "0.5.2",
-              "from": "forever-agent@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-            },
-            "form-data": {
-              "version": "0.2.0",
-              "from": "form-data@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-                }
-              }
-            },
-            "hawk": {
-              "version": "2.3.1",
-              "from": "hawk@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "dependencies": {
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "dependencies": {
-                "asn1": {
-                  "version": "0.1.11",
-                  "from": "asn1@0.1.11",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.3",
-                  "from": "ctype@0.5.3",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                }
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.0.14",
-              "from": "mime-types@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.12.0",
-                  "from": "mime-db@>=1.12.0 <1.13.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.7",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-            },
-            "oauth-sign": {
-              "version": "0.6.0",
-              "from": "oauth-sign@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
-            },
-            "qs": {
-              "version": "2.3.3",
-              "from": "qs@>=2.3.1 <2.4.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.1",
-              "from": "tough-cookie@>=0.12.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.2",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-            }
-          }
-        },
-        "request-progress": {
-          "version": "0.3.1",
-          "from": "request-progress@0.3.1",
-          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
-          "dependencies": {
-            "throttleit": {
-              "version": "0.0.2",
-              "from": "throttleit@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
-            }
-          }
-        },
-        "retry": {
-          "version": "0.6.1",
-          "from": "retry@0.6.1",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
-        },
-        "rimraf": {
-          "version": "2.5.0",
-          "from": "rimraf@>=2.2.8 <3.0.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "6.0.3",
-              "from": "glob@>=6.0.1 <7.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.2",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "semver": {
-          "version": "2.3.2",
-          "from": "semver@>=2.3.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
-        },
-        "shell-quote": {
-          "version": "1.4.3",
-          "from": "shell-quote@>=1.4.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
-          "dependencies": {
-            "array-filter": {
-              "version": "0.0.1",
-              "from": "array-filter@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
-            },
-            "array-map": {
-              "version": "0.0.0",
-              "from": "array-map@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
-            },
-            "array-reduce": {
-              "version": "0.0.0",
-              "from": "array-reduce@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
-            },
-            "jsonify": {
-              "version": "0.0.0",
-              "from": "jsonify@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-            }
-          }
-        },
-        "stringify-object": {
-          "version": "1.0.1",
-          "from": "stringify-object@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
-        },
-        "tar-fs": {
-          "version": "1.9.0",
-          "from": "tar-fs@>=1.4.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.9.0.tgz",
-          "dependencies": {
-            "pump": {
-              "version": "1.0.1",
-              "from": "pump@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz",
-              "dependencies": {
-                "end-of-stream": {
-                  "version": "1.1.0",
-                  "from": "end-of-stream@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@>=1.3.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "tar-stream": {
-              "version": "1.3.1",
-              "from": "tar-stream@>=1.1.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.3.1.tgz",
-              "dependencies": {
-                "bl": {
-                  "version": "1.0.0",
-                  "from": "bl@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
-                },
-                "end-of-stream": {
-                  "version": "1.1.0",
-                  "from": "end-of-stream@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-                  "dependencies": {
-                    "once": {
-                      "version": "1.3.3",
-                      "from": "once@>=1.3.0 <1.4.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "tmp": {
-          "version": "0.0.24",
-          "from": "tmp@0.0.24",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
-        },
-        "update-notifier": {
-          "version": "0.6.0",
-          "from": "update-notifier@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.6.0.tgz",
-          "dependencies": {
-            "configstore": {
-              "version": "1.4.0",
-              "from": "configstore@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                },
-                "object-assign": {
-                  "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "from": "osenv@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    }
-                  }
-                },
-                "uuid": {
-                  "version": "2.0.1",
-                  "from": "uuid@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
-                },
-                "write-file-atomic": {
-                  "version": "1.1.4",
-                  "from": "write-file-atomic@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-                  "dependencies": {
-                    "imurmurhash": {
-                      "version": "0.1.4",
-                      "from": "imurmurhash@>=0.1.4 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-                    },
-                    "slide": {
-                      "version": "1.1.6",
-                      "from": "slide@>=1.1.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-                    }
-                  }
-                },
-                "xdg-basedir": {
-                  "version": "2.0.0",
-                  "from": "xdg-basedir@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "is-npm": {
-              "version": "1.0.0",
-              "from": "is-npm@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
-            },
-            "latest-version": {
-              "version": "2.0.0",
-              "from": "latest-version@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
-              "dependencies": {
-                "package-json": {
-                  "version": "2.3.0",
-                  "from": "package-json@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.3.0.tgz",
-                  "dependencies": {
-                    "got": {
-                      "version": "5.3.0",
-                      "from": "got@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/got/-/got-5.3.0.tgz",
-                      "dependencies": {
-                        "create-error-class": {
-                          "version": "2.0.1",
-                          "from": "create-error-class@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-2.0.1.tgz",
-                          "dependencies": {
-                            "capture-stack-trace": {
-                              "version": "1.0.0",
-                              "from": "capture-stack-trace@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.4.2",
-                          "from": "duplexify@>=3.2.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
-                          "dependencies": {
-                            "end-of-stream": {
-                              "version": "1.0.0",
-                              "from": "end-of-stream@1.0.0",
-                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-                              "dependencies": {
-                                "once": {
-                                  "version": "1.3.3",
-                                  "from": "once@>=1.3.0 <1.4.0",
-                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                                  "dependencies": {
-                                    "wrappy": {
-                                      "version": "1.0.1",
-                                      "from": "wrappy@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "readable-stream": {
-                              "version": "2.0.5",
-                              "from": "readable-stream@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                },
-                                "process-nextick-args": {
-                                  "version": "1.0.6",
-                                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                },
-                                "util-deprecate": {
-                                  "version": "1.0.2",
-                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "is-plain-obj": {
-                          "version": "1.1.0",
-                          "from": "is-plain-obj@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
-                        },
-                        "is-redirect": {
-                          "version": "1.0.0",
-                          "from": "is-redirect@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
-                        },
-                        "is-stream": {
-                          "version": "1.0.1",
-                          "from": "is-stream@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
-                        },
-                        "lowercase-keys": {
-                          "version": "1.0.0",
-                          "from": "lowercase-keys@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
-                        },
-                        "node-status-codes": {
-                          "version": "1.0.0",
-                          "from": "node-status-codes@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
-                        },
-                        "object-assign": {
-                          "version": "4.0.1",
-                          "from": "object-assign@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                        },
-                        "parse-json": {
-                          "version": "2.2.0",
-                          "from": "parse-json@>=2.1.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                          "dependencies": {
-                            "error-ex": {
-                              "version": "1.3.0",
-                              "from": "error-ex@>=1.2.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                              "dependencies": {
-                                "is-arrayish": {
-                                  "version": "0.2.1",
-                                  "from": "is-arrayish@>=0.2.1 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.0",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.1",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                            }
-                          }
-                        },
-                        "read-all-stream": {
-                          "version": "3.0.1",
-                          "from": "read-all-stream@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
-                          "dependencies": {
-                            "pinkie-promise": {
-                              "version": "1.0.0",
-                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "1.0.0",
-                                  "from": "pinkie@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "readable-stream": {
-                              "version": "2.0.5",
-                              "from": "readable-stream@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                },
-                                "process-nextick-args": {
-                                  "version": "1.0.6",
-                                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                },
-                                "util-deprecate": {
-                                  "version": "1.0.2",
-                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "timed-out": {
-                          "version": "2.0.0",
-                          "from": "timed-out@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
-                        },
-                        "unzip-response": {
-                          "version": "1.0.0",
-                          "from": "unzip-response@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz"
-                        },
-                        "url-parse-lax": {
-                          "version": "1.0.0",
-                          "from": "url-parse-lax@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-                          "dependencies": {
-                            "prepend-http": {
-                              "version": "1.0.3",
-                              "from": "prepend-http@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "rc": {
-                      "version": "1.1.6",
-                      "from": "rc@>=1.1.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-                      "dependencies": {
-                        "deep-extend": {
-                          "version": "0.4.0",
-                          "from": "deep-extend@>=0.4.0 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
-                        },
-                        "ini": {
-                          "version": "1.3.4",
-                          "from": "ini@>=1.3.0 <1.4.0",
-                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                        },
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@>=1.2.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        },
-                        "strip-json-comments": {
-                          "version": "1.0.4",
-                          "from": "strip-json-comments@>=1.0.4 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-                        }
-                      }
-                    },
-                    "registry-url": {
-                      "version": "3.0.3",
-                      "from": "registry-url@>=3.0.3 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz"
-                    },
-                    "semver": {
-                      "version": "5.1.0",
-                      "from": "semver@>=5.1.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "repeating": {
-              "version": "2.0.0",
-              "from": "repeating@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "semver-diff": {
-              "version": "2.1.0",
-              "from": "semver-diff@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-              "dependencies": {
-                "semver": {
-                  "version": "5.1.0",
-                  "from": "semver@>=5.0.3 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                }
-              }
-            },
-            "string-length": {
-              "version": "1.0.1",
-              "from": "string-length@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "user-home": {
-          "version": "1.1.1",
-          "from": "user-home@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-        },
-        "which": {
-          "version": "1.2.1",
-          "from": "which@>=1.0.8 <2.0.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.1.tgz",
-          "dependencies": {
-            "is-absolute": {
-              "version": "0.1.7",
-              "from": "is-absolute@>=0.1.7 <0.2.0",
-              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-              "dependencies": {
-                "is-relative": {
-                  "version": "0.1.3",
-                  "from": "is-relative@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+      "dev": true
     },
     "boxen": {
       "version": "0.6.0",
       "from": "boxen@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
-      "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "from": "camelcase@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
-        }
-      }
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.6",
       "from": "brace-expansion@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+      "dev": true
     },
     "braces": {
-      "version": "1.8.3",
+      "version": "1.8.5",
       "from": "braces@>=1.8.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz"
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "dev": true
+    },
+    "browserify-aes": {
+      "version": "0.4.0",
+      "from": "browserify-aes@0.4.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
+      "dev": true
     },
     "browserify-zlib": {
       "version": "0.1.4",
-      "from": "browserify-zlib@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
+      "from": "browserify-zlib@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "dev": true,
+      "dependencies": {
+        "pako": {
+          "version": "0.2.9",
+          "from": "pako@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+          "dev": true
+        }
+      }
     },
     "browserstack": {
-      "version": "1.2.0",
-      "from": "browserstack@1.2.0",
-      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.2.0.tgz"
+      "version": "1.3.1",
+      "from": "browserstack@1.3.1",
+      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.3.1.tgz",
+      "dev": true
     },
     "browserstacktunnel-wrapper": {
       "version": "1.4.2",
       "from": "browserstacktunnel-wrapper@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/browserstacktunnel-wrapper/-/browserstacktunnel-wrapper-1.4.2.tgz"
+      "resolved": "https://registry.npmjs.org/browserstacktunnel-wrapper/-/browserstacktunnel-wrapper-1.4.2.tgz",
+      "dev": true
     },
     "buffer": {
       "version": "4.9.1",
       "from": "buffer@>=4.9.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
         }
       }
     },
     "buffer-crc32": {
-      "version": "0.2.5",
+      "version": "0.2.13",
       "from": "buffer-crc32@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "dev": true
     },
     "buffer-shims": {
       "version": "1.0.0",
       "from": "buffer-shims@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "dev": true
     },
     "buffers": {
       "version": "0.1.1",
       "from": "buffers@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
       "from": "builtin-modules@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "dev": true
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "from": "builtin-status-codes@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "dev": true
     },
     "bytes": {
       "version": "2.1.0",
       "from": "bytes@2.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
+      "dev": true
     },
     "callsite": {
       "version": "1.0.0",
       "from": "callsite@1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "dev": true
     },
     "camelcase": {
-      "version": "2.0.1",
+      "version": "2.1.1",
       "from": "camelcase@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "dev": true
     },
     "camelcase-keys": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "from": "camelcase-keys@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "dev": true
     },
     "capture-stack-trace": {
       "version": "1.0.0",
       "from": "capture-stack-trace@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "dev": true
     },
     "caseless": {
-      "version": "0.11.0",
-      "from": "caseless@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+      "version": "0.9.0",
+      "from": "caseless@>=0.9.0 <0.10.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+      "dev": true
     },
     "center-align": {
-      "version": "0.1.2",
+      "version": "0.1.3",
       "from": "center-align@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "dev": true
     },
     "chainsaw": {
       "version": "0.1.0",
       "from": "chainsaw@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "dev": true
     },
     "chalk": {
       "version": "1.1.3",
-      "from": "chalk@>=1.1.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+      "from": "chalk@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "dev": true
     },
     "chokidar": {
-      "version": "1.4.2",
+      "version": "1.6.1",
       "from": "chokidar@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz"
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+      "dev": true
     },
     "clang-format": {
-      "version": "1.0.41",
-      "from": "clang-format@1.0.41",
-      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.41.tgz",
+      "version": "1.0.46",
+      "from": "clang-format@>=1.0.32 <2.0.0",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.46.tgz",
+      "dev": true,
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.5.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-        },
         "glob": {
-          "version": "7.0.3",
+          "version": "7.1.1",
           "from": "glob@>=7.0.0 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "dev": true
         }
       }
     },
     "cldr": {
       "version": "3.5.2",
-      "from": "cldr@>=3.5.0 <4.0.0",
+      "from": "cldr@>=3.5.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/cldr/-/cldr-3.5.2.tgz",
-      "dependencies": {
-        "uglify-js": {
-          "version": "1.3.3",
-          "from": "uglify-js@1.3.3",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.3.tgz"
-        },
-        "underscore": {
-          "version": "1.3.3",
-          "from": "underscore@1.3.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.3.3.tgz"
-        }
-      }
+      "dev": true
     },
     "cli-boxes": {
       "version": "1.0.0",
       "from": "cli-boxes@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "dev": true
     },
     "cli-color": {
       "version": "1.1.0",
       "from": "cli-color@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.1.0.tgz",
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-        }
-      }
+      "dev": true
     },
     "cliui": {
-      "version": "3.1.0",
-      "from": "cliui@>=3.0.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.1.0.tgz",
+      "version": "2.1.0",
+      "from": "cliui@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-        },
-        "strip-ansi": {
-          "version": "3.0.0",
-          "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+        "wordwrap": {
+          "version": "0.0.2",
+          "from": "wordwrap@0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "dev": true
         }
       }
     },
     "clone": {
       "version": "1.0.2",
       "from": "clone@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+      "dev": true
     },
     "clone-stats": {
       "version": "0.0.1",
       "from": "clone-stats@>=0.0.1 <0.0.2",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "dev": true
     },
     "code-point-at": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "code-point-at@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "dev": true
     },
     "colors": {
       "version": "1.1.2",
       "from": "colors@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "dev": true
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "from": "combined-stream@>=1.0.5 <1.1.0",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+      "version": "0.0.7",
+      "from": "combined-stream@>=0.0.5 <0.1.0",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+      "dev": true
     },
     "commander": {
-      "version": "2.9.0",
-      "from": "commander@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+      "version": "2.6.0",
+      "from": "commander@2.6.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+      "dev": true
+    },
+    "commoner": {
+      "version": "0.10.8",
+      "from": "commoner@>=0.10.1 <0.11.0",
+      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "from": "glob@>=5.0.15 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "from": "graceful-fs@>=4.1.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true
+        }
+      }
     },
     "compare-func": {
       "version": "1.3.2",
       "from": "compare-func@>=1.3.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
+      "dev": true
     },
     "component-bind": {
       "version": "1.0.0",
       "from": "component-bind@1.0.0",
-      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.1.2",
       "from": "component-emitter@1.1.2",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+      "dev": true
     },
     "component-inherit": {
       "version": "0.0.3",
       "from": "component-inherit@0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "dev": true
     },
     "compress-commons": {
-      "version": "0.2.9",
-      "from": "compress-commons@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.9.tgz",
+      "version": "1.1.0",
+      "from": "compress-commons@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.1.0.tgz",
+      "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "1.0.33",
-          "from": "readable-stream@>=1.0.26 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
         }
       }
     },
     "compressible": {
-      "version": "2.0.6",
+      "version": "2.0.9",
       "from": "compressible@>=2.0.5 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.6.tgz",
-      "dependencies": {
-        "mime-db": {
-          "version": "1.20.0",
-          "from": "mime-db@1.20.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.9.tgz",
+      "dev": true
     },
     "compression": {
       "version": "1.5.2",
       "from": "compression@>=1.5.2 <1.6.0",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz"
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "vary": {
+          "version": "1.0.1",
+          "from": "vary@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
+          "dev": true
+        }
+      }
     },
     "concat-map": {
       "version": "0.0.1",
       "from": "concat-map@0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "from": "concat-stream@>=1.5.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.2.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
+        }
+      }
     },
     "configstore": {
       "version": "2.1.0",
       "from": "configstore@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+      "dev": true,
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true
         }
       }
     },
     "connect": {
-      "version": "3.4.0",
-      "from": "connect@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.0.tgz"
+      "version": "2.30.2",
+      "from": "connect@>=2.30.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
+      "dev": true
     },
     "connect-livereload": {
       "version": "0.5.4",
       "from": "connect-livereload@>=0.5.4 <0.6.0",
-      "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.5.4.tgz"
+      "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.5.4.tgz",
+      "dev": true
     },
     "connect-timeout": {
       "version": "1.6.2",
       "from": "connect-timeout@>=1.6.2 <1.7.0",
-      "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz"
+      "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
+      "dev": true
     },
     "console-browserify": {
       "version": "1.1.0",
       "from": "console-browserify@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "dev": true
     },
     "constants-browserify": {
-      "version": "0.0.1",
-      "from": "constants-browserify@>=0.0.1 <0.1.0",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+      "version": "1.0.0",
+      "from": "constants-browserify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "dev": true
     },
     "content-type": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "from": "content-type@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+      "dev": true
     },
     "conventional-changelog": {
       "version": "1.1.0",
-      "from": "conventional-changelog@latest",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.0.tgz"
+      "from": "conventional-changelog@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.0.tgz",
+      "dev": true
     },
     "conventional-changelog-angular": {
       "version": "1.3.0",
       "from": "conventional-changelog-angular@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.3.0.tgz",
+      "dev": true
     },
     "conventional-changelog-atom": {
       "version": "0.1.0",
       "from": "conventional-changelog-atom@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.0.tgz",
+      "dev": true
     },
     "conventional-changelog-codemirror": {
       "version": "0.1.0",
       "from": "conventional-changelog-codemirror@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.1.0.tgz",
+      "dev": true
     },
     "conventional-changelog-core": {
       "version": "1.5.0",
       "from": "conventional-changelog-core@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.5.0.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "lodash": {
-          "version": "4.14.2",
-          "from": "lodash@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.2.tgz"
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
-        }
-      }
+      "dev": true
     },
     "conventional-changelog-ember": {
       "version": "0.2.2",
       "from": "conventional-changelog-ember@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.2.tgz",
+      "dev": true
     },
     "conventional-changelog-eslint": {
       "version": "0.1.0",
       "from": "conventional-changelog-eslint@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.1.0.tgz",
+      "dev": true
     },
     "conventional-changelog-express": {
       "version": "0.1.0",
       "from": "conventional-changelog-express@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.1.0.tgz",
+      "dev": true
     },
     "conventional-changelog-jquery": {
       "version": "0.1.0",
       "from": "conventional-changelog-jquery@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
+      "dev": true
     },
     "conventional-changelog-jscs": {
       "version": "0.1.0",
       "from": "conventional-changelog-jscs@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
+      "dev": true
     },
     "conventional-changelog-jshint": {
       "version": "0.1.0",
       "from": "conventional-changelog-jshint@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.1.0.tgz",
+      "dev": true
     },
     "conventional-changelog-writer": {
       "version": "1.4.1",
       "from": "conventional-changelog-writer@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-1.4.1.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "lodash": {
-          "version": "4.14.2",
-          "from": "lodash@4.14.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.2.tgz"
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "from": "through2@2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
-        }
-      }
+      "dev": true
     },
     "conventional-commits-filter": {
       "version": "1.0.0",
       "from": "conventional-commits-filter@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz",
+      "dev": true
     },
     "conventional-commits-parser": {
-      "version": "1.2.3",
+      "version": "1.3.0",
       "from": "conventional-commits-parser@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.2.3.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "lodash": {
-          "version": "4.14.2",
-          "from": "lodash@4.14.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.2.tgz"
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "from": "through2@2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz",
+      "dev": true
     },
     "cookie": {
       "version": "0.1.3",
       "from": "cookie@0.1.3",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
+      "dev": true
     },
     "cookie-parser": {
       "version": "1.3.5",
       "from": "cookie-parser@>=1.3.5 <1.4.0",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz"
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
+      "dev": true
     },
     "cookie-signature": {
       "version": "1.0.6",
       "from": "cookie-signature@1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "dev": true
     },
     "core-js": {
       "version": "2.4.1",
-      "from": "core-js@2.4.1",
+      "from": "core-js@>=2.4.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
     },
     "core-util-is": {
       "version": "1.0.2",
       "from": "core-util-is@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "dev": true
     },
     "cors": {
-      "version": "2.7.1",
+      "version": "2.8.1",
       "from": "cors@>=2.7.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz"
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.1.tgz",
+      "dev": true
     },
     "crc": {
-      "version": "3.3.0",
-      "from": "crc@3.3.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz"
+      "version": "3.4.4",
+      "from": "crc@>=3.4.4 <4.0.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
+      "dev": true
     },
     "crc32-stream": {
-      "version": "0.3.4",
-      "from": "crc32-stream@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
+      "version": "1.0.1",
+      "from": "crc32-stream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.1.tgz",
+      "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "1.0.33",
-          "from": "readable-stream@>=1.0.24 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
         }
       }
     },
     "create-error-class": {
       "version": "3.0.2",
       "from": "create-error-class@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "dev": true
     },
     "cryptiles": {
       "version": "2.0.5",
       "from": "cryptiles@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "dev": true
     },
     "crypto-browserify": {
-      "version": "3.2.8",
-      "from": "crypto-browserify@>=3.2.6 <3.3.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz"
+      "version": "3.3.0",
+      "from": "crypto-browserify@3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
+      "dev": true
     },
     "csrf": {
-      "version": "3.0.0",
+      "version": "3.0.4",
       "from": "csrf@>=3.0.0 <3.1.0",
-      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.4.tgz",
+      "dev": true
     },
     "csurf": {
       "version": "1.8.3",
       "from": "csurf@>=1.8.3 <1.9.0",
-      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz"
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
+      "dev": true
     },
     "ctype": {
       "version": "0.5.3",
       "from": "ctype@0.5.3",
-      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "dev": true
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "from": "currently-unhandled@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "dev": true
     },
     "custom-event": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "custom-event@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
+      "dev": true
     },
     "d": {
       "version": "0.1.1",
       "from": "d@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+      "dev": true
     },
     "dargs": {
       "version": "4.1.0",
       "from": "dargs@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
+      "dev": true
     },
     "dashdash": {
-      "version": "1.14.0",
+      "version": "1.14.1",
       "from": "dashdash@>=1.12.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "dev": true
         }
       }
     },
     "date-now": {
       "version": "0.1.4",
       "from": "date-now@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "dev": true
     },
     "dateformat": {
       "version": "1.0.12",
-      "from": "dateformat@>=1.0.11 <2.0.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz"
+      "from": "dateformat@>=1.0.12 <2.0.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+      "dev": true
     },
     "debug": {
       "version": "2.2.0",
       "from": "debug@>=2.2.0 <2.3.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "dev": true
     },
     "decamelize": {
-      "version": "1.1.2",
-      "from": "decamelize@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz"
+      "version": "1.2.0",
+      "from": "decamelize@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "dev": true
     },
     "deep-extend": {
       "version": "0.4.1",
       "from": "deep-extend@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+      "dev": true
     },
     "defaults": {
       "version": "1.0.3",
       "from": "defaults@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "dev": true
+    },
+    "defined": {
+      "version": "1.0.0",
+      "from": "defined@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "dev": true
     },
     "del": {
       "version": "2.2.2",
       "from": "del@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "dev": true
     },
     "delayed-stream": {
-      "version": "1.0.0",
-      "from": "delayed-stream@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+      "version": "0.0.5",
+      "from": "delayed-stream@0.0.5",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+      "dev": true
     },
     "depd": {
       "version": "1.0.1",
       "from": "depd@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+      "dev": true
     },
     "deprecated": {
       "version": "0.0.1",
       "from": "deprecated@>=0.0.1 <0.0.2",
-      "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+      "dev": true
     },
     "destroy": {
-      "version": "1.0.3",
-      "from": "destroy@1.0.3",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+      "version": "1.0.4",
+      "from": "destroy@>=1.0.4 <1.1.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "dev": true
+    },
+    "detect-file": {
+      "version": "0.1.0",
+      "from": "detect-file@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+      "dev": true
+    },
+    "detective": {
+      "version": "4.3.2",
+      "from": "detective@>=4.3.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "from": "acorn@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "dev": true
+        }
+      }
     },
     "di": {
       "version": "0.0.1",
       "from": "di@>=0.0.1 <0.0.2",
-      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
+      "dev": true
     },
     "diff": {
-      "version": "2.2.1",
+      "version": "2.2.3",
       "from": "diff@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+      "dev": true
     },
     "doctrine": {
       "version": "0.7.2",
       "from": "doctrine@>=0.7.2 <0.8.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz"
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "esutils": {
+          "version": "1.1.6",
+          "from": "esutils@>=1.1.6 <2.0.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "dev": true
+        }
+      }
     },
     "dom-serialize": {
       "version": "2.2.1",
       "from": "dom-serialize@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
+      "dev": true
     },
     "domain-browser": {
       "version": "1.1.7",
-      "from": "domain-browser@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+      "from": "domain-browser@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "dev": true
     },
     "dot-prop": {
       "version": "3.0.0",
       "from": "dot-prop@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+      "dev": true
     },
     "duplexer": {
       "version": "0.1.1",
       "from": "duplexer@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "dev": true
     },
     "duplexer2": {
       "version": "0.0.2",
-      "from": "duplexer2@>=0.0.2 <0.1.0",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+      "from": "duplexer2@0.0.2",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.9 <1.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "dev": true
+        }
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "dev": true,
+      "optional": true
     },
     "ee-first": {
       "version": "1.1.1",
       "from": "ee-first@1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "dev": true
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "from": "emojis-list@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.1.0",
       "from": "end-of-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "once": {
+          "version": "1.3.3",
+          "from": "once@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "dev": true
+        }
+      }
     },
     "engine.io": {
-      "version": "1.6.9",
-      "from": "engine.io@1.6.9",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.9.tgz",
+      "version": "1.8.2",
+      "from": "engine.io@1.8.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.2.tgz",
+      "dev": true,
       "dependencies": {
         "accepts": {
-          "version": "1.1.4",
-          "from": "accepts@1.1.4",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz"
+          "version": "1.3.3",
+          "from": "accepts@1.3.3",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+          "dev": true
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "from": "cookie@0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "dev": true
         },
         "negotiator": {
-          "version": "0.4.9",
-          "from": "negotiator@0.4.9",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
-        },
-        "ws": {
-          "version": "1.0.1",
-          "from": "ws@1.0.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz"
+          "version": "0.6.1",
+          "from": "negotiator@0.6.1",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+          "dev": true
         }
       }
     },
     "engine.io-client": {
-      "version": "1.6.9",
-      "from": "engine.io-client@1.6.9",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.9.tgz",
+      "version": "1.8.2",
+      "from": "engine.io-client@1.8.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.2.tgz",
+      "dev": true,
       "dependencies": {
-        "ws": {
-          "version": "1.0.1",
-          "from": "ws@1.0.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz"
+        "component-emitter": {
+          "version": "1.2.1",
+          "from": "component-emitter@1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "dev": true
         }
       }
     },
     "engine.io-parser": {
-      "version": "1.2.4",
-      "from": "engine.io-parser@1.2.4",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
-      "dependencies": {
-        "has-binary": {
-          "version": "0.1.6",
-          "from": "has-binary@0.1.6",
-          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz"
-        }
-      }
+      "version": "1.3.2",
+      "from": "engine.io-parser@1.3.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
+      "dev": true
     },
     "enhanced-resolve": {
       "version": "0.9.1",
       "from": "enhanced-resolve@>=0.9.0 <0.10.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2",
+          "version": "4.1.11",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true
         },
         "memory-fs": {
           "version": "0.2.0",
           "from": "memory-fs@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+          "dev": true
         }
       }
     },
     "ent": {
       "version": "2.2.0",
       "from": "ent@>=2.2.0 <2.3.0",
-      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "dev": true
     },
     "envify": {
-      "version": "3.4.0",
+      "version": "3.4.1",
       "from": "envify@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
+      "dev": true
     },
     "errno": {
       "version": "0.1.4",
       "from": "errno@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.0",
       "from": "error-ex@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+      "dev": true
     },
     "errorhandler": {
-      "version": "1.4.2",
+      "version": "1.4.3",
       "from": "errorhandler@>=1.4.2 <1.5.0",
-      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.2.tgz"
+      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
+      "dev": true,
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.3",
+          "from": "accepts@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+          "dev": true
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "from": "negotiator@0.6.1",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+          "dev": true
+        }
+      }
     },
     "es5-ext": {
-      "version": "0.10.11",
+      "version": "0.10.12",
       "from": "es5-ext@>=0.10.8 <0.11.0",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
+      "dev": true
     },
     "es6-iterator": {
       "version": "2.0.0",
       "from": "es6-iterator@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+      "dev": true
     },
     "es6-module-loader": {
-      "version": "0.17.9",
+      "version": "0.17.11",
       "from": "es6-module-loader@>=0.17.4 <0.18.0",
-      "resolved": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.17.9.tgz"
+      "resolved": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.17.11.tgz",
+      "dev": true
     },
     "es6-symbol": {
-      "version": "3.0.2",
-      "from": "es6-symbol@>=3.0.2 <3.1.0",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+      "version": "3.1.0",
+      "from": "es6-symbol@>=3.1.0 <3.2.0",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
+      "dev": true
     },
     "es6-weak-map": {
       "version": "0.1.4",
       "from": "es6-weak-map@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+      "dev": true,
       "dependencies": {
         "es6-iterator": {
           "version": "0.1.3",
           "from": "es6-iterator@>=0.1.3 <0.2.0",
-          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+          "dev": true
         },
         "es6-symbol": {
           "version": "2.0.1",
           "from": "es6-symbol@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+          "dev": true
         }
       }
     },
     "escape-html": {
-      "version": "1.0.2",
-      "from": "escape-html@1.0.2",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
+      "version": "1.0.3",
+      "from": "escape-html@>=1.0.3 <1.1.0",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "dev": true
     },
     "escape-string-regexp": {
-      "version": "1.0.4",
-      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+      "version": "1.0.5",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "dev": true
     },
-    "esprima": {
-      "version": "2.7.1",
-      "from": "esprima@>=2.6.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+    "esprima-fb": {
+      "version": "15001.1.0-dev-harmony-fb",
+      "from": "esprima-fb@>=15001.1.0-dev-harmony-fb <15002.0.0",
+      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+      "dev": true
     },
     "estree-walker": {
       "version": "0.2.1",
       "from": "estree-walker@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
+      "dev": true
     },
     "esutils": {
-      "version": "1.1.6",
-      "from": "esutils@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+      "version": "2.0.2",
+      "from": "esutils@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "dev": true
     },
     "etag": {
       "version": "1.7.0",
       "from": "etag@>=1.7.0 <1.8.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+      "dev": true
     },
     "event-emitter": {
       "version": "0.3.4",
-      "from": "event-emitter@>=0.3.3 <0.4.0",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+      "from": "event-emitter@>=0.3.4 <0.4.0",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
+      "dev": true
     },
     "event-stream": {
-      "version": "3.3.2",
+      "version": "3.3.4",
       "from": "event-stream@>=3.1.5 <4.0.0",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "dev": true,
       "dependencies": {
         "split": {
           "version": "0.3.3",
           "from": "split@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
+          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+          "dev": true
         }
       }
     },
     "eventemitter3": {
       "version": "1.2.0",
       "from": "eventemitter3@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+      "dev": true
     },
     "events": {
       "version": "1.1.1",
       "from": "events@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "dev": true
     },
     "exit": {
       "version": "0.1.2",
       "from": "exit@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "dev": true
     },
     "expand-braces": {
       "version": "0.1.2",
       "from": "expand-braces@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
+      "dev": true,
       "dependencies": {
         "braces": {
           "version": "0.1.5",
           "from": "braces@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz"
+          "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
+          "dev": true
         },
         "expand-range": {
           "version": "0.1.1",
           "from": "expand-range@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
+          "dev": true
         },
         "is-number": {
           "version": "0.1.1",
           "from": "is-number@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
+          "dev": true
         },
         "repeat-string": {
           "version": "0.2.2",
           "from": "repeat-string@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
+          "dev": true
         }
       }
     },
     "expand-brackets": {
-      "version": "0.1.4",
+      "version": "0.1.5",
       "from": "expand-brackets@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "dev": true
     },
     "expand-range": {
-      "version": "1.8.1",
+      "version": "1.8.2",
       "from": "expand-range@>=1.8.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz"
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "dev": true
+    },
+    "expand-tilde": {
+      "version": "1.2.2",
+      "from": "expand-tilde@>=1.2.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+      "dev": true
     },
     "express-session": {
       "version": "1.11.3",
       "from": "express-session@>=1.11.3 <1.12.0",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz"
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
+      "dev": true,
+      "dependencies": {
+        "base64-url": {
+          "version": "1.2.1",
+          "from": "base64-url@1.2.1",
+          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
+          "dev": true
+        },
+        "crc": {
+          "version": "3.3.0",
+          "from": "crc@3.3.0",
+          "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
+          "dev": true
+        },
+        "uid-safe": {
+          "version": "2.0.0",
+          "from": "uid-safe@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
+          "dev": true
+        }
+      }
     },
     "extend": {
       "version": "3.0.0",
-      "from": "extend@>=3.0.0 <3.1.0",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+      "from": "extend@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+      "dev": true
     },
     "extglob": {
-      "version": "0.3.1",
+      "version": "0.3.2",
       "from": "extglob@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "dev": true
     },
     "extsprintf": {
       "version": "1.0.2",
       "from": "extsprintf@1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "dev": true
     },
     "fancy-log": {
-      "version": "1.1.0",
+      "version": "1.3.0",
       "from": "fancy-log@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-        },
-        "ansi-styles": {
-          "version": "2.1.0",
-          "from": "ansi-styles@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-        },
-        "strip-ansi": {
-          "version": "3.0.0",
-          "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+      "dev": true
     },
     "faye-websocket": {
       "version": "0.10.0",
       "from": "faye-websocket@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz"
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "dev": true
     },
     "fbjs": {
-      "version": "0.6.0",
-      "from": "fbjs@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.0.tgz",
+      "version": "0.6.1",
+      "from": "fbjs@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz",
+      "dev": true,
       "dependencies": {
         "core-js": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "from": "core-js@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "dev": true
         }
       }
     },
     "filename-regex": {
       "version": "2.0.0",
       "from": "filename-regex@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+      "dev": true
     },
     "fill-range": {
       "version": "2.2.3",
       "from": "fill-range@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "dev": true
     },
     "filled-array": {
       "version": "1.1.0",
       "from": "filled-array@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
+      "dev": true
     },
     "finalhandler": {
       "version": "0.4.0",
       "from": "finalhandler@0.4.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "escape-html": {
+          "version": "1.0.2",
+          "from": "escape-html@1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
+          "dev": true
+        }
+      }
     },
     "find-index": {
       "version": "0.1.1",
       "from": "find-index@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+      "dev": true
     },
     "find-up": {
-      "version": "1.1.0",
+      "version": "1.1.2",
       "from": "find-up@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "dev": true
     },
     "findup-sync": {
-      "version": "0.3.0",
-      "from": "findup-sync@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "from": "glob@>=5.0.0 <5.1.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-        }
-      }
+      "version": "0.4.3",
+      "from": "findup-sync@>=0.4.2 <0.5.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+      "dev": true
+    },
+    "fined": {
+      "version": "1.0.2",
+      "from": "fined@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
+      "dev": true
     },
     "firefox-profile": {
-      "version": "0.3.11",
+      "version": "0.3.13",
       "from": "firefox-profile@>=0.3.4 <0.4.0",
-      "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-0.3.11.tgz",
+      "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-0.3.13.tgz",
+      "dev": true,
       "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-        },
         "fs-extra": {
-          "version": "0.16.5",
-          "from": "fs-extra@>=0.16.0 <0.17.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz"
+          "version": "0.28.0",
+          "from": "fs-extra@>=0.28.0 <0.29.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.28.0.tgz",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "from": "graceful-fs@>=4.1.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true
         },
         "lodash": {
-          "version": "3.5.0",
-          "from": "lodash@>=3.5.0 <3.6.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
+          "version": "4.11.2",
+          "from": "lodash@>=4.11.1 <4.12.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.11.2.tgz",
+          "dev": true
         }
       }
     },
     "first-chunk-stream": {
       "version": "1.0.0",
       "from": "first-chunk-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "dev": true
     },
     "flagged-respawn": {
-      "version": "0.3.1",
-      "from": "flagged-respawn@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
+      "version": "0.3.2",
+      "from": "flagged-respawn@>=0.3.2 <0.4.0",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
+      "dev": true
     },
     "for-in": {
-      "version": "0.1.4",
-      "from": "for-in@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+      "version": "0.1.6",
+      "from": "for-in@>=0.1.5 <0.2.0",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
+      "dev": true
     },
     "for-own": {
-      "version": "0.1.3",
-      "from": "for-own@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz"
+      "version": "0.1.4",
+      "from": "for-own@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
-      "from": "forever-agent@>=0.6.1 <0.7.0",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+      "from": "forever-agent@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "dev": true
     },
     "form-data": {
-      "version": "2.1.2",
-      "from": "form-data@>=2.1.1 <2.2.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+      "version": "0.2.0",
+      "from": "form-data@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+      "dev": true,
       "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "dev": true
+        },
         "mime-db": {
-          "version": "1.24.0",
-          "from": "mime-db@>=1.24.0 <1.25.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+          "version": "1.12.0",
+          "from": "mime-db@>=1.12.0 <1.13.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "dev": true
         },
         "mime-types": {
-          "version": "2.1.12",
-          "from": "mime-types@^2.1.12",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
+          "version": "2.0.14",
+          "from": "mime-types@>=2.0.3 <2.1.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "dev": true
         }
       }
     },
     "fresh": {
       "version": "0.3.0",
       "from": "fresh@0.3.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+      "dev": true
     },
     "from": {
       "version": "0.1.3",
       "from": "from@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
+      "dev": true
     },
     "fs-access": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "fs-access@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "dev": true
+    },
+    "fs-exists-sync": {
+      "version": "0.1.0",
+      "from": "fs-exists-sync@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "dev": true
     },
     "fs-extra": {
-      "version": "0.26.3",
-      "from": "fs-extra@0.26.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.3.tgz",
+      "version": "0.26.7",
+      "from": "fs-extra@>=0.26.3 <0.27.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2",
+          "version": "4.1.11",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true
         }
       }
     },
     "fs-promise": {
       "version": "0.3.1",
       "from": "fs-promise@0.3.1",
-      "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-0.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-0.3.1.tgz",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
       "from": "fs.realpath@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "dev": true
     },
     "fsevents": {
-      "version": "1.0.14",
-      "from": "fsevents@latest",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.14.tgz",
+      "version": "1.0.17",
+      "from": "fsevents@>=1.0.14 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.17.tgz",
+      "optional": true,
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
           "from": "abbrev@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.0.0",
@@ -3311,54 +1907,61 @@
         "ansi-styles": {
           "version": "2.2.1",
           "from": "ansi-styles@>=2.2.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "optional": true
         },
         "aproba": {
           "version": "1.0.4",
           "from": "aproba@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.2",
           "from": "are-we-there-yet@>=1.1.2 <1.2.0",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+          "optional": true
         },
         "asn1": {
           "version": "0.2.3",
           "from": "asn1@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
           "from": "assert-plus@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "optional": true
         },
-        "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.5.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        "asynckit": {
+          "version": "0.4.0",
+          "from": "asynckit@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
           "from": "aws-sign2@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "optional": true
         },
         "aws4": {
-          "version": "1.4.1",
+          "version": "1.5.0",
           "from": "aws4@>=1.2.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+          "optional": true
         },
-        "bl": {
-          "version": "1.1.2",
-          "from": "bl@>=1.1.2 <1.2.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.6",
-              "from": "readable-stream@>=2.0.5 <2.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-            }
-          }
+        "balanced-match": {
+          "version": "0.4.2",
+          "from": "balanced-match@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.0",
+          "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+          "optional": true
         },
         "block-stream": {
           "version": "0.0.9",
@@ -3370,6 +1973,11 @@
           "from": "boom@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
         },
+        "brace-expansion": {
+          "version": "1.1.6",
+          "from": "brace-expansion@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+        },
         "buffer-shims": {
           "version": "1.0.0",
           "from": "buffer-shims@>=1.0.0 <2.0.0",
@@ -3378,17 +1986,27 @@
         "caseless": {
           "version": "0.11.0",
           "from": "caseless@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "optional": true
         },
         "chalk": {
           "version": "1.1.3",
           "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "optional": true,
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "optional": true
+            }
+          }
         },
         "code-point-at": {
-          "version": "1.0.0",
+          "version": "1.1.0",
           "from": "code-point-at@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
@@ -3398,7 +2016,13 @@
         "commander": {
           "version": "2.9.0",
           "from": "commander@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "optional": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "from": "concat-map@0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -3413,29 +2037,34 @@
         "cryptiles": {
           "version": "2.0.5",
           "from": "cryptiles@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "optional": true
         },
         "dashdash": {
-          "version": "1.14.0",
+          "version": "1.14.1",
           "from": "dashdash@>=1.12.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "optional": true,
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
               "from": "assert-plus@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
             }
           }
         },
         "debug": {
           "version": "2.2.0",
           "from": "debug@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "optional": true
         },
         "deep-extend": {
           "version": "0.4.1",
           "from": "deep-extend@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+          "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
@@ -3445,22 +2074,26 @@
         "delegates": {
           "version": "1.0.0",
           "from": "delegates@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
           "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "optional": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "optional": true
         },
         "extend": {
           "version": "3.0.0",
           "from": "extend@>=3.0.0 <3.1.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+          "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
@@ -3470,12 +2103,14 @@
         "forever-agent": {
           "version": "0.6.1",
           "from": "forever-agent@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "optional": true
         },
         "form-data": {
-          "version": "1.0.0-rc4",
-          "from": "form-data@>=1.0.0-rc4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
+          "version": "2.1.2",
+          "from": "form-data@>=2.1.1 <2.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+          "optional": true
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -3490,74 +2125,80 @@
         "fstream-ignore": {
           "version": "1.0.5",
           "from": "fstream-ignore@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "optional": true
         },
         "gauge": {
-          "version": "2.6.0",
-          "from": "gauge@>=2.6.0 <2.7.0",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz"
+          "version": "2.7.2",
+          "from": "gauge@>=2.7.1 <2.8.0",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
+          "optional": true
         },
         "generate-function": {
           "version": "2.0.0",
           "from": "generate-function@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+          "optional": true
         },
         "generate-object-property": {
           "version": "1.2.0",
           "from": "generate-object-property@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+          "optional": true
         },
         "getpass": {
           "version": "0.1.6",
           "from": "getpass@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+          "optional": true,
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
               "from": "assert-plus@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
             }
           }
         },
         "glob": {
-          "version": "7.0.5",
+          "version": "7.1.1",
           "from": "glob@>=7.0.5 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
         },
         "graceful-fs": {
-          "version": "4.1.4",
+          "version": "4.1.11",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
         },
         "graceful-readlink": {
           "version": "1.0.1",
           "from": "graceful-readlink@>=1.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+          "optional": true
         },
         "har-validator": {
           "version": "2.0.6",
           "from": "har-validator@>=2.0.6 <2.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "optional": true
         },
         "has-ansi": {
           "version": "2.0.0",
           "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-        },
-        "has-color": {
-          "version": "0.1.7",
-          "from": "has-color@>=0.1.7 <0.2.0",
-          "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "optional": true
         },
         "has-unicode": {
           "version": "2.0.1",
           "from": "has-unicode@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "optional": true
         },
         "hawk": {
           "version": "3.1.3",
           "from": "hawk@>=3.1.3 <3.2.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "optional": true
         },
         "hoek": {
           "version": "2.16.3",
@@ -3567,22 +2208,24 @@
         "http-signature": {
           "version": "1.1.1",
           "from": "http-signature@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "optional": true
         },
         "inflight": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "from": "inflight@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
         },
         "inherits": {
-          "version": "2.0.1",
+          "version": "2.0.3",
           "from": "inherits@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
         },
         "ini": {
           "version": "1.3.4",
           "from": "ini@>=1.3.0 <1.4.0",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -3590,19 +2233,22 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
         },
         "is-my-json-valid": {
-          "version": "2.13.1",
+          "version": "2.15.0",
           "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+          "optional": true
         },
         "is-property": {
           "version": "1.0.2",
           "from": "is-property@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+          "optional": true
         },
         "is-typedarray": {
           "version": "1.0.0",
           "from": "is-typedarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "optional": true
         },
         "isarray": {
           "version": "1.0.0",
@@ -3612,47 +2258,59 @@
         "isstream": {
           "version": "0.1.2",
           "from": "isstream@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
           "from": "jodid25519@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "optional": true
         },
         "jsbn": {
           "version": "0.1.0",
           "from": "jsbn@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+          "optional": true
         },
         "json-schema": {
-          "version": "0.2.2",
-          "from": "json-schema@0.2.2",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+          "version": "0.2.3",
+          "from": "json-schema@0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "optional": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
           "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "optional": true
         },
         "jsonpointer": {
-          "version": "2.0.0",
-          "from": "jsonpointer@2.0.0",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+          "version": "4.0.1",
+          "from": "jsonpointer@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+          "optional": true
         },
         "jsprim": {
-          "version": "1.3.0",
+          "version": "1.3.1",
           "from": "jsprim@>=1.2.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+          "optional": true
         },
         "mime-db": {
-          "version": "1.23.0",
-          "from": "mime-db@>=1.23.0 <1.24.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+          "version": "1.25.0",
+          "from": "mime-db@>=1.25.0 <1.26.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
         },
         "mime-types": {
-          "version": "2.1.11",
+          "version": "2.1.13",
           "from": "mime-types@>=2.1.7 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "from": "minimatch@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         },
         "minimist": {
           "version": "0.0.8",
@@ -3661,140 +2319,155 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
         },
         "ms": {
           "version": "0.7.1",
           "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-        },
-        "nan": {
-          "version": "2.4.0",
-          "from": "nan@>=2.3.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "optional": true
         },
         "node-pre-gyp": {
-          "version": "0.6.29",
+          "version": "0.6.32",
           "from": "node-pre-gyp@>=0.6.29 <0.7.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.29.tgz"
-        },
-        "node-uuid": {
-          "version": "1.4.7",
-          "from": "node-uuid@>=1.4.7 <1.5.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz",
+          "optional": true
         },
         "nopt": {
           "version": "3.0.6",
-          "from": "nopt@>=3.0.1 <3.1.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+          "from": "nopt@>=3.0.6 <3.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "optional": true
         },
         "npmlog": {
-          "version": "3.1.2",
-          "from": "npmlog@>=3.1.2 <3.2.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz"
+          "version": "4.0.2",
+          "from": "npmlog@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+          "optional": true
         },
         "number-is-nan": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "from": "number-is-nan@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
         },
         "oauth-sign": {
           "version": "0.8.2",
           "from": "oauth-sign@>=0.8.1 <0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.0",
           "from": "object-assign@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+          "optional": true
         },
         "once": {
-          "version": "1.3.3",
+          "version": "1.4.0",
           "from": "once@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
         },
         "path-is-absolute": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "from": "path-is-absolute@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
         },
         "pinkie": {
           "version": "2.0.4",
           "from": "pinkie@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "optional": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
           "from": "pinkie-promise@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
           "from": "process-nextick-args@>=1.0.6 <1.1.0",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
         },
+        "punycode": {
+          "version": "1.4.1",
+          "from": "punycode@>=1.4.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "optional": true
+        },
         "qs": {
-          "version": "6.2.0",
-          "from": "qs@>=6.2.0 <6.3.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
+          "version": "6.3.0",
+          "from": "qs@>=6.3.0 <6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
+          "optional": true
         },
         "rc": {
           "version": "1.1.6",
-          "from": "rc@>=1.1.0 <1.2.0",
+          "from": "rc@>=1.1.6 <1.2.0",
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+          "optional": true,
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
               "from": "minimist@>=1.2.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "optional": true
             }
           }
         },
         "readable-stream": {
-          "version": "2.1.4",
+          "version": "2.2.2",
           "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "optional": true
         },
         "request": {
-          "version": "2.73.0",
-          "from": "request@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.73.0.tgz"
+          "version": "2.79.0",
+          "from": "request@>=2.79.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "optional": true
         },
         "rimraf": {
-          "version": "2.5.3",
-          "from": "rimraf@>=2.5.0 <2.6.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz"
+          "version": "2.5.4",
+          "from": "rimraf@>=2.5.4 <2.6.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
         },
         "semver": {
-          "version": "5.2.0",
-          "from": "semver@>=5.2.0 <5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz"
+          "version": "5.3.0",
+          "from": "semver@>=5.3.0 <5.4.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "from": "set-blocking@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "optional": true
         },
         "signal-exit": {
-          "version": "3.0.0",
+          "version": "3.0.2",
           "from": "signal-exit@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "optional": true
         },
         "sntp": {
           "version": "1.0.9",
           "from": "sntp@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "optional": true
         },
         "sshpk": {
-          "version": "1.8.3",
+          "version": "1.10.1",
           "from": "sshpk@>=1.7.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+          "optional": true,
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
               "from": "assert-plus@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
             }
           }
         },
@@ -3804,14 +2477,15 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "string-width": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "from": "string-width@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
           "from": "stringstream@>=0.0.4 <0.1.0",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -3821,57 +2495,86 @@
         "strip-json-comments": {
           "version": "1.0.4",
           "from": "strip-json-comments@>=1.0.4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "optional": true
         },
         "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+          "version": "0.2.0",
+          "from": "supports-color@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "from": "tar@>=2.2.0 <2.3.0",
+          "from": "tar@>=2.2.1 <2.3.0",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
         },
         "tar-pack": {
-          "version": "3.1.4",
-          "from": "tar-pack@>=3.1.0 <3.2.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz"
+          "version": "3.3.0",
+          "from": "tar-pack@>=3.3.0 <3.4.0",
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
+          "optional": true,
+          "dependencies": {
+            "once": {
+              "version": "1.3.3",
+              "from": "once@>=1.3.3 <1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "optional": true
+            },
+            "readable-stream": {
+              "version": "2.1.5",
+              "from": "readable-stream@>=2.1.4 <2.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+              "optional": true
+            }
+          }
         },
         "tough-cookie": {
-          "version": "2.2.2",
-          "from": "tough-cookie@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+          "version": "2.3.2",
+          "from": "tough-cookie@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "optional": true
         },
         "tunnel-agent": {
           "version": "0.4.3",
           "from": "tunnel-agent@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "optional": true
         },
         "tweetnacl": {
-          "version": "0.13.3",
-          "from": "tweetnacl@>=0.13.0 <0.14.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+          "version": "0.14.5",
+          "from": "tweetnacl@>=0.14.0 <0.15.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
           "from": "uid-number@>=0.0.6 <0.1.0",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
           "from": "util-deprecate@>=1.0.1 <1.1.0",
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
         },
+        "uuid": {
+          "version": "3.0.1",
+          "from": "uuid@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "optional": true
+        },
         "verror": {
           "version": "1.3.6",
           "from": "verror@1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.0",
           "from": "wide-align@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+          "optional": true
         },
         "wrappy": {
           "version": "1.0.2",
@@ -3881,88 +2584,78 @@
         "xtend": {
           "version": "4.0.1",
           "from": "xtend@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "optional": true
         }
       }
     },
     "fstream": {
       "version": "0.1.31",
       "from": "fstream@>=0.1.30 <1.0.0",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz"
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+      "dev": true
     },
     "fx-runner": {
       "version": "0.0.7",
       "from": "fx-runner@0.0.7",
       "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-0.0.7.tgz",
+      "dev": true,
       "dependencies": {
-        "commander": {
-          "version": "2.6.0",
-          "from": "commander@2.6.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
-        },
         "lodash": {
           "version": "2.4.1",
           "from": "lodash@2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+          "dev": true
         },
         "when": {
           "version": "3.6.4",
           "from": "when@3.6.4",
-          "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz"
+          "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz",
+          "dev": true
         }
       }
     },
     "gaze": {
       "version": "0.5.2",
       "from": "gaze@>=0.5.1 <0.6.0",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+      "dev": true
     },
     "generate-function": {
       "version": "2.0.0",
       "from": "generate-function@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "dev": true
     },
     "generate-object-property": {
       "version": "1.2.0",
       "from": "generate-object-property@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "dev": true
     },
     "get-pkg-repo": {
-      "version": "1.2.1",
+      "version": "1.3.0",
       "from": "get-pkg-repo@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.2.1.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "from": "through2@2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.3.0.tgz",
+      "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
       "from": "get-stdin@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "dev": true
     },
     "getpass": {
       "version": "0.1.6",
       "from": "getpass@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+      "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "dev": true
         }
       }
     },
@@ -3970,107 +2663,113 @@
       "version": "1.1.2",
       "from": "git-raw-commits@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.1.2.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "lodash.template": {
-          "version": "4.3.0",
-          "from": "lodash.template@>=4.0.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.3.0.tgz"
-        },
-        "lodash.templatesettings": {
-          "version": "4.1.0",
-          "from": "lodash.templatesettings@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz"
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "from": "through2@2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
-        }
-      }
+      "dev": true
     },
     "git-remote-origin-url": {
       "version": "2.0.0",
       "from": "git-remote-origin-url@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+      "dev": true
     },
     "git-semver-tags": {
       "version": "1.1.2",
-      "from": "git-semver-tags@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.1.2.tgz"
+      "from": "git-semver-tags@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.1.2.tgz",
+      "dev": true
     },
     "gitconfiglocal": {
       "version": "1.0.0",
       "from": "gitconfiglocal@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+      "dev": true
     },
     "github-url-from-git": {
-      "version": "1.4.0",
+      "version": "1.5.0",
       "from": "github-url-from-git@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
+      "dev": true
     },
     "glob": {
       "version": "4.5.3",
       "from": "glob@>=4.0.6 <5.0.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+      "dev": true,
       "dependencies": {
         "minimatch": {
           "version": "2.0.10",
           "from": "minimatch@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "dev": true
         }
       }
     },
     "glob-base": {
       "version": "0.3.0",
       "from": "glob-base@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "dev": true
     },
     "glob-parent": {
       "version": "2.0.0",
       "from": "glob-parent@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "dev": true
     },
     "glob-stream": {
       "version": "3.1.18",
       "from": "glob-stream@>=3.1.5 <4.0.0",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+      "dev": true,
       "dependencies": {
         "minimatch": {
           "version": "2.0.10",
           "from": "minimatch@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dev": true
         }
       }
     },
     "glob-watcher": {
       "version": "0.0.6",
       "from": "glob-watcher@>=0.0.6 <0.0.7",
-      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+      "dev": true
     },
     "glob2base": {
       "version": "0.0.12",
       "from": "glob2base@>=0.0.12 <0.0.13",
-      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz"
+      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+      "dev": true
+    },
+    "global-modules": {
+      "version": "0.2.3",
+      "from": "global-modules@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "dev": true
+    },
+    "global-prefix": {
+      "version": "0.1.5",
+      "from": "global-prefix@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+      "dev": true
     },
     "globby": {
       "version": "5.0.0",
       "from": "globby@>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "dev": true,
       "dependencies": {
         "glob": {
           "version": "7.1.1",
-          "from": "glob@^7.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+          "from": "glob@>=7.0.3 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "dev": true
         }
       }
     },
@@ -4078,122 +2777,95 @@
       "version": "0.1.0",
       "from": "globule@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+      "dev": true,
       "dependencies": {
         "glob": {
           "version": "3.1.21",
           "from": "glob@>=3.1.21 <3.2.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "dev": true
         },
         "graceful-fs": {
           "version": "1.2.3",
           "from": "graceful-fs@>=1.2.0 <1.3.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "dev": true
         },
         "inherits": {
           "version": "1.0.2",
           "from": "inherits@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "dev": true
         },
         "lodash": {
           "version": "1.0.2",
           "from": "lodash@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "dev": true
         },
         "minimatch": {
           "version": "0.2.14",
           "from": "minimatch@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "dependencies": {
-            "lru-cache": {
-              "version": "2.7.3",
-              "from": "lru-cache@2.7.3",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-            },
-            "sigmund": {
-              "version": "1.0.1",
-              "from": "sigmund@1.0.1",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-            }
-          }
+          "dev": true
         }
       }
     },
     "glogg": {
       "version": "1.0.0",
       "from": "glogg@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+      "dev": true
     },
     "got": {
       "version": "5.7.1",
       "from": "got@>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+      "dev": true,
       "dependencies": {
         "duplexer2": {
           "version": "0.1.4",
           "from": "duplexer2@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+          "dev": true
         },
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
         },
         "readable-stream": {
           "version": "2.2.2",
           "from": "readable-stream@>=2.0.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
         }
       }
     },
     "graceful-fs": {
-      "version": "3.0.8",
+      "version": "3.0.11",
       "from": "graceful-fs@>=3.0.2 <3.1.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+      "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
       "from": "graceful-readlink@>=1.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "dev": true
     },
     "gulp": {
-      "version": "3.9.0",
+      "version": "3.9.1",
       "from": "gulp@>=3.8.8 <4.0.0",
-      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-        },
-        "ansi-styles": {
-          "version": "2.1.0",
-          "from": "ansi-styles@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-        },
         "semver": {
           "version": "4.3.6",
           "from": "semver@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-        },
-        "strip-ansi": {
-          "version": "3.0.0",
-          "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "dev": true
         }
       }
     },
@@ -4201,1035 +2873,1270 @@
       "version": "1.0.23",
       "from": "gulp-clang-format@>=1.0.23 <2.0.0",
       "resolved": "https://registry.npmjs.org/gulp-clang-format/-/gulp-clang-format-1.0.23.tgz",
+      "dev": true,
       "dependencies": {
-        "duplexer2": {
-          "version": "0.1.4",
-          "from": "duplexer2@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "readable-stream": {
-          "version": "2.1.4",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-          "dependencies": {
-            "buffer-shims": {
-              "version": "1.0.0",
-              "from": "buffer-shims@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-            }
-          }
-        },
-        "stream-combiner2": {
-          "version": "1.1.1",
-          "from": "stream-combiner2@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz"
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.3 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dev": true
         }
       }
     },
     "gulp-connect": {
       "version": "2.3.1",
-      "from": "gulp-connect@2.3.1",
+      "from": "gulp-connect@>=2.3.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/gulp-connect/-/gulp-connect-2.3.1.tgz",
-      "dependencies": {
-        "connect": {
-          "version": "2.30.2",
-          "from": "connect@>=2.30.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz"
-        }
-      }
+      "dev": true
     },
     "gulp-conventional-changelog": {
       "version": "1.1.0",
-      "from": "gulp-conventional-changelog@latest",
+      "from": "gulp-conventional-changelog@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/gulp-conventional-changelog/-/gulp-conventional-changelog-1.1.0.tgz",
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.5.1",
-          "from": "concat-stream@>=1.5.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz"
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
-        }
-      }
+      "dev": true
     },
     "gulp-diff": {
       "version": "1.0.0",
       "from": "gulp-diff@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/gulp-diff/-/gulp-diff-1.0.0.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
-        }
-      }
+      "dev": true
     },
     "gulp-tslint": {
       "version": "7.0.1",
       "from": "gulp-tslint@>=7.0.1 <8.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-tslint/-/gulp-tslint-7.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/gulp-tslint/-/gulp-tslint-7.0.1.tgz",
+      "dev": true
     },
     "gulp-util": {
-      "version": "3.0.7",
+      "version": "3.0.8",
       "from": "gulp-util@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": {
+        "dateformat": {
           "version": "2.0.0",
-          "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+          "from": "dateformat@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+          "dev": true
         },
-        "ansi-styles": {
-          "version": "2.1.0",
-          "from": "ansi-styles@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+        "lodash.template": {
+          "version": "3.6.2",
+          "from": "lodash.template@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "dev": true
         },
-        "chalk": {
-          "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+        "lodash.templatesettings": {
+          "version": "3.1.1",
+          "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+          "dev": true
         },
         "object-assign": {
           "version": "3.0.0",
           "from": "object-assign@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-        },
-        "readable-stream": {
-          "version": "2.0.5",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
-        },
-        "strip-ansi": {
-          "version": "3.0.0",
-          "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-        },
-        "through2": {
-          "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz"
-        },
-        "vinyl": {
-          "version": "0.5.3",
-          "from": "vinyl@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "dev": true
         }
       }
     },
     "gulplog": {
       "version": "1.0.0",
       "from": "gulplog@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "dev": true
     },
     "hammerjs": {
       "version": "2.0.8",
-      "from": "hammerjs@latest",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz"
+      "from": "hammerjs@>=2.0.8 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "dev": true
     },
     "handlebars": {
-      "version": "4.0.5",
+      "version": "4.0.6",
       "from": "handlebars@>=4.0.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+      "dev": true,
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.4.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        "camelcase": {
+          "version": "1.2.1",
+          "from": "camelcase@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "dev": true,
+          "optional": true
         },
         "source-map": {
           "version": "0.4.4",
           "from": "source-map@>=0.4.4 <0.5.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.7.5",
+          "from": "uglify-js@>=2.6.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+          "dev": true,
+          "optional": true,
           "dependencies": {
-            "amdefine": {
-              "version": "1.0.1",
-              "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "dev": true,
+              "optional": true
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "from": "source-map@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+              "dev": true,
+              "optional": true
             }
           }
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "from": "yargs@>=3.10.0 <3.11.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "dev": true,
+          "optional": true
         }
       }
     },
     "har-validator": {
-      "version": "2.0.6",
-      "from": "har-validator@>=2.0.6 <2.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "version": "1.8.0",
+      "from": "har-validator@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
+      "dev": true,
       "dependencies": {
-        "is-my-json-valid": {
-          "version": "2.15.0",
-          "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz"
-        },
-        "jsonpointer": {
-          "version": "4.0.0",
-          "from": "jsonpointer@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
+        "commander": {
+          "version": "2.9.0",
+          "from": "commander@>=2.8.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "dev": true
         }
       }
     },
     "has-ansi": {
       "version": "2.0.0",
       "from": "has-ansi@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "dev": true
     },
     "has-binary": {
       "version": "0.1.7",
       "from": "has-binary@0.1.7",
-      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz"
+      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+      "dev": true
     },
     "has-cors": {
       "version": "1.1.0",
       "from": "has-cors@1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "dev": true
     },
     "has-flag": {
       "version": "1.0.0",
       "from": "has-flag@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "dev": true
     },
     "has-gulplog": {
       "version": "0.1.0",
       "from": "has-gulplog@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "dev": true
     },
     "hashish": {
       "version": "0.0.4",
       "from": "hashish@>=0.0.2 <0.1.0",
-      "resolved": "https://registry.npmjs.org/hashish/-/hashish-0.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/hashish/-/hashish-0.0.4.tgz",
+      "dev": true
     },
     "hawk": {
-      "version": "3.1.3",
-      "from": "hawk@>=3.1.3 <3.2.0",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+      "version": "2.3.1",
+      "from": "hawk@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+      "dev": true
     },
     "hoek": {
       "version": "2.16.3",
       "from": "hoek@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "dev": true
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "from": "homedir-polyfill@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "dev": true
     },
     "hosted-git-info": {
-      "version": "2.1.4",
+      "version": "2.1.5",
       "from": "hosted-git-info@>=2.1.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
-    },
-    "http-browserify": {
-      "version": "1.7.0",
-      "from": "http-browserify@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz"
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+      "dev": true
     },
     "http-errors": {
       "version": "1.3.1",
       "from": "http-errors@>=1.3.1 <1.4.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+      "dev": true
     },
     "http-proxy": {
-      "version": "1.13.3",
+      "version": "1.16.2",
       "from": "http-proxy@>=1.13.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.3.tgz"
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+      "dev": true
     },
     "http-signature": {
-      "version": "1.1.1",
-      "from": "http-signature@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "from": "assert-plus@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-        }
-      }
+      "version": "0.10.1",
+      "from": "http-signature@>=0.10.0 <0.11.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+      "dev": true
     },
     "https-browserify": {
-      "version": "0.0.0",
-      "from": "https-browserify@0.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+      "version": "0.0.1",
+      "from": "https-browserify@0.0.1",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+      "dev": true
     },
     "https-proxy-agent": {
       "version": "1.0.0",
       "from": "https-proxy-agent@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.11",
       "from": "iconv-lite@0.4.11",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
+      "dev": true
     },
     "ieee754": {
       "version": "1.1.8",
       "from": "ieee754@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
       "from": "imurmurhash@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "dev": true
     },
     "incremental-dom": {
       "version": "0.4.1",
-      "from": "incremental-dom@latest",
-      "resolved": "https://registry.npmjs.org/incremental-dom/-/incremental-dom-0.4.1.tgz"
+      "from": "incremental-dom@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/incremental-dom/-/incremental-dom-0.4.1.tgz",
+      "dev": true
     },
     "indent-string": {
       "version": "2.1.0",
       "from": "indent-string@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "dev": true
     },
     "indexof": {
       "version": "0.0.1",
       "from": "indexof@0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "dev": true
     },
     "inflight": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "from": "inflight@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "dev": true
     },
     "inherits": {
-      "version": "2.0.1",
-      "from": "inherits@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+      "version": "2.0.3",
+      "from": "inherits@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "dev": true
     },
     "ini": {
       "version": "1.3.4",
-      "from": "ini@>=1.3.3 <1.4.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+      "from": "ini@>=1.3.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "dev": true
     },
     "interpret": {
-      "version": "0.6.6",
-      "from": "interpret@>=0.6.2 <0.7.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+      "version": "1.0.1",
+      "from": "interpret@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
+      "dev": true
     },
     "invert-kv": {
       "version": "1.0.0",
       "from": "invert-kv@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "dev": true
+    },
+    "is-absolute": {
+      "version": "0.2.6",
+      "from": "is-absolute@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
       "from": "is-arrayish@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
       "from": "is-binary-path@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "dev": true
     },
     "is-buffer": {
-      "version": "1.1.0",
-      "from": "is-buffer@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+      "version": "1.1.4",
+      "from": "is-buffer@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
       "from": "is-builtin-module@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "dev": true
     },
     "is-dotfile": {
       "version": "1.0.2",
       "from": "is-dotfile@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+      "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "from": "is-equal-shallow@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
       "from": "is-extendable@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
       "from": "is-extglob@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "dev": true
     },
     "is-finite": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "from": "is-finite@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "dev": true
     },
     "is-glob": {
       "version": "2.0.1",
       "from": "is-glob@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "dev": true
     },
     "is-my-json-valid": {
-      "version": "2.12.3",
-      "from": "is-my-json-valid@>=2.12.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+      "version": "2.15.0",
+      "from": "is-my-json-valid@>=2.12.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+      "dev": true
     },
     "is-npm": {
       "version": "1.0.0",
       "from": "is-npm@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "dev": true
     },
     "is-number": {
       "version": "2.1.0",
       "from": "is-number@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "dev": true
     },
     "is-obj": {
       "version": "1.0.1",
       "from": "is-obj@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "dev": true
     },
     "is-path-cwd": {
       "version": "1.0.0",
       "from": "is-path-cwd@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "dev": true
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
       "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "dev": true
     },
     "is-path-inside": {
       "version": "1.0.0",
       "from": "is-path-inside@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "dev": true
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
       "from": "is-primitive@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "dev": true
     },
     "is-property": {
       "version": "1.0.2",
       "from": "is-property@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
       "from": "is-redirect@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "dev": true
+    },
+    "is-relative": {
+      "version": "0.2.1",
+      "from": "is-relative@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+      "dev": true
     },
     "is-retry-allowed": {
       "version": "1.1.0",
       "from": "is-retry-allowed@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
       "from": "is-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "dev": true
     },
     "is-subset": {
       "version": "0.1.1",
       "from": "is-subset@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "dev": true
     },
     "is-text-path": {
       "version": "1.0.1",
       "from": "is-text-path@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
       "from": "is-typedarray@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "dev": true
+    },
+    "is-unc-path": {
+      "version": "0.1.2",
+      "from": "is-unc-path@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
       "from": "is-utf8@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "0.2.0",
+      "from": "is-windows@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+      "dev": true
     },
     "isarray": {
       "version": "0.0.1",
       "from": "isarray@0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "dev": true
     },
     "isbinaryfile": {
-      "version": "3.0.0",
+      "version": "3.0.2",
       "from": "isbinaryfile@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
+      "dev": true
     },
     "isexe": {
       "version": "1.1.2",
       "from": "isexe@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+      "dev": true
     },
     "isobject": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "from": "isobject@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        }
+      }
     },
     "isstream": {
       "version": "0.1.2",
-      "from": "isstream@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+      "from": "isstream@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "dev": true
     },
     "jasmine": {
-      "version": "2.4.1",
-      "from": "jasmine@>=2.4.0 <2.5.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.4.1.tgz",
+      "version": "2.5.3",
+      "from": "jasmine@>=2.4.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.5.3.tgz",
+      "dev": true,
       "dependencies": {
         "glob": {
-          "version": "3.2.11",
-          "from": "glob@>=3.2.11 <4.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
-        },
-        "jasmine-core": {
-          "version": "2.4.1",
-          "from": "jasmine-core@>=2.4.0 <2.5.0",
-          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz"
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "from": "minimatch@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
+          "version": "7.1.1",
+          "from": "glob@>=7.0.6 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "dev": true
         }
       }
     },
     "jasmine-core": {
-      "version": "2.3.4",
-      "from": "jasmine-core@2.3.4",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz"
+      "version": "2.5.2",
+      "from": "jasmine-core@>=2.3.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.5.2.tgz",
+      "dev": true
     },
     "jasminewd2": {
       "version": "0.0.10",
       "from": "jasminewd2@0.0.10",
-      "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.10.tgz"
+      "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.10.tgz",
+      "dev": true
     },
     "jetpack-id": {
-      "version": "0.0.4",
-      "from": "jetpack-id@0.0.4",
-      "resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-0.0.4.tgz"
+      "version": "1.0.0",
+      "from": "jetpack-id@1.0.0",
+      "resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-1.0.0.tgz",
+      "dev": true
     },
     "jetpack-validation": {
       "version": "0.0.4",
       "from": "jetpack-validation@0.0.4",
       "resolved": "https://registry.npmjs.org/jetpack-validation/-/jetpack-validation-0.0.4.tgz",
+      "dev": true,
       "dependencies": {
+        "jetpack-id": {
+          "version": "0.0.4",
+          "from": "jetpack-id@0.0.4",
+          "resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-0.0.4.tgz",
+          "dev": true
+        },
         "resolve": {
           "version": "0.7.4",
           "from": "resolve@>=0.7.1 <0.8.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
+          "dev": true
         },
         "semver": {
           "version": "2.3.2",
           "from": "semver@>=2.3.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+          "dev": true
         }
       }
     },
     "jodid25519": {
       "version": "1.0.2",
       "from": "jodid25519@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+      "dev": true,
+      "optional": true
     },
     "jpm": {
       "version": "1.0.0",
       "from": "jpm@1.0.0",
       "resolved": "https://registry.npmjs.org/jpm/-/jpm-1.0.0.tgz",
+      "dev": true,
       "dependencies": {
+        "archiver": {
+          "version": "0.14.4",
+          "from": "archiver@>=0.14.3 <0.15.0",
+          "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.14.4.tgz",
+          "dev": true,
+          "dependencies": {
+            "lodash": {
+              "version": "3.2.0",
+              "from": "lodash@>=3.2.0 <3.3.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
+              "dev": true
+            }
+          }
+        },
         "async": {
           "version": "0.9.2",
           "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "dev": true
         },
-        "commander": {
-          "version": "2.6.0",
-          "from": "commander@2.6.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+        "bl": {
+          "version": "0.9.5",
+          "from": "bl@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+          "dev": true
+        },
+        "compress-commons": {
+          "version": "0.2.9",
+          "from": "compress-commons@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.9.tgz",
+          "dev": true
+        },
+        "crc32-stream": {
+          "version": "0.3.4",
+          "from": "crc32-stream@>=0.3.1 <0.4.0",
+          "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
+          "dev": true
         },
         "firefox-profile": {
           "version": "0.3.9",
           "from": "firefox-profile@0.3.9",
           "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-0.3.9.tgz",
+          "dev": true,
           "dependencies": {
             "lodash": {
               "version": "3.5.0",
               "from": "lodash@>=3.5.0 <3.6.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
+              "dev": true
             }
           }
         },
         "fs-extra": {
           "version": "0.16.4",
           "from": "fs-extra@0.16.4",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.4.tgz"
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.4.tgz",
+          "dev": true
+        },
+        "glob": {
+          "version": "4.3.5",
+          "from": "glob@>=4.3.0 <4.4.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+          "dev": true
+        },
+        "jetpack-id": {
+          "version": "0.0.4",
+          "from": "jetpack-id@0.0.4",
+          "resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-0.0.4.tgz",
+          "dev": true
+        },
+        "lazystream": {
+          "version": "0.1.0",
+          "from": "lazystream@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
+          "dev": true
         },
         "lodash": {
           "version": "3.3.1",
           "from": "lodash@3.3.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.3.1.tgz",
+          "dev": true
         },
         "minimatch": {
           "version": "2.0.4",
           "from": "minimatch@2.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz"
-        },
-        "open": {
-          "version": "0.0.5",
-          "from": "open@0.0.5",
-          "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+          "dev": true
         },
         "semver": {
           "version": "4.3.3",
           "from": "semver@4.3.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz",
+          "dev": true
+        },
+        "tar-stream": {
+          "version": "1.1.5",
+          "from": "tar-stream@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
+          "dev": true
+        },
+        "zip-stream": {
+          "version": "0.5.2",
+          "from": "zip-stream@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.2.tgz",
+          "dev": true,
+          "dependencies": {
+            "lodash": {
+              "version": "3.2.0",
+              "from": "lodash@>=3.2.0 <3.3.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
+              "dev": true
+            }
+          }
         }
       }
     },
     "jpm-core": {
       "version": "0.0.9",
       "from": "jpm-core@0.0.9",
-      "resolved": "https://registry.npmjs.org/jpm-core/-/jpm-core-0.0.9.tgz"
+      "resolved": "https://registry.npmjs.org/jpm-core/-/jpm-core-0.0.9.tgz",
+      "dev": true
     },
     "js-tokens": {
-      "version": "1.0.2",
-      "from": "js-tokens@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+      "version": "3.0.0",
+      "from": "js-tokens@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz",
+      "dev": true
     },
     "jsbn": {
       "version": "0.1.0",
       "from": "jsbn@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+      "dev": true,
+      "optional": true
     },
     "json-schema": {
       "version": "0.2.3",
       "from": "json-schema@0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+      "from": "json-stringify-safe@>=5.0.1 <6.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "dev": true
     },
     "json3": {
-      "version": "3.2.6",
-      "from": "json3@3.2.6",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+      "version": "3.3.2",
+      "from": "json3@3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "dev": true
     },
     "json5": {
-      "version": "0.4.0",
-      "from": "json5@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+      "version": "0.5.1",
+      "from": "json5@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "dev": true
     },
     "jsonfile": {
-      "version": "2.2.3",
-      "from": "jsonfile@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
+      "version": "2.4.0",
+      "from": "jsonfile@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "from": "graceful-fs@>=4.1.6 <5.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "jsonparse": {
       "version": "1.2.0",
-      "from": "jsonparse@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
+      "from": "jsonparse@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+      "dev": true
     },
     "jsonpointer": {
-      "version": "2.0.0",
-      "from": "jsonpointer@2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+      "version": "4.0.1",
+      "from": "jsonpointer@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "dev": true
     },
     "JSONStream": {
-      "version": "1.0.7",
-      "from": "JSONStream@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz"
+      "version": "1.3.0",
+      "from": "JSONStream@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.0.tgz",
+      "dev": true
     },
     "jsontoxml": {
       "version": "0.0.11",
       "from": "jsontoxml@0.0.11",
-      "resolved": "https://registry.npmjs.org/jsontoxml/-/jsontoxml-0.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/jsontoxml/-/jsontoxml-0.0.11.tgz",
+      "dev": true
     },
     "jsprim": {
       "version": "1.3.1",
       "from": "jsprim@>=1.2.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+      "dev": true
     },
     "jstransform": {
-      "version": "10.1.0",
-      "from": "jstransform@>=10.0.1 <11.0.0",
-      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
+      "version": "11.0.3",
+      "from": "jstransform@>=11.0.3 <12.0.0",
+      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
+      "dev": true,
       "dependencies": {
-        "esprima-fb": {
-          "version": "13001.1001.0-dev-harmony-fb",
-          "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
+        "object-assign": {
+          "version": "2.1.1",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "dev": true
         },
         "source-map": {
-          "version": "0.1.31",
-          "from": "source-map@0.1.31",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.1",
-              "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-            }
-          }
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.2 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "dev": true
         }
       }
     },
     "jszip": {
-      "version": "2.5.0",
+      "version": "2.6.1",
       "from": "jszip@>=2.4.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
+      "dev": true
     },
     "karma": {
-      "version": "0.13.20",
-      "from": "karma@0.13.20",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-0.13.20.tgz",
+      "version": "0.13.22",
+      "from": "karma@>=0.13.20 <0.14.0",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-0.13.22.tgz",
+      "dev": true,
       "dependencies": {
-        "batch": {
-          "version": "0.5.3",
-          "from": "batch@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
+        "connect": {
+          "version": "3.5.0",
+          "from": "connect@>=3.3.5 <4.0.0",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
+          "dev": true
+        },
+        "finalhandler": {
+          "version": "0.5.0",
+          "from": "finalhandler@0.5.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+          "dev": true
         },
         "glob": {
-          "version": "7.0.3",
+          "version": "7.1.1",
           "from": "glob@>=7.0.0 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "dev": true
         },
         "graceful-fs": {
-          "version": "4.1.4",
+          "version": "4.1.11",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.8.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "dev": true
         },
         "source-map": {
           "version": "0.5.6",
           "from": "source-map@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "dev": true
         }
       }
     },
     "karma-browserstack-launcher": {
-      "version": "0.1.9",
-      "from": "karma-browserstack-launcher@0.1.9",
-      "resolved": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-0.1.9.tgz"
+      "version": "0.1.11",
+      "from": "karma-browserstack-launcher@>=0.1.9 <0.2.0",
+      "resolved": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-0.1.11.tgz",
+      "dev": true
     },
     "karma-chrome-launcher": {
-      "version": "0.2.2",
+      "version": "0.2.3",
       "from": "karma-chrome-launcher@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.2.3.tgz",
+      "dev": true
     },
     "karma-jasmine": {
-      "version": "0.3.6",
+      "version": "0.3.8",
       "from": "karma-jasmine@>=0.3.6 <0.4.0",
-      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.6.tgz"
+      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.8.tgz",
+      "dev": true
     },
     "karma-sauce-launcher": {
-      "version": "0.3.0",
-      "from": "karma-sauce-launcher@0.3.0",
-      "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.3.0.tgz"
+      "version": "0.3.1",
+      "from": "karma-sauce-launcher@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.3.1.tgz",
+      "dev": true
     },
     "karma-sourcemap-loader": {
-      "version": "0.3.6",
+      "version": "0.3.7",
       "from": "karma-sourcemap-loader@>=0.3.6 <0.4.0",
-      "resolved": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.6.tgz"
+      "resolved": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "from": "graceful-fs@>=4.1.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true
+        }
+      }
     },
     "kind-of": {
-      "version": "3.0.2",
+      "version": "3.1.0",
       "from": "kind-of@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+      "dev": true
     },
     "klaw": {
-      "version": "1.1.3",
+      "version": "1.3.1",
       "from": "klaw@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "from": "graceful-fs@>=4.1.9 <5.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "latest-version": {
       "version": "2.0.0",
       "from": "latest-version@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+      "dev": true
     },
     "lazy-cache": {
-      "version": "0.2.7",
-      "from": "lazy-cache@>=0.2.4 <0.3.0",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+      "version": "1.0.4",
+      "from": "lazy-cache@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "dev": true
     },
     "lazy-req": {
       "version": "1.1.0",
       "from": "lazy-req@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+      "dev": true
     },
     "lazystream": {
-      "version": "0.1.0",
-      "from": "lazystream@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
+      "version": "1.0.0",
+      "from": "lazystream@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "1.0.33",
-          "from": "readable-stream@>=1.0.2 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.5 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
         }
       }
     },
     "lcid": {
       "version": "1.0.0",
       "from": "lcid@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "dev": true
     },
     "liftoff": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "from": "liftoff@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
-      "dependencies": {
-        "extend": {
-          "version": "2.0.1",
-          "from": "extend@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
-        },
-        "findup-sync": {
-          "version": "0.3.0",
-          "from": "findup-sync@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz"
-        },
-        "glob": {
-          "version": "5.0.15",
-          "from": "glob@>=5.0.0 <5.1.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
+      "dev": true
     },
     "livereload-js": {
       "version": "2.2.2",
       "from": "livereload-js@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
+      "dev": true
     },
     "load-json-file": {
       "version": "1.1.0",
       "from": "load-json-file@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2",
+          "version": "4.1.11",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true
         }
       }
     },
     "loader-utils": {
-      "version": "0.2.12",
-      "from": "loader-utils@>=0.2.2 <0.3.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz"
+      "version": "0.2.16",
+      "from": "loader-utils@>=0.2.11 <0.3.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz",
+      "dev": true
     },
     "lodash": {
-      "version": "3.10.1",
-      "from": "lodash@3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+      "version": "4.17.4",
+      "from": "lodash@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "dev": true
     },
     "lodash._basecopy": {
       "version": "3.0.1",
       "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "dev": true
     },
     "lodash._basetostring": {
       "version": "3.0.1",
       "from": "lodash._basetostring@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "dev": true
     },
     "lodash._basevalues": {
       "version": "3.0.0",
       "from": "lodash._basevalues@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
       "from": "lodash._getnative@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
       "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "dev": true
     },
     "lodash._reescape": {
       "version": "3.0.0",
       "from": "lodash._reescape@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "dev": true
     },
     "lodash._reevaluate": {
       "version": "3.0.0",
       "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+      "from": "lodash._reinterpolate@>=3.0.0 <3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "dev": true
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "from": "lodash._root@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "dev": true
+    },
+    "lodash.assignwith": {
+      "version": "4.2.0",
+      "from": "lodash.assignwith@>=4.0.7 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
+      "dev": true
     },
     "lodash.escape": {
-      "version": "3.0.0",
+      "version": "3.2.0",
       "from": "lodash.escape@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "dev": true
     },
     "lodash.isarguments": {
-      "version": "3.0.4",
+      "version": "3.1.0",
       "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "from": "lodash.isarray@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "dev": true
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "from": "lodash.isempty@>=4.2.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "from": "lodash.isplainobject@>=4.0.4 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "dev": true
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "from": "lodash.isstring@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
       "from": "lodash.keys@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "dev": true
+    },
+    "lodash.mapvalues": {
+      "version": "4.6.0",
+      "from": "lodash.mapvalues@>=4.4.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "dev": true
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "from": "lodash.pick@>=4.2.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "dev": true
     },
     "lodash.restparam": {
       "version": "3.6.1",
       "from": "lodash.restparam@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "dev": true
     },
     "lodash.template": {
-      "version": "3.6.2",
-      "from": "lodash.template@>=3.6.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz"
+      "version": "4.4.0",
+      "from": "lodash.template@>=4.0.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "dev": true
     },
     "lodash.templatesettings": {
-      "version": "3.1.0",
-      "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+      "version": "4.1.0",
+      "from": "lodash.templatesettings@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "dev": true
     },
     "log4js": {
-      "version": "0.6.36",
+      "version": "0.6.38",
       "from": "log4js@>=0.6.31 <0.7.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.36.tgz",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
+      "dev": true,
       "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@>=1.0.2 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        },
         "semver": {
           "version": "4.3.6",
           "from": "semver@>=4.3.3 <4.4.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "dev": true
         }
       }
     },
     "longest": {
       "version": "1.0.1",
       "from": "longest@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "dev": true
     },
     "loose-envify": {
-      "version": "1.1.0",
+      "version": "1.3.1",
       "from": "loose-envify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "dev": true
     },
     "loud-rejection": {
-      "version": "1.2.0",
+      "version": "1.6.0",
       "from": "loud-rejection@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "dev": true
     },
     "lowercase-keys": {
       "version": "1.0.0",
       "from": "lowercase-keys@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "dev": true
     },
     "lru-cache": {
-      "version": "2.7.3",
-      "from": "lru-cache@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+      "version": "2.5.0",
+      "from": "lru-cache@2.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+      "dev": true
     },
     "lru-queue": {
       "version": "0.1.0",
       "from": "lru-queue@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "dev": true
     },
     "madge": {
       "version": "0.5.0",
       "from": "madge@0.5.0",
       "resolved": "https://registry.npmjs.org/madge/-/madge-0.5.0.tgz",
+      "dev": true,
       "dependencies": {
         "amdetective": {
           "version": "0.0.2",
           "from": "amdetective@https://registry.npmjs.org/amdetective/-/amdetective-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/amdetective/-/amdetective-0.0.2.tgz",
+          "dev": true,
           "dependencies": {
             "esprima": {
               "version": "1.2.2",
               "from": "esprima@https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+              "dev": true
             }
           }
         },
         "coffee-script": {
           "version": "1.3.3",
           "from": "coffee-script@https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "dev": true
         },
         "colors": {
           "version": "0.6.0-1",
           "from": "colors@https://registry.npmjs.org/colors/-/colors-0.6.0-1.tgz",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.0-1.tgz"
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.0-1.tgz",
+          "dev": true
         },
         "commander": {
           "version": "1.0.0",
           "from": "commander@https://registry.npmjs.org/commander/-/commander-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/commander/-/commander-1.0.0.tgz",
+          "dev": true
         },
         "commondir": {
           "version": "0.0.1",
           "from": "commondir@https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+          "dev": true
         },
         "detective": {
           "version": "0.1.1",
           "from": "detective@https://registry.npmjs.org/detective/-/detective-0.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/detective/-/detective-0.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/detective/-/detective-0.1.1.tgz",
+          "dev": true
         },
         "detective-es6": {
           "version": "1.1.0",
           "from": "detective-es6@https://registry.npmjs.org/detective-es6/-/detective-es6-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-1.1.0.tgz",
+          "dev": true
         },
         "graphviz": {
           "version": "0.0.7",
           "from": "graphviz@https://registry.npmjs.org/graphviz/-/graphviz-0.0.7.tgz",
           "resolved": "https://registry.npmjs.org/graphviz/-/graphviz-0.0.7.tgz",
+          "dev": true,
           "dependencies": {
             "temp": {
               "version": "0.4.0",
               "from": "temp@https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
+              "dev": true
             }
           }
         },
@@ -5237,53 +4144,63 @@
           "version": "0.12.1",
           "from": "react-tools@https://registry.npmjs.org/react-tools/-/react-tools-0.12.1.tgz",
           "resolved": "https://registry.npmjs.org/react-tools/-/react-tools-0.12.1.tgz",
+          "dev": true,
           "dependencies": {
             "commoner": {
               "version": "0.10.1",
               "from": "commoner@https://registry.npmjs.org/commoner/-/commoner-0.10.1.tgz",
               "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.1.tgz",
+              "dev": true,
               "dependencies": {
                 "commander": {
                   "version": "2.5.1",
                   "from": "commander@https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
+                  "dev": true
                 },
                 "glob": {
                   "version": "4.2.2",
                   "from": "glob@https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
+                  "dev": true,
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
                       "from": "inflight@https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dev": true,
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
                           "from": "wrappy@https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "dev": true
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
                       "from": "inherits@https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "dev": true
                     },
                     "minimatch": {
                       "version": "1.0.0",
                       "from": "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                      "dev": true,
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
                           "from": "lru-cache@https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+                          "dev": true
                         },
                         "sigmund": {
                           "version": "1.0.0",
                           "from": "sigmund@https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
+                          "dev": true
                         }
                       }
                     },
@@ -5291,11 +4208,13 @@
                       "version": "1.3.1",
                       "from": "once@https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dev": true,
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
                           "from": "wrappy@https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "dev": true
                         }
                       }
                     }
@@ -5304,64 +4223,76 @@
                 "graceful-fs": {
                   "version": "3.0.5",
                   "from": "graceful-fs@https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
+                  "dev": true
                 },
                 "iconv-lite": {
                   "version": "0.4.5",
                   "from": "iconv-lite@https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz"
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz",
+                  "dev": true
                 },
                 "install": {
                   "version": "0.1.8",
                   "from": "install@https://registry.npmjs.org/install/-/install-0.1.8.tgz",
-                  "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
+                  "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz",
+                  "dev": true
                 },
                 "mkdirp": {
                   "version": "0.5.0",
                   "from": "mkdirp@https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "dev": true,
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
                       "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "dev": true
                     }
                   }
                 },
                 "private": {
                   "version": "0.1.6",
                   "from": "private@https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+                  "dev": true
                 },
                 "q": {
                   "version": "1.1.2",
                   "from": "q@https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
+                  "dev": true
                 },
                 "recast": {
                   "version": "0.9.11",
                   "from": "recast@https://registry.npmjs.org/recast/-/recast-0.9.11.tgz",
                   "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.11.tgz",
+                  "dev": true,
                   "dependencies": {
                     "ast-types": {
                       "version": "0.6.7",
                       "from": "ast-types@https://registry.npmjs.org/ast-types/-/ast-types-0.6.7.tgz",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.7.tgz"
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.7.tgz",
+                      "dev": true
                     },
                     "esprima-fb": {
                       "version": "8001.1001.0-dev-harmony-fb",
                       "from": "esprima-fb@https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
+                      "dev": true
                     },
                     "source-map": {
                       "version": "0.1.41",
                       "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
+                      "dev": true,
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
                           "from": "amdefine@https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                          "dev": true
                         }
                       }
                     }
@@ -5373,26 +4304,31 @@
               "version": "8.2.0",
               "from": "jstransform@https://registry.npmjs.org/jstransform/-/jstransform-8.2.0.tgz",
               "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-8.2.0.tgz",
+              "dev": true,
               "dependencies": {
                 "base62": {
                   "version": "0.1.1",
                   "from": "base62@https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
+                  "dev": true
                 },
                 "esprima-fb": {
                   "version": "8001.1001.0-dev-harmony-fb",
                   "from": "esprima-fb@https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
+                  "dev": true
                 },
                 "source-map": {
                   "version": "0.1.31",
                   "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
+                  "dev": true,
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
                       "from": "amdefine@https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "dev": true
                     }
                   }
                 }
@@ -5403,1398 +4339,1717 @@
         "resolve": {
           "version": "0.2.3",
           "from": "resolve@https://registry.npmjs.org/resolve/-/resolve-0.2.3.tgz",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.2.3.tgz",
+          "dev": true
         },
         "uglify-js": {
           "version": "1.2.6",
           "from": "uglify-js@https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.6.tgz",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.6.tgz"
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.6.tgz",
+          "dev": true
         },
         "walkdir": {
           "version": "0.0.5",
           "from": "walkdir@https://registry.npmjs.org/walkdir/-/walkdir-0.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.5.tgz",
+          "dev": true
         }
       }
     },
     "magic-string": {
       "version": "0.16.0",
       "from": "magic-string@>=0.16.0 <0.17.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz"
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz",
+      "dev": true
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "from": "map-cache@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "dev": true
     },
     "map-obj": {
       "version": "1.0.1",
-      "from": "map-obj@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+      "from": "map-obj@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "dev": true
     },
     "map-stream": {
       "version": "0.1.0",
       "from": "map-stream@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "dev": true
     },
     "match-stream": {
       "version": "0.0.2",
       "from": "match-stream@>=0.0.2 <1.0.0",
       "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.33",
-          "from": "readable-stream@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
-        }
-      }
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
       "from": "media-typer@0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "dev": true
     },
     "memoizeasync": {
       "version": "0.8.0",
       "from": "memoizeasync@0.8.0",
       "resolved": "https://registry.npmjs.org/memoizeasync/-/memoizeasync-0.8.0.tgz",
+      "dev": true,
       "dependencies": {
-        "lru-cache": {
-          "version": "2.5.0",
-          "from": "lru-cache@2.5.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
-        },
         "passerror": {
           "version": "0.0.2",
           "from": "passerror@0.0.2",
-          "resolved": "https://registry.npmjs.org/passerror/-/passerror-0.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/passerror/-/passerror-0.0.2.tgz",
+          "dev": true
         }
       }
     },
     "memoizee": {
       "version": "0.3.10",
       "from": "memoizee@>=0.3.9 <0.4.0",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.10.tgz"
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.10.tgz",
+      "dev": true
     },
     "memory-fs": {
       "version": "0.3.0",
       "from": "memory-fs@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+      "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "2.0.5",
+          "version": "2.2.2",
           "from": "readable-stream@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
         }
       }
     },
     "meow": {
-      "version": "3.6.0",
+      "version": "3.7.0",
       "from": "meow@>=3.3.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz"
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "dev": true
     },
     "method-override": {
-      "version": "2.3.5",
+      "version": "2.3.7",
       "from": "method-override@>=2.3.5 <2.4.0",
-      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.5.tgz"
+      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.7.tgz",
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "dev": true
+        }
+      }
     },
     "methods": {
-      "version": "1.1.1",
-      "from": "methods@*",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
+      "version": "1.1.2",
+      "from": "methods@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "dev": true
     },
     "micromatch": {
-      "version": "2.3.7",
+      "version": "2.3.11",
       "from": "micromatch@>=2.1.5 <3.0.0",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz"
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "dev": true
     },
     "mime": {
       "version": "1.3.4",
-      "from": "mime@>=1.2.11 <2.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+      "from": "mime@1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "dev": true
     },
     "mime-db": {
-      "version": "1.12.0",
-      "from": "mime-db@>=1.12.0 <1.13.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+      "version": "1.26.0",
+      "from": "mime-db@>=1.26.0 <1.27.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
+      "dev": true
     },
     "mime-types": {
-      "version": "2.0.14",
-      "from": "mime-types@>=2.0.9 <2.1.0",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
+      "version": "2.1.14",
+      "from": "mime-types@>=2.1.13 <2.2.0",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.3",
-      "from": "minimatch@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+      "from": "minimatch@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+      "dev": true
     },
     "minimist": {
       "version": "1.2.0",
       "from": "minimist@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.1 <0.6.0",
+      "from": "mkdirp@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "dev": true,
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
           "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "dev": true
         }
       }
     },
     "modify-values": {
       "version": "1.0.0",
       "from": "modify-values@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
+      "dev": true
     },
     "morgan": {
       "version": "1.6.1",
       "from": "morgan@>=1.6.1 <1.7.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz"
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
+      "dev": true
     },
     "mozilla-toolkit-versioning": {
       "version": "0.0.2",
       "from": "mozilla-toolkit-versioning@0.0.2",
-      "resolved": "https://registry.npmjs.org/mozilla-toolkit-versioning/-/mozilla-toolkit-versioning-0.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/mozilla-toolkit-versioning/-/mozilla-toolkit-versioning-0.0.2.tgz",
+      "dev": true
     },
     "mozilla-version-comparator": {
       "version": "1.0.2",
       "from": "mozilla-version-comparator@1.0.2",
-      "resolved": "https://registry.npmjs.org/mozilla-version-comparator/-/mozilla-version-comparator-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/mozilla-version-comparator/-/mozilla-version-comparator-1.0.2.tgz",
+      "dev": true
     },
     "ms": {
       "version": "0.7.1",
       "from": "ms@0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "dev": true
     },
     "multiparty": {
       "version": "3.3.2",
       "from": "multiparty@3.3.2",
-      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.9 <1.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "dev": true
+        }
+      }
     },
     "multipipe": {
       "version": "0.1.2",
       "from": "multipipe@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "dev": true
     },
     "mute-stream": {
-      "version": "0.0.5",
+      "version": "0.0.7",
       "from": "mute-stream@>=0.0.4 <0.1.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "dev": true
     },
     "nan": {
-      "version": "2.4.0",
-      "from": "nan@latest",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
+      "version": "2.5.0",
+      "from": "nan@>=2.3.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.0.tgz"
+    },
+    "natives": {
+      "version": "1.1.0",
+      "from": "natives@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+      "dev": true
     },
     "negotiator": {
       "version": "0.5.3",
       "from": "negotiator@0.5.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
+      "dev": true
     },
     "next-tick": {
       "version": "0.2.2",
       "from": "next-tick@>=0.2.2 <0.3.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+      "dev": true
     },
     "node-int64": {
       "version": "0.3.3",
       "from": "node-int64@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz"
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz",
+      "dev": true
     },
     "node-libs-browser": {
-      "version": "0.6.0",
-      "from": "node-libs-browser@0.6.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.6.0.tgz"
+      "version": "0.7.0",
+      "from": "node-libs-browser@>=0.7.0 <0.8.0",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.5 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
+        }
+      }
     },
     "node-source-walk": {
       "version": "1.4.2",
       "from": "node-source-walk@>=1.4.0 <1.5.0",
-      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-1.4.2.tgz"
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-1.4.2.tgz",
+      "dev": true
     },
     "node-status-codes": {
       "version": "1.0.0",
       "from": "node-status-codes@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "dev": true
     },
     "node-uuid": {
       "version": "1.4.7",
       "from": "node-uuid@>=1.4.0 <1.5.0",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+      "dev": true
     },
     "node-watch": {
       "version": "0.3.4",
       "from": "node-watch@0.3.4",
-      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.3.4.tgz",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.3.5",
-      "from": "normalize-package-data@>=2.3.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
+      "from": "normalize-package-data@>=2.3.5 <3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+      "dev": true
     },
     "normalize-path": {
       "version": "2.0.1",
       "from": "normalize-path@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+      "dev": true
     },
     "null-check": {
       "version": "1.0.0",
       "from": "null-check@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+      "dev": true
     },
     "number-is-nan": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "number-is-nan@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "dev": true
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "from": "oauth-sign@>=0.8.1 <0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+      "version": "0.6.0",
+      "from": "oauth-sign@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+      "dev": true
     },
     "object-assign": {
-      "version": "4.0.1",
+      "version": "4.1.0",
       "from": "object-assign@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+      "dev": true
     },
     "object-component": {
       "version": "0.0.3",
       "from": "object-component@0.0.3",
-      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "dev": true
     },
     "object.omit": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "from": "object.omit@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "dev": true
     },
     "on-finished": {
       "version": "2.3.0",
       "from": "on-finished@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "dev": true
     },
     "on-headers": {
       "version": "1.0.1",
       "from": "on-headers@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "dev": true
     },
     "once": {
-      "version": "1.3.3",
+      "version": "1.4.0",
       "from": "once@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "dev": true
+    },
+    "open": {
+      "version": "0.0.5",
+      "from": "open@0.0.5",
+      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
+      "dev": true
     },
     "optimist": {
       "version": "0.6.1",
       "from": "optimist@>=0.6.1 <0.7.0",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "dev": true,
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
           "from": "minimist@>=0.0.1 <0.1.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "dev": true
         }
       }
     },
     "options": {
       "version": "0.0.6",
       "from": "options@>=0.0.5",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "dev": true
     },
     "orchestrator": {
-      "version": "0.3.7",
+      "version": "0.3.8",
       "from": "orchestrator@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+      "dev": true,
       "dependencies": {
         "end-of-stream": {
           "version": "0.1.5",
           "from": "end-of-stream@>=0.1.5 <0.2.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz"
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+          "dev": true
+        },
+        "once": {
+          "version": "1.3.3",
+          "from": "once@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "dev": true
         }
       }
     },
     "ordered-read-streams": {
       "version": "0.1.0",
       "from": "ordered-read-streams@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+      "dev": true
     },
     "os-browserify": {
-      "version": "0.1.2",
-      "from": "os-browserify@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+      "version": "0.2.1",
+      "from": "os-browserify@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+      "dev": true
     },
     "os-homedir": {
-      "version": "1.0.1",
-      "from": "os-homedir@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+      "version": "1.0.2",
+      "from": "os-homedir@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
       "from": "os-locale@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "from": "os-tmpdir@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "dev": true
     },
     "osenv": {
-      "version": "0.1.3",
+      "version": "0.1.4",
       "from": "osenv@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "dev": true
     },
     "over": {
       "version": "0.0.5",
       "from": "over@>=0.0.5 <1.0.0",
-      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
+      "dev": true
     },
     "package-json": {
       "version": "2.4.0",
       "from": "package-json@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+      "dev": true
     },
     "pako": {
-      "version": "0.2.8",
-      "from": "pako@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+      "version": "1.0.4",
+      "from": "pako@>=1.0.2 <1.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.4.tgz",
+      "dev": true
+    },
+    "parse-filepath": {
+      "version": "1.0.1",
+      "from": "parse-filepath@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
+      "dev": true
     },
     "parse-github-repo-url": {
       "version": "1.3.0",
-      "from": "parse-github-repo-url@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.3.0.tgz"
+      "from": "parse-github-repo-url@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.3.0.tgz",
+      "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
       "from": "parse-glob@>=3.0.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "dev": true
     },
     "parse-json": {
       "version": "2.2.0",
       "from": "parse-json@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "dev": true
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "from": "parse-passwd@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "dev": true
     },
     "parse5": {
-      "version": "2.2.1",
-      "from": "parse5@2.2.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.1.tgz"
+      "version": "2.2.3",
+      "from": "parse5@>=2.2.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
+      "dev": true
     },
     "parsejson": {
-      "version": "0.0.1",
-      "from": "parsejson@0.0.1",
-      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz"
+      "version": "0.0.3",
+      "from": "parsejson@0.0.3",
+      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+      "dev": true
     },
     "parseqs": {
-      "version": "0.0.2",
-      "from": "parseqs@0.0.2",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz"
+      "version": "0.0.5",
+      "from": "parseqs@0.0.5",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "dev": true
     },
     "parseuri": {
-      "version": "0.0.4",
-      "from": "parseuri@0.0.4",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz"
+      "version": "0.0.5",
+      "from": "parseuri@0.0.5",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "dev": true
     },
     "parseurl": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "from": "parseurl@>=1.3.0 <1.4.0",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+      "dev": true
     },
     "passerror": {
       "version": "0.0.1",
       "from": "passerror@0.0.1",
-      "resolved": "https://registry.npmjs.org/passerror/-/passerror-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/passerror/-/passerror-0.0.1.tgz",
+      "dev": true
     },
     "path-browserify": {
       "version": "0.0.0",
-      "from": "path-browserify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+      "from": "path-browserify@0.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "dev": true
     },
     "path-exists": {
       "version": "2.1.0",
       "from": "path-exists@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "dev": true
     },
     "path-is-absolute": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "path-is-absolute@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
       "from": "path-is-inside@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "dev": true
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "from": "path-root@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "dev": true
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "from": "path-root-regex@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "dev": true
     },
     "path-type": {
       "version": "1.1.0",
       "from": "path-type@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2",
+          "version": "4.1.11",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true
         }
       }
     },
     "pause": {
       "version": "0.1.0",
       "from": "pause@0.1.0",
-      "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz",
+      "dev": true
     },
     "pause-stream": {
       "version": "0.0.11",
       "from": "pause-stream@0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "dev": true
     },
     "pbkdf2-compat": {
       "version": "2.0.1",
       "from": "pbkdf2-compat@2.0.1",
-      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
+      "dev": true
     },
     "pegjs": {
       "version": "0.9.0",
       "from": "pegjs@0.9.0",
-      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.9.0.tgz"
+      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.9.0.tgz",
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
       "from": "pify@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "dev": true
     },
     "pinkie": {
-      "version": "2.0.1",
+      "version": "2.0.4",
       "from": "pinkie@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "dev": true
     },
     "pinkie-promise": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "from": "pinkie-promise@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "dev": true
     },
     "pkginfo": {
       "version": "0.3.1",
       "from": "pkginfo@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+      "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
       "from": "prepend-http@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "dev": true
     },
     "preserve": {
       "version": "0.2.0",
       "from": "preserve@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "dev": true
     },
     "pretty-hrtime": {
-      "version": "1.0.1",
+      "version": "1.0.3",
       "from": "pretty-hrtime@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "dev": true
+    },
+    "private": {
+      "version": "0.1.6",
+      "from": "private@>=0.1.6 <0.2.0",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+      "dev": true
     },
     "process": {
       "version": "0.11.9",
       "from": "process@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz",
+      "dev": true
     },
     "process-nextick-args": {
-      "version": "1.0.6",
+      "version": "1.0.7",
       "from": "process-nextick-args@>=1.0.6 <1.1.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "dev": true
     },
     "promise": {
       "version": "7.1.1",
       "from": "promise@>=7.0.3 <8.0.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+      "dev": true
     },
     "promzard": {
       "version": "0.3.0",
       "from": "promzard@0.3.0",
-      "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+      "dev": true
     },
     "protractor": {
-      "version": "4.0.11",
-      "from": "protractor@4.0.11",
-      "resolved": "https://registry.npmjs.org/protractor/-/protractor-4.0.11.tgz",
+      "version": "4.0.14",
+      "from": "protractor@>=4.0.11 <5.0.0",
+      "resolved": "https://registry.npmjs.org/protractor/-/protractor-4.0.14.tgz",
+      "dev": true,
       "dependencies": {
-        "@types/jasmine": {
-          "version": "2.5.37",
-          "from": "@types/jasmine@>=2.5.36 <3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.5.37.tgz"
-        },
         "@types/node": {
-          "version": "6.0.46",
+          "version": "6.0.60",
           "from": "@types/node@>=6.0.46 <7.0.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.46.tgz"
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.60.tgz",
+          "dev": true
+        },
+        "@types/selenium-webdriver": {
+          "version": "2.53.37",
+          "from": "@types/selenium-webdriver@2.53.37",
+          "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.37.tgz",
+          "dev": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "from": "assert-plus@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "from": "aws-sign2@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "from": "caseless@>=0.11.0 <0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "from": "combined-stream@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.9.0",
+          "from": "commander@>=2.9.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "dev": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "from": "delayed-stream@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.1.2",
+          "from": "form-data@>=2.1.1 <2.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+          "dev": true
         },
         "glob": {
           "version": "7.1.1",
           "from": "glob@>=7.0.3 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "dev": true
         },
-        "mime-db": {
-          "version": "1.24.0",
-          "from": "mime-db@~1.24.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+        "har-validator": {
+          "version": "2.0.6",
+          "from": "har-validator@>=2.0.6 <2.1.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "dev": true
         },
-        "mime-types": {
-          "version": "2.1.12",
-          "from": "mime-types@>=2.1.7 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
+        "hawk": {
+          "version": "3.1.3",
+          "from": "hawk@>=3.1.3 <3.2.0",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "from": "http-signature@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "dev": true
+        },
+        "jasmine": {
+          "version": "2.4.1",
+          "from": "jasmine@2.4.1",
+          "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.4.1.tgz",
+          "dev": true,
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.11 <4.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "from": "minimatch@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "dev": true
+            }
+          }
+        },
+        "jasmine-core": {
+          "version": "2.4.1",
+          "from": "jasmine-core@>=2.4.0 <2.5.0",
+          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "from": "oauth-sign@>=0.8.1 <0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "dev": true
         },
         "qs": {
           "version": "6.3.0",
           "from": "qs@>=6.3.0 <6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
+          "dev": true
         },
         "request": {
-          "version": "2.78.0",
+          "version": "2.79.0",
           "from": "request@>=2.78.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.78.0.tgz"
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "dev": true
         },
-        "rimraf": {
-          "version": "2.5.4",
-          "from": "rimraf@>=2.5.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-        },
-        "saucelabs": {
-          "version": "1.3.0",
-          "from": "saucelabs@>=1.3.0 <1.4.0",
-          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.3.0.tgz"
-        },
-        "semver": {
-          "version": "5.3.0",
-          "from": "semver@>=5.3.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "from": "tough-cookie@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+        "uuid": {
+          "version": "3.0.1",
+          "from": "uuid@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "dev": true
         },
         "webdriver-manager": {
-          "version": "10.2.8",
-          "from": "webdriver-manager@>=10.2.8 <11.0.0",
-          "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-10.2.8.tgz"
+          "version": "10.3.0",
+          "from": "webdriver-manager@>=10.3.0 <11.0.0",
+          "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-10.3.0.tgz",
+          "dev": true
         }
       }
     },
     "prr": {
       "version": "0.0.0",
       "from": "prr@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+      "dev": true
     },
     "pullstream": {
       "version": "0.4.1",
       "from": "pullstream@>=0.4.1 <1.0.0",
       "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.33",
-          "from": "readable-stream@>=1.0.31 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
-        }
-      }
+      "dev": true
     },
     "punycode": {
       "version": "1.4.1",
-      "from": "punycode@>=1.2.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+      "from": "punycode@>=1.4.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "dev": true
     },
     "q": {
       "version": "1.4.1",
-      "from": "q@>=1.4.1 <1.5.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+      "from": "q@>=1.4.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+      "dev": true
     },
     "qs": {
       "version": "4.0.0",
       "from": "qs@4.0.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+      "dev": true
     },
     "querystring": {
       "version": "0.2.0",
       "from": "querystring@0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
       "from": "querystring-es3@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "dev": true
+    },
+    "random-bytes": {
+      "version": "1.0.0",
+      "from": "random-bytes@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "dev": true
     },
     "randomatic": {
-      "version": "1.1.5",
+      "version": "1.1.6",
       "from": "randomatic@>=1.1.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+      "dev": true
     },
     "range-parser": {
       "version": "1.0.3",
-      "from": "range-parser@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+      "from": "range-parser@>=1.0.3 <1.1.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+      "dev": true
     },
     "raw-body": {
-      "version": "2.1.5",
+      "version": "2.1.7",
       "from": "raw-body@>=2.1.2 <2.2.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+      "dev": true,
       "dependencies": {
         "bytes": {
-          "version": "2.2.0",
-          "from": "bytes@2.2.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
+          "version": "2.4.0",
+          "from": "bytes@2.4.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+          "dev": true
         },
         "iconv-lite": {
           "version": "0.4.13",
           "from": "iconv-lite@0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "dev": true
         }
       }
     },
     "rc": {
       "version": "1.1.6",
       "from": "rc@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+      "dev": true
     },
     "react": {
-      "version": "0.14.5",
+      "version": "0.14.8",
       "from": "react@>=0.14.0 <0.15.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.14.5.tgz"
+      "resolved": "https://registry.npmjs.org/react/-/react-0.14.8.tgz",
+      "dev": true
     },
     "read": {
       "version": "1.0.5",
       "from": "read@1.0.5",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
+      "dev": true
     },
     "read-all-stream": {
       "version": "3.1.0",
       "from": "read-all-stream@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@~1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
         },
         "readable-stream": {
           "version": "2.2.2",
-          "from": "readable-stream@^2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
         }
       }
     },
     "read-pkg": {
       "version": "1.1.0",
-      "from": "read-pkg@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+      "from": "read-pkg@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "dev": true
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "from": "read-pkg-up@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "dev": true
     },
     "readable-stream": {
-      "version": "1.1.13",
-      "from": "readable-stream@>=1.1.13 <2.0.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+      "version": "1.0.34",
+      "from": "readable-stream@>=1.0.31 <1.1.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "dev": true
     },
     "readdirp": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "from": "readdirp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2",
+          "version": "4.1.11",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true
         },
-        "minimatch": {
-          "version": "2.0.10",
-          "from": "minimatch@>=2.0.10 <3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
         },
         "readable-stream": {
-          "version": "2.0.5",
+          "version": "2.2.2",
           "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
+        }
+      }
+    },
+    "recast": {
+      "version": "0.11.18",
+      "from": "recast@>=0.11.17 <0.12.0",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.18.tgz",
+      "dev": true,
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "from": "esprima@>=3.1.0 <3.2.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "dev": true
         }
       }
     },
     "rechoir": {
       "version": "0.6.2",
-      "from": "rechoir@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
+      "from": "rechoir@>=0.6.2 <0.7.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "dev": true
     },
     "redent": {
       "version": "1.0.0",
       "from": "redent@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "dev": true
     },
     "reflect-metadata": {
-      "version": "0.1.3",
-      "from": "reflect-metadata@0.1.3",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.3.tgz"
+      "version": "0.1.9",
+      "from": "reflect-metadata@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.9.tgz"
     },
     "regex-cache": {
-      "version": "0.4.2",
+      "version": "0.4.3",
       "from": "regex-cache@>=0.4.2 <0.5.0",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz"
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+      "dev": true
     },
     "registry-auth-token": {
       "version": "3.1.0",
       "from": "registry-auth-token@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz",
+      "dev": true
     },
     "registry-url": {
       "version": "3.1.0",
       "from": "registry-url@>=3.0.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
       "from": "repeat-element@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "dev": true
     },
     "repeat-string": {
-      "version": "1.5.2",
+      "version": "1.6.1",
       "from": "repeat-string@>=1.5.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "dev": true
     },
     "repeating": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "from": "repeating@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "dev": true
     },
     "replace-ext": {
       "version": "0.0.1",
       "from": "replace-ext@0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "dev": true
     },
     "request": {
-      "version": "2.51.0",
-      "from": "request@>=2.51.0 <2.52.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+      "version": "2.55.0",
+      "from": "request@>=2.55.0 <2.56.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+      "dev": true,
       "dependencies": {
-        "asn1": {
-          "version": "0.1.11",
-          "from": "asn1@0.1.11",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+        "bl": {
+          "version": "0.9.5",
+          "from": "bl@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+          "dev": true
         },
-        "async": {
-          "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-        },
-        "aws-sign2": {
-          "version": "0.5.0",
-          "from": "aws-sign2@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-        },
-        "boom": {
-          "version": "0.4.2",
-          "from": "boom@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-        },
-        "caseless": {
-          "version": "0.8.0",
-          "from": "caseless@>=0.8.0 <0.9.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
-        },
-        "combined-stream": {
-          "version": "0.0.7",
-          "from": "combined-stream@>=0.0.5 <0.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
-        },
-        "cryptiles": {
-          "version": "0.2.2",
-          "from": "cryptiles@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-        },
-        "delayed-stream": {
-          "version": "0.0.5",
-          "from": "delayed-stream@0.0.5",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-        },
-        "forever-agent": {
-          "version": "0.5.2",
-          "from": "forever-agent@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-        },
-        "form-data": {
-          "version": "0.2.0",
-          "from": "form-data@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-          "dependencies": {
-            "mime-types": {
-              "version": "2.0.14",
-              "from": "mime-types@2.0.14",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
-            }
-          }
-        },
-        "hawk": {
-          "version": "1.1.1",
-          "from": "hawk@1.1.1",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz"
-        },
-        "hoek": {
-          "version": "0.9.1",
-          "from": "hoek@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-        },
-        "http-signature": {
-          "version": "0.10.1",
-          "from": "http-signature@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz"
+        "mime-db": {
+          "version": "1.12.0",
+          "from": "mime-db@>=1.12.0 <1.13.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "dev": true
         },
         "mime-types": {
-          "version": "1.0.2",
-          "from": "mime-types@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-        },
-        "oauth-sign": {
-          "version": "0.5.0",
-          "from": "oauth-sign@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+          "version": "2.0.14",
+          "from": "mime-types@>=2.0.1 <2.1.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "dev": true
         },
         "qs": {
-          "version": "2.3.3",
-          "from": "qs@>=2.3.1 <2.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-        },
-        "sntp": {
-          "version": "0.2.4",
-          "from": "sntp@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+          "version": "2.4.2",
+          "from": "qs@>=2.4.0 <2.5.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
+          "dev": true
         }
       }
     },
     "requires-port": {
       "version": "1.0.0",
       "from": "requires-port@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "dev": true
     },
     "resolve": {
-      "version": "1.1.6",
-      "from": "resolve@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+      "version": "1.2.0",
+      "from": "resolve@>=1.1.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz",
+      "dev": true
+    },
+    "resolve-dir": {
+      "version": "0.1.1",
+      "from": "resolve-dir@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+      "dev": true
     },
     "response-time": {
-      "version": "2.3.1",
+      "version": "2.3.2",
       "from": "response-time@>=2.3.1 <2.4.0",
-      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "depd": {
+          "version": "1.1.0",
+          "from": "depd@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "dev": true
+        }
+      }
     },
     "rewire": {
-      "version": "2.5.1",
+      "version": "2.5.2",
       "from": "rewire@>=2.3.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.5.2.tgz",
+      "dev": true
     },
     "right-align": {
       "version": "0.1.3",
       "from": "right-align@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "dev": true
     },
     "rimraf": {
-      "version": "2.5.0",
-      "from": "rimraf@>=2.2.8 <3.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
+      "version": "2.5.4",
+      "from": "rimraf@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+      "dev": true,
       "dependencies": {
         "glob": {
-          "version": "6.0.3",
-          "from": "glob@>=6.0.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz"
+          "version": "7.1.1",
+          "from": "glob@>=7.0.5 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "dev": true
         }
       }
     },
     "ripemd160": {
       "version": "0.2.0",
       "from": "ripemd160@0.2.0",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
+      "dev": true
     },
     "rndm": {
-      "version": "1.1.1",
-      "from": "rndm@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.1.tgz"
+      "version": "1.2.0",
+      "from": "rndm@1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "dev": true
     },
     "rollup": {
-      "version": "0.26.3",
-      "from": "rollup@0.26.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.26.3.tgz",
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "from": "ansi-styles@>=2.2.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-        },
-        "source-map": {
-          "version": "0.1.32",
-          "from": "source-map@0.1.32",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.1",
-              "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-            }
-          }
-        },
-        "source-map-support": {
-          "version": "0.4.0",
-          "from": "source-map-support@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.0.tgz"
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-        }
-      }
+      "version": "0.26.7",
+      "from": "rollup@>=0.26.3 <0.27.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.26.7.tgz",
+      "dev": true
     },
     "rollup-plugin-commonjs": {
       "version": "5.0.5",
-      "from": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-5.0.5.tgz",
+      "from": "rollup-plugin-commonjs@>=5.0.5 <6.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-5.0.5.tgz",
+      "dev": true,
       "dependencies": {
         "acorn": {
-          "version": "4.0.3",
+          "version": "4.0.4",
           "from": "acorn@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz"
-        },
-        "resolve": {
-          "version": "1.1.7",
-          "from": "resolve@>=1.1.7 <2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
+          "dev": true
         }
       }
     },
     "rollup-pluginutils": {
       "version": "1.5.2",
       "from": "rollup-pluginutils@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz"
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
+      "dev": true
     },
     "rxjs": {
-      "version": "5.0.1",
-      "from": "rxjs@5.0.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.1.tgz"
+      "version": "5.0.3",
+      "from": "rxjs@>=5.0.1 <6.0.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.3.tgz"
     },
     "sauce-connect-launcher": {
       "version": "0.13.0",
       "from": "sauce-connect-launcher@>=0.13.0 <0.14.0",
       "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.13.0.tgz",
+      "dev": true,
       "dependencies": {
         "async": {
           "version": "1.4.0",
           "from": "async@1.4.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz",
+          "dev": true
         },
         "glob": {
           "version": "5.0.15",
           "from": "glob@>=5.0.14 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "dev": true
         },
         "lodash": {
           "version": "3.10.1",
           "from": "lodash@3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "dev": true
         },
         "rimraf": {
           "version": "2.4.3",
           "from": "rimraf@2.4.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
+          "dev": true
         }
       }
     },
     "saucelabs": {
-      "version": "1.0.1",
+      "version": "1.3.0",
       "from": "saucelabs@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.3.0.tgz",
+      "dev": true
     },
     "sax": {
-      "version": "1.1.4",
+      "version": "1.2.1",
       "from": "sax@>=0.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz"
-    },
-    "scmp": {
-      "version": "1.0.0",
-      "from": "scmp@1.0.0",
-      "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "dev": true
     },
     "selenium-webdriver": {
       "version": "2.53.3",
-      "from": "selenium-webdriver@2.53.3",
+      "from": "selenium-webdriver@>=2.53.3 <3.0.0",
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.53.3.tgz",
+      "dev": true,
       "dependencies": {
         "adm-zip": {
           "version": "0.4.4",
           "from": "adm-zip@0.4.4",
-          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
+          "dev": true
         },
         "sax": {
           "version": "0.6.1",
           "from": "sax@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
+          "dev": true
         },
         "tmp": {
           "version": "0.0.24",
           "from": "tmp@0.0.24",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
+          "dev": true
         },
         "xml2js": {
           "version": "0.4.4",
           "from": "xml2js@0.4.4",
-          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz"
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
+          "dev": true
         }
       }
     },
     "semver": {
-      "version": "5.1.0",
-      "from": "semver@5.1.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+      "version": "5.3.0",
+      "from": "semver@>=5.1.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "dev": true
     },
     "semver-diff": {
       "version": "2.1.0",
       "from": "semver-diff@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz"
-    },
-    "semver-utils": {
-      "version": "1.1.1",
-      "from": "semver-utils@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "dev": true
     },
     "send": {
-      "version": "0.13.0",
-      "from": "send@0.13.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz"
+      "version": "0.13.2",
+      "from": "send@0.13.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "depd": {
+          "version": "1.1.0",
+          "from": "depd@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.2.1",
+          "from": "statuses@>=1.2.1 <1.3.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+          "dev": true
+        }
+      }
     },
     "seq": {
       "version": "0.3.5",
       "from": "seq@0.3.5",
       "resolved": "https://registry.npmjs.org/seq/-/seq-0.3.5.tgz",
+      "dev": true,
       "dependencies": {
         "chainsaw": {
           "version": "0.0.9",
           "from": "chainsaw@>=0.0.7 <0.1.0",
-          "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.0.9.tgz"
+          "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.0.9.tgz",
+          "dev": true
         }
       }
     },
     "sequencify": {
       "version": "0.0.7",
       "from": "sequencify@>=0.0.7 <0.1.0",
-      "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
+      "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+      "dev": true
     },
     "serve-favicon": {
-      "version": "2.3.0",
+      "version": "2.3.2",
       "from": "serve-favicon@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz"
-    },
-    "serve-index": {
-      "version": "1.7.2",
-      "from": "serve-index@>=1.7.2 <1.8.0",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.2.tgz",
+      "dev": true,
       "dependencies": {
-        "mime-db": {
-          "version": "1.20.0",
-          "from": "mime-db@1.20.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
-        },
-        "mime-types": {
-          "version": "2.1.8",
-          "from": "mime-types@2.1.8",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz"
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "dev": true
         }
       }
     },
+    "serve-index": {
+      "version": "1.7.3",
+      "from": "serve-index@>=1.7.2 <1.8.0",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
+      "dev": true
+    },
     "serve-static": {
-      "version": "1.10.0",
+      "version": "1.10.3",
       "from": "serve-static@>=1.10.0 <1.11.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.0.tgz"
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
+      "dev": true
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "from": "set-immediate-shim@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "dev": true
     },
     "setimmediate": {
-      "version": "1.0.4",
+      "version": "1.0.5",
       "from": "setimmediate@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "dev": true
     },
     "sha.js": {
       "version": "2.2.6",
       "from": "sha.js@2.2.6",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
+      "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
       "from": "sigmund@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "dev": true
     },
     "signal-exit": {
-      "version": "2.1.2",
-      "from": "signal-exit@>=2.1.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+      "version": "3.0.2",
+      "from": "signal-exit@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "dev": true
     },
     "slice-stream": {
       "version": "1.0.0",
       "from": "slice-stream@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.33",
-          "from": "readable-stream@>=1.0.31 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
-        }
-      }
+      "dev": true
     },
     "slide": {
       "version": "1.1.6",
       "from": "slide@>=1.1.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "dev": true
     },
     "sntp": {
       "version": "1.0.9",
       "from": "sntp@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "dev": true
     },
     "socket.io": {
-      "version": "1.4.6",
+      "version": "1.7.2",
       "from": "socket.io@>=1.4.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.6.tgz"
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "dev": true
+        }
+      }
     },
     "socket.io-adapter": {
-      "version": "0.4.0",
-      "from": "socket.io-adapter@0.4.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
+      "version": "0.5.0",
+      "from": "socket.io-adapter@0.5.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
+      "dev": true,
       "dependencies": {
-        "socket.io-parser": {
-          "version": "2.2.2",
-          "from": "socket.io-parser@2.2.2",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
-          "dependencies": {
-            "debug": {
-              "version": "0.7.4",
-              "from": "debug@0.7.4",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-            }
-          }
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "dev": true
         }
       }
     },
     "socket.io-client": {
-      "version": "1.4.6",
-      "from": "socket.io-client@1.4.6",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.6.tgz",
+      "version": "1.7.2",
+      "from": "socket.io-client@1.7.2",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.2.tgz",
+      "dev": true,
       "dependencies": {
         "component-emitter": {
-          "version": "1.2.0",
-          "from": "component-emitter@1.2.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
+          "version": "1.2.1",
+          "from": "component-emitter@1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.3.3",
+          "from": "debug@2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "dev": true
         }
       }
     },
     "socket.io-parser": {
-      "version": "2.2.6",
-      "from": "socket.io-parser@2.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
-      "dependencies": {
-        "json3": {
-          "version": "3.3.2",
-          "from": "json3@3.3.2",
-          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
-        }
-      }
+      "version": "2.3.1",
+      "from": "socket.io-parser@2.3.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+      "dev": true
     },
     "source-list-map": {
-      "version": "0.1.5",
-      "from": "source-list-map@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
+      "version": "0.1.8",
+      "from": "source-list-map@>=0.1.7 <0.2.0",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+      "dev": true
     },
     "source-map": {
       "version": "0.3.0",
       "from": "source-map@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+      "dev": true
     },
     "source-map-support": {
-      "version": "0.4.2",
-      "from": "source-map-support@latest",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.2.tgz",
+      "version": "0.4.9",
+      "from": "source-map-support@>=0.4.2 <0.5.0",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.9.tgz",
+      "dev": true,
       "dependencies": {
         "source-map": {
-          "version": "0.1.32",
-          "from": "source-map@0.1.32",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.1",
-              "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-            }
-          }
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.3 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "dev": true
         }
       }
     },
     "sparkles": {
       "version": "1.0.0",
       "from": "sparkles@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+      "dev": true
     },
     "spdx-correct": {
       "version": "1.0.2",
       "from": "spdx-correct@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
-    },
-    "spdx-exceptions": {
-      "version": "1.0.4",
-      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "dev": true
     },
     "spdx-expression-parse": {
-      "version": "1.0.2",
+      "version": "1.0.4",
       "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "dev": true
     },
     "spdx-license-ids": {
-      "version": "1.1.0",
+      "version": "1.2.2",
       "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "dev": true
     },
     "split": {
       "version": "1.0.0",
       "from": "split@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
+      "dev": true
     },
     "split2": {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "from": "split2@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-2.1.0.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "from": "readable-stream@2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
-        },
-        "through2": {
-          "version": "2.0.1",
-          "from": "through2@2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "from": "sprintf-js@>=1.0.2 <1.1.0",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+      "from": "sprintf-js@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "dev": true
     },
     "sshpk": {
-      "version": "1.10.1",
+      "version": "1.10.2",
       "from": "sshpk@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
+      "dev": true,
       "dependencies": {
+        "asn1": {
+          "version": "0.2.3",
+          "from": "asn1@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "dev": true
+        },
         "assert-plus": {
           "version": "1.0.0",
           "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "dev": true
         }
       }
     },
     "statuses": {
-      "version": "1.2.1",
+      "version": "1.3.1",
       "from": "statuses@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "dev": true
     },
     "stream-browserify": {
-      "version": "1.0.0",
-      "from": "stream-browserify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
+      "version": "2.0.1",
+      "from": "stream-browserify@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
+        }
+      }
     },
     "stream-combiner": {
       "version": "0.0.4",
       "from": "stream-combiner@>=0.0.4 <0.1.0",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "dev": true
+    },
+    "stream-combiner2": {
+      "version": "1.1.1",
+      "from": "stream-combiner2@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "duplexer2": {
+          "version": "0.1.4",
+          "from": "duplexer2@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
+        }
+      }
     },
     "stream-consume": {
       "version": "0.1.0",
       "from": "stream-consume@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
+      "dev": true
     },
     "stream-counter": {
       "version": "0.2.0",
       "from": "stream-counter@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.8 <1.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "dev": true
+        }
+      }
     },
     "stream-equal": {
       "version": "0.1.6",
       "from": "stream-equal@0.1.6",
-      "resolved": "https://registry.npmjs.org/stream-equal/-/stream-equal-0.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/stream-equal/-/stream-equal-0.1.6.tgz",
+      "dev": true
+    },
+    "stream-http": {
+      "version": "2.6.1",
+      "from": "stream-http@>=2.3.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
+        }
+      }
     },
     "string_decoder": {
       "version": "0.10.31",
       "from": "string_decoder@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "dev": true
     },
     "string-width": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "from": "string-width@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-        },
-        "strip-ansi": {
-          "version": "3.0.0",
-          "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",
       "from": "stringstream@>=0.0.4 <0.1.0",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
       "from": "strip-ansi@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "dev": true
     },
     "strip-bom": {
       "version": "2.0.0",
       "from": "strip-bom@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "dev": true
     },
     "strip-indent": {
       "version": "1.0.1",
       "from": "strip-indent@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "1.0.4",
       "from": "strip-json-comments@>=1.0.4 <1.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-    },
-    "success-symbol": {
-      "version": "0.1.0",
-      "from": "success-symbol@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
       "from": "supports-color@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "dev": true
     },
     "symbol-observable": {
       "version": "1.0.4",
@@ -6804,540 +6059,587 @@
     "systemjs": {
       "version": "0.18.10",
       "from": "systemjs@0.18.10",
-      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.18.10.tgz"
+      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.18.10.tgz",
+      "dev": true
     },
     "tapable": {
       "version": "0.1.10",
       "from": "tapable@>=0.1.8 <0.2.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+      "dev": true
     },
     "tar-stream": {
-      "version": "1.1.5",
-      "from": "tar-stream@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
+      "version": "1.5.2",
+      "from": "tar-stream@>=1.5.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
+      "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "1.0.33",
-          "from": "readable-stream@>=1.0.33 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
         }
       }
     },
     "text-extensions": {
-      "version": "1.3.3",
+      "version": "1.4.0",
       "from": "text-extensions@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.3.3.tgz"
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.4.0.tgz",
+      "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.2.7 <3.0.0",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      "from": "through@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "dev": true
     },
     "through2": {
-      "version": "0.6.5",
-      "from": "through2@>=0.6.3 <0.7.0",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "version": "2.0.3",
+      "from": "through2@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "dev": true,
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
+        },
         "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.1.5 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
         }
       }
     },
     "tildify": {
-      "version": "1.1.2",
+      "version": "1.2.0",
       "from": "tildify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+      "dev": true
+    },
+    "time-stamp": {
+      "version": "1.0.1",
+      "from": "time-stamp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.1.tgz",
+      "dev": true
     },
     "timed-out": {
-      "version": "3.0.0",
+      "version": "3.1.3",
       "from": "timed-out@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+      "dev": true
     },
     "timers-browserify": {
-      "version": "1.4.2",
-      "from": "timers-browserify@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+      "version": "2.0.2",
+      "from": "timers-browserify@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
+      "dev": true
     },
     "timers-ext": {
       "version": "0.1.0",
       "from": "timers-ext@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+      "dev": true
     },
     "tiny-lr": {
       "version": "0.2.1",
       "from": "tiny-lr@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
+      "dev": true,
       "dependencies": {
         "body-parser": {
           "version": "1.14.2",
           "from": "body-parser@>=1.14.0 <1.15.0",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
+          "dev": true,
           "dependencies": {
             "qs": {
               "version": "5.2.0",
               "from": "qs@5.2.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+              "dev": true
             }
           }
         },
         "bytes": {
           "version": "2.2.0",
           "from": "bytes@2.2.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+          "dev": true
         },
         "depd": {
           "version": "1.1.0",
           "from": "depd@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "dev": true
         },
         "iconv-lite": {
           "version": "0.4.13",
           "from": "iconv-lite@0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "dev": true
         },
         "qs": {
           "version": "5.1.0",
           "from": "qs@>=5.1.0 <5.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
+          "dev": true
         }
       }
     },
     "tmp": {
       "version": "0.0.25",
       "from": "tmp@0.0.25",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz"
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz",
+      "dev": true
     },
     "to-array": {
       "version": "0.1.4",
       "from": "to-array@0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "dev": true
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "from": "to-arraybuffer@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "dev": true
     },
     "tough-cookie": {
-      "version": "2.2.1",
-      "from": "tough-cookie@>=2.2.0 <2.3.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+      "version": "2.3.2",
+      "from": "tough-cookie@>=0.12.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "dev": true
     },
     "traverse": {
       "version": "0.3.9",
       "from": "traverse@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
       "from": "trim-newlines@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "dev": true
     },
     "trim-off-newlines": {
       "version": "1.0.1",
       "from": "trim-off-newlines@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+      "dev": true
     },
     "ts-api-guardian": {
       "version": "0.1.4",
       "from": "ts-api-guardian@0.1.4",
       "resolved": "https://registry.npmjs.org/ts-api-guardian/-/ts-api-guardian-0.1.4.tgz",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "from": "ansi-styles@>=2.2.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
-        },
-        "diff": {
-          "version": "2.2.3",
-          "from": "diff@>=2.2.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz"
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-        },
         "typescript": {
           "version": "1.7.3",
           "from": "typescript@1.7.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.7.3.tgz"
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.7.3.tgz",
+          "dev": true
         }
       }
     },
     "tsickle": {
-      "version": "0.2.2",
-      "from": "tsickle@0.2.2",
-      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.2.2.tgz",
+      "version": "0.2.4",
+      "from": "tsickle@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.2.4.tgz",
+      "dev": true,
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
           "from": "source-map@>=0.5.6 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "dev": true
         }
       }
     },
     "tslint": {
-      "version": "4.1.1",
+      "version": "4.3.1",
       "from": "tslint@>=4.1.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.3.1.tgz",
+      "dev": true,
       "dependencies": {
         "diff": {
-          "version": "3.1.0",
+          "version": "3.2.0",
           "from": "diff@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+          "dev": true
         },
-        "glob": {
-          "version": "7.1.1",
-          "from": "glob@>=7.0.3 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
-        },
-        "resolve": {
-          "version": "1.2.0",
-          "from": "resolve@>=1.1.7 <2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz"
-        }
-      }
-    },
-    "tslint-eslint-rules": {
-      "version": "3.1.0",
-      "from": "tslint-eslint-rules@>=3.1.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-3.1.0.tgz",
-      "dependencies": {
-        "diff": {
-          "version": "3.1.0",
-          "from": "diff@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.1.0.tgz"
+        "findup-sync": {
+          "version": "0.3.0",
+          "from": "findup-sync@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+          "dev": true,
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "from": "glob@>=5.0.0 <5.1.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "dev": true
+            }
+          }
         },
         "glob": {
           "version": "7.1.1",
           "from": "glob@>=7.1.1 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "dev": true
         },
-        "resolve": {
-          "version": "1.1.7",
-          "from": "resolve@>=1.1.7 <2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-        },
-        "tslint": {
-          "version": "4.0.2",
-          "from": "tslint@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.0.2.tgz"
+        "underscore.string": {
+          "version": "3.3.4",
+          "from": "underscore.string@>=3.3.4 <4.0.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+          "dev": true
         }
       }
+    },
+    "tslint-eslint-rules": {
+      "version": "3.2.3",
+      "from": "tslint-eslint-rules@>=3.1.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-3.2.3.tgz",
+      "dev": true
+    },
+    "tsscmp": {
+      "version": "1.0.5",
+      "from": "tsscmp@1.0.5",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
+      "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "from": "tty-browserify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+      "from": "tty-browserify@0.0.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "dev": true
     },
     "tunnel-agent": {
-      "version": "0.4.2",
-      "from": "tunnel-agent@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+      "version": "0.4.3",
+      "from": "tunnel-agent@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "dev": true
     },
     "tweetnacl": {
-      "version": "0.14.3",
+      "version": "0.14.5",
       "from": "tweetnacl@>=0.14.0 <0.15.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "dev": true,
+      "optional": true
     },
     "type-is": {
-      "version": "1.6.10",
+      "version": "1.6.14",
       "from": "type-is@>=1.6.6 <1.7.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.10.tgz",
-      "dependencies": {
-        "mime-db": {
-          "version": "1.20.0",
-          "from": "mime-db@>=1.20.0 <1.21.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
-        },
-        "mime-types": {
-          "version": "2.1.8",
-          "from": "mime-types@>=2.1.8 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@>=0.0.5 <0.1.0",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+      "from": "typedarray@>=0.0.6 <0.0.7",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "dev": true
     },
     "typescript": {
-      "version": "2.0.2",
-      "from": "typescript@rc",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.2.tgz"
+      "version": "2.1.5",
+      "from": "typescript@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.1.5.tgz",
+      "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.10",
+      "version": "0.7.12",
       "from": "ua-parser-js@>=0.7.9 <0.8.0",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
+      "dev": true
     },
     "uglify-js": {
-      "version": "2.7.0",
-      "from": "uglify-js@>=2.6.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.0.tgz",
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "from": "camelcase@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "from": "cliui@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "from": "window-size@0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "from": "yargs@>=3.10.0 <3.11.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
-        }
-      }
+      "version": "1.3.3",
+      "from": "uglify-js@1.3.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.3.tgz",
+      "dev": true
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
       "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "dev": true
     },
     "uid-safe": {
-      "version": "2.0.0",
-      "from": "uid-safe@>=2.0.0 <2.1.0",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz"
+      "version": "2.1.3",
+      "from": "uid-safe@2.1.3",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.3.tgz",
+      "dev": true
     },
     "ultron": {
       "version": "1.0.2",
       "from": "ultron@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "dev": true
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "from": "unc-path-regex@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "dev": true
     },
     "underscore": {
-      "version": "1.8.3",
-      "from": "underscore@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+      "version": "1.3.3",
+      "from": "underscore@1.3.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.3.3.tgz",
+      "dev": true
     },
     "underscore.string": {
-      "version": "3.3.4",
-      "from": "underscore.string@>=3.3.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz"
+      "version": "3.0.3",
+      "from": "underscore.string@>=3.0.3 <3.1.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz",
+      "dev": true
     },
     "unicoderegexp": {
       "version": "0.4.1",
       "from": "unicoderegexp@0.4.1",
-      "resolved": "https://registry.npmjs.org/unicoderegexp/-/unicoderegexp-0.4.1.tgz"
+      "resolved": "https://registry.npmjs.org/unicoderegexp/-/unicoderegexp-0.4.1.tgz",
+      "dev": true
     },
     "unique-stream": {
       "version": "1.0.0",
       "from": "unique-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+      "dev": true
     },
     "universal-analytics": {
-      "version": "0.3.10",
+      "version": "0.3.11",
       "from": "universal-analytics@>=0.3.9 <0.4.0",
-      "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.3.10.tgz"
+      "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.3.11.tgz",
+      "dev": true,
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "dev": true
+        }
+      }
     },
     "unpipe": {
       "version": "1.0.0",
-      "from": "unpipe@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+      "from": "unpipe@1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "dev": true
     },
     "unzip": {
       "version": "0.1.11",
       "from": "unzip@>=0.1.9 <0.2.0",
       "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.33",
-          "from": "readable-stream@>=1.0.31 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
-        }
-      }
+      "dev": true
     },
     "unzip-response": {
       "version": "1.0.2",
       "from": "unzip-response@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "dev": true
     },
     "update-notifier": {
       "version": "1.0.3",
       "from": "update-notifier@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
+      "dev": true
     },
     "url": {
-      "version": "0.10.3",
-      "from": "url@>=0.10.1 <0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "version": "0.11.0",
+      "from": "url@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "dev": true,
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
           "from": "punycode@1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "dev": true
         }
       }
     },
     "url-parse-lax": {
       "version": "1.0.0",
       "from": "url-parse-lax@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "dev": true
     },
     "user-home": {
       "version": "1.1.1",
       "from": "user-home@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "dev": true
     },
     "useragent": {
-      "version": "2.1.9",
+      "version": "2.1.10",
       "from": "useragent@>=2.1.6 <3.0.0",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.10.tgz",
+      "dev": true,
       "dependencies": {
         "lru-cache": {
           "version": "2.2.4",
           "from": "lru-cache@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+          "dev": true
         }
       }
     },
-    "utf8": {
-      "version": "2.1.0",
-      "from": "utf8@2.1.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
-    },
     "util": {
       "version": "0.10.3",
-      "from": "util@>=0.10.1 <0.11.0",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+      "from": "util@>=0.10.3 <0.11.0",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "dev": true,
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "from": "inherits@2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "dev": true
+        }
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
       "from": "util-deprecate@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.0",
       "from": "utils-merge@1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "dev": true
     },
     "uuid": {
       "version": "2.0.3",
       "from": "uuid@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+      "dev": true
     },
     "v8flags": {
       "version": "2.0.11",
       "from": "v8flags@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "dev": true
     },
     "vargs": {
       "version": "0.1.0",
       "from": "vargs@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
+      "dev": true
     },
     "vary": {
-      "version": "1.0.1",
-      "from": "vary@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+      "version": "1.1.0",
+      "from": "vary@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
+      "dev": true
     },
     "verror": {
       "version": "1.3.6",
       "from": "verror@1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "dev": true
     },
     "vhost": {
       "version": "3.0.2",
       "from": "vhost@>=3.0.1 <3.1.0",
-      "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz",
+      "dev": true
+    },
+    "vinyl": {
+      "version": "0.5.3",
+      "from": "vinyl@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+      "dev": true
     },
     "vinyl-fs": {
       "version": "0.3.14",
       "from": "vinyl-fs@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+      "dev": true,
       "dependencies": {
         "clone": {
           "version": "0.2.0",
           "from": "clone@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "dev": true
         },
         "strip-bom": {
           "version": "1.0.0",
           "from": "strip-bom@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dev": true
         },
         "vinyl": {
           "version": "0.4.6",
           "from": "vinyl@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "dev": true
         }
       }
     },
     "vlq": {
       "version": "0.2.1",
       "from": "vlq@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.1.tgz",
+      "dev": true
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "from": "vm-browserify@>=0.0.1 <0.1.0",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+      "from": "vm-browserify@0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "dev": true
     },
     "void-elements": {
       "version": "2.0.1",
       "from": "void-elements@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "dev": true
     },
     "vrsource-tslint-rules": {
-      "version": "4.0.0",
+      "version": "4.0.1",
       "from": "vrsource-tslint-rules@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/vrsource-tslint-rules/-/vrsource-tslint-rules-4.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/vrsource-tslint-rules/-/vrsource-tslint-rules-4.0.1.tgz",
+      "dev": true
     },
     "watchpack": {
       "version": "0.2.9",
       "from": "watchpack@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+      "dev": true,
       "dependencies": {
         "async": {
           "version": "0.9.2",
           "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "dev": true
         },
         "graceful-fs": {
-          "version": "4.1.2",
+          "version": "4.1.11",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true
         }
       }
     },
@@ -7345,345 +6647,372 @@
       "version": "0.3.12",
       "from": "wd@>=0.3.4 <0.4.0",
       "resolved": "https://registry.npmjs.org/wd/-/wd-0.3.12.tgz",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-        },
-        "ansi-styles": {
-          "version": "2.1.0",
-          "from": "ansi-styles@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-        },
-        "asn1": {
-          "version": "0.1.11",
-          "from": "asn1@0.1.11",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-        },
-        "async": {
-          "version": "1.0.0",
-          "from": "async@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
-        },
-        "aws-sign2": {
-          "version": "0.5.0",
-          "from": "aws-sign2@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-        },
-        "caseless": {
-          "version": "0.9.0",
-          "from": "caseless@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
-        },
-        "combined-stream": {
-          "version": "0.0.7",
-          "from": "combined-stream@>=0.0.5 <0.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
-        },
-        "delayed-stream": {
-          "version": "0.0.5",
-          "from": "delayed-stream@0.0.5",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-        },
-        "form-data": {
-          "version": "0.2.0",
-          "from": "form-data@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+        "archiver": {
+          "version": "0.14.4",
+          "from": "archiver@>=0.14.0 <0.15.0",
+          "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.14.4.tgz",
+          "dev": true,
           "dependencies": {
             "async": {
               "version": "0.9.2",
               "from": "async@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+              "dev": true
+            },
+            "lodash": {
+              "version": "3.2.0",
+              "from": "lodash@>=3.2.0 <3.3.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
+              "dev": true
             }
           }
         },
-        "har-validator": {
-          "version": "1.8.0",
-          "from": "har-validator@>=1.4.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz"
+        "async": {
+          "version": "1.0.0",
+          "from": "async@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "dev": true
         },
-        "has-ansi": {
-          "version": "2.0.0",
-          "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+        "bl": {
+          "version": "0.9.5",
+          "from": "bl@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+          "dev": true
         },
-        "hawk": {
-          "version": "2.3.1",
-          "from": "hawk@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz"
+        "compress-commons": {
+          "version": "0.2.9",
+          "from": "compress-commons@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.9.tgz",
+          "dev": true
         },
-        "http-signature": {
-          "version": "0.10.1",
-          "from": "http-signature@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz"
+        "crc32-stream": {
+          "version": "0.3.4",
+          "from": "crc32-stream@>=0.3.1 <0.4.0",
+          "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
+          "dev": true
+        },
+        "glob": {
+          "version": "4.3.5",
+          "from": "glob@>=4.3.0 <4.4.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+          "dev": true
+        },
+        "lazystream": {
+          "version": "0.1.0",
+          "from": "lazystream@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
+          "dev": true
         },
         "lodash": {
           "version": "3.9.3",
           "from": "lodash@>=3.9.3 <3.10.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
+          "dev": true
         },
-        "oauth-sign": {
-          "version": "0.6.0",
-          "from": "oauth-sign@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "minimatch@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "dev": true
         },
-        "qs": {
-          "version": "2.4.2",
-          "from": "qs@>=2.4.0 <2.5.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
+        "tar-stream": {
+          "version": "1.1.5",
+          "from": "tar-stream@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
+          "dev": true
         },
-        "request": {
-          "version": "2.55.0",
-          "from": "request@>=2.55.0 <2.56.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz"
-        },
-        "strip-ansi": {
-          "version": "3.0.0",
-          "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-        },
-        "underscore.string": {
-          "version": "3.0.3",
-          "from": "underscore.string@>=3.0.3 <3.1.0",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz"
+        "zip-stream": {
+          "version": "0.5.2",
+          "from": "zip-stream@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.2.tgz",
+          "dev": true,
+          "dependencies": {
+            "lodash": {
+              "version": "3.2.0",
+              "from": "lodash@>=3.2.0 <3.3.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
+              "dev": true
+            }
+          }
         }
       }
     },
     "webpack": {
-      "version": "1.12.9",
+      "version": "1.14.0",
       "from": "webpack@>=1.12.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.12.9.tgz",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.14.0.tgz",
+      "dev": true,
       "dependencies": {
-        "async": {
-          "version": "1.5.0",
-          "from": "async@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+        "acorn": {
+          "version": "3.3.0",
+          "from": "acorn@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "dev": true
         },
         "camelcase": {
           "version": "1.2.1",
           "from": "camelcase@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "dev": true
         },
-        "cliui": {
-          "version": "2.1.0",
-          "from": "cliui@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
+        "interpret": {
+          "version": "0.6.6",
+          "from": "interpret@>=0.6.4 <0.7.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
+          "dev": true
         },
         "source-map": {
-          "version": "0.5.3",
+          "version": "0.5.6",
           "from": "source-map@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "dev": true
         },
         "supports-color": {
-          "version": "3.1.2",
+          "version": "3.2.3",
           "from": "supports-color@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "dev": true
         },
         "uglify-js": {
-          "version": "2.6.1",
-          "from": "uglify-js@>=2.6.0 <2.7.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+          "version": "2.7.5",
+          "from": "uglify-js@>=2.7.3 <2.8.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+          "dev": true,
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@0.2.10",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+              "from": "async@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "dev": true
             }
           }
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "from": "window-size@0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
         },
         "yargs": {
           "version": "3.10.0",
           "from": "yargs@>=3.10.0 <3.11.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "dev": true
         }
       }
     },
     "webpack-core": {
-      "version": "0.6.8",
-      "from": "webpack-core@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
+      "version": "0.6.9",
+      "from": "webpack-core@>=0.6.9 <0.7.0",
+      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
+      "dev": true,
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
           "from": "source-map@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "dev": true
         }
       }
     },
     "websocket-driver": {
-      "version": "0.6.3",
+      "version": "0.6.5",
       "from": "websocket-driver@>=0.5.1",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.3.tgz"
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+      "dev": true
     },
     "websocket-extensions": {
       "version": "0.1.1",
       "from": "websocket-extensions@>=0.1.1",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+      "dev": true
     },
     "whatwg-fetch": {
       "version": "0.9.0",
       "from": "whatwg-fetch@>=0.9.0 <0.10.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
+      "dev": true
     },
     "when": {
       "version": "3.7.2",
       "from": "when@3.7.2",
-      "resolved": "https://registry.npmjs.org/when/-/when-3.7.2.tgz"
+      "resolved": "https://registry.npmjs.org/when/-/when-3.7.2.tgz",
+      "dev": true
     },
     "which": {
-      "version": "1.2.10",
-      "from": "which@>=1.0.9 <2.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
+      "version": "1.2.12",
+      "from": "which@>=1.2.12 <2.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
+      "dev": true
     },
     "widest-line": {
       "version": "1.0.0",
       "from": "widest-line@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "dev": true
     },
     "window-size": {
-      "version": "0.1.4",
-      "from": "window-size@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+      "version": "0.1.0",
+      "from": "window-size@0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "dev": true
     },
     "winreg": {
       "version": "0.0.12",
       "from": "winreg@0.0.12",
-      "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz"
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz",
+      "dev": true
     },
     "wordwrap": {
       "version": "0.0.3",
       "from": "wordwrap@>=0.0.2 <0.1.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "dev": true
     },
     "wrap-ansi": {
-      "version": "1.0.0",
-      "from": "wrap-ansi@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz"
+      "version": "2.1.0",
+      "from": "wrap-ansi@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "dev": true
     },
     "wrappy": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "from": "wrappy@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "dev": true
     },
     "wrench": {
-      "version": "1.5.8",
+      "version": "1.5.9",
       "from": "wrench@>=1.5.8 <1.6.0",
-      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz"
+      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.9.tgz",
+      "dev": true
     },
     "write-file-atomic": {
-      "version": "1.2.0",
+      "version": "1.3.1",
       "from": "write-file-atomic@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
+      "dev": true,
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
-          "from": "graceful-fs@^4.1.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+          "from": "graceful-fs@>=4.1.11 <5.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "dev": true
         }
       }
     },
     "ws": {
       "version": "1.1.1",
-      "from": "ws@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz"
+      "from": "ws@1.1.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
+      "dev": true
+    },
+    "wtf-8": {
+      "version": "1.0.0",
+      "from": "wtf-8@1.0.0",
+      "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+      "dev": true
     },
     "xdg-basedir": {
       "version": "2.0.0",
       "from": "xdg-basedir@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+      "dev": true
     },
     "xml2js": {
-      "version": "0.4.15",
+      "version": "0.4.17",
       "from": "xml2js@>=0.4.4 <0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.15.tgz"
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "dev": true
     },
     "xmlbuilder": {
-      "version": "8.2.2",
-      "from": "xmlbuilder@>=1.0.0",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz"
+      "version": "4.2.1",
+      "from": "xmlbuilder@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "dev": true
     },
     "xmldom": {
       "version": "0.1.19",
       "from": "xmldom@0.1.19",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz"
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
+      "dev": true
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.1",
-      "from": "xmlhttprequest-ssl@1.5.1",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
+      "version": "1.5.3",
+      "from": "xmlhttprequest-ssl@1.5.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
+      "dev": true
     },
     "xpath": {
       "version": "0.0.7",
       "from": "xpath@0.0.7",
-      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.7.tgz"
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.7.tgz",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      "from": "xtend@>=4.0.1 <4.1.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "dev": true
     },
     "y18n": {
-      "version": "3.2.0",
+      "version": "3.2.1",
       "from": "y18n@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "dev": true
     },
     "yargs": {
-      "version": "3.31.0",
-      "from": "yargs@3.31.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.31.0.tgz"
+      "version": "3.32.0",
+      "from": "yargs@>=3.31.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "cliui": {
+          "version": "3.2.0",
+          "from": "cliui@>=3.0.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.4",
+          "from": "window-size@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+          "dev": true
+        }
+      }
     },
     "yeast": {
       "version": "0.1.2",
       "from": "yeast@0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "dev": true
     },
     "zip-dir": {
       "version": "1.0.0",
       "from": "zip-dir@1.0.0",
-      "resolved": "https://registry.npmjs.org/zip-dir/-/zip-dir-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/zip-dir/-/zip-dir-1.0.0.tgz",
+      "dev": true
     },
     "zip-stream": {
-      "version": "0.5.2",
-      "from": "zip-stream@>=0.5.0 <0.6.0",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.2.tgz",
+      "version": "1.1.1",
+      "from": "zip-stream@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.1.1.tgz",
+      "dev": true,
       "dependencies": {
-        "lodash": {
-          "version": "3.2.0",
-          "from": "lodash@>=3.2.0 <3.3.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "dev": true
         },
         "readable-stream": {
-          "version": "1.0.33",
-          "from": "readable-stream@>=1.0.26 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "dev": true
         }
       }
     },
     "zone.js": {
-      "version": "0.7.2",
-      "from": "zone.js@0.7.2",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.7.2.tgz"
+      "version": "0.7.5",
+      "from": "zone.js@>=0.7.2 <0.8.0",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.7.5.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "rxjs": "^5.0.1",
     "zone.js": "^0.7.2"
   },
+  "optionalDependencies": {
+    "fsevents": "^1.0.14"  
+  },
   "devDependencies": {
     "@types/angularjs": "^1.5.13-alpha",
     "@types/base64-js": "^1.2.5",
@@ -45,7 +48,6 @@
     "cors": "^2.7.1",
     "firefox-profile": "^0.3.4",
     "fs-extra": "^0.26.3",
-    "fsevents": "^1.0.14",
     "glob": "^4.0.6",
     "gulp": "^3.8.8",
     "gulp-clang-format": "^1.0.23",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

non-Mac developers can not set up their environment because of explicitly dependency on `fsevents`.


**What is the new behavior?**

Mark `fsevents` as an optional dependency.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

Fixes #13935, #12443

