### PR TITLE
fix(tsc-wrapped): fix #14073, modify UserError to avoid infinite loop after using zone.js 0.7.6

### DIFF
--- a/tools/@angular/tsc-wrapped/src/tsc.ts
+++ b/tools/@angular/tsc-wrapped/src/tsc.ts
@@ -30,7 +30,11 @@ export class UserError extends Error {
   constructor(message: string) {
     // Errors don't use current this, instead they create a new instance.
     // We have to do forward all of our api to the nativeInstance.
-    const nativeError = super(message) as any as Error;
+    // fix issue #14073, UserError should be implemented as the same as
+    // BaseError in @angular/common/facade, nativeError should be a
+    // new Error without initialized with current this.
+    super(message);
+    const nativeError = new Error(message) as any as Error;
     this._nativeError = nativeError;
   }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [*] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [*] Tests for the changes have been added (for bug fixes / features)
I used the original test cases.


**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Because zone.js has handle Error this issue in this PR, https://github.com/angular/zone.js/pull/597
cause a issue in angular/tsc-wrapper.
issue #14073 

**What is the new behavior?**

UserError can get message correctly.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[*] No
```

Implement UserError as described in here.
https://github.com/angular/angular/issues/14073#issuecomment-274795633

