### PR TITLE
[4.x] feat(router): remove href attr when commands are null/undefined

### DIFF
--- a/modules/@angular/router/src/directives/router_link.ts
+++ b/modules/@angular/router/src/directives/router_link.ts
@@ -148,7 +148,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   private subscription: Subscription;
 
   // the url displayed on the anchor element.
-  @HostBinding() href: string;
+  @HostBinding('attr.href') href: string;
 
   constructor(
       private router: Router, private route: ActivatedRoute,
@@ -165,7 +165,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
     if (commands != null) {
       this.commands = Array.isArray(commands) ? commands : [commands];
     } else {
-      this.commands = [];
+      this.commands = null;
     }
   }
 
@@ -178,23 +178,28 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
       return true;
     }
 
-    if (typeof this.target === 'string' && this.target != '_self') {
+    if (typeof this.target === 'string' && this.target !== '_self') {
       return true;
     }
 
-    const extras = {
-      skipLocationChange: attrBoolValue(this.skipLocationChange),
-      replaceUrl: attrBoolValue(this.replaceUrl),
-    };
-    this.router.navigateByUrl(this.urlTree, extras);
+    if (this.commands != null) {
+      const extras = {
+        skipLocationChange: attrBoolValue(this.skipLocationChange),
+        replaceUrl: attrBoolValue(this.replaceUrl),
+      };
+      this.router.navigateByUrl(this.urlTree, extras);
+    }
     return false;
   }
 
   private updateTargetUrlAndHref(): void {
-    this.href = this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(this.urlTree));
+    this.href = this.commands != null ?
+        this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(this.urlTree)) :
+        null;
   }
 
   get urlTree(): UrlTree {
+    if (this.commands == null) return null;
     return this.router.createUrlTree(this.commands, {
       relativeTo: this.route,
       queryParams: this.queryParams,

--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -543,6 +543,7 @@ export class Router {
 
   /** Returns whether the url is activated */
   isActive(url: string|UrlTree, exact: boolean): boolean {
+    if (url == null) return false;
     if (url instanceof UrlTree) {
       return containsTree(this.currentUrlTree, url, exact);
     } else {

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -1050,24 +1050,53 @@ describe('Integration', () => {
          expect(native.getAttribute('href')).toEqual('/home');
        }));
 
-    it('should not throw when commands is null', fakeAsync(() => {
+    it('should remove href attr from anchor when commands are null', fakeAsync(() => {
          @Component({
-           selector: 'someCmp',
-           template:
-               `<router-outlet></router-outlet><a [routerLink]="null">Link</a><button [routerLink]="null">Button</button>`
+           selector: 'some-cmp',
+           template: `<router-outlet></router-outlet><a [routerLink]="commands">Link</a>`
+         })
+         class CmpWithLink {
+           commands: string[] = [];
+         }
+
+         TestBed.configureTestingModule({declarations: [CmpWithLink]});
+         const router: Router = TestBed.get(Router);
+         const location: Location = TestBed.get(Location);
+
+         const fixture = createRoot(router, CmpWithLink);
+
+         const anchor = fixture.nativeElement.querySelector('a');
+         expect(anchor.hasAttribute('href')).toBe(true);
+         expect(location.path()).toEqual('/');
+
+         fixture.componentInstance.commands = null;
+         advance(fixture);
+         expect(anchor.hasAttribute('href')).toBe(false);
+
+         anchor.click();
+         advance(fixture);
+         expect(location.path()).toEqual('/');
+       }));
+
+    it('should not throw when routerLink is bound to null', fakeAsync(() => {
+         @Component({
+           selector: 'some-cmp',
+           template: `<router-outlet></router-outlet><button [routerLink]="null">Button</button>`
          })
          class CmpWithLink {
          }
 
          TestBed.configureTestingModule({declarations: [CmpWithLink]});
          const router: Router = TestBed.get(Router);
+         const location: Location = TestBed.get(Location);
 
-         let fixture: ComponentFixture<CmpWithLink> = createRoot(router, CmpWithLink);
-         router.resetConfig([{path: 'home', component: SimpleCmp}]);
-         const anchor = fixture.nativeElement.querySelector('a');
+         const fixture = createRoot(router, CmpWithLink);
+         expect(location.path()).toEqual('/');
+
          const button = fixture.nativeElement.querySelector('button');
-         expect(() => anchor.click()).not.toThrow();
-         expect(() => button.click()).not.toThrow();
+         button.click();
+         advance(fixture);
+         expect(location.path()).toEqual('/');
        }));
 
     it('should update hrefs when query params or fragment change', fakeAsync(() => {
@@ -2102,7 +2131,6 @@ describe('Integration', () => {
 
          TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
          const router: Router = TestBed.get(Router);
-         const loc: any = TestBed.get(Location);
 
          const f = TestBed.createComponent(RootCmpWithLink);
          advance(f);
@@ -2116,6 +2144,22 @@ describe('Integration', () => {
          expect(link.className).toEqual('active');
        }));
 
+    it('should not set the class when routerLink is bound to null', fakeAsync(() => {
+         @Component({
+           template:
+               '<router-outlet></router-outlet><a [routerLink]="null" routerLinkActive="active">Link</a>'
+         })
+         class RootCmpWithLink {
+         }
+
+         TestBed.configureTestingModule({declarations: [RootCmpWithLink]});
+         const router: Router = TestBed.get(Router);
+
+         const fixture = createRoot(router, RootCmpWithLink);
+
+         const link = fixture.nativeElement.querySelector('a');
+         expect(link.className).toEqual('');
+       }));
 
     it('should set the class on a parent element when the link is active',
        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {

--- a/modules/@angular/router/test/router.spec.ts
+++ b/modules/@angular/router/test/router.spec.ts
@@ -52,6 +52,20 @@ describe('Router', () => {
        }));
   });
 
+  describe('isActive', () => {
+    beforeEach(() => TestBed.configureTestingModule({imports: [RouterTestingModule]}));
+
+    it('should return false for null', inject([Router], (router: Router) => {
+         expect(router.isActive(null, false)).toBe(false);
+         expect(router.isActive(null, true)).toBe(false);
+       }));
+
+    it('should return false for undefined', inject([Router], (router: Router) => {
+         expect(router.isActive(undefined, false)).toBe(false);
+         expect(router.isActive(undefined, true)).toBe(false);
+       }));
+  });
+
   describe('PreActivation', () => {
     const serializer = new DefaultUrlSerializer();
     const inj = {get: (token: any) => () => `${token}_value`};


### PR DESCRIPTION
BREAKING CHANGE: binding routerLink to null/undefined no longer adds href
attribute to an anchor element.

Before:
`<a [routerLink]="null"/> yields <a href=""/>`

After:
`<a [routerLink]="null"/> yields <a/>`

Closes #13980