### PR TITLE
fix(core): Let Chrome be able to use source-maps in the style tag

### DIFF
--- a/modules/@angular/compiler/src/style_url_resolver.ts
+++ b/modules/@angular/compiler/src/style_url_resolver.ts
@@ -29,19 +29,20 @@ export function extractStyleUrls(
     resolver: UrlResolver, baseUrl: string, cssText: string): StyleWithImports {
   const foundUrls: string[] = [];
 
-  const modifiedCssText =
-      cssText.replace(CSS_COMMENT_REGEXP, '').replace(CSS_IMPORT_REGEXP, (...m: string[]) => {
-        const url = m[1] || m[2];
-        if (!isStyleUrlResolvable(url)) {
-          // Do not attempt to resolve non-package absolute URLs with URI scheme
-          return m[0];
-        }
-        foundUrls.push(resolver.resolve(baseUrl, url));
-        return '';
-      });
+  const modifiedCssText = cssText.replace(CSS_COMMENT_WITH_NO_SOURCE_MAP_REGEXP, '')
+                              .replace(CSS_IMPORT_REGEXP, (...m: string[]) => {
+                                const url = m[1] || m[2];
+                                if (!isStyleUrlResolvable(url)) {
+                                  // Do not attempt to resolve non-package absolute URLs with URI
+                                  // scheme
+                                  return m[0];
+                                }
+                                foundUrls.push(resolver.resolve(baseUrl, url));
+                                return '';
+                              });
   return new StyleWithImports(modifiedCssText, foundUrls);
 }
 
 const CSS_IMPORT_REGEXP = /@import\s+(?:url\()?\s*(?:(?:['"]([^'"]*))|([^;\)\s]*))[^;]*;?/g;
-const CSS_COMMENT_REGEXP = /\/\*.+?\*\//g;
+const CSS_COMMENT_WITH_NO_SOURCE_MAP_REGEXP = /\/\*[^#].*?\*\//g;
 const URL_WITH_SCHEMA_REGEXP = /^([^:/?#]+):/;

--- a/modules/@angular/compiler/test/shadow_css_spec.ts
+++ b/modules/@angular/compiler/test/shadow_css_spec.ts
@@ -258,10 +258,14 @@ export function main() {
        () => { expect(s('/* \n */b {c}', 'a')).toEqual('b[a] {c}'); });
 
     it('should keep sourceMappingURL comments', () => {
-      expect(s('b {c}/*# sourceMappingURL=data:x */', 'a'))
-          .toEqual('b[a] {c}/*# sourceMappingURL=data:x */');
-      expect(s('b {c}/* #sourceMappingURL=data:x */', 'a'))
-          .toEqual('b[a] {c}/* #sourceMappingURL=data:x */');
+      expect(s('b {c}\n/*# sourceMappingURL=data:x */', 'a'))
+          .toEqual('b[a] {c}/*# sourceURL=any-name.css *//*# sourceMappingURL=data:x */');
+    });
+    it('should add sourceURL placeholder if and only if it does not exist', () => {
+      expect(s('b {c}\n/*# sourceMappingURL=data:x */', 'a'))
+          .toEqual('b[a] {c}/*# sourceURL=any-name.css *//*# sourceMappingURL=data:x */');
+      expect(s('b {c}\n/*# sourceURL=my-name.scss */\n/*# sourceMappingURL=data:x */', 'a'))
+          .toEqual('b[a] {c}/*# sourceURL=my-name.scss *//*# sourceMappingURL=data:x */');
     });
   });
 

--- a/modules/@angular/compiler/test/style_url_resolver_spec.ts
+++ b/modules/@angular/compiler/test/style_url_resolver_spec.ts
@@ -47,6 +47,15 @@ export function main() {
       expect(styleWithImports.styleUrls).not.toContain('http://ng.io/2.css');
     });
 
+    it('should keep /*# ... */ comments', () => {
+      const css =
+          `@import '1.css';\n/*@import '2.css';*/\n/*# sourceURL=2.scss */\n/*# sourceMappingURL=data:x */`;
+      const styleWithImports = extractStyleUrls(urlResolver, 'http://ng.io', css);
+      expect(styleWithImports.style.trim())
+          .toEqual('/*# sourceURL=2.scss */\n/*# sourceMappingURL=data:x */');
+      expect(styleWithImports.styleUrls).not.toContain('http://ng.io/2.css');
+    });
+
     it('should extract "@import url()" urls', () => {
       const css = `
       @import url('3.css');


### PR DESCRIPTION
The component style creates a style tag that contains the source-maps, and Chrome will not be able to use it. We need to add /*@ sourceURL=... */ comments to make Chrome happy.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The component style will create a style tag that contains the sourcemap information, which chrome will not be able to use

**What is the new behavior?**

The component style will create a style tag that contains the sourcemap information, which chrome will be able to use it.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

