### PR TITLE
refactor(core): have different data types for each node.

### DIFF
--- a/modules/@angular/core/src/view/index.ts
+++ b/modules/@angular/core/src/view/index.ts
@@ -9,6 +9,7 @@
 export {anchorDef, elementDef} from './element';
 export {providerDef} from './provider';
 export {pureArrayDef, pureObjectDef, purePipeDef} from './pure_expression';
+export {queryDef} from './query';
 export {textDef} from './text';
 export {checkAndUpdateView, checkNoChangesView, createEmbeddedView, createRootView, destroyView, viewDef} from './view';
 export {attachEmbeddedView, detachEmbeddedView, rootRenderNodes} from './view_attach';

--- a/modules/@angular/core/src/view/pure_expression.ts
+++ b/modules/@angular/core/src/view/pure_expression.ts
@@ -7,7 +7,7 @@
  */
 
 import {resolveDep, tokenKey} from './provider';
-import {BindingDef, BindingType, DepDef, DepFlags, NodeData, NodeDef, NodeType, ProviderData, PureExpressionType, ViewData} from './types';
+import {BindingDef, BindingType, DepDef, DepFlags, NodeData, NodeDef, NodeType, ProviderData, PureExpressionData, PureExpressionType, ViewData, asPureExpressionData} from './types';
 import {checkAndUpdateBinding} from './util';
 
 export function purePipeDef(pipeToken: any, argCount: number): NodeDef {
@@ -47,7 +47,6 @@ function _pureExpressionDef(
     childMatchedQueries: undefined,
     bindingIndex: undefined,
     disposableIndex: undefined,
-    providerIndices: undefined,
     // regular values
     flags: 0,
     matchedQueries: {},
@@ -56,15 +55,16 @@ function _pureExpressionDef(
     element: undefined,
     provider: undefined,
     text: undefined,
-    pureExpression: {type, pipeDep}
+    pureExpression: {type, pipeDep},
+    query: undefined,
   };
 }
 
-export function createPureExpression(view: ViewData, def: NodeDef): NodeData {
+export function createPureExpression(view: ViewData, def: NodeDef): PureExpressionData {
   const pipe = def.pureExpression.pipeDep ?
       resolveDep(view, def.parent, def.pureExpression.pipeDep) :
       undefined;
-  return {elementOrText: undefined, provider: undefined, pureExpression: {value: undefined, pipe}};
+  return {value: undefined, pipe};
 }
 
 export function checkAndUpdatePureExpressionInline(
@@ -97,7 +97,7 @@ export function checkAndUpdatePureExpressionInline(
   }
 
   if (changed) {
-    const data = view.nodes[def.index].pureExpression;
+    const data = asPureExpressionData(view, def.index);
     let value: any;
     switch (def.pureExpression.type) {
       case PureExpressionType.Array:
@@ -202,7 +202,7 @@ export function checkAndUpdatePureExpressionDynamic(view: ViewData, def: NodeDef
     }
   }
   if (changed) {
-    const data = view.nodes[def.index].pureExpression;
+    const data = asPureExpressionData(view, def.index);
     let value: any;
     switch (def.pureExpression.type) {
       case PureExpressionType.Array:

--- a/modules/@angular/core/src/view/query.ts
+++ b/modules/@angular/core/src/view/query.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ElementRef} from '../linker/element_ref';
+import {ExpressionChangedAfterItHasBeenCheckedError} from '../linker/errors';
+import {QueryList} from '../linker/query_list';
+import {TemplateRef} from '../linker/template_ref';
+import {ViewContainerRef} from '../linker/view_container_ref';
+
+import {NodeDef, NodeFlags, NodeType, QueryBindingDef, QueryBindingType, QueryDef, QueryValueType, ViewData, asElementData, asProviderData, asQueryList} from './types';
+import {declaredViewContainer} from './util';
+
+export function queryDef(
+    flags: NodeFlags, id: string, bindings: {[propName: string]: QueryBindingType}): NodeDef {
+  let bindingDefs: QueryBindingDef[] = [];
+  for (let propName in bindings) {
+    const bindingType = bindings[propName];
+    bindingDefs.push({propName, bindingType});
+  }
+
+  return {
+    type: NodeType.Query,
+    // will bet set by the view definition
+    index: undefined,
+    reverseChildIndex: undefined,
+    parent: undefined,
+    childFlags: undefined,
+    childMatchedQueries: undefined,
+    bindingIndex: undefined,
+    disposableIndex: undefined,
+    // regular values
+    flags,
+    matchedQueries: {},
+    childCount: 0,
+    bindings: [],
+    disposableCount: 0,
+    element: undefined,
+    provider: undefined,
+    text: undefined,
+    pureExpression: undefined,
+    query: {id, bindings: bindingDefs}
+  };
+}
+
+export function createQuery(): QueryList<any> {
+  return new QueryList();
+}
+
+export function dirtyParentQuery(queryId: string, view: ViewData) {
+  let nodeIndex = view.parentIndex;
+  view = view.parent;
+  let queryIdx: number;
+  while (view) {
+    const elementDef = view.def.nodes[nodeIndex];
+    queryIdx = elementDef.element.providerIndices[queryId];
+    if (queryIdx != null) {
+      break;
+    }
+    nodeIndex = view.parentIndex;
+    view = view.parent;
+  }
+  if (!view) {
+    throw new Error(
+        `Illegal State: Tried to dirty parent query ${queryId} but the query could not be found!`);
+  }
+  asQueryList(view, queryIdx).setDirty();
+}
+
+export function checkAndUpdateQuery(view: ViewData, nodeDef: NodeDef) {
+  const queryList = asQueryList(view, nodeDef.index);
+  if (!queryList.dirty) {
+    return;
+  }
+  const queryId = nodeDef.query.id;
+  const providerDef = view.def.nodes[nodeDef.parent];
+  const providerData = asProviderData(view, providerDef.index);
+  let newValues: any[];
+  if (nodeDef.flags & NodeFlags.HasContentQuery) {
+    const elementDef = view.def.nodes[providerDef.parent];
+    newValues = calcQueryValues(
+        view, elementDef.index, elementDef.index + elementDef.childCount, queryId, []);
+  } else if (nodeDef.flags & NodeFlags.HasViewQuery) {
+    const compView = providerData.componentView;
+    newValues = calcQueryValues(compView, 0, compView.def.nodes.length - 1, queryId, []);
+  }
+  queryList.reset(newValues);
+  let boundValue: any;
+  const bindings = nodeDef.query.bindings;
+  for (let i = 0; i < bindings.length; i++) {
+    const binding = bindings[i];
+    switch (binding.bindingType) {
+      case QueryBindingType.First:
+        boundValue = queryList.first;
+        break;
+      case QueryBindingType.All:
+        boundValue = queryList;
+        break;
+    }
+    providerData.instance[binding.propName] = boundValue;
+  }
+}
+
+function calcQueryValues(
+    view: ViewData, startIndex: number, endIndex: number, queryId: string, values: any[]): any[] {
+  const len = view.def.nodes.length;
+  for (let i = startIndex; i <= endIndex; i++) {
+    const nodeDef = view.def.nodes[i];
+    const queryValueType = <QueryValueType>nodeDef.matchedQueries[queryId];
+    if (queryValueType != null) {
+      // a match
+      let value: any;
+      switch (queryValueType) {
+        case QueryValueType.ElementRef:
+          value = new ElementRef(asElementData(view, i).renderElement);
+          break;
+        case QueryValueType.TemplateRef:
+          value = view.services.createTemplateRef(view, nodeDef);
+          break;
+        case QueryValueType.ViewContainerRef:
+          value = view.services.createViewContainerRef(asElementData(view, i));
+          break;
+        case QueryValueType.Provider:
+          value = asProviderData(view, i).instance;
+          break;
+      }
+      values.push(value);
+    }
+    if (nodeDef.flags & NodeFlags.HasEmbeddedViews &&
+        queryId in nodeDef.element.template.nodeMatchedQueries) {
+      // check embedded views that were attached at the place of their template.
+      const elementData = asElementData(view, i);
+      const embeddedViews = elementData.embeddedViews;
+      for (let k = 0; k < embeddedViews.length; k++) {
+        const embeddedView = embeddedViews[k];
+        const dvc = declaredViewContainer(embeddedView);
+        if (dvc && dvc === elementData) {
+          calcQueryValues(embeddedView, 0, embeddedView.def.nodes.length - 1, queryId, values);
+        }
+      }
+      const projectedViews = elementData.projectedViews;
+      if (projectedViews) {
+        for (let k = 0; k < projectedViews.length; k++) {
+          const projectedView = projectedViews[k];
+          calcQueryValues(projectedView, 0, projectedView.def.nodes.length - 1, queryId, values);
+        }
+      }
+    }
+    if (!(queryId in nodeDef.childMatchedQueries)) {
+      // If don't check descendants, skip the children.
+      // Or: no child matches the query, then skip the children as well.
+      i += nodeDef.childCount;
+    }
+  }
+  return values;
+}

--- a/modules/@angular/core/src/view/text.ts
+++ b/modules/@angular/core/src/view/text.ts
@@ -8,7 +8,7 @@
 
 import {looseIdentical} from '../facade/lang';
 
-import {BindingDef, BindingType, NodeData, NodeDef, NodeFlags, NodeType, Services, ViewData} from './types';
+import {BindingDef, BindingType, NodeData, NodeDef, NodeFlags, NodeType, Services, TextData, ViewData, asElementData, asTextData} from './types';
 import {checkAndUpdateBinding} from './util';
 
 export function textDef(constants: string[]): NodeDef {
@@ -32,7 +32,6 @@ export function textDef(constants: string[]): NodeDef {
     childMatchedQueries: undefined,
     bindingIndex: undefined,
     disposableIndex: undefined,
-    providerIndices: undefined,
     // regular values
     flags: 0,
     matchedQueries: {},
@@ -41,12 +40,14 @@ export function textDef(constants: string[]): NodeDef {
     element: undefined,
     provider: undefined,
     text: {prefix: constants[0]},
-    pureExpression: undefined
+    pureExpression: undefined,
+    query: undefined,
   };
 }
 
-export function createText(view: ViewData, renderHost: any, def: NodeDef): NodeData {
-  const parentNode = def.parent != null ? view.nodes[def.parent].elementOrText.node : renderHost;
+export function createText(view: ViewData, renderHost: any, def: NodeDef): TextData {
+  const parentNode =
+      def.parent != null ? asElementData(view, def.parent).renderElement : renderHost;
   let renderNode: any;
   if (view.renderer) {
     renderNode = view.renderer.createText(parentNode, def.text.prefix);
@@ -56,11 +57,7 @@ export function createText(view: ViewData, renderHost: any, def: NodeDef): NodeD
       parentNode.appendChild(renderNode);
     }
   }
-  return {
-    elementOrText: {node: renderNode, embeddedViews: undefined, projectedViews: undefined},
-    provider: undefined,
-    pureExpression: undefined
-  };
+  return {renderText: renderNode};
 }
 
 export function checkAndUpdateTextInline(
@@ -118,7 +115,7 @@ export function checkAndUpdateTextInline(
         value = _addInterpolationPart(v0, bindings[0]) + value;
     }
     value = def.text.prefix + value;
-    const renderNode = view.nodes[def.index].elementOrText.node;
+    const renderNode = asTextData(view, def.index).renderText;
     if (view.renderer) {
       view.renderer.setText(renderNode, value);
     } else {
@@ -143,7 +140,7 @@ export function checkAndUpdateTextDynamic(view: ViewData, def: NodeDef, values: 
       value = value + _addInterpolationPart(values[i], bindings[i]);
     }
     value = def.text.prefix + value;
-    const renderNode = view.nodes[def.index].elementOrText.node;
+    const renderNode = asTextData(view, def.index).renderText;
     if (view.renderer) {
       view.renderer.setText(renderNode, value);
     } else {

--- a/modules/@angular/core/src/view/util.ts
+++ b/modules/@angular/core/src/view/util.ts
@@ -12,7 +12,7 @@ import {looseIdentical} from '../facade/lang';
 import {ExpressionChangedAfterItHasBeenCheckedError} from '../linker/errors';
 import {Renderer} from '../render/api';
 
-import {NodeData, NodeDef, NodeFlags, NodeType, ViewData, ViewDefinition} from './types';
+import {ElementData, NodeData, NodeDef, NodeFlags, NodeType, ViewData, ViewDefinition, asElementData, asTextData} from './types';
 
 export function setBindingDebugInfo(
     renderer: Renderer, renderNode: any, propName: string, value: any) {
@@ -61,10 +61,19 @@ export function checkAndUpdateBindingWithChange(
   return null;
 }
 
-export function declaredViewContainer(view: ViewData) {
+export function declaredViewContainer(view: ViewData): ElementData {
   if (view.parent) {
     const parentView = view.parent;
-    return parentView.nodes[view.parentIndex];
+    return asElementData(parentView, view.parentIndex);
   }
   return undefined;
+}
+
+export function renderNode(view: ViewData, def: NodeDef): any {
+  switch (def.type) {
+    case NodeType.Element:
+      return asElementData(view, def.index).renderElement;
+    case NodeType.Text:
+      return asTextData(view, def.index).renderText;
+  }
 }

--- a/modules/@angular/core/test/view/component_view_spec.ts
+++ b/modules/@angular/core/test/view/component_view_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation} from '@angular/core';
-import {BindingType, DefaultServices, NodeDef, NodeFlags, NodeUpdater, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, checkAndUpdateView, checkNoChangesView, createRootView, destroyView, elementDef, providerDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
+import {BindingType, DefaultServices, NodeDef, NodeFlags, NodeUpdater, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asProviderData, checkAndUpdateView, checkNoChangesView, createRootView, destroyView, elementDef, providerDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
 import {inject} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
@@ -54,13 +54,13 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
       const {view, rootNodes} = createAndGetRootNodes(compViewDef([
         elementDef(NodeFlags.None, null, 1, 'div'),
         providerDef(
-            NodeFlags.None, null, AComp, [], null, null, null,
+            NodeFlags.None, null, 0, AComp, [], null, null,
             () => compViewDef([
               elementDef(NodeFlags.None, null, 0, 'span'),
             ])),
       ]));
 
-      const compView = view.nodes[1].provider.componentView;
+      const compView = asProviderData(view, 1).componentView;
 
       expect(compView.context).toBe(instance);
       expect(compView.component).toBe(instance);
@@ -81,13 +81,13 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
       const {view, rootNodes} = createAndGetRootNodes(
         compViewDef([
           elementDef(NodeFlags.None, null, 1, 'div'),
-          providerDef(NodeFlags.None, null, AComp, [], null, null, null, () => compViewDef(
+          providerDef(NodeFlags.None, null, 0, AComp, [], null, null, () => compViewDef(
             [
               elementDef(NodeFlags.None, null, 0, 'span', null, [[BindingType.ElementAttribute, 'a', SecurityContext.NONE]]),
             ], update
           )),
         ], jasmine.createSpy('parentUpdater')));
-      const compView = view.nodes[1].provider.componentView;
+      const compView = asProviderData(view, 1).componentView;
 
       checkAndUpdateView(view);
 
@@ -118,10 +118,10 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
       const {view, rootNodes} = createAndGetRootNodes(compViewDef([
         elementDef(NodeFlags.None, null, 1, 'div'),
         providerDef(
-            NodeFlags.None, null, AComp, [], null, null, null,
+            NodeFlags.None, null, 0, AComp, [], null, null,
             () => compViewDef([
               elementDef(NodeFlags.None, null, 1, 'span'),
-              providerDef(NodeFlags.OnDestroy, null, ChildProvider, [])
+              providerDef(NodeFlags.OnDestroy, null, 0, ChildProvider, [])
             ])),
       ]));
 

--- a/modules/@angular/core/test/view/embedded_view_spec.ts
+++ b/modules/@angular/core/test/view/embedded_view_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation} from '@angular/core';
-import {BindingType, DefaultServices, NodeDef, NodeFlags, NodeUpdater, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, attachEmbeddedView, checkAndUpdateView, checkNoChangesView, createEmbeddedView, createRootView, destroyView, detachEmbeddedView, elementDef, providerDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
+import {BindingType, DefaultServices, NodeDef, NodeFlags, NodeUpdater, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, attachEmbeddedView, checkAndUpdateView, checkNoChangesView, createEmbeddedView, createRootView, destroyView, detachEmbeddedView, elementDef, providerDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
 import {inject} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
@@ -83,16 +83,16 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
       const childView1 = createEmbeddedView(parentView, parentView.def.nodes[2]);
 
       const rootChildren = getDOM().childNodes(rootNodes[0]);
-      attachEmbeddedView(parentView.nodes[1], 0, childView0);
-      attachEmbeddedView(parentView.nodes[1], 1, childView1);
+      attachEmbeddedView(asElementData(parentView, 1), 0, childView0);
+      attachEmbeddedView(asElementData(parentView, 1), 1, childView1);
 
       // 2 anchors + 2 elements
       expect(rootChildren.length).toBe(4);
       expect(getDOM().getAttribute(rootChildren[1], 'name')).toBe('child0');
       expect(getDOM().getAttribute(rootChildren[2], 'name')).toBe('child1');
 
-      detachEmbeddedView(parentView.nodes[1], 1);
-      detachEmbeddedView(parentView.nodes[1], 0);
+      detachEmbeddedView(asElementData(parentView, 1), 1);
+      detachEmbeddedView(asElementData(parentView, 1), 0);
 
       expect(getDOM().childNodes(rootNodes[0]).length).toBe(2);
     });
@@ -106,7 +106,7 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
       ]));
 
       const childView0 = createEmbeddedView(parentView, parentView.def.nodes[0]);
-      attachEmbeddedView(parentView.nodes[0], 0, childView0);
+      attachEmbeddedView(asElementData(parentView, 0), 0, childView0);
 
       const rootNodes = rootRenderNodes(parentView);
       expect(rootNodes.length).toBe(3);
@@ -133,7 +133,7 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
       const childView0 = createEmbeddedView(parentView, parentView.def.nodes[1]);
 
       const rootEl = rootNodes[0];
-      attachEmbeddedView(parentView.nodes[1], 0, childView0);
+      attachEmbeddedView(asElementData(parentView, 1), 0, childView0);
 
       checkAndUpdateView(parentView);
 
@@ -163,13 +163,13 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
         elementDef(NodeFlags.None, null, 1, 'div'),
         anchorDef(NodeFlags.HasEmbeddedViews, null, 0, embeddedViewDef([
                     elementDef(NodeFlags.None, null, 1, 'span'),
-                    providerDef(NodeFlags.OnDestroy, null, ChildProvider, [])
+                    providerDef(NodeFlags.OnDestroy, null, 0, ChildProvider, [])
                   ]))
       ]));
 
       const childView0 = createEmbeddedView(parentView, parentView.def.nodes[1]);
 
-      attachEmbeddedView(parentView.nodes[1], 0, childView0);
+      attachEmbeddedView(asElementData(parentView, 1), 0, childView0);
       destroyView(parentView);
 
       expect(log).toEqual(['ngOnDestroy']);

--- a/modules/@angular/core/test/view/provider_spec.ts
+++ b/modules/@angular/core/test/view/provider_spec.ts
@@ -58,7 +58,7 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
 
         createAndGetRootNodes(compViewDef([
           elementDef(NodeFlags.None, null, 1, 'span'),
-          providerDef(NodeFlags.None, null, SomeService, [])
+          providerDef(NodeFlags.None, null, 0, SomeService, [])
         ]));
 
         expect(instances.length).toBe(1);
@@ -76,8 +76,9 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
 
         it('should inject deps from the same element', () => {
           createAndGetRootNodes(compViewDef([
-            elementDef(NodeFlags.None, null, 2, 'span'), providerDef(NodeFlags.None, null, Dep, []),
-            providerDef(NodeFlags.None, null, SomeService, [Dep])
+            elementDef(NodeFlags.None, null, 2, 'span'),
+            providerDef(NodeFlags.None, null, 0, Dep, []),
+            providerDef(NodeFlags.None, null, 0, SomeService, [Dep])
           ]));
 
           expect(instance.dep instanceof Dep).toBeTruthy();
@@ -85,9 +86,10 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
 
         it('should inject deps from a parent element', () => {
           createAndGetRootNodes(compViewDef([
-            elementDef(NodeFlags.None, null, 3, 'span'), providerDef(NodeFlags.None, null, Dep, []),
+            elementDef(NodeFlags.None, null, 3, 'span'),
+            providerDef(NodeFlags.None, null, 0, Dep, []),
             elementDef(NodeFlags.None, null, 1, 'span'),
-            providerDef(NodeFlags.None, null, SomeService, [Dep])
+            providerDef(NodeFlags.None, null, 0, SomeService, [Dep])
           ]));
 
           expect(instance.dep instanceof Dep).toBeTruthy();
@@ -95,9 +97,10 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
 
         it('should not inject deps from sibling root elements', () => {
           const nodes = [
-            elementDef(NodeFlags.None, null, 1, 'span'), providerDef(NodeFlags.None, null, Dep, []),
             elementDef(NodeFlags.None, null, 1, 'span'),
-            providerDef(NodeFlags.None, null, SomeService, [Dep])
+            providerDef(NodeFlags.None, null, 0, Dep, []),
+            elementDef(NodeFlags.None, null, 1, 'span'),
+            providerDef(NodeFlags.None, null, 0, SomeService, [Dep])
           ];
 
           // root elements
@@ -115,10 +118,10 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
           createAndGetRootNodes(compViewDef([
             elementDef(NodeFlags.None, null, 1, 'div'),
             providerDef(
-                NodeFlags.None, null, Dep, [], null, null, null,
+                NodeFlags.None, null, 0, Dep, [], null, null,
                 () => compViewDef([
                   elementDef(NodeFlags.None, null, 1, 'span'),
-                  providerDef(NodeFlags.None, null, SomeService, [Dep])
+                  providerDef(NodeFlags.None, null, 0, SomeService, [Dep])
                 ])),
           ]));
 
@@ -129,7 +132,7 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
           it('should inject ViewContainerRef', () => {
             createAndGetRootNodes(compViewDef([
               anchorDef(NodeFlags.HasEmbeddedViews, null, 1),
-              providerDef(NodeFlags.None, null, SomeService, [ViewContainerRef])
+              providerDef(NodeFlags.None, null, 0, SomeService, [ViewContainerRef])
             ]));
 
             expect(instance.dep.createEmbeddedView).toBeTruthy();
@@ -139,7 +142,7 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
             createAndGetRootNodes(compViewDef([
               anchorDef(
                   NodeFlags.None, null, 1, embeddedViewDef([anchorDef(NodeFlags.None, null, 0)])),
-              providerDef(NodeFlags.None, null, SomeService, [TemplateRef])
+              providerDef(NodeFlags.None, null, 0, SomeService, [TemplateRef])
             ]));
 
             expect(instance.dep.createEmbeddedView).toBeTruthy();
@@ -148,7 +151,7 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
           it('should inject ElementRef', () => {
             createAndGetRootNodes(compViewDef([
               elementDef(NodeFlags.None, null, 1, 'span'),
-              providerDef(NodeFlags.None, null, SomeService, [ElementRef])
+              providerDef(NodeFlags.None, null, 0, SomeService, [ElementRef])
             ]));
 
             expect(getDOM().nodeName(instance.dep.nativeElement).toLowerCase()).toBe('span');
@@ -158,7 +161,7 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
             it('should not inject Renderer when using directDom', () => {
               expect(() => createAndGetRootNodes(compViewDef([
                        elementDef(NodeFlags.None, null, 1, 'span'),
-                       providerDef(NodeFlags.None, null, SomeService, [Renderer])
+                       providerDef(NodeFlags.None, null, 0, SomeService, [Renderer])
                      ])))
                   .toThrowError('No provider for Renderer!');
             });
@@ -166,7 +169,7 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
             it('should inject Renderer when not using directDom', () => {
               createAndGetRootNodes(compViewDef([
                 elementDef(NodeFlags.None, null, 1, 'span'),
-                providerDef(NodeFlags.None, null, SomeService, [Renderer])
+                providerDef(NodeFlags.None, null, 0, SomeService, [Renderer])
               ]));
 
               expect(instance.dep.createElement).toBeTruthy();
@@ -199,7 +202,7 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
           const {view, rootNodes} = createAndGetRootNodes(compViewDef(
               [
                 elementDef(NodeFlags.None, null, 1, 'span'),
-                providerDef(NodeFlags.None, null, SomeService, [], {a: [0, 'a'], b: [1, 'b']})
+                providerDef(NodeFlags.None, null, 0, SomeService, [], {a: [0, 'a'], b: [1, 'b']})
               ],
               config.update));
 
@@ -219,7 +222,7 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
         const {view, rootNodes} = createAndGetRootNodes(compViewDef(
             [
               elementDef(NodeFlags.None, null, 1, 'span'),
-              providerDef(NodeFlags.None, null, SomeService, [], {a: [0, 'a']})
+              providerDef(NodeFlags.None, null, 0, SomeService, [], {a: [0, 'a']})
             ],
             (updater, view) => updater.checkInline(view, 1, propValue)));
 
@@ -254,7 +257,8 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
         const {view, rootNodes} = createAndGetRootNodes(compViewDef(
             [
               elementDef(NodeFlags.None, null, 1, 'span'),
-              providerDef(NodeFlags.None, null, SomeService, [], null, {emitter: 'someEventName'})
+              providerDef(
+                  NodeFlags.None, null, 0, SomeService, [], null, {emitter: 'someEventName'})
             ],
             null, handleEvent));
 
@@ -292,9 +296,9 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
         const {view, rootNodes} = createAndGetRootNodes(compViewDef(
             [
               elementDef(NodeFlags.None, null, 3, 'span'),
-              providerDef(allFlags, null, SomeService, [], {a: [0, 'a']}),
+              providerDef(allFlags, null, 0, SomeService, [], {a: [0, 'a']}),
               elementDef(NodeFlags.None, null, 1, 'span'),
-              providerDef(allFlags, null, SomeService, [], {a: [0, 'a']})
+              providerDef(allFlags, null, 0, SomeService, [], {a: [0, 'a']})
             ],
             (updater) => {
               updater.checkInline(view, 1, 'someValue');
@@ -351,7 +355,7 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
         const {view, rootNodes} = createAndGetRootNodes(compViewDef(
             [
               elementDef(NodeFlags.None, null, 1, 'span'),
-              providerDef(NodeFlags.OnChanges, null, SomeService, [], {a: [0, 'nonMinifiedA']})
+              providerDef(NodeFlags.OnChanges, null, 0, SomeService, [], {a: [0, 'nonMinifiedA']})
             ],
             (updater) => updater.checkInline(view, 1, currValue)));
 

--- a/modules/@angular/core/test/view/pure_expression_spec.ts
+++ b/modules/@angular/core/test/view/pure_expression_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {PipeTransform, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation} from '@angular/core';
-import {DefaultServices, NodeDef, NodeFlags, NodeUpdater, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, checkAndUpdateView, checkNoChangesView, createRootView, elementDef, providerDef, pureArrayDef, pureObjectDef, purePipeDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
+import {DefaultServices, NodeDef, NodeFlags, NodeUpdater, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asProviderData, checkAndUpdateView, checkNoChangesView, createRootView, elementDef, providerDef, pureArrayDef, pureObjectDef, purePipeDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
 import {inject} from '@angular/core/testing';
 
 import {INLINE_DYNAMIC_VALUES, InlineDynamic, callUpdater} from './helper';
@@ -46,14 +46,14 @@ export function main() {
         const {view, rootNodes} = createAndGetRootNodes(compViewDef(
             [
               elementDef(NodeFlags.None, null, 2, 'span'), pureArrayDef(2),
-              providerDef(NodeFlags.None, null, Service, [], {data: [0, 'data']})
+              providerDef(NodeFlags.None, null, 0, Service, [], {data: [0, 'data']})
             ],
             (updater, view) => {
               callUpdater(
                   updater, inlineDynamic, view, 2,
                   [callUpdater(updater, inlineDynamic, view, 1, values)]);
             }));
-        const service = view.nodes[2].provider.instance;
+        const service = asProviderData(view, 2).instance;
 
         values = [1, 2];
         checkAndUpdateView(view);
@@ -80,14 +80,14 @@ export function main() {
         const {view, rootNodes} = createAndGetRootNodes(compViewDef(
             [
               elementDef(NodeFlags.None, null, 2, 'span'), pureObjectDef(['a', 'b']),
-              providerDef(NodeFlags.None, null, Service, [], {data: [0, 'data']})
+              providerDef(NodeFlags.None, null, 0, Service, [], {data: [0, 'data']})
             ],
             (updater, view) => {
               callUpdater(
                   updater, inlineDynamic, view, 2,
                   [callUpdater(updater, inlineDynamic, view, 1, values)]);
             }));
-        const service = view.nodes[2].provider.instance;
+        const service = asProviderData(view, 2).instance;
 
         values = [1, 2];
         checkAndUpdateView(view);
@@ -118,15 +118,15 @@ export function main() {
         const {view, rootNodes} = createAndGetRootNodes(compViewDef(
             [
               elementDef(NodeFlags.None, null, 3, 'span'),
-              providerDef(NodeFlags.None, null, SomePipe, []), purePipeDef(SomePipe, 2),
-              providerDef(NodeFlags.None, null, Service, [], {data: [0, 'data']})
+              providerDef(NodeFlags.None, null, 0, SomePipe, []), purePipeDef(SomePipe, 2),
+              providerDef(NodeFlags.None, null, 0, Service, [], {data: [0, 'data']})
             ],
             (updater, view) => {
               callUpdater(
                   updater, inlineDynamic, view, 3,
                   [callUpdater(updater, inlineDynamic, view, 2, values)]);
             }));
-        const service = view.nodes[3].provider.instance;
+        const service = asProviderData(view, 3).instance;
 
         values = [1, 2];
         checkAndUpdateView(view);

--- a/modules/@angular/core/test/view/query_spec.ts
+++ b/modules/@angular/core/test/view/query_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ElementRef, QueryList, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, TemplateRef, ViewContainerRef, ViewEncapsulation} from '@angular/core';
-import {BindingType, DefaultServices, NodeDef, NodeFlags, NodeUpdater, QueryBindingType, QueryValueType, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, attachEmbeddedView, checkAndUpdateView, checkNoChangesView, createEmbeddedView, createRootView, destroyView, detachEmbeddedView, elementDef, providerDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
+import {BindingType, DefaultServices, NodeDef, NodeFlags, NodeUpdater, QueryBindingType, QueryValueType, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, asProviderData, attachEmbeddedView, checkAndUpdateView, checkNoChangesView, createEmbeddedView, createRootView, destroyView, detachEmbeddedView, elementDef, providerDef, queryDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
 import {inject} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
@@ -45,57 +45,59 @@ export function main() {
       a: QueryList<AService>;
     }
 
-    function contentQueryProvider() {
-      return providerDef(
-          NodeFlags.None, null, QueryService, [], null, null,
-          {'a': ['query1', QueryBindingType.All]});
+    function contentQueryProviders() {
+      return [
+        providerDef(NodeFlags.None, null, 1, QueryService, []),
+        queryDef(NodeFlags.HasContentQuery, 'query1', {'a': QueryBindingType.All})
+      ];
+    }
+
+    function viewQueryProviders(compView: ViewDefinition) {
+      return [
+        providerDef(NodeFlags.None, null, 1, QueryService, [], null, null, () => compView),
+        queryDef(NodeFlags.HasViewQuery, 'query1', {'a': QueryBindingType.All})
+      ];
     }
 
     function aServiceProvider() {
-      return providerDef(NodeFlags.None, [['query1', QueryValueType.Provider]], AService, []);
-    }
-
-    function viewQueryProvider(compView: ViewDefinition) {
-      return providerDef(
-          NodeFlags.None, null, QueryService, [], null, null, null, () => compView,
-          {'a': ['query1', QueryBindingType.All]});
+      return providerDef(NodeFlags.None, [['query1', QueryValueType.Provider]], 0, AService, []);
     }
 
     describe('content queries', () => {
 
       it('should query providers on the same element and child elements', () => {
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null, 4, 'div'),
-          contentQueryProvider(),
+          elementDef(NodeFlags.None, null, 5, 'div'),
+          ...contentQueryProviders(),
           aServiceProvider(),
           elementDef(NodeFlags.None, null, 1, 'div'),
           aServiceProvider(),
         ]));
 
-        const qs: QueryService = view.nodes[1].provider.instance;
+        const qs: QueryService = asProviderData(view, 1).instance;
         expect(qs.a).toBeUndefined();
 
         checkAndUpdateView(view);
 
         const as = qs.a.toArray();
         expect(as.length).toBe(2);
-        expect(as[0]).toBe(view.nodes[2].provider.instance);
-        expect(as[1]).toBe(view.nodes[4].provider.instance);
+        expect(as[0]).toBe(asProviderData(view, 3).instance);
+        expect(as[1]).toBe(asProviderData(view, 5).instance);
       });
 
       it('should not query providers on sibling or parent elements', () => {
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null, 5, 'div'),
+          elementDef(NodeFlags.None, null, 6, 'div'),
           aServiceProvider(),
-          elementDef(NodeFlags.None, null, 1, 'div'),
-          contentQueryProvider(),
+          elementDef(NodeFlags.None, null, 2, 'div'),
+          ...contentQueryProviders(),
           elementDef(NodeFlags.None, null, 1, 'div'),
           aServiceProvider(),
         ]));
 
         checkAndUpdateView(view);
 
-        const qs: QueryService = view.nodes[3].provider.instance;
+        const qs: QueryService = asProviderData(view, 3).instance;
         expect(qs.a.length).toBe(0);
       });
     });
@@ -103,8 +105,8 @@ export function main() {
     describe('view queries', () => {
       it('should query providers in the view', () => {
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null, 1, 'div'),
-          viewQueryProvider(compViewDef([
+          elementDef(NodeFlags.None, null, 2, 'div'),
+          ...viewQueryProviders(compViewDef([
             elementDef(NodeFlags.None, null, 1, 'span'),
             aServiceProvider(),
           ])),
@@ -112,23 +114,23 @@ export function main() {
 
         checkAndUpdateView(view);
 
-        const comp: QueryService = view.nodes[1].provider.instance;
-        const compView = view.nodes[1].provider.componentView;
+        const comp: QueryService = asProviderData(view, 1).instance;
+        const compView = asProviderData(view, 1).componentView;
         expect(comp.a.length).toBe(1);
-        expect(comp.a.first).toBe(compView.nodes[1].provider.instance);
+        expect(comp.a.first).toBe(asProviderData(compView, 1).instance);
       });
 
       it('should not query providers on the host element', () => {
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null, 2, 'div'),
-          viewQueryProvider(compViewDef([
+          elementDef(NodeFlags.None, null, 3, 'div'),
+          ...viewQueryProviders(compViewDef([
             elementDef(NodeFlags.None, null, 1, 'span'),
           ])),
           aServiceProvider(),
         ]));
 
         checkAndUpdateView(view);
-        const comp: QueryService = view.nodes[1].provider.instance;
+        const comp: QueryService = asProviderData(view, 1).instance;
         expect(comp.a.length).toBe(0);
       });
     });
@@ -136,37 +138,37 @@ export function main() {
     describe('embedded views', () => {
       it('should query providers in embedded views', () => {
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null, 3, 'div'),
-          contentQueryProvider(),
+          elementDef(NodeFlags.None, null, 5, 'div'),
+          ...contentQueryProviders(),
           anchorDef(
-              NodeFlags.HasEmbeddedViews, null, 1, viewDef(
+              NodeFlags.HasEmbeddedViews, null, 2, viewDef(
                                                        ViewFlags.None,
                                                        [
                                                          elementDef(NodeFlags.None, null, 1, 'div'),
                                                          aServiceProvider(),
                                                        ])),
-          contentQueryProvider(),
+          ...contentQueryProviders(),
         ]));
 
-        const childView = createEmbeddedView(view, view.def.nodes[2]);
-        attachEmbeddedView(view.nodes[2], 0, childView);
+        const childView = createEmbeddedView(view, view.def.nodes[3]);
+        attachEmbeddedView(asElementData(view, 3), 0, childView);
         checkAndUpdateView(view);
 
         // queries on parent elements of anchors
-        const qs1: QueryService = view.nodes[1].provider.instance;
+        const qs1: QueryService = asProviderData(view, 1).instance;
         expect(qs1.a.length).toBe(1);
         expect(qs1.a.first instanceof AService).toBe(true);
 
         // queries on the anchor
-        const qs2: QueryService = view.nodes[3].provider.instance;
+        const qs2: QueryService = asProviderData(view, 4).instance;
         expect(qs2.a.length).toBe(1);
         expect(qs2.a.first instanceof AService).toBe(true);
       });
 
       it('should query providers in embedded views only at the template declaration', () => {
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null, 2, 'div'),
-          contentQueryProvider(),
+          elementDef(NodeFlags.None, null, 3, 'div'),
+          ...contentQueryProviders(),
           anchorDef(
               NodeFlags.HasEmbeddedViews, null, 0, viewDef(
                                                        ViewFlags.None,
@@ -174,31 +176,31 @@ export function main() {
                                                          elementDef(NodeFlags.None, null, 1, 'div'),
                                                          aServiceProvider(),
                                                        ])),
-          elementDef(NodeFlags.None, null, 2, 'div'),
-          contentQueryProvider(),
+          elementDef(NodeFlags.None, null, 3, 'div'),
+          ...contentQueryProviders(),
           anchorDef(NodeFlags.HasEmbeddedViews, null, 0),
         ]));
 
-        const childView = createEmbeddedView(view, view.def.nodes[2]);
+        const childView = createEmbeddedView(view, view.def.nodes[3]);
         // attach at a different place than the one where the template was defined
-        attachEmbeddedView(view.nodes[5], 0, childView);
+        attachEmbeddedView(asElementData(view, 7), 0, childView);
 
         checkAndUpdateView(view);
 
         // query on the declaration place
-        const qs1: QueryService = view.nodes[1].provider.instance;
+        const qs1: QueryService = asProviderData(view, 1).instance;
         expect(qs1.a.length).toBe(1);
         expect(qs1.a.first instanceof AService).toBe(true);
 
         // query on the attach place
-        const qs2: QueryService = view.nodes[4].provider.instance;
+        const qs2: QueryService = asProviderData(view, 5).instance;
         expect(qs2.a.length).toBe(0);
       });
 
       it('should checkNoChanges', () => {
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null, 3, 'div'),
-          contentQueryProvider(),
+          elementDef(NodeFlags.None, null, 4, 'div'),
+          ...contentQueryProviders(),
           anchorDef(
               NodeFlags.HasEmbeddedViews, null, 1, viewDef(
                                                        ViewFlags.None,
@@ -211,18 +213,18 @@ export function main() {
         checkAndUpdateView(view);
         checkNoChangesView(view);
 
-        const childView = createEmbeddedView(view, view.def.nodes[2]);
-        attachEmbeddedView(view.nodes[2], 0, childView);
+        const childView = createEmbeddedView(view, view.def.nodes[3]);
+        attachEmbeddedView(asElementData(view, 3), 0, childView);
 
         expect(() => checkNoChangesView(view))
             .toThrowError(
-                `Expression has changed after it was checked. Previous value: ''. Current value: '[object Object]'.`);
+                `Expression has changed after it was checked. Previous value: 'false'. Current value: 'true'.`);
       });
 
       it('should update content queries if embedded views are added or removed', () => {
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null, 2, 'div'),
-          contentQueryProvider(),
+          elementDef(NodeFlags.None, null, 3, 'div'),
+          ...contentQueryProviders(),
           anchorDef(
               NodeFlags.HasEmbeddedViews, null, 0, viewDef(
                                                        ViewFlags.None,
@@ -234,16 +236,16 @@ export function main() {
 
         checkAndUpdateView(view);
 
-        const qs: QueryService = view.nodes[1].provider.instance;
+        const qs: QueryService = asProviderData(view, 1).instance;
         expect(qs.a.length).toBe(0);
 
-        const childView = createEmbeddedView(view, view.def.nodes[2]);
-        attachEmbeddedView(view.nodes[2], 0, childView);
+        const childView = createEmbeddedView(view, view.def.nodes[3]);
+        attachEmbeddedView(asElementData(view, 3), 0, childView);
         checkAndUpdateView(view);
 
         expect(qs.a.length).toBe(1);
 
-        detachEmbeddedView(view.nodes[2], 0);
+        detachEmbeddedView(asElementData(view, 3), 0);
         checkAndUpdateView(view);
 
         expect(qs.a.length).toBe(0);
@@ -251,8 +253,8 @@ export function main() {
 
       it('should update view queries if embedded views are added or removed', () => {
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null, 1, 'div'),
-          viewQueryProvider(compViewDef([
+          elementDef(NodeFlags.None, null, 2, 'div'),
+          ...viewQueryProviders(compViewDef([
             anchorDef(
                 NodeFlags.HasEmbeddedViews, null, 0,
                 viewDef(
@@ -266,17 +268,17 @@ export function main() {
 
         checkAndUpdateView(view);
 
-        const comp: QueryService = view.nodes[1].provider.instance;
+        const comp: QueryService = asProviderData(view, 1).instance;
         expect(comp.a.length).toBe(0);
 
-        const compView = view.nodes[1].provider.componentView;
+        const compView = asProviderData(view, 1).componentView;
         const childView = createEmbeddedView(compView, compView.def.nodes[0]);
-        attachEmbeddedView(compView.nodes[0], 0, childView);
+        attachEmbeddedView(asElementData(compView, 0), 0, childView);
         checkAndUpdateView(view);
 
         expect(comp.a.length).toBe(1);
 
-        detachEmbeddedView(compView.nodes[0], 0);
+        detachEmbeddedView(asElementData(compView, 0), 0);
         checkAndUpdateView(view);
 
         expect(comp.a.length).toBe(0);
@@ -290,21 +292,20 @@ export function main() {
         }
 
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null, 3, 'div'),
-          providerDef(
-              NodeFlags.None, null, QueryService, [], null, null,
-              {'a': ['query1', QueryBindingType.All]}),
+          elementDef(NodeFlags.None, null, 4, 'div'),
+          providerDef(NodeFlags.None, null, 1, QueryService, []),
+          queryDef(NodeFlags.HasContentQuery, 'query1', {'a': QueryBindingType.All}),
           aServiceProvider(),
           aServiceProvider(),
         ]));
 
         checkAndUpdateView(view);
 
-        const qs: QueryService = view.nodes[1].provider.instance;
+        const qs: QueryService = asProviderData(view, 1).instance;
         expect(qs.a instanceof QueryList).toBeTruthy();
         expect(qs.a.toArray()).toEqual([
-          view.nodes[2].provider.instance,
-          view.nodes[3].provider.instance,
+          asProviderData(view, 3).instance,
+          asProviderData(view, 4).instance,
         ]);
       });
 
@@ -314,18 +315,17 @@ export function main() {
         }
 
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, null, 3, 'div'),
-          providerDef(
-              NodeFlags.None, null, QueryService, [], null, null,
-              {'a': ['query1', QueryBindingType.First]}),
+          elementDef(NodeFlags.None, null, 4, 'div'),
+          providerDef(NodeFlags.None, null, 1, QueryService, []),
+          queryDef(NodeFlags.HasContentQuery, 'query1', {'a': QueryBindingType.First}),
           aServiceProvider(),
           aServiceProvider(),
         ]));
 
         checkAndUpdateView(view);
 
-        const qs: QueryService = view.nodes[1].provider.instance;
-        expect(qs.a).toBe(view.nodes[2].provider.instance);
+        const qs: QueryService = asProviderData(view, 1).instance;
+        expect(qs.a).toBe(asProviderData(view, 3).instance);
       });
     });
 
@@ -336,16 +336,15 @@ export function main() {
         }
 
         const {view} = createAndGetRootNodes(compViewDef([
-          elementDef(NodeFlags.None, [['query1', QueryValueType.ElementRef]], 1, 'div'),
-          providerDef(
-              NodeFlags.None, null, QueryService, [], null, null,
-              {'a': ['query1', QueryBindingType.First]}),
+          elementDef(NodeFlags.None, [['query1', QueryValueType.ElementRef]], 2, 'div'),
+          providerDef(NodeFlags.None, null, 1, QueryService, []),
+          queryDef(NodeFlags.HasContentQuery, 'query1', {'a': QueryBindingType.First}),
         ]));
 
         checkAndUpdateView(view);
 
-        const qs: QueryService = view.nodes[1].provider.instance;
-        expect(qs.a.nativeElement).toBe(view.nodes[0].elementOrText.node);
+        const qs: QueryService = asProviderData(view, 1).instance;
+        expect(qs.a.nativeElement).toBe(asElementData(view, 0).renderElement);
       });
 
       it('should query TemplateRef', () => {
@@ -355,16 +354,15 @@ export function main() {
 
         const {view} = createAndGetRootNodes(compViewDef([
           anchorDef(
-              NodeFlags.None, [['query1', QueryValueType.TemplateRef]], 1,
+              NodeFlags.None, [['query1', QueryValueType.TemplateRef]], 2,
               viewDef(ViewFlags.None, [anchorDef(NodeFlags.None, null, 0)])),
-          providerDef(
-              NodeFlags.None, null, QueryService, [], null, null,
-              {'a': ['query1', QueryBindingType.First]}),
+          providerDef(NodeFlags.None, null, 1, QueryService, []),
+          queryDef(NodeFlags.HasContentQuery, 'query1', {'a': QueryBindingType.First}),
         ]));
 
         checkAndUpdateView(view);
 
-        const qs: QueryService = view.nodes[1].provider.instance;
+        const qs: QueryService = asProviderData(view, 1).instance;
         expect(qs.a.createEmbeddedView).toBeTruthy();
       });
 
@@ -374,15 +372,14 @@ export function main() {
         }
 
         const {view} = createAndGetRootNodes(compViewDef([
-          anchorDef(NodeFlags.None, [['query1', QueryValueType.ViewContainerRef]], 1),
-          providerDef(
-              NodeFlags.None, null, QueryService, [], null, null,
-              {'a': ['query1', QueryBindingType.First]}),
+          anchorDef(NodeFlags.None, [['query1', QueryValueType.ViewContainerRef]], 2),
+          providerDef(NodeFlags.None, null, 1, QueryService, []),
+          queryDef(NodeFlags.HasContentQuery, 'query1', {'a': QueryBindingType.First}),
         ]));
 
         checkAndUpdateView(view);
 
-        const qs: QueryService = view.nodes[1].provider.instance;
+        const qs: QueryService = asProviderData(view, 1).instance;
         expect(qs.a.createEmbeddedView).toBeTruthy();
       });
     });

--- a/modules/@angular/core/test/view/view_def_spec.ts
+++ b/modules/@angular/core/test/view/view_def_spec.ts
@@ -124,7 +124,7 @@ export function main() {
       it('should calculate childFlags for one level', () => {
         const vd = viewDef(ViewFlags.None, [
           elementDef(NodeFlags.None, null, 1, 'span'),
-          providerDef(NodeFlags.AfterContentChecked, null, AService, [])
+          providerDef(NodeFlags.AfterContentChecked, null, 0, AService, [])
         ]);
 
         expect(childFlags(vd)).toEqual([NodeFlags.AfterContentChecked, NodeFlags.None]);
@@ -133,7 +133,7 @@ export function main() {
       it('should calculate childFlags for two levels', () => {
         const vd = viewDef(ViewFlags.None, [
           elementDef(NodeFlags.None, null, 2, 'span'), elementDef(NodeFlags.None, null, 1, 'span'),
-          providerDef(NodeFlags.AfterContentChecked, null, AService, [])
+          providerDef(NodeFlags.AfterContentChecked, null, 0, AService, [])
         ]);
 
         expect(childFlags(vd)).toEqual([
@@ -144,10 +144,10 @@ export function main() {
       it('should calculate childFlags for one level, multiple roots', () => {
         const vd = viewDef(ViewFlags.None, [
           elementDef(NodeFlags.None, null, 1, 'span'),
-          providerDef(NodeFlags.AfterContentChecked, null, AService, []),
+          providerDef(NodeFlags.AfterContentChecked, null, 0, AService, []),
           elementDef(NodeFlags.None, null, 2, 'span'),
-          providerDef(NodeFlags.AfterContentInit, null, AService, []),
-          providerDef(NodeFlags.AfterViewChecked, null, AService, []),
+          providerDef(NodeFlags.AfterContentInit, null, 0, AService, []),
+          providerDef(NodeFlags.AfterViewChecked, null, 0, AService, []),
         ]);
 
         expect(childFlags(vd)).toEqual([
@@ -160,10 +160,10 @@ export function main() {
         const vd = viewDef(ViewFlags.None, [
           elementDef(NodeFlags.None, null, 2, 'span'),
           elementDef(NodeFlags.None, null, 1, 'span'),
-          providerDef(NodeFlags.AfterContentChecked, null, AService, []),
+          providerDef(NodeFlags.AfterContentChecked, null, 0, AService, []),
           elementDef(NodeFlags.None, null, 2, 'span'),
-          providerDef(NodeFlags.AfterContentInit, null, AService, []),
-          providerDef(NodeFlags.AfterViewInit, null, AService, []),
+          providerDef(NodeFlags.AfterContentInit, null, 0, AService, []),
+          providerDef(NodeFlags.AfterViewInit, null, 0, AService, []),
         ]);
 
         expect(childFlags(vd)).toEqual([
@@ -181,7 +181,7 @@ export function main() {
       it('should calculate childMatchedQueries for one level', () => {
         const vd = viewDef(ViewFlags.None, [
           elementDef(NodeFlags.None, null, 1, 'span'),
-          providerDef(NodeFlags.None, [['q1', QueryValueType.Provider]], AService, [])
+          providerDef(NodeFlags.None, [['q1', QueryValueType.Provider]], 0, AService, [])
         ]);
 
         expect(childMatchedQueries(vd)).toEqual([['q1'], []]);
@@ -190,7 +190,7 @@ export function main() {
       it('should calculate childMatchedQueries for two levels', () => {
         const vd = viewDef(ViewFlags.None, [
           elementDef(NodeFlags.None, null, 2, 'span'), elementDef(NodeFlags.None, null, 1, 'span'),
-          providerDef(NodeFlags.None, [['q1', QueryValueType.Provider]], AService, [])
+          providerDef(NodeFlags.None, [['q1', QueryValueType.Provider]], 0, AService, [])
         ]);
 
         expect(childMatchedQueries(vd)).toEqual([['q1'], ['q1'], []]);
@@ -199,10 +199,10 @@ export function main() {
       it('should calculate childMatchedQueries for one level, multiple roots', () => {
         const vd = viewDef(ViewFlags.None, [
           elementDef(NodeFlags.None, null, 1, 'span'),
-          providerDef(NodeFlags.None, [['q1', QueryValueType.Provider]], AService, []),
+          providerDef(NodeFlags.None, [['q1', QueryValueType.Provider]], 0, AService, []),
           elementDef(NodeFlags.None, null, 2, 'span'),
-          providerDef(NodeFlags.None, [['q2', QueryValueType.Provider]], AService, []),
-          providerDef(NodeFlags.None, [['q3', QueryValueType.Provider]], AService, []),
+          providerDef(NodeFlags.None, [['q2', QueryValueType.Provider]], 0, AService, []),
+          providerDef(NodeFlags.None, [['q3', QueryValueType.Provider]], 0, AService, []),
         ]);
 
         expect(childMatchedQueries(vd)).toEqual([['q1'], [], ['q2', 'q3'], [], []]);
@@ -212,10 +212,10 @@ export function main() {
         const vd = viewDef(ViewFlags.None, [
           elementDef(NodeFlags.None, null, 2, 'span'),
           elementDef(NodeFlags.None, null, 1, 'span'),
-          providerDef(NodeFlags.None, [['q1', QueryValueType.Provider]], AService, []),
+          providerDef(NodeFlags.None, [['q1', QueryValueType.Provider]], 0, AService, []),
           elementDef(NodeFlags.None, null, 2, 'span'),
-          providerDef(NodeFlags.None, [['q2', QueryValueType.Provider]], AService, []),
-          providerDef(NodeFlags.None, [['q3', QueryValueType.Provider]], AService, []),
+          providerDef(NodeFlags.None, [['q2', QueryValueType.Provider]], 0, AService, []),
+          providerDef(NodeFlags.None, [['q3', QueryValueType.Provider]], 0, AService, []),
         ]);
 
         expect(childMatchedQueries(vd)).toEqual([['q1'], ['q1'], [], ['q2', 'q3'], [], []]);

--- a/modules/benchmarks/src/tree/ng2_next/tree.ts
+++ b/modules/benchmarks/src/tree/ng2_next/tree.ts
@@ -8,7 +8,7 @@
 
 import {NgIf} from '@angular/common';
 import {Component, NgModule, TemplateRef, ViewContainerRef, ViewEncapsulation} from '@angular/core';
-import {BindingType, DefaultServices, NodeFlags, NodeUpdater, ViewData, ViewDefinition, ViewFlags, anchorDef, checkAndUpdateView, createRootView, elementDef, providerDef, textDef, viewDef} from '@angular/core/src/view/index';
+import {BindingType, DefaultServices, NodeFlags, NodeUpdater, ViewData, ViewDefinition, ViewFlags, anchorDef, asElementData, asProviderData, checkAndUpdateView, createRootView, elementDef, providerDef, textDef, viewDef} from '@angular/core/src/view/index';
 import {DomSanitizer, DomSanitizerImpl, SafeStyle} from '@angular/platform-browser/src/security/dom_sanitization_service';
 
 import {TreeNode, emptyTree} from '../util';
@@ -25,7 +25,7 @@ let viewFlags = ViewFlags.DirectDom;
 
 const TreeComponent_Host: ViewDefinition = viewDef(viewFlags, [
   elementDef(NodeFlags.None, null, 1, 'tree'),
-  providerDef(NodeFlags.None, null, TreeComponent, [], null, null, null, () => TreeComponent_0),
+  providerDef(NodeFlags.None, null, 0, TreeComponent, [], null, null, () => TreeComponent_0),
 ]);
 
 const TreeComponent_1: ViewDefinition = viewDef(
@@ -33,7 +33,7 @@ const TreeComponent_1: ViewDefinition = viewDef(
     [
       elementDef(NodeFlags.None, null, 1, 'tree'),
       providerDef(
-          NodeFlags.None, null, TreeComponent, [], {data: [0, 'data']}, null, null,
+          NodeFlags.None, null, 0, TreeComponent, [], {data: [0, 'data']}, null,
           () => TreeComponent_0),
     ],
     (updater: NodeUpdater, view: ViewData) => {
@@ -46,7 +46,7 @@ const TreeComponent_2: ViewDefinition = viewDef(
     [
       elementDef(NodeFlags.None, null, 1, 'tree'),
       providerDef(
-          NodeFlags.None, null, TreeComponent, [], {data: [0, 'data']}, null, null,
+          NodeFlags.None, null, 0, TreeComponent, [], {data: [0, 'data']}, null,
           () => TreeComponent_0),
     ],
     (updater: NodeUpdater, view: ViewData) => {
@@ -62,9 +62,11 @@ const TreeComponent_0: ViewDefinition = viewDef(
           [[BindingType.ElementStyle, 'backgroundColor', null]]),
       textDef([' ', ' ']),
       anchorDef(NodeFlags.HasEmbeddedViews, null, 1, TreeComponent_1),
-      providerDef(NodeFlags.None, null, NgIf, [ViewContainerRef, TemplateRef], {ngIf: [0, 'ngIf']}),
+      providerDef(
+          NodeFlags.None, null, 0, NgIf, [ViewContainerRef, TemplateRef], {ngIf: [0, 'ngIf']}),
       anchorDef(NodeFlags.HasEmbeddedViews, null, 1, TreeComponent_2),
-      providerDef(NodeFlags.None, null, NgIf, [ViewContainerRef, TemplateRef], {ngIf: [0, 'ngIf']}),
+      providerDef(
+          NodeFlags.None, null, 0, NgIf, [ViewContainerRef, TemplateRef], {ngIf: [0, 'ngIf']}),
     ],
     (updater: NodeUpdater, view: ViewData) => {
       const cmp = view.component;
@@ -87,8 +89,8 @@ export class AppModule {
   }
   bootstrap() {
     this.rootView = createRootView(new DefaultServices(null, this.sanitizer), TreeComponent_Host);
-    this.rootComp = this.rootView.nodes[1].provider.instance;
-    this.rootEl = this.rootView.nodes[0].elementOrText.node;
+    this.rootComp = asProviderData(this.rootView, 1).instance;
+    this.rootEl = asElementData(this.rootView, 0).renderElement;
   }
   tick() { checkAndUpdateView(this.rootView); }
 }


### PR DESCRIPTION
Also have a new node tpye for queries.

This leads to less memory usage and better performance.

Deep Tree Benchmark results (depth 11):
- createAndDestroy (view engine vs current codegen):
  * pureScriptTime: 78.80+-4% vs 72.34+-4%
  * scriptTime: 78.80+-4% vs 90.71+-9%
  * gc: 5371.66+-108% vs 9717.53+-174%
  * i.e. faster when gc is also considered and about 2x less memory usage!
- update unchanged

Part of #14013

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

