### PR TITLE
fix(upgrade/static): ensure upgraded injector is initialized early enough

### DIFF
--- a/modules/@angular/upgrade/src/aot/upgrade_module.ts
+++ b/modules/@angular/upgrade/src/aot/upgrade_module.ts
@@ -150,10 +150,12 @@ export class UpgradeModule {
    */
   bootstrap(
       element: Element, modules: string[] = [], config?: any /*angular.IAngularBootstrapConfig*/) {
+    const INIT_MODULE_NAME = UPGRADE_MODULE_NAME + '.init';
+
     // Create an ng1 module to bootstrap
-    const upgradeModule =
+    const initModule =
         angular
-            .module(UPGRADE_MODULE_NAME, modules)
+            .module(INIT_MODULE_NAME, [])
 
             .value(INJECTOR_KEY, this.injector)
 
@@ -204,6 +206,8 @@ export class UpgradeModule {
                     () => this.ngZone.runOutsideAngular(() => $rootScope.$evalAsync()));
               }
             ]);
+
+    const upgradeModule = angular.module(UPGRADE_MODULE_NAME, [INIT_MODULE_NAME].concat(modules));
 
     // Make sure resumeBootstrap() only exists if the current bootstrap is deferred
     const windowAngular = (window as any /** TODO #???? */)['angular'];


### PR DESCRIPTION
This change ensures that the upgraded AngularJS injector is initialized
before the application run blocks are executed.

Closes #13811

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The upgraded injector is initialized in a run block that is executed after the application's run
blocks are executed, which means that this injector is not available to downgraded Angular
services that are used in AngularJS run blocks.

**What is the new behavior?**

The injector is now initialized before the application run blocks are executed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

