### PR TITLE
feat(common): add a type parameter to NgFor

### DIFF
--- a/modules/@angular/compiler/src/aot/static_reflector.ts
+++ b/modules/@angular/compiler/src/aot/static_reflector.ts
@@ -290,8 +290,9 @@ export class StaticReflector implements ReflectorReader {
    * @param declarationFile the absolute path of the file where the symbol is declared
    * @param name the name of the type.
    */
-  getStaticSymbol(declarationFile: string, name: string, members?: string[]): StaticSymbol {
-    return this.symbolResolver.getStaticSymbol(declarationFile, name, members);
+  getStaticSymbol(declarationFile: string, name: string, members?: string[], arity?: number):
+      StaticSymbol {
+    return this.symbolResolver.getStaticSymbol(declarationFile, name, members, arity);
   }
 
   private reportError(error: Error, context: StaticSymbol, path?: string) {

--- a/modules/@angular/compiler/src/aot/static_symbol.ts
+++ b/modules/@angular/compiler/src/aot/static_symbol.ts
@@ -12,7 +12,9 @@
  * This token is unique for a filePath and name and can be used as a hash table key.
  */
 export class StaticSymbol {
-  constructor(public filePath: string, public name: string, public members: string[]) {}
+  constructor(
+      public filePath: string, public name: string, public members: string[],
+      public arity?: number) {}
 
   assertNoMembers() {
     if (this.members.length) {
@@ -29,13 +31,13 @@ export class StaticSymbol {
 export class StaticSymbolCache {
   private cache = new Map<string, StaticSymbol>();
 
-  get(declarationFile: string, name: string, members?: string[]): StaticSymbol {
+  get(declarationFile: string, name: string, members?: string[], arity?: number): StaticSymbol {
     members = members || [];
     const memberSuffix = members.length ? `.${ members.join('.')}` : '';
     const key = `"${declarationFile}".${name}${memberSuffix}`;
     let result = this.cache.get(key);
     if (!result) {
-      result = new StaticSymbol(declarationFile, name, members);
+      result = new StaticSymbol(declarationFile, name, members, arity);
       this.cache.set(key, result);
     }
     return result;

--- a/modules/@angular/compiler/src/output/output_ast.ts
+++ b/modules/@angular/compiler/src/output/output_ast.ts
@@ -44,11 +44,7 @@ export class BuiltinType extends Type {
 }
 
 export class ExpressionType extends Type {
-  constructor(
-      public value: Expression, public typeParams: Type[] = null,
-      modifiers: TypeModifier[] = null) {
-    super(modifiers);
-  }
+  constructor(public value: Expression, modifiers: TypeModifier[] = null) { super(modifiers); }
   visitType(visitor: TypeVisitor, context: any): any {
     return visitor.visitExpressionType(this, context);
   }
@@ -881,13 +877,12 @@ export function importExpr(id: CompileIdentifierMetadata, typeParams: Type[] = n
 export function importType(
     id: CompileIdentifierMetadata, typeParams: Type[] = null,
     typeModifiers: TypeModifier[] = null): ExpressionType {
-  return isPresent(id) ? expressionType(importExpr(id), typeParams, typeModifiers) : null;
+  return isPresent(id) ? expressionType(importExpr(id, typeParams), typeModifiers) : null;
 }
 
 export function expressionType(
-    expr: Expression, typeParams: Type[] = null,
-    typeModifiers: TypeModifier[] = null): ExpressionType {
-  return isPresent(expr) ? new ExpressionType(expr, typeParams, typeModifiers) : null;
+    expr: Expression, typeModifiers: TypeModifier[] = null): ExpressionType {
+  return isPresent(expr) ? new ExpressionType(expr, typeModifiers) : null;
 }
 
 export function literalArr(values: Expression[], type: Type = null): LiteralArrayExpr {

--- a/modules/@angular/compiler/test/output/ts_emitter_spec.ts
+++ b/modules/@angular/compiler/test/output/ts_emitter_spec.ts
@@ -429,11 +429,19 @@ export function main() {
     });
 
     it('should support expression types', () => {
+      expect(
+          emitStmt(o.variable('a').set(o.NULL_EXPR).toDeclStmt(o.expressionType(o.variable('b')))))
+          .toEqual('var a:b = (null as any);');
+    });
+
+    it('should support expressions with type parameters', () => {
       expect(emitStmt(o.variable('a')
                           .set(o.NULL_EXPR)
-                          .toDeclStmt(o.expressionType(
-                              o.variable('b'), [o.expressionType(o.variable('c'))]))))
-          .toEqual('var a:b<c> = (null as any);');
+                          .toDeclStmt(o.importType(externalModuleIdentifier, [o.STRING_TYPE]))))
+          .toEqual([
+            `import * as import0 from 'somePackage/someOtherPath';`,
+            `var a:import0.someExternalId<string> = (null as any);`
+          ].join('\n'));
     });
 
     it('should support combined types', () => {

--- a/modules/@angular/core/src/change_detection.ts
+++ b/modules/@angular/core/src/change_detection.ts
@@ -12,4 +12,4 @@
  * Change detection enables data binding in Angular.
  */
 
-export {ChangeDetectionStrategy, ChangeDetectorRef, CollectionChangeRecord, DefaultIterableDiffer, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers, PipeTransform, SimpleChange, SimpleChanges, TrackByFn, WrappedValue} from './change_detection/change_detection';
+export {ChangeDetectionStrategy, ChangeDetectorRef, CollectionChangeRecord, DefaultIterableDiffer, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers, NgIterable, PipeTransform, SimpleChange, SimpleChanges, TrackByFn, TrackByFunction, WrappedValue} from './change_detection/change_detection';

--- a/modules/@angular/core/src/change_detection/change_detection.ts
+++ b/modules/@angular/core/src/change_detection/change_detection.ts
@@ -18,7 +18,7 @@ export {ChangeDetectionStrategy, ChangeDetectorStatus, isDefaultChangeDetectionS
 export {DefaultIterableDifferFactory} from './differs/default_iterable_differ';
 export {DefaultIterableDiffer} from './differs/default_iterable_differ';
 export {DefaultKeyValueDifferFactory} from './differs/default_keyvalue_differ';
-export {CollectionChangeRecord, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, TrackByFn} from './differs/iterable_differs';
+export {CollectionChangeRecord, IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, IterableDiffers, NgIterable, TrackByFn, TrackByFunction} from './differs/iterable_differs';
 export {KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory, KeyValueDiffers} from './differs/keyvalue_differs';
 export {PipeTransform} from './pipe_transform';
 

--- a/modules/@angular/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/modules/@angular/core/src/change_detection/differs/default_iterable_differ.ts
@@ -10,13 +10,13 @@ import {isListLikeIterable, iterateListLike} from '../../facade/collection';
 import {isBlank, looseIdentical, stringify} from '../../facade/lang';
 import {ChangeDetectorRef} from '../change_detector_ref';
 
-import {IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, TrackByFn} from './iterable_differs';
+import {IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, TrackByFunction} from './iterable_differs';
 
 
 export class DefaultIterableDifferFactory implements IterableDifferFactory {
   constructor() {}
   supports(obj: Object): boolean { return isListLikeIterable(obj); }
-  create<V>(cdRef: ChangeDetectorRef, trackByFn?: TrackByFn): DefaultIterableDiffer<V> {
+  create<V>(cdRef: ChangeDetectorRef, trackByFn?: TrackByFunction<any>): DefaultIterableDiffer<V> {
     return new DefaultIterableDiffer<V>(trackByFn);
   }
 }
@@ -46,7 +46,7 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
   private _identityChangesHead: IterableChangeRecord_<V> = null;
   private _identityChangesTail: IterableChangeRecord_<V> = null;
 
-  constructor(private _trackByFn?: TrackByFn) {
+  constructor(private _trackByFn?: TrackByFunction<V>) {
     this._trackByFn = this._trackByFn || trackByIdentity;
   }
 

--- a/modules/@angular/core/src/change_detection/differs/iterable_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/iterable_differs.ts
@@ -10,6 +10,7 @@ import {Optional, Provider, SkipSelf} from '../../di';
 import {getTypeNameForDebugging, isPresent} from '../../facade/lang';
 import {ChangeDetectorRef} from '../change_detector_ref';
 
+export type NgIterable<T> = Array<T>| Iterable<T>;
 
 /**
  * A strategy for tracking changes over time to an iterable. Used by {@link NgFor} to
@@ -112,13 +113,19 @@ export interface CollectionChangeRecord<V> extends IterableChangeRecord<V> {}
 
 
 /**
- * An optional function passed into {@link NgFor} that defines how to track
- * items in an iterable (e.g. by index or id)
+ * Nolonger used.
  *
- * @stable
+ * @deprecated v4.0.0 - Use TrackByFunction instead
  */
 export interface TrackByFn { (index: number, item: any): any; }
 
+/**
+ * An optional function passed into {@link NgForOf} that defines how to track
+ * items in an iterable (e.g. fby index or id)
+ *
+ * @stable
+ */
+export interface TrackByFunction<T> { (index: number, item: T): any; }
 
 /**
  * Provides a factory for {@link IterableDiffer}.
@@ -127,7 +134,7 @@ export interface TrackByFn { (index: number, item: any): any; }
  */
 export interface IterableDifferFactory {
   supports(objects: any): boolean;
-  create<V>(cdRef: ChangeDetectorRef, trackByFn?: TrackByFn): IterableDiffer<V>;
+  create<V>(cdRef: ChangeDetectorRef, trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
 }
 
 /**

--- a/modules/@angular/language-service/src/expressions.ts
+++ b/modules/@angular/language-service/src/expressions.ts
@@ -728,7 +728,8 @@ function getVarDeclarations(info: TemplateInfo, path: TemplateAstPath): SymbolDe
           const value = context.get(variable.value);
           if (value) {
             type = value.type;
-            if (info.template.query.getTypeKind(type) === BuiltinType.Any) {
+            let kind = info.template.query.getTypeKind(type);
+            if (kind === BuiltinType.Any || kind == BuiltinType.Unbound) {
               // The any type is not very useful here. For special cases, such as ngFor, we can do
               // better.
               type = refinedVariableType(type, info, current);

--- a/modules/@angular/language-service/src/types.ts
+++ b/modules/@angular/language-service/src/types.ts
@@ -190,6 +190,11 @@ export enum BuiltinType {
   Null,
 
   /**
+   * the type is an unbound type parameter.
+   */
+  Unbound,
+
+  /**
    * Not a built-in type.
    */
   Other

--- a/modules/@angular/language-service/src/typescript_host.ts
+++ b/modules/@angular/language-service/src/typescript_host.ts
@@ -1263,6 +1263,8 @@ function typeKindOf(type: ts.Type): BuiltinType {
         }
       }
       return candidate;
+    } else if (type.flags & ts.TypeFlags.TypeParameter) {
+      return BuiltinType.Unbound;
     }
   }
   return BuiltinType.Other;

--- a/tools/@angular/tsc-wrapped/src/collector.ts
+++ b/tools/@angular/tsc-wrapped/src/collector.ts
@@ -128,6 +128,12 @@ export class MetadataCollector {
         });
       }
 
+      // Add arity if the type is generic
+      const typeParameters = classDeclaration.typeParameters;
+      if (typeParameters && typeParameters.length) {
+        result.arity = typeParameters.length;
+      }
+
       // Add class decorators
       if (classDeclaration.decorators) {
         result.decorators = getDecorators(classDeclaration.decorators);

--- a/tools/@angular/tsc-wrapped/src/schema.ts
+++ b/tools/@angular/tsc-wrapped/src/schema.ts
@@ -37,6 +37,7 @@ export interface ModuleExportMetadata {
 export interface ClassMetadata {
   __symbolic: 'class';
   extends?: MetadataSymbolicExpression|MetadataError;
+  arity?: number;
   decorators?: (MetadataSymbolicExpression|MetadataError)[];
   members?: MetadataMap;
   statics?: {[name: string]: MetadataValue | FunctionMetadata};


### PR DESCRIPTION
feat(compile): generate a type parameters for generic type references
feat(tsc-wrapped): record arity of generic classes

DEPRECATION:
- `NgFor` is now deprecated. Use `NgForOf<T>` instead.
- `TrackByFn` is not deprecated. Use `TrackByFunciton<T>` instead.

Migration:
- Most code is unaffected by this change as references to `NgFor`
  are generated by the AOT compiler. No template changes required.
- Replace references to `NgFor` to `NgForOf<any>`.
- Replace references to `TrackByFn` to `TrackByFunction<any>`.

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Feature
```

**What is the current behavior?** (You can also link to an open issue here)

The type of the `$implicit` in the context of an `NgFor` is `any` implying that the type of the `let` of the binding expression `*ngFor="let person of people"` is also `any`.

**What is the new behavior?**

The type of the `$implicit` is the context of an `NgForOf` is `T` allowing the `let` of the binding expression to be `T`. A follow-on PR will implement a type inference block allowing the parameter `T` to be inferred as `Person` if `people` is `Person[]`.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
