### PR TITLE
fix(http): use params without RequestOptions

### DIFF
--- a/modules/@angular/http/src/http.ts
+++ b/modules/@angular/http/src/http.ts
@@ -28,6 +28,7 @@ function mergeOptions(
       method: providedOpts.method || method,
       url: providedOpts.url || url,
       search: providedOpts.search,
+      params: providedOpts.params,
       headers: providedOpts.headers,
       body: providedOpts.body,
       withCredentials: providedOpts.withCredentials,

--- a/modules/@angular/http/test/http_spec.ts
+++ b/modules/@angular/http/test/http_spec.ts
@@ -353,7 +353,6 @@ export function main() {
                  .subscribe((res: Response) => {});
            }));
 
-
         it('should append string search params to url',
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
              backend.connections.subscribe((c: MockConnection) => {
@@ -365,7 +364,6 @@ export function main() {
                  .subscribe((res: Response) => {});
            }));
 
-
         it('should produce valid url when url already contains a query',
            inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
              backend.connections.subscribe((c: MockConnection) => {
@@ -374,6 +372,19 @@ export function main() {
                async.done();
              });
              http.get('https://www.google.com?q=angular', new RequestOptions({search: 'as_eq=1.x'}))
+                 .subscribe((res: Response) => {});
+           }));
+      });
+
+      describe('params', () => {
+        it('should append params to url',
+           inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+             backend.connections.subscribe((c: MockConnection) => {
+               expect(c.request.url).toEqual('https://www.google.com?q=puppies');
+               backend.resolveAllConnections();
+               async.done();
+             });
+             http.get('https://www.google.com', {params: {q: 'puppies'}})
                  .subscribe((res: Response) => {});
            }));
       });


### PR DESCRIPTION
`params` has been introduced in 4.0.0-beta.0

Before:

    http.get(url, new RequestOptions({params: searchParams}))

After:

    http.get(url, {params: searchParams})

Fixes #14100 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

See #14100

    http.get(url, new RequestOptions({params: searchParams}))


**What is the new behavior?**

    http.get(url, {params: searchParams})

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

