### PR TITLE
fix(tsconfig): Add mapRoot to tsconfig-build.json

### DIFF
--- a/modules/@angular/benchpress/tsconfig-build.json
+++ b/modules/@angular/benchpress/tsconfig-build.json
@@ -1,26 +1,27 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es5",
-        "lib": ["es6", "dom"],
-        "noImplicitAny": true,
-        "sourceMap": true,
-        "baseUrl": ".",
-        "paths": {
-          "@angular/core": ["../../../dist/packages-dist/core"]
-        },
-        "experimentalDecorators": true,
-        "rootDir": ".",
-        "sourceRoot": ".",
-        "outDir": "../../../dist/packages-dist/benchpress",
-        "declaration": true,
-        "skipLibCheck": true
+  "compilerOptions": {
+    "mapRoot": "./modules/@angular/benchpress/",
+    "module": "commonjs",
+    "target": "es5",
+    "lib": ["es6", "dom"],
+    "noImplicitAny": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@angular/core": ["../../../dist/packages-dist/core"]
     },
-    "exclude": ["integrationtest"],
-    "files": [
-        "index.ts",
-        "../../../node_modules/@types/node/index.d.ts",
-        "../../../node_modules/@types/jasmine/index.d.ts",
-        "../../../node_modules/zone.js/dist/zone.js.d.ts"
-    ]
+    "experimentalDecorators": true,
+    "rootDir": ".",
+    "sourceRoot": ".",
+    "outDir": "../../../dist/packages-dist/benchpress",
+    "declaration": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["integrationtest"],
+  "files": [
+    "index.ts",
+    "../../../node_modules/@types/node/index.d.ts",
+    "../../../node_modules/@types/jasmine/index.d.ts",
+    "../../../node_modules/zone.js/dist/zone.js.d.ts"
+  ]
 }

--- a/modules/@angular/common/tsconfig-build.json
+++ b/modules/@angular/common/tsconfig-build.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "mapRoot": "./modules/@angular/common/",
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,

--- a/modules/@angular/compiler-cli/tsconfig-build.json
+++ b/modules/@angular/compiler-cli/tsconfig-build.json
@@ -1,33 +1,34 @@
 {
-    "compilerOptions": {
-        "baseUrl": ".",
-        "declaration": true,
-        "experimentalDecorators": true,
-        "noImplicitAny": true,
-        "module": "commonjs",
-        "outDir": "../../../dist/packages-dist/compiler-cli",
-        "paths": {
-          "@angular/core": ["../../../dist/packages-dist/core"],
-          "@angular/common": ["../../../dist/packages-dist/common"],
-          "@angular/compiler": ["../../../dist/packages-dist/compiler"],
-          "@angular/platform-server": ["../../../dist/packages-dist/platform-server"],
-          "@angular/platform-browser": ["../../../dist/packages-dist/platform-browser"],
-          "@angular/tsc-wrapped": ["../../../dist/tools/@angular/tsc-wrapped"]
-        },
-        "rootDir": ".",
-        "sourceMap": true,
-        "inlineSources": true,
-        "target": "es5",
-        "lib": ["es6", "dom"],
-        "skipLibCheck": true
+  "compilerOptions": {
+    "mapRoot": "./modules/@angular/compiler-cli/",
+    "baseUrl": ".",
+    "declaration": true,
+    "experimentalDecorators": true,
+    "noImplicitAny": true,
+    "module": "commonjs",
+    "outDir": "../../../dist/packages-dist/compiler-cli",
+    "paths": {
+      "@angular/core": ["../../../dist/packages-dist/core"],
+      "@angular/common": ["../../../dist/packages-dist/common"],
+      "@angular/compiler": ["../../../dist/packages-dist/compiler"],
+      "@angular/platform-server": ["../../../dist/packages-dist/platform-server"],
+      "@angular/platform-browser": ["../../../dist/packages-dist/platform-browser"],
+      "@angular/tsc-wrapped": ["../../../dist/tools/@angular/tsc-wrapped"]
     },
-    "exclude": ["integrationtest"],
-    "files": [
-        "index.ts",
-        "src/main.ts",
-        "src/extract_i18n.ts",
-        "../../../node_modules/@types/node/index.d.ts",
-        "../../../node_modules/@types/jasmine/index.d.ts",
-        "../../../node_modules/zone.js/dist/zone.js.d.ts"
-    ]
+    "rootDir": ".",
+    "sourceMap": true,
+    "inlineSources": true,
+    "target": "es5",
+    "lib": ["es6", "dom"],
+    "skipLibCheck": true
+  },
+  "exclude": ["integrationtest"],
+  "files": [
+    "index.ts",
+    "src/main.ts",
+    "src/extract_i18n.ts",
+    "../../../node_modules/@types/node/index.d.ts",
+    "../../../node_modules/@types/jasmine/index.d.ts",
+    "../../../node_modules/zone.js/dist/zone.js.d.ts"
+  ]
 }

--- a/modules/@angular/compiler/tsconfig-build.json
+++ b/modules/@angular/compiler/tsconfig-build.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "mapRoot": "./modules/@angular/compiler/",
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,

--- a/modules/@angular/core/tsconfig-build.json
+++ b/modules/@angular/core/tsconfig-build.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "mapRoot": "./modules/@angular/core/",
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,
@@ -10,7 +11,7 @@
     "paths": {
       "rxjs/*": ["../../../node_modules/rxjs/*"]
     },
-    "rootDir": ".",
+    "rootDir": "./modules/@angular/core/",
     "sourceMap": true,
     "inlineSources": true,
     "target": "es5",

--- a/modules/@angular/examples/tsconfig-build.json
+++ b/modules/@angular/examples/tsconfig-build.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "mapRoot": "./modules/@angular/examples/",
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,

--- a/modules/@angular/forms/tsconfig-build.json
+++ b/modules/@angular/forms/tsconfig-build.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "mapRoot": "./modules/@angular/forms/",
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,

--- a/modules/@angular/http/tsconfig-build.json
+++ b/modules/@angular/http/tsconfig-build.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "mapRoot": "./modules/@angular/http/",
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,

--- a/modules/@angular/language-service/tsconfig-build.json
+++ b/modules/@angular/language-service/tsconfig-build.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "mapRoot": "./modules/@angular/language-service/",
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,

--- a/modules/@angular/platform-browser-dynamic/tsconfig-build.json
+++ b/modules/@angular/platform-browser-dynamic/tsconfig-build.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "mapRoot": "./modules/@angular/platform-browser-dynamic/",
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,

--- a/modules/@angular/platform-browser/tsconfig-build.json
+++ b/modules/@angular/platform-browser/tsconfig-build.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "mapRoot": "./modules/@angular/platform-browser/",
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,

--- a/modules/@angular/platform-server/tsconfig-build.json
+++ b/modules/@angular/platform-server/tsconfig-build.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "mapRoot": "./modules/@angular/platform-server/",
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,

--- a/modules/@angular/platform-webworker-dynamic/tsconfig-build.json
+++ b/modules/@angular/platform-webworker-dynamic/tsconfig-build.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "mapRoot": "./modules/@angular/platform-webworker-dynamic/",
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,

--- a/modules/@angular/platform-webworker/tsconfig-build.json
+++ b/modules/@angular/platform-webworker/tsconfig-build.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "mapRoot": "./modules/@angular/platform-webworker/",
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,

--- a/modules/@angular/router/tsconfig-build.json
+++ b/modules/@angular/router/tsconfig-build.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "mapRoot": "../modules/@angular/router/",
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,

--- a/modules/@angular/upgrade/tsconfig-build.json
+++ b/modules/@angular/upgrade/tsconfig-build.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "mapRoot": "./modules/@angular/upgrade/",
     "baseUrl": ".",
     "declaration": true,
     "stripInternal": true,


### PR DESCRIPTION
Add mapRoot compiler option to tsconfig-build.json for all modules.
This is needed to give sourcemaps a proper root directory.
Currently the sourcemaps include the following path:
`../../../../../modules/@angular/<moduleName>/<filePath>`
With this fix only the filePath will display starting at the module root.
Fixed spacing in 2x tsconfig files from 4 space to 2 space.

https://github.com/angular/angular/issues/14021

**Please check if the PR fulfills these requirements**
- [ x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ x ] Bugfix
[ ] Feature
[ x ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
tsconfig for build was missing mapRoot, sourcemaps were showing unexpected paths
https://github.com/angular/angular/issues/14021

**What is the new behavior?**
Added mapRoot for each module. sourcemap should show path from module root.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

I haven't tested yet. I'm working on setting up my dev environment to build. I'll update this once I've tested.