### PR TITLE
refactor(forms): use isObservable instead of instanceof

### DIFF
--- a/modules/@angular/forms/src/model.ts
+++ b/modules/@angular/forms/src/model.ts
@@ -11,7 +11,7 @@ import {fromPromise} from 'rxjs/observable/fromPromise';
 import {composeAsyncValidators, composeValidators} from './directives/shared';
 import {AsyncValidatorFn, ValidatorFn} from './directives/validators';
 import {EventEmitter, Observable} from './facade/async';
-import {isPromise} from './private_import_core';
+import {isObservable, isPromise} from './private_import_core';
 
 
 /**
@@ -419,7 +419,7 @@ export abstract class AbstractControl {
     if (this.asyncValidator) {
       this._status = PENDING;
       const obs = toObservable(this.asyncValidator(this));
-      if (!(obs instanceof Observable)) {
+      if (!isObservable(obs)) {
         throw new Error(
             `expected the following validator to return Promise or Observable: ${this.asyncValidator}. If you are using FormBuilder; did you forget to brace your validators in an array?`);
       }

--- a/modules/@angular/forms/src/private_import_core.ts
+++ b/modules/@angular/forms/src/private_import_core.ts
@@ -9,3 +9,4 @@
 import {__core_private__ as r} from '@angular/core';
 
 export const isPromise: typeof r.isPromise = r.isPromise;
+export const isObservable: typeof r.isObservable = r.isObservable;


### PR DESCRIPTION
Replaces the use of `obs instanceof Observable` with `isObservable()` introduced in #14067