### PR TITLE
fix(common): Location add 'pushState' and deprecate 'go' method

### DIFF
--- a/modules/@angular/common/src/location/location.ts
+++ b/modules/@angular/common/src/location/location.ts
@@ -91,14 +91,18 @@ export class Location {
     return this._platformStrategy.prepareExternalUrl(url);
   }
 
-  // TODO: rename this method to pushState
   /**
    * Changes the browsers URL to the normalized version of the given URL, and pushes a
    * new item onto the platform's history.
    */
-  go(path: string, query: string = ''): void {
+  pushState(path: string, query: string = ''): void {
     this._platformStrategy.pushState(null, '', path, query);
   }
+
+  /**
+   * @deprecated use pushState instead
+   */
+  go(path: string, query: string = ''): void { this.pushState(path, query); }
 
   /**
    * Changes the browsers URL to the normalized version of the given URL, and replaces

--- a/modules/@angular/common/testing/location_mock.ts
+++ b/modules/@angular/common/testing/location_mock.ts
@@ -57,7 +57,7 @@ export class SpyLocation implements Location {
     return this._baseHref + url;
   }
 
-  go(path: string, query: string = '') {
+  pushState(path: string, query: string = ''): void {
     path = this.prepareExternalUrl(path);
 
     if (this._historyIndex > 0) {
@@ -76,7 +76,10 @@ export class SpyLocation implements Location {
     this._subject.emit({'url': url, 'pop': false});
   }
 
-  replaceState(path: string, query: string = '') {
+  /** @deprecated use pushState instead */
+  go(path: string, query: string = ''): void { this.pushState(path, query); }
+
+  replaceState(path: string, query: string = ''): void {
     path = this.prepareExternalUrl(path);
 
     const history = this._history[this._historyIndex];
@@ -91,7 +94,7 @@ export class SpyLocation implements Location {
     this.urlChanges.push('replace: ' + url);
   }
 
-  forward() {
+  forward(): void {
     if (this._historyIndex < (this._history.length - 1)) {
       this._historyIndex++;
       this._subject.emit({'url': this.path(), 'pop': true});

--- a/modules/@angular/router/src/router.ts
+++ b/modules/@angular/router/src/router.ts
@@ -650,7 +650,7 @@ export class Router {
       url: UrlTree, rawUrl: UrlTree, shouldPreventPushState: boolean, shouldReplaceUrl: boolean,
       id: number, precreatedState: RouterStateSnapshot): Promise<boolean> {
     if (id !== this.navigationId) {
-      this.location.go(this.urlSerializer.serialize(this.currentUrlTree));
+      this.location.pushState(this.urlSerializer.serialize(this.currentUrlTree));
       this.routerEvents.next(new NavigationCancel(
           id, this.serializeUrl(url),
           `Navigation ID ${id} is not equal to the current navigation id ${this.navigationId}`));
@@ -748,7 +748,7 @@ export class Router {
               if (this.location.isCurrentPathEqualTo(path) || shouldReplaceUrl) {
                 this.location.replaceState(path);
               } else {
-                this.location.go(path);
+                this.location.pushState(path);
               }
             }
 

--- a/modules/@angular/router/test/integration.spec.ts
+++ b/modules/@angular/router/test/integration.spec.ts
@@ -1245,8 +1245,8 @@ describe('Integration', () => {
            {path: 'team/:id', component: TeamCmp}
          ]);
 
-         location.go('initial');
-         location.go('old/team/22');
+         location.pushState('initial');
+         location.pushState('old/team/22');
 
          // initial navigation
          router.initialNavigation();
@@ -1258,7 +1258,7 @@ describe('Integration', () => {
          expect(location.path()).toEqual('/initial');
 
          // location change
-         (<any>location).go('/old/team/33');
+         location.pushState('/old/team/33');
 
 
          advance(fixture);
@@ -1448,7 +1448,7 @@ describe('Integration', () => {
              advance(fixture);
              expect(location.path()).toEqual('/one');
 
-             location.go('/two');
+             location.pushState('/two');
              advance(fixture);
              expect(location.path()).toEqual('/one');
 
@@ -2638,14 +2638,14 @@ describe('Integration', () => {
            events.splice(0);
 
            // another unsupported URL
-           location.go('/exclude/two');
+           location.pushState('/exclude/two');
            advance(fixture);
 
            expect(location.path()).toEqual('/exclude/two');
            expectEvents(events, []);
 
            // back to a supported URL
-           location.go('/include/simple');
+           location.pushState('/include/simple');
            advance(fixture);
 
            expect(location.path()).toEqual('/include/simple');
@@ -2672,7 +2672,7 @@ describe('Integration', () => {
            const events: any[] = [];
            router.events.subscribe(e => events.push(e));
 
-           location.go('/include/user/kate(aux:excluded)');
+           location.pushState('/include/user/kate(aux:excluded)');
            advance(fixture);
 
            expect(location.path()).toEqual('/include/user/kate(aux:excluded)');
@@ -2682,7 +2682,7 @@ describe('Integration', () => {
            ]);
            events.splice(0);
 
-           location.go('/include/user/kate(aux:excluded2)');
+           location.pushState('/include/user/kate(aux:excluded2)');
            advance(fixture);
            expectEvents(events, []);
 

--- a/tools/public_api_guard/common/index.d.ts
+++ b/tools/public_api_guard/common/index.d.ts
@@ -68,11 +68,12 @@ export declare class Location {
     constructor(platformStrategy: LocationStrategy);
     back(): void;
     forward(): void;
-    go(path: string, query?: string): void;
+    /** @deprecated */ go(path: string, query?: string): void;
     isCurrentPathEqualTo(path: string, query?: string): boolean;
     normalize(url: string): string;
     path(includeHash?: boolean): string;
     prepareExternalUrl(url: string): string;
+    pushState(path: string, query?: string): void;
     replaceState(path: string, query?: string): void;
     subscribe(onNext: (value: any) => void, onThrow?: (exception: any) => void, onReturn?: () => void): Object;
     static joinWithSlash(start: string, end: string): string;

--- a/tools/public_api_guard/common/testing/index.d.ts
+++ b/tools/public_api_guard/common/testing/index.d.ts
@@ -21,11 +21,12 @@ export declare class SpyLocation implements Location {
     urlChanges: string[];
     back(): void;
     forward(): void;
-    go(path: string, query?: string): void;
+    /** @deprecated */ go(path: string, query?: string): void;
     isCurrentPathEqualTo(path: string, query?: string): boolean;
     normalize(url: string): string;
     path(): string;
     prepareExternalUrl(url: string): string;
+    pushState(path: string, query?: string): void;
     replaceState(path: string, query?: string): void;
     setBaseHref(url: string): void;
     setInitialPath(url: string): void;


### PR DESCRIPTION
Closes #12691

I think the origin of the issue is a misleading method name `go`. `Location.go` doesn't trigger navigation. It should be called `pushState` (as specified in the [TODO](https://github.com/angular/angular/blob/master/modules/%40angular/common/src/location/location.ts#L94)).
According to the [spec](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onpopstate) `history.pushState()` won't trigger a `popstate` event. 

Location.subscribe [jsdoc](https://github.com/angular/angular/blob/master/modules/%40angular/common/src/location/location.ts#L122)
> Subscribe to the platform's `popstate` events.

So to me it works as intended.

