### PR TITLE
[4.x branch only] ci: remove type checking on 1.8

### DIFF
--- a/tools/typings-test/test.sh
+++ b/tools/typings-test/test.sh
@@ -19,7 +19,7 @@ cp -R -v tools/typings-test/* $TMP
   npm init --yes
   npm install ${LINKABLE_PKGS[*]}
   npm install @types/es6-promise @types/es6-collections @types/jasmine rxjs@5.0.0-beta.11
-  npm install typescript@1.8.10
+  npm install typescript@2.0.2
   $(npm bin)/tsc --version
   $(npm bin)/tsc -p tsconfig.json
 )


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] CI related changes
```

**What is the current behavior?** (You can also link to an open issue here)

We validate our typings against 1.8.

**What is the new behavior?**

We no longer validate against 1.8.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
