### PR TITLE
build(travis): fix travis environment to build es2015 distro

### DIFF
--- a/scripts/ci-lite/env.sh
+++ b/scripts/ci-lite/env.sh
@@ -58,6 +58,11 @@ if [[ ${TRAVIS} ]]; then
   # more info: https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements
   export CXX=g++-4.8
 
+  # Build ES2015 distro only in the e2e job (don't need to slow down other jobs)
+  if [ "${CI_MODE}" = "e2e" ]; then
+    export EXPERIMENTAL_ES2015_DISTRO=1
+  fi
+
   # Used by karma and karma-chrome-launcher
   # In order to have a meaningful SauceLabs badge on the repo page,
   # the angular2-ci account is used only when pushing commits to master;


### PR DESCRIPTION
Too inconvenient to test master-upstream-only Travis features :(
I misread the docs, you can't set multiple variables on a matrix line, only on env lines:
https://docs.travis-ci.com/user/environment-variables/#Defining-Multiple-Variables-per-Item

Just do this in env.sh