### PR TITLE
build(aio): scrape the guides from angular.io

### DIFF
--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -3,507 +3,383 @@
   "version": "4.0.0-beta.5",
   "dependencies": {
     "@types/angularjs": {
-      "version": "1.5.13-alpha",
-      "dev": true
+      "version": "1.5.13-alpha"
     },
     "@types/base64-js": {
-      "version": "1.2.5",
-      "dev": true
+      "version": "1.2.5"
     },
     "@types/fs-extra": {
-      "version": "0.0.22-alpha",
-      "dev": true
+      "version": "0.0.22-alpha"
     },
     "@types/hammerjs": {
-      "version": "2.0.33",
-      "dev": true
+      "version": "2.0.33"
     },
     "@types/jasmine": {
-      "version": "2.2.22-alpha",
-      "dev": true
+      "version": "2.2.22-alpha"
     },
     "@types/jquery": {
-      "version": "1.10.21-alpha",
-      "dev": true
+      "version": "1.10.21-alpha"
     },
     "@types/node": {
-      "version": "4.0.22-alpha",
-      "dev": true
+      "version": "4.0.22-alpha"
     },
     "@types/q": {
-      "version": "0.0.32",
-      "dev": true
+      "version": "0.0.32"
     },
     "@types/selenium-webdriver": {
-      "version": "2.53.35",
-      "dev": true
+      "version": "2.53.35"
     },
     "@types/systemjs": {
-      "version": "0.19.32",
-      "dev": true
+      "version": "0.19.32"
     },
-    "abbrev": {
-      "version": "1.0.9",
-      "dev": true
+    "abab": {
+      "version": "1.0.3"
     },
     "accepts": {
       "version": "1.2.13",
-      "dev": true,
       "dependencies": {
         "mime-db": {
-          "version": "1.20.0",
-          "dev": true
+          "version": "1.20.0"
         },
         "mime-types": {
-          "version": "2.1.8",
-          "dev": true
+          "version": "2.1.8"
         }
       }
     },
     "acorn": {
-      "version": "1.2.2",
-      "dev": true
+      "version": "1.2.2"
+    },
+    "acorn-globals": {
+      "version": "1.0.9",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0"
+        }
+      }
     },
     "add-stream": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "adm-zip": {
-      "version": "0.4.7",
-      "dev": true
+      "version": "0.4.7"
     },
     "after": {
-      "version": "0.8.1",
-      "dev": true
+      "version": "0.8.1"
     },
     "agent-base": {
       "version": "2.0.1",
-      "dev": true,
       "dependencies": {
         "semver": {
-          "version": "5.0.3",
-          "dev": true
+          "version": "5.0.3"
         }
       }
     },
     "align-text": {
       "version": "0.1.3",
-      "dev": true,
       "dependencies": {
         "kind-of": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
         }
       }
     },
     "amdefine": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "angular": {
-      "version": "1.5.0",
-      "dev": true
+      "version": "1.5.0"
     },
     "angular-animate": {
-      "version": "1.5.0",
-      "dev": true
+      "version": "1.5.0"
     },
     "angular-mocks": {
-      "version": "1.5.0",
-      "dev": true
+      "version": "1.5.0"
     },
     "ansi-align": {
-      "version": "1.1.0",
-      "dev": true
-    },
-    "ansi-escapes": {
-      "version": "1.4.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "ansi-green": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
     },
     "ansi-regex": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "dev": true
+      "version": "2.2.1"
     },
     "ansi-wrap": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "any-promise": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "anymatch": {
-      "version": "1.3.0",
-      "dev": true
-    },
-    "aproba": {
-      "version": "1.0.4",
-      "dev": true
+      "version": "1.3.0"
     },
     "archiver": {
       "version": "0.14.4",
-      "dev": true,
       "dependencies": {
         "async": {
-          "version": "0.9.2",
-          "dev": true
+          "version": "0.9.2"
         },
         "glob": {
           "version": "4.3.5",
-          "dev": true,
           "dependencies": {
             "minimatch": {
-              "version": "2.0.10",
-              "dev": true
+              "version": "2.0.10"
             }
           }
         },
         "lodash": {
-          "version": "3.2.0",
-          "dev": true
+          "version": "3.2.0"
         },
         "readable-stream": {
-          "version": "1.0.33",
-          "dev": true
+          "version": "1.0.33"
         }
       }
     },
     "archy": {
-      "version": "1.0.0",
-      "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.2",
-      "dev": true
+      "version": "1.0.0"
     },
     "arr-diff": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "arr-flatten": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "array-differ": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
+    },
+    "array-equal": {
+      "version": "1.0.0"
     },
     "array-ify": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "array-slice": {
-      "version": "0.2.3",
-      "dev": true
+      "version": "0.2.3"
     },
     "array-union": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "array-uniq": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "array-unique": {
-      "version": "0.2.1",
-      "dev": true
+      "version": "0.2.1"
     },
     "arraybuffer.slice": {
-      "version": "0.0.6",
-      "dev": true
+      "version": "0.0.6"
     },
     "arrify": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "asap": {
-      "version": "2.0.3",
-      "dev": true
+      "version": "2.0.3"
     },
     "asn1": {
-      "version": "0.2.3",
-      "dev": true
+      "version": "0.2.3"
     },
     "assert": {
-      "version": "1.4.1",
-      "dev": true
+      "version": "1.4.1"
     },
     "assert-plus": {
-      "version": "0.1.5",
-      "dev": true
+      "version": "0.1.5"
     },
     "async": {
-      "version": "0.2.10",
-      "dev": true
+      "version": "0.2.10"
     },
     "async-each": {
-      "version": "0.1.6",
-      "dev": true
+      "version": "0.1.6"
     },
     "asynckit": {
-      "version": "0.4.0",
-      "dev": true
+      "version": "0.4.0"
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "dev": true
+      "version": "0.6.0"
     },
     "aws4": {
-      "version": "1.5.0",
-      "dev": true
+      "version": "1.5.0"
     },
     "babel-code-frame": {
       "version": "6.20.0",
-      "dev": true,
       "dependencies": {
         "esutils": {
-          "version": "2.0.2",
-          "dev": true
+          "version": "2.0.2"
         },
         "js-tokens": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         }
       }
     },
-    "babel-runtime": {
-      "version": "6.22.0",
-      "dev": true
-    },
     "backo2": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "dev": true
+      "version": "0.4.2"
     },
     "base62": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
     },
     "Base64": {
-      "version": "0.2.1",
-      "dev": true
+      "version": "0.2.1"
     },
     "base64-arraybuffer": {
-      "version": "0.1.2",
-      "dev": true
+      "version": "0.1.2"
     },
     "base64-js": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "base64-url": {
-      "version": "1.2.1",
-      "dev": true
+      "version": "1.2.1"
     },
     "base64id": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "basic-auth": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
     },
     "basic-auth-connect": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "batch": {
-      "version": "0.5.2",
-      "dev": true
+      "version": "0.5.2"
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.0",
-      "dev": true,
-      "optional": true
+      "version": "1.0.0"
     },
     "beeper": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "benchmark": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "better-assert": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "big.js": {
-      "version": "3.1.3",
-      "dev": true
+      "version": "3.1.3"
     },
     "binary": {
-      "version": "0.3.0",
-      "dev": true
+      "version": "0.3.0"
     },
     "binary-extensions": {
-      "version": "1.4.0",
-      "dev": true
+      "version": "1.4.0"
     },
     "bl": {
       "version": "0.9.4",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.33",
-          "dev": true
+          "version": "1.0.33"
         }
       }
     },
     "blob": {
-      "version": "0.0.4",
-      "dev": true
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "dev": true
+      "version": "0.0.4"
     },
     "bluebird": {
-      "version": "2.10.2",
-      "dev": true
+      "version": "2.10.2"
     },
     "body-parser": {
-      "version": "1.13.3",
-      "dev": true
+      "version": "1.13.3"
     },
     "boom": {
-      "version": "2.10.1",
-      "dev": true
+      "version": "2.10.1"
     },
     "bower": {
       "version": "1.7.2",
-      "dev": true,
       "dependencies": {
         "abbrev": {
-          "version": "1.0.7",
-          "dev": true
+          "version": "1.0.7"
         },
         "archy": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "bower-config": {
           "version": "1.3.0",
-          "dev": true,
           "dependencies": {
             "graceful-fs": {
-              "version": "4.1.2",
-              "dev": true
+              "version": "4.1.2"
             },
             "optimist": {
               "version": "0.6.1",
-              "dev": true,
               "dependencies": {
                 "minimist": {
-                  "version": "0.0.10",
-                  "dev": true
+                  "version": "0.0.10"
                 },
                 "wordwrap": {
-                  "version": "0.0.3",
-                  "dev": true
+                  "version": "0.0.3"
                 }
               }
             },
             "osenv": {
               "version": "0.1.3",
-              "dev": true,
               "dependencies": {
                 "os-homedir": {
-                  "version": "1.0.1",
-                  "dev": true
+                  "version": "1.0.1"
                 },
                 "os-tmpdir": {
-                  "version": "1.0.1",
-                  "dev": true
+                  "version": "1.0.1"
                 }
               }
             },
             "untildify": {
               "version": "2.1.0",
-              "dev": true,
               "dependencies": {
                 "os-homedir": {
-                  "version": "1.0.1",
-                  "dev": true
+                  "version": "1.0.1"
                 }
               }
             }
           }
         },
         "bower-endpoint-parser": {
-          "version": "0.2.2",
-          "dev": true
+          "version": "0.2.2"
         },
         "bower-json": {
           "version": "0.4.0",
-          "dev": true,
           "dependencies": {
             "deep-extend": {
-              "version": "0.2.11",
-              "dev": true
+              "version": "0.2.11"
             },
             "graceful-fs": {
-              "version": "2.0.3",
-              "dev": true
+              "version": "2.0.3"
             },
             "intersect": {
-              "version": "0.0.3",
-              "dev": true
+              "version": "0.0.3"
             }
           }
         },
         "bower-logger": {
-          "version": "0.2.2",
-          "dev": true
+          "version": "0.2.2"
         },
         "bower-registry-client": {
           "version": "1.0.0",
-          "dev": true,
           "dependencies": {
             "async": {
-              "version": "0.2.10",
-              "dev": true
+              "version": "0.2.10"
             },
             "graceful-fs": {
-              "version": "4.1.2",
-              "dev": true
+              "version": "4.1.2"
             },
             "mkdirp": {
-              "version": "0.3.5",
-              "dev": true
+              "version": "0.3.5"
             },
             "request-replay": {
-              "version": "0.2.0",
-              "dev": true
+              "version": "0.2.0"
             }
           }
         },
         "cardinal": {
           "version": "0.4.4",
-          "dev": true,
           "dependencies": {
             "ansicolors": {
-              "version": "0.2.1",
-              "dev": true
+              "version": "0.2.1"
             },
             "redeyed": {
               "version": "0.4.4",
-              "dev": true,
               "dependencies": {
                 "esprima": {
-                  "version": "1.0.4",
-                  "dev": true
+                  "version": "1.0.4"
                 }
               }
             }
@@ -511,223 +387,175 @@
         },
         "chalk": {
           "version": "1.1.1",
-          "dev": true,
           "dependencies": {
             "ansi-styles": {
-              "version": "2.1.0",
-              "dev": true
+              "version": "2.1.0"
             },
             "escape-string-regexp": {
-              "version": "1.0.4",
-              "dev": true
+              "version": "1.0.4"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "dev": true,
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "dev": true
+                  "version": "2.0.0"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "dev": true,
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "dev": true
+                  "version": "2.0.0"
                 }
               }
             },
             "supports-color": {
-              "version": "2.0.0",
-              "dev": true
+              "version": "2.0.0"
             }
           }
         },
         "chmodr": {
-          "version": "1.0.2",
-          "dev": true
+          "version": "1.0.2"
         },
         "configstore": {
           "version": "0.3.2",
-          "dev": true,
           "dependencies": {
             "js-yaml": {
               "version": "3.4.6",
-              "dev": true,
               "dependencies": {
                 "argparse": {
                   "version": "1.0.3",
-                  "dev": true,
                   "dependencies": {
                     "lodash": {
-                      "version": "3.10.1",
-                      "dev": true
+                      "version": "3.10.1"
                     },
                     "sprintf-js": {
-                      "version": "1.0.3",
-                      "dev": true
+                      "version": "1.0.3"
                     }
                   }
                 },
                 "esprima": {
-                  "version": "2.7.1",
-                  "dev": true
+                  "version": "2.7.1"
                 },
                 "inherit": {
-                  "version": "2.2.2",
-                  "dev": true
+                  "version": "2.2.2"
                 }
               }
             },
             "object-assign": {
-              "version": "2.1.1",
-              "dev": true
+              "version": "2.1.1"
             },
             "osenv": {
               "version": "0.1.3",
-              "dev": true,
               "dependencies": {
                 "os-homedir": {
-                  "version": "1.0.1",
-                  "dev": true
+                  "version": "1.0.1"
                 },
                 "os-tmpdir": {
-                  "version": "1.0.1",
-                  "dev": true
+                  "version": "1.0.1"
                 }
               }
             },
             "uuid": {
-              "version": "2.0.1",
-              "dev": true
+              "version": "2.0.1"
             },
             "xdg-basedir": {
-              "version": "1.0.1",
-              "dev": true
+              "version": "1.0.1"
             }
           }
         },
         "decompress-zip": {
           "version": "0.1.0",
-          "dev": true,
           "dependencies": {
             "binary": {
               "version": "0.3.0",
-              "dev": true,
               "dependencies": {
                 "buffers": {
-                  "version": "0.1.1",
-                  "dev": true
+                  "version": "0.1.1"
                 },
                 "chainsaw": {
                   "version": "0.1.0",
-                  "dev": true,
                   "dependencies": {
                     "traverse": {
-                      "version": "0.3.9",
-                      "dev": true
+                      "version": "0.3.9"
                     }
                   }
                 }
               }
             },
             "mkpath": {
-              "version": "0.1.0",
-              "dev": true
+              "version": "0.1.0"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "dev": true,
               "dependencies": {
                 "core-util-is": {
-                  "version": "1.0.2",
-                  "dev": true
+                  "version": "1.0.2"
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "dev": true
+                  "version": "2.0.1"
                 },
                 "isarray": {
-                  "version": "0.0.1",
-                  "dev": true
+                  "version": "0.0.1"
                 },
                 "string_decoder": {
-                  "version": "0.10.31",
-                  "dev": true
+                  "version": "0.10.31"
                 }
               }
             },
             "touch": {
               "version": "0.0.3",
-              "dev": true,
               "dependencies": {
                 "nopt": {
-                  "version": "1.0.10",
-                  "dev": true
+                  "version": "1.0.10"
                 }
               }
             }
           }
         },
         "destroy": {
-          "version": "1.0.3",
-          "dev": true
+          "version": "1.0.3"
         },
         "fs-write-stream-atomic": {
           "version": "1.0.5",
-          "dev": true,
           "dependencies": {
             "graceful-fs": {
-              "version": "4.1.2",
-              "dev": true
+              "version": "4.1.2"
             },
             "imurmurhash": {
-              "version": "0.1.4",
-              "dev": true
+              "version": "0.1.4"
             }
           }
         },
         "fstream": {
           "version": "1.0.8",
-          "dev": true,
           "dependencies": {
             "graceful-fs": {
-              "version": "4.1.2",
-              "dev": true
+              "version": "4.1.2"
             },
             "inherits": {
-              "version": "2.0.1",
-              "dev": true
+              "version": "2.0.1"
             }
           }
         },
         "fstream-ignore": {
           "version": "1.0.3",
-          "dev": true,
           "dependencies": {
             "inherits": {
-              "version": "2.0.1",
-              "dev": true
+              "version": "2.0.1"
             },
             "minimatch": {
               "version": "3.0.0",
-              "dev": true,
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.2",
-                  "dev": true,
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.3.0",
-                      "dev": true
+                      "version": "0.3.0"
                     },
                     "concat-map": {
-                      "version": "0.0.1",
-                      "dev": true
+                      "version": "0.0.1"
                     }
                   }
                 }
@@ -737,47 +565,37 @@
         },
         "github": {
           "version": "0.2.4",
-          "dev": true,
           "dependencies": {
             "mime": {
-              "version": "1.3.4",
-              "dev": true
+              "version": "1.3.4"
             }
           }
         },
         "glob": {
           "version": "4.5.3",
-          "dev": true,
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "dev": true,
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "dev": true
+                  "version": "1.0.1"
                 }
               }
             },
             "inherits": {
-              "version": "2.0.1",
-              "dev": true
+              "version": "2.0.1"
             },
             "minimatch": {
               "version": "2.0.10",
-              "dev": true,
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.2",
-                  "dev": true,
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.3.0",
-                      "dev": true
+                      "version": "0.3.0"
                     },
                     "concat-map": {
-                      "version": "0.0.1",
-                      "dev": true
+                      "version": "0.0.1"
                     }
                   }
                 }
@@ -785,53 +603,39 @@
             },
             "once": {
               "version": "1.3.3",
-              "dev": true,
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "dev": true
+                  "version": "1.0.1"
                 }
               }
             }
           }
         },
         "graceful-fs": {
-          "version": "3.0.8",
-          "dev": true
+          "version": "3.0.8"
         },
         "handlebars": {
           "version": "2.0.0",
-          "dev": true,
           "dependencies": {
             "optimist": {
               "version": "0.3.7",
-              "dev": true,
               "dependencies": {
                 "wordwrap": {
-                  "version": "0.0.3",
-                  "dev": true
+                  "version": "0.0.3"
                 }
               }
             },
             "uglify-js": {
               "version": "2.3.6",
-              "dev": true,
-              "optional": true,
               "dependencies": {
                 "async": {
-                  "version": "0.2.10",
-                  "dev": true,
-                  "optional": true
+                  "version": "0.2.10"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "dev": true,
-                  "optional": true,
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.0",
-                      "dev": true,
-                      "optional": true
+                      "version": "1.0.0"
                     }
                   }
                 }
@@ -841,163 +645,128 @@
         },
         "inquirer": {
           "version": "0.10.0",
-          "dev": true,
           "dependencies": {
             "ansi-escapes": {
-              "version": "1.1.0",
-              "dev": true
+              "version": "1.1.0"
             },
             "ansi-regex": {
-              "version": "2.0.0",
-              "dev": true
+              "version": "2.0.0"
             },
             "cli-cursor": {
               "version": "1.0.2",
-              "dev": true,
               "dependencies": {
                 "restore-cursor": {
                   "version": "1.0.1",
-                  "dev": true,
                   "dependencies": {
                     "exit-hook": {
-                      "version": "1.1.1",
-                      "dev": true
+                      "version": "1.1.1"
                     },
                     "onetime": {
-                      "version": "1.1.0",
-                      "dev": true
+                      "version": "1.1.0"
                     }
                   }
                 }
               }
             },
             "cli-width": {
-              "version": "1.1.0",
-              "dev": true
+              "version": "1.1.0"
             },
             "figures": {
-              "version": "1.4.0",
-              "dev": true
+              "version": "1.4.0"
             },
             "lodash": {
-              "version": "3.10.1",
-              "dev": true
+              "version": "3.10.1"
             },
             "readline2": {
               "version": "1.0.1",
-              "dev": true,
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
-                  "dev": true,
                   "dependencies": {
                     "number-is-nan": {
-                      "version": "1.0.0",
-                      "dev": true
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "dev": true,
                   "dependencies": {
                     "number-is-nan": {
-                      "version": "1.0.0",
-                      "dev": true
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "mute-stream": {
-                  "version": "0.0.5",
-                  "dev": true
+                  "version": "0.0.5"
                 }
               }
             },
             "run-async": {
               "version": "0.1.0",
-              "dev": true,
               "dependencies": {
                 "once": {
                   "version": "1.3.3",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "dev": true
+                      "version": "1.0.1"
                     }
                   }
                 }
               }
             },
             "rx-lite": {
-              "version": "3.1.2",
-              "dev": true
+              "version": "3.1.2"
             },
             "strip-ansi": {
-              "version": "3.0.0",
-              "dev": true
+              "version": "3.0.0"
             },
             "through": {
-              "version": "2.3.8",
-              "dev": true
+              "version": "2.3.8"
             }
           }
         },
         "insight": {
           "version": "0.7.0",
-          "dev": true,
           "dependencies": {
             "async": {
-              "version": "1.5.0",
-              "dev": true
+              "version": "1.5.0"
             },
             "configstore": {
               "version": "1.4.0",
-              "dev": true,
               "dependencies": {
                 "graceful-fs": {
-                  "version": "4.1.2",
-                  "dev": true
+                  "version": "4.1.2"
                 },
                 "os-tmpdir": {
-                  "version": "1.0.1",
-                  "dev": true
+                  "version": "1.0.1"
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "dev": true,
                   "dependencies": {
                     "os-homedir": {
-                      "version": "1.0.1",
-                      "dev": true
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "uuid": {
-                  "version": "2.0.1",
-                  "dev": true
+                  "version": "2.0.1"
                 },
                 "write-file-atomic": {
                   "version": "1.1.4",
-                  "dev": true,
                   "dependencies": {
                     "imurmurhash": {
-                      "version": "0.1.4",
-                      "dev": true
+                      "version": "0.1.4"
                     },
                     "slide": {
-                      "version": "1.1.6",
-                      "dev": true
+                      "version": "1.1.6"
                     }
                   }
                 },
                 "xdg-basedir": {
                   "version": "2.0.0",
-                  "dev": true,
                   "dependencies": {
                     "os-homedir": {
-                      "version": "1.0.1",
-                      "dev": true
+                      "version": "1.0.1"
                     }
                   }
                 }
@@ -1005,327 +774,256 @@
             },
             "lodash.debounce": {
               "version": "3.1.1",
-              "dev": true,
               "dependencies": {
                 "lodash._getnative": {
-                  "version": "3.9.1",
-                  "dev": true
+                  "version": "3.9.1"
                 }
               }
             },
             "object-assign": {
-              "version": "4.0.1",
-              "dev": true
+              "version": "4.0.1"
             },
             "os-name": {
               "version": "1.0.3",
-              "dev": true,
               "dependencies": {
                 "osx-release": {
                   "version": "1.1.0",
-                  "dev": true,
                   "dependencies": {
                     "minimist": {
-                      "version": "1.2.0",
-                      "dev": true
+                      "version": "1.2.0"
                     }
                   }
                 },
                 "win-release": {
                   "version": "1.1.1",
-                  "dev": true,
                   "dependencies": {
                     "semver": {
-                      "version": "5.1.0",
-                      "dev": true
+                      "version": "5.1.0"
                     }
                   }
                 }
               }
             },
             "tough-cookie": {
-              "version": "2.2.1",
-              "dev": true
+              "version": "2.2.1"
             }
           }
         },
         "is-root": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "junk": {
-          "version": "1.0.2",
-          "dev": true
+          "version": "1.0.2"
         },
         "lockfile": {
-          "version": "1.0.1",
-          "dev": true
+          "version": "1.0.1"
         },
         "lru-cache": {
-          "version": "2.7.3",
-          "dev": true
+          "version": "2.7.3"
         },
         "md5-hex": {
           "version": "1.2.0",
-          "dev": true,
           "dependencies": {
             "md5-o-matic": {
-              "version": "0.1.1",
-              "dev": true
+              "version": "0.1.1"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.0",
-          "dev": true,
           "dependencies": {
             "minimist": {
-              "version": "0.0.8",
-              "dev": true
+              "version": "0.0.8"
             }
           }
         },
         "mout": {
-          "version": "0.11.1",
-          "dev": true
+          "version": "0.11.1"
         },
         "nopt": {
-          "version": "3.0.6",
-          "dev": true
+          "version": "3.0.6"
         },
         "opn": {
-          "version": "1.0.2",
-          "dev": true
+          "version": "1.0.2"
         },
         "p-throttler": {
           "version": "0.1.1",
-          "dev": true,
           "dependencies": {
             "q": {
-              "version": "0.9.7",
-              "dev": true
+              "version": "0.9.7"
             }
           }
         },
         "promptly": {
           "version": "0.2.0",
-          "dev": true,
           "dependencies": {
             "read": {
               "version": "1.0.7",
-              "dev": true,
               "dependencies": {
                 "mute-stream": {
-                  "version": "0.0.5",
-                  "dev": true
+                  "version": "0.0.5"
                 }
               }
             }
           }
         },
         "q": {
-          "version": "1.4.1",
-          "dev": true
+          "version": "1.4.1"
         },
         "request": {
           "version": "2.53.0",
-          "dev": true,
           "dependencies": {
             "aws-sign2": {
-              "version": "0.5.0",
-              "dev": true
+              "version": "0.5.0"
             },
             "bl": {
               "version": "0.9.4",
-              "dev": true,
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "dev": true,
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.2",
-                      "dev": true
+                      "version": "1.0.2"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "dev": true
+                      "version": "2.0.1"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "dev": true
+                      "version": "0.0.1"
                     },
                     "string_decoder": {
-                      "version": "0.10.31",
-                      "dev": true
+                      "version": "0.10.31"
                     }
                   }
                 }
               }
             },
             "caseless": {
-              "version": "0.9.0",
-              "dev": true
+              "version": "0.9.0"
             },
             "combined-stream": {
               "version": "0.0.7",
-              "dev": true,
               "dependencies": {
                 "delayed-stream": {
-                  "version": "0.0.5",
-                  "dev": true
+                  "version": "0.0.5"
                 }
               }
             },
             "forever-agent": {
-              "version": "0.5.2",
-              "dev": true
+              "version": "0.5.2"
             },
             "form-data": {
               "version": "0.2.0",
-              "dev": true,
               "dependencies": {
                 "async": {
-                  "version": "0.9.2",
-                  "dev": true
+                  "version": "0.9.2"
                 }
               }
             },
             "hawk": {
               "version": "2.3.1",
-              "dev": true,
               "dependencies": {
                 "boom": {
-                  "version": "2.10.1",
-                  "dev": true
+                  "version": "2.10.1"
                 },
                 "cryptiles": {
-                  "version": "2.0.5",
-                  "dev": true
+                  "version": "2.0.5"
                 },
                 "hoek": {
-                  "version": "2.16.3",
-                  "dev": true
+                  "version": "2.16.3"
                 },
                 "sntp": {
-                  "version": "1.0.9",
-                  "dev": true
+                  "version": "1.0.9"
                 }
               }
             },
             "http-signature": {
               "version": "0.10.1",
-              "dev": true,
               "dependencies": {
                 "asn1": {
-                  "version": "0.1.11",
-                  "dev": true
+                  "version": "0.1.11"
                 },
                 "assert-plus": {
-                  "version": "0.1.5",
-                  "dev": true
+                  "version": "0.1.5"
                 },
                 "ctype": {
-                  "version": "0.5.3",
-                  "dev": true
+                  "version": "0.5.3"
                 }
               }
             },
             "isstream": {
-              "version": "0.1.2",
-              "dev": true
+              "version": "0.1.2"
             },
             "json-stringify-safe": {
-              "version": "5.0.1",
-              "dev": true
+              "version": "5.0.1"
             },
             "mime-types": {
               "version": "2.0.14",
-              "dev": true,
               "dependencies": {
                 "mime-db": {
-                  "version": "1.12.0",
-                  "dev": true
+                  "version": "1.12.0"
                 }
               }
             },
             "node-uuid": {
-              "version": "1.4.7",
-              "dev": true
+              "version": "1.4.7"
             },
             "oauth-sign": {
-              "version": "0.6.0",
-              "dev": true
+              "version": "0.6.0"
             },
             "qs": {
-              "version": "2.3.3",
-              "dev": true
+              "version": "2.3.3"
             },
             "stringstream": {
-              "version": "0.0.5",
-              "dev": true
+              "version": "0.0.5"
             },
             "tough-cookie": {
-              "version": "2.2.1",
-              "dev": true
+              "version": "2.2.1"
             },
             "tunnel-agent": {
-              "version": "0.4.2",
-              "dev": true
+              "version": "0.4.2"
             }
           }
         },
         "request-progress": {
           "version": "0.3.1",
-          "dev": true,
           "dependencies": {
             "throttleit": {
-              "version": "0.0.2",
-              "dev": true
+              "version": "0.0.2"
             }
           }
         },
         "retry": {
-          "version": "0.6.1",
-          "dev": true
+          "version": "0.6.1"
         },
         "rimraf": {
           "version": "2.5.0",
-          "dev": true,
           "dependencies": {
             "glob": {
               "version": "6.0.3",
-              "dev": true,
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "dev": true
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "dev": true
+                  "version": "2.0.1"
                 },
                 "minimatch": {
                   "version": "3.0.0",
-                  "dev": true,
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.2",
-                      "dev": true,
                       "dependencies": {
                         "balanced-match": {
-                          "version": "0.3.0",
-                          "dev": true
+                          "version": "0.3.0"
                         },
                         "concat-map": {
-                          "version": "0.0.1",
-                          "dev": true
+                          "version": "0.0.1"
                         }
                       }
                     }
@@ -1333,71 +1031,56 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "dev": true
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "path-is-absolute": {
-                  "version": "1.0.0",
-                  "dev": true
+                  "version": "1.0.0"
                 }
               }
             }
           }
         },
         "semver": {
-          "version": "2.3.2",
-          "dev": true
+          "version": "2.3.2"
         },
         "shell-quote": {
           "version": "1.4.3",
-          "dev": true,
           "dependencies": {
             "array-filter": {
-              "version": "0.0.1",
-              "dev": true
+              "version": "0.0.1"
             },
             "array-map": {
-              "version": "0.0.0",
-              "dev": true
+              "version": "0.0.0"
             },
             "array-reduce": {
-              "version": "0.0.0",
-              "dev": true
+              "version": "0.0.0"
             },
             "jsonify": {
-              "version": "0.0.0",
-              "dev": true
+              "version": "0.0.0"
             }
           }
         },
         "stringify-object": {
-          "version": "1.0.1",
-          "dev": true
+          "version": "1.0.1"
         },
         "tar-fs": {
           "version": "1.9.0",
-          "dev": true,
           "dependencies": {
             "pump": {
               "version": "1.0.1",
-              "dev": true,
               "dependencies": {
                 "end-of-stream": {
-                  "version": "1.1.0",
-                  "dev": true
+                  "version": "1.1.0"
                 },
                 "once": {
                   "version": "1.3.3",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "dev": true
+                      "version": "1.0.1"
                     }
                   }
                 }
@@ -1405,23 +1088,18 @@
             },
             "tar-stream": {
               "version": "1.3.1",
-              "dev": true,
               "dependencies": {
                 "bl": {
-                  "version": "1.0.0",
-                  "dev": true
+                  "version": "1.0.0"
                 },
                 "end-of-stream": {
                   "version": "1.1.0",
-                  "dev": true,
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "dev": true,
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "dev": true
+                          "version": "1.0.1"
                         }
                       }
                     }
@@ -1429,151 +1107,118 @@
                 },
                 "readable-stream": {
                   "version": "2.0.5",
-                  "dev": true,
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.2",
-                      "dev": true
+                      "version": "1.0.2"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "dev": true
+                      "version": "2.0.1"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "dev": true
+                      "version": "0.0.1"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.6",
-                      "dev": true
+                      "version": "1.0.6"
                     },
                     "string_decoder": {
-                      "version": "0.10.31",
-                      "dev": true
+                      "version": "0.10.31"
                     },
                     "util-deprecate": {
-                      "version": "1.0.2",
-                      "dev": true
+                      "version": "1.0.2"
                     }
                   }
                 },
                 "xtend": {
-                  "version": "4.0.1",
-                  "dev": true
+                  "version": "4.0.1"
                 }
               }
             }
           }
         },
         "tmp": {
-          "version": "0.0.24",
-          "dev": true
+          "version": "0.0.24"
         },
         "update-notifier": {
           "version": "0.6.0",
-          "dev": true,
           "dependencies": {
             "configstore": {
               "version": "1.4.0",
-              "dev": true,
               "dependencies": {
                 "graceful-fs": {
-                  "version": "4.1.2",
-                  "dev": true
+                  "version": "4.1.2"
                 },
                 "object-assign": {
-                  "version": "4.0.1",
-                  "dev": true
+                  "version": "4.0.1"
                 },
                 "os-tmpdir": {
-                  "version": "1.0.1",
-                  "dev": true
+                  "version": "1.0.1"
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "dev": true,
                   "dependencies": {
                     "os-homedir": {
-                      "version": "1.0.1",
-                      "dev": true
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "uuid": {
-                  "version": "2.0.1",
-                  "dev": true
+                  "version": "2.0.1"
                 },
                 "write-file-atomic": {
                   "version": "1.1.4",
-                  "dev": true,
                   "dependencies": {
                     "imurmurhash": {
-                      "version": "0.1.4",
-                      "dev": true
+                      "version": "0.1.4"
                     },
                     "slide": {
-                      "version": "1.1.6",
-                      "dev": true
+                      "version": "1.1.6"
                     }
                   }
                 },
                 "xdg-basedir": {
                   "version": "2.0.0",
-                  "dev": true,
                   "dependencies": {
                     "os-homedir": {
-                      "version": "1.0.1",
-                      "dev": true
+                      "version": "1.0.1"
                     }
                   }
                 }
               }
             },
             "is-npm": {
-              "version": "1.0.0",
-              "dev": true
+              "version": "1.0.0"
             },
             "latest-version": {
               "version": "2.0.0",
-              "dev": true,
               "dependencies": {
                 "package-json": {
                   "version": "2.3.0",
-                  "dev": true,
                   "dependencies": {
                     "got": {
                       "version": "5.3.0",
-                      "dev": true,
                       "dependencies": {
                         "create-error-class": {
                           "version": "2.0.1",
-                          "dev": true,
                           "dependencies": {
                             "capture-stack-trace": {
-                              "version": "1.0.0",
-                              "dev": true
+                              "version": "1.0.0"
                             },
                             "inherits": {
-                              "version": "2.0.1",
-                              "dev": true
+                              "version": "2.0.1"
                             }
                           }
                         },
                         "duplexify": {
                           "version": "3.4.2",
-                          "dev": true,
                           "dependencies": {
                             "end-of-stream": {
                               "version": "1.0.0",
-                              "dev": true,
                               "dependencies": {
                                 "once": {
                                   "version": "1.3.3",
-                                  "dev": true,
                                   "dependencies": {
                                     "wrappy": {
-                                      "version": "1.0.1",
-                                      "dev": true
+                                      "version": "1.0.1"
                                     }
                                   }
                                 }
@@ -1581,71 +1226,55 @@
                             },
                             "readable-stream": {
                               "version": "2.0.5",
-                              "dev": true,
                               "dependencies": {
                                 "core-util-is": {
-                                  "version": "1.0.2",
-                                  "dev": true
+                                  "version": "1.0.2"
                                 },
                                 "inherits": {
-                                  "version": "2.0.1",
-                                  "dev": true
+                                  "version": "2.0.1"
                                 },
                                 "isarray": {
-                                  "version": "0.0.1",
-                                  "dev": true
+                                  "version": "0.0.1"
                                 },
                                 "process-nextick-args": {
-                                  "version": "1.0.6",
-                                  "dev": true
+                                  "version": "1.0.6"
                                 },
                                 "string_decoder": {
-                                  "version": "0.10.31",
-                                  "dev": true
+                                  "version": "0.10.31"
                                 },
                                 "util-deprecate": {
-                                  "version": "1.0.2",
-                                  "dev": true
+                                  "version": "1.0.2"
                                 }
                               }
                             }
                           }
                         },
                         "is-plain-obj": {
-                          "version": "1.1.0",
-                          "dev": true
+                          "version": "1.1.0"
                         },
                         "is-redirect": {
-                          "version": "1.0.0",
-                          "dev": true
+                          "version": "1.0.0"
                         },
                         "is-stream": {
-                          "version": "1.0.1",
-                          "dev": true
+                          "version": "1.0.1"
                         },
                         "lowercase-keys": {
-                          "version": "1.0.0",
-                          "dev": true
+                          "version": "1.0.0"
                         },
                         "node-status-codes": {
-                          "version": "1.0.0",
-                          "dev": true
+                          "version": "1.0.0"
                         },
                         "object-assign": {
-                          "version": "4.0.1",
-                          "dev": true
+                          "version": "4.0.1"
                         },
                         "parse-json": {
                           "version": "2.2.0",
-                          "dev": true,
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.0",
-                              "dev": true,
                               "dependencies": {
                                 "is-arrayish": {
-                                  "version": "0.2.1",
-                                  "dev": true
+                                  "version": "0.2.1"
                                 }
                               }
                             }
@@ -1653,75 +1282,59 @@
                         },
                         "pinkie-promise": {
                           "version": "2.0.0",
-                          "dev": true,
                           "dependencies": {
                             "pinkie": {
-                              "version": "2.0.1",
-                              "dev": true
+                              "version": "2.0.1"
                             }
                           }
                         },
                         "read-all-stream": {
                           "version": "3.0.1",
-                          "dev": true,
                           "dependencies": {
                             "pinkie-promise": {
                               "version": "1.0.0",
-                              "dev": true,
                               "dependencies": {
                                 "pinkie": {
-                                  "version": "1.0.0",
-                                  "dev": true
+                                  "version": "1.0.0"
                                 }
                               }
                             },
                             "readable-stream": {
                               "version": "2.0.5",
-                              "dev": true,
                               "dependencies": {
                                 "core-util-is": {
-                                  "version": "1.0.2",
-                                  "dev": true
+                                  "version": "1.0.2"
                                 },
                                 "inherits": {
-                                  "version": "2.0.1",
-                                  "dev": true
+                                  "version": "2.0.1"
                                 },
                                 "isarray": {
-                                  "version": "0.0.1",
-                                  "dev": true
+                                  "version": "0.0.1"
                                 },
                                 "process-nextick-args": {
-                                  "version": "1.0.6",
-                                  "dev": true
+                                  "version": "1.0.6"
                                 },
                                 "string_decoder": {
-                                  "version": "0.10.31",
-                                  "dev": true
+                                  "version": "0.10.31"
                                 },
                                 "util-deprecate": {
-                                  "version": "1.0.2",
-                                  "dev": true
+                                  "version": "1.0.2"
                                 }
                               }
                             }
                           }
                         },
                         "timed-out": {
-                          "version": "2.0.0",
-                          "dev": true
+                          "version": "2.0.0"
                         },
                         "unzip-response": {
-                          "version": "1.0.0",
-                          "dev": true
+                          "version": "1.0.0"
                         },
                         "url-parse-lax": {
                           "version": "1.0.0",
-                          "dev": true,
                           "dependencies": {
                             "prepend-http": {
-                              "version": "1.0.3",
-                              "dev": true
+                              "version": "1.0.3"
                             }
                           }
                         }
@@ -1729,33 +1342,26 @@
                     },
                     "rc": {
                       "version": "1.1.6",
-                      "dev": true,
                       "dependencies": {
                         "deep-extend": {
-                          "version": "0.4.0",
-                          "dev": true
+                          "version": "0.4.0"
                         },
                         "ini": {
-                          "version": "1.3.4",
-                          "dev": true
+                          "version": "1.3.4"
                         },
                         "minimist": {
-                          "version": "1.2.0",
-                          "dev": true
+                          "version": "1.2.0"
                         },
                         "strip-json-comments": {
-                          "version": "1.0.4",
-                          "dev": true
+                          "version": "1.0.4"
                         }
                       }
                     },
                     "registry-url": {
-                      "version": "3.0.3",
-                      "dev": true
+                      "version": "3.0.3"
                     },
                     "semver": {
-                      "version": "5.1.0",
-                      "dev": true
+                      "version": "5.1.0"
                     }
                   }
                 }
@@ -1763,15 +1369,12 @@
             },
             "repeating": {
               "version": "2.0.0",
-              "dev": true,
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "dev": true,
                   "dependencies": {
                     "number-is-nan": {
-                      "version": "1.0.0",
-                      "dev": true
+                      "version": "1.0.0"
                     }
                   }
                 }
@@ -1779,25 +1382,20 @@
             },
             "semver-diff": {
               "version": "2.1.0",
-              "dev": true,
               "dependencies": {
                 "semver": {
-                  "version": "5.1.0",
-                  "dev": true
+                  "version": "5.1.0"
                 }
               }
             },
             "string-length": {
               "version": "1.0.1",
-              "dev": true,
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "dev": true,
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "2.0.0",
-                      "dev": true
+                      "version": "2.0.0"
                     }
                   }
                 }
@@ -1806,20 +1404,16 @@
           }
         },
         "user-home": {
-          "version": "1.1.1",
-          "dev": true
+          "version": "1.1.1"
         },
         "which": {
           "version": "1.2.1",
-          "dev": true,
           "dependencies": {
             "is-absolute": {
               "version": "0.1.7",
-              "dev": true,
               "dependencies": {
                 "is-relative": {
-                  "version": "0.1.3",
-                  "dev": true
+                  "version": "0.1.3"
                 }
               }
             }
@@ -1829,1885 +1423,1487 @@
     },
     "boxen": {
       "version": "0.6.0",
-      "dev": true,
       "dependencies": {
         "camelcase": {
-          "version": "2.1.1",
-          "dev": true
+          "version": "2.1.1"
         }
       }
     },
     "brace-expansion": {
-      "version": "1.1.6",
-      "dev": true
+      "version": "1.1.6"
     },
     "braces": {
-      "version": "1.8.3",
-      "dev": true
+      "version": "1.8.3"
     },
     "browserify-zlib": {
-      "version": "0.1.4",
-      "dev": true
+      "version": "0.1.4"
     },
     "browserstack": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "browserstacktunnel-wrapper": {
-      "version": "1.4.2",
-      "dev": true
+      "version": "1.4.2"
     },
     "buffer": {
       "version": "4.9.1",
-      "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         }
       }
     },
     "buffer-crc32": {
-      "version": "0.2.5",
-      "dev": true
+      "version": "0.2.5"
     },
     "buffer-shims": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "buffers": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
     },
     "builtin-modules": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "bytes": {
-      "version": "2.1.0",
-      "dev": true
+      "version": "2.1.0"
     },
     "callsite": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
+    },
+    "camel-case": {
+      "version": "3.0.0"
     },
     "camelcase": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.1"
     },
     "camelcase-keys": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
+    },
+    "canonical-path": {
+      "version": "0.0.2"
     },
     "capture-stack-trace": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "caseless": {
-      "version": "0.11.0",
-      "dev": true
+      "version": "0.11.0"
+    },
+    "catharsis": {
+      "version": "0.8.8"
     },
     "center-align": {
-      "version": "0.1.2",
-      "dev": true
+      "version": "0.1.2"
     },
     "chainsaw": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "chalk": {
-      "version": "1.1.3",
-      "dev": true
+      "version": "1.1.3"
+    },
+    "change-case": {
+      "version": "3.0.0"
     },
     "chokidar": {
-      "version": "1.4.2",
-      "dev": true
-    },
-    "ci-info": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.4.2"
     },
     "clang-format": {
       "version": "1.0.41",
-      "dev": true,
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "dev": true
+          "version": "1.5.2"
         },
         "glob": {
-          "version": "7.0.3",
-          "dev": true
+          "version": "7.0.3"
         }
       }
     },
     "cldr": {
       "version": "3.5.2",
-      "dev": true,
       "dependencies": {
         "uglify-js": {
-          "version": "1.3.3",
-          "dev": true
+          "version": "1.3.3"
         },
         "underscore": {
-          "version": "1.3.3",
-          "dev": true
+          "version": "1.3.3"
         }
       }
     },
     "cli-boxes": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "cli-color": {
       "version": "1.1.0",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         }
       }
     },
-    "cli-cursor": {
-      "version": "1.0.2",
-      "dev": true
-    },
-    "cli-width": {
-      "version": "2.1.0",
-      "dev": true
-    },
     "cliui": {
       "version": "3.1.0",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "strip-ansi": {
-          "version": "3.0.0",
-          "dev": true
+          "version": "3.0.0"
         }
       }
     },
     "clone": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "clone-stats": {
-      "version": "0.0.1",
-      "dev": true
-    },
-    "cmd-shim": {
-      "version": "2.0.2",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "dev": true
-        }
-      }
+      "version": "0.0.1"
     },
     "code-point-at": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "colors": {
-      "version": "1.1.2",
-      "dev": true
+      "version": "1.1.2"
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "dev": true
+      "version": "1.0.5"
     },
     "commander": {
-      "version": "2.9.0",
-      "dev": true
+      "version": "2.9.0"
     },
     "compare-func": {
-      "version": "1.3.2",
-      "dev": true
+      "version": "1.3.2"
     },
     "component-bind": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "component-emitter": {
-      "version": "1.1.2",
-      "dev": true
+      "version": "1.1.2"
     },
     "component-inherit": {
-      "version": "0.0.3",
-      "dev": true
+      "version": "0.0.3"
     },
     "compress-commons": {
       "version": "0.2.9",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.33",
-          "dev": true
+          "version": "1.0.33"
         }
       }
     },
     "compressible": {
       "version": "2.0.6",
-      "dev": true,
       "dependencies": {
         "mime-db": {
-          "version": "1.20.0",
-          "dev": true
+          "version": "1.20.0"
         }
       }
     },
     "compression": {
-      "version": "1.5.2",
-      "dev": true
+      "version": "1.5.2"
     },
     "concat-map": {
-      "version": "0.0.1",
-      "dev": true
-    },
-    "concat-stream": {
-      "version": "1.6.0",
-      "dev": true,
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.2.2",
-          "dev": true
-        }
-      }
+      "version": "0.0.1"
     },
     "configstore": {
       "version": "2.1.0",
-      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.11",
-          "dev": true
+          "version": "4.1.11"
         }
       }
     },
     "connect": {
-      "version": "3.4.0",
-      "dev": true
+      "version": "3.4.0"
     },
     "connect-livereload": {
-      "version": "0.5.4",
-      "dev": true
+      "version": "0.5.4"
     },
     "connect-timeout": {
-      "version": "1.6.2",
-      "dev": true
+      "version": "1.6.2"
     },
     "console-browserify": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "dev": true
+    "constant-case": {
+      "version": "2.0.0"
     },
     "constants-browserify": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "0.0.1"
     },
     "content-type": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
+    },
+    "content-type-parser": {
+      "version": "1.0.1"
     },
     "conventional-changelog": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "conventional-changelog-angular": {
-      "version": "1.3.0",
-      "dev": true
+      "version": "1.3.0"
     },
     "conventional-changelog-atom": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "conventional-changelog-codemirror": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "conventional-changelog-core": {
       "version": "1.5.0",
-      "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "lodash": {
-          "version": "4.14.2",
-          "dev": true
+          "version": "4.14.2"
         },
         "readable-stream": {
-          "version": "2.0.6",
-          "dev": true
+          "version": "2.0.6"
         },
         "through2": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
         }
       }
     },
     "conventional-changelog-ember": {
-      "version": "0.2.2",
-      "dev": true
+      "version": "0.2.2"
     },
     "conventional-changelog-eslint": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "conventional-changelog-express": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "conventional-changelog-jquery": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "conventional-changelog-jscs": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "conventional-changelog-jshint": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "conventional-changelog-writer": {
       "version": "1.4.1",
-      "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "lodash": {
-          "version": "4.14.2",
-          "dev": true
+          "version": "4.14.2"
         },
         "readable-stream": {
-          "version": "2.0.6",
-          "dev": true
+          "version": "2.0.6"
         },
         "through2": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
         }
       }
     },
     "conventional-commits-filter": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "conventional-commits-parser": {
       "version": "1.2.3",
-      "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "lodash": {
-          "version": "4.14.2",
-          "dev": true
+          "version": "4.14.2"
         },
         "readable-stream": {
-          "version": "2.0.6",
-          "dev": true
+          "version": "2.0.6"
         },
         "through2": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
         }
       }
     },
     "cookie": {
-      "version": "0.1.3",
-      "dev": true
+      "version": "0.1.3"
     },
     "cookie-parser": {
-      "version": "1.3.5",
-      "dev": true
+      "version": "1.3.5"
     },
     "cookie-signature": {
-      "version": "1.0.6",
-      "dev": true
+      "version": "1.0.6"
     },
     "core-js": {
       "version": "2.4.1"
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "cors": {
-      "version": "2.7.1",
-      "dev": true
+      "version": "2.7.1"
     },
     "crc": {
-      "version": "3.3.0",
-      "dev": true
+      "version": "3.3.0"
     },
     "crc32-stream": {
       "version": "0.3.4",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.33",
-          "dev": true
+          "version": "1.0.33"
         }
       }
     },
     "create-error-class": {
-      "version": "3.0.2",
-      "dev": true
+      "version": "3.0.2"
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "dev": true
+      "version": "2.0.5"
     },
     "crypto-browserify": {
-      "version": "3.2.8",
-      "dev": true
+      "version": "3.2.8"
     },
     "csrf": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
+    },
+    "cssom": {
+      "version": "0.3.2"
+    },
+    "cssstyle": {
+      "version": "0.2.37"
     },
     "csurf": {
-      "version": "1.8.3",
-      "dev": true
+      "version": "1.8.3"
     },
     "ctype": {
-      "version": "0.5.3",
-      "dev": true
+      "version": "0.5.3"
     },
     "custom-event": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
+    },
+    "cycle": {
+      "version": "1.0.3"
     },
     "d": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
     },
     "dargs": {
-      "version": "4.1.0",
-      "dev": true
+      "version": "4.1.0"
     },
     "dashdash": {
       "version": "1.14.0",
-      "dev": true,
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         }
       }
     },
     "date-now": {
-      "version": "0.1.4",
-      "dev": true
+      "version": "0.1.4"
     },
     "dateformat": {
-      "version": "1.0.12",
-      "dev": true
-    },
-    "death": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.0.12"
     },
     "debug": {
-      "version": "2.2.0",
-      "dev": true
+      "version": "2.2.0"
     },
     "decamelize": {
-      "version": "1.1.2",
-      "dev": true
+      "version": "1.1.2"
     },
     "deep-extend": {
-      "version": "0.4.1",
-      "dev": true
+      "version": "0.4.1"
+    },
+    "deep-is": {
+      "version": "0.1.3"
     },
     "defaults": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
     },
     "del": {
-      "version": "2.2.2",
-      "dev": true
+      "version": "2.2.2"
     },
     "delayed-stream": {
-      "version": "1.0.0",
-      "dev": true
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "depd": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
+    },
+    "dependency-graph": {
+      "version": "0.4.1"
     },
     "deprecated": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "0.0.1"
     },
     "destroy": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
     },
-    "detect-indent": {
-      "version": "4.0.0",
-      "dev": true
+    "dgeni": {
+      "version": "0.4.2"
+    },
+    "dgeni-packages": {
+      "version": "0.16.5",
+      "dependencies": {
+        "espree": {
+          "version": "2.2.5"
+        },
+        "glob": {
+          "version": "7.1.1"
+        },
+        "lodash": {
+          "version": "4.17.4"
+        },
+        "semver": {
+          "version": "5.3.0"
+        },
+        "typescript": {
+          "version": "1.8.10"
+        }
+      }
     },
     "di": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "0.0.1"
     },
     "diff": {
-      "version": "2.2.1",
-      "dev": true
+      "version": "2.2.1"
     },
     "doctrine": {
-      "version": "0.7.2",
-      "dev": true
+      "version": "0.7.2"
     },
     "dom-serialize": {
-      "version": "2.2.1",
-      "dev": true
+      "version": "2.2.1"
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3"
+        }
+      }
     },
     "domain-browser": {
-      "version": "1.1.7",
-      "dev": true
+      "version": "1.1.7"
+    },
+    "domelementtype": {
+      "version": "1.3.0"
+    },
+    "domhandler": {
+      "version": "2.3.0"
+    },
+    "domutils": {
+      "version": "1.5.1"
+    },
+    "dot-case": {
+      "version": "2.1.0"
     },
     "dot-prop": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "duplexer": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
     },
     "duplexer2": {
-      "version": "0.0.2",
-      "dev": true
+      "version": "0.0.2"
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "dev": true,
-      "optional": true
+      "version": "0.1.1"
     },
     "ee-first": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "end-of-stream": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "engine.io": {
       "version": "1.6.9",
-      "dev": true,
       "dependencies": {
         "accepts": {
-          "version": "1.1.4",
-          "dev": true
+          "version": "1.1.4"
         },
         "negotiator": {
-          "version": "0.4.9",
-          "dev": true
+          "version": "0.4.9"
         },
         "ws": {
-          "version": "1.0.1",
-          "dev": true
+          "version": "1.0.1"
         }
       }
     },
     "engine.io-client": {
       "version": "1.6.9",
-      "dev": true,
       "dependencies": {
         "ws": {
-          "version": "1.0.1",
-          "dev": true
+          "version": "1.0.1"
         }
       }
     },
     "engine.io-parser": {
       "version": "1.2.4",
-      "dev": true,
       "dependencies": {
         "has-binary": {
-          "version": "0.1.6",
-          "dev": true
+          "version": "0.1.6"
         }
       }
     },
     "enhanced-resolve": {
       "version": "0.9.1",
-      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2",
-          "dev": true
+          "version": "4.1.2"
         },
         "memory-fs": {
-          "version": "0.2.0",
-          "dev": true
+          "version": "0.2.0"
         }
       }
     },
     "ent": {
-      "version": "2.2.0",
-      "dev": true
+      "version": "2.2.0"
+    },
+    "entities": {
+      "version": "1.1.1"
     },
     "envify": {
-      "version": "3.4.0",
-      "dev": true
+      "version": "3.4.0"
     },
     "errno": {
-      "version": "0.1.4",
-      "dev": true
+      "version": "0.1.4"
     },
     "error-ex": {
-      "version": "1.3.0",
-      "dev": true
+      "version": "1.3.0"
     },
     "errorhandler": {
-      "version": "1.4.2",
-      "dev": true
+      "version": "1.4.2"
     },
     "es5-ext": {
-      "version": "0.10.11",
-      "dev": true
+      "version": "0.10.11"
     },
     "es6-iterator": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "es6-module-loader": {
-      "version": "0.17.9",
-      "dev": true
+      "version": "0.17.9"
     },
     "es6-symbol": {
-      "version": "3.0.2",
-      "dev": true
+      "version": "3.0.2"
     },
     "es6-weak-map": {
       "version": "0.1.4",
-      "dev": true,
       "dependencies": {
         "es6-iterator": {
-          "version": "0.1.3",
-          "dev": true
+          "version": "0.1.3"
         },
         "es6-symbol": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
         }
       }
     },
     "escape-html": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "escape-string-regexp": {
-      "version": "1.0.4",
-      "dev": true
+      "version": "1.0.4"
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "dependencies": {
+        "estraverse": {
+          "version": "1.9.3"
+        },
+        "esutils": {
+          "version": "2.0.2"
+        },
+        "source-map": {
+          "version": "0.2.0"
+        }
+      }
     },
     "esprima": {
-      "version": "2.7.1",
-      "dev": true
+      "version": "2.7.1"
+    },
+    "estraverse": {
+      "version": "4.2.0"
     },
     "estree-walker": {
-      "version": "0.2.1",
-      "dev": true
+      "version": "0.2.1"
     },
     "esutils": {
-      "version": "1.1.6",
-      "dev": true
+      "version": "1.1.6"
     },
     "etag": {
-      "version": "1.7.0",
-      "dev": true
+      "version": "1.7.0"
     },
     "event-emitter": {
-      "version": "0.3.4",
-      "dev": true
+      "version": "0.3.4"
     },
     "event-stream": {
       "version": "3.3.2",
-      "dev": true,
       "dependencies": {
         "split": {
-          "version": "0.3.3",
-          "dev": true
+          "version": "0.3.3"
         }
       }
     },
     "eventemitter3": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "events": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "exit": {
-      "version": "0.1.2",
-      "dev": true
-    },
-    "exit-hook": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "0.1.2"
     },
     "expand-braces": {
       "version": "0.1.2",
-      "dev": true,
       "dependencies": {
         "braces": {
-          "version": "0.1.5",
-          "dev": true
+          "version": "0.1.5"
         },
         "expand-range": {
-          "version": "0.1.1",
-          "dev": true
+          "version": "0.1.1"
         },
         "is-number": {
-          "version": "0.1.1",
-          "dev": true
+          "version": "0.1.1"
         },
         "repeat-string": {
-          "version": "0.2.2",
-          "dev": true
+          "version": "0.2.2"
         }
       }
     },
     "expand-brackets": {
-      "version": "0.1.4",
-      "dev": true
+      "version": "0.1.4"
     },
     "expand-range": {
-      "version": "1.8.1",
-      "dev": true
+      "version": "1.8.1"
     },
     "express-session": {
-      "version": "1.11.3",
-      "dev": true
+      "version": "1.11.3"
     },
     "extend": {
-      "version": "3.0.0",
-      "dev": true
-    },
-    "external-editor": {
-      "version": "1.1.1",
-      "dev": true,
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.29",
-          "dev": true
-        }
-      }
+      "version": "3.0.0"
     },
     "extglob": {
-      "version": "0.3.1",
-      "dev": true
+      "version": "0.3.1"
     },
     "extsprintf": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
+    },
+    "eyes": {
+      "version": "0.1.8"
     },
     "fancy-log": {
       "version": "1.1.0",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "ansi-styles": {
-          "version": "2.1.0",
-          "dev": true
+          "version": "2.1.0"
         },
         "chalk": {
-          "version": "1.1.1",
-          "dev": true
+          "version": "1.1.1"
         },
         "has-ansi": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "strip-ansi": {
-          "version": "3.0.0",
-          "dev": true
+          "version": "3.0.0"
         },
         "supports-color": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         }
       }
     },
+    "fast-levenshtein": {
+      "version": "2.0.6"
+    },
     "faye-websocket": {
-      "version": "0.10.0",
-      "dev": true
+      "version": "0.10.0"
     },
     "fbjs": {
       "version": "0.6.0",
-      "dev": true,
       "dependencies": {
         "core-js": {
-          "version": "1.2.6",
-          "dev": true
-        }
-      }
-    },
-    "figures": {
-      "version": "1.7.0",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "dev": true
+          "version": "1.2.6"
         }
       }
     },
     "filename-regex": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "fill-range": {
-      "version": "2.2.3",
-      "dev": true
+      "version": "2.2.3"
     },
     "filled-array": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "finalhandler": {
-      "version": "0.4.0",
-      "dev": true
+      "version": "0.4.0"
     },
     "find-index": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
     },
     "find-up": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "findup-sync": {
       "version": "0.3.0",
-      "dev": true,
       "dependencies": {
         "glob": {
-          "version": "5.0.15",
-          "dev": true
+          "version": "5.0.15"
         }
       }
     },
     "firefox-profile": {
       "version": "0.3.11",
-      "dev": true,
       "dependencies": {
         "async": {
-          "version": "0.9.2",
-          "dev": true
+          "version": "0.9.2"
         },
         "fs-extra": {
-          "version": "0.16.5",
-          "dev": true
+          "version": "0.16.5"
         },
         "lodash": {
-          "version": "3.5.0",
-          "dev": true
+          "version": "3.5.0"
         }
       }
     },
     "first-chunk-stream": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "flagged-respawn": {
-      "version": "0.3.1",
-      "dev": true
+      "version": "0.3.1"
     },
     "for-in": {
-      "version": "0.1.4",
-      "dev": true
+      "version": "0.1.4"
     },
     "for-own": {
-      "version": "0.1.3",
-      "dev": true
+      "version": "0.1.3"
     },
     "forever-agent": {
-      "version": "0.6.1",
-      "dev": true
+      "version": "0.6.1"
     },
     "form-data": {
       "version": "2.1.2",
-      "dev": true,
       "dependencies": {
         "mime-db": {
-          "version": "1.24.0",
-          "dev": true
+          "version": "1.24.0"
         },
         "mime-types": {
-          "version": "2.1.12",
-          "dev": true
+          "version": "2.1.12"
         }
       }
     },
     "fresh": {
-      "version": "0.3.0",
-      "dev": true
+      "version": "0.3.0"
     },
     "from": {
-      "version": "0.1.3",
-      "dev": true
+      "version": "0.1.3"
     },
     "fs-access": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "fs-extra": {
       "version": "0.26.3",
-      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2",
-          "dev": true
+          "version": "4.1.2"
         }
       }
     },
     "fs-promise": {
-      "version": "0.3.1",
-      "dev": true
+      "version": "0.3.1"
     },
     "fs.realpath": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "fsevents": {
       "version": "1.0.14",
-      "dev": true,
       "dependencies": {
         "abbrev": {
-          "version": "1.0.9",
-          "dev": true
+          "version": "1.0.9"
         },
         "ansi-regex": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "ansi-styles": {
-          "version": "2.2.1",
-          "dev": true
+          "version": "2.2.1"
         },
         "aproba": {
-          "version": "1.0.4",
-          "dev": true
+          "version": "1.0.4"
         },
         "are-we-there-yet": {
-          "version": "1.1.2",
-          "dev": true
+          "version": "1.1.2"
         },
         "asn1": {
-          "version": "0.2.3",
-          "dev": true
+          "version": "0.2.3"
         },
         "assert-plus": {
-          "version": "0.2.0",
-          "dev": true
+          "version": "0.2.0"
         },
         "async": {
-          "version": "1.5.2",
-          "dev": true
+          "version": "1.5.2"
         },
         "aws-sign2": {
-          "version": "0.6.0",
-          "dev": true
+          "version": "0.6.0"
         },
         "aws4": {
-          "version": "1.4.1",
-          "dev": true
+          "version": "1.4.1"
         },
         "bl": {
           "version": "1.1.2",
-          "dev": true,
           "dependencies": {
             "readable-stream": {
-              "version": "2.0.6",
-              "dev": true
+              "version": "2.0.6"
             }
           }
         },
         "block-stream": {
-          "version": "0.0.9",
-          "dev": true
+          "version": "0.0.9"
         },
         "boom": {
-          "version": "2.10.1",
-          "dev": true
+          "version": "2.10.1"
         },
         "buffer-shims": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "caseless": {
-          "version": "0.11.0",
-          "dev": true
+          "version": "0.11.0"
         },
         "chalk": {
-          "version": "1.1.3",
-          "dev": true
+          "version": "1.1.3"
         },
         "code-point-at": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "combined-stream": {
-          "version": "1.0.5",
-          "dev": true
+          "version": "1.0.5"
         },
         "commander": {
-          "version": "2.9.0",
-          "dev": true
+          "version": "2.9.0"
         },
         "console-control-strings": {
-          "version": "1.1.0",
-          "dev": true
+          "version": "1.1.0"
         },
         "core-util-is": {
-          "version": "1.0.2",
-          "dev": true
+          "version": "1.0.2"
         },
         "cryptiles": {
-          "version": "2.0.5",
-          "dev": true
+          "version": "2.0.5"
         },
         "dashdash": {
           "version": "1.14.0",
-          "dev": true,
           "dependencies": {
             "assert-plus": {
-              "version": "1.0.0",
-              "dev": true
+              "version": "1.0.0"
             }
           }
         },
         "debug": {
-          "version": "2.2.0",
-          "dev": true
+          "version": "2.2.0"
         },
         "deep-extend": {
-          "version": "0.4.1",
-          "dev": true
+          "version": "0.4.1"
         },
         "delayed-stream": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "delegates": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "ecc-jsbn": {
-          "version": "0.1.1",
-          "dev": true,
-          "optional": true
+          "version": "0.1.1"
         },
         "escape-string-regexp": {
-          "version": "1.0.5",
-          "dev": true
+          "version": "1.0.5"
         },
         "extend": {
-          "version": "3.0.0",
-          "dev": true
+          "version": "3.0.0"
         },
         "extsprintf": {
-          "version": "1.0.2",
-          "dev": true
+          "version": "1.0.2"
         },
         "forever-agent": {
-          "version": "0.6.1",
-          "dev": true
+          "version": "0.6.1"
         },
         "form-data": {
-          "version": "1.0.0-rc4",
-          "dev": true
+          "version": "1.0.0-rc4"
         },
         "fs.realpath": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "fstream": {
-          "version": "1.0.10",
-          "dev": true
+          "version": "1.0.10"
         },
         "fstream-ignore": {
-          "version": "1.0.5",
-          "dev": true
+          "version": "1.0.5"
         },
         "gauge": {
-          "version": "2.6.0",
-          "dev": true
+          "version": "2.6.0"
         },
         "generate-function": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "generate-object-property": {
-          "version": "1.2.0",
-          "dev": true
+          "version": "1.2.0"
         },
         "getpass": {
           "version": "0.1.6",
-          "dev": true,
           "dependencies": {
             "assert-plus": {
-              "version": "1.0.0",
-              "dev": true
+              "version": "1.0.0"
             }
           }
         },
         "glob": {
-          "version": "7.0.5",
-          "dev": true
+          "version": "7.0.5"
         },
         "graceful-fs": {
-          "version": "4.1.4",
-          "dev": true
+          "version": "4.1.4"
         },
         "graceful-readlink": {
-          "version": "1.0.1",
-          "dev": true
+          "version": "1.0.1"
         },
         "har-validator": {
-          "version": "2.0.6",
-          "dev": true
+          "version": "2.0.6"
         },
         "has-ansi": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "has-color": {
-          "version": "0.1.7",
-          "dev": true
+          "version": "0.1.7"
         },
         "has-unicode": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
         },
         "hawk": {
-          "version": "3.1.3",
-          "dev": true
+          "version": "3.1.3"
         },
         "hoek": {
-          "version": "2.16.3",
-          "dev": true
+          "version": "2.16.3"
         },
         "http-signature": {
-          "version": "1.1.1",
-          "dev": true
+          "version": "1.1.1"
         },
         "inflight": {
-          "version": "1.0.5",
-          "dev": true
+          "version": "1.0.5"
         },
         "inherits": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
         },
         "ini": {
-          "version": "1.3.4",
-          "dev": true
+          "version": "1.3.4"
         },
         "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "is-my-json-valid": {
-          "version": "2.13.1",
-          "dev": true
+          "version": "2.13.1"
         },
         "is-property": {
-          "version": "1.0.2",
-          "dev": true
+          "version": "1.0.2"
         },
         "is-typedarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "isstream": {
-          "version": "0.1.2",
-          "dev": true
+          "version": "0.1.2"
         },
         "jodid25519": {
-          "version": "1.0.2",
-          "dev": true,
-          "optional": true
+          "version": "1.0.2"
         },
         "jsbn": {
-          "version": "0.1.0",
-          "dev": true,
-          "optional": true
+          "version": "0.1.0"
         },
         "json-schema": {
-          "version": "0.2.2",
-          "dev": true
+          "version": "0.2.2"
         },
         "json-stringify-safe": {
-          "version": "5.0.1",
-          "dev": true
+          "version": "5.0.1"
         },
         "jsonpointer": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "jsprim": {
-          "version": "1.3.0",
-          "dev": true
+          "version": "1.3.0"
         },
         "mime-db": {
-          "version": "1.23.0",
-          "dev": true
+          "version": "1.23.0"
         },
         "mime-types": {
-          "version": "2.1.11",
-          "dev": true
+          "version": "2.1.11"
         },
         "minimist": {
-          "version": "0.0.8",
-          "dev": true
+          "version": "0.0.8"
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "dev": true
+          "version": "0.5.1"
         },
         "ms": {
-          "version": "0.7.1",
-          "dev": true
+          "version": "0.7.1"
         },
         "nan": {
-          "version": "2.4.0",
-          "dev": true
+          "version": "2.4.0"
         },
         "node-pre-gyp": {
-          "version": "0.6.29",
-          "dev": true
+          "version": "0.6.29"
         },
         "node-uuid": {
-          "version": "1.4.7",
-          "dev": true
+          "version": "1.4.7"
         },
         "nopt": {
-          "version": "3.0.6",
-          "dev": true
+          "version": "3.0.6"
         },
         "npmlog": {
-          "version": "3.1.2",
-          "dev": true
+          "version": "3.1.2"
         },
         "number-is-nan": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "oauth-sign": {
-          "version": "0.8.2",
-          "dev": true
+          "version": "0.8.2"
         },
         "object-assign": {
-          "version": "4.1.0",
-          "dev": true
+          "version": "4.1.0"
         },
         "once": {
-          "version": "1.3.3",
-          "dev": true
+          "version": "1.3.3"
         },
         "path-is-absolute": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "pinkie": {
-          "version": "2.0.4",
-          "dev": true
+          "version": "2.0.4"
         },
         "pinkie-promise": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
         },
         "process-nextick-args": {
-          "version": "1.0.7",
-          "dev": true
+          "version": "1.0.7"
         },
         "qs": {
-          "version": "6.2.0",
-          "dev": true
+          "version": "6.2.0"
         },
         "rc": {
           "version": "1.1.6",
-          "dev": true,
           "dependencies": {
             "minimist": {
-              "version": "1.2.0",
-              "dev": true
+              "version": "1.2.0"
             }
           }
         },
         "readable-stream": {
-          "version": "2.1.4",
-          "dev": true
+          "version": "2.1.4"
         },
         "request": {
-          "version": "2.73.0",
-          "dev": true
+          "version": "2.73.0"
         },
         "rimraf": {
-          "version": "2.5.3",
-          "dev": true
+          "version": "2.5.3"
         },
         "semver": {
-          "version": "5.2.0",
-          "dev": true
+          "version": "5.2.0"
         },
         "set-blocking": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "signal-exit": {
-          "version": "3.0.0",
-          "dev": true
+          "version": "3.0.0"
         },
         "sntp": {
-          "version": "1.0.9",
-          "dev": true
+          "version": "1.0.9"
         },
         "sshpk": {
           "version": "1.8.3",
-          "dev": true,
           "dependencies": {
             "assert-plus": {
-              "version": "1.0.0",
-              "dev": true
+              "version": "1.0.0"
             }
           }
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "dev": true
+          "version": "0.10.31"
         },
         "string-width": {
-          "version": "1.0.1",
-          "dev": true
+          "version": "1.0.1"
         },
         "stringstream": {
-          "version": "0.0.5",
-          "dev": true
+          "version": "0.0.5"
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "dev": true
+          "version": "3.0.1"
         },
         "strip-json-comments": {
-          "version": "1.0.4",
-          "dev": true
+          "version": "1.0.4"
         },
         "supports-color": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "tar": {
-          "version": "2.2.1",
-          "dev": true
+          "version": "2.2.1"
         },
         "tar-pack": {
-          "version": "3.1.4",
-          "dev": true
+          "version": "3.1.4"
         },
         "tough-cookie": {
-          "version": "2.2.2",
-          "dev": true
+          "version": "2.2.2"
         },
         "tunnel-agent": {
-          "version": "0.4.3",
-          "dev": true
+          "version": "0.4.3"
         },
         "tweetnacl": {
-          "version": "0.13.3",
-          "dev": true,
-          "optional": true
+          "version": "0.13.3"
         },
         "uid-number": {
-          "version": "0.0.6",
-          "dev": true
+          "version": "0.0.6"
         },
         "util-deprecate": {
-          "version": "1.0.2",
-          "dev": true
+          "version": "1.0.2"
         },
         "verror": {
-          "version": "1.3.6",
-          "dev": true
+          "version": "1.3.6"
         },
         "wide-align": {
-          "version": "1.1.0",
-          "dev": true
+          "version": "1.1.0"
         },
         "wrappy": {
-          "version": "1.0.2",
-          "dev": true
+          "version": "1.0.2"
         },
         "xtend": {
-          "version": "4.0.1",
-          "dev": true
+          "version": "4.0.1"
         }
       }
     },
     "fstream": {
-      "version": "0.1.31",
-      "dev": true
+      "version": "0.1.31"
     },
     "fx-runner": {
       "version": "0.0.7",
-      "dev": true,
       "dependencies": {
         "commander": {
-          "version": "2.6.0",
-          "dev": true
+          "version": "2.6.0"
         },
         "lodash": {
-          "version": "2.4.1",
-          "dev": true
+          "version": "2.4.1"
         },
         "when": {
-          "version": "3.6.4",
-          "dev": true
-        }
-      }
-    },
-    "gauge": {
-      "version": "2.7.2",
-      "dev": true,
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "0.2.0",
-          "dev": true
+          "version": "3.6.4"
         }
       }
     },
     "gaze": {
-      "version": "0.5.2",
-      "dev": true
+      "version": "0.5.2"
     },
     "generate-function": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "generate-object-property": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "get-pkg-repo": {
       "version": "1.2.1",
-      "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
-          "version": "2.0.6",
-          "dev": true
+          "version": "2.0.6"
         },
         "through2": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
         }
       }
     },
     "get-stdin": {
-      "version": "4.0.1",
-      "dev": true
+      "version": "4.0.1"
     },
     "getpass": {
       "version": "0.1.6",
-      "dev": true,
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         }
       }
     },
     "git-raw-commits": {
       "version": "1.1.2",
-      "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "lodash.template": {
-          "version": "4.3.0",
-          "dev": true
+          "version": "4.3.0"
         },
         "lodash.templatesettings": {
-          "version": "4.1.0",
-          "dev": true
+          "version": "4.1.0"
         },
         "readable-stream": {
-          "version": "2.0.6",
-          "dev": true
+          "version": "2.0.6"
         },
         "through2": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
         }
       }
     },
     "git-remote-origin-url": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "git-semver-tags": {
-      "version": "1.1.2",
-      "dev": true
+      "version": "1.1.2"
     },
     "gitconfiglocal": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "github-url-from-git": {
-      "version": "1.4.0",
-      "dev": true
+      "version": "1.4.0"
     },
     "glob": {
       "version": "4.5.3",
-      "dev": true,
       "dependencies": {
         "minimatch": {
-          "version": "2.0.10",
-          "dev": true
+          "version": "2.0.10"
         }
       }
     },
     "glob-base": {
-      "version": "0.3.0",
-      "dev": true
+      "version": "0.3.0"
     },
     "glob-parent": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "glob-stream": {
       "version": "3.1.18",
-      "dev": true,
       "dependencies": {
         "minimatch": {
-          "version": "2.0.10",
-          "dev": true
+          "version": "2.0.10"
         }
       }
     },
     "glob-watcher": {
-      "version": "0.0.6",
-      "dev": true
+      "version": "0.0.6"
     },
     "glob2base": {
-      "version": "0.0.12",
-      "dev": true
+      "version": "0.0.12"
     },
     "globby": {
       "version": "5.0.0",
-      "dev": true,
       "dependencies": {
         "glob": {
-          "version": "7.1.1",
-          "dev": true
+          "version": "7.1.1"
         }
       }
     },
     "globule": {
       "version": "0.1.0",
-      "dev": true,
       "dependencies": {
         "glob": {
-          "version": "3.1.21",
-          "dev": true
+          "version": "3.1.21"
         },
         "graceful-fs": {
-          "version": "1.2.3",
-          "dev": true
+          "version": "1.2.3"
         },
         "inherits": {
-          "version": "1.0.2",
-          "dev": true
+          "version": "1.0.2"
         },
         "lodash": {
-          "version": "1.0.2",
-          "dev": true
+          "version": "1.0.2"
         },
         "minimatch": {
           "version": "0.2.14",
-          "dev": true,
           "dependencies": {
             "lru-cache": {
-              "version": "2.7.3",
-              "dev": true
+              "version": "2.7.3"
             },
             "sigmund": {
-              "version": "1.0.1",
-              "dev": true
+              "version": "1.0.1"
             }
           }
         }
       }
     },
     "glogg": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "got": {
       "version": "5.7.1",
-      "dev": true,
       "dependencies": {
         "duplexer2": {
-          "version": "0.1.4",
-          "dev": true
+          "version": "0.1.4"
         },
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
-          "version": "2.2.2",
-          "dev": true
+          "version": "2.2.2"
         }
       }
     },
     "graceful-fs": {
-      "version": "3.0.8",
-      "dev": true
+      "version": "3.0.8"
     },
     "graceful-readlink": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "gulp": {
       "version": "3.9.0",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "ansi-styles": {
-          "version": "2.1.0",
-          "dev": true
+          "version": "2.1.0"
         },
         "chalk": {
-          "version": "1.1.1",
-          "dev": true
+          "version": "1.1.1"
         },
         "has-ansi": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "semver": {
-          "version": "4.3.6",
-          "dev": true
+          "version": "4.3.6"
         },
         "strip-ansi": {
-          "version": "3.0.0",
-          "dev": true
+          "version": "3.0.0"
         },
         "supports-color": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         }
       }
     },
     "gulp-clang-format": {
       "version": "1.0.23",
-      "dev": true,
       "dependencies": {
         "duplexer2": {
-          "version": "0.1.4",
-          "dev": true
+          "version": "0.1.4"
         },
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
           "version": "2.1.4",
-          "dev": true,
           "dependencies": {
             "buffer-shims": {
-              "version": "1.0.0",
-              "dev": true
+              "version": "1.0.0"
             }
           }
         },
         "stream-combiner2": {
-          "version": "1.1.1",
-          "dev": true
+          "version": "1.1.1"
         }
       }
     },
     "gulp-connect": {
       "version": "2.3.1",
-      "dev": true,
       "dependencies": {
         "connect": {
-          "version": "2.30.2",
-          "dev": true
+          "version": "2.30.2"
         }
       }
     },
     "gulp-conventional-changelog": {
       "version": "1.1.0",
-      "dev": true,
       "dependencies": {
         "concat-stream": {
-          "version": "1.5.1",
-          "dev": true
+          "version": "1.5.1"
         },
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
-          "version": "2.0.6",
-          "dev": true
+          "version": "2.0.6"
         },
         "through2": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
         }
       }
     },
     "gulp-diff": {
       "version": "1.0.0",
-      "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
-          "version": "2.0.6",
-          "dev": true
+          "version": "2.0.6"
         },
         "through2": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
+        }
+      }
+    },
+    "gulp-dom": {
+      "version": "0.9.17",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "readable-stream": {
+          "version": "2.0.6"
+        },
+        "through2": {
+          "version": "2.0.1"
+        }
+      }
+    },
+    "gulp-tap": {
+      "version": "0.1.3",
+      "dependencies": {
+        "event-stream": {
+          "version": "3.1.7"
+        },
+        "split": {
+          "version": "0.2.10"
         }
       }
     },
     "gulp-tslint": {
-      "version": "7.0.1",
-      "dev": true
+      "version": "7.0.1"
     },
     "gulp-util": {
       "version": "3.0.7",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "ansi-styles": {
-          "version": "2.1.0",
-          "dev": true
+          "version": "2.1.0"
         },
         "chalk": {
-          "version": "1.1.1",
-          "dev": true
+          "version": "1.1.1"
         },
         "has-ansi": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "object-assign": {
-          "version": "3.0.0",
-          "dev": true
+          "version": "3.0.0"
         },
         "readable-stream": {
-          "version": "2.0.5",
-          "dev": true
+          "version": "2.0.5"
         },
         "strip-ansi": {
-          "version": "3.0.0",
-          "dev": true
+          "version": "3.0.0"
         },
         "supports-color": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "through2": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "vinyl": {
-          "version": "0.5.3",
-          "dev": true
+          "version": "0.5.3"
         }
       }
     },
     "gulplog": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "hammerjs": {
-      "version": "2.0.8",
-      "dev": true
+      "version": "2.0.8"
     },
     "handlebars": {
       "version": "4.0.5",
-      "dev": true,
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "dev": true
+          "version": "1.5.2"
         },
         "source-map": {
           "version": "0.4.4",
-          "dev": true,
           "dependencies": {
             "amdefine": {
-              "version": "1.0.1",
-              "dev": true
+              "version": "1.0.1"
             }
           }
         }
@@ -3715,827 +2911,668 @@
     },
     "har-validator": {
       "version": "2.0.6",
-      "dev": true,
       "dependencies": {
         "is-my-json-valid": {
-          "version": "2.15.0",
-          "dev": true
+          "version": "2.15.0"
         },
         "jsonpointer": {
-          "version": "4.0.0",
-          "dev": true
+          "version": "4.0.0"
         }
       }
     },
     "has-ansi": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "has-binary": {
-      "version": "0.1.7",
-      "dev": true
+      "version": "0.1.7"
     },
     "has-cors": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "has-flag": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "has-gulplog": {
-      "version": "0.1.0",
-      "dev": true
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "0.1.0"
     },
     "hashish": {
-      "version": "0.0.4",
-      "dev": true
+      "version": "0.0.4"
     },
     "hawk": {
-      "version": "3.1.3",
-      "dev": true
+      "version": "3.1.3"
+    },
+    "header-case": {
+      "version": "1.0.0"
     },
     "hoek": {
-      "version": "2.16.3",
-      "dev": true
+      "version": "2.16.3"
     },
     "hosted-git-info": {
-      "version": "2.1.4",
-      "dev": true
+      "version": "2.1.4"
+    },
+    "html-encoding-sniffer": {
+      "version": "1.0.1"
+    },
+    "htmlparser2": {
+      "version": "3.9.2",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "readable-stream": {
+          "version": "2.2.2"
+        }
+      }
     },
     "http-browserify": {
-      "version": "1.7.0",
-      "dev": true
+      "version": "1.7.0"
     },
     "http-errors": {
-      "version": "1.3.1",
-      "dev": true
+      "version": "1.3.1"
     },
     "http-proxy": {
-      "version": "1.13.3",
-      "dev": true
+      "version": "1.13.3"
     },
     "http-signature": {
       "version": "1.1.1",
-      "dev": true,
       "dependencies": {
         "assert-plus": {
-          "version": "0.2.0",
-          "dev": true
+          "version": "0.2.0"
         }
       }
     },
     "https-browserify": {
-      "version": "0.0.0",
-      "dev": true
+      "version": "0.0.0"
     },
     "https-proxy-agent": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "iconv-lite": {
-      "version": "0.4.11",
-      "dev": true
+      "version": "0.4.11"
     },
     "ieee754": {
-      "version": "1.1.8",
-      "dev": true
+      "version": "1.1.8"
     },
     "imurmurhash": {
-      "version": "0.1.4",
-      "dev": true
+      "version": "0.1.4"
     },
     "incremental-dom": {
-      "version": "0.4.1",
-      "dev": true
+      "version": "0.4.1"
     },
     "indent-string": {
-      "version": "2.1.0",
-      "dev": true
+      "version": "2.1.0"
     },
     "indexof": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "0.0.1"
     },
     "inflight": {
-      "version": "1.0.5",
-      "dev": true
+      "version": "1.0.5"
     },
     "inherits": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.1"
     },
     "ini": {
-      "version": "1.3.4",
-      "dev": true
-    },
-    "inquirer": {
-      "version": "1.2.3",
-      "dev": true,
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "dev": true
-        },
-        "mute-stream": {
-          "version": "0.0.6",
-          "dev": true
-        }
-      }
+      "version": "1.3.4"
     },
     "interpret": {
-      "version": "0.6.6",
-      "dev": true
-    },
-    "invariant": {
-      "version": "2.2.2",
-      "dev": true
+      "version": "0.6.6"
     },
     "invert-kv": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "is-arrayish": {
-      "version": "0.2.1",
-      "dev": true
+      "version": "0.2.1"
     },
     "is-binary-path": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "is-buffer": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "is-builtin-module": {
-      "version": "1.0.0",
-      "dev": true
-    },
-    "is-ci": {
-      "version": "1.0.10",
-      "dev": true
+      "version": "1.0.0"
     },
     "is-dotfile": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "is-equal-shallow": {
-      "version": "0.1.3",
-      "dev": true
+      "version": "0.1.3"
     },
     "is-extendable": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
     },
     "is-extglob": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "is-finite": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "is-glob": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.1"
+    },
+    "is-lower-case": {
+      "version": "1.1.3"
     },
     "is-my-json-valid": {
-      "version": "2.12.3",
-      "dev": true
+      "version": "2.12.3"
     },
     "is-npm": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "is-number": {
-      "version": "2.1.0",
-      "dev": true
+      "version": "2.1.0"
     },
     "is-obj": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "is-path-cwd": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "is-primitive": {
-      "version": "2.0.0",
-      "dev": true
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "is-property": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "is-redirect": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "is-retry-allowed": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "is-stream": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "is-subset": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
     },
     "is-text-path": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "is-typedarray": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
+    },
+    "is-upper-case": {
+      "version": "1.1.2"
     },
     "is-utf8": {
-      "version": "0.2.1",
-      "dev": true
+      "version": "0.2.1"
     },
     "isarray": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "0.0.1"
     },
     "isbinaryfile": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "isexe": {
-      "version": "1.1.2",
-      "dev": true
+      "version": "1.1.2"
     },
     "isobject": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "isstream": {
-      "version": "0.1.2",
-      "dev": true
+      "version": "0.1.2"
     },
     "jasmine": {
       "version": "2.4.1",
-      "dev": true,
       "dependencies": {
         "glob": {
-          "version": "3.2.11",
-          "dev": true
+          "version": "3.2.11"
         },
         "jasmine-core": {
-          "version": "2.4.1",
-          "dev": true
+          "version": "2.4.1"
         },
         "minimatch": {
-          "version": "0.3.0",
-          "dev": true
+          "version": "0.3.0"
         }
       }
     },
     "jasmine-core": {
-      "version": "2.3.4",
-      "dev": true
+      "version": "2.3.4"
     },
     "jasminewd2": {
-      "version": "0.0.10",
-      "dev": true
+      "version": "0.0.10"
     },
     "jetpack-id": {
-      "version": "0.0.4",
-      "dev": true
+      "version": "0.0.4"
     },
     "jetpack-validation": {
       "version": "0.0.4",
-      "dev": true,
       "dependencies": {
         "resolve": {
-          "version": "0.7.4",
-          "dev": true
+          "version": "0.7.4"
         },
         "semver": {
-          "version": "2.3.2",
-          "dev": true
+          "version": "2.3.2"
         }
       }
     },
     "jodid25519": {
-      "version": "1.0.2",
-      "dev": true,
-      "optional": true
+      "version": "1.0.2"
     },
     "jpm": {
       "version": "1.0.0",
-      "dev": true,
       "dependencies": {
         "async": {
-          "version": "0.9.2",
-          "dev": true
+          "version": "0.9.2"
         },
         "commander": {
-          "version": "2.6.0",
-          "dev": true
+          "version": "2.6.0"
         },
         "firefox-profile": {
           "version": "0.3.9",
-          "dev": true,
           "dependencies": {
             "lodash": {
-              "version": "3.5.0",
-              "dev": true
+              "version": "3.5.0"
             }
           }
         },
         "fs-extra": {
-          "version": "0.16.4",
-          "dev": true
+          "version": "0.16.4"
         },
         "lodash": {
-          "version": "3.3.1",
-          "dev": true
+          "version": "3.3.1"
         },
         "minimatch": {
-          "version": "2.0.4",
-          "dev": true
+          "version": "2.0.4"
         },
         "open": {
-          "version": "0.0.5",
-          "dev": true
+          "version": "0.0.5"
         },
         "semver": {
-          "version": "4.3.3",
-          "dev": true
+          "version": "4.3.3"
         }
       }
     },
     "jpm-core": {
-      "version": "0.0.9",
-      "dev": true
+      "version": "0.0.9"
     },
     "js-tokens": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "jsbn": {
-      "version": "0.1.0",
-      "dev": true,
-      "optional": true
+      "version": "0.1.0"
+    },
+    "jsdom": {
+      "version": "9.8.3",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0"
+        },
+        "iconv-lite": {
+          "version": "0.4.15"
+        },
+        "mime-db": {
+          "version": "1.26.0"
+        },
+        "mime-types": {
+          "version": "2.1.14"
+        },
+        "parse5": {
+          "version": "1.5.1"
+        },
+        "qs": {
+          "version": "6.3.0"
+        },
+        "request": {
+          "version": "2.79.0"
+        },
+        "tough-cookie": {
+          "version": "2.3.2"
+        },
+        "uuid": {
+          "version": "3.0.1"
+        }
+      }
     },
     "json-schema": {
-      "version": "0.2.3",
-      "dev": true
+      "version": "0.2.3"
     },
     "json-stringify-safe": {
-      "version": "5.0.1",
-      "dev": true
+      "version": "5.0.1"
     },
     "json3": {
-      "version": "3.2.6",
-      "dev": true
+      "version": "3.2.6"
     },
     "json5": {
-      "version": "0.4.0",
-      "dev": true
+      "version": "0.4.0"
     },
     "jsonfile": {
-      "version": "2.2.3",
-      "dev": true
+      "version": "2.2.3"
     },
     "jsonparse": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "jsonpointer": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "JSONStream": {
-      "version": "1.0.7",
-      "dev": true
+      "version": "1.0.7"
     },
     "jsontoxml": {
-      "version": "0.0.11",
-      "dev": true
+      "version": "0.0.11"
     },
     "jsprim": {
-      "version": "1.3.1",
-      "dev": true
+      "version": "1.3.1"
     },
     "jstransform": {
       "version": "10.1.0",
-      "dev": true,
       "dependencies": {
         "esprima-fb": {
-          "version": "13001.1001.0-dev-harmony-fb",
-          "dev": true
+          "version": "13001.1001.0-dev-harmony-fb"
         },
         "source-map": {
           "version": "0.1.31",
-          "dev": true,
           "dependencies": {
             "amdefine": {
-              "version": "1.0.1",
-              "dev": true
+              "version": "1.0.1"
             }
           }
         }
       }
     },
     "jszip": {
-      "version": "2.5.0",
-      "dev": true
+      "version": "2.5.0"
     },
     "karma": {
       "version": "0.13.20",
-      "dev": true,
       "dependencies": {
         "batch": {
-          "version": "0.5.3",
-          "dev": true
+          "version": "0.5.3"
         },
         "glob": {
-          "version": "7.0.3",
-          "dev": true
+          "version": "7.0.3"
         },
         "graceful-fs": {
-          "version": "4.1.4",
-          "dev": true
+          "version": "4.1.4"
         },
         "source-map": {
-          "version": "0.5.6",
-          "dev": true
+          "version": "0.5.6"
         }
       }
     },
     "karma-browserstack-launcher": {
-      "version": "0.1.9",
-      "dev": true
+      "version": "0.1.9"
     },
     "karma-chrome-launcher": {
-      "version": "0.2.2",
-      "dev": true
+      "version": "0.2.2"
     },
     "karma-jasmine": {
-      "version": "0.3.6",
-      "dev": true
+      "version": "0.3.6"
     },
     "karma-sauce-launcher": {
-      "version": "0.3.0",
-      "dev": true
+      "version": "0.3.0"
     },
     "karma-sourcemap-loader": {
-      "version": "0.3.6",
-      "dev": true
+      "version": "0.3.6"
     },
     "kind-of": {
-      "version": "3.0.2",
-      "dev": true
+      "version": "3.0.2"
     },
     "klaw": {
-      "version": "1.1.3",
-      "dev": true
+      "version": "1.1.3"
     },
     "latest-version": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "lazy-cache": {
-      "version": "0.2.7",
-      "dev": true
+      "version": "0.2.7"
     },
     "lazy-req": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "lazystream": {
       "version": "0.1.0",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.33",
-          "dev": true
+          "version": "1.0.33"
         }
       }
     },
     "lcid": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
-    "leven": {
-      "version": "2.0.0",
-      "dev": true
+    "levn": {
+      "version": "0.3.0"
     },
     "liftoff": {
       "version": "2.2.0",
-      "dev": true,
       "dependencies": {
         "extend": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
         },
         "findup-sync": {
-          "version": "0.3.0",
-          "dev": true
+          "version": "0.3.0"
         },
         "glob": {
-          "version": "5.0.15",
-          "dev": true
+          "version": "5.0.15"
         }
       }
     },
     "livereload-js": {
-      "version": "2.2.2",
-      "dev": true
+      "version": "2.2.2"
     },
     "load-json-file": {
       "version": "1.1.0",
-      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2",
-          "dev": true
+          "version": "4.1.2"
         }
       }
     },
     "loader-utils": {
-      "version": "0.2.12",
-      "dev": true
+      "version": "0.2.12"
     },
     "lodash": {
-      "version": "3.10.1",
-      "dev": true
+      "version": "3.10.1"
     },
     "lodash._basecopy": {
-      "version": "3.0.1",
-      "dev": true
+      "version": "3.0.1"
     },
     "lodash._basetostring": {
-      "version": "3.0.1",
-      "dev": true
+      "version": "3.0.1"
     },
     "lodash._basevalues": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "lodash._getnative": {
-      "version": "3.9.1",
-      "dev": true
+      "version": "3.9.1"
     },
     "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "dev": true
+      "version": "3.0.9"
     },
     "lodash._reescape": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "lodash._reevaluate": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "lodash.escape": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "lodash.isarguments": {
-      "version": "3.0.4",
-      "dev": true
+      "version": "3.0.4"
     },
     "lodash.isarray": {
-      "version": "3.0.4",
-      "dev": true
+      "version": "3.0.4"
     },
     "lodash.keys": {
-      "version": "3.1.2",
-      "dev": true
+      "version": "3.1.2"
     },
     "lodash.restparam": {
-      "version": "3.6.1",
-      "dev": true
+      "version": "3.6.1"
     },
     "lodash.template": {
-      "version": "3.6.2",
-      "dev": true
+      "version": "3.6.2"
     },
     "lodash.templatesettings": {
-      "version": "3.1.0",
-      "dev": true
+      "version": "3.1.0"
     },
     "log4js": {
       "version": "0.6.36",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.34",
-          "dev": true
+          "version": "1.0.34"
         },
         "semver": {
-          "version": "4.3.6",
-          "dev": true
+          "version": "4.3.6"
         }
       }
     },
     "longest": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "loose-envify": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "loud-rejection": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
+    },
+    "lower-case": {
+      "version": "1.1.3"
+    },
+    "lower-case-first": {
+      "version": "1.0.2"
     },
     "lowercase-keys": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "lru-cache": {
-      "version": "2.7.3",
-      "dev": true
+      "version": "2.7.3"
     },
     "lru-queue": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "madge": {
       "version": "0.5.0",
-      "dev": true,
       "dependencies": {
         "amdetective": {
           "version": "0.0.2",
-          "dev": true,
           "dependencies": {
             "esprima": {
-              "version": "1.2.2",
-              "dev": true
+              "version": "1.2.2"
             }
           }
         },
         "coffee-script": {
-          "version": "1.3.3",
-          "dev": true
+          "version": "1.3.3"
         },
         "colors": {
-          "version": "0.6.0-1",
-          "dev": true
+          "version": "0.6.0-1"
         },
         "commander": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "commondir": {
-          "version": "0.0.1",
-          "dev": true
+          "version": "0.0.1"
         },
         "detective": {
-          "version": "0.1.1",
-          "dev": true
+          "version": "0.1.1"
         },
         "detective-es6": {
-          "version": "1.1.0",
-          "dev": true
+          "version": "1.1.0"
         },
         "graphviz": {
           "version": "0.0.7",
-          "dev": true,
           "dependencies": {
             "temp": {
-              "version": "0.4.0",
-              "dev": true
+              "version": "0.4.0"
             }
           }
         },
         "react-tools": {
           "version": "0.12.1",
-          "dev": true,
           "dependencies": {
             "commoner": {
               "version": "0.10.1",
-              "dev": true,
               "dependencies": {
                 "commander": {
-                  "version": "2.5.1",
-                  "dev": true
+                  "version": "2.5.1"
                 },
                 "glob": {
                   "version": "4.2.2",
-                  "dev": true,
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "dev": true,
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "dev": true
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "dev": true
+                      "version": "2.0.1"
                     },
                     "minimatch": {
                       "version": "1.0.0",
-                      "dev": true,
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.5.0",
-                          "dev": true
+                          "version": "2.5.0"
                         },
                         "sigmund": {
-                          "version": "1.0.0",
-                          "dev": true
+                          "version": "1.0.0"
                         }
                       }
                     },
                     "once": {
                       "version": "1.3.1",
-                      "dev": true,
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "dev": true
+                          "version": "1.0.1"
                         }
                       }
                     }
                   }
                 },
                 "graceful-fs": {
-                  "version": "3.0.5",
-                  "dev": true
+                  "version": "3.0.5"
                 },
                 "iconv-lite": {
-                  "version": "0.4.5",
-                  "dev": true
+                  "version": "0.4.5"
                 },
                 "install": {
-                  "version": "0.1.8",
-                  "dev": true
+                  "version": "0.1.8"
                 },
                 "mkdirp": {
                   "version": "0.5.0",
-                  "dev": true,
                   "dependencies": {
                     "minimist": {
-                      "version": "0.0.8",
-                      "dev": true
+                      "version": "0.0.8"
                     }
                   }
                 },
                 "private": {
-                  "version": "0.1.6",
-                  "dev": true
+                  "version": "0.1.6"
                 },
                 "q": {
-                  "version": "1.1.2",
-                  "dev": true
+                  "version": "1.1.2"
                 },
                 "recast": {
                   "version": "0.9.11",
-                  "dev": true,
                   "dependencies": {
                     "ast-types": {
-                      "version": "0.6.7",
-                      "dev": true
+                      "version": "0.6.7"
                     },
                     "esprima-fb": {
-                      "version": "8001.1001.0-dev-harmony-fb",
-                      "dev": true
+                      "version": "8001.1001.0-dev-harmony-fb"
                     },
                     "source-map": {
                       "version": "0.1.41",
-                      "dev": true,
                       "dependencies": {
                         "amdefine": {
-                          "version": "0.1.0",
-                          "dev": true
+                          "version": "0.1.0"
                         }
                       }
                     }
@@ -4545,23 +3582,18 @@
             },
             "jstransform": {
               "version": "8.2.0",
-              "dev": true,
               "dependencies": {
                 "base62": {
-                  "version": "0.1.1",
-                  "dev": true
+                  "version": "0.1.1"
                 },
                 "esprima-fb": {
-                  "version": "8001.1001.0-dev-harmony-fb",
-                  "dev": true
+                  "version": "8001.1001.0-dev-harmony-fb"
                 },
                 "source-map": {
                   "version": "0.1.31",
-                  "dev": true,
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.0",
-                      "dev": true
+                      "version": "0.1.0"
                     }
                   }
                 }
@@ -4570,1042 +3602,799 @@
           }
         },
         "resolve": {
-          "version": "0.2.3",
-          "dev": true
+          "version": "0.2.3"
         },
         "uglify-js": {
-          "version": "1.2.6",
-          "dev": true
+          "version": "1.2.6"
         },
         "walkdir": {
-          "version": "0.0.5",
-          "dev": true
+          "version": "0.0.5"
         }
       }
     },
     "magic-string": {
-      "version": "0.16.0",
-      "dev": true
+      "version": "0.16.0"
     },
     "map-obj": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "map-stream": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
+    },
+    "marked": {
+      "version": "0.3.6"
     },
     "match-stream": {
       "version": "0.0.2",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.33",
-          "dev": true
+          "version": "1.0.33"
         }
       }
     },
     "media-typer": {
-      "version": "0.3.0",
-      "dev": true
+      "version": "0.3.0"
     },
     "memoizeasync": {
       "version": "0.8.0",
-      "dev": true,
       "dependencies": {
         "lru-cache": {
-          "version": "2.5.0",
-          "dev": true
+          "version": "2.5.0"
         },
         "passerror": {
-          "version": "0.0.2",
-          "dev": true
+          "version": "0.0.2"
         }
       }
     },
     "memoizee": {
-      "version": "0.3.10",
-      "dev": true
+      "version": "0.3.10"
     },
     "memory-fs": {
       "version": "0.3.0",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "2.0.5",
-          "dev": true
+          "version": "2.0.5"
         }
       }
     },
     "meow": {
-      "version": "3.6.0",
-      "dev": true
+      "version": "3.6.0"
     },
     "method-override": {
-      "version": "2.3.5",
-      "dev": true
+      "version": "2.3.5"
     },
     "methods": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "micromatch": {
-      "version": "2.3.7",
-      "dev": true
+      "version": "2.3.7"
     },
     "mime": {
-      "version": "1.3.4",
-      "dev": true
+      "version": "1.3.4"
     },
     "mime-db": {
-      "version": "1.12.0",
-      "dev": true
+      "version": "1.12.0"
     },
     "mime-types": {
-      "version": "2.0.14",
-      "dev": true
+      "version": "2.0.14"
     },
     "minimatch": {
-      "version": "3.0.3",
-      "dev": true
+      "version": "3.0.3"
     },
     "minimist": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "mkdirp": {
       "version": "0.5.1",
-      "dev": true,
       "dependencies": {
         "minimist": {
-          "version": "0.0.8",
-          "dev": true
+          "version": "0.0.8"
         }
       }
+    },
+    "mkdirp-promise": {
+      "version": "5.0.0"
     },
     "modify-values": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "morgan": {
-      "version": "1.6.1",
-      "dev": true
+      "version": "1.6.1"
     },
     "mozilla-toolkit-versioning": {
-      "version": "0.0.2",
-      "dev": true
+      "version": "0.0.2"
     },
     "mozilla-version-comparator": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "ms": {
-      "version": "0.7.1",
-      "dev": true
+      "version": "0.7.1"
     },
     "multiparty": {
-      "version": "3.3.2",
-      "dev": true
+      "version": "3.3.2"
     },
     "multipipe": {
-      "version": "0.1.2",
-      "dev": true
+      "version": "0.1.2"
     },
     "mute-stream": {
-      "version": "0.0.5",
-      "dev": true
+      "version": "0.0.5"
     },
     "nan": {
-      "version": "2.4.0",
-      "dev": true
+      "version": "2.4.0"
     },
     "negotiator": {
-      "version": "0.5.3",
-      "dev": true
+      "version": "0.5.3"
     },
     "next-tick": {
-      "version": "0.2.2",
-      "dev": true
+      "version": "0.2.2"
     },
-    "node-emoji": {
-      "version": "1.5.1",
-      "dev": true
+    "no-case": {
+      "version": "2.3.1"
     },
-    "node-gyp": {
-      "version": "3.5.0",
-      "dev": true,
+    "node-html-encoder": {
+      "version": "0.0.2"
+    },
+    "node-int64": {
+      "version": "0.3.3"
+    },
+    "node-libs-browser": {
+      "version": "0.6.0"
+    },
+    "node-source-walk": {
+      "version": "1.4.2"
+    },
+    "node-status-codes": {
+      "version": "1.0.0"
+    },
+    "node-uuid": {
+      "version": "1.4.7"
+    },
+    "node-watch": {
+      "version": "0.3.4"
+    },
+    "normalize-package-data": {
+      "version": "2.3.5"
+    },
+    "normalize-path": {
+      "version": "2.0.1"
+    },
+    "null-check": {
+      "version": "1.0.0"
+    },
+    "number-is-nan": {
+      "version": "1.0.0"
+    },
+    "nunjucks": {
+      "version": "2.5.2",
       "dependencies": {
-        "fstream": {
-          "version": "1.0.10",
-          "dev": true
+        "async-each": {
+          "version": "1.0.1"
         },
-        "glob": {
-          "version": "7.1.1",
-          "dev": true
+        "chokidar": {
+          "version": "1.6.1"
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "dev": true
+        "yargs": {
+          "version": "3.32.0"
         }
       }
     },
-    "node-int64": {
-      "version": "0.3.3",
-      "dev": true
-    },
-    "node-libs-browser": {
-      "version": "0.6.0",
-      "dev": true
-    },
-    "node-source-walk": {
-      "version": "1.4.2",
-      "dev": true
-    },
-    "node-status-codes": {
-      "version": "1.0.0",
-      "dev": true
-    },
-    "node-uuid": {
-      "version": "1.4.7",
-      "dev": true
-    },
-    "node-watch": {
-      "version": "0.3.4",
-      "dev": true
-    },
-    "nopt": {
-      "version": "3.0.6",
-      "dev": true
-    },
-    "normalize-package-data": {
-      "version": "2.3.5",
-      "dev": true
-    },
-    "normalize-path": {
-      "version": "2.0.1",
-      "dev": true
-    },
-    "npmlog": {
-      "version": "4.0.2",
-      "dev": true
-    },
-    "null-check": {
-      "version": "1.0.0",
-      "dev": true
-    },
-    "number-is-nan": {
-      "version": "1.0.0",
-      "dev": true
+    "nwmatcher": {
+      "version": "1.3.9"
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "dev": true
+      "version": "0.8.2"
     },
     "object-assign": {
-      "version": "4.0.1",
-      "dev": true
+      "version": "4.0.1"
     },
     "object-component": {
-      "version": "0.0.3",
-      "dev": true
-    },
-    "object-path": {
-      "version": "0.11.3",
-      "dev": true
+      "version": "0.0.3"
     },
     "object.omit": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "on-finished": {
-      "version": "2.3.0",
-      "dev": true
+      "version": "2.3.0"
     },
     "on-headers": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "once": {
-      "version": "1.3.3",
-      "dev": true
-    },
-    "onetime": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.3.3"
     },
     "optimist": {
       "version": "0.6.1",
-      "dev": true,
       "dependencies": {
         "minimist": {
-          "version": "0.0.10",
-          "dev": true
+          "version": "0.0.10"
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0"
         }
       }
     },
     "options": {
-      "version": "0.0.6",
-      "dev": true
+      "version": "0.0.6"
     },
     "orchestrator": {
       "version": "0.3.7",
-      "dev": true,
       "dependencies": {
         "end-of-stream": {
-          "version": "0.1.5",
-          "dev": true
+          "version": "0.1.5"
         }
       }
     },
     "ordered-read-streams": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "os-browserify": {
-      "version": "0.1.2",
-      "dev": true
+      "version": "0.1.2"
     },
     "os-homedir": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "os-locale": {
-      "version": "1.4.0",
-      "dev": true
-    },
-    "os-shim": {
-      "version": "0.1.3",
-      "dev": true
+      "version": "1.4.0"
     },
     "os-tmpdir": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "osenv": {
-      "version": "0.1.3",
-      "dev": true
+      "version": "0.1.3"
     },
     "over": {
-      "version": "0.0.5",
-      "dev": true
+      "version": "0.0.5"
     },
     "package-json": {
-      "version": "2.4.0",
-      "dev": true
+      "version": "2.4.0"
     },
     "pako": {
-      "version": "0.2.8",
-      "dev": true
+      "version": "0.2.8"
+    },
+    "param-case": {
+      "version": "2.1.0"
     },
     "parse-github-repo-url": {
-      "version": "1.3.0",
-      "dev": true
+      "version": "1.3.0"
     },
     "parse-glob": {
-      "version": "3.0.4",
-      "dev": true
+      "version": "3.0.4"
     },
     "parse-json": {
-      "version": "2.2.0",
-      "dev": true
+      "version": "2.2.0"
     },
     "parse5": {
-      "version": "2.2.1",
-      "dev": true
+      "version": "2.2.1"
     },
     "parsejson": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "0.0.1"
     },
     "parseqs": {
-      "version": "0.0.2",
-      "dev": true
+      "version": "0.0.2"
     },
     "parseuri": {
-      "version": "0.0.4",
-      "dev": true
+      "version": "0.0.4"
     },
     "parseurl": {
-      "version": "1.3.0",
-      "dev": true
+      "version": "1.3.0"
+    },
+    "pascal-case": {
+      "version": "2.0.0"
     },
     "passerror": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "0.0.1"
     },
     "path-browserify": {
-      "version": "0.0.0",
-      "dev": true
+      "version": "0.0.0"
+    },
+    "path-case": {
+      "version": "2.1.0"
     },
     "path-exists": {
-      "version": "2.1.0",
-      "dev": true
+      "version": "2.1.0"
     },
     "path-is-absolute": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "path-is-inside": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "path-type": {
       "version": "1.1.0",
-      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2",
-          "dev": true
+          "version": "4.1.2"
         }
       }
     },
     "pause": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "pause-stream": {
-      "version": "0.0.11",
-      "dev": true
+      "version": "0.0.11"
     },
     "pbkdf2-compat": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.1"
     },
     "pegjs": {
-      "version": "0.9.0",
-      "dev": true
+      "version": "0.9.0"
     },
     "pify": {
-      "version": "2.3.0",
-      "dev": true
+      "version": "2.3.0"
     },
     "pinkie": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.1"
     },
     "pinkie-promise": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "pkginfo": {
-      "version": "0.3.1",
-      "dev": true
+      "version": "0.3.1"
+    },
+    "prelude-ls": {
+      "version": "1.1.2"
     },
     "prepend-http": {
-      "version": "1.0.4",
-      "dev": true
+      "version": "1.0.4"
     },
     "preserve": {
-      "version": "0.2.0",
-      "dev": true
+      "version": "0.2.0"
     },
     "pretty-hrtime": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "process": {
-      "version": "0.11.9",
-      "dev": true
+      "version": "0.11.9"
     },
     "process-nextick-args": {
-      "version": "1.0.6",
-      "dev": true
+      "version": "1.0.6"
     },
     "promise": {
-      "version": "7.1.1",
-      "dev": true
+      "version": "7.1.1"
     },
     "promzard": {
-      "version": "0.3.0",
-      "dev": true
-    },
-    "proper-lockfile": {
-      "version": "2.0.0",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "dev": true
-        }
-      }
+      "version": "0.3.0"
     },
     "protractor": {
       "version": "4.0.11",
-      "dev": true,
       "dependencies": {
         "@types/jasmine": {
-          "version": "2.5.37",
-          "dev": true
+          "version": "2.5.37"
         },
         "@types/node": {
-          "version": "6.0.46",
-          "dev": true
+          "version": "6.0.46"
         },
         "glob": {
-          "version": "7.1.1",
-          "dev": true
+          "version": "7.1.1"
         },
         "mime-db": {
-          "version": "1.24.0",
-          "dev": true
+          "version": "1.24.0"
         },
         "mime-types": {
-          "version": "2.1.12",
-          "dev": true
+          "version": "2.1.12"
         },
         "qs": {
-          "version": "6.3.0",
-          "dev": true
+          "version": "6.3.0"
         },
         "request": {
-          "version": "2.78.0",
-          "dev": true
+          "version": "2.78.0"
         },
         "rimraf": {
-          "version": "2.5.4",
-          "dev": true
+          "version": "2.5.4"
         },
         "saucelabs": {
-          "version": "1.3.0",
-          "dev": true
+          "version": "1.3.0"
         },
         "semver": {
-          "version": "5.3.0",
-          "dev": true
+          "version": "5.3.0"
         },
         "tough-cookie": {
-          "version": "2.3.2",
-          "dev": true
+          "version": "2.3.2"
         },
         "webdriver-manager": {
-          "version": "10.2.8",
-          "dev": true
+          "version": "10.2.8"
         }
       }
     },
     "prr": {
-      "version": "0.0.0",
-      "dev": true
+      "version": "0.0.0"
     },
     "pullstream": {
       "version": "0.4.1",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.33",
-          "dev": true
+          "version": "1.0.33"
         }
       }
     },
     "punycode": {
-      "version": "1.4.1",
-      "dev": true
+      "version": "1.4.1"
     },
     "q": {
-      "version": "1.4.1",
-      "dev": true
+      "version": "1.4.1"
     },
     "qs": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
     },
     "querystring": {
-      "version": "0.2.0",
-      "dev": true
+      "version": "0.2.0"
     },
     "querystring-es3": {
-      "version": "0.2.1",
-      "dev": true
+      "version": "0.2.1"
     },
     "randomatic": {
-      "version": "1.1.5",
-      "dev": true
+      "version": "1.1.5"
     },
     "range-parser": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
     },
     "raw-body": {
       "version": "2.1.5",
-      "dev": true,
       "dependencies": {
         "bytes": {
-          "version": "2.2.0",
-          "dev": true
+          "version": "2.2.0"
         },
         "iconv-lite": {
-          "version": "0.4.13",
-          "dev": true
+          "version": "0.4.13"
         }
       }
     },
     "rc": {
-      "version": "1.1.6",
-      "dev": true
+      "version": "1.1.6"
     },
     "react": {
-      "version": "0.14.5",
-      "dev": true
+      "version": "0.14.5"
     },
     "read": {
-      "version": "1.0.5",
-      "dev": true
+      "version": "1.0.5"
     },
     "read-all-stream": {
       "version": "3.1.0",
-      "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
-          "version": "2.2.2",
-          "dev": true
+          "version": "2.2.2"
         }
       }
     },
     "read-pkg": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
     },
     "read-pkg-up": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "readable-stream": {
-      "version": "1.1.13",
-      "dev": true
+      "version": "1.1.13"
     },
     "readdirp": {
       "version": "2.0.0",
-      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.2",
-          "dev": true
+          "version": "4.1.2"
         },
         "minimatch": {
-          "version": "2.0.10",
-          "dev": true
+          "version": "2.0.10"
         },
         "readable-stream": {
-          "version": "2.0.5",
-          "dev": true
+          "version": "2.0.5"
         }
       }
     },
     "rechoir": {
-      "version": "0.6.2",
-      "dev": true
+      "version": "0.6.2"
     },
     "redent": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "reflect-metadata": {
       "version": "0.1.3"
     },
-    "regenerator-runtime": {
-      "version": "0.10.1",
-      "dev": true
-    },
     "regex-cache": {
-      "version": "0.4.2",
-      "dev": true
+      "version": "0.4.2"
     },
     "registry-auth-token": {
-      "version": "3.1.0",
-      "dev": true
+      "version": "3.1.0"
     },
     "registry-url": {
-      "version": "3.1.0",
-      "dev": true
+      "version": "3.1.0"
     },
     "repeat-element": {
-      "version": "1.1.2",
-      "dev": true
+      "version": "1.1.2"
     },
     "repeat-string": {
-      "version": "1.5.2",
-      "dev": true
+      "version": "1.5.2"
     },
     "repeating": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "replace-ext": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "0.0.1"
     },
     "request": {
       "version": "2.51.0",
-      "dev": true,
       "dependencies": {
         "asn1": {
-          "version": "0.1.11",
-          "dev": true
+          "version": "0.1.11"
         },
         "async": {
-          "version": "0.9.2",
-          "dev": true
+          "version": "0.9.2"
         },
         "aws-sign2": {
-          "version": "0.5.0",
-          "dev": true
+          "version": "0.5.0"
         },
         "boom": {
-          "version": "0.4.2",
-          "dev": true
+          "version": "0.4.2"
         },
         "caseless": {
-          "version": "0.8.0",
-          "dev": true
+          "version": "0.8.0"
         },
         "combined-stream": {
-          "version": "0.0.7",
-          "dev": true
+          "version": "0.0.7"
         },
         "cryptiles": {
-          "version": "0.2.2",
-          "dev": true
+          "version": "0.2.2"
         },
         "delayed-stream": {
-          "version": "0.0.5",
-          "dev": true
+          "version": "0.0.5"
         },
         "forever-agent": {
-          "version": "0.5.2",
-          "dev": true
+          "version": "0.5.2"
         },
         "form-data": {
           "version": "0.2.0",
-          "dev": true,
           "dependencies": {
             "mime-types": {
-              "version": "2.0.14",
-              "dev": true
+              "version": "2.0.14"
             }
           }
         },
         "hawk": {
-          "version": "1.1.1",
-          "dev": true
+          "version": "1.1.1"
         },
         "hoek": {
-          "version": "0.9.1",
-          "dev": true
+          "version": "0.9.1"
         },
         "http-signature": {
-          "version": "0.10.1",
-          "dev": true
+          "version": "0.10.1"
         },
         "mime-types": {
-          "version": "1.0.2",
-          "dev": true
+          "version": "1.0.2"
         },
         "oauth-sign": {
-          "version": "0.5.0",
-          "dev": true
+          "version": "0.5.0"
         },
         "qs": {
-          "version": "2.3.3",
-          "dev": true
+          "version": "2.3.3"
         },
         "sntp": {
-          "version": "0.2.4",
-          "dev": true
+          "version": "0.2.4"
         }
       }
     },
-    "request-capture-har": {
-      "version": "1.1.4",
-      "dev": true
-    },
     "requires-port": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "resolve": {
-      "version": "1.1.6",
-      "dev": true
+      "version": "1.1.6"
     },
     "response-time": {
-      "version": "2.3.1",
-      "dev": true
-    },
-    "restore-cursor": {
-      "version": "1.0.1",
-      "dev": true
-    },
-    "retry": {
-      "version": "0.10.1",
-      "dev": true
+      "version": "2.3.1"
     },
     "rewire": {
-      "version": "2.5.1",
-      "dev": true
+      "version": "2.5.1"
     },
     "right-align": {
-      "version": "0.1.3",
-      "dev": true
+      "version": "0.1.3"
     },
     "rimraf": {
       "version": "2.5.0",
-      "dev": true,
       "dependencies": {
         "glob": {
-          "version": "6.0.3",
-          "dev": true
+          "version": "6.0.3"
         }
       }
     },
     "ripemd160": {
-      "version": "0.2.0",
-      "dev": true
+      "version": "0.2.0"
     },
     "rndm": {
-      "version": "1.1.1",
-      "dev": true
-    },
-    "roadrunner": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.1"
     },
     "rollup": {
       "version": "0.26.3",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "ansi-styles": {
-          "version": "2.2.1",
-          "dev": true
+          "version": "2.2.1"
         },
         "chalk": {
-          "version": "1.1.3",
-          "dev": true
+          "version": "1.1.3"
         },
         "has-ansi": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "source-map": {
           "version": "0.1.32",
-          "dev": true,
           "dependencies": {
             "amdefine": {
-              "version": "1.0.1",
-              "dev": true
+              "version": "1.0.1"
             }
           }
         },
         "source-map-support": {
-          "version": "0.4.0",
-          "dev": true
+          "version": "0.4.0"
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "dev": true
+          "version": "3.0.1"
         },
         "supports-color": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         }
       }
     },
     "rollup-plugin-commonjs": {
       "version": "5.0.5",
-      "dev": true,
       "dependencies": {
         "acorn": {
-          "version": "4.0.3",
-          "dev": true
+          "version": "4.0.3"
         },
         "resolve": {
-          "version": "1.1.7",
-          "dev": true
+          "version": "1.1.7"
         }
       }
     },
     "rollup-pluginutils": {
-      "version": "1.5.2",
-      "dev": true
-    },
-    "run-async": {
-      "version": "2.3.0",
-      "dev": true
-    },
-    "rx": {
-      "version": "4.1.0",
-      "dev": true
+      "version": "1.5.2"
     },
     "rxjs": {
       "version": "5.0.1"
     },
     "sauce-connect-launcher": {
       "version": "0.13.0",
-      "dev": true,
       "dependencies": {
         "async": {
-          "version": "1.4.0",
-          "dev": true
+          "version": "1.4.0"
         },
         "glob": {
-          "version": "5.0.15",
-          "dev": true
+          "version": "5.0.15"
         },
         "lodash": {
-          "version": "3.10.1",
-          "dev": true
+          "version": "3.10.1"
         },
         "rimraf": {
-          "version": "2.4.3",
-          "dev": true
+          "version": "2.4.3"
         }
       }
     },
     "saucelabs": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "sax": {
-      "version": "1.1.4",
-      "dev": true
+      "version": "1.1.4"
     },
     "scmp": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "selenium-webdriver": {
       "version": "2.53.3",
-      "dev": true,
       "dependencies": {
         "adm-zip": {
-          "version": "0.4.4",
-          "dev": true
+          "version": "0.4.4"
         },
         "sax": {
-          "version": "0.6.1",
-          "dev": true
+          "version": "0.6.1"
         },
         "tmp": {
-          "version": "0.0.24",
-          "dev": true
+          "version": "0.0.24"
         },
         "xml2js": {
-          "version": "0.4.4",
-          "dev": true
+          "version": "0.4.4"
         }
       }
     },
     "semver": {
-      "version": "5.1.0",
-      "dev": true
+      "version": "5.1.0"
     },
     "semver-diff": {
-      "version": "2.1.0",
-      "dev": true
+      "version": "2.1.0"
     },
     "semver-utils": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "send": {
-      "version": "0.13.0",
-      "dev": true
+      "version": "0.13.0"
+    },
+    "sentence-case": {
+      "version": "2.1.0"
     },
     "seq": {
       "version": "0.3.5",
-      "dev": true,
       "dependencies": {
         "chainsaw": {
-          "version": "0.0.9",
-          "dev": true
+          "version": "0.0.9"
         }
       }
     },
     "sequencify": {
-      "version": "0.0.7",
-      "dev": true
+      "version": "0.0.7"
     },
     "serve-favicon": {
-      "version": "2.3.0",
-      "dev": true
+      "version": "2.3.0"
     },
     "serve-index": {
       "version": "1.7.2",
-      "dev": true,
       "dependencies": {
         "mime-db": {
-          "version": "1.20.0",
-          "dev": true
+          "version": "1.20.0"
         },
         "mime-types": {
-          "version": "2.1.8",
-          "dev": true
+          "version": "2.1.8"
         }
       }
     },
     "serve-static": {
-      "version": "1.10.0",
-      "dev": true
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "1.10.0"
     },
     "setimmediate": {
-      "version": "1.0.4",
-      "dev": true
+      "version": "1.0.4"
     },
     "sha.js": {
-      "version": "2.2.6",
-      "dev": true
+      "version": "2.2.6"
+    },
+    "shelljs": {
+      "version": "0.7.6",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1"
+        },
+        "interpret": {
+          "version": "1.0.1"
+        }
+      }
     },
     "sigmund": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "signal-exit": {
-      "version": "2.1.2",
-      "dev": true
+      "version": "2.1.2"
     },
     "slice-stream": {
       "version": "1.0.0",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.33",
-          "dev": true
+          "version": "1.0.33"
         }
       }
     },
     "slide": {
-      "version": "1.1.6",
-      "dev": true
+      "version": "1.1.6"
+    },
+    "snake-case": {
+      "version": "2.1.0"
     },
     "sntp": {
-      "version": "1.0.9",
-      "dev": true
+      "version": "1.0.9"
     },
     "socket.io": {
-      "version": "1.4.6",
-      "dev": true
+      "version": "1.4.6"
     },
     "socket.io-adapter": {
       "version": "0.4.0",
-      "dev": true,
       "dependencies": {
         "socket.io-parser": {
           "version": "2.2.2",
-          "dev": true,
           "dependencies": {
             "debug": {
-              "version": "0.7.4",
-              "dev": true
+              "version": "0.7.4"
             }
           }
         }
@@ -5613,982 +4402,749 @@
     },
     "socket.io-client": {
       "version": "1.4.6",
-      "dev": true,
       "dependencies": {
         "component-emitter": {
-          "version": "1.2.0",
-          "dev": true
+          "version": "1.2.0"
         }
       }
     },
     "socket.io-parser": {
       "version": "2.2.6",
-      "dev": true,
       "dependencies": {
         "json3": {
-          "version": "3.3.2",
-          "dev": true
+          "version": "3.3.2"
         }
       }
     },
     "source-list-map": {
-      "version": "0.1.5",
-      "dev": true
+      "version": "0.1.5"
     },
     "source-map": {
-      "version": "0.3.0",
-      "dev": true
+      "version": "0.3.0"
     },
     "source-map-support": {
       "version": "0.4.2",
-      "dev": true,
       "dependencies": {
         "source-map": {
           "version": "0.1.32",
-          "dev": true,
           "dependencies": {
             "amdefine": {
-              "version": "1.0.1",
-              "dev": true
+              "version": "1.0.1"
             }
           }
         }
       }
     },
     "sparkles": {
-      "version": "1.0.0",
-      "dev": true
-    },
-    "spawn-sync": {
-      "version": "1.0.15",
-      "dev": true
+      "version": "1.0.0"
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "spdx-exceptions": {
-      "version": "1.0.4",
-      "dev": true
+      "version": "1.0.4"
     },
     "spdx-expression-parse": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "spdx-license-ids": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.1.0"
+    },
+    "spdx-license-list": {
+      "version": "2.1.0"
     },
     "split": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "split2": {
       "version": "2.1.0",
-      "dev": true,
       "dependencies": {
         "isarray": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "readable-stream": {
-          "version": "2.0.6",
-          "dev": true
+          "version": "2.0.6"
         },
         "through2": {
-          "version": "2.0.1",
-          "dev": true
+          "version": "2.0.1"
         }
       }
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
     },
     "sshpk": {
       "version": "1.10.1",
-      "dev": true,
       "dependencies": {
         "assert-plus": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         }
       }
     },
+    "stack-trace": {
+      "version": "0.0.9"
+    },
     "statuses": {
-      "version": "1.2.1",
-      "dev": true
+      "version": "1.2.1"
     },
     "stream-browserify": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "stream-combiner": {
-      "version": "0.0.4",
-      "dev": true
+      "version": "0.0.4"
     },
     "stream-consume": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "stream-counter": {
-      "version": "0.2.0",
-      "dev": true
+      "version": "0.2.0"
     },
     "stream-equal": {
-      "version": "0.1.6",
-      "dev": true
+      "version": "0.1.6"
     },
     "string_decoder": {
-      "version": "0.10.31",
-      "dev": true
+      "version": "0.10.31"
     },
     "string-width": {
       "version": "1.0.1",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "strip-ansi": {
-          "version": "3.0.0",
-          "dev": true
+          "version": "3.0.0"
         }
       }
     },
-    "string.prototype.codepointat": {
-      "version": "0.2.0",
-      "dev": true
+    "stringmap": {
+      "version": "0.2.2"
     },
     "stringstream": {
-      "version": "0.0.5",
-      "dev": true
+      "version": "0.0.5"
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "dev": true
+      "version": "3.0.1"
     },
     "strip-bom": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "strip-indent": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "strip-json-comments": {
-      "version": "1.0.4",
-      "dev": true
+      "version": "1.0.4"
     },
     "success-symbol": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "supports-color": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
+    },
+    "swap-case": {
+      "version": "1.1.2"
     },
     "symbol-observable": {
       "version": "1.0.4"
     },
+    "symbol-tree": {
+      "version": "3.2.1"
+    },
     "systemjs": {
-      "version": "0.18.10",
-      "dev": true
+      "version": "0.18.10"
     },
     "tapable": {
-      "version": "0.1.10",
-      "dev": true
-    },
-    "tar": {
-      "version": "2.2.1",
-      "dev": true,
-      "dependencies": {
-        "fstream": {
-          "version": "1.0.10",
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "dev": true
-        }
-      }
+      "version": "0.1.10"
     },
     "tar-stream": {
       "version": "1.1.5",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.33",
-          "dev": true
+          "version": "1.0.33"
         }
       }
     },
     "text-extensions": {
-      "version": "1.3.3",
-      "dev": true
+      "version": "1.3.3"
     },
     "through": {
-      "version": "2.3.8",
-      "dev": true
+      "version": "2.3.8"
     },
     "through2": {
       "version": "0.6.5",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.34",
-          "dev": true
+          "version": "1.0.34"
         }
       }
     },
     "tildify": {
-      "version": "1.1.2",
-      "dev": true
+      "version": "1.1.2"
     },
     "timed-out": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "timers-browserify": {
-      "version": "1.4.2",
-      "dev": true
+      "version": "1.4.2"
     },
     "timers-ext": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "tiny-lr": {
       "version": "0.2.1",
-      "dev": true,
       "dependencies": {
         "body-parser": {
           "version": "1.14.2",
-          "dev": true,
           "dependencies": {
             "qs": {
-              "version": "5.2.0",
-              "dev": true
+              "version": "5.2.0"
             }
           }
         },
         "bytes": {
-          "version": "2.2.0",
-          "dev": true
+          "version": "2.2.0"
         },
         "depd": {
-          "version": "1.1.0",
-          "dev": true
+          "version": "1.1.0"
         },
         "iconv-lite": {
-          "version": "0.4.13",
-          "dev": true
+          "version": "0.4.13"
         },
         "qs": {
-          "version": "5.1.0",
-          "dev": true
+          "version": "5.1.0"
         }
       }
     },
+    "title-case": {
+      "version": "2.1.0"
+    },
     "tmp": {
-      "version": "0.0.25",
-      "dev": true
+      "version": "0.0.25"
     },
     "to-array": {
-      "version": "0.1.4",
-      "dev": true
+      "version": "0.1.4"
     },
     "tough-cookie": {
-      "version": "2.2.1",
-      "dev": true
+      "version": "2.2.1"
+    },
+    "tr46": {
+      "version": "0.0.3"
     },
     "traverse": {
-      "version": "0.3.9",
-      "dev": true
+      "version": "0.3.9"
     },
     "trim-newlines": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "trim-off-newlines": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "ts-api-guardian": {
       "version": "0.1.4",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "ansi-styles": {
-          "version": "2.2.1",
-          "dev": true
+          "version": "2.2.1"
         },
         "chalk": {
-          "version": "1.1.3",
-          "dev": true
+          "version": "1.1.3"
         },
         "diff": {
-          "version": "2.2.3",
-          "dev": true
+          "version": "2.2.3"
         },
         "has-ansi": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "dev": true
+          "version": "3.0.1"
         },
         "supports-color": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "typescript": {
-          "version": "1.7.3",
-          "dev": true
+          "version": "1.7.3"
         }
       }
     },
     "tsickle": {
       "version": "0.2.4",
-      "dev": true,
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "dev": true
+          "version": "0.5.6"
         }
       }
     },
     "tslint": {
       "version": "4.1.1",
-      "dev": true,
       "dependencies": {
         "diff": {
-          "version": "3.1.0",
-          "dev": true
+          "version": "3.1.0"
         },
         "glob": {
-          "version": "7.1.1",
-          "dev": true
+          "version": "7.1.1"
         },
         "resolve": {
-          "version": "1.2.0",
-          "dev": true
+          "version": "1.2.0"
         }
       }
     },
     "tslint-eslint-rules": {
       "version": "3.1.0",
-      "dev": true,
       "dependencies": {
         "diff": {
-          "version": "3.1.0",
-          "dev": true
+          "version": "3.1.0"
         },
         "glob": {
-          "version": "7.1.1",
-          "dev": true
+          "version": "7.1.1"
         },
         "resolve": {
-          "version": "1.1.7",
-          "dev": true
+          "version": "1.1.7"
         },
         "tslint": {
-          "version": "4.0.2",
-          "dev": true
+          "version": "4.0.2"
         }
       }
     },
     "tty-browserify": {
-      "version": "0.0.0",
-      "dev": true
+      "version": "0.0.0"
     },
     "tunnel-agent": {
-      "version": "0.4.2",
-      "dev": true
+      "version": "0.4.2"
     },
     "tweetnacl": {
-      "version": "0.14.3",
-      "dev": true,
-      "optional": true
+      "version": "0.14.3"
+    },
+    "type-check": {
+      "version": "0.3.2"
     },
     "type-is": {
       "version": "1.6.10",
-      "dev": true,
       "dependencies": {
         "mime-db": {
-          "version": "1.20.0",
-          "dev": true
+          "version": "1.20.0"
         },
         "mime-types": {
-          "version": "2.1.8",
-          "dev": true
+          "version": "2.1.8"
         }
       }
     },
     "typedarray": {
-      "version": "0.0.6",
-      "dev": true
+      "version": "0.0.6"
     },
     "typescript": {
-      "version": "2.0.2",
-      "dev": true
+      "version": "2.0.2"
     },
     "ua-parser-js": {
-      "version": "0.7.10",
-      "dev": true
+      "version": "0.7.10"
     },
     "uglify-js": {
       "version": "2.7.0",
-      "dev": true,
-      "optional": true,
       "dependencies": {
         "camelcase": {
-          "version": "1.2.1",
-          "dev": true,
-          "optional": true
+          "version": "1.2.1"
         },
         "cliui": {
-          "version": "2.1.0",
-          "dev": true,
-          "optional": true
+          "version": "2.1.0"
         },
         "source-map": {
-          "version": "0.5.6",
-          "dev": true,
-          "optional": true
+          "version": "0.5.6"
         },
         "window-size": {
-          "version": "0.1.0",
-          "dev": true,
-          "optional": true
+          "version": "0.1.0"
         },
         "wordwrap": {
-          "version": "0.0.2",
-          "dev": true,
-          "optional": true
+          "version": "0.0.2"
         },
         "yargs": {
-          "version": "3.10.0",
-          "dev": true,
-          "optional": true
+          "version": "3.10.0"
         }
       }
     },
     "uglify-to-browserify": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "uid-safe": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "ultron": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "underscore": {
-      "version": "1.8.3",
-      "dev": true
+      "version": "1.8.3"
+    },
+    "underscore-contrib": {
+      "version": "0.3.0",
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0"
+        }
+      }
     },
     "underscore.string": {
-      "version": "3.3.4",
-      "dev": true
+      "version": "3.3.4"
     },
     "unicoderegexp": {
-      "version": "0.4.1",
-      "dev": true
+      "version": "0.4.1"
     },
     "unique-stream": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "universal-analytics": {
-      "version": "0.3.10",
-      "dev": true
+      "version": "0.3.10"
     },
     "unpipe": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "unzip": {
       "version": "0.1.11",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
-          "version": "1.0.33",
-          "dev": true
+          "version": "1.0.33"
         }
       }
     },
     "unzip-response": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "update-notifier": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
+    },
+    "upper-case": {
+      "version": "1.1.3"
+    },
+    "upper-case-first": {
+      "version": "1.1.2"
     },
     "url": {
       "version": "0.10.3",
-      "dev": true,
       "dependencies": {
         "punycode": {
-          "version": "1.3.2",
-          "dev": true
+          "version": "1.3.2"
         }
       }
     },
     "url-parse-lax": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "user-home": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "useragent": {
       "version": "2.1.9",
-      "dev": true,
       "dependencies": {
         "lru-cache": {
-          "version": "2.2.4",
-          "dev": true
+          "version": "2.2.4"
         }
       }
     },
     "utf8": {
-      "version": "2.1.0",
-      "dev": true
+      "version": "2.1.0"
     },
     "util": {
-      "version": "0.10.3",
-      "dev": true
+      "version": "0.10.3"
     },
     "util-deprecate": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "uuid": {
-      "version": "2.0.3",
-      "dev": true
+      "version": "2.0.3"
     },
     "v8flags": {
-      "version": "2.0.11",
-      "dev": true
+      "version": "2.0.11"
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "dev": true
+      "version": "3.0.1"
+    },
+    "validate.js": {
+      "version": "0.9.0"
     },
     "vargs": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     },
     "vary": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "verror": {
-      "version": "1.3.6",
-      "dev": true
+      "version": "1.3.6"
     },
     "vhost": {
-      "version": "3.0.2",
-      "dev": true
+      "version": "3.0.2"
     },
     "vinyl-fs": {
       "version": "0.3.14",
-      "dev": true,
       "dependencies": {
         "clone": {
-          "version": "0.2.0",
-          "dev": true
+          "version": "0.2.0"
         },
         "strip-bom": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "vinyl": {
-          "version": "0.4.6",
-          "dev": true
+          "version": "0.4.6"
         }
       }
     },
     "vlq": {
-      "version": "0.2.1",
-      "dev": true
+      "version": "0.2.1"
     },
     "vm-browserify": {
-      "version": "0.0.4",
-      "dev": true
+      "version": "0.0.4"
     },
     "void-elements": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.1"
     },
     "vrsource-tslint-rules": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
     },
     "watchpack": {
       "version": "0.2.9",
-      "dev": true,
       "dependencies": {
         "async": {
-          "version": "0.9.2",
-          "dev": true
+          "version": "0.9.2"
         },
         "graceful-fs": {
-          "version": "4.1.2",
-          "dev": true
+          "version": "4.1.2"
         }
       }
     },
     "wd": {
       "version": "0.3.12",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "ansi-styles": {
-          "version": "2.1.0",
-          "dev": true
+          "version": "2.1.0"
         },
         "asn1": {
-          "version": "0.1.11",
-          "dev": true
+          "version": "0.1.11"
         },
         "async": {
-          "version": "1.0.0",
-          "dev": true
+          "version": "1.0.0"
         },
         "aws-sign2": {
-          "version": "0.5.0",
-          "dev": true
+          "version": "0.5.0"
         },
         "caseless": {
-          "version": "0.9.0",
-          "dev": true
+          "version": "0.9.0"
         },
         "chalk": {
-          "version": "1.1.1",
-          "dev": true
+          "version": "1.1.1"
         },
         "combined-stream": {
-          "version": "0.0.7",
-          "dev": true
+          "version": "0.0.7"
         },
         "delayed-stream": {
-          "version": "0.0.5",
-          "dev": true
+          "version": "0.0.5"
         },
         "form-data": {
           "version": "0.2.0",
-          "dev": true,
           "dependencies": {
             "async": {
-              "version": "0.9.2",
-              "dev": true
+              "version": "0.9.2"
             }
           }
         },
         "har-validator": {
-          "version": "1.8.0",
-          "dev": true
+          "version": "1.8.0"
         },
         "has-ansi": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "hawk": {
-          "version": "2.3.1",
-          "dev": true
+          "version": "2.3.1"
         },
         "http-signature": {
-          "version": "0.10.1",
-          "dev": true
+          "version": "0.10.1"
         },
         "lodash": {
-          "version": "3.9.3",
-          "dev": true
+          "version": "3.9.3"
         },
         "oauth-sign": {
-          "version": "0.6.0",
-          "dev": true
+          "version": "0.6.0"
         },
         "qs": {
-          "version": "2.4.2",
-          "dev": true
+          "version": "2.4.2"
         },
         "request": {
-          "version": "2.55.0",
-          "dev": true
+          "version": "2.55.0"
         },
         "strip-ansi": {
-          "version": "3.0.0",
-          "dev": true
+          "version": "3.0.0"
         },
         "supports-color": {
-          "version": "2.0.0",
-          "dev": true
+          "version": "2.0.0"
         },
         "underscore.string": {
-          "version": "3.0.3",
-          "dev": true
+          "version": "3.0.3"
         }
       }
     },
+    "webidl-conversions": {
+      "version": "3.0.1"
+    },
     "webpack": {
       "version": "1.12.9",
-      "dev": true,
       "dependencies": {
         "async": {
-          "version": "1.5.0",
-          "dev": true
+          "version": "1.5.0"
         },
         "camelcase": {
-          "version": "1.2.1",
-          "dev": true
+          "version": "1.2.1"
         },
         "cliui": {
-          "version": "2.1.0",
-          "dev": true
+          "version": "2.1.0"
         },
         "source-map": {
-          "version": "0.5.3",
-          "dev": true
+          "version": "0.5.3"
         },
         "supports-color": {
-          "version": "3.1.2",
-          "dev": true
+          "version": "3.1.2"
         },
         "uglify-js": {
           "version": "2.6.1",
-          "dev": true,
           "dependencies": {
             "async": {
-              "version": "0.2.10",
-              "dev": true
+              "version": "0.2.10"
             }
           }
         },
         "window-size": {
-          "version": "0.1.0",
-          "dev": true
+          "version": "0.1.0"
         },
         "wordwrap": {
-          "version": "0.0.2",
-          "dev": true
+          "version": "0.0.2"
         },
         "yargs": {
-          "version": "3.10.0",
-          "dev": true
+          "version": "3.10.0"
         }
       }
     },
     "webpack-core": {
       "version": "0.6.8",
-      "dev": true,
       "dependencies": {
         "source-map": {
-          "version": "0.4.4",
-          "dev": true
+          "version": "0.4.4"
         }
       }
     },
     "websocket-driver": {
-      "version": "0.6.3",
-      "dev": true
+      "version": "0.6.3"
     },
     "websocket-extensions": {
-      "version": "0.1.1",
-      "dev": true
+      "version": "0.1.1"
+    },
+    "whatwg-encoding": {
+      "version": "1.0.1",
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.13"
+        }
+      }
     },
     "whatwg-fetch": {
-      "version": "0.9.0",
-      "dev": true
+      "version": "0.9.0"
+    },
+    "whatwg-url": {
+      "version": "3.1.0"
     },
     "when": {
-      "version": "3.7.2",
-      "dev": true
+      "version": "3.7.2"
     },
     "which": {
-      "version": "1.2.10",
-      "dev": true
-    },
-    "wide-align": {
-      "version": "1.1.0",
-      "dev": true
+      "version": "1.2.10"
     },
     "widest-line": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "window-size": {
-      "version": "0.1.4",
-      "dev": true
+      "version": "0.1.4"
     },
     "winreg": {
-      "version": "0.0.12",
-      "dev": true
+      "version": "0.0.12"
+    },
+    "winston": {
+      "version": "2.3.1",
+      "dependencies": {
+        "async": {
+          "version": "1.0.0"
+        },
+        "colors": {
+          "version": "1.0.3"
+        }
+      }
     },
     "wordwrap": {
-      "version": "0.0.3",
-      "dev": true
+      "version": "0.0.3"
     },
     "wrap-ansi": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "wrappy": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "wrench": {
-      "version": "1.5.8",
-      "dev": true
+      "version": "1.5.8"
     },
     "write-file-atomic": {
       "version": "1.2.0",
-      "dev": true,
       "dependencies": {
         "graceful-fs": {
-          "version": "4.1.11",
-          "dev": true
+          "version": "4.1.11"
         }
       }
     },
     "ws": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "xdg-basedir": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
+    },
+    "xml-name-validator": {
+      "version": "2.0.1"
     },
     "xml2js": {
-      "version": "0.4.15",
-      "dev": true
+      "version": "0.4.15"
     },
     "xmlbuilder": {
-      "version": "8.2.2",
-      "dev": true
+      "version": "8.2.2"
     },
     "xmldom": {
-      "version": "0.1.19",
-      "dev": true
+      "version": "0.1.19"
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.1",
-      "dev": true
+      "version": "1.5.1"
     },
     "xpath": {
-      "version": "0.0.7",
-      "dev": true
+      "version": "0.0.7"
     },
     "xtend": {
-      "version": "4.0.1",
-      "dev": true
+      "version": "4.0.1"
     },
     "y18n": {
-      "version": "3.2.0",
-      "dev": true
+      "version": "3.2.0"
     },
     "yargs": {
-      "version": "3.31.0",
-      "dev": true
-    },
-    "yarn": {
-      "version": "0.19.1",
-      "dev": true,
-      "dependencies": {
-        "bl": {
-          "version": "1.2.0",
-          "dev": true
-        },
-        "bytes": {
-          "version": "2.4.0",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "3.0.0",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.26.0",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.14",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.3.0",
-          "dev": true
-        },
-        "read": {
-          "version": "1.0.7",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.2.2",
-          "dev": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "dev": true
-        },
-        "tar-stream": {
-          "version": "1.5.2",
-          "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "dev": true
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "dev": true
-        }
-      }
+      "version": "3.31.0"
     },
     "yeast": {
-      "version": "0.1.2",
-      "dev": true
+      "version": "0.1.2"
     },
     "zip-dir": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "zip-stream": {
       "version": "0.5.2",
-      "dev": true,
       "dependencies": {
         "lodash": {
-          "version": "3.2.0",
-          "dev": true
+          "version": "3.2.0"
         },
         "readable-stream": {
-          "version": "1.0.33",
-          "dev": true
+          "version": "1.0.33"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5,124 +5,116 @@
     "@types/angularjs": {
       "version": "1.5.13-alpha",
       "from": "@types/angularjs@latest",
-      "resolved": "https://registry.npmjs.org/@types/angularjs/-/angularjs-1.5.13-alpha.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/@types/angularjs/-/angularjs-1.5.13-alpha.tgz"
     },
     "@types/base64-js": {
       "version": "1.2.5",
       "from": "@types/base64-js@latest",
-      "resolved": "https://registry.npmjs.org/@types/base64-js/-/base64-js-1.2.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/@types/base64-js/-/base64-js-1.2.5.tgz"
     },
     "@types/fs-extra": {
       "version": "0.0.22-alpha",
       "from": "@types/fs-extra@latest",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-0.0.22-alpha.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-0.0.22-alpha.tgz"
     },
     "@types/hammerjs": {
       "version": "2.0.33",
       "from": "@types/hammerjs@latest",
-      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.33.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.33.tgz"
     },
     "@types/jasmine": {
       "version": "2.2.22-alpha",
       "from": "@types/jasmine@latest",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.2.22-alpha.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.2.22-alpha.tgz"
     },
     "@types/jquery": {
       "version": "1.10.21-alpha",
       "from": "@types/jquery@*",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-1.10.21-alpha.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-1.10.21-alpha.tgz"
     },
     "@types/node": {
       "version": "4.0.22-alpha",
       "from": "@types/node@latest",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-4.0.22-alpha.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-4.0.22-alpha.tgz"
     },
     "@types/q": {
       "version": "0.0.32",
       "from": "@types/q@>=0.0.32 <0.0.33",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz"
     },
     "@types/selenium-webdriver": {
       "version": "2.53.35",
       "from": "@types/selenium-webdriver@latest",
-      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.35.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.35.tgz"
     },
     "@types/systemjs": {
       "version": "0.19.32",
       "from": "@types/systemjs@latest",
-      "resolved": "https://registry.npmjs.org/@types/systemjs/-/systemjs-0.19.32.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/@types/systemjs/-/systemjs-0.19.32.tgz"
     },
-    "abbrev": {
-      "version": "1.0.9",
-      "from": "abbrev@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "dev": true
+    "abab": {
+      "version": "1.0.3",
+      "from": "abab@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz"
     },
     "accepts": {
       "version": "1.2.13",
       "from": "accepts@>=1.2.12 <1.3.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-      "dev": true,
       "dependencies": {
         "mime-db": {
           "version": "1.20.0",
           "from": "mime-db@1.20.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
         },
         "mime-types": {
           "version": "2.1.8",
           "from": "mime-types@2.1.8",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz"
         }
       }
     },
     "acorn": {
       "version": "1.2.2",
       "from": "acorn@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+    },
+    "acorn-globals": {
+      "version": "1.0.9",
+      "from": "acorn-globals@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "from": "acorn@^2.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+        }
+      }
     },
     "add-stream": {
       "version": "1.0.0",
       "from": "add-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz"
     },
     "adm-zip": {
       "version": "0.4.7",
       "from": "adm-zip@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
     },
     "after": {
       "version": "0.8.1",
       "from": "after@0.8.1",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
     },
     "agent-base": {
       "version": "2.0.1",
       "from": "agent-base@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
-      "dev": true,
       "dependencies": {
         "semver": {
           "version": "5.0.3",
           "from": "semver@>=5.0.1 <5.1.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
         }
       }
     },
@@ -130,486 +122,386 @@
       "version": "0.1.3",
       "from": "align-text@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-      "dev": true,
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
           "from": "kind-of@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz"
         }
       }
     },
     "amdefine": {
       "version": "1.0.1",
       "from": "amdefine@1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
     },
     "angular": {
       "version": "1.5.0",
       "from": "angular@1.5.0",
-      "resolved": "https://registry.npmjs.org/angular/-/angular-1.5.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.5.0.tgz"
     },
     "angular-animate": {
       "version": "1.5.0",
       "from": "angular-animate@1.5.0",
-      "resolved": "https://registry.npmjs.org/angular-animate/-/angular-animate-1.5.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/angular-animate/-/angular-animate-1.5.0.tgz"
     },
     "angular-mocks": {
       "version": "1.5.0",
       "from": "angular-mocks@1.5.0",
-      "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.5.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.5.0.tgz"
     },
     "ansi-align": {
       "version": "1.1.0",
       "from": "ansi-align@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
-      "dev": true
-    },
-    "ansi-escapes": {
-      "version": "1.4.0",
-      "from": "ansi-escapes@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz"
     },
     "ansi-green": {
       "version": "0.1.1",
       "from": "ansi-green@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
       "from": "ansi-regex@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
     },
     "ansi-styles": {
       "version": "2.2.1",
       "from": "ansi-styles@>=2.2.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
     },
     "ansi-wrap": {
       "version": "0.1.0",
       "from": "ansi-wrap@0.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
     },
     "any-promise": {
       "version": "0.1.0",
       "from": "any-promise@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz"
     },
     "anymatch": {
       "version": "1.3.0",
       "from": "anymatch@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-      "dev": true
-    },
-    "aproba": {
-      "version": "1.0.4",
-      "from": "aproba@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
     },
     "archiver": {
       "version": "0.14.4",
       "from": "archiver@>=0.14.3 <0.15.0",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.14.4.tgz",
-      "dev": true,
       "dependencies": {
         "async": {
           "version": "0.9.2",
           "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "glob": {
           "version": "4.3.5",
           "from": "glob@>=4.3.0 <4.4.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-          "dev": true,
           "dependencies": {
             "minimatch": {
               "version": "2.0.10",
               "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
             }
           }
         },
         "lodash": {
           "version": "3.2.0",
           "from": "lodash@>=3.2.0 <3.3.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
         },
         "readable-stream": {
           "version": "1.0.33",
           "from": "readable-stream@>=1.0.26 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "archy": {
       "version": "1.0.0",
       "from": "archy@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.2",
-      "from": "are-we-there-yet@>=1.1.2 <1.2.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
     },
     "arr-diff": {
       "version": "2.0.0",
       "from": "arr-diff@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
     },
     "arr-flatten": {
       "version": "1.0.1",
       "from": "arr-flatten@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
     },
     "array-differ": {
       "version": "1.0.0",
       "from": "array-differ@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+    },
+    "array-equal": {
+      "version": "1.0.0",
+      "from": "array-equal@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz"
     },
     "array-ify": {
       "version": "1.0.0",
       "from": "array-ify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz"
     },
     "array-slice": {
       "version": "0.2.3",
       "from": "array-slice@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
     },
     "array-union": {
       "version": "1.0.2",
       "from": "array-union@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz"
     },
     "array-uniq": {
       "version": "1.0.2",
       "from": "array-uniq@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
     },
     "array-unique": {
       "version": "0.2.1",
       "from": "array-unique@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
     },
     "arraybuffer.slice": {
       "version": "0.0.6",
       "from": "arraybuffer.slice@0.0.6",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
     },
     "arrify": {
       "version": "1.0.1",
       "from": "arrify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
     },
     "asap": {
       "version": "2.0.3",
       "from": "asap@>=2.0.3 <2.1.0",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
     },
     "asn1": {
       "version": "0.2.3",
       "from": "asn1@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "assert": {
       "version": "1.4.1",
       "from": "assert@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
     },
     "assert-plus": {
       "version": "0.1.5",
       "from": "assert-plus@>=0.1.5 <0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
     },
     "async": {
       "version": "0.2.10",
       "from": "async@>=0.2.6 <0.3.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
     },
     "async-each": {
       "version": "0.1.6",
       "from": "async-each@>=0.1.6 <0.2.0",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
     },
     "asynckit": {
       "version": "0.4.0",
       "from": "asynckit@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
     },
     "aws-sign2": {
       "version": "0.6.0",
       "from": "aws-sign2@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
     },
     "aws4": {
       "version": "1.5.0",
       "from": "aws4@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
     },
     "babel-code-frame": {
       "version": "6.20.0",
       "from": "babel-code-frame@>=6.20.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.20.0.tgz",
-      "dev": true,
       "dependencies": {
         "esutils": {
           "version": "2.0.2",
           "from": "esutils@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
         },
         "js-tokens": {
           "version": "2.0.0",
           "from": "js-tokens@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
         }
       }
-    },
-    "babel-runtime": {
-      "version": "6.22.0",
-      "from": "babel-runtime@>=6.0.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
-      "dev": true
     },
     "backo2": {
       "version": "1.0.2",
       "from": "backo2@1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
     },
     "balanced-match": {
       "version": "0.4.2",
       "from": "balanced-match@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "base62": {
       "version": "0.1.1",
       "from": "base62@0.1.1",
-      "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
     },
     "Base64": {
       "version": "0.2.1",
       "from": "Base64@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
     },
     "base64-arraybuffer": {
       "version": "0.1.2",
       "from": "base64-arraybuffer@0.1.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
     },
     "base64-js": {
       "version": "1.2.0",
       "from": "base64-js@latest",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
     },
     "base64-url": {
       "version": "1.2.1",
       "from": "base64-url@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
     },
     "base64id": {
       "version": "0.1.0",
       "from": "base64id@0.1.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
     },
     "basic-auth": {
       "version": "1.0.3",
       "from": "basic-auth@>=1.0.3 <1.1.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz"
     },
     "basic-auth-connect": {
       "version": "1.0.0",
       "from": "basic-auth-connect@1.0.0",
-      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
     },
     "batch": {
       "version": "0.5.2",
       "from": "batch@0.5.2",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz"
     },
     "bcrypt-pbkdf": {
       "version": "1.0.0",
       "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-      "dev": true,
-      "optional": true
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
     },
     "beeper": {
       "version": "1.1.0",
       "from": "beeper@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
     },
     "benchmark": {
       "version": "1.0.0",
       "from": "benchmark@1.0.0",
-      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
     },
     "better-assert": {
       "version": "1.0.2",
       "from": "better-assert@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
     },
     "big.js": {
       "version": "3.1.3",
       "from": "big.js@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
     },
     "binary": {
       "version": "0.3.0",
       "from": "binary@>=0.3.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz"
     },
     "binary-extensions": {
       "version": "1.4.0",
       "from": "binary-extensions@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
     },
     "bl": {
       "version": "0.9.4",
       "from": "bl@>=0.9.0 <0.10.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
           "from": "readable-stream@>=1.0.26 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "blob": {
       "version": "0.0.4",
       "from": "blob@0.0.4",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "dev": true
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "from": "block-stream@*",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
     },
     "bluebird": {
       "version": "2.10.2",
       "from": "bluebird@>=2.9.27 <3.0.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
     },
     "body-parser": {
       "version": "1.13.3",
       "from": "body-parser@>=1.13.3 <1.14.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz"
     },
     "boom": {
       "version": "2.10.1",
       "from": "boom@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "bower": {
       "version": "1.7.2",
       "from": "bower@>=1.3.12 <2.0.0",
       "resolved": "https://registry.npmjs.org/bower/-/bower-1.7.2.tgz",
-      "dev": true,
       "dependencies": {
         "abbrev": {
           "version": "1.0.7",
           "from": "abbrev@>=1.0.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
         },
         "archy": {
           "version": "1.0.0",
           "from": "archy@1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
         },
         "bower-config": {
           "version": "1.3.0",
           "from": "bower-config@>=1.3.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.3.0.tgz",
-          "dev": true,
           "dependencies": {
             "graceful-fs": {
               "version": "4.1.2",
               "from": "graceful-fs@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
             },
             "optimist": {
               "version": "0.6.1",
               "from": "optimist@>=0.6.1 <0.7.0",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "dev": true,
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
                   "from": "minimist@>=0.0.1 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
                 },
                 "wordwrap": {
                   "version": "0.0.3",
                   "from": "wordwrap@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 }
               }
             },
@@ -617,19 +509,16 @@
               "version": "0.1.3",
               "from": "osenv@>=0.1.3 <0.2.0",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-              "dev": true,
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
                   "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
                   "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 }
               }
             },
@@ -637,13 +526,11 @@
               "version": "2.1.0",
               "from": "untildify@2.1.0",
               "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
-              "dev": true,
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
                   "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                 }
               }
             }
@@ -652,70 +539,59 @@
         "bower-endpoint-parser": {
           "version": "0.2.2",
           "from": "bower-endpoint-parser@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
         },
         "bower-json": {
           "version": "0.4.0",
           "from": "bower-json@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
-          "dev": true,
           "dependencies": {
             "deep-extend": {
               "version": "0.2.11",
               "from": "deep-extend@>=0.2.5 <0.3.0",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
             },
             "graceful-fs": {
               "version": "2.0.3",
               "from": "graceful-fs@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
             },
             "intersect": {
               "version": "0.0.3",
               "from": "intersect@>=0.0.3 <0.1.0",
-              "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
             }
           }
         },
         "bower-logger": {
           "version": "0.2.2",
           "from": "bower-logger@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
         },
         "bower-registry-client": {
           "version": "1.0.0",
           "from": "bower-registry-client@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-1.0.0.tgz",
-          "dev": true,
           "dependencies": {
             "async": {
               "version": "0.2.10",
               "from": "async@>=0.2.8 <0.3.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "graceful-fs": {
               "version": "4.1.2",
               "from": "graceful-fs@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
             },
             "mkdirp": {
               "version": "0.3.5",
               "from": "mkdirp@>=0.3.5 <0.4.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             },
             "request-replay": {
               "version": "0.2.0",
               "from": "request-replay@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
             }
           }
         },
@@ -723,25 +599,21 @@
           "version": "0.4.4",
           "from": "cardinal@0.4.4",
           "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
-          "dev": true,
           "dependencies": {
             "ansicolors": {
               "version": "0.2.1",
               "from": "ansicolors@>=0.2.1 <0.3.0",
-              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
             },
             "redeyed": {
               "version": "0.4.4",
               "from": "redeyed@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
-              "dev": true,
               "dependencies": {
                 "esprima": {
                   "version": "1.0.4",
                   "from": "esprima@>=1.0.4 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 }
               }
             }
@@ -751,31 +623,26 @@
           "version": "1.1.1",
           "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dev": true,
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
               "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.4",
               "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
               "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dev": true,
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
                   "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
@@ -783,113 +650,96 @@
               "version": "3.0.0",
               "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "dev": true,
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
                   "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
               "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "chmodr": {
           "version": "1.0.2",
           "from": "chmodr@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz"
         },
         "configstore": {
           "version": "0.3.2",
           "from": "configstore@>=0.3.2 <0.4.0",
           "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
-          "dev": true,
           "dependencies": {
             "js-yaml": {
               "version": "3.4.6",
               "from": "js-yaml@>=3.1.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
-              "dev": true,
               "dependencies": {
                 "argparse": {
                   "version": "1.0.3",
                   "from": "argparse@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "lodash": {
                       "version": "3.10.1",
                       "from": "lodash@>=3.2.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "sprintf-js": {
                       "version": "1.0.3",
                       "from": "sprintf-js@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                     }
                   }
                 },
                 "esprima": {
                   "version": "2.7.1",
                   "from": "esprima@>=2.6.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
                 },
                 "inherit": {
                   "version": "2.2.2",
                   "from": "inherit@>=2.2.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.2.tgz"
                 }
               }
             },
             "object-assign": {
               "version": "2.1.1",
               "from": "object-assign@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
             },
             "osenv": {
               "version": "0.1.3",
               "from": "osenv@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-              "dev": true,
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
                   "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
                   "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 }
               }
             },
             "uuid": {
               "version": "2.0.1",
               "from": "uuid@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
             },
             "xdg-basedir": {
               "version": "1.0.1",
               "from": "xdg-basedir@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
             }
           }
         },
@@ -897,31 +747,26 @@
           "version": "0.1.0",
           "from": "decompress-zip@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
-          "dev": true,
           "dependencies": {
             "binary": {
               "version": "0.3.0",
               "from": "binary@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-              "dev": true,
               "dependencies": {
                 "buffers": {
                   "version": "0.1.1",
                   "from": "buffers@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                 },
                 "chainsaw": {
                   "version": "0.1.0",
                   "from": "chainsaw@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "traverse": {
                       "version": "0.3.9",
                       "from": "traverse@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
                     }
                   }
                 }
@@ -930,38 +775,32 @@
             "mkpath": {
               "version": "0.1.0",
               "from": "mkpath@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
             },
             "readable-stream": {
               "version": "1.1.13",
               "from": "readable-stream@>=1.1.8 <2.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "dev": true,
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
                   "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
                   "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
                   "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 }
               }
             },
@@ -969,13 +808,11 @@
               "version": "0.0.3",
               "from": "touch@0.0.3",
               "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
-              "dev": true,
               "dependencies": {
                 "nopt": {
                   "version": "1.0.10",
                   "from": "nopt@>=1.0.10 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
                 }
               }
             }
@@ -984,26 +821,22 @@
         "destroy": {
           "version": "1.0.3",
           "from": "destroy@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
         },
         "fs-write-stream-atomic": {
           "version": "1.0.5",
           "from": "fs-write-stream-atomic@1.0.5",
           "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.5.tgz",
-          "dev": true,
           "dependencies": {
             "graceful-fs": {
               "version": "4.1.2",
               "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
             },
             "imurmurhash": {
               "version": "0.1.4",
               "from": "imurmurhash@>=0.1.4 <0.2.0",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
             }
           }
         },
@@ -1011,19 +844,16 @@
           "version": "1.0.8",
           "from": "fstream@>=1.0.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-          "dev": true,
           "dependencies": {
             "graceful-fs": {
               "version": "4.1.2",
               "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
             },
             "inherits": {
               "version": "2.0.1",
               "from": "inherits@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
@@ -1031,37 +861,31 @@
           "version": "1.0.3",
           "from": "fstream-ignore@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
-          "dev": true,
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
               "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "3.0.0",
               "from": "minimatch@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "dev": true,
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.2",
                   "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "dev": true,
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
                       "from": "balanced-match@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
                       "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
                 }
@@ -1073,13 +897,11 @@
           "version": "0.2.4",
           "from": "github@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
-          "dev": true,
           "dependencies": {
             "mime": {
               "version": "1.3.4",
               "from": "mime@>=1.2.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             }
           }
         },
@@ -1087,51 +909,43 @@
           "version": "4.5.3",
           "from": "glob@>=4.3.2 <5.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "dev": true,
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
               "from": "inflight@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "dev": true,
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
                   "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
               "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "minimatch": {
               "version": "2.0.10",
               "from": "minimatch@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dev": true,
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.2",
                   "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "dev": true,
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
                       "from": "balanced-match@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
                       "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
                 }
@@ -1141,13 +955,11 @@
               "version": "1.3.3",
               "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "dev": true,
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
                   "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                 }
               }
             }
@@ -1156,26 +968,22 @@
         "graceful-fs": {
           "version": "3.0.8",
           "from": "graceful-fs@>=3.0.5 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
         },
         "handlebars": {
           "version": "2.0.0",
           "from": "handlebars@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
-          "dev": true,
           "dependencies": {
             "optimist": {
               "version": "0.3.7",
               "from": "optimist@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "dev": true,
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.3",
                   "from": "wordwrap@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                 }
               }
             },
@@ -1183,29 +991,21 @@
               "version": "2.3.6",
               "from": "uglify-js@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-              "dev": true,
-              "optional": true,
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
                   "from": "async@>=0.2.6 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                  "dev": true,
-                  "optional": true
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
                   "from": "source-map@>=0.1.7 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                  "dev": true,
-                  "optional": true,
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
                       "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                      "dev": true,
-                      "optional": true
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 }
@@ -1217,43 +1017,36 @@
           "version": "0.10.0",
           "from": "inquirer@0.10.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.10.0.tgz",
-          "dev": true,
           "dependencies": {
             "ansi-escapes": {
               "version": "1.1.0",
               "from": "ansi-escapes@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.0.tgz"
             },
             "ansi-regex": {
               "version": "2.0.0",
               "from": "ansi-regex@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
             },
             "cli-cursor": {
               "version": "1.0.2",
               "from": "cli-cursor@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-              "dev": true,
               "dependencies": {
                 "restore-cursor": {
                   "version": "1.0.1",
                   "from": "restore-cursor@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "exit-hook": {
                       "version": "1.1.1",
                       "from": "exit-hook@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
                     },
                     "onetime": {
                       "version": "1.1.0",
                       "from": "onetime@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
                     }
                   }
                 }
@@ -1262,38 +1055,32 @@
             "cli-width": {
               "version": "1.1.0",
               "from": "cli-width@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz"
             },
             "figures": {
               "version": "1.4.0",
               "from": "figures@>=1.3.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
             },
             "lodash": {
               "version": "3.10.1",
               "from": "lodash@>=3.3.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             },
             "readline2": {
               "version": "1.0.1",
               "from": "readline2@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-              "dev": true,
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
                   "from": "code-point-at@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
                       "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 },
@@ -1301,21 +1088,18 @@
                   "version": "1.0.0",
                   "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
                       "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 },
                 "mute-stream": {
                   "version": "0.0.5",
                   "from": "mute-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
                 }
               }
             },
@@ -1323,19 +1107,16 @@
               "version": "0.1.0",
               "from": "run-async@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-              "dev": true,
               "dependencies": {
                 "once": {
                   "version": "1.3.3",
                   "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
                       "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 }
@@ -1344,20 +1125,17 @@
             "rx-lite": {
               "version": "3.1.2",
               "from": "rx-lite@>=3.1.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
             },
             "strip-ansi": {
               "version": "3.0.0",
               "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
             },
             "through": {
               "version": "2.3.8",
               "from": "through@>=2.3.6 <3.0.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
@@ -1365,69 +1143,58 @@
           "version": "0.7.0",
           "from": "insight@>=0.7.0 <0.8.0",
           "resolved": "https://registry.npmjs.org/insight/-/insight-0.7.0.tgz",
-          "dev": true,
           "dependencies": {
             "async": {
               "version": "1.5.0",
               "from": "async@>=1.4.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
             },
             "configstore": {
               "version": "1.4.0",
               "from": "configstore@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
-              "dev": true,
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.2",
                   "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
                   "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 },
                 "osenv": {
                   "version": "0.1.3",
                   "from": "osenv@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
                       "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     }
                   }
                 },
                 "uuid": {
                   "version": "2.0.1",
                   "from": "uuid@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
                 },
                 "write-file-atomic": {
                   "version": "1.1.4",
                   "from": "write-file-atomic@>=1.1.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-                  "dev": true,
                   "dependencies": {
                     "imurmurhash": {
                       "version": "0.1.4",
                       "from": "imurmurhash@>=0.1.4 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
                     },
                     "slide": {
                       "version": "1.1.6",
                       "from": "slide@>=1.1.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
                     }
                   }
                 },
@@ -1435,13 +1202,11 @@
                   "version": "2.0.0",
                   "from": "xdg-basedir@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
                       "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     }
                   }
                 }
@@ -1451,39 +1216,33 @@
               "version": "3.1.1",
               "from": "lodash.debounce@>=3.0.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
-              "dev": true,
               "dependencies": {
                 "lodash._getnative": {
                   "version": "3.9.1",
                   "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                 }
               }
             },
             "object-assign": {
               "version": "4.0.1",
               "from": "object-assign@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
             },
             "os-name": {
               "version": "1.0.3",
               "from": "os-name@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
-              "dev": true,
               "dependencies": {
                 "osx-release": {
                   "version": "1.1.0",
                   "from": "osx-release@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "minimist": {
                       "version": "1.2.0",
                       "from": "minimist@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                     }
                   }
                 },
@@ -1491,13 +1250,11 @@
                   "version": "1.1.1",
                   "from": "win-release@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "semver": {
                       "version": "5.1.0",
                       "from": "semver@>=5.0.1 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                     }
                   }
                 }
@@ -1506,46 +1263,39 @@
             "tough-cookie": {
               "version": "2.2.1",
               "from": "tough-cookie@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
             }
           }
         },
         "is-root": {
           "version": "1.0.0",
           "from": "is-root@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
         },
         "junk": {
           "version": "1.0.2",
           "from": "junk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.2.tgz"
         },
         "lockfile": {
           "version": "1.0.1",
           "from": "lockfile@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
         },
         "lru-cache": {
           "version": "2.7.3",
           "from": "lru-cache@>=2.5.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
         },
         "md5-hex": {
           "version": "1.2.0",
           "from": "md5-hex@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.2.0.tgz",
-          "dev": true,
           "dependencies": {
             "md5-o-matic": {
               "version": "0.1.1",
               "from": "md5-o-matic@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
             }
           }
         },
@@ -1553,45 +1303,38 @@
           "version": "0.5.0",
           "from": "mkdirp@0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "dev": true,
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
               "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "mout": {
           "version": "0.11.1",
           "from": "mout@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz"
         },
         "nopt": {
           "version": "3.0.6",
           "from": "nopt@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
         },
         "opn": {
           "version": "1.0.2",
           "from": "opn@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
         },
         "p-throttler": {
           "version": "0.1.1",
           "from": "p-throttler@0.1.1",
           "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.1.tgz",
-          "dev": true,
           "dependencies": {
             "q": {
               "version": "0.9.7",
               "from": "q@>=0.9.2 <0.10.0",
-              "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
             }
           }
         },
@@ -1599,19 +1342,16 @@
           "version": "0.2.0",
           "from": "promptly@0.2.0",
           "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
-          "dev": true,
           "dependencies": {
             "read": {
               "version": "1.0.7",
               "from": "read@>=1.0.4 <1.1.0",
               "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-              "dev": true,
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.5",
                   "from": "mute-stream@>=0.0.4 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
                 }
               }
             }
@@ -1620,56 +1360,47 @@
         "q": {
           "version": "1.4.1",
           "from": "q@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
         },
         "request": {
           "version": "2.53.0",
           "from": "request@2.53.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
-          "dev": true,
           "dependencies": {
             "aws-sign2": {
               "version": "0.5.0",
               "from": "aws-sign2@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
             },
             "bl": {
               "version": "0.9.4",
               "from": "bl@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-              "dev": true,
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
                   "from": "readable-stream@>=1.0.26 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dev": true,
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
                       "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
                       "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
                 }
@@ -1678,40 +1409,34 @@
             "caseless": {
               "version": "0.9.0",
               "from": "caseless@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
             },
             "combined-stream": {
               "version": "0.0.7",
               "from": "combined-stream@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "dev": true,
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
                   "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
             "forever-agent": {
               "version": "0.5.2",
               "from": "forever-agent@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
             },
             "form-data": {
               "version": "0.2.0",
               "from": "form-data@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-              "dev": true,
               "dependencies": {
                 "async": {
                   "version": "0.9.2",
                   "from": "async@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                 }
               }
             },
@@ -1719,31 +1444,26 @@
               "version": "2.3.1",
               "from": "hawk@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "dev": true,
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
                   "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
                   "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "hoek": {
                   "version": "2.16.3",
                   "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
                   "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
@@ -1751,89 +1471,75 @@
               "version": "0.10.1",
               "from": "http-signature@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "dev": true,
               "dependencies": {
                 "asn1": {
                   "version": "0.1.11",
                   "from": "asn1@0.1.11",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "assert-plus": {
                   "version": "0.1.5",
                   "from": "assert-plus@>=0.1.5 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
                   "from": "ctype@0.5.3",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
             "isstream": {
               "version": "0.1.2",
               "from": "isstream@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
               "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.0.14",
               "from": "mime-types@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-              "dev": true,
               "dependencies": {
                 "mime-db": {
                   "version": "1.12.0",
                   "from": "mime-db@>=1.12.0 <1.13.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.7",
               "from": "node-uuid@>=1.4.0 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "oauth-sign": {
               "version": "0.6.0",
               "from": "oauth-sign@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
             },
             "qs": {
               "version": "2.3.3",
               "from": "qs@>=2.3.1 <2.4.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
               "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tough-cookie": {
               "version": "2.2.1",
               "from": "tough-cookie@>=0.12.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.2",
               "from": "tunnel-agent@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             }
           }
         },
@@ -1841,77 +1547,65 @@
           "version": "0.3.1",
           "from": "request-progress@0.3.1",
           "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
-          "dev": true,
           "dependencies": {
             "throttleit": {
               "version": "0.0.2",
               "from": "throttleit@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
             }
           }
         },
         "retry": {
           "version": "0.6.1",
           "from": "retry@0.6.1",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
         },
         "rimraf": {
           "version": "2.5.0",
           "from": "rimraf@>=2.2.8 <3.0.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
-          "dev": true,
           "dependencies": {
             "glob": {
               "version": "6.0.3",
               "from": "glob@>=6.0.1 <7.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
-              "dev": true,
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
                   "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
                       "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
                   "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.0",
                   "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.2",
                       "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                      "dev": true,
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
                           "from": "balanced-match@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
                           "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
                     }
@@ -1921,21 +1615,18 @@
                   "version": "1.3.3",
                   "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
                       "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
                   "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             }
@@ -1944,76 +1635,64 @@
         "semver": {
           "version": "2.3.2",
           "from": "semver@>=2.3.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
         },
         "shell-quote": {
           "version": "1.4.3",
           "from": "shell-quote@>=1.4.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
-          "dev": true,
           "dependencies": {
             "array-filter": {
               "version": "0.0.1",
               "from": "array-filter@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
             },
             "array-map": {
               "version": "0.0.0",
               "from": "array-map@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
             },
             "array-reduce": {
               "version": "0.0.0",
               "from": "array-reduce@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
             },
             "jsonify": {
               "version": "0.0.0",
               "from": "jsonify@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
             }
           }
         },
         "stringify-object": {
           "version": "1.0.1",
           "from": "stringify-object@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
         },
         "tar-fs": {
           "version": "1.9.0",
           "from": "tar-fs@>=1.4.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.9.0.tgz",
-          "dev": true,
           "dependencies": {
             "pump": {
               "version": "1.0.1",
               "from": "pump@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz",
-              "dev": true,
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.1.0",
                   "from": "end-of-stream@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
                 },
                 "once": {
                   "version": "1.3.3",
                   "from": "once@>=1.3.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
                       "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 }
@@ -2023,31 +1702,26 @@
               "version": "1.3.1",
               "from": "tar-stream@>=1.1.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.3.1.tgz",
-              "dev": true,
               "dependencies": {
                 "bl": {
                   "version": "1.0.0",
                   "from": "bl@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
                 },
                 "end-of-stream": {
                   "version": "1.1.0",
                   "from": "end-of-stream@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
                       "from": "once@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dev": true,
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
                           "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     }
@@ -2057,51 +1731,43 @@
                   "version": "2.0.5",
                   "from": "readable-stream@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "dev": true,
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
                       "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
                       "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
                       "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
                       "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
                   "from": "xtend@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             }
@@ -2110,76 +1776,64 @@
         "tmp": {
           "version": "0.0.24",
           "from": "tmp@0.0.24",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
         },
         "update-notifier": {
           "version": "0.6.0",
           "from": "update-notifier@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.6.0.tgz",
-          "dev": true,
           "dependencies": {
             "configstore": {
               "version": "1.4.0",
               "from": "configstore@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
-              "dev": true,
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.2",
                   "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                 },
                 "object-assign": {
                   "version": "4.0.1",
                   "from": "object-assign@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
                   "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 },
                 "osenv": {
                   "version": "0.1.3",
                   "from": "osenv@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
                       "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     }
                   }
                 },
                 "uuid": {
                   "version": "2.0.1",
                   "from": "uuid@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
                 },
                 "write-file-atomic": {
                   "version": "1.1.4",
                   "from": "write-file-atomic@>=1.1.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-                  "dev": true,
                   "dependencies": {
                     "imurmurhash": {
                       "version": "0.1.4",
                       "from": "imurmurhash@>=0.1.4 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
                     },
                     "slide": {
                       "version": "1.1.6",
                       "from": "slide@>=1.1.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
                     }
                   }
                 },
@@ -2187,13 +1841,11 @@
                   "version": "2.0.0",
                   "from": "xdg-basedir@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
                       "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     }
                   }
                 }
@@ -2202,44 +1854,37 @@
             "is-npm": {
               "version": "1.0.0",
               "from": "is-npm@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
             },
             "latest-version": {
               "version": "2.0.0",
               "from": "latest-version@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
-              "dev": true,
               "dependencies": {
                 "package-json": {
                   "version": "2.3.0",
                   "from": "package-json@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.3.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "got": {
                       "version": "5.3.0",
                       "from": "got@>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/got/-/got-5.3.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "create-error-class": {
                           "version": "2.0.1",
                           "from": "create-error-class@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-2.0.1.tgz",
-                          "dev": true,
                           "dependencies": {
                             "capture-stack-trace": {
                               "version": "1.0.0",
                               "from": "capture-stack-trace@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
                               "from": "inherits@>=2.0.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
                         },
@@ -2247,25 +1892,21 @@
                           "version": "3.4.2",
                           "from": "duplexify@>=3.2.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
-                          "dev": true,
                           "dependencies": {
                             "end-of-stream": {
                               "version": "1.0.0",
                               "from": "end-of-stream@1.0.0",
                               "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "once": {
                                   "version": "1.3.3",
                                   "from": "once@>=1.3.0 <1.4.0",
                                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                                  "dev": true,
                                   "dependencies": {
                                     "wrappy": {
                                       "version": "1.0.1",
                                       "from": "wrappy@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                                      "dev": true
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                     }
                                   }
                                 }
@@ -2275,43 +1916,36 @@
                               "version": "2.0.5",
                               "from": "readable-stream@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
                                   "from": "core-util-is@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
                                   "from": "inherits@>=2.0.1 <2.1.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
                                   "from": "isarray@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 },
                                 "process-nextick-args": {
                                   "version": "1.0.6",
                                   "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
                                   "from": "string_decoder@>=0.10.0 <0.11.0",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
                                 "util-deprecate": {
                                   "version": "1.0.2",
                                   "from": "util-deprecate@>=1.0.1 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                                 }
                               }
                             }
@@ -2320,56 +1954,47 @@
                         "is-plain-obj": {
                           "version": "1.1.0",
                           "from": "is-plain-obj@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
                         },
                         "is-redirect": {
                           "version": "1.0.0",
                           "from": "is-redirect@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
                         },
                         "is-stream": {
                           "version": "1.0.1",
                           "from": "is-stream@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
                         },
                         "lowercase-keys": {
                           "version": "1.0.0",
                           "from": "lowercase-keys@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
                         },
                         "node-status-codes": {
                           "version": "1.0.0",
                           "from": "node-status-codes@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
                         },
                         "object-assign": {
                           "version": "4.0.1",
                           "from": "object-assign@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                         },
                         "parse-json": {
                           "version": "2.2.0",
                           "from": "parse-json@>=2.1.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.0",
                               "from": "error-ex@>=1.2.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "is-arrayish": {
                                   "version": "0.2.1",
                                   "from": "is-arrayish@>=0.2.1 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                 }
                               }
                             }
@@ -2379,13 +2004,11 @@
                           "version": "2.0.0",
                           "from": "pinkie-promise@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.1",
                               "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                             }
                           }
                         },
@@ -2393,19 +2016,16 @@
                           "version": "3.0.1",
                           "from": "read-all-stream@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
-                          "dev": true,
                           "dependencies": {
                             "pinkie-promise": {
                               "version": "1.0.0",
                               "from": "pinkie-promise@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "pinkie": {
                                   "version": "1.0.0",
                                   "from": "pinkie@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
                                 }
                               }
                             },
@@ -2413,43 +2033,36 @@
                               "version": "2.0.5",
                               "from": "readable-stream@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                              "dev": true,
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
                                   "from": "core-util-is@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
                                   "from": "inherits@>=2.0.1 <2.1.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
                                   "from": "isarray@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 },
                                 "process-nextick-args": {
                                   "version": "1.0.6",
                                   "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
                                   "from": "string_decoder@>=0.10.0 <0.11.0",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
                                 "util-deprecate": {
                                   "version": "1.0.2",
                                   "from": "util-deprecate@>=1.0.1 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                                  "dev": true
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                                 }
                               }
                             }
@@ -2458,26 +2071,22 @@
                         "timed-out": {
                           "version": "2.0.0",
                           "from": "timed-out@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
                         },
                         "unzip-response": {
                           "version": "1.0.0",
                           "from": "unzip-response@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz"
                         },
                         "url-parse-lax": {
                           "version": "1.0.0",
                           "from": "url-parse-lax@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-                          "dev": true,
                           "dependencies": {
                             "prepend-http": {
                               "version": "1.0.3",
                               "from": "prepend-http@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
                             }
                           }
                         }
@@ -2487,45 +2096,38 @@
                       "version": "1.1.6",
                       "from": "rc@>=1.1.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-                      "dev": true,
                       "dependencies": {
                         "deep-extend": {
                           "version": "0.4.0",
                           "from": "deep-extend@>=0.4.0 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
                         },
                         "ini": {
                           "version": "1.3.4",
                           "from": "ini@>=1.3.0 <1.4.0",
-                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                         },
                         "minimist": {
                           "version": "1.2.0",
                           "from": "minimist@>=1.2.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         },
                         "strip-json-comments": {
                           "version": "1.0.4",
                           "from": "strip-json-comments@>=1.0.4 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                         }
                       }
                     },
                     "registry-url": {
                       "version": "3.0.3",
                       "from": "registry-url@>=3.0.3 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz"
                     },
                     "semver": {
                       "version": "5.1.0",
                       "from": "semver@>=5.1.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                     }
                   }
                 }
@@ -2535,19 +2137,16 @@
               "version": "2.0.0",
               "from": "repeating@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-              "dev": true,
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
                   "from": "is-finite@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
                       "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 }
@@ -2557,13 +2156,11 @@
               "version": "2.1.0",
               "from": "semver-diff@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-              "dev": true,
               "dependencies": {
                 "semver": {
                   "version": "5.1.0",
                   "from": "semver@>=5.0.3 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                 }
               }
             },
@@ -2571,19 +2168,16 @@
               "version": "1.0.1",
               "from": "string-length@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-              "dev": true,
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.0",
                   "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
                       "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 }
@@ -2594,26 +2188,22 @@
         "user-home": {
           "version": "1.1.1",
           "from": "user-home@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
         },
         "which": {
           "version": "1.2.1",
           "from": "which@>=1.0.8 <2.0.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.1.tgz",
-          "dev": true,
           "dependencies": {
             "is-absolute": {
               "version": "0.1.7",
               "from": "is-absolute@>=0.1.7 <0.2.0",
               "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-              "dev": true,
               "dependencies": {
                 "is-relative": {
                   "version": "0.1.3",
                   "from": "is-relative@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
                 }
               }
             }
@@ -2625,167 +2215,155 @@
       "version": "0.6.0",
       "from": "boxen@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
-      "dev": true,
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
           "from": "camelcase@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
         }
       }
     },
     "brace-expansion": {
       "version": "1.1.6",
       "from": "brace-expansion@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
     },
     "braces": {
       "version": "1.8.3",
       "from": "braces@>=1.8.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz"
     },
     "browserify-zlib": {
       "version": "0.1.4",
       "from": "browserify-zlib@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "browserstack": {
       "version": "1.2.0",
       "from": "browserstack@1.2.0",
-      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.2.0.tgz"
     },
     "browserstacktunnel-wrapper": {
       "version": "1.4.2",
       "from": "browserstacktunnel-wrapper@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/browserstacktunnel-wrapper/-/browserstacktunnel-wrapper-1.4.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/browserstacktunnel-wrapper/-/browserstacktunnel-wrapper-1.4.2.tgz"
     },
     "buffer": {
       "version": "4.9.1",
       "from": "buffer@>=4.9.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         }
       }
     },
     "buffer-crc32": {
       "version": "0.2.5",
       "from": "buffer-crc32@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
     },
     "buffer-shims": {
       "version": "1.0.0",
       "from": "buffer-shims@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
     },
     "buffers": {
       "version": "0.1.1",
       "from": "buffers@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
     },
     "builtin-modules": {
       "version": "1.1.1",
       "from": "builtin-modules@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
     },
     "bytes": {
       "version": "2.1.0",
       "from": "bytes@2.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
     },
     "callsite": {
       "version": "1.0.0",
       "from": "callsite@1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+    },
+    "camel-case": {
+      "version": "3.0.0",
+      "from": "camel-case@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz"
     },
     "camelcase": {
       "version": "2.0.1",
       "from": "camelcase@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
     },
     "camelcase-keys": {
       "version": "2.0.0",
       "from": "camelcase-keys@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz"
+    },
+    "canonical-path": {
+      "version": "0.0.2",
+      "from": "canonical-path@>=0.0.2 <0.0.3",
+      "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-0.0.2.tgz"
     },
     "capture-stack-trace": {
       "version": "1.0.0",
       "from": "capture-stack-trace@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
     },
     "caseless": {
       "version": "0.11.0",
       "from": "caseless@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+    },
+    "catharsis": {
+      "version": "0.8.8",
+      "from": "catharsis@>=0.8.1 <0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.8.tgz"
     },
     "center-align": {
       "version": "0.1.2",
       "from": "center-align@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz"
     },
     "chainsaw": {
       "version": "0.1.0",
       "from": "chainsaw@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz"
     },
     "chalk": {
       "version": "1.1.3",
       "from": "chalk@>=1.1.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+    },
+    "change-case": {
+      "version": "3.0.0",
+      "from": "change-case@3.0.0",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.0.0.tgz"
     },
     "chokidar": {
       "version": "1.4.2",
       "from": "chokidar@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz",
-      "dev": true
-    },
-    "ci-info": {
-      "version": "1.0.0",
-      "from": "ci-info@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz"
     },
     "clang-format": {
       "version": "1.0.41",
       "from": "clang-format@1.0.41",
       "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.41.tgz",
-      "dev": true,
       "dependencies": {
         "async": {
           "version": "1.5.2",
           "from": "async@>=1.5.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "glob": {
           "version": "7.0.3",
           "from": "glob@>=7.0.0 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz"
         }
       }
     },
@@ -2793,159 +2371,112 @@
       "version": "3.5.2",
       "from": "cldr@>=3.5.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/cldr/-/cldr-3.5.2.tgz",
-      "dev": true,
       "dependencies": {
         "uglify-js": {
           "version": "1.3.3",
           "from": "uglify-js@1.3.3",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.3.tgz"
         },
         "underscore": {
           "version": "1.3.3",
           "from": "underscore@1.3.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.3.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.3.3.tgz"
         }
       }
     },
     "cli-boxes": {
       "version": "1.0.0",
       "from": "cli-boxes@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz"
     },
     "cli-color": {
       "version": "1.1.0",
       "from": "cli-color@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
           "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         }
       }
-    },
-    "cli-cursor": {
-      "version": "1.0.2",
-      "from": "cli-cursor@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "dev": true
-    },
-    "cli-width": {
-      "version": "2.1.0",
-      "from": "cli-width@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "dev": true
     },
     "cliui": {
       "version": "3.1.0",
       "from": "cliui@>=3.0.3 <4.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
           "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "strip-ansi": {
           "version": "3.0.0",
           "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
         }
       }
     },
     "clone": {
       "version": "1.0.2",
       "from": "clone@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
     },
     "clone-stats": {
       "version": "0.0.1",
       "from": "clone-stats@>=0.0.1 <0.0.2",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "dev": true
-    },
-    "cmd-shim": {
-      "version": "2.0.2",
-      "from": "cmd-shim@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "dev": true
-        }
-      }
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
     },
     "code-point-at": {
       "version": "1.0.0",
       "from": "code-point-at@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
     },
     "colors": {
       "version": "1.1.2",
       "from": "colors@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
     },
     "combined-stream": {
       "version": "1.0.5",
       "from": "combined-stream@>=1.0.5 <1.1.0",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
     },
     "commander": {
       "version": "2.9.0",
       "from": "commander@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
     },
     "compare-func": {
       "version": "1.3.2",
       "from": "compare-func@>=1.3.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz"
     },
     "component-bind": {
       "version": "1.0.0",
       "from": "component-bind@1.0.0",
-      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
     },
     "component-emitter": {
       "version": "1.1.2",
       "from": "component-emitter@1.1.2",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
     },
     "component-inherit": {
       "version": "0.0.3",
       "from": "component-inherit@0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
     },
     "compress-commons": {
       "version": "0.2.9",
       "from": "compress-commons@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.9.tgz",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
           "from": "readable-stream@>=1.0.26 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
@@ -2953,289 +2484,226 @@
       "version": "2.0.6",
       "from": "compressible@>=2.0.5 <2.1.0",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.6.tgz",
-      "dev": true,
       "dependencies": {
         "mime-db": {
           "version": "1.20.0",
           "from": "mime-db@1.20.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
         }
       }
     },
     "compression": {
       "version": "1.5.2",
       "from": "compression@>=1.5.2 <1.6.0",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
       "from": "concat-map@0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "dev": true
-    },
-    "concat-stream": {
-      "version": "1.6.0",
-      "from": "concat-stream@>=1.4.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "from": "inherits@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.2.2",
-          "from": "readable-stream@>=2.2.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-          "dev": true
-        }
-      }
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "configstore": {
       "version": "2.1.0",
       "from": "configstore@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
         }
       }
     },
     "connect": {
       "version": "3.4.0",
       "from": "connect@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.0.tgz"
     },
     "connect-livereload": {
       "version": "0.5.4",
       "from": "connect-livereload@>=0.5.4 <0.6.0",
-      "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.5.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.5.4.tgz"
     },
     "connect-timeout": {
       "version": "1.6.2",
       "from": "connect-timeout@>=1.6.2 <1.7.0",
-      "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz"
     },
     "console-browserify": {
       "version": "1.1.0",
       "from": "console-browserify@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
     },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "from": "console-control-strings@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "dev": true
+    "constant-case": {
+      "version": "2.0.0",
+      "from": "constant-case@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz"
     },
     "constants-browserify": {
       "version": "0.0.1",
       "from": "constants-browserify@>=0.0.1 <0.1.0",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
     },
     "content-type": {
       "version": "1.0.1",
       "from": "content-type@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+    },
+    "content-type-parser": {
+      "version": "1.0.1",
+      "from": "content-type-parser@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz"
     },
     "conventional-changelog": {
       "version": "1.1.0",
       "from": "conventional-changelog@latest",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.0.tgz"
     },
     "conventional-changelog-angular": {
       "version": "1.3.0",
       "from": "conventional-changelog-angular@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.3.0.tgz"
     },
     "conventional-changelog-atom": {
       "version": "0.1.0",
       "from": "conventional-changelog-atom@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.0.tgz"
     },
     "conventional-changelog-codemirror": {
       "version": "0.1.0",
       "from": "conventional-changelog-codemirror@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.1.0.tgz"
     },
     "conventional-changelog-core": {
       "version": "1.5.0",
       "from": "conventional-changelog-core@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.5.0.tgz",
-      "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "lodash": {
           "version": "4.14.2",
           "from": "lodash@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.2.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
           "from": "readable-stream@2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "through2": {
           "version": "2.0.1",
           "from": "through2@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         }
       }
     },
     "conventional-changelog-ember": {
       "version": "0.2.2",
       "from": "conventional-changelog-ember@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.2.tgz"
     },
     "conventional-changelog-eslint": {
       "version": "0.1.0",
       "from": "conventional-changelog-eslint@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.1.0.tgz"
     },
     "conventional-changelog-express": {
       "version": "0.1.0",
       "from": "conventional-changelog-express@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.1.0.tgz"
     },
     "conventional-changelog-jquery": {
       "version": "0.1.0",
       "from": "conventional-changelog-jquery@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz"
     },
     "conventional-changelog-jscs": {
       "version": "0.1.0",
       "from": "conventional-changelog-jscs@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz"
     },
     "conventional-changelog-jshint": {
       "version": "0.1.0",
       "from": "conventional-changelog-jshint@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.1.0.tgz"
     },
     "conventional-changelog-writer": {
       "version": "1.4.1",
       "from": "conventional-changelog-writer@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-1.4.1.tgz",
-      "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "lodash": {
           "version": "4.14.2",
           "from": "lodash@4.14.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.2.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
           "from": "readable-stream@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "through2": {
           "version": "2.0.1",
           "from": "through2@2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         }
       }
     },
     "conventional-commits-filter": {
       "version": "1.0.0",
       "from": "conventional-commits-filter@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz"
     },
     "conventional-commits-parser": {
       "version": "1.2.3",
       "from": "conventional-commits-parser@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.2.3.tgz",
-      "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "lodash": {
           "version": "4.14.2",
           "from": "lodash@4.14.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.14.2.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
           "from": "readable-stream@2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "through2": {
           "version": "2.0.1",
           "from": "through2@2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         }
       }
     },
     "cookie": {
       "version": "0.1.3",
       "from": "cookie@0.1.3",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
     },
     "cookie-parser": {
       "version": "1.3.5",
       "from": "cookie-parser@>=1.3.5 <1.4.0",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz"
     },
     "cookie-signature": {
       "version": "1.0.6",
       "from": "cookie-signature@1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
     },
     "core-js": {
       "version": "2.4.1",
@@ -3245,277 +2713,310 @@
     "core-util-is": {
       "version": "1.0.2",
       "from": "core-util-is@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "cors": {
       "version": "2.7.1",
       "from": "cors@>=2.7.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz"
     },
     "crc": {
       "version": "3.3.0",
       "from": "crc@3.3.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz"
     },
     "crc32-stream": {
       "version": "0.3.4",
       "from": "crc32-stream@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
           "from": "readable-stream@>=1.0.24 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "create-error-class": {
       "version": "3.0.2",
       "from": "create-error-class@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz"
     },
     "cryptiles": {
       "version": "2.0.5",
       "from": "cryptiles@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
     },
     "crypto-browserify": {
       "version": "3.2.8",
       "from": "crypto-browserify@>=3.2.6 <3.3.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz"
     },
     "csrf": {
       "version": "3.0.0",
       "from": "csrf@>=3.0.0 <3.1.0",
-      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.0.tgz"
+    },
+    "cssom": {
+      "version": "0.3.2",
+      "from": "cssom@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz"
+    },
+    "cssstyle": {
+      "version": "0.2.37",
+      "from": "cssstyle@>=0.2.36 <0.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz"
     },
     "csurf": {
       "version": "1.8.3",
       "from": "csurf@>=1.8.3 <1.9.0",
-      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz"
     },
     "ctype": {
       "version": "0.5.3",
       "from": "ctype@0.5.3",
-      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
     },
     "custom-event": {
       "version": "1.0.0",
       "from": "custom-event@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz"
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "from": "cycle@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
     },
     "d": {
       "version": "0.1.1",
       "from": "d@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
     },
     "dargs": {
       "version": "4.1.0",
       "from": "dargs@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz"
     },
     "dashdash": {
       "version": "1.14.0",
       "from": "dashdash@>=1.12.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-      "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "date-now": {
       "version": "0.1.4",
       "from": "date-now@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
     },
     "dateformat": {
       "version": "1.0.12",
       "from": "dateformat@>=1.0.11 <2.0.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-      "dev": true
-    },
-    "death": {
-      "version": "1.1.0",
-      "from": "death@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/death/-/death-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz"
     },
     "debug": {
       "version": "2.2.0",
       "from": "debug@>=2.2.0 <2.3.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
     },
     "decamelize": {
       "version": "1.1.2",
       "from": "decamelize@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz"
     },
     "deep-extend": {
       "version": "0.4.1",
       "from": "deep-extend@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "from": "deep-is@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
     },
     "defaults": {
       "version": "1.0.3",
       "from": "defaults@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
     },
     "del": {
       "version": "2.2.2",
       "from": "del@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz"
     },
     "delayed-stream": {
       "version": "1.0.0",
       "from": "delayed-stream@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "dev": true
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "from": "delegates@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
     },
     "depd": {
       "version": "1.0.1",
       "from": "depd@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+    },
+    "dependency-graph": {
+      "version": "0.4.1",
+      "from": "dependency-graph@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.4.1.tgz"
     },
     "deprecated": {
       "version": "0.0.1",
       "from": "deprecated@>=0.0.1 <0.0.2",
-      "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
     },
     "destroy": {
       "version": "1.0.3",
       "from": "destroy@1.0.3",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
     },
-    "detect-indent": {
-      "version": "4.0.0",
-      "from": "detect-indent@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "dev": true
+    "dgeni": {
+      "version": "0.4.2",
+      "from": "dgeni@>=0.4.2 <0.5.0",
+      "resolved": "https://registry.npmjs.org/dgeni/-/dgeni-0.4.2.tgz"
+    },
+    "dgeni-packages": {
+      "version": "0.16.5",
+      "from": "dgeni-packages@>=0.16.0 <0.17.0",
+      "resolved": "https://registry.npmjs.org/dgeni-packages/-/dgeni-packages-0.16.5.tgz",
+      "dependencies": {
+        "espree": {
+          "version": "2.2.5",
+          "from": "espree@>=2.2.3 <3.0.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
+        },
+        "glob": {
+          "version": "7.1.1",
+          "from": "glob@>=7.0.5 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "from": "lodash@>=4.13.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        },
+        "semver": {
+          "version": "5.3.0",
+          "from": "semver@>=5.2.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+        },
+        "typescript": {
+          "version": "1.8.10",
+          "from": "typescript@>=1.7.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.8.10.tgz"
+        }
+      }
     },
     "di": {
       "version": "0.0.1",
       "from": "di@>=0.0.1 <0.0.2",
-      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
     },
     "diff": {
       "version": "2.2.1",
       "from": "diff@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.1.tgz"
     },
     "doctrine": {
       "version": "0.7.2",
       "from": "doctrine@>=0.7.2 <0.8.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz"
     },
     "dom-serialize": {
       "version": "2.2.1",
       "from": "dom-serialize@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz"
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "from": "dom-serializer@>=0.0.0 <1.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "from": "domelementtype@>=1.1.1 <1.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+        }
+      }
     },
     "domain-browser": {
       "version": "1.1.7",
       "from": "domain-browser@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "from": "domelementtype@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "from": "domhandler@>=2.3.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "from": "domutils@>=1.5.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
+    },
+    "dot-case": {
+      "version": "2.1.0",
+      "from": "dot-case@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.0.tgz"
     },
     "dot-prop": {
       "version": "3.0.0",
       "from": "dot-prop@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz"
     },
     "duplexer": {
       "version": "0.1.1",
       "from": "duplexer@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
     },
     "duplexer2": {
       "version": "0.0.2",
       "from": "duplexer2@>=0.0.2 <0.1.0",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "dev": true,
-      "optional": true
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
     },
     "ee-first": {
       "version": "1.1.1",
       "from": "ee-first@1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
     },
     "end-of-stream": {
       "version": "1.1.0",
       "from": "end-of-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
     },
     "engine.io": {
       "version": "1.6.9",
       "from": "engine.io@1.6.9",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.9.tgz",
-      "dev": true,
       "dependencies": {
         "accepts": {
           "version": "1.1.4",
           "from": "accepts@1.1.4",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz"
         },
         "negotiator": {
           "version": "0.4.9",
           "from": "negotiator@0.4.9",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
         },
         "ws": {
           "version": "1.0.1",
           "from": "ws@1.0.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz"
         }
       }
     },
@@ -3523,13 +3024,11 @@
       "version": "1.6.9",
       "from": "engine.io-client@1.6.9",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.9.tgz",
-      "dev": true,
       "dependencies": {
         "ws": {
           "version": "1.0.1",
           "from": "ws@1.0.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz"
         }
       }
     },
@@ -3537,13 +3036,11 @@
       "version": "1.2.4",
       "from": "engine.io-parser@1.2.4",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
-      "dev": true,
       "dependencies": {
         "has-binary": {
           "version": "0.1.6",
           "from": "has-binary@0.1.6",
-          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz"
         }
       }
     },
@@ -3551,389 +3048,335 @@
       "version": "0.9.1",
       "from": "enhanced-resolve@>=0.9.0 <0.10.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
-      "dev": true,
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.2",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
         },
         "memory-fs": {
           "version": "0.2.0",
           "from": "memory-fs@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
         }
       }
     },
     "ent": {
       "version": "2.2.0",
       "from": "ent@>=2.2.0 <2.3.0",
-      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz"
+    },
+    "entities": {
+      "version": "1.1.1",
+      "from": "entities@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
     "envify": {
       "version": "3.4.0",
       "from": "envify@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz"
     },
     "errno": {
       "version": "0.1.4",
       "from": "errno@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
     },
     "error-ex": {
       "version": "1.3.0",
       "from": "error-ex@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
     },
     "errorhandler": {
       "version": "1.4.2",
       "from": "errorhandler@>=1.4.2 <1.5.0",
-      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.2.tgz"
     },
     "es5-ext": {
       "version": "0.10.11",
       "from": "es5-ext@>=0.10.8 <0.11.0",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
     },
     "es6-iterator": {
       "version": "2.0.0",
       "from": "es6-iterator@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
     },
     "es6-module-loader": {
       "version": "0.17.9",
       "from": "es6-module-loader@>=0.17.4 <0.18.0",
-      "resolved": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.17.9.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/es6-module-loader/-/es6-module-loader-0.17.9.tgz"
     },
     "es6-symbol": {
       "version": "3.0.2",
       "from": "es6-symbol@>=3.0.2 <3.1.0",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
     },
     "es6-weak-map": {
       "version": "0.1.4",
       "from": "es6-weak-map@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
-      "dev": true,
       "dependencies": {
         "es6-iterator": {
           "version": "0.1.3",
           "from": "es6-iterator@>=0.1.3 <0.2.0",
-          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
         },
         "es6-symbol": {
           "version": "2.0.1",
           "from": "es6-symbol@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
         }
       }
     },
     "escape-html": {
       "version": "1.0.2",
       "from": "escape-html@1.0.2",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
     },
     "escape-string-regexp": {
       "version": "1.0.4",
       "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "from": "escodegen@>=1.6.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "dependencies": {
+        "estraverse": {
+          "version": "1.9.3",
+          "from": "estraverse@>=1.9.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "from": "esutils@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "from": "source-map@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+        }
+      }
     },
     "esprima": {
       "version": "2.7.1",
       "from": "esprima@>=2.6.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "from": "estraverse@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
     },
     "estree-walker": {
       "version": "0.2.1",
       "from": "estree-walker@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz"
     },
     "esutils": {
       "version": "1.1.6",
       "from": "esutils@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
     },
     "etag": {
       "version": "1.7.0",
       "from": "etag@>=1.7.0 <1.8.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
     },
     "event-emitter": {
       "version": "0.3.4",
       "from": "event-emitter@>=0.3.3 <0.4.0",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
     },
     "event-stream": {
       "version": "3.3.2",
       "from": "event-stream@>=3.1.5 <4.0.0",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
-      "dev": true,
       "dependencies": {
         "split": {
           "version": "0.3.3",
           "from": "split@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
         }
       }
     },
     "eventemitter3": {
       "version": "1.2.0",
       "from": "eventemitter3@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
     },
     "events": {
       "version": "1.1.1",
       "from": "events@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz"
     },
     "exit": {
       "version": "0.1.2",
       "from": "exit@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "dev": true
-    },
-    "exit-hook": {
-      "version": "1.1.1",
-      "from": "exit-hook@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
     },
     "expand-braces": {
       "version": "0.1.2",
       "from": "expand-braces@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
-      "dev": true,
       "dependencies": {
         "braces": {
           "version": "0.1.5",
           "from": "braces@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz"
         },
         "expand-range": {
           "version": "0.1.1",
           "from": "expand-range@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz"
         },
         "is-number": {
           "version": "0.1.1",
           "from": "is-number@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz"
         },
         "repeat-string": {
           "version": "0.2.2",
           "from": "repeat-string@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz"
         }
       }
     },
     "expand-brackets": {
       "version": "0.1.4",
       "from": "expand-brackets@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
     },
     "expand-range": {
       "version": "1.8.1",
       "from": "expand-range@>=1.8.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz"
     },
     "express-session": {
       "version": "1.11.3",
       "from": "express-session@>=1.11.3 <1.12.0",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz"
     },
     "extend": {
       "version": "3.0.0",
       "from": "extend@>=3.0.0 <3.1.0",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-      "dev": true
-    },
-    "external-editor": {
-      "version": "1.1.1",
-      "from": "external-editor@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-      "dev": true,
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.29",
-          "from": "tmp@>=0.0.29 <0.0.30",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-          "dev": true
-        }
-      }
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
     },
     "extglob": {
       "version": "0.3.1",
       "from": "extglob@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz"
     },
     "extsprintf": {
       "version": "1.0.2",
       "from": "extsprintf@1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "from": "eyes@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
     },
     "fancy-log": {
       "version": "1.1.0",
       "from": "fancy-log@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
           "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "ansi-styles": {
           "version": "2.1.0",
           "from": "ansi-styles@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
         },
         "chalk": {
           "version": "1.1.1",
           "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
           "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "strip-ansi": {
           "version": "3.0.0",
           "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
           "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "from": "fast-levenshtein@>=2.0.4 <2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
     },
     "faye-websocket": {
       "version": "0.10.0",
       "from": "faye-websocket@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz"
     },
     "fbjs": {
       "version": "0.6.0",
       "from": "fbjs@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.0.tgz",
-      "dev": true,
       "dependencies": {
         "core-js": {
           "version": "1.2.6",
           "from": "core-js@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
-          "dev": true
-        }
-      }
-    },
-    "figures": {
-      "version": "1.7.0",
-      "from": "figures@>=1.3.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "from": "escape-string-regexp@>=1.0.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "from": "object-assign@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
         }
       }
     },
     "filename-regex": {
       "version": "2.0.0",
       "from": "filename-regex@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
     },
     "fill-range": {
       "version": "2.2.3",
       "from": "fill-range@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
     },
     "filled-array": {
       "version": "1.1.0",
       "from": "filled-array@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz"
     },
     "finalhandler": {
       "version": "0.4.0",
       "from": "finalhandler@0.4.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz"
     },
     "find-index": {
       "version": "0.1.1",
       "from": "find-index@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
     },
     "find-up": {
       "version": "1.1.0",
       "from": "find-up@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz"
     },
     "findup-sync": {
       "version": "0.3.0",
       "from": "findup-sync@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-      "dev": true,
       "dependencies": {
         "glob": {
           "version": "5.0.15",
           "from": "glob@>=5.0.0 <5.1.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         }
       }
     },
@@ -3941,953 +3384,773 @@
       "version": "0.3.11",
       "from": "firefox-profile@>=0.3.4 <0.4.0",
       "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-0.3.11.tgz",
-      "dev": true,
       "dependencies": {
         "async": {
           "version": "0.9.2",
           "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "fs-extra": {
           "version": "0.16.5",
           "from": "fs-extra@>=0.16.0 <0.17.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz"
         },
         "lodash": {
           "version": "3.5.0",
           "from": "lodash@>=3.5.0 <3.6.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
         }
       }
     },
     "first-chunk-stream": {
       "version": "1.0.0",
       "from": "first-chunk-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
     },
     "flagged-respawn": {
       "version": "0.3.1",
       "from": "flagged-respawn@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
     },
     "for-in": {
       "version": "0.1.4",
       "from": "for-in@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
     },
     "for-own": {
       "version": "0.1.3",
       "from": "for-own@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz"
     },
     "forever-agent": {
       "version": "0.6.1",
       "from": "forever-agent@>=0.6.1 <0.7.0",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
     },
     "form-data": {
       "version": "2.1.2",
       "from": "form-data@>=2.1.1 <2.2.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-      "dev": true,
       "dependencies": {
         "mime-db": {
           "version": "1.24.0",
           "from": "mime-db@>=1.24.0 <1.25.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
         },
         "mime-types": {
           "version": "2.1.12",
           "from": "mime-types@^2.1.12",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
         }
       }
     },
     "fresh": {
       "version": "0.3.0",
       "from": "fresh@0.3.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
     },
     "from": {
       "version": "0.1.3",
       "from": "from@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
     },
     "fs-access": {
       "version": "1.0.0",
       "from": "fs-access@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.0.tgz"
     },
     "fs-extra": {
       "version": "0.26.3",
       "from": "fs-extra@0.26.3",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.3.tgz",
-      "dev": true,
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.2",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
         }
       }
     },
     "fs-promise": {
       "version": "0.3.1",
       "from": "fs-promise@0.3.1",
-      "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-0.3.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-0.3.1.tgz"
     },
     "fs.realpath": {
       "version": "1.0.0",
       "from": "fs.realpath@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
     },
     "fsevents": {
       "version": "1.0.14",
       "from": "fsevents@latest",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.14.tgz",
-      "dev": true,
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
           "from": "abbrev@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
         },
         "ansi-regex": {
           "version": "2.0.0",
           "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "ansi-styles": {
           "version": "2.2.1",
           "from": "ansi-styles@>=2.2.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
         },
         "aproba": {
           "version": "1.0.4",
           "from": "aproba@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
         },
         "are-we-there-yet": {
           "version": "1.1.2",
           "from": "are-we-there-yet@>=1.1.2 <1.2.0",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
         },
         "asn1": {
           "version": "0.2.3",
           "from": "asn1@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
         },
         "assert-plus": {
           "version": "0.2.0",
           "from": "assert-plus@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
         },
         "async": {
           "version": "1.5.2",
           "from": "async@>=1.5.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "aws-sign2": {
           "version": "0.6.0",
           "from": "aws-sign2@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
           "version": "1.4.1",
           "from": "aws4@>=1.2.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
         },
         "bl": {
           "version": "1.1.2",
           "from": "bl@>=1.1.2 <1.2.0",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-          "dev": true,
           "dependencies": {
             "readable-stream": {
               "version": "2.0.6",
               "from": "readable-stream@>=2.0.5 <2.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
             }
           }
         },
         "block-stream": {
           "version": "0.0.9",
           "from": "block-stream@*",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
         },
         "boom": {
           "version": "2.10.1",
           "from": "boom@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
         },
         "buffer-shims": {
           "version": "1.0.0",
           "from": "buffer-shims@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
         },
         "caseless": {
           "version": "0.11.0",
           "from": "caseless@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
         },
         "chalk": {
           "version": "1.1.3",
           "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
         },
         "code-point-at": {
           "version": "1.0.0",
           "from": "code-point-at@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
           "from": "combined-stream@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
         },
         "commander": {
           "version": "2.9.0",
           "from": "commander@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
         },
         "console-control-strings": {
           "version": "1.1.0",
           "from": "console-control-strings@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
         },
         "core-util-is": {
           "version": "1.0.2",
           "from": "core-util-is@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
         },
         "cryptiles": {
           "version": "2.0.5",
           "from": "cryptiles@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
         },
         "dashdash": {
           "version": "1.14.0",
           "from": "dashdash@>=1.12.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-          "dev": true,
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
               "from": "assert-plus@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
             }
           }
         },
         "debug": {
           "version": "2.2.0",
           "from": "debug@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         },
         "deep-extend": {
           "version": "0.4.1",
           "from": "deep-extend@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
         },
         "delayed-stream": {
           "version": "1.0.0",
           "from": "delayed-stream@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
         },
         "delegates": {
           "version": "1.0.0",
           "from": "delegates@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
         },
         "ecc-jsbn": {
           "version": "0.1.1",
           "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "dev": true,
-          "optional": true
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
         },
         "extend": {
           "version": "3.0.0",
           "from": "extend@>=3.0.0 <3.1.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         },
         "extsprintf": {
           "version": "1.0.2",
           "from": "extsprintf@1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
           "from": "forever-agent@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "1.0.0-rc4",
           "from": "form-data@>=1.0.0-rc4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
         },
         "fs.realpath": {
           "version": "1.0.0",
           "from": "fs.realpath@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
         },
         "fstream": {
           "version": "1.0.10",
           "from": "fstream@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
         },
         "fstream-ignore": {
           "version": "1.0.5",
           "from": "fstream-ignore@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
         },
         "gauge": {
           "version": "2.6.0",
           "from": "gauge@>=2.6.0 <2.7.0",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz"
         },
         "generate-function": {
           "version": "2.0.0",
           "from": "generate-function@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
         },
         "generate-object-property": {
           "version": "1.2.0",
           "from": "generate-object-property@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
         },
         "getpass": {
           "version": "0.1.6",
           "from": "getpass@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-          "dev": true,
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
               "from": "assert-plus@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
             }
           }
         },
         "glob": {
           "version": "7.0.5",
           "from": "glob@>=7.0.5 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz"
         },
         "graceful-fs": {
           "version": "4.1.4",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
         },
         "graceful-readlink": {
           "version": "1.0.1",
           "from": "graceful-readlink@>=1.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
         },
         "har-validator": {
           "version": "2.0.6",
           "from": "har-validator@>=2.0.6 <2.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
           "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "has-color": {
           "version": "0.1.7",
           "from": "has-color@>=0.1.7 <0.2.0",
-          "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
         },
         "has-unicode": {
           "version": "2.0.1",
           "from": "has-unicode@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
         },
         "hawk": {
           "version": "3.1.3",
           "from": "hawk@>=3.1.3 <3.2.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
         },
         "hoek": {
           "version": "2.16.3",
           "from": "hoek@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         },
         "http-signature": {
           "version": "1.1.1",
           "from": "http-signature@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
         },
         "inflight": {
           "version": "1.0.5",
           "from": "inflight@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
         },
         "inherits": {
           "version": "2.0.1",
           "from": "inherits@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "ini": {
           "version": "1.3.4",
           "from": "ini@>=1.3.0 <1.4.0",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
         },
         "is-my-json-valid": {
           "version": "2.13.1",
           "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
         },
         "is-property": {
           "version": "1.0.2",
           "from": "is-property@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
         },
         "is-typedarray": {
           "version": "1.0.0",
           "from": "is-typedarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
         },
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "isstream": {
           "version": "0.1.2",
           "from": "isstream@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "jodid25519": {
           "version": "1.0.2",
           "from": "jodid25519@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "dev": true,
-          "optional": true
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
         },
         "jsbn": {
           "version": "0.1.0",
           "from": "jsbn@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-          "dev": true,
-          "optional": true
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
         },
         "json-schema": {
           "version": "0.2.2",
           "from": "json-schema@0.2.2",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.1",
           "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "jsonpointer": {
           "version": "2.0.0",
           "from": "jsonpointer@2.0.0",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
         },
         "jsprim": {
           "version": "1.3.0",
           "from": "jsprim@>=1.2.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz"
         },
         "mime-db": {
           "version": "1.23.0",
           "from": "mime-db@>=1.23.0 <1.24.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
         },
         "mime-types": {
           "version": "2.1.11",
           "from": "mime-types@>=2.1.7 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
         },
         "minimist": {
           "version": "0.0.8",
           "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         },
         "mkdirp": {
           "version": "0.5.1",
           "from": "mkdirp@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
         },
         "ms": {
           "version": "0.7.1",
           "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "nan": {
           "version": "2.4.0",
           "from": "nan@>=2.3.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
         },
         "node-pre-gyp": {
           "version": "0.6.29",
           "from": "node-pre-gyp@>=0.6.29 <0.7.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.29.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.29.tgz"
         },
         "node-uuid": {
           "version": "1.4.7",
           "from": "node-uuid@>=1.4.7 <1.5.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "nopt": {
           "version": "3.0.6",
           "from": "nopt@>=3.0.1 <3.1.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
         },
         "npmlog": {
           "version": "3.1.2",
           "from": "npmlog@>=3.1.2 <3.2.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz"
         },
         "number-is-nan": {
           "version": "1.0.0",
           "from": "number-is-nan@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
         },
         "oauth-sign": {
           "version": "0.8.2",
           "from": "oauth-sign@>=0.8.1 <0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "object-assign": {
           "version": "4.1.0",
           "from": "object-assign@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         },
         "once": {
           "version": "1.3.3",
           "from": "once@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
         },
         "path-is-absolute": {
           "version": "1.0.0",
           "from": "path-is-absolute@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "pinkie": {
           "version": "2.0.4",
           "from": "pinkie@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
         },
         "pinkie-promise": {
           "version": "2.0.1",
           "from": "pinkie-promise@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
         },
         "process-nextick-args": {
           "version": "1.0.7",
           "from": "process-nextick-args@>=1.0.6 <1.1.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
         },
         "qs": {
           "version": "6.2.0",
           "from": "qs@>=6.2.0 <6.3.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
         },
         "rc": {
           "version": "1.1.6",
           "from": "rc@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-          "dev": true,
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
               "from": "minimist@>=1.2.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             }
           }
         },
         "readable-stream": {
           "version": "2.1.4",
           "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
         },
         "request": {
           "version": "2.73.0",
           "from": "request@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.73.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/request/-/request-2.73.0.tgz"
         },
         "rimraf": {
           "version": "2.5.3",
           "from": "rimraf@>=2.5.0 <2.6.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz"
         },
         "semver": {
           "version": "5.2.0",
           "from": "semver@>=5.2.0 <5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz"
         },
         "set-blocking": {
           "version": "2.0.0",
           "from": "set-blocking@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
         },
         "signal-exit": {
           "version": "3.0.0",
           "from": "signal-exit@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
         },
         "sntp": {
           "version": "1.0.9",
           "from": "sntp@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
         },
         "sshpk": {
           "version": "1.8.3",
           "from": "sshpk@>=1.7.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
-          "dev": true,
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
               "from": "assert-plus@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
             }
           }
         },
         "string_decoder": {
           "version": "0.10.31",
           "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "string-width": {
           "version": "1.0.1",
           "from": "string-width@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
           "from": "stringstream@>=0.0.4 <0.1.0",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "strip-ansi": {
           "version": "3.0.1",
           "from": "strip-ansi@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.4",
           "from": "strip-json-comments@>=1.0.4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
           "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         },
         "tar": {
           "version": "2.2.1",
           "from": "tar@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
         },
         "tar-pack": {
           "version": "3.1.4",
           "from": "tar-pack@>=3.1.0 <3.2.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz"
         },
         "tough-cookie": {
           "version": "2.2.2",
           "from": "tough-cookie@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.3",
           "from": "tunnel-agent@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         },
         "tweetnacl": {
           "version": "0.13.3",
           "from": "tweetnacl@>=0.13.0 <0.14.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-          "dev": true,
-          "optional": true
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
         },
         "uid-number": {
           "version": "0.0.6",
           "from": "uid-number@>=0.0.6 <0.1.0",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
         },
         "util-deprecate": {
           "version": "1.0.2",
           "from": "util-deprecate@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
         },
         "verror": {
           "version": "1.3.6",
           "from": "verror@1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
         },
         "wide-align": {
           "version": "1.1.0",
           "from": "wide-align@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
         },
         "wrappy": {
           "version": "1.0.2",
           "from": "wrappy@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
         },
         "xtend": {
           "version": "4.0.1",
           "from": "xtend@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "fstream": {
       "version": "0.1.31",
       "from": "fstream@>=0.1.30 <1.0.0",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz"
     },
     "fx-runner": {
       "version": "0.0.7",
       "from": "fx-runner@0.0.7",
       "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-0.0.7.tgz",
-      "dev": true,
       "dependencies": {
         "commander": {
           "version": "2.6.0",
           "from": "commander@2.6.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
         },
         "lodash": {
           "version": "2.4.1",
           "from": "lodash@2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "when": {
           "version": "3.6.4",
           "from": "when@3.6.4",
-          "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz",
-          "dev": true
-        }
-      }
-    },
-    "gauge": {
-      "version": "2.7.2",
-      "from": "gauge@>=2.7.1 <2.8.0",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
-      "dev": true,
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "from": "object-assign@^4.1.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "from": "signal-exit@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "0.2.0",
-          "from": "supports-color@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz"
         }
       }
     },
     "gaze": {
       "version": "0.5.2",
       "from": "gaze@>=0.5.1 <0.6.0",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
     },
     "generate-function": {
       "version": "2.0.0",
       "from": "generate-function@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
     },
     "generate-object-property": {
       "version": "1.2.0",
       "from": "generate-object-property@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
     "get-pkg-repo": {
       "version": "1.2.1",
       "from": "get-pkg-repo@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.2.1.tgz",
-      "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
           "from": "readable-stream@2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "through2": {
           "version": "2.0.1",
           "from": "through2@2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         }
       }
     },
     "get-stdin": {
       "version": "4.0.1",
       "from": "get-stdin@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "getpass": {
       "version": "0.1.6",
       "from": "getpass@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-      "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
@@ -4895,127 +4158,107 @@
       "version": "1.1.2",
       "from": "git-raw-commits@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.1.2.tgz",
-      "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "lodash.template": {
           "version": "4.3.0",
           "from": "lodash.template@>=4.0.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.3.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.3.0.tgz"
         },
         "lodash.templatesettings": {
           "version": "4.1.0",
           "from": "lodash.templatesettings@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
           "from": "readable-stream@2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "through2": {
           "version": "2.0.1",
           "from": "through2@2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         }
       }
     },
     "git-remote-origin-url": {
       "version": "2.0.0",
       "from": "git-remote-origin-url@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz"
     },
     "git-semver-tags": {
       "version": "1.1.2",
       "from": "git-semver-tags@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.1.2.tgz"
     },
     "gitconfiglocal": {
       "version": "1.0.0",
       "from": "gitconfiglocal@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz"
     },
     "github-url-from-git": {
       "version": "1.4.0",
       "from": "github-url-from-git@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz"
     },
     "glob": {
       "version": "4.5.3",
       "from": "glob@>=4.0.6 <5.0.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-      "dev": true,
       "dependencies": {
         "minimatch": {
           "version": "2.0.10",
           "from": "minimatch@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
         }
       }
     },
     "glob-base": {
       "version": "0.3.0",
       "from": "glob-base@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
     },
     "glob-parent": {
       "version": "2.0.0",
       "from": "glob-parent@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
     },
     "glob-stream": {
       "version": "3.1.18",
       "from": "glob-stream@>=3.1.5 <4.0.0",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-      "dev": true,
       "dependencies": {
         "minimatch": {
           "version": "2.0.10",
           "from": "minimatch@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
         }
       }
     },
     "glob-watcher": {
       "version": "0.0.6",
       "from": "glob-watcher@>=0.0.6 <0.0.7",
-      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz"
     },
     "glob2base": {
       "version": "0.0.12",
       "from": "glob2base@>=0.0.12 <0.0.13",
-      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz"
     },
     "globby": {
       "version": "5.0.0",
       "from": "globby@>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "dev": true,
       "dependencies": {
         "glob": {
           "version": "7.1.1",
           "from": "glob@^7.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
         }
       }
     },
@@ -5023,49 +4266,41 @@
       "version": "0.1.0",
       "from": "globule@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "glob": {
           "version": "3.1.21",
           "from": "glob@>=3.1.21 <3.2.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz"
         },
         "graceful-fs": {
           "version": "1.2.3",
           "from": "graceful-fs@>=1.2.0 <1.3.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
         },
         "inherits": {
           "version": "1.0.2",
           "from": "inherits@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
         },
         "lodash": {
           "version": "1.0.2",
           "from": "lodash@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
           "from": "minimatch@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "dev": true,
           "dependencies": {
             "lru-cache": {
               "version": "2.7.3",
               "from": "lru-cache@2.7.3",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
             },
             "sigmund": {
               "version": "1.0.1",
               "from": "sigmund@1.0.1",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         }
@@ -5074,94 +4309,79 @@
     "glogg": {
       "version": "1.0.0",
       "from": "glogg@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
     },
     "got": {
       "version": "5.7.1",
       "from": "got@>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
-      "dev": true,
       "dependencies": {
         "duplexer2": {
           "version": "0.1.4",
           "from": "duplexer2@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
         },
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.2.2",
           "from": "readable-stream@>=2.0.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
         }
       }
     },
     "graceful-fs": {
       "version": "3.0.8",
       "from": "graceful-fs@>=3.0.2 <3.1.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
     },
     "graceful-readlink": {
       "version": "1.0.1",
       "from": "graceful-readlink@>=1.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
     "gulp": {
       "version": "3.9.0",
       "from": "gulp@>=3.8.8 <4.0.0",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.0.tgz",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
           "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "ansi-styles": {
           "version": "2.1.0",
           "from": "ansi-styles@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
         },
         "chalk": {
           "version": "1.1.1",
           "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
           "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "semver": {
           "version": "4.3.6",
           "from": "semver@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         },
         "strip-ansi": {
           "version": "3.0.0",
           "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
           "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
     },
@@ -5169,39 +4389,33 @@
       "version": "1.0.23",
       "from": "gulp-clang-format@>=1.0.23 <2.0.0",
       "resolved": "https://registry.npmjs.org/gulp-clang-format/-/gulp-clang-format-1.0.23.tgz",
-      "dev": true,
       "dependencies": {
         "duplexer2": {
           "version": "0.1.4",
           "from": "duplexer2@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
         },
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.1.4",
           "from": "readable-stream@>=2.0.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
-          "dev": true,
           "dependencies": {
             "buffer-shims": {
               "version": "1.0.0",
               "from": "buffer-shims@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
             }
           }
         },
         "stream-combiner2": {
           "version": "1.1.1",
           "from": "stream-combiner2@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz"
         }
       }
     },
@@ -5209,13 +4423,11 @@
       "version": "2.3.1",
       "from": "gulp-connect@2.3.1",
       "resolved": "https://registry.npmjs.org/gulp-connect/-/gulp-connect-2.3.1.tgz",
-      "dev": true,
       "dependencies": {
         "connect": {
           "version": "2.30.2",
           "from": "connect@>=2.30.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz"
         }
       }
     },
@@ -5223,31 +4435,26 @@
       "version": "1.1.0",
       "from": "gulp-conventional-changelog@latest",
       "resolved": "https://registry.npmjs.org/gulp-conventional-changelog/-/gulp-conventional-changelog-1.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "concat-stream": {
           "version": "1.5.1",
           "from": "concat-stream@>=1.5.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz"
         },
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
           "from": "readable-stream@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "through2": {
           "version": "2.0.1",
           "from": "through2@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         }
       }
     },
@@ -5255,137 +4462,154 @@
       "version": "1.0.0",
       "from": "gulp-diff@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/gulp-diff/-/gulp-diff-1.0.0.tgz",
-      "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
           "from": "readable-stream@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "through2": {
           "version": "2.0.1",
           "from": "through2@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+        }
+      }
+    },
+    "gulp-dom": {
+      "version": "0.9.17",
+      "from": "gulp-dom@latest",
+      "resolved": "https://registry.npmjs.org/gulp-dom/-/gulp-dom-0.9.17.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "from": "readable-stream@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+        },
+        "through2": {
+          "version": "2.0.1",
+          "from": "through2@2.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+        }
+      }
+    },
+    "gulp-tap": {
+      "version": "0.1.3",
+      "from": "gulp-tap@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-tap/-/gulp-tap-0.1.3.tgz",
+      "dependencies": {
+        "event-stream": {
+          "version": "3.1.7",
+          "from": "event-stream@>=3.1.0 <3.2.0",
+          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.1.7.tgz"
+        },
+        "split": {
+          "version": "0.2.10",
+          "from": "split@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
         }
       }
     },
     "gulp-tslint": {
       "version": "7.0.1",
       "from": "gulp-tslint@>=7.0.1 <8.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-tslint/-/gulp-tslint-7.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/gulp-tslint/-/gulp-tslint-7.0.1.tgz"
     },
     "gulp-util": {
       "version": "3.0.7",
       "from": "gulp-util@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
           "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "ansi-styles": {
           "version": "2.1.0",
           "from": "ansi-styles@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
         },
         "chalk": {
           "version": "1.1.1",
           "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
           "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "object-assign": {
           "version": "3.0.0",
           "from": "object-assign@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.5",
           "from": "readable-stream@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
         },
         "strip-ansi": {
           "version": "3.0.0",
           "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
           "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         },
         "through2": {
           "version": "2.0.0",
           "from": "through2@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz"
         },
         "vinyl": {
           "version": "0.5.3",
           "from": "vinyl@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
         }
       }
     },
     "gulplog": {
       "version": "1.0.0",
       "from": "gulplog@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
     },
     "hammerjs": {
       "version": "2.0.8",
       "from": "hammerjs@latest",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz"
     },
     "handlebars": {
       "version": "4.0.5",
       "from": "handlebars@>=4.0.2 <5.0.0",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
-      "dev": true,
       "dependencies": {
         "async": {
           "version": "1.5.2",
           "from": "async@>=1.4.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "source-map": {
           "version": "0.4.4",
           "from": "source-map@>=0.4.4 <0.5.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "dev": true,
           "dependencies": {
             "amdefine": {
               "version": "1.0.1",
               "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
             }
           }
         }
@@ -5395,659 +4619,602 @@
       "version": "2.0.6",
       "from": "har-validator@>=2.0.6 <2.1.0",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "dev": true,
       "dependencies": {
         "is-my-json-valid": {
           "version": "2.15.0",
           "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz"
         },
         "jsonpointer": {
           "version": "4.0.0",
           "from": "jsonpointer@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
         }
       }
     },
     "has-ansi": {
       "version": "2.0.0",
       "from": "has-ansi@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
     },
     "has-binary": {
       "version": "0.1.7",
       "from": "has-binary@0.1.7",
-      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz"
     },
     "has-cors": {
       "version": "1.1.0",
       "from": "has-cors@1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
     },
     "has-flag": {
       "version": "1.0.0",
       "from": "has-flag@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
     },
     "has-gulplog": {
       "version": "0.1.0",
       "from": "has-gulplog@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-      "dev": true
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "from": "has-unicode@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
     },
     "hashish": {
       "version": "0.0.4",
       "from": "hashish@>=0.0.2 <0.1.0",
-      "resolved": "https://registry.npmjs.org/hashish/-/hashish-0.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/hashish/-/hashish-0.0.4.tgz"
     },
     "hawk": {
       "version": "3.1.3",
       "from": "hawk@>=3.1.3 <3.2.0",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+    },
+    "header-case": {
+      "version": "1.0.0",
+      "from": "header-case@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.0.tgz"
     },
     "hoek": {
       "version": "2.16.3",
       "from": "hoek@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
     "hosted-git-info": {
       "version": "2.1.4",
       "from": "hosted-git-info@>=2.1.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+    },
+    "html-encoding-sniffer": {
+      "version": "1.0.1",
+      "from": "html-encoding-sniffer@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz"
+    },
+    "htmlparser2": {
+      "version": "3.9.2",
+      "from": "htmlparser2@>=3.7.3 <4.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+        }
+      }
     },
     "http-browserify": {
       "version": "1.7.0",
       "from": "http-browserify@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz"
     },
     "http-errors": {
       "version": "1.3.1",
       "from": "http-errors@>=1.3.1 <1.4.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
     },
     "http-proxy": {
       "version": "1.13.3",
       "from": "http-proxy@>=1.13.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.3.tgz"
     },
     "http-signature": {
       "version": "1.1.1",
       "from": "http-signature@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "0.2.0",
           "from": "assert-plus@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
         }
       }
     },
     "https-browserify": {
       "version": "0.0.0",
       "from": "https-browserify@0.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
     },
     "https-proxy-agent": {
       "version": "1.0.0",
       "from": "https-proxy-agent@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz"
     },
     "iconv-lite": {
       "version": "0.4.11",
       "from": "iconv-lite@0.4.11",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
     },
     "ieee754": {
       "version": "1.1.8",
       "from": "ieee754@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
     },
     "imurmurhash": {
       "version": "0.1.4",
       "from": "imurmurhash@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
     },
     "incremental-dom": {
       "version": "0.4.1",
       "from": "incremental-dom@latest",
-      "resolved": "https://registry.npmjs.org/incremental-dom/-/incremental-dom-0.4.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/incremental-dom/-/incremental-dom-0.4.1.tgz"
     },
     "indent-string": {
       "version": "2.1.0",
       "from": "indent-string@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz"
     },
     "indexof": {
       "version": "0.0.1",
       "from": "indexof@0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
     },
     "inflight": {
       "version": "1.0.5",
       "from": "inflight@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
     },
     "inherits": {
       "version": "2.0.1",
       "from": "inherits@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "ini": {
       "version": "1.3.4",
       "from": "ini@>=1.3.3 <1.4.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "dev": true
-    },
-    "inquirer": {
-      "version": "1.2.3",
-      "from": "inquirer@>=1.2.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
-      "dev": true,
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "from": "lodash@>=4.3.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "dev": true
-        },
-        "mute-stream": {
-          "version": "0.0.6",
-          "from": "mute-stream@0.0.6",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-          "dev": true
-        }
-      }
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "interpret": {
       "version": "0.6.6",
       "from": "interpret@>=0.6.2 <0.7.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
-      "dev": true
-    },
-    "invariant": {
-      "version": "2.2.2",
-      "from": "invariant@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
     },
     "invert-kv": {
       "version": "1.0.0",
       "from": "invert-kv@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
     },
     "is-arrayish": {
       "version": "0.2.1",
       "from": "is-arrayish@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
     "is-binary-path": {
       "version": "1.0.1",
       "from": "is-binary-path@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
     },
     "is-buffer": {
       "version": "1.1.0",
       "from": "is-buffer@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
     },
     "is-builtin-module": {
       "version": "1.0.0",
       "from": "is-builtin-module@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "dev": true
-    },
-    "is-ci": {
-      "version": "1.0.10",
-      "from": "is-ci@>=1.0.10 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
     "is-dotfile": {
       "version": "1.0.2",
       "from": "is-dotfile@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "from": "is-equal-shallow@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
     },
     "is-extendable": {
       "version": "0.1.1",
       "from": "is-extendable@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
     },
     "is-extglob": {
       "version": "1.0.0",
       "from": "is-extglob@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
     },
     "is-finite": {
       "version": "1.0.1",
       "from": "is-finite@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
     },
     "is-glob": {
       "version": "2.0.1",
       "from": "is-glob@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+    },
+    "is-lower-case": {
+      "version": "1.1.3",
+      "from": "is-lower-case@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
     },
     "is-my-json-valid": {
       "version": "2.12.3",
       "from": "is-my-json-valid@>=2.12.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
     },
     "is-npm": {
       "version": "1.0.0",
       "from": "is-npm@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
     },
     "is-number": {
       "version": "2.1.0",
       "from": "is-number@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
     },
     "is-obj": {
       "version": "1.0.1",
       "from": "is-obj@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
       "from": "is-path-cwd@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
       "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
     },
     "is-path-inside": {
       "version": "1.0.0",
       "from": "is-path-inside@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
     },
     "is-primitive": {
       "version": "2.0.0",
       "from": "is-primitive@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "dev": true
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "from": "is-promise@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
     },
     "is-property": {
       "version": "1.0.2",
       "from": "is-property@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
     },
     "is-redirect": {
       "version": "1.0.0",
       "from": "is-redirect@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
     },
     "is-retry-allowed": {
       "version": "1.1.0",
       "from": "is-retry-allowed@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz"
     },
     "is-stream": {
       "version": "1.1.0",
       "from": "is-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
     "is-subset": {
       "version": "0.1.1",
       "from": "is-subset@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz"
     },
     "is-text-path": {
       "version": "1.0.1",
       "from": "is-text-path@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz"
     },
     "is-typedarray": {
       "version": "1.0.0",
       "from": "is-typedarray@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+    },
+    "is-upper-case": {
+      "version": "1.1.2",
+      "from": "is-upper-case@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
     },
     "is-utf8": {
       "version": "0.2.1",
       "from": "is-utf8@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
     },
     "isarray": {
       "version": "0.0.1",
       "from": "isarray@0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
     },
     "isbinaryfile": {
       "version": "3.0.0",
       "from": "isbinaryfile@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.0.tgz"
     },
     "isexe": {
       "version": "1.1.2",
       "from": "isexe@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
     },
     "isobject": {
       "version": "2.0.0",
       "from": "isobject@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
     },
     "isstream": {
       "version": "0.1.2",
       "from": "isstream@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "jasmine": {
       "version": "2.4.1",
       "from": "jasmine@>=2.4.0 <2.5.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.4.1.tgz",
-      "dev": true,
       "dependencies": {
         "glob": {
           "version": "3.2.11",
           "from": "glob@>=3.2.11 <4.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
         },
         "jasmine-core": {
           "version": "2.4.1",
           "from": "jasmine-core@>=2.4.0 <2.5.0",
-          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz"
         },
         "minimatch": {
           "version": "0.3.0",
           "from": "minimatch@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
         }
       }
     },
     "jasmine-core": {
       "version": "2.3.4",
       "from": "jasmine-core@2.3.4",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz"
     },
     "jasminewd2": {
       "version": "0.0.10",
       "from": "jasminewd2@0.0.10",
-      "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.10.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.10.tgz"
     },
     "jetpack-id": {
       "version": "0.0.4",
       "from": "jetpack-id@0.0.4",
-      "resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-0.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-0.0.4.tgz"
     },
     "jetpack-validation": {
       "version": "0.0.4",
       "from": "jetpack-validation@0.0.4",
       "resolved": "https://registry.npmjs.org/jetpack-validation/-/jetpack-validation-0.0.4.tgz",
-      "dev": true,
       "dependencies": {
         "resolve": {
           "version": "0.7.4",
           "from": "resolve@>=0.7.1 <0.8.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
         },
         "semver": {
           "version": "2.3.2",
           "from": "semver@>=2.3.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
         }
       }
     },
     "jodid25519": {
       "version": "1.0.2",
       "from": "jodid25519@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "dev": true,
-      "optional": true
+      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
     },
     "jpm": {
       "version": "1.0.0",
       "from": "jpm@1.0.0",
       "resolved": "https://registry.npmjs.org/jpm/-/jpm-1.0.0.tgz",
-      "dev": true,
       "dependencies": {
         "async": {
           "version": "0.9.2",
           "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "commander": {
           "version": "2.6.0",
           "from": "commander@2.6.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
         },
         "firefox-profile": {
           "version": "0.3.9",
           "from": "firefox-profile@0.3.9",
           "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-0.3.9.tgz",
-          "dev": true,
           "dependencies": {
             "lodash": {
               "version": "3.5.0",
               "from": "lodash@>=3.5.0 <3.6.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
             }
           }
         },
         "fs-extra": {
           "version": "0.16.4",
           "from": "fs-extra@0.16.4",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.4.tgz"
         },
         "lodash": {
           "version": "3.3.1",
           "from": "lodash@3.3.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.3.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.3.1.tgz"
         },
         "minimatch": {
           "version": "2.0.4",
           "from": "minimatch@2.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz"
         },
         "open": {
           "version": "0.0.5",
           "from": "open@0.0.5",
-          "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz"
         },
         "semver": {
           "version": "4.3.3",
           "from": "semver@4.3.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
         }
       }
     },
     "jpm-core": {
       "version": "0.0.9",
       "from": "jpm-core@0.0.9",
-      "resolved": "https://registry.npmjs.org/jpm-core/-/jpm-core-0.0.9.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/jpm-core/-/jpm-core-0.0.9.tgz"
     },
     "js-tokens": {
       "version": "1.0.2",
       "from": "js-tokens@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
     },
     "jsbn": {
       "version": "0.1.0",
       "from": "jsbn@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-      "dev": true,
-      "optional": true
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+    },
+    "jsdom": {
+      "version": "9.8.3",
+      "from": "jsdom@9.8.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.8.3.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "from": "acorn@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+        },
+        "iconv-lite": {
+          "version": "0.4.15",
+          "from": "iconv-lite@>=0.4.13 <0.5.0",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
+        },
+        "mime-db": {
+          "version": "1.26.0",
+          "from": "mime-db@>=1.26.0 <1.27.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.14",
+          "from": "mime-types@>=2.1.7 <2.2.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz"
+        },
+        "parse5": {
+          "version": "1.5.1",
+          "from": "parse5@>=1.5.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz"
+        },
+        "qs": {
+          "version": "6.3.0",
+          "from": "qs@>=6.3.0 <6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
+        },
+        "request": {
+          "version": "2.79.0",
+          "from": "request@>=2.55.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz"
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "from": "tough-cookie@>=2.3.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "from": "uuid@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+        }
+      }
     },
     "json-schema": {
       "version": "0.2.3",
       "from": "json-schema@0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "json3": {
       "version": "3.2.6",
       "from": "json3@3.2.6",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
     },
     "json5": {
       "version": "0.4.0",
       "from": "json5@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
     },
     "jsonfile": {
       "version": "2.2.3",
       "from": "jsonfile@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
     },
     "jsonparse": {
       "version": "1.2.0",
       "from": "jsonparse@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
     },
     "jsonpointer": {
       "version": "2.0.0",
       "from": "jsonpointer@2.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
     },
     "JSONStream": {
       "version": "1.0.7",
       "from": "JSONStream@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz"
     },
     "jsontoxml": {
       "version": "0.0.11",
       "from": "jsontoxml@0.0.11",
-      "resolved": "https://registry.npmjs.org/jsontoxml/-/jsontoxml-0.0.11.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/jsontoxml/-/jsontoxml-0.0.11.tgz"
     },
     "jsprim": {
       "version": "1.3.1",
       "from": "jsprim@>=1.2.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz"
     },
     "jstransform": {
       "version": "10.1.0",
       "from": "jstransform@>=10.0.1 <11.0.0",
       "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "esprima-fb": {
           "version": "13001.1001.0-dev-harmony-fb",
           "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
         },
         "source-map": {
           "version": "0.1.31",
           "from": "source-map@0.1.31",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
-          "dev": true,
           "dependencies": {
             "amdefine": {
               "version": "1.0.1",
               "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
             }
           }
         }
@@ -6056,398 +5223,344 @@
     "jszip": {
       "version": "2.5.0",
       "from": "jszip@>=2.4.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz"
     },
     "karma": {
       "version": "0.13.20",
       "from": "karma@0.13.20",
       "resolved": "https://registry.npmjs.org/karma/-/karma-0.13.20.tgz",
-      "dev": true,
       "dependencies": {
         "batch": {
           "version": "0.5.3",
           "from": "batch@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
         },
         "glob": {
           "version": "7.0.3",
           "from": "glob@>=7.0.0 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz"
         },
         "graceful-fs": {
           "version": "4.1.4",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
         },
         "source-map": {
           "version": "0.5.6",
           "from": "source-map@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
     "karma-browserstack-launcher": {
       "version": "0.1.9",
       "from": "karma-browserstack-launcher@0.1.9",
-      "resolved": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-0.1.9.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/karma-browserstack-launcher/-/karma-browserstack-launcher-0.1.9.tgz"
     },
     "karma-chrome-launcher": {
       "version": "0.2.2",
       "from": "karma-chrome-launcher@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.2.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.2.2.tgz"
     },
     "karma-jasmine": {
       "version": "0.3.6",
       "from": "karma-jasmine@>=0.3.6 <0.4.0",
-      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.6.tgz"
     },
     "karma-sauce-launcher": {
       "version": "0.3.0",
       "from": "karma-sauce-launcher@0.3.0",
-      "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-0.3.0.tgz"
     },
     "karma-sourcemap-loader": {
       "version": "0.3.6",
       "from": "karma-sourcemap-loader@>=0.3.6 <0.4.0",
-      "resolved": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.6.tgz"
     },
     "kind-of": {
       "version": "3.0.2",
       "from": "kind-of@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
     },
     "klaw": {
       "version": "1.1.3",
       "from": "klaw@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.1.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.1.3.tgz"
     },
     "latest-version": {
       "version": "2.0.0",
       "from": "latest-version@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz"
     },
     "lazy-cache": {
       "version": "0.2.7",
       "from": "lazy-cache@>=0.2.4 <0.3.0",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
     },
     "lazy-req": {
       "version": "1.1.0",
       "from": "lazy-req@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz"
     },
     "lazystream": {
       "version": "0.1.0",
       "from": "lazystream@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
           "from": "readable-stream@>=1.0.2 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "lcid": {
       "version": "1.0.0",
       "from": "lcid@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
     },
-    "leven": {
-      "version": "2.0.0",
-      "from": "leven@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-2.0.0.tgz",
-      "dev": true
+    "levn": {
+      "version": "0.3.0",
+      "from": "levn@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
     },
     "liftoff": {
       "version": "2.2.0",
       "from": "liftoff@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
-      "dev": true,
       "dependencies": {
         "extend": {
           "version": "2.0.1",
           "from": "extend@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
         },
         "findup-sync": {
           "version": "0.3.0",
           "from": "findup-sync@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz"
         },
         "glob": {
           "version": "5.0.15",
           "from": "glob@>=5.0.0 <5.1.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         }
       }
     },
     "livereload-js": {
       "version": "2.2.2",
       "from": "livereload-js@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz"
     },
     "load-json-file": {
       "version": "1.1.0",
       "from": "load-json-file@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.2",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
         }
       }
     },
     "loader-utils": {
       "version": "0.2.12",
       "from": "loader-utils@>=0.2.2 <0.3.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz"
     },
     "lodash": {
       "version": "3.10.1",
       "from": "lodash@3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
     "lodash._basecopy": {
       "version": "3.0.1",
       "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
     },
     "lodash._basetostring": {
       "version": "3.0.1",
       "from": "lodash._basetostring@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
     },
     "lodash._basevalues": {
       "version": "3.0.0",
       "from": "lodash._basevalues@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
     },
     "lodash._getnative": {
       "version": "3.9.1",
       "from": "lodash._getnative@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
       "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
     },
     "lodash._reescape": {
       "version": "3.0.0",
       "from": "lodash._reescape@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
     },
     "lodash._reevaluate": {
       "version": "3.0.0",
       "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
     },
     "lodash.escape": {
       "version": "3.0.0",
       "from": "lodash.escape@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
     },
     "lodash.isarguments": {
       "version": "3.0.4",
       "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "from": "lodash.isarray@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
     },
     "lodash.keys": {
       "version": "3.1.2",
       "from": "lodash.keys@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
     },
     "lodash.restparam": {
       "version": "3.6.1",
       "from": "lodash.restparam@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
     },
     "lodash.template": {
       "version": "3.6.2",
       "from": "lodash.template@>=3.6.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz"
     },
     "lodash.templatesettings": {
       "version": "3.1.0",
       "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
     },
     "log4js": {
       "version": "0.6.36",
       "from": "log4js@>=0.6.31 <0.7.0",
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.36.tgz",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
           "from": "readable-stream@>=1.0.2 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "semver": {
           "version": "4.3.6",
           "from": "semver@>=4.3.3 <4.4.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "longest": {
       "version": "1.0.1",
       "from": "longest@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
     "loose-envify": {
       "version": "1.1.0",
       "from": "loose-envify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz"
     },
     "loud-rejection": {
       "version": "1.2.0",
       "from": "loud-rejection@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz"
+    },
+    "lower-case": {
+      "version": "1.1.3",
+      "from": "lower-case@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
+    },
+    "lower-case-first": {
+      "version": "1.0.2",
+      "from": "lower-case-first@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
     },
     "lowercase-keys": {
       "version": "1.0.0",
       "from": "lowercase-keys@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
     },
     "lru-cache": {
       "version": "2.7.3",
       "from": "lru-cache@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
     },
     "lru-queue": {
       "version": "0.1.0",
       "from": "lru-queue@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
     },
     "madge": {
       "version": "0.5.0",
       "from": "madge@0.5.0",
       "resolved": "https://registry.npmjs.org/madge/-/madge-0.5.0.tgz",
-      "dev": true,
       "dependencies": {
         "amdetective": {
           "version": "0.0.2",
           "from": "amdetective@https://registry.npmjs.org/amdetective/-/amdetective-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/amdetective/-/amdetective-0.0.2.tgz",
-          "dev": true,
           "dependencies": {
             "esprima": {
               "version": "1.2.2",
               "from": "esprima@https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
             }
           }
         },
         "coffee-script": {
           "version": "1.3.3",
           "from": "coffee-script@https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.0-1",
           "from": "colors@https://registry.npmjs.org/colors/-/colors-0.6.0-1.tgz",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.0-1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.0-1.tgz"
         },
         "commander": {
           "version": "1.0.0",
           "from": "commander@https://registry.npmjs.org/commander/-/commander-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/commander/-/commander-1.0.0.tgz"
         },
         "commondir": {
           "version": "0.0.1",
           "from": "commondir@https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
         },
         "detective": {
           "version": "0.1.1",
           "from": "detective@https://registry.npmjs.org/detective/-/detective-0.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/detective/-/detective-0.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/detective/-/detective-0.1.1.tgz"
         },
         "detective-es6": {
           "version": "1.1.0",
           "from": "detective-es6@https://registry.npmjs.org/detective-es6/-/detective-es6-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-1.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-1.1.0.tgz"
         },
         "graphviz": {
           "version": "0.0.7",
           "from": "graphviz@https://registry.npmjs.org/graphviz/-/graphviz-0.0.7.tgz",
           "resolved": "https://registry.npmjs.org/graphviz/-/graphviz-0.0.7.tgz",
-          "dev": true,
           "dependencies": {
             "temp": {
               "version": "0.4.0",
               "from": "temp@https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz"
             }
           }
         },
@@ -6455,63 +5568,53 @@
           "version": "0.12.1",
           "from": "react-tools@https://registry.npmjs.org/react-tools/-/react-tools-0.12.1.tgz",
           "resolved": "https://registry.npmjs.org/react-tools/-/react-tools-0.12.1.tgz",
-          "dev": true,
           "dependencies": {
             "commoner": {
               "version": "0.10.1",
               "from": "commoner@https://registry.npmjs.org/commoner/-/commoner-0.10.1.tgz",
               "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.1.tgz",
-              "dev": true,
               "dependencies": {
                 "commander": {
                   "version": "2.5.1",
                   "from": "commander@https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
                 },
                 "glob": {
                   "version": "4.2.2",
                   "from": "glob@https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
-                  "dev": true,
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
                       "from": "inflight@https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dev": true,
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
                           "from": "wrappy@https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
                       "from": "inherits@https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "1.0.0",
                       "from": "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "lru-cache": {
                           "version": "2.5.0",
                           "from": "lru-cache@https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.0",
                           "from": "sigmund@https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                         }
                       }
                     },
@@ -6519,13 +5622,11 @@
                       "version": "1.3.1",
                       "from": "once@https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                      "dev": true,
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
                           "from": "wrappy@https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     }
@@ -6534,76 +5635,64 @@
                 "graceful-fs": {
                   "version": "3.0.5",
                   "from": "graceful-fs@https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
                 },
                 "iconv-lite": {
                   "version": "0.4.5",
                   "from": "iconv-lite@https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.5.tgz"
                 },
                 "install": {
                   "version": "0.1.8",
                   "from": "install@https://registry.npmjs.org/install/-/install-0.1.8.tgz",
-                  "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.0",
                   "from": "mkdirp@https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
                       "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "private": {
                   "version": "0.1.6",
                   "from": "private@https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
                 },
                 "q": {
                   "version": "1.1.2",
                   "from": "q@https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
                 },
                 "recast": {
                   "version": "0.9.11",
                   "from": "recast@https://registry.npmjs.org/recast/-/recast-0.9.11.tgz",
                   "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.11.tgz",
-                  "dev": true,
                   "dependencies": {
                     "ast-types": {
                       "version": "0.6.7",
                       "from": "ast-types@https://registry.npmjs.org/ast-types/-/ast-types-0.6.7.tgz",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.7.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.7.tgz"
                     },
                     "esprima-fb": {
                       "version": "8001.1001.0-dev-harmony-fb",
                       "from": "esprima-fb@https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
                     },
                     "source-map": {
                       "version": "0.1.41",
                       "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.41.tgz",
-                      "dev": true,
                       "dependencies": {
                         "amdefine": {
                           "version": "0.1.0",
                           "from": "amdefine@https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                         }
                       }
                     }
@@ -6615,31 +5704,26 @@
               "version": "8.2.0",
               "from": "jstransform@https://registry.npmjs.org/jstransform/-/jstransform-8.2.0.tgz",
               "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-8.2.0.tgz",
-              "dev": true,
               "dependencies": {
                 "base62": {
                   "version": "0.1.1",
                   "from": "base62@https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
                 },
                 "esprima-fb": {
                   "version": "8001.1001.0-dev-harmony-fb",
                   "from": "esprima-fb@https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
                 },
                 "source-map": {
                   "version": "0.1.31",
                   "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
-                  "dev": true,
                   "dependencies": {
                     "amdefine": {
                       "version": "0.1.0",
                       "from": "amdefine@https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
                     }
                   }
                 }
@@ -6650,1251 +5734,1040 @@
         "resolve": {
           "version": "0.2.3",
           "from": "resolve@https://registry.npmjs.org/resolve/-/resolve-0.2.3.tgz",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.2.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.2.3.tgz"
         },
         "uglify-js": {
           "version": "1.2.6",
           "from": "uglify-js@https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.6.tgz",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.6.tgz"
         },
         "walkdir": {
           "version": "0.0.5",
           "from": "walkdir@https://registry.npmjs.org/walkdir/-/walkdir-0.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.5.tgz"
         }
       }
     },
     "magic-string": {
       "version": "0.16.0",
       "from": "magic-string@>=0.16.0 <0.17.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz"
     },
     "map-obj": {
       "version": "1.0.1",
       "from": "map-obj@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
     "map-stream": {
       "version": "0.1.0",
       "from": "map-stream@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+    },
+    "marked": {
+      "version": "0.3.6",
+      "from": "marked@>=0.3.2 <0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz"
     },
     "match-stream": {
       "version": "0.0.2",
       "from": "match-stream@>=0.0.2 <1.0.0",
       "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
           "from": "readable-stream@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "media-typer": {
       "version": "0.3.0",
       "from": "media-typer@0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
     },
     "memoizeasync": {
       "version": "0.8.0",
       "from": "memoizeasync@0.8.0",
       "resolved": "https://registry.npmjs.org/memoizeasync/-/memoizeasync-0.8.0.tgz",
-      "dev": true,
       "dependencies": {
         "lru-cache": {
           "version": "2.5.0",
           "from": "lru-cache@2.5.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
         },
         "passerror": {
           "version": "0.0.2",
           "from": "passerror@0.0.2",
-          "resolved": "https://registry.npmjs.org/passerror/-/passerror-0.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/passerror/-/passerror-0.0.2.tgz"
         }
       }
     },
     "memoizee": {
       "version": "0.3.10",
       "from": "memoizee@>=0.3.9 <0.4.0",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.10.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.10.tgz"
     },
     "memory-fs": {
       "version": "0.3.0",
       "from": "memory-fs@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "2.0.5",
           "from": "readable-stream@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
         }
       }
     },
     "meow": {
       "version": "3.6.0",
       "from": "meow@>=3.3.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz"
     },
     "method-override": {
       "version": "2.3.5",
       "from": "method-override@>=2.3.5 <2.4.0",
-      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.5.tgz"
     },
     "methods": {
       "version": "1.1.1",
       "from": "methods@*",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
     },
     "micromatch": {
       "version": "2.3.7",
       "from": "micromatch@>=2.1.5 <3.0.0",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz"
     },
     "mime": {
       "version": "1.3.4",
       "from": "mime@>=1.2.11 <2.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
     },
     "mime-db": {
       "version": "1.12.0",
       "from": "mime-db@>=1.12.0 <1.13.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
     },
     "mime-types": {
       "version": "2.0.14",
       "from": "mime-types@>=2.0.9 <2.1.0",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
     },
     "minimatch": {
       "version": "3.0.3",
       "from": "minimatch@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
     },
     "minimist": {
       "version": "1.2.0",
       "from": "minimist@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
       "from": "mkdirp@>=0.5.1 <0.6.0",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "dev": true,
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
           "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
+    },
+    "mkdirp-promise": {
+      "version": "5.0.0",
+      "from": "mkdirp-promise@>=5.0.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.0.tgz"
     },
     "modify-values": {
       "version": "1.0.0",
       "from": "modify-values@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz"
     },
     "morgan": {
       "version": "1.6.1",
       "from": "morgan@>=1.6.1 <1.7.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz"
     },
     "mozilla-toolkit-versioning": {
       "version": "0.0.2",
       "from": "mozilla-toolkit-versioning@0.0.2",
-      "resolved": "https://registry.npmjs.org/mozilla-toolkit-versioning/-/mozilla-toolkit-versioning-0.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/mozilla-toolkit-versioning/-/mozilla-toolkit-versioning-0.0.2.tgz"
     },
     "mozilla-version-comparator": {
       "version": "1.0.2",
       "from": "mozilla-version-comparator@1.0.2",
-      "resolved": "https://registry.npmjs.org/mozilla-version-comparator/-/mozilla-version-comparator-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/mozilla-version-comparator/-/mozilla-version-comparator-1.0.2.tgz"
     },
     "ms": {
       "version": "0.7.1",
       "from": "ms@0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
     },
     "multiparty": {
       "version": "3.3.2",
       "from": "multiparty@3.3.2",
-      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz"
     },
     "multipipe": {
       "version": "0.1.2",
       "from": "multipipe@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz"
     },
     "mute-stream": {
       "version": "0.0.5",
       "from": "mute-stream@>=0.0.4 <0.1.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
     },
     "nan": {
       "version": "2.4.0",
       "from": "nan@latest",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
     },
     "negotiator": {
       "version": "0.5.3",
       "from": "negotiator@0.5.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
     },
     "next-tick": {
       "version": "0.2.2",
       "from": "next-tick@>=0.2.2 <0.3.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
     },
-    "node-emoji": {
-      "version": "1.5.1",
-      "from": "node-emoji@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.5.1.tgz",
-      "dev": true
+    "no-case": {
+      "version": "2.3.1",
+      "from": "no-case@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz"
     },
-    "node-gyp": {
-      "version": "3.5.0",
-      "from": "node-gyp@>=3.2.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "fstream": {
-          "version": "1.0.10",
-          "from": "fstream@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.1",
-          "from": "glob@>=7.0.3 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "from": "graceful-fs@^4.1.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "dev": true
-        }
-      }
+    "node-html-encoder": {
+      "version": "0.0.2",
+      "from": "node-html-encoder@0.0.2",
+      "resolved": "https://registry.npmjs.org/node-html-encoder/-/node-html-encoder-0.0.2.tgz"
     },
     "node-int64": {
       "version": "0.3.3",
       "from": "node-int64@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz"
     },
     "node-libs-browser": {
       "version": "0.6.0",
       "from": "node-libs-browser@0.6.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.6.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.6.0.tgz"
     },
     "node-source-walk": {
       "version": "1.4.2",
       "from": "node-source-walk@>=1.4.0 <1.5.0",
-      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-1.4.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-1.4.2.tgz"
     },
     "node-status-codes": {
       "version": "1.0.0",
       "from": "node-status-codes@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
     },
     "node-uuid": {
       "version": "1.4.7",
       "from": "node-uuid@>=1.4.0 <1.5.0",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "node-watch": {
       "version": "0.3.4",
       "from": "node-watch@0.3.4",
-      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.3.4.tgz",
-      "dev": true
-    },
-    "nopt": {
-      "version": "3.0.6",
-      "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.3.4.tgz"
     },
     "normalize-package-data": {
       "version": "2.3.5",
       "from": "normalize-package-data@>=2.3.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
     },
     "normalize-path": {
       "version": "2.0.1",
       "from": "normalize-path@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-      "dev": true
-    },
-    "npmlog": {
-      "version": "4.0.2",
-      "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0||>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
     },
     "null-check": {
       "version": "1.0.0",
       "from": "null-check@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz"
     },
     "number-is-nan": {
       "version": "1.0.0",
       "from": "number-is-nan@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+    },
+    "nunjucks": {
+      "version": "2.5.2",
+      "from": "nunjucks@>=2.4.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-2.5.2.tgz",
+      "dependencies": {
+        "async-each": {
+          "version": "1.0.1",
+          "from": "async-each@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
+        },
+        "chokidar": {
+          "version": "1.6.1",
+          "from": "chokidar@>=1.6.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz"
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "from": "yargs@>=3.32.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
+        }
+      }
+    },
+    "nwmatcher": {
+      "version": "1.3.9",
+      "from": "nwmatcher@>=1.3.7 <2.0.0",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.9.tgz"
     },
     "oauth-sign": {
       "version": "0.8.2",
       "from": "oauth-sign@>=0.8.1 <0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
     },
     "object-assign": {
       "version": "4.0.1",
       "from": "object-assign@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
     },
     "object-component": {
       "version": "0.0.3",
       "from": "object-component@0.0.3",
-      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-      "dev": true
-    },
-    "object-path": {
-      "version": "0.11.3",
-      "from": "object-path@>=0.11.2 <0.12.0",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
     },
     "object.omit": {
       "version": "2.0.0",
       "from": "object.omit@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
     },
     "on-finished": {
       "version": "2.3.0",
       "from": "on-finished@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
     },
     "on-headers": {
       "version": "1.0.1",
       "from": "on-headers@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
     },
     "once": {
       "version": "1.3.3",
       "from": "once@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-      "dev": true
-    },
-    "onetime": {
-      "version": "1.1.0",
-      "from": "onetime@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
     },
     "optimist": {
       "version": "0.6.1",
       "from": "optimist@>=0.6.1 <0.7.0",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "dev": true,
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
           "from": "minimist@>=0.0.1 <0.1.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "from": "optionator@>=0.8.1 <0.9.0",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0",
+          "from": "wordwrap@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
         }
       }
     },
     "options": {
       "version": "0.0.6",
       "from": "options@>=0.0.5",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
     },
     "orchestrator": {
       "version": "0.3.7",
       "from": "orchestrator@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
-      "dev": true,
       "dependencies": {
         "end-of-stream": {
           "version": "0.1.5",
           "from": "end-of-stream@>=0.1.5 <0.2.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz"
         }
       }
     },
     "ordered-read-streams": {
       "version": "0.1.0",
       "from": "ordered-read-streams@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
     },
     "os-browserify": {
       "version": "0.1.2",
       "from": "os-browserify@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
     },
     "os-homedir": {
       "version": "1.0.1",
       "from": "os-homedir@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
     },
     "os-locale": {
       "version": "1.4.0",
       "from": "os-locale@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "dev": true
-    },
-    "os-shim": {
-      "version": "0.1.3",
-      "from": "os-shim@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "from": "os-tmpdir@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
     },
     "osenv": {
       "version": "0.1.3",
       "from": "osenv@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz"
     },
     "over": {
       "version": "0.0.5",
       "from": "over@>=0.0.5 <1.0.0",
-      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz"
     },
     "package-json": {
       "version": "2.4.0",
       "from": "package-json@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz"
     },
     "pako": {
       "version": "0.2.8",
       "from": "pako@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+    },
+    "param-case": {
+      "version": "2.1.0",
+      "from": "param-case@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.0.tgz"
     },
     "parse-github-repo-url": {
       "version": "1.3.0",
       "from": "parse-github-repo-url@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.3.0.tgz"
     },
     "parse-glob": {
       "version": "3.0.4",
       "from": "parse-glob@>=3.0.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
     },
     "parse-json": {
       "version": "2.2.0",
       "from": "parse-json@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "parse5": {
       "version": "2.2.1",
       "from": "parse5@2.2.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.1.tgz"
     },
     "parsejson": {
       "version": "0.0.1",
       "from": "parsejson@0.0.1",
-      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz"
     },
     "parseqs": {
       "version": "0.0.2",
       "from": "parseqs@0.0.2",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz"
     },
     "parseuri": {
       "version": "0.0.4",
       "from": "parseuri@0.0.4",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz"
     },
     "parseurl": {
       "version": "1.3.0",
       "from": "parseurl@>=1.3.0 <1.4.0",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+    },
+    "pascal-case": {
+      "version": "2.0.0",
+      "from": "pascal-case@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.0.tgz"
     },
     "passerror": {
       "version": "0.0.1",
       "from": "passerror@0.0.1",
-      "resolved": "https://registry.npmjs.org/passerror/-/passerror-0.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/passerror/-/passerror-0.0.1.tgz"
     },
     "path-browserify": {
       "version": "0.0.0",
       "from": "path-browserify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+    },
+    "path-case": {
+      "version": "2.1.0",
+      "from": "path-case@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.0.tgz"
     },
     "path-exists": {
       "version": "2.1.0",
       "from": "path-exists@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.0",
       "from": "path-is-absolute@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
     },
     "path-is-inside": {
       "version": "1.0.2",
       "from": "path-is-inside@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
     },
     "path-type": {
       "version": "1.1.0",
       "from": "path-type@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.2",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
         }
       }
     },
     "pause": {
       "version": "0.1.0",
       "from": "pause@0.1.0",
-      "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz"
     },
     "pause-stream": {
       "version": "0.0.11",
       "from": "pause-stream@0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
     },
     "pbkdf2-compat": {
       "version": "2.0.1",
       "from": "pbkdf2-compat@2.0.1",
-      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
     },
     "pegjs": {
       "version": "0.9.0",
       "from": "pegjs@0.9.0",
-      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.9.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.9.0.tgz"
     },
     "pify": {
       "version": "2.3.0",
       "from": "pify@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
       "version": "2.0.1",
       "from": "pinkie@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
     },
     "pinkie-promise": {
       "version": "2.0.0",
       "from": "pinkie-promise@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
     },
     "pkginfo": {
       "version": "0.3.1",
       "from": "pkginfo@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "from": "prelude-ls@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
     },
     "prepend-http": {
       "version": "1.0.4",
       "from": "prepend-http@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
     },
     "preserve": {
       "version": "0.2.0",
       "from": "preserve@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
     },
     "pretty-hrtime": {
       "version": "1.0.1",
       "from": "pretty-hrtime@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz"
     },
     "process": {
       "version": "0.11.9",
       "from": "process@>=0.11.0 <0.12.0",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
     },
     "process-nextick-args": {
       "version": "1.0.6",
       "from": "process-nextick-args@>=1.0.6 <1.1.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
     },
     "promise": {
       "version": "7.1.1",
       "from": "promise@>=7.0.3 <8.0.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
     },
     "promzard": {
       "version": "0.3.0",
       "from": "promzard@0.3.0",
-      "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-      "dev": true
-    },
-    "proper-lockfile": {
-      "version": "2.0.0",
-      "from": "proper-lockfile@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-2.0.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "from": "graceful-fs@^4.1.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "dev": true
-        }
-      }
+      "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz"
     },
     "protractor": {
       "version": "4.0.11",
       "from": "protractor@4.0.11",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-4.0.11.tgz",
-      "dev": true,
       "dependencies": {
         "@types/jasmine": {
           "version": "2.5.37",
           "from": "@types/jasmine@>=2.5.36 <3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.5.37.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.5.37.tgz"
         },
         "@types/node": {
           "version": "6.0.46",
           "from": "@types/node@>=6.0.46 <7.0.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.46.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.46.tgz"
         },
         "glob": {
           "version": "7.1.1",
           "from": "glob@>=7.0.3 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
         },
         "mime-db": {
           "version": "1.24.0",
           "from": "mime-db@~1.24.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
         },
         "mime-types": {
           "version": "2.1.12",
           "from": "mime-types@>=2.1.7 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
         },
         "qs": {
           "version": "6.3.0",
           "from": "qs@>=6.3.0 <6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
         },
         "request": {
           "version": "2.78.0",
           "from": "request@>=2.78.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/request/-/request-2.78.0.tgz"
         },
         "rimraf": {
           "version": "2.5.4",
           "from": "rimraf@>=2.5.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
         },
         "saucelabs": {
           "version": "1.3.0",
           "from": "saucelabs@>=1.3.0 <1.4.0",
-          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.3.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.3.0.tgz"
         },
         "semver": {
           "version": "5.3.0",
           "from": "semver@>=5.3.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
         },
         "tough-cookie": {
           "version": "2.3.2",
           "from": "tough-cookie@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
         },
         "webdriver-manager": {
           "version": "10.2.8",
           "from": "webdriver-manager@>=10.2.8 <11.0.0",
-          "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-10.2.8.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-10.2.8.tgz"
         }
       }
     },
     "prr": {
       "version": "0.0.0",
       "from": "prr@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
     },
     "pullstream": {
       "version": "0.4.1",
       "from": "pullstream@>=0.4.1 <1.0.0",
       "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
           "from": "readable-stream@>=1.0.31 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "punycode": {
       "version": "1.4.1",
       "from": "punycode@>=1.2.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
     },
     "q": {
       "version": "1.4.1",
       "from": "q@>=1.4.1 <1.5.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
     },
     "qs": {
       "version": "4.0.0",
       "from": "qs@4.0.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
     },
     "querystring": {
       "version": "0.2.0",
       "from": "querystring@0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
     },
     "querystring-es3": {
       "version": "0.2.1",
       "from": "querystring-es3@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
     },
     "randomatic": {
       "version": "1.1.5",
       "from": "randomatic@>=1.1.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
     },
     "range-parser": {
       "version": "1.0.3",
       "from": "range-parser@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
     },
     "raw-body": {
       "version": "2.1.5",
       "from": "raw-body@>=2.1.2 <2.2.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.5.tgz",
-      "dev": true,
       "dependencies": {
         "bytes": {
           "version": "2.2.0",
           "from": "bytes@2.2.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
         },
         "iconv-lite": {
           "version": "0.4.13",
           "from": "iconv-lite@0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
         }
       }
     },
     "rc": {
       "version": "1.1.6",
       "from": "rc@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz"
     },
     "react": {
       "version": "0.14.5",
       "from": "react@>=0.14.0 <0.15.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.14.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/react/-/react-0.14.5.tgz"
     },
     "read": {
       "version": "1.0.5",
       "from": "read@1.0.5",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz"
     },
     "read-all-stream": {
       "version": "3.1.0",
       "from": "read-all-stream@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@~1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.2.2",
           "from": "readable-stream@^2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
         }
       }
     },
     "read-pkg": {
       "version": "1.1.0",
       "from": "read-pkg@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "from": "read-pkg-up@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
       "version": "1.1.13",
       "from": "readable-stream@>=1.1.13 <2.0.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
     },
     "readdirp": {
       "version": "2.0.0",
       "from": "readdirp@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
-      "dev": true,
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.2",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
         },
         "minimatch": {
           "version": "2.0.10",
           "from": "minimatch@>=2.0.10 <3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
         },
         "readable-stream": {
           "version": "2.0.5",
           "from": "readable-stream@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
         }
       }
     },
     "rechoir": {
       "version": "0.6.2",
       "from": "rechoir@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
     },
     "redent": {
       "version": "1.0.0",
       "from": "redent@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
     },
     "reflect-metadata": {
       "version": "0.1.3",
       "from": "reflect-metadata@0.1.3",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.3.tgz"
     },
-    "regenerator-runtime": {
-      "version": "0.10.1",
-      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz",
-      "dev": true
-    },
     "regex-cache": {
       "version": "0.4.2",
       "from": "regex-cache@>=0.4.2 <0.5.0",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz"
     },
     "registry-auth-token": {
       "version": "3.1.0",
       "from": "registry-auth-token@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz"
     },
     "registry-url": {
       "version": "3.1.0",
       "from": "registry-url@>=3.0.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz"
     },
     "repeat-element": {
       "version": "1.1.2",
       "from": "repeat-element@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
     },
     "repeat-string": {
       "version": "1.5.2",
       "from": "repeat-string@>=1.5.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
     },
     "repeating": {
       "version": "2.0.0",
       "from": "repeating@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz"
     },
     "replace-ext": {
       "version": "0.0.1",
       "from": "replace-ext@0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
     },
     "request": {
       "version": "2.51.0",
       "from": "request@>=2.51.0 <2.52.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
-      "dev": true,
       "dependencies": {
         "asn1": {
           "version": "0.1.11",
           "from": "asn1@0.1.11",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
         },
         "async": {
           "version": "0.9.2",
           "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "aws-sign2": {
           "version": "0.5.0",
           "from": "aws-sign2@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         },
         "boom": {
           "version": "0.4.2",
           "from": "boom@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
         },
         "caseless": {
           "version": "0.8.0",
           "from": "caseless@>=0.8.0 <0.9.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
         },
         "combined-stream": {
           "version": "0.0.7",
           "from": "combined-stream@>=0.0.5 <0.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
         },
         "cryptiles": {
           "version": "0.2.2",
           "from": "cryptiles@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
         },
         "delayed-stream": {
           "version": "0.0.5",
           "from": "delayed-stream@0.0.5",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
           "from": "forever-agent@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "form-data": {
           "version": "0.2.0",
           "from": "form-data@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-          "dev": true,
           "dependencies": {
             "mime-types": {
               "version": "2.0.14",
               "from": "mime-types@2.0.14",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
             }
           }
         },
         "hawk": {
           "version": "1.1.1",
           "from": "hawk@1.1.1",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz"
         },
         "hoek": {
           "version": "0.9.1",
           "from": "hoek@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
         },
         "http-signature": {
           "version": "0.10.1",
           "from": "http-signature@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz"
         },
         "mime-types": {
           "version": "1.0.2",
           "from": "mime-types@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
         },
         "oauth-sign": {
           "version": "0.5.0",
           "from": "oauth-sign@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
         },
         "qs": {
           "version": "2.3.3",
           "from": "qs@>=2.3.1 <2.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         },
         "sntp": {
           "version": "0.2.4",
           "from": "sntp@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
         }
       }
-    },
-    "request-capture-har": {
-      "version": "1.1.4",
-      "from": "request-capture-har@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/request-capture-har/-/request-capture-har-1.1.4.tgz",
-      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
       "from": "requires-port@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
     },
     "resolve": {
       "version": "1.1.6",
       "from": "resolve@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
     },
     "response-time": {
       "version": "2.3.1",
       "from": "response-time@>=2.3.1 <2.4.0",
-      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.1.tgz",
-      "dev": true
-    },
-    "restore-cursor": {
-      "version": "1.0.1",
-      "from": "restore-cursor@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "dev": true
-    },
-    "retry": {
-      "version": "0.10.1",
-      "from": "retry@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.1.tgz"
     },
     "rewire": {
       "version": "2.5.1",
       "from": "rewire@>=2.3.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.5.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.5.1.tgz"
     },
     "right-align": {
       "version": "0.1.3",
       "from": "right-align@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
     },
     "rimraf": {
       "version": "2.5.0",
       "from": "rimraf@>=2.2.8 <3.0.0",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
-      "dev": true,
       "dependencies": {
         "glob": {
           "version": "6.0.3",
           "from": "glob@>=6.0.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz"
         }
       }
     },
     "ripemd160": {
       "version": "0.2.0",
       "from": "ripemd160@0.2.0",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
     },
     "rndm": {
       "version": "1.1.1",
       "from": "rndm@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.1.tgz",
-      "dev": true
-    },
-    "roadrunner": {
-      "version": "1.1.0",
-      "from": "roadrunner@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/roadrunner/-/roadrunner-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.1.tgz"
     },
     "rollup": {
       "version": "0.26.3",
       "from": "rollup@0.26.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.26.3.tgz",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
           "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "ansi-styles": {
           "version": "2.2.1",
           "from": "ansi-styles@>=2.2.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
         },
         "chalk": {
           "version": "1.1.3",
           "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
           "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "source-map": {
           "version": "0.1.32",
           "from": "source-map@0.1.32",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-          "dev": true,
           "dependencies": {
             "amdefine": {
               "version": "1.0.1",
               "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
             }
           }
         },
         "source-map-support": {
           "version": "0.4.0",
           "from": "source-map-support@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.0.tgz"
         },
         "strip-ansi": {
           "version": "3.0.1",
           "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
           "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         }
       }
     },
@@ -7902,39 +6775,23 @@
       "version": "5.0.5",
       "from": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-5.0.5.tgz",
       "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-5.0.5.tgz",
-      "dev": true,
       "dependencies": {
         "acorn": {
           "version": "4.0.3",
           "from": "acorn@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz"
         },
         "resolve": {
           "version": "1.1.7",
           "from": "resolve@>=1.1.7 <2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
         }
       }
     },
     "rollup-pluginutils": {
       "version": "1.5.2",
       "from": "rollup-pluginutils@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
-      "dev": true
-    },
-    "run-async": {
-      "version": "2.3.0",
-      "from": "run-async@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "dev": true
-    },
-    "rx": {
-      "version": "4.1.0",
-      "from": "rx@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz"
     },
     "rxjs": {
       "version": "5.0.1",
@@ -7945,239 +6802,223 @@
       "version": "0.13.0",
       "from": "sauce-connect-launcher@>=0.13.0 <0.14.0",
       "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.13.0.tgz",
-      "dev": true,
       "dependencies": {
         "async": {
           "version": "1.4.0",
           "from": "async@1.4.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/async/-/async-1.4.0.tgz"
         },
         "glob": {
           "version": "5.0.15",
           "from": "glob@>=5.0.14 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         },
         "lodash": {
           "version": "3.10.1",
           "from": "lodash@3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "rimraf": {
           "version": "2.4.3",
           "from": "rimraf@2.4.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz"
         }
       }
     },
     "saucelabs": {
       "version": "1.0.1",
       "from": "saucelabs@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.0.1.tgz"
     },
     "sax": {
       "version": "1.1.4",
       "from": "sax@>=0.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz"
     },
     "scmp": {
       "version": "1.0.0",
       "from": "scmp@1.0.0",
-      "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
     },
     "selenium-webdriver": {
       "version": "2.53.3",
       "from": "selenium-webdriver@2.53.3",
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.53.3.tgz",
-      "dev": true,
       "dependencies": {
         "adm-zip": {
           "version": "0.4.4",
           "from": "adm-zip@0.4.4",
-          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
         },
         "sax": {
           "version": "0.6.1",
           "from": "sax@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
         },
         "tmp": {
           "version": "0.0.24",
           "from": "tmp@0.0.24",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
         },
         "xml2js": {
           "version": "0.4.4",
           "from": "xml2js@0.4.4",
-          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz"
         }
       }
     },
     "semver": {
       "version": "5.1.0",
       "from": "semver@5.1.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
     },
     "semver-diff": {
       "version": "2.1.0",
       "from": "semver-diff@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz"
     },
     "semver-utils": {
       "version": "1.1.1",
       "from": "semver-utils@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.1.tgz"
     },
     "send": {
       "version": "0.13.0",
       "from": "send@0.13.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz"
+    },
+    "sentence-case": {
+      "version": "2.1.0",
+      "from": "sentence-case@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.0.tgz"
     },
     "seq": {
       "version": "0.3.5",
       "from": "seq@0.3.5",
       "resolved": "https://registry.npmjs.org/seq/-/seq-0.3.5.tgz",
-      "dev": true,
       "dependencies": {
         "chainsaw": {
           "version": "0.0.9",
           "from": "chainsaw@>=0.0.7 <0.1.0",
-          "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.0.9.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.0.9.tgz"
         }
       }
     },
     "sequencify": {
       "version": "0.0.7",
       "from": "sequencify@>=0.0.7 <0.1.0",
-      "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
     },
     "serve-favicon": {
       "version": "2.3.0",
       "from": "serve-favicon@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz"
     },
     "serve-index": {
       "version": "1.7.2",
       "from": "serve-index@>=1.7.2 <1.8.0",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.2.tgz",
-      "dev": true,
       "dependencies": {
         "mime-db": {
           "version": "1.20.0",
           "from": "mime-db@1.20.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
         },
         "mime-types": {
           "version": "2.1.8",
           "from": "mime-types@2.1.8",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz"
         }
       }
     },
     "serve-static": {
       "version": "1.10.0",
       "from": "serve-static@>=1.10.0 <1.11.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.0.tgz",
-      "dev": true
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "from": "set-blocking@>=2.0.0 <2.1.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.0.tgz"
     },
     "setimmediate": {
       "version": "1.0.4",
       "from": "setimmediate@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz"
     },
     "sha.js": {
       "version": "2.2.6",
       "from": "sha.js@2.2.6",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+    },
+    "shelljs": {
+      "version": "0.7.6",
+      "from": "shelljs@>=0.7.0 <0.8.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1",
+          "from": "glob@^7.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+        },
+        "interpret": {
+          "version": "1.0.1",
+          "from": "interpret@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz"
+        }
+      }
     },
     "sigmund": {
       "version": "1.0.1",
       "from": "sigmund@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
     },
     "signal-exit": {
       "version": "2.1.2",
       "from": "signal-exit@>=2.1.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
     },
     "slice-stream": {
       "version": "1.0.0",
       "from": "slice-stream@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
           "from": "readable-stream@>=1.0.31 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "slide": {
       "version": "1.1.6",
       "from": "slide@>=1.1.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+    },
+    "snake-case": {
+      "version": "2.1.0",
+      "from": "snake-case@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz"
     },
     "sntp": {
       "version": "1.0.9",
       "from": "sntp@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
     },
     "socket.io": {
       "version": "1.4.6",
       "from": "socket.io@>=1.4.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.6.tgz"
     },
     "socket.io-adapter": {
       "version": "0.4.0",
       "from": "socket.io-adapter@0.4.0",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
-      "dev": true,
       "dependencies": {
         "socket.io-parser": {
           "version": "2.2.2",
           "from": "socket.io-parser@2.2.2",
           "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
-          "dev": true,
           "dependencies": {
             "debug": {
               "version": "0.7.4",
               "from": "debug@0.7.4",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             }
           }
         }
@@ -8187,13 +7028,11 @@
       "version": "1.4.6",
       "from": "socket.io-client@1.4.6",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.6.tgz",
-      "dev": true,
       "dependencies": {
         "component-emitter": {
           "version": "1.2.0",
           "from": "component-emitter@1.2.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
         }
       }
     },
@@ -8201,45 +7040,38 @@
       "version": "2.2.6",
       "from": "socket.io-parser@2.2.6",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
-      "dev": true,
       "dependencies": {
         "json3": {
           "version": "3.3.2",
           "from": "json3@3.3.2",
-          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
         }
       }
     },
     "source-list-map": {
       "version": "0.1.5",
       "from": "source-list-map@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
     },
     "source-map": {
       "version": "0.3.0",
       "from": "source-map@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz"
     },
     "source-map-support": {
       "version": "0.4.2",
       "from": "source-map-support@latest",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.2.tgz",
-      "dev": true,
       "dependencies": {
         "source-map": {
           "version": "0.1.32",
           "from": "source-map@0.1.32",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-          "dev": true,
           "dependencies": {
             "amdefine": {
               "version": "1.0.1",
               "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
             }
           }
         }
@@ -8248,437 +7080,376 @@
     "sparkles": {
       "version": "1.0.0",
       "from": "sparkles@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-      "dev": true
-    },
-    "spawn-sync": {
-      "version": "1.0.15",
-      "from": "spawn-sync@>=1.0.15 <2.0.0",
-      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
     },
     "spdx-correct": {
       "version": "1.0.2",
       "from": "spdx-correct@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
     },
     "spdx-exceptions": {
       "version": "1.0.4",
       "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
     },
     "spdx-expression-parse": {
       "version": "1.0.2",
       "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
     },
     "spdx-license-ids": {
       "version": "1.1.0",
       "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+    },
+    "spdx-license-list": {
+      "version": "2.1.0",
+      "from": "spdx-license-list@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-2.1.0.tgz"
     },
     "split": {
       "version": "1.0.0",
       "from": "split@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz"
     },
     "split2": {
       "version": "2.1.0",
       "from": "split2@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
           "from": "readable-stream@2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "through2": {
           "version": "2.0.1",
           "from": "through2@2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         }
       }
     },
     "sprintf-js": {
       "version": "1.0.3",
       "from": "sprintf-js@>=1.0.2 <1.1.0",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sshpk": {
       "version": "1.10.1",
       "from": "sshpk@>=1.7.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
-      "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
+    },
+    "stack-trace": {
+      "version": "0.0.9",
+      "from": "stack-trace@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
     },
     "statuses": {
       "version": "1.2.1",
       "from": "statuses@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
     },
     "stream-browserify": {
       "version": "1.0.0",
       "from": "stream-browserify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
     },
     "stream-combiner": {
       "version": "0.0.4",
       "from": "stream-combiner@>=0.0.4 <0.1.0",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
     },
     "stream-consume": {
       "version": "0.1.0",
       "from": "stream-consume@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
     },
     "stream-counter": {
       "version": "0.2.0",
       "from": "stream-counter@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
     },
     "stream-equal": {
       "version": "0.1.6",
       "from": "stream-equal@0.1.6",
-      "resolved": "https://registry.npmjs.org/stream-equal/-/stream-equal-0.1.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/stream-equal/-/stream-equal-0.1.6.tgz"
     },
     "string_decoder": {
       "version": "0.10.31",
       "from": "string_decoder@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "string-width": {
       "version": "1.0.1",
       "from": "string-width@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
           "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "strip-ansi": {
           "version": "3.0.0",
           "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
         }
       }
     },
-    "string.prototype.codepointat": {
-      "version": "0.2.0",
-      "from": "string.prototype.codepointat@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz",
-      "dev": true
+    "stringmap": {
+      "version": "0.2.2",
+      "from": "stringmap@>=0.2.2 <0.3.0",
+      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
     },
     "stringstream": {
       "version": "0.0.5",
       "from": "stringstream@>=0.0.4 <0.1.0",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-ansi": {
       "version": "3.0.1",
       "from": "strip-ansi@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "strip-bom": {
       "version": "2.0.0",
       "from": "strip-bom@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
     },
     "strip-indent": {
       "version": "1.0.1",
       "from": "strip-indent@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
     },
     "strip-json-comments": {
       "version": "1.0.4",
       "from": "strip-json-comments@>=1.0.4 <1.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
     "success-symbol": {
       "version": "0.1.0",
       "from": "success-symbol@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
     },
     "supports-color": {
       "version": "2.0.0",
       "from": "supports-color@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+    },
+    "swap-case": {
+      "version": "1.1.2",
+      "from": "swap-case@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
     },
     "symbol-observable": {
       "version": "1.0.4",
       "from": "symbol-observable@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz"
     },
+    "symbol-tree": {
+      "version": "3.2.1",
+      "from": "symbol-tree@>=3.1.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.1.tgz"
+    },
     "systemjs": {
       "version": "0.18.10",
       "from": "systemjs@0.18.10",
-      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.18.10.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.18.10.tgz"
     },
     "tapable": {
       "version": "0.1.10",
       "from": "tapable@>=0.1.8 <0.2.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
-      "dev": true
-    },
-    "tar": {
-      "version": "2.2.1",
-      "from": "tar@>=2.2.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "dev": true,
-      "dependencies": {
-        "fstream": {
-          "version": "1.0.10",
-          "from": "fstream@^1.0.2",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "from": "graceful-fs@^4.1.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "dev": true
-        }
-      }
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
     },
     "tar-stream": {
       "version": "1.1.5",
       "from": "tar-stream@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
           "from": "readable-stream@>=1.0.33 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "text-extensions": {
       "version": "1.3.3",
       "from": "text-extensions@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.3.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.3.3.tgz"
     },
     "through": {
       "version": "2.3.8",
       "from": "through@>=2.2.7 <3.0.0",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
       "version": "0.6.5",
       "from": "through2@>=0.6.3 <0.7.0",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
           "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
         }
       }
     },
     "tildify": {
       "version": "1.1.2",
       "from": "tildify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz"
     },
     "timed-out": {
       "version": "3.0.0",
       "from": "timed-out@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.0.0.tgz"
     },
     "timers-browserify": {
       "version": "1.4.2",
       "from": "timers-browserify@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
     },
     "timers-ext": {
       "version": "0.1.0",
       "from": "timers-ext@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz"
     },
     "tiny-lr": {
       "version": "0.2.1",
       "from": "tiny-lr@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
-      "dev": true,
       "dependencies": {
         "body-parser": {
           "version": "1.14.2",
           "from": "body-parser@>=1.14.0 <1.15.0",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
-          "dev": true,
           "dependencies": {
             "qs": {
               "version": "5.2.0",
               "from": "qs@5.2.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
             }
           }
         },
         "bytes": {
           "version": "2.2.0",
           "from": "bytes@2.2.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
         },
         "depd": {
           "version": "1.1.0",
           "from": "depd@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "iconv-lite": {
           "version": "0.4.13",
           "from": "iconv-lite@0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
         },
         "qs": {
           "version": "5.1.0",
           "from": "qs@>=5.1.0 <5.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
         }
       }
+    },
+    "title-case": {
+      "version": "2.1.0",
+      "from": "title-case@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.0.tgz"
     },
     "tmp": {
       "version": "0.0.25",
       "from": "tmp@0.0.25",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.25.tgz"
     },
     "to-array": {
       "version": "0.1.4",
       "from": "to-array@0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
     },
     "tough-cookie": {
       "version": "2.2.1",
       "from": "tough-cookie@>=2.2.0 <2.3.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "from": "tr46@>=0.0.3 <0.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
     },
     "traverse": {
       "version": "0.3.9",
       "from": "traverse@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
     },
     "trim-newlines": {
       "version": "1.0.0",
       "from": "trim-newlines@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
     },
     "trim-off-newlines": {
       "version": "1.0.1",
       "from": "trim-off-newlines@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz"
     },
     "ts-api-guardian": {
       "version": "0.1.4",
       "from": "ts-api-guardian@0.1.4",
       "resolved": "https://registry.npmjs.org/ts-api-guardian/-/ts-api-guardian-0.1.4.tgz",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
           "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "ansi-styles": {
           "version": "2.2.1",
           "from": "ansi-styles@>=2.2.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
         },
         "chalk": {
           "version": "1.1.3",
           "from": "chalk@>=1.1.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
         },
         "diff": {
           "version": "2.2.3",
           "from": "diff@>=2.2.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
           "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "strip-ansi": {
           "version": "3.0.1",
           "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
           "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         },
         "typescript": {
           "version": "1.7.3",
           "from": "typescript@1.7.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.7.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.7.3.tgz"
         }
       }
     },
@@ -8686,13 +7457,11 @@
       "version": "0.2.4",
       "from": "tsickle@0.2.4",
       "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.2.4.tgz",
-      "dev": true,
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
           "from": "source-map@>=0.5.6 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
@@ -8700,25 +7469,21 @@
       "version": "4.1.1",
       "from": "tslint@>=4.1.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.1.1.tgz",
-      "dev": true,
       "dependencies": {
         "diff": {
           "version": "3.1.0",
           "from": "diff@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.1.0.tgz"
         },
         "glob": {
           "version": "7.1.1",
           "from": "glob@>=7.0.3 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
         },
         "resolve": {
           "version": "1.2.0",
           "from": "resolve@>=1.1.7 <2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz"
         }
       }
     },
@@ -8726,395 +7491,357 @@
       "version": "3.1.0",
       "from": "tslint-eslint-rules@>=3.1.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-3.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "diff": {
           "version": "3.1.0",
           "from": "diff@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.1.0.tgz"
         },
         "glob": {
           "version": "7.1.1",
           "from": "glob@>=7.1.1 <8.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
         },
         "resolve": {
           "version": "1.1.7",
           "from": "resolve@>=1.1.7 <2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
         },
         "tslint": {
           "version": "4.0.2",
           "from": "tslint@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.0.2.tgz"
         }
       }
     },
     "tty-browserify": {
       "version": "0.0.0",
       "from": "tty-browserify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
     },
     "tunnel-agent": {
       "version": "0.4.2",
       "from": "tunnel-agent@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
     },
     "tweetnacl": {
       "version": "0.14.3",
       "from": "tweetnacl@>=0.14.0 <0.15.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-      "dev": true,
-      "optional": true
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "from": "type-check@>=0.3.2 <0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
     },
     "type-is": {
       "version": "1.6.10",
       "from": "type-is@>=1.6.6 <1.7.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.10.tgz",
-      "dev": true,
       "dependencies": {
         "mime-db": {
           "version": "1.20.0",
           "from": "mime-db@>=1.20.0 <1.21.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
         },
         "mime-types": {
           "version": "2.1.8",
           "from": "mime-types@>=2.1.8 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz"
         }
       }
     },
     "typedarray": {
       "version": "0.0.6",
       "from": "typedarray@>=0.0.5 <0.1.0",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "typescript": {
       "version": "2.0.2",
       "from": "typescript@rc",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.2.tgz"
     },
     "ua-parser-js": {
       "version": "0.7.10",
       "from": "ua-parser-js@>=0.7.9 <0.8.0",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
     },
     "uglify-js": {
       "version": "2.7.0",
       "from": "uglify-js@>=2.6.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.0.tgz",
-      "dev": true,
-      "optional": true,
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
           "from": "camelcase@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "dev": true,
-          "optional": true
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
         },
         "cliui": {
           "version": "2.1.0",
           "from": "cliui@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "dev": true,
-          "optional": true
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
         },
         "source-map": {
           "version": "0.5.6",
           "from": "source-map@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "dev": true,
-          "optional": true
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         },
         "window-size": {
           "version": "0.1.0",
           "from": "window-size@0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "dev": true,
-          "optional": true
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
         },
         "wordwrap": {
           "version": "0.0.2",
           "from": "wordwrap@0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "dev": true,
-          "optional": true
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
         },
         "yargs": {
           "version": "3.10.0",
           "from": "yargs@>=3.10.0 <3.11.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "dev": true,
-          "optional": true
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
         }
       }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
       "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
     },
     "uid-safe": {
       "version": "2.0.0",
       "from": "uid-safe@>=2.0.0 <2.1.0",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz"
     },
     "ultron": {
       "version": "1.0.2",
       "from": "ultron@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
     },
     "underscore": {
       "version": "1.8.3",
       "from": "underscore@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+    },
+    "underscore-contrib": {
+      "version": "0.3.0",
+      "from": "underscore-contrib@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+      "dependencies": {
+        "underscore": {
+          "version": "1.6.0",
+          "from": "underscore@1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+        }
+      }
     },
     "underscore.string": {
       "version": "3.3.4",
       "from": "underscore.string@>=3.3.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz"
     },
     "unicoderegexp": {
       "version": "0.4.1",
       "from": "unicoderegexp@0.4.1",
-      "resolved": "https://registry.npmjs.org/unicoderegexp/-/unicoderegexp-0.4.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/unicoderegexp/-/unicoderegexp-0.4.1.tgz"
     },
     "unique-stream": {
       "version": "1.0.0",
       "from": "unique-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
     },
     "universal-analytics": {
       "version": "0.3.10",
       "from": "universal-analytics@>=0.3.9 <0.4.0",
-      "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.3.10.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.3.10.tgz"
     },
     "unpipe": {
       "version": "1.0.0",
       "from": "unpipe@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
     },
     "unzip": {
       "version": "0.1.11",
       "from": "unzip@>=0.1.9 <0.2.0",
       "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
-      "dev": true,
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
           "from": "readable-stream@>=1.0.31 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "unzip-response": {
       "version": "1.0.2",
       "from": "unzip-response@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz"
     },
     "update-notifier": {
       "version": "1.0.3",
       "from": "update-notifier@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz"
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "from": "upper-case@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
+    },
+    "upper-case-first": {
+      "version": "1.1.2",
+      "from": "upper-case-first@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
     },
     "url": {
       "version": "0.10.3",
       "from": "url@>=0.10.1 <0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "dev": true,
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
           "from": "punycode@1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
         }
       }
     },
     "url-parse-lax": {
       "version": "1.0.0",
       "from": "url-parse-lax@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz"
     },
     "user-home": {
       "version": "1.1.1",
       "from": "user-home@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
     },
     "useragent": {
       "version": "2.1.9",
       "from": "useragent@>=2.1.6 <3.0.0",
       "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.9.tgz",
-      "dev": true,
       "dependencies": {
         "lru-cache": {
           "version": "2.2.4",
           "from": "lru-cache@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
         }
       }
     },
     "utf8": {
       "version": "2.1.0",
       "from": "utf8@2.1.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
     },
     "util": {
       "version": "0.10.3",
       "from": "util@>=0.10.1 <0.11.0",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
     },
     "util-deprecate": {
       "version": "1.0.2",
       "from": "util-deprecate@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "utils-merge": {
       "version": "1.0.0",
       "from": "utils-merge@1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
     },
     "uuid": {
       "version": "2.0.3",
       "from": "uuid@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
     },
     "v8flags": {
       "version": "2.0.11",
       "from": "v8flags@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz"
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+    },
+    "validate.js": {
+      "version": "0.9.0",
+      "from": "validate.js@>=0.9.0 <0.10.0",
+      "resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.9.0.tgz"
     },
     "vargs": {
       "version": "0.1.0",
       "from": "vargs@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz"
     },
     "vary": {
       "version": "1.0.1",
       "from": "vary@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
     },
     "verror": {
       "version": "1.3.6",
       "from": "verror@1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
     "vhost": {
       "version": "3.0.2",
       "from": "vhost@>=3.0.1 <3.1.0",
-      "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz"
     },
     "vinyl-fs": {
       "version": "0.3.14",
       "from": "vinyl-fs@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-      "dev": true,
       "dependencies": {
         "clone": {
           "version": "0.2.0",
           "from": "clone@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
         },
         "strip-bom": {
           "version": "1.0.0",
           "from": "strip-bom@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz"
         },
         "vinyl": {
           "version": "0.4.6",
           "from": "vinyl@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
         }
       }
     },
     "vlq": {
       "version": "0.2.1",
       "from": "vlq@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.1.tgz"
     },
     "vm-browserify": {
       "version": "0.0.4",
       "from": "vm-browserify@>=0.0.1 <0.1.0",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
     },
     "void-elements": {
       "version": "2.0.1",
       "from": "void-elements@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
     },
     "vrsource-tslint-rules": {
       "version": "4.0.0",
       "from": "vrsource-tslint-rules@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/vrsource-tslint-rules/-/vrsource-tslint-rules-4.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/vrsource-tslint-rules/-/vrsource-tslint-rules-4.0.0.tgz"
     },
     "watchpack": {
       "version": "0.2.9",
       "from": "watchpack@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
-      "dev": true,
       "dependencies": {
         "async": {
           "version": "0.9.2",
           "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "graceful-fs": {
           "version": "4.1.2",
           "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
         }
       }
     },
@@ -9122,211 +7849,182 @@
       "version": "0.3.12",
       "from": "wd@>=0.3.4 <0.4.0",
       "resolved": "https://registry.npmjs.org/wd/-/wd-0.3.12.tgz",
-      "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "2.0.0",
           "from": "ansi-regex@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
         },
         "ansi-styles": {
           "version": "2.1.0",
           "from": "ansi-styles@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
         },
         "asn1": {
           "version": "0.1.11",
           "from": "asn1@0.1.11",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
         },
         "async": {
           "version": "1.0.0",
           "from": "async@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
         },
         "aws-sign2": {
           "version": "0.5.0",
           "from": "aws-sign2@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         },
         "caseless": {
           "version": "0.9.0",
           "from": "caseless@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
         },
         "chalk": {
           "version": "1.1.1",
           "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
         },
         "combined-stream": {
           "version": "0.0.7",
           "from": "combined-stream@>=0.0.5 <0.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
         },
         "delayed-stream": {
           "version": "0.0.5",
           "from": "delayed-stream@0.0.5",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
         },
         "form-data": {
           "version": "0.2.0",
           "from": "form-data@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-          "dev": true,
           "dependencies": {
             "async": {
               "version": "0.9.2",
               "from": "async@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
             }
           }
         },
         "har-validator": {
           "version": "1.8.0",
           "from": "har-validator@>=1.4.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
           "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "hawk": {
           "version": "2.3.1",
           "from": "hawk@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz"
         },
         "http-signature": {
           "version": "0.10.1",
           "from": "http-signature@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz"
         },
         "lodash": {
           "version": "3.9.3",
           "from": "lodash@>=3.9.3 <3.10.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
         },
         "oauth-sign": {
           "version": "0.6.0",
           "from": "oauth-sign@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
         },
         "qs": {
           "version": "2.4.2",
           "from": "qs@>=2.4.0 <2.5.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
         },
         "request": {
           "version": "2.55.0",
           "from": "request@>=2.55.0 <2.56.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz"
         },
         "strip-ansi": {
           "version": "3.0.0",
           "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
           "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         },
         "underscore.string": {
           "version": "3.0.3",
           "from": "underscore.string@>=3.0.3 <3.1.0",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz"
         }
       }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "from": "webidl-conversions@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
     },
     "webpack": {
       "version": "1.12.9",
       "from": "webpack@>=1.12.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.12.9.tgz",
-      "dev": true,
       "dependencies": {
         "async": {
           "version": "1.5.0",
           "from": "async@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
         },
         "camelcase": {
           "version": "1.2.1",
           "from": "camelcase@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
         },
         "cliui": {
           "version": "2.1.0",
           "from": "cliui@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
         },
         "source-map": {
           "version": "0.5.3",
           "from": "source-map@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
         },
         "supports-color": {
           "version": "3.1.2",
           "from": "supports-color@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
         },
         "uglify-js": {
           "version": "2.6.1",
           "from": "uglify-js@>=2.6.0 <2.7.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
-          "dev": true,
           "dependencies": {
             "async": {
               "version": "0.2.10",
               "from": "async@0.2.10",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             }
           }
         },
         "window-size": {
           "version": "0.1.0",
           "from": "window-size@0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
         },
         "wordwrap": {
           "version": "0.0.2",
           "from": "wordwrap@0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
         },
         "yargs": {
           "version": "3.10.0",
           "from": "yargs@>=3.10.0 <3.11.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
         }
       }
     },
@@ -9334,289 +8032,199 @@
       "version": "0.6.8",
       "from": "webpack-core@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
-      "dev": true,
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
           "from": "source-map@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
         }
       }
     },
     "websocket-driver": {
       "version": "0.6.3",
       "from": "websocket-driver@>=0.5.1",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.3.tgz"
     },
     "websocket-extensions": {
       "version": "0.1.1",
       "from": "websocket-extensions@>=0.1.1",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+    },
+    "whatwg-encoding": {
+      "version": "1.0.1",
+      "from": "whatwg-encoding@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.13",
+          "from": "iconv-lite@0.4.13",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+        }
+      }
     },
     "whatwg-fetch": {
       "version": "0.9.0",
       "from": "whatwg-fetch@>=0.9.0 <0.10.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
+    },
+    "whatwg-url": {
+      "version": "3.1.0",
+      "from": "whatwg-url@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-3.1.0.tgz"
     },
     "when": {
       "version": "3.7.2",
       "from": "when@3.7.2",
-      "resolved": "https://registry.npmjs.org/when/-/when-3.7.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/when/-/when-3.7.2.tgz"
     },
     "which": {
       "version": "1.2.10",
       "from": "which@>=1.0.9 <2.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
-      "dev": true
-    },
-    "wide-align": {
-      "version": "1.1.0",
-      "from": "wide-align@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz"
     },
     "widest-line": {
       "version": "1.0.0",
       "from": "widest-line@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz"
     },
     "window-size": {
       "version": "0.1.4",
       "from": "window-size@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
     },
     "winreg": {
       "version": "0.0.12",
       "from": "winreg@0.0.12",
-      "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz"
+    },
+    "winston": {
+      "version": "2.3.1",
+      "from": "winston@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "from": "async@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
+        },
+        "colors": {
+          "version": "1.0.3",
+          "from": "colors@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+        }
+      }
     },
     "wordwrap": {
       "version": "0.0.3",
       "from": "wordwrap@>=0.0.2 <0.1.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
     },
     "wrap-ansi": {
       "version": "1.0.0",
       "from": "wrap-ansi@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz"
     },
     "wrappy": {
       "version": "1.0.1",
       "from": "wrappy@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
     },
     "wrench": {
       "version": "1.5.8",
       "from": "wrench@>=1.5.8 <1.6.0",
-      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz"
     },
     "write-file-atomic": {
       "version": "1.2.0",
       "from": "write-file-atomic@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.2.0.tgz",
-      "dev": true,
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
           "from": "graceful-fs@^4.1.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
         }
       }
     },
     "ws": {
       "version": "1.1.1",
       "from": "ws@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz"
     },
     "xdg-basedir": {
       "version": "2.0.0",
       "from": "xdg-basedir@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz"
+    },
+    "xml-name-validator": {
+      "version": "2.0.1",
+      "from": "xml-name-validator@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
     },
     "xml2js": {
       "version": "0.4.15",
       "from": "xml2js@>=0.4.4 <0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.15.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.15.tgz"
     },
     "xmlbuilder": {
       "version": "8.2.2",
       "from": "xmlbuilder@>=1.0.0",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz"
     },
     "xmldom": {
       "version": "0.1.19",
       "from": "xmldom@0.1.19",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz"
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.1",
       "from": "xmlhttprequest-ssl@1.5.1",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
     },
     "xpath": {
       "version": "0.0.7",
       "from": "xpath@0.0.7",
-      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.7.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.7.tgz"
     },
     "xtend": {
       "version": "4.0.1",
       "from": "xtend@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "y18n": {
       "version": "3.2.0",
       "from": "y18n@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
     },
     "yargs": {
       "version": "3.31.0",
       "from": "yargs@3.31.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.31.0.tgz",
-      "dev": true
-    },
-    "yarn": {
-      "version": "0.19.1",
-      "from": "yarn@latest",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-0.19.1.tgz",
-      "dev": true,
-      "dependencies": {
-        "bl": {
-          "version": "1.2.0",
-          "from": "bl@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.0.tgz",
-          "dev": true
-        },
-        "bytes": {
-          "version": "2.4.0",
-          "from": "bytes@>=2.4.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "3.0.0",
-          "from": "camelcase@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "from": "isarray@~1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.26.0",
-          "from": "mime-db@>=1.26.0 <1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.14",
-          "from": "mime-types@>=2.1.7 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.3.0",
-          "from": "qs@>=6.3.0 <6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
-          "dev": true
-        },
-        "read": {
-          "version": "1.0.7",
-          "from": "read@>=1.0.7 <2.0.0",
-          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.2.2",
-          "from": "readable-stream@^2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-          "dev": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "from": "request@>=2.75.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "dev": true
-        },
-        "tar-stream": {
-          "version": "1.5.2",
-          "from": "tar-stream@>=1.5.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
-          "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "from": "tough-cookie@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "dev": true
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "from": "user-home@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "from": "uuid@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "dev": true
-        }
-      }
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.31.0.tgz"
     },
     "yeast": {
       "version": "0.1.2",
       "from": "yeast@0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
     },
     "zip-dir": {
       "version": "1.0.0",
       "from": "zip-dir@1.0.0",
-      "resolved": "https://registry.npmjs.org/zip-dir/-/zip-dir-1.0.0.tgz",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/zip-dir/-/zip-dir-1.0.0.tgz"
     },
     "zip-stream": {
       "version": "0.5.2",
       "from": "zip-stream@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.2.tgz",
-      "dev": true,
       "dependencies": {
         "lodash": {
           "version": "3.2.0",
           "from": "lodash@>=3.2.0 <3.3.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
         },
         "readable-stream": {
           "version": "1.0.33",
           "from": "readable-stream@>=1.0.26 <1.1.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "gulp-clang-format": "^1.0.23",
     "gulp-connect": "^2.3.1",
     "gulp-conventional-changelog": "^1.1.0",
+    "gulp-dom": "^0.9.17",
+    "gulp-tap": "^0.1.3",
     "gulp-tslint": "^7.0.1",
     "hammerjs": "^2.0.8",
     "incremental-dom": "^0.4.1",


### PR DESCRIPTION
Basically I judged that since the guides are currently written in Jade, we would have to compile them with harp somehow. And rather than reproduce all the build setup (which is substantial with all the example shredding and jade macros, etc), I thought we might as well let the angular.io build do the heavy lifting.

This approach scrapes the guides from their compiled HTML, and places them in `docs/content/guide`, along with their titles, which it puts into `docs/content/guides.json`.

I may have missed some important metadata and it may be that we need to do some transformation of the link hrefs but the basic approach seems to work.

What do you think @IgorMinar and @wardbell ?