### PR TITLE
feat(Compiler): Allow computed property names in map expressions

### DIFF
--- a/modules/@angular/common/test/directives/ng_class_spec.ts
+++ b/modules/@angular/common/test/directives/ng_class_spec.ts
@@ -54,8 +54,8 @@ export function main() {
          }));
 
       it('should add and remove classes based on changes in object literal values', async(() => {
-           fixture =
-               createTestComponent('<div [ngClass]="{foo: condition, bar: !condition}"></div>');
+           fixture = createTestComponent(
+               '<div [ngClass]="{[strExpr]: condition, bar: !condition}"></div>');
 
            detectChangesAndExpectClassName('foo');
 

--- a/modules/@angular/compiler/src/expression_parser/ast.ts
+++ b/modules/@angular/compiler/src/expression_parser/ast.ts
@@ -138,7 +138,7 @@ export class LiteralArray extends AST {
 }
 
 export class LiteralMap extends AST {
-  constructor(span: ParseSpan, public keys: any[], public values: any[]) { super(span); }
+  constructor(span: ParseSpan, public keys: (string|AST)[], public values: any[]) { super(span); }
   visit(visitor: AstVisitor, context: any = null): any {
     return visitor.visitLiteralMap(this, context);
   }
@@ -271,7 +271,15 @@ export class RecursiveAstVisitor implements AstVisitor {
   visitLiteralArray(ast: LiteralArray, context: any): any {
     return this.visitAll(ast.expressions, context);
   }
-  visitLiteralMap(ast: LiteralMap, context: any): any { return this.visitAll(ast.values, context); }
+  visitLiteralMap(ast: LiteralMap, context: any): any {
+    for (let i = 0; i < ast.keys.length; i++) {
+      let key = ast.keys[i];
+      if (key instanceof AST) {
+        key.visit(this);
+      }
+    }
+    return this.visitAll(ast.values, context);
+  }
   visitLiteralPrimitive(ast: LiteralPrimitive, context: any): any { return null; }
   visitMethodCall(ast: MethodCall, context: any): any {
     ast.receiver.visit(this);

--- a/modules/@angular/compiler/src/expression_parser/parser.ts
+++ b/modules/@angular/compiler/src/expression_parser/parser.ts
@@ -600,15 +600,23 @@ export class _ParseAST {
   }
 
   parseLiteralMap(): LiteralMap {
-    const keys: string[] = [];
+    const keys: (string | AST)[] = [];
     const values: AST[] = [];
     const start = this.inputIndex;
     this.expectCharacter(chars.$LBRACE);
     if (!this.optionalCharacter(chars.$RBRACE)) {
       this.rbracesExpected++;
       do {
-        const key = this.expectIdentifierOrKeywordOrString();
-        keys.push(key);
+        if (this.optionalCharacter(chars.$LBRACKET)) {
+          this.rbracketsExpected++;
+          const key = this.parsePipe();
+          keys.push(key);
+          this.rbracketsExpected--;
+          this.expectCharacter(chars.$RBRACKET);
+        } else {
+          const key = this.expectIdentifierOrKeywordOrString();
+          keys.push(key);
+        }
         this.expectCharacter(chars.$COLON);
         values.push(this.parsePipe());
       } while (this.optionalCharacter(chars.$COMMA));

--- a/modules/@angular/compiler/src/output/abstract_emitter.ts
+++ b/modules/@angular/compiler/src/output/abstract_emitter.ts
@@ -367,11 +367,18 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     ctx.print(`{`, useNewLine);
     ctx.incIndent();
     this.visitAllObjects(entry => {
-      ctx.print(`${escapeIdentifier(entry.key, this._escapeDollarInStrings, entry.quoted)}: `);
+      let key = entry.key;
+      if (key instanceof o.Expression) {
+        ctx.print(`[`);
+        key.visitExpression(this, ctx);
+        ctx.print(`]: `);
+      } else if (typeof key === 'string') {
+        ctx.print(`${escapeIdentifier(key, this._escapeDollarInStrings, entry.quoted)}: `);
+      }
       entry.value.visitExpression(this, ctx);
     }, ast.entries, ctx, ',', useNewLine);
     ctx.decIndent();
-    ctx.print(`}`, useNewLine);
+    ctx.print(`}`);
     return null;
   }
 

--- a/modules/@angular/compiler/src/output/output_interpreter.ts
+++ b/modules/@angular/compiler/src/output/output_interpreter.ts
@@ -299,9 +299,15 @@ class StatementInterpreter implements o.StatementVisitor, o.ExpressionVisitor {
     return this.visitAllExpressions(ast.entries, ctx);
   }
   visitLiteralMapExpr(ast: o.LiteralMapExpr, ctx: _ExecutionContext): any {
-    const result = {};
-    ast.entries.forEach(
-        (entry) => (result as any)[entry.key] = entry.value.visitExpression(this, ctx));
+    const result: any = {};
+    ast.entries.forEach((entry) => {
+      let key = entry.key;
+      if (key instanceof o.Expression) {
+        result[key.visitExpression(this, ctx)] = entry.value.visitExpression(this, ctx);
+      } else if (typeof key === 'string') {
+        result[key] = entry.value.visitExpression(this, ctx);
+      }
+    });
     return result;
   }
 

--- a/modules/@angular/compiler/test/expression_parser/parser_spec.ts
+++ b/modules/@angular/compiler/test/expression_parser/parser_spec.ts
@@ -162,6 +162,7 @@ export function main() {
           checkAction('{}');
           checkAction('{a: 1}[2]');
           checkAction('{}["a"]');
+          checkAction('{[a + 1]: 1}[2]');
         });
 
         it('should only allow identifier, string, or keyword as map key', () => {

--- a/modules/@angular/compiler/test/expression_parser/unparser.ts
+++ b/modules/@angular/compiler/test/expression_parser/unparser.ts
@@ -124,7 +124,14 @@ class Unparser implements AstVisitor {
     for (let i = 0; i < ast.keys.length; i++) {
       if (!isFirst) this._expression += ', ';
       isFirst = false;
-      this._expression += `${ast.keys[i]}: `;
+      let key = ast.keys[i];
+      if (key instanceof AST) {
+        this._expression += '[';
+        this._visit(key);
+        this._expression += ']: ';
+      } else {
+        this._expression += `${ast.keys[i]}: `;
+      }
       this._visit(ast.values[i]);
     }
 

--- a/modules/@angular/compiler/test/output/js_emitter_spec.ts
+++ b/modules/@angular/compiler/test/output/js_emitter_spec.ts
@@ -111,7 +111,11 @@ export function main() {
       expect(emitStmt(o.literal(true).toStmt())).toEqual('true;');
       expect(emitStmt(o.literal('someStr').toStmt())).toEqual(`'someStr';`);
       expect(emitStmt(o.literalArr([o.literal(1)]).toStmt())).toEqual(`[1];`);
-      expect(emitStmt(o.literalMap([['someKey', o.literal(1)]]).toStmt())).toEqual(`{someKey: 1};`);
+      expect(emitStmt(o.literalMap([
+                         ['someKey', o.literal(1)],
+                         [o.variable('computedKey'), o.literal(2)],
+                       ]).toStmt()))
+          .toEqual([`{`, `  someKey: 1,`, `  [computedKey]: 2`, `};`].join('\n'));
     });
 
     it('should support blank literals', () => {


### PR DESCRIPTION
 feat(Compiler): Allow computed property names in map expressions

Add support for ES2015-like computed property names, which allow to put an
expression between brackets [] that will be computed as the property name.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Feature
```

**What is the current behavior?** (You can also link to an open issue here)
angular/angular#13855

**Does this PR introduce a breaking change?** (check one with "x")
```
[x] No
```

**Other information**:

