### PR TITLE
ci: update typings test to use standard typings

### DIFF
--- a/tools/typings-test/test.sh
+++ b/tools/typings-test/test.sh
@@ -17,9 +17,7 @@ cp -R -v tools/typings-test/* $TMP
   cd $TMP
   # create package.json so that npm install doesn't pollute any parent node_modules's directory
   npm init --yes
-  npm install ${LINKABLE_PKGS[*]}
-  npm install @types/es6-promise @types/es6-collections @types/jasmine rxjs@5.0.0-beta.11
-  npm install typescript@2.0.2
+  npm install ${LINKABLE_PKGS[*]} @types/jasmine rxjs@5.0 zone.js@0.7 typescript@2.0.2
   $(npm bin)/tsc --version
   $(npm bin)/tsc -p tsconfig.json
 )

--- a/tools/typings-test/tsconfig.json
+++ b/tools/typings-test/tsconfig.json
@@ -6,12 +6,11 @@
     "moduleResolution": "node",
     "outDir": "../../dist/typing-test/",
     "rootDir": ".",
-    "target": "es5"
+    "target": "es5",
+    "lib": ["es5", "dom", "es2015.collection", "es2015.iterable", "es2015.promise"]
   },
   "files": [
     "include-all.ts",
-    "node_modules/@types/es6-promise/index.d.ts",
-    "node_modules/@types/es6-collections/index.d.ts",
     "node_modules/@types/jasmine/index.d.ts"
   ]
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] CI related changes
```

**What is the current behavior?** (You can also link to an open issue here)

The typings test validates against `@types/es6-collections` and `@types/es6-promises`. Standard versions of these typings are part of 2.0.

**What is the new behavior?**

Changed to use the TypeScript definition of ES6 types. Added `Iterable`.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
