### PR TITLE
refactor(compiler): improve error messages in aot compiler

### DIFF
--- a/modules/@angular/compiler/src/aot/static_reflector.ts
+++ b/modules/@angular/compiler/src/aot/static_reflector.ts
@@ -9,6 +9,7 @@
 import {Attribute, Component, ContentChild, ContentChildren, Directive, Host, HostBinding, HostListener, Inject, Injectable, Input, NgModule, Optional, Output, Pipe, Self, SkipSelf, ViewChild, ViewChildren, animate, group, keyframes, sequence, state, style, transition, trigger} from '@angular/core';
 
 import {ReflectorReader} from '../private_import_core';
+import {SyntaxError} from '../util';
 
 import {StaticSymbol} from './static_symbol';
 import {StaticSymbolResolver} from './static_symbol_resolver';
@@ -554,7 +555,7 @@ export class StaticReflector implements ReflectorReader {
         if (e.fileName) {
           throw positionalError(message, e.fileName, e.line, e.column);
         }
-        throw new Error(message);
+        throw new SyntaxError(message);
       }
     }
 

--- a/modules/@angular/compiler/test/aot/static_reflector_spec.ts
+++ b/modules/@angular/compiler/test/aot/static_reflector_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, StaticSymbolResolverHost} from '@angular/compiler';
+import {StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, StaticSymbolResolverHost, SyntaxError} from '@angular/compiler';
 import {HostListener, Inject, animate, group, keyframes, sequence, state, style, transition, trigger} from '@angular/core';
 
 import {MockStaticSymbolResolverHost, MockSummaryResolver} from './static_symbol_resolver_spec';
@@ -343,6 +343,20 @@ describe('StaticReflector', () => {
         .toThrow(new Error(
             'Recursion not supported, resolving symbol recursive in /tmp/src/function-recursive.d.ts, resolving symbol recursion in /tmp/src/function-reference.ts, resolving symbol  in /tmp/src/function-reference.ts'));
   });
+
+  it('should throw a SyntaxError without stack trace when the required resource cannot be resolved',
+     () => {
+       expect(
+           () => simplify(
+               reflector.getStaticSymbol('/tmp/src/function-reference.ts', 'AppModule'), ({
+                 __symbolic: 'error',
+                 message:
+                     'Could not resolve ./does-not-exist.component relative to /tmp/src/function-reference.ts'
+               })))
+           .toThrowError(
+               SyntaxError,
+               'Error encountered resolving symbol values statically. Could not resolve ./does-not-exist.component relative to /tmp/src/function-reference.ts, resolving symbol AppModule in /tmp/src/function-reference.ts');
+     });
 
   it('should record data about the error in the exception', () => {
     let threw = false;


### PR DESCRIPTION
Previously aot compiler prints stack traces when it fails to resolve.
New behavior: aot compiler outputs the error message.
Example: https://gist.github.com/bowenni/a7fe81d916e8cd4a06b0e133436f40fb


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```