### PR TITLE
fix(language-service): do not crash when Angular cannot be located

### DIFF
--- a/modules/@angular/compiler/src/aot/static_symbol_resolver.ts
+++ b/modules/@angular/compiler/src/aot/static_symbol_resolver.ts
@@ -321,7 +321,12 @@ export class StaticSymbolResolver {
   getSymbolByModule(module: string, symbolName: string, containingFile?: string): StaticSymbol {
     const filePath = this.resolveModule(module, containingFile);
     if (!filePath) {
-      throw new Error(`Could not resolve module ${module} relative to ${containingFile}`);
+      this.reportError(
+          new Error(`Could not resolve module ${module}${containingFile ? ` relative to $ {
+            containingFile
+          } `: ''}`),
+          null);
+      return this.getStaticSymbol(`ERROR:${module}`, symbolName);
     }
     return this.getStaticSymbol(filePath, symbolName);
   }

--- a/modules/@angular/language-service/test/language_service_spec.ts
+++ b/modules/@angular/language-service/test/language_service_spec.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+import {createLanguageService} from '../src/language_service';
+import {Completions, LanguageService} from '../src/types';
+import {TypeScriptServiceHost} from '../src/typescript_host';
+
+import {toh} from './test_data';
+import {MockTypescriptHost} from './test_utils';
+
+describe('service without angular', () => {
+  let mockHost = new MockTypescriptHost(['/app/main.ts', '/app/parsing-cases.ts'], toh);
+  mockHost.forgetAngular();
+  let service = ts.createLanguageService(mockHost);
+  let ngHost = new TypeScriptServiceHost(mockHost, service);
+  let ngService = createLanguageService(ngHost);
+  const fileName = '/app/test.ng';
+  let position = mockHost.getMarkerLocations(fileName)['h1-content'];
+
+  it('should not crash a get template references',
+     () => expect(() => ngService.getTemplateReferences()));
+  it('should not crash a get dianostics',
+     () => expect(() => ngService.getDiagnostics(fileName)).not.toThrow());
+  it('should not crash a completion',
+     () => expect(() => ngService.getCompletionsAt(fileName, position)).not.toThrow());
+  it('should not crash a get defintion',
+     () => expect(() => ngService.getDefinitionAt(fileName, position)).not.toThrow());
+  it('should not crash a hover', () => expect(() => ngService.getHoverAt(fileName, position)));
+});

--- a/modules/@angular/language-service/test/test_utils.ts
+++ b/modules/@angular/language-service/test/test_utils.ts
@@ -98,6 +98,8 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
     this.scriptNames.push(fileName);
   }
 
+  forgetAngular() { this.angularPath = undefined; }
+
   getCompilationSettings(): ts.CompilerOptions {
     return {
       target: ts.ScriptTarget.ES5,


### PR DESCRIPTION
Fixes #14122

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

The language service crashes when open on project that does not contain angular (#14122)

**What is the new behavior?**

The language service returns undefined for all calls.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
