### PR TITLE
fix(compiler-cli): prevent ng-xi18n from emitting the compilation output

### DIFF
--- a/modules/@angular/compiler-cli/integrationtest/test/i18n_spec.ts
+++ b/modules/@angular/compiler-cli/integrationtest/test/i18n_spec.ts
@@ -65,6 +65,7 @@ const EXPECTED_XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 
 describe('template i18n extraction output', () => {
   const outDir = '';
+  const genDir = 'out';
 
   it('should extract i18n messages as xmb', () => {
     const xmbOutput = path.join(outDir, 'messages.xmb');
@@ -78,5 +79,10 @@ describe('template i18n extraction output', () => {
     expect(fs.existsSync(xlfOutput)).toBeTruthy();
     const xlf = fs.readFileSync(xlfOutput, {encoding: 'utf-8'});
     expect(xlf).toEqual(EXPECTED_XLIFF);
+  });
+
+  it('should not emit js', () => {
+    const genOutput = path.join(genDir, '');
+    expect(fs.existsSync(genOutput)).toBeFalsy();
   });
 });

--- a/modules/@angular/compiler-cli/integrationtest/tsconfig-xi18n.json
+++ b/modules/@angular/compiler-cli/integrationtest/tsconfig-xi18n.json
@@ -1,0 +1,34 @@
+{
+  "angularCompilerOptions": {
+    // For TypeScript 1.8, we have to lay out generated files
+    // in the same source directory with your code.
+    "genDir": ".",
+    "debug": true
+  },
+
+  "compilerOptions": {
+    "target": "es5",
+    "experimentalDecorators": true,
+    "noImplicitAny": true,
+    "moduleResolution": "node",
+    "outDir": "./out",
+    "rootDir": "",
+    "declaration": true,
+    "lib": ["es6", "dom"],
+    "baseUrl": ".",
+    // Prevent scanning up the directory tree for types
+    "typeRoots": ["node_modules/@types"]
+  },
+
+  "files": [
+    "src/module",
+    "src/bootstrap",
+    "test/all_spec",
+    "test/test_ngtools_api",
+    "test/test_summaries",
+    "benchmarks/src/tree/ng2/index_aot.ts",
+    "benchmarks/src/tree/ng2_switch/index_aot.ts",
+    "benchmarks/src/largetable/ng2/index_aot.ts",
+    "benchmarks/src/largetable/ng2_switch/index_aot.ts"
+  ]
+}

--- a/modules/@angular/compiler-cli/src/extract_i18n.ts
+++ b/modules/@angular/compiler-cli/src/extract_i18n.ts
@@ -30,7 +30,7 @@ if (require.main === module) {
   const args = require('minimist')(process.argv.slice(2));
   const project = args.p || args.project || '.';
   const cliOptions = new tsc.I18nExtractionCliOptions(args);
-  tsc.main(project, cliOptions, extract)
+  tsc.main(project, cliOptions, extract, {noEmit: true})
       .then((exitCode: any) => process.exit(exitCode))
       .catch((e: any) => {
         console.error(e.stack);

--- a/scripts/ci-lite/offline_compiler_test.sh
+++ b/scripts/ci-lite/offline_compiler_test.sh
@@ -48,8 +48,8 @@ cp -v package.json $TMP
 
   ./node_modules/.bin/ngc -p tsconfig-build.json --i18nFile=src/messages.fi.xlf --locale=fi --i18nFormat=xlf
 
-  ./node_modules/.bin/ng-xi18n -p tsconfig-build.json --i18nFormat=xlf
-  ./node_modules/.bin/ng-xi18n -p tsconfig-build.json --i18nFormat=xmb
+  ./node_modules/.bin/ng-xi18n -p tsconfig-xi18n.json --i18nFormat=xlf
+  ./node_modules/.bin/ng-xi18n -p tsconfig-xi18n.json --i18nFormat=xmb
 
   node test/test_summaries.js
   node test/test_ngtools_api.js


### PR DESCRIPTION
Fixes #13567 by using the `noEmit` option of the TS compiler.