### PR TITLE
fix(forms): verify function passed as an async validator returns Observable or Promise

### DIFF
--- a/modules/@angular/forms/src/model.ts
+++ b/modules/@angular/forms/src/model.ts
@@ -419,6 +419,10 @@ export abstract class AbstractControl {
       this._status = PENDING;
       this._cancelExistingSubscription();
       const obs = toObservable(this.asyncValidator(this));
+      if (!(obs instanceof Observable)) {
+        throw new Error(
+            `expected the following validator to return Promise or Observable: ${this.asyncValidator}. If you are using FormBuilder; did you forget to brace your validators in an array?`);
+      }
       this._asyncValidationSubscription =
           obs.subscribe({next: (res: {[key: string]: any}) => this.setErrors(res, {emitEvent})});
     }

--- a/modules/@angular/forms/test/form_builder_spec.ts
+++ b/modules/@angular/forms/test/form_builder_spec.ts
@@ -66,5 +66,14 @@ export function main() {
       expect(a.validator).toBe(syncValidator);
       expect(a.asyncValidator).toBe(asyncValidator);
     });
+
+    it('should throw when sync validator passed into async validator param', () => {
+      const fn = () => b.group({units: ['', syncValidator, syncValidator]});
+      // test for the specific error since without the error check it would still throw an error but
+      // not a meaningful one
+      expect(fn).toThrow(new Error(`
+      expected the following validator to return Promise or Observable: ${syncValidator}. If you are using FormBuilder; did you forget to brace y
+our validators in an array?`));
+    });
   });
 }

--- a/modules/@angular/forms/test/form_builder_spec.ts
+++ b/modules/@angular/forms/test/form_builder_spec.ts
@@ -66,13 +66,5 @@ export function main() {
       expect(a.validator).toBe(syncValidator);
       expect(a.asyncValidator).toBe(asyncValidator);
     });
-
-    it('should throw when sync validator passed into async validator param', () => {
-      const fn = () => b.group({units: ['', syncValidator, syncValidator]});
-      // test for the specific error since without the error check it would still throw an error but
-      // not a meaningful one
-      expect(fn).toThrow(new Error(
-          `expected the following validator to return Promise or Observable: ${syncValidator}. If you are using FormBuilder; did you forget to brace your validators in an array?`));
-    });
   });
 }

--- a/modules/@angular/forms/test/form_builder_spec.ts
+++ b/modules/@angular/forms/test/form_builder_spec.ts
@@ -71,9 +71,8 @@ export function main() {
       const fn = () => b.group({units: ['', syncValidator, syncValidator]});
       // test for the specific error since without the error check it would still throw an error but
       // not a meaningful one
-      expect(fn).toThrow(new Error(`
-      expected the following validator to return Promise or Observable: ${syncValidator}. If you are using FormBuilder; did you forget to brace y
-our validators in an array?`));
+      expect(fn).toThrow(new Error(
+          `expected the following validator to return Promise or Observable: ${syncValidator}. If you are using FormBuilder; did you forget to brace your validators in an array?`));
     });
   });
 }

--- a/modules/@angular/forms/test/form_control_spec.ts
+++ b/modules/@angular/forms/test/form_control_spec.ts
@@ -40,6 +40,8 @@ export function main() {
 
   function otherAsyncValidator() { return Promise.resolve({'other': true}); }
 
+  function syncValidator(_: any /** TODO #9100 */): any /** TODO #9100 */ { return null; }
+
   describe('FormControl', () => {
     it('should default the value to null', () => {
       const c = new FormControl();
@@ -975,6 +977,15 @@ export function main() {
 
           c.disable();
           expect(logger).toEqual(['control', 'group']);
+        });
+
+        it('should throw when sync validator passed into async validator param', () => {
+          const fn = () => new FormControl('', syncValidator, syncValidator);
+          // test for the specific error since without the error check it would still throw an error
+          // but
+          // not a meaningful one
+          expect(fn).toThrowError(
+              `expected the following validator to return Promise or Observable: ${syncValidator}. If you are using FormBuilder; did you forget to brace your validators in an array?`);
         });
 
       });


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
fixes #13951

**What is the new behavior?**
It should throw a meaningful error when you pass a syncValidator into the asyncValidator spot

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x ] No
```