### PR TITLE
ci(pullapprove): fix `compiler-cli` paths

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -108,13 +108,12 @@ groups:
       - tbosch #primary
       - mhevery
       - IgorMinar #fallback
-      - mhevery #fallback
 
   compiler-cli:
     conditions:
       files:
         - "tools/@angular/tsc-wrapped/*"
-        - "modules/@angular/compiler-cli"
+        - "modules/@angular/compiler-cli/*"
     users:
       - alexeagle
       - chuckjaz


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Files under `modules/@angular/compiler-cli/` are not mapped to the `compiler-cli` group.


**What is the new behavior?**
Files under `modules/@angular/compiler-cli/` are mapped to the `compiler-cli` group.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```


**Other information**:
Follow-up to #14167.