### PR TITLE
ci(pullapprove): fix `file` conditions

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -33,9 +33,9 @@ groups:
   root:
     conditions:
       files:
-        includes:
+        include:
           - "*"
-        excludes:
+        exclude:
           - "angular.io/*"
           - "integration/*"
           - "modules/*"
@@ -47,12 +47,12 @@ groups:
   build-and-ci:
     conditions:
       files:
-        includes:
+        include:
           - "*.yml"
           - "*.json"
           - "*.lock"
           - "tools/*"
-        excludes:
+        exclude:
           - "tools/@angular/tsc-wrapped/*"
     users:
       - IgorMinar #primary


### PR DESCRIPTION
According to [the docs](http://docs.pullapprove.com/groups/conditions/), the correct keywords are `include`/`exclude`, without the trailing `s`.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The groups `root` and `build-and-ci` incorrectly use `includes`/`excludes`, which are apparently ignored by PullApprove and cause thoe two groups to match any file.


**What is the new behavior?**
The groups `root` and `build-and-ci` only match the intended files (TBD :smiley:).


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
