### PR TITLE
fix(i18n): XMB/XTB placeholder names can contain only A-Z, 0-9, _

### DIFF
--- a/modules/@angular/compiler/src/i18n/digest.ts
+++ b/modules/@angular/compiler/src/i18n/digest.ts
@@ -13,9 +13,13 @@ export function digest(message: i18n.Message): string {
 }
 
 export function decimalDigest(message: i18n.Message): string {
+  if (message.id) {
+    return message.id;
+  }
+
   const visitor = new _SerializerIgnoreIcuExpVisitor();
   const parts = message.nodes.map(a => a.visit(visitor, null));
-  return message.id || computeMsgId(parts.join(''), message.meaning);
+  return computeMsgId(parts.join(''), message.meaning);
 }
 
 /**

--- a/modules/@angular/compiler/src/i18n/extractor.ts
+++ b/modules/@angular/compiler/src/i18n/extractor.ts
@@ -52,7 +52,7 @@ export class Extractor {
 
   extract(rootFiles: string[]): Promise<MessageBundle> {
     const programSymbols = extractProgramSymbols(this.staticSymbolResolver, rootFiles, this.host);
-    const {ngModuleByPipeOrDirective, files, ngModules} =
+    const {files, ngModules} =
         analyzeAndValidateNgModules(programSymbols, this.host, this.metadataResolver);
     return Promise
         .all(ngModules.map(

--- a/modules/@angular/compiler/src/i18n/message_bundle.ts
+++ b/modules/@angular/compiler/src/i18n/message_bundle.ts
@@ -72,26 +72,9 @@ export class MessageBundle {
 }
 
 // Transform an i18n AST by renaming the placeholder nodes with the given mapper
-class MapPlaceholderNames implements i18n.Visitor {
+class MapPlaceholderNames extends i18n.CloneVisitor {
   convert(nodes: i18n.Node[], mapper: PlaceholderMapper): i18n.Node[] {
     return mapper ? nodes.map(n => n.visit(this, mapper)) : nodes;
-  }
-
-  visitText(text: i18n.Text, mapper: PlaceholderMapper): i18n.Text {
-    return new i18n.Text(text.value, text.sourceSpan);
-  }
-
-  visitContainer(container: i18n.Container, mapper: PlaceholderMapper): i18n.Container {
-    const children = container.children.map(n => n.visit(this, mapper));
-    return new i18n.Container(children, container.sourceSpan);
-  }
-
-  visitIcu(icu: i18n.Icu, mapper: PlaceholderMapper): i18n.Icu {
-    const cases: {[k: string]: i18n.Node} = {};
-    Object.keys(icu.cases).forEach(key => cases[key] = icu.cases[key].visit(this, mapper));
-    const msg = new i18n.Icu(icu.expression, icu.type, cases, icu.sourceSpan);
-    msg.expressionPlaceholder = icu.expressionPlaceholder;
-    return msg;
   }
 
   visitTagPlaceholder(ph: i18n.TagPlaceholder, mapper: PlaceholderMapper): i18n.TagPlaceholder {

--- a/modules/@angular/compiler/src/i18n/message_bundle.ts
+++ b/modules/@angular/compiler/src/i18n/message_bundle.ts
@@ -11,14 +11,15 @@ import {InterpolationConfig} from '../ml_parser/interpolation_config';
 import {ParseError} from '../parse_util';
 
 import {extractMessages} from './extractor_merger';
-import {Message} from './i18n_ast';
-import {Serializer} from './serializers/serializer';
+import * as i18n from './i18n_ast';
+import {PlaceholderMapper, Serializer} from './serializers/serializer';
+
 
 /**
  * A container for message extracted from the templates.
  */
 export class MessageBundle {
-  private _messages: Message[] = [];
+  private _messages: i18n.Message[] = [];
 
   constructor(
       private _htmlParser: HtmlParser, private _implicitTags: string[],
@@ -42,7 +43,70 @@ export class MessageBundle {
     this._messages.push(...i18nParserResult.messages);
   }
 
-  getMessages(): Message[] { return this._messages; }
+  // Return the message in the internal format
+  // The public (serialized) format might be different, see the `write` method.
+  getMessages(): i18n.Message[] { return this._messages; }
 
-  write(serializer: Serializer): string { return serializer.write(this._messages); }
+  write(serializer: Serializer): string {
+    const messages: {[id: string]: i18n.Message} = {};
+    const mapperVisitor = new MapPlaceholderNames();
+
+    // Deduplicate messages based on their ID
+    this._messages.forEach(message => {
+      const id = serializer.digest(message);
+      if (!messages.hasOwnProperty(id)) {
+        messages[id] = message;
+      }
+    });
+
+    // Transform placeholder names using the serializer mapping
+    const msgList = Object.keys(messages).map(id => {
+      const mapper = serializer.createNameMapper(messages[id]);
+      const src = messages[id];
+      const nodes = mapper ? mapperVisitor.convert(src.nodes, mapper) : src.nodes;
+      return new i18n.Message(nodes, {}, {}, src.meaning, src.description, id);
+    });
+
+    return serializer.write(msgList);
+  }
+}
+
+// Transform an i18n AST by renaming the placeholder nodes with the given mapper
+class MapPlaceholderNames implements i18n.Visitor {
+  convert(nodes: i18n.Node[], mapper: PlaceholderMapper): i18n.Node[] {
+    return mapper ? nodes.map(n => n.visit(this, mapper)) : nodes;
+  }
+
+  visitText(text: i18n.Text, mapper: PlaceholderMapper): i18n.Text {
+    return new i18n.Text(text.value, text.sourceSpan);
+  }
+
+  visitContainer(container: i18n.Container, mapper: PlaceholderMapper): i18n.Container {
+    const children = container.children.map(n => n.visit(this, mapper));
+    return new i18n.Container(children, container.sourceSpan);
+  }
+
+  visitIcu(icu: i18n.Icu, mapper: PlaceholderMapper): i18n.Icu {
+    const cases: {[k: string]: i18n.Node} = {};
+    Object.keys(icu.cases).forEach(key => cases[key] = icu.cases[key].visit(this, mapper));
+    const msg = new i18n.Icu(icu.expression, icu.type, cases, icu.sourceSpan);
+    msg.expressionPlaceholder = icu.expressionPlaceholder;
+    return msg;
+  }
+
+  visitTagPlaceholder(ph: i18n.TagPlaceholder, mapper: PlaceholderMapper): i18n.TagPlaceholder {
+    const startName = mapper.toPublicName(ph.startName);
+    const closeName = ph.closeName ? mapper.toPublicName(ph.closeName) : ph.closeName;
+    const children = ph.children.map(n => n.visit(this, mapper));
+    return new i18n.TagPlaceholder(
+        ph.tag, ph.attrs, startName, closeName, children, ph.isVoid, ph.sourceSpan);
+  }
+
+  visitPlaceholder(ph: i18n.Placeholder, mapper: PlaceholderMapper): i18n.Placeholder {
+    return new i18n.Placeholder(ph.value, mapper.toPublicName(ph.name), ph.sourceSpan);
+  }
+
+  visitIcuPlaceholder(ph: i18n.IcuPlaceholder, mapper: PlaceholderMapper): i18n.IcuPlaceholder {
+    return new i18n.IcuPlaceholder(ph.value, mapper.toPublicName(ph.name), ph.sourceSpan);
+  }
 }

--- a/modules/@angular/compiler/src/i18n/serializers/placeholder.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/placeholder.ts
@@ -111,8 +111,14 @@ export class PlaceholderRegistry {
   private _hashClosingTag(tag: string): string { return this._hashTag(`/${tag}`, {}, false); }
 
   private _generateUniqueName(base: string): string {
-    const next = this._placeHolderNameCounts[base];
-    this._placeHolderNameCounts[base] = next ? next + 1 : 1;
-    return next ? `${base}_${next}` : base;
+    const seen = this._placeHolderNameCounts.hasOwnProperty(base);
+    if (!seen) {
+      this._placeHolderNameCounts[base] = 1;
+      return base;
+    }
+
+    const id = this._placeHolderNameCounts[base];
+    this._placeHolderNameCounts[base] = id + 1;
+    return `${base}_${id}`;
   }
 }

--- a/modules/@angular/compiler/src/i18n/serializers/serializer.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/serializer.ts
@@ -34,3 +34,64 @@ export interface PlaceholderMapper {
 
   toInternalName(publicName: string): string;
 }
+
+/**
+ * A simple mapper that take a function to transform an internal name to a public name
+ */
+export class SimplePlaceholderMapper extends i18n.RecurseVisitor implements PlaceholderMapper {
+  private internalToPublic: {[k: string]: string} = {};
+  private publicToNextId: {[k: string]: number} = {};
+  private publicToInternal: {[k: string]: string} = {};
+
+  // create a mapping from the message
+  constructor(message: i18n.Message, private mapName: (name: string) => string) {
+    super();
+    message.nodes.forEach(node => node.visit(this));
+  }
+
+  toPublicName(internalName: string): string {
+    return this.internalToPublic.hasOwnProperty(internalName) ?
+        this.internalToPublic[internalName] :
+        null;
+  }
+
+  toInternalName(publicName: string): string {
+    return this.publicToInternal.hasOwnProperty(publicName) ? this.publicToInternal[publicName] :
+                                                              null;
+  }
+
+  visitText(text: i18n.Text, context?: any): any { return null; }
+
+  visitTagPlaceholder(ph: i18n.TagPlaceholder, context?: any): any {
+    this.visitPlaceholderName(ph.startName);
+    super.visitTagPlaceholder(ph, context);
+    this.visitPlaceholderName(ph.closeName);
+  }
+
+  visitPlaceholder(ph: i18n.Placeholder, context?: any): any { this.visitPlaceholderName(ph.name); }
+
+  visitIcuPlaceholder(ph: i18n.IcuPlaceholder, context?: any): any {
+    this.visitPlaceholderName(ph.name);
+  }
+
+  // XMB placeholders could only contains A-Z, 0-9 and _
+  private visitPlaceholderName(internalName: string): void {
+    if (!internalName || this.internalToPublic.hasOwnProperty(internalName)) {
+      return;
+    }
+
+    let publicName = this.mapName(internalName);
+
+    if (this.publicToInternal.hasOwnProperty(publicName)) {
+      // Create a new XMB when it has already been used
+      const nextId = this.publicToNextId[publicName];
+      this.publicToNextId[publicName] = nextId + 1;
+      publicName = `${publicName}_${nextId}`;
+    } else {
+      this.publicToNextId[publicName] = 1;
+    }
+
+    this.internalToPublic[internalName] = publicName;
+    this.publicToInternal[publicName] = internalName;
+  }
+}

--- a/modules/@angular/compiler/src/i18n/serializers/serializer.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/serializer.ts
@@ -8,10 +8,26 @@
 
 import * as i18n from '../i18n_ast';
 
-export interface Serializer {
-  write(messages: i18n.Message[]): string;
+export abstract class Serializer {
+  abstract write(messages: i18n.Message[]): string;
 
-  load(content: string, url: string): {[msgId: string]: i18n.Node[]};
+  abstract load(content: string, url: string): {[msgId: string]: i18n.Node[]};
 
-  digest(message: i18n.Message): string;
+  abstract digest(message: i18n.Message): string;
+
+  // Creates a name mapper, see `PlaceholderMapper`
+  // Returning `null` means that no name mapping is used.
+  createNameMapper(message: i18n.Message): PlaceholderMapper { return null; }
+}
+
+/**
+ * A `PlaceholderMapper` converts placeholder names from internal to serialized representation and
+ * back.
+ *
+ * It should be used for serialization format that put constraints on the placeholder names.
+ */
+export interface PlaceholderMapper {
+  toPublicName(internalName: string): string;
+
+  toInternalName(publicName: string): string;
 }

--- a/modules/@angular/compiler/src/i18n/serializers/serializer.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/serializer.ts
@@ -9,6 +9,9 @@
 import * as i18n from '../i18n_ast';
 
 export abstract class Serializer {
+  // - The `placeholders` and `placeholderToMessage` properties are irrelevant in the input messages
+  // - The `id` contains the message id that the serializer is expected to use
+  // - Placeholder names are already map to public names using the provided mapper
   abstract write(messages: i18n.Message[]): string;
 
   abstract load(content: string, url: string): {[msgId: string]: i18n.Node[]};

--- a/modules/@angular/compiler/src/i18n/serializers/xliff.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/xliff.ts
@@ -30,17 +30,10 @@ const _UNIT_TAG = 'trans-unit';
 export class Xliff extends Serializer {
   write(messages: i18n.Message[]): string {
     const visitor = new _WriteVisitor();
-    const visited: {[id: string]: boolean} = {};
     const transUnits: xml.Node[] = [];
 
     messages.forEach(message => {
-      const id = this.digest(message);
-
-      // deduplicate messages
-      if (visited[id]) return;
-      visited[id] = true;
-
-      const transUnit = new xml.Tag(_UNIT_TAG, {id, datatype: 'html'});
+      const transUnit = new xml.Tag(_UNIT_TAG, {id: message.id, datatype: 'html'});
       transUnit.children.push(
           new xml.CR(8), new xml.Tag(_SOURCE_TAG, {}, visitor.serialize(message.nodes)),
           new xml.CR(8), new xml.Tag(_TARGET_TAG));

--- a/modules/@angular/compiler/src/i18n/serializers/xliff.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/xliff.ts
@@ -27,7 +27,7 @@ const _UNIT_TAG = 'trans-unit';
 
 // http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html
 // http://docs.oasis-open.org/xliff/v1.2/xliff-profile-html/xliff-profile-html-1.2.html
-export class Xliff implements Serializer {
+export class Xliff extends Serializer {
   write(messages: i18n.Message[]): string {
     const visitor = new _WriteVisitor();
     const visited: {[id: string]: boolean} = {};

--- a/modules/@angular/compiler/src/i18n/serializers/xtb.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/xtb.ts
@@ -11,8 +11,8 @@ import {XmlParser} from '../../ml_parser/xml_parser';
 import * as i18n from '../i18n_ast';
 import {I18nError} from '../parse_util';
 
-import {PlaceholderMapper, Serializer} from './serializer';
-import {XmbPlaceholderMapper, digest} from './xmb';
+import {PlaceholderMapper, Serializer, SimplePlaceholderMapper} from './serializer';
+import {digest, toPublicName} from './xmb';
 
 const _TRANSLATIONS_TAG = 'translationbundle';
 const _TRANSLATION_TAG = 'translation';
@@ -45,7 +45,7 @@ export class Xtb extends Serializer {
   digest(message: i18n.Message): string { return digest(message); }
 
   createNameMapper(message: i18n.Message): PlaceholderMapper {
-    return new XmbPlaceholderMapper(message);
+    return new SimplePlaceholderMapper(message, toPublicName);
   }
 }
 

--- a/modules/@angular/compiler/src/i18n/serializers/xtb.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/xtb.ts
@@ -11,14 +11,14 @@ import {XmlParser} from '../../ml_parser/xml_parser';
 import * as i18n from '../i18n_ast';
 import {I18nError} from '../parse_util';
 
-import {Serializer} from './serializer';
-import {digest} from './xmb';
+import {PlaceholderMapper, Serializer} from './serializer';
+import {XmbPlaceholderMapper, digest} from './xmb';
 
 const _TRANSLATIONS_TAG = 'translationbundle';
 const _TRANSLATION_TAG = 'translation';
 const _PLACEHOLDER_TAG = 'ph';
 
-export class Xtb implements Serializer {
+export class Xtb extends Serializer {
   write(messages: i18n.Message[]): string { throw new Error('Unsupported'); }
 
   load(content: string, url: string): {[msgId: string]: i18n.Node[]} {
@@ -43,6 +43,10 @@ export class Xtb implements Serializer {
   }
 
   digest(message: i18n.Message): string { return digest(message); }
+
+  createNameMapper(message: i18n.Message): PlaceholderMapper {
+    return new XmbPlaceholderMapper(message);
+  }
 }
 
 // Extract messages as xml nodes from the xtb file

--- a/modules/@angular/compiler/test/i18n/i18n_parser_spec.ts
+++ b/modules/@angular/compiler/test/i18n/i18n_parser_spec.ts
@@ -291,7 +291,7 @@ export function main() {
   });
 }
 
-function _humanizeMessages(
+export function _humanizeMessages(
     html: string, implicitTags: string[] = [],
     implicitAttrs: {[k: string]: string[]} = {}): [string[], string, string][] {
   // clang-format off
@@ -322,7 +322,7 @@ function _humanizePlaceholdersToMessage(
 }
 
 
-function _extractMessages(
+export function _extractMessages(
     html: string, implicitTags: string[] = [],
     implicitAttrs: {[k: string]: string[]} = {}): Message[] {
   const htmlParser = new HtmlParser();

--- a/modules/@angular/compiler/test/i18n/integration_spec.ts
+++ b/modules/@angular/compiler/test/i18n/integration_spec.ts
@@ -165,6 +165,7 @@ const XTB = `
   name="START_BOLD_TEXT"><ex>&lt;b&gt;</ex></ph>beaucoup<ph name="CLOSE_BOLD_TEXT"><ex>&lt;/b&gt;</ex></ph>} }</translation>
   <translation id="4085484936881858615">{VAR_PLURAL, plural, =0 {Pas de réponse} =1 {une réponse} other {<ph name="INTERPOLATION"><ex>INTERPOLATION</ex></ph> réponse} }</translation>
   <translation id="4035252431381981115">FOO<ph name="START_LINK"><ex>&lt;a&gt;</ex></ph>BAR<ph name="CLOSE_LINK"><ex>&lt;/a&gt;</ex></ph></translation>
+  <translation id="5339604010413301604"><ph name="MAP_NAME"><ex>MAP_NAME</ex></ph></translation>
 </translationbundle>`;
 
 const XMB = ` <msg id="615790887472569365">i18n attribute on tags</msg>
@@ -191,7 +192,8 @@ const XMB = ` <msg id="615790887472569365">i18n attribute on tags</msg>
   <msg id="i18n16">with an explicit ID</msg>
   <msg id="i18n17">{VAR_PLURAL, plural, =0 {zero} =1 {one} =2 {two} other {<ph name="START_BOLD_TEXT"><ex>&lt;b&gt;</ex></ph>many<ph name="CLOSE_BOLD_TEXT"><ex>&lt;/b&gt;</ex></ph>} }</msg>
   <msg id="4085484936881858615" desc="desc">{VAR_PLURAL, plural, =0 {Found no results} =1 {Found one result} other {Found <ph name="INTERPOLATION"><ex>INTERPOLATION</ex></ph> results} }</msg>
-  <msg id="4035252431381981115">foo<ph name="START_LINK"><ex>&lt;a&gt;</ex></ph>bar<ph name="CLOSE_LINK"><ex>&lt;/a&gt;</ex></ph></msg>`;
+  <msg id="4035252431381981115">foo<ph name="START_LINK"><ex>&lt;a&gt;</ex></ph>bar<ph name="CLOSE_LINK"><ex>&lt;/a&gt;</ex></ph></msg>
+  <msg id="5339604010413301604"><ph name="MAP_NAME"><ex>MAP_NAME</ex></ph></msg>`;
 
 const HTML = `
 <div>
@@ -246,4 +248,6 @@ const HTML = `
 }</div>
 
 <div i18n id="i18n-18">foo<a i18n-title title="in a translatable section">bar</a></div>
+
+<div i18n>{{ 'test' //i18n(ph="map name") }}</div>
 `;

--- a/modules/@angular/compiler/test/i18n/message_bundle_spec.ts
+++ b/modules/@angular/compiler/test/i18n/message_bundle_spec.ts
@@ -28,13 +28,12 @@ export function main(): void {
         ]);
       });
 
-      it('should extract the all messages and duplicates', () => {
+      it('should extract and dedup messages', () => {
         messages.updateFromTemplate(
-            '<p i18n="m|d">Translate Me</p><p i18n>Translate Me</p><p i18n>Translate Me</p>', 'url',
-            DEFAULT_INTERPOLATION_CONFIG);
+            '<p i18n="m|d@@1">Translate Me</p><p i18n="@@2">Translate Me</p><p i18n="@@2">Translate Me</p>',
+            'url', DEFAULT_INTERPOLATION_CONFIG);
         expect(humanizeMessages(messages)).toEqual([
           'Translate Me (m|d)',
-          'Translate Me (|)',
           'Translate Me (|)',
         ]);
       });
@@ -50,7 +49,7 @@ class _TestSerializer extends Serializer {
 
   load(content: string, url: string): {} { return null; }
 
-  digest(msg: i18n.Message): string { return 'unused'; }
+  digest(msg: i18n.Message): string { return msg.id || `default`; }
 }
 
 function humanizeMessages(catalog: MessageBundle): string[] {

--- a/modules/@angular/compiler/test/i18n/message_bundle_spec.ts
+++ b/modules/@angular/compiler/test/i18n/message_bundle_spec.ts
@@ -42,7 +42,7 @@ export function main(): void {
   });
 }
 
-class _TestSerializer implements Serializer {
+class _TestSerializer extends Serializer {
   write(messages: i18n.Message[]): string {
     return messages.map(msg => `${serializeNodes(msg.nodes)} (${msg.meaning}|${msg.description})`)
         .join('//');

--- a/modules/@angular/compiler/test/i18n/serializers/i18n_ast_spec.ts
+++ b/modules/@angular/compiler/test/i18n/serializers/i18n_ast_spec.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as i18n from '@angular/compiler/src/i18n/i18n_ast';
+
+import {serializeNodes} from '../../../src/i18n/digest';
+import {_extractMessages} from '../i18n_parser_spec';
+
+export function main(): void {
+  describe('i18n AST', () => {
+    describe('CloneVisitor', () => {
+      it('should clone an AST', () => {
+        const messages = _extractMessages(
+            '<div i18n="m|d">b{count, plural, =0 {{sex, select, male {m}}}}a</div>');
+        const nodes = messages[0].nodes;
+        const text = serializeNodes(nodes).join('');
+        expect(text).toEqual(
+            'b<ph icu name="ICU">{count, plural, =0 {[{sex, select, male {[m]}}]}}</ph>a');
+        const visitor = new i18n.CloneVisitor();
+        const cloneNodes = nodes.map(n => n.visit(visitor));
+        expect(serializeNodes(nodes)).toEqual(serializeNodes(cloneNodes));
+        nodes.forEach((n: i18n.Node, i: number) => {
+          expect(n).toEqual(cloneNodes[i]);
+          expect(n).not.toBe(cloneNodes[i]);
+        });
+      });
+    });
+
+    describe('RecurseVisitor', () => {
+      it('should visit all nodes', () => {
+        const visitor = new RecurseVisitor();
+        const container = new i18n.Container(
+            [
+              new i18n.Text('', null),
+              new i18n.Placeholder('', '', null),
+              new i18n.IcuPlaceholder(null, '', null),
+            ],
+            null);
+        const tag = new i18n.TagPlaceholder('', {}, '', '', [container], false, null);
+        const icu = new i18n.Icu('', '', {tag}, null);
+
+        icu.visit(visitor);
+        expect(visitor.textCount).toEqual(1);
+        expect(visitor.phCount).toEqual(1);
+        expect(visitor.icuPhCount).toEqual(1);
+      });
+    });
+  });
+}
+
+class RecurseVisitor extends i18n.RecurseVisitor {
+  textCount = 0;
+  phCount = 0;
+  icuPhCount = 0;
+
+  visitText(text: i18n.Text, context?: any): any { this.textCount++; }
+
+  visitPlaceholder(ph: i18n.Placeholder, context?: any): any { this.phCount++; }
+
+  visitIcuPlaceholder(ph: i18n.IcuPlaceholder, context?: any): any { this.icuPhCount++; }
+}


### PR DESCRIPTION
There are restrictions on the character set that can be used for xmb and xtb
placeholder names.

However because changing the placeholder names would change the message IDs it
is not possible to add those restrictions to the names used internally. Then we
have to map internal name to public names when generating an xmb file and back
when translating using an xtb file.

Note for implementors of `Serializer`:
- When writing a file, the implementor should take care of converting the
internal names to public names while visiting the message nodes - this is
required because the original nodes are needed to compute the message ID.
- When reading a file, the implementor does not need to take care of the mapping
back to internal names as this is handled in the `I18nToHtmlVisitor` used by the
`TranslationBundle`.

fixes b/34339636
