### PR TITLE
fix(router): fix CanActivateChild guard provided in a lazy loaded module

### DIFF
--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -959,7 +959,7 @@ export class PreActivation {
 
     return andObservables(map.call(from(canActivateChildGuards), (d: any) => {
       const obs = map.call(from(d.guards), (c: any) => {
-        const guard = this.getToken(c, c.node);
+        const guard = this.getToken(c, d.node);
         let observable: Observable<boolean>;
         if (guard.canActivateChild) {
           observable = wrapIntoObservable(guard.canActivateChild(future, this.future));

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -1816,6 +1816,47 @@ describe('Integration', () => {
              expect(location.path()).toEqual('/team/22');
            })));
       });
+
+      it('should find the guard provided in lazy loaded module',
+         fakeAsync(inject(
+             [Router, Location, NgModuleFactoryLoader],
+             (router: Router, location: Location, loader: SpyNgModuleFactoryLoader) => {
+
+               @Component({selector: 'admin', template: '<router-outlet></router-outlet>'})
+               class AdminComponent {
+               }
+
+               @Component({selector: 'lazy', template: 'lazy-loaded'})
+               class LazyLoadedComponent {
+               }
+
+               @NgModule({
+                 declarations: [AdminComponent, LazyLoadedComponent],
+                 imports: [RouterModule.forChild([{
+                   path: '',
+                   component: AdminComponent,
+                   children: [{
+                     path: '',
+                     canActivateChild: ['alwaysTrue'],
+                     children: [{path: '', component: LazyLoadedComponent}]
+                   }]
+                 }])],
+                 providers: [{provide: 'alwaysTrue', useValue: () => true}],
+               })
+               class LazyLoadedModule {
+               }
+
+               loader.stubbedModules = {lazy: LazyLoadedModule};
+               const fixture = createRoot(router, RootCmp);
+
+               router.resetConfig([{path: 'admin', loadChildren: 'lazy'}]);
+
+               router.navigateByUrl('/admin');
+               advance(fixture);
+
+               expect(location.path()).toEqual('/admin');
+               expect(fixture.nativeElement).toHaveText('lazy-loaded');
+             })));
     });
 
     describe('CanLoad', () => {


### PR DESCRIPTION
Closes #12275

Description:
`.node` is called [on a wrong object](https://github.com/angular/angular/blob/master/modules/%40angular/router/src/router.ts#L962). It should be `d.node` instead of `c.node`.