### PR TITLE
test(integration): add systemjs+umd env

### DIFF
--- a/integration/hello_world__systemjs_umd/.gitignore
+++ b/integration/hello_world__systemjs_umd/.gitignore
@@ -1,0 +1,3 @@
+**/*.js
+**/*.js.map
+!src/systemjs.config.js

--- a/integration/hello_world__systemjs_umd/bs-config.e2e.json
+++ b/integration/hello_world__systemjs_umd/bs-config.e2e.json
@@ -1,0 +1,14 @@
+{
+  "open": false,
+  "logLevel": "silent",
+  "port": 8000,
+  "server": {
+    "baseDir": "src",
+    "routes": {
+      "/node_modules": "node_modules"
+    },
+    "middleware": {
+      "0": null
+    }
+  }
+}

--- a/integration/hello_world__systemjs_umd/e2e/app.e2e-spec.ts
+++ b/integration/hello_world__systemjs_umd/e2e/app.e2e-spec.ts
@@ -1,0 +1,8 @@
+import { browser, element, by } from 'protractor';
+
+describe('Hello world E2E Tests', function () {
+  it('should display: Hello world!', function () {
+    browser.get('');
+    expect(element(by.css('div')).getText()).toEqual('Hello world!');
+  });
+});

--- a/integration/hello_world__systemjs_umd/e2e/tsconfig.json
+++ b/integration/hello_world__systemjs_umd/e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "lib": [ "es2015", "dom" ],
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "types": [
+      "jasmine"
+    ]
+  }
+}

--- a/integration/hello_world__systemjs_umd/package.json
+++ b/integration/hello_world__systemjs_umd/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "angular-integration",
+  "description": "Ensure SystemJS ^0.22 UMD compatibility via __esModule flag.",
+  "version": "0.0.0",
+  "license": "MIT",
+  "scripts": {
+    "test": "concurrently \"npm run serve\" \"npm run protractor\" --kill-others --success first",
+    "serve": "lite-server -c bs-config.e2e.json",
+    "preprotractor": "tsc -p e2e",
+    "protractor": "protractor protractor.config.js"
+  },
+  "dependencies": {
+    "@angular/common": "file:../../dist/packages-dist/common",
+    "@angular/core": "file:../../dist/packages-dist/core",
+    "@angular/compiler": "file:../../dist/packages-dist/compiler",
+    "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
+    "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
+    "core-js": "2.4.1",
+    "plugin-typescript": "6.0.4",
+    "rxjs": "file:../../node_modules/rxjs",
+    "systemjs": "0.20.2",
+    "typescript": "2.1.6",
+    "zone.js": "0.7.6"
+  },
+  "devDependencies": {
+    "@types/jasmine": "2.5.41",
+    "concurrently": "3.1.0",
+    "lite-server": "2.2.2",
+    "protractor": "file:../../node_modules/protractor"
+  }
+}

--- a/integration/hello_world__systemjs_umd/protractor.config.js
+++ b/integration/hello_world__systemjs_umd/protractor.config.js
@@ -1,0 +1,16 @@
+exports.config = {
+  specs: [
+    './e2e/**/*.e2e-spec.js'
+  ],
+  capabilities: {
+    browserName: 'chrome',
+    chromeOptions: {
+      'args': ['--no-sandbox'],
+      'binary': process.env.CHROME_BIN,
+    }
+  },
+  directConnect: true,
+  baseUrl: 'http://localhost:8000/',
+  framework: 'jasmine',
+  useAllAngular2AppRoots: true,
+};

--- a/integration/hello_world__systemjs_umd/src/app/app.ts
+++ b/integration/hello_world__systemjs_umd/src/app/app.ts
@@ -1,0 +1,11 @@
+import {HelloWorldComponent} from './hello-world.component';
+
+import {NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+
+@NgModule({
+  declarations: [HelloWorldComponent],
+  bootstrap: [HelloWorldComponent],
+  imports: [BrowserModule],
+})
+export class AppModule {}

--- a/integration/hello_world__systemjs_umd/src/app/hello-world.component.ts
+++ b/integration/hello_world__systemjs_umd/src/app/hello-world.component.ts
@@ -1,0 +1,10 @@
+import {Component, Injectable} from '@angular/core';
+
+@Component({
+  selector: 'hello-world-app',
+  template: '<div>Hello {{ name }}!</div>',
+})
+@Injectable()
+export class HelloWorldComponent {
+  name: string = 'world';
+}

--- a/integration/hello_world__systemjs_umd/src/index.html
+++ b/integration/hello_world__systemjs_umd/src/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Hello World</title>
+  <base href="/">
+  <script src="node_modules/core-js/client/shim.min.js"></script>
+  <script src="node_modules/zone.js/dist/zone.js"></script>
+  <script src="node_modules/systemjs/dist/system.src.js"></script>
+  <script src="systemjs.config.js"></script>
+  <script>
+    System.import('main.ts').catch(function (err) { console.error(err); });
+  </script>
+</head>
+
+<body>
+  <hello-world-app>Loading...</hello-world-app>
+</body>
+
+</html>

--- a/integration/hello_world__systemjs_umd/src/main.ts
+++ b/integration/hello_world__systemjs_umd/src/main.ts
@@ -1,0 +1,4 @@
+import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+import {AppModule} from './app/app';
+
+platformBrowserDynamic().bootstrapModule(AppModule);

--- a/integration/hello_world__systemjs_umd/src/systemjs.config.js
+++ b/integration/hello_world__systemjs_umd/src/systemjs.config.js
@@ -1,0 +1,45 @@
+(function (global) {
+  SystemJS.typescriptOptions = {
+    "target": "es5",
+    "module": "system",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "noImplicitAny": true,
+    "suppressImplicitAnyIndexErrors": true
+  };
+  System.config({
+    transpiler: 'ts',
+    meta: {
+      'typescript': {
+        "exports": "ts"
+      }
+    },
+    paths: {
+      'npm:': 'node_modules/'
+    },
+    map: {
+      app: 'app',
+      '@angular/core': 'npm:@angular/core/bundles/core.umd.min.js',
+      '@angular/common': 'npm:@angular/common/bundles/common.umd.min.js',
+      '@angular/compiler': 'npm:@angular/compiler/bundles/compiler.umd.min.js',
+      '@angular/platform-browser':
+         'npm:@angular/platform-browser/bundles/platform-browser.umd.min.js',
+      '@angular/platform-browser-dynamic':
+         'npm:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.min.js',
+      'rxjs': 'npm:rxjs',
+      'angular-in-memory-web-api': 'npm:angular-in-memory-web-api/bundles/in-memory-web-api.umd.js',
+      'ts': 'npm:plugin-typescript/lib/plugin.js',
+      'typescript': 'npm:typescript/lib/typescript.js',
+    },
+    packages: {
+      app: {
+        defaultExtension: 'ts'
+      },
+      rxjs: {
+        defaultExtension: 'js'
+      }
+    }
+  });
+})(this);

--- a/integration/hello_world__systemjs_umd/src/tsconfig.json
+++ b/integration/hello_world__systemjs_umd/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "system",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "lib": [ "es2015", "dom" ],
+    "noImplicitAny": true,
+    "suppressImplicitAnyIndexErrors": true
+  }
+}

--- a/packages/animations/browser/rollup.config.js
+++ b/packages/animations/browser/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../../dist/packages-dist/animations/@angular/animations/browser.es5.js',
   dest: '../../../dist/packages-dist/animations/bundles/animations-browser.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.animations.browser',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/animations/browser/testing/rollup.config.js
+++ b/packages/animations/browser/testing/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../../../dist/packages-dist/animations/@angular/animations/browser/testing.es5.js',
   dest: '../../../../dist/packages-dist/animations/bundles/animations-browser-testing.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.animations.browser.testing',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/animations/rollup.config.js
+++ b/packages/animations/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../dist/packages-dist/animations/@angular/animations.es5.js',
   dest: '../../dist/packages-dist/animations/bundles/animations.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.animations',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/common/rollup.config.js
+++ b/packages/common/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../dist/packages-dist/common/@angular/common.es5.js',
   dest: '../../dist/packages-dist/common/bundles/common.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.common',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/common/testing/rollup.config.js
+++ b/packages/common/testing/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../../dist/packages-dist/common/@angular/common/testing.es5.js',
   dest: '../../../dist/packages-dist/common/bundles/common-testing.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.common.testing',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/compiler/rollup.config.js
+++ b/packages/compiler/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../dist/packages-dist/compiler/@angular/compiler.es5.js',
   dest: '../../dist/packages-dist/compiler/bundles/compiler.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.compiler',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/compiler/testing/rollup.config.js
+++ b/packages/compiler/testing/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../../dist/packages-dist/compiler/@angular/compiler/testing.es5.js',
   dest: '../../../dist/packages-dist/compiler/bundles/compiler-testing.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.compiler.testing',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../dist/packages-dist/core/@angular/core.es5.js',
   dest: '../../dist/packages-dist/core/bundles/core.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.core',
   globals: {
     'rxjs/Observable': 'Rx',

--- a/packages/core/testing/rollup.config.js
+++ b/packages/core/testing/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../../dist/packages-dist/core/@angular/core/testing.es5.js',
   dest: '../../../dist/packages-dist/core/bundles/core-testing.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.core.testing',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/forms/rollup.config.js
+++ b/packages/forms/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../dist/packages-dist/forms/@angular/forms.es5.js',
   dest: '../../dist/packages-dist/forms/bundles/forms.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.forms',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/http/rollup.config.js
+++ b/packages/http/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../dist/packages-dist/http/@angular/http.es5.js',
   dest: '../../dist/packages-dist/http/bundles/http.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.http',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/http/testing/rollup.config.js
+++ b/packages/http/testing/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../../dist/packages-dist/http/@angular/http/testing.es5.js',
   dest: '../../../dist/packages-dist/http/bundles/http-testing.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.http.testing',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/platform-browser-dynamic/rollup.config.js
+++ b/packages/platform-browser-dynamic/rollup.config.js
@@ -11,6 +11,7 @@ export default {
       '../../dist/packages-dist/platform-browser-dynamic/@angular/platform-browser-dynamic.es5.js',
   dest: '../../dist/packages-dist/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.platformBrowserDynamic',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/platform-browser-dynamic/testing/rollup.config.js
+++ b/packages/platform-browser-dynamic/testing/rollup.config.js
@@ -12,6 +12,7 @@ export default {
   dest:
       '../../../dist/packages-dist/platform-browser-dynamic/bundles/platform-browser-dynamic-testing.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.platformBrowserDynamic.testing',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/platform-browser/animations/rollup.config.js
+++ b/packages/platform-browser/animations/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../../dist/packages-dist/platform-browser/@angular/platform-browser/animations.es5.js',
   dest: '../../../dist/packages-dist/platform-browser/bundles/platform-browser-animations.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.platformBrowser.animations',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/platform-browser/rollup.config.js
+++ b/packages/platform-browser/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../dist/packages-dist/platform-browser/@angular/platform-browser.es5.js',
   dest: '../../dist/packages-dist/platform-browser/bundles/platform-browser.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.platformBrowser',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/platform-browser/testing/rollup.config.js
+++ b/packages/platform-browser/testing/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../../dist/packages-dist/platform-browser/@angular/platform-browser/testing.es5.js',
   dest: '../../../dist/packages-dist/platform-browser/bundles/platform-browser-testing.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.platformBrowser.testing',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/platform-server/rollup.config.js
+++ b/packages/platform-server/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../dist/packages-dist/platform-server/@angular/platform-server.es5.js',
   dest: '../../dist/packages-dist/platform-server/bundles/platform-server.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.platformServer',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/platform-server/testing/rollup.config.js
+++ b/packages/platform-server/testing/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../../dist/packages-dist/platform-server/@angular/platform-server/testing.es5.js',
   dest: '../../../dist/packages-dist/platform-server/bundles/platform-server-testing.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.platformServer.testing',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/platform-webworker-dynamic/rollup.config.js
+++ b/packages/platform-webworker-dynamic/rollup.config.js
@@ -12,6 +12,7 @@ export default {
   dest:
       '../../dist/packages-dist/platform-webworker-dynamic/bundles/platform-webworker-dynamic.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.platformWebworkerDynamic',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/platform-webworker/rollup.config.js
+++ b/packages/platform-webworker/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../dist/packages-dist/platform-webworker/@angular/platform-webworker.es5.js',
   dest: '../../dist/packages-dist/platform-webworker/bundles/platform-webworker.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.platformWebworker',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/router/rollup.config.js
+++ b/packages/router/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../dist/packages-dist/router/@angular/router.es5.js',
   dest: '../../dist/packages-dist/router/bundles/router.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.router',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/router/testing/rollup.config.js
+++ b/packages/router/testing/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../../dist/packages-dist/router/@angular/router/testing.es5.js',
   dest: '../../../dist/packages-dist/router/bundles/router-testing.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.router.testing',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/router/upgrade/rollup.config.js
+++ b/packages/router/upgrade/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../../dist/packages-dist/router/@angular/router/upgrade.es5.js',
   dest: '../../../dist/packages-dist/router/bundles/router-upgrade.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.router.upgrade',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/upgrade/rollup.config.js
+++ b/packages/upgrade/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../dist/packages-dist/upgrade/@angular/upgrade.es5.js',
   dest: '../../dist/packages-dist/upgrade/bundles/upgrade.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.upgrade',
   globals: {
     '@angular/core': 'ng.core',

--- a/packages/upgrade/static/rollup.config.js
+++ b/packages/upgrade/static/rollup.config.js
@@ -10,6 +10,7 @@ export default {
   entry: '../../../dist/packages-dist/upgrade/@angular/upgrade/static.es5.js',
   dest: '../../../dist/packages-dist/upgrade/bundles/upgrade-static.umd.js',
   format: 'umd',
+  exports: 'named',
   moduleName: 'ng.upgrade.static',
   globals: {'@angular/core': 'ng.core'}
 };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When doing all these:
- using SystemJS@^0.22, 
- compiling Typescript with `"module": "system"`
- using Angular UMD bundles, 

Named exports of Angular packages cannot be loaded, showing errors like `Error: core_1.Component is not a function`.

This is because SystemJS has dropped named exports support from CommonJS modules:
http://guybedford.com/systemjs-alignment#node-modules-compatibility

Using `__esModule` re-enables the named exports.


**What is the new behavior?**
This test ensures the `__esModule` interop flag is set on UMD bundles (see https://github.com/rollup/rollup/issues/650), thus making them compatible with SystemJS@^0.22.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

Based on https://github.com/angular/angular/pull/14130.
Followup from https://github.com/frankwallis/plugin-typescript/issues/185.

/cc @alexeagle 

Fix https://github.com/angular/angular/issues/15211