### PR TITLE
fix(http): do not create a blob out of ArrayBuffer when type is application/octet-stream

### DIFF
--- a/modules/@angular/http/src/static_request.ts
+++ b/modules/@angular/http/src/static_request.ts
@@ -112,7 +112,7 @@ export class Request extends Body {
       case 'text/html':
         return ContentType.TEXT;
       case 'application/octet-stream':
-        return ContentType.BLOB;
+        return this._body instanceof ArrayBuffer ? ContentType.ARRAY_BUFFER : ContentType.BLOB;
       default:
         return this.detectContentTypeFromBody();
     }
@@ -132,7 +132,7 @@ export class Request extends Body {
       return ContentType.BLOB;
     } else if (this._body instanceof ArrayBuffer) {
       return ContentType.ARRAY_BUFFER;
-    } else if (this._body && typeof this._body == 'object') {
+    } else if (this._body && typeof this._body === 'object') {
       return ContentType.JSON;
     } else {
       return ContentType.TEXT;
@@ -167,4 +167,4 @@ const noop = function() {};
 const w = typeof window == 'object' ? window : noop;
 const FormData = (w as any /** TODO #9100 */)['FormData'] || noop;
 const Blob = (w as any /** TODO #9100 */)['Blob'] || noop;
-const ArrayBuffer = (w as any /** TODO #9100 */)['ArrayBuffer'] || noop;
+export const ArrayBuffer = (w as any /** TODO #9100 */)['ArrayBuffer'] || noop;

--- a/modules/@angular/http/test/static_request_spec.ts
+++ b/modules/@angular/http/test/static_request_spec.ts
@@ -11,7 +11,7 @@ import {describe, expect, it} from '@angular/core/testing/testing_internal';
 import {RequestOptions} from '../src/base_request_options';
 import {ContentType} from '../src/enums';
 import {Headers} from '../src/headers';
-import {Request} from '../src/static_request';
+import {ArrayBuffer, Request} from '../src/static_request';
 
 export function main() {
   describe('Request', () => {
@@ -75,6 +75,17 @@ export function main() {
         }));
 
         expect(req.detectContentType()).toEqual(ContentType.BLOB);
+      });
+
+      it('should not create a blob out of ArrayBuffer', () => {
+        const req = new Request(new RequestOptions({
+          url: 'test',
+          method: 'GET',
+          body: new ArrayBuffer(1),
+          headers: new Headers({'content-type': 'application/octet-stream'})
+        }));
+
+        expect(req.detectContentType()).toEqual(ContentType.ARRAY_BUFFER);
       });
     });
 


### PR DESCRIPTION
Closes #13973

I'd like the proposed solution 
```
 case 'application/octet-stream':
      default:
        return this.detectContentTypeFromBody();
```
but it will be a breaking change. [This test](https://github.com/angular/angular/blob/90c223591f1ea403e08fd52afa2043d10bbf02dc/modules/%40angular/http/test/static_request_spec.ts#L69) will fail.