### PR TITLE
ci: find latest tag when deeper than the git clone depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ sudo: false
 node_js:
   - '6.9.5'
 
-git:
-  # Increased from default (50) to ensure last release tag is in this range
-  depth: 150
-
 addons:
 #  firefox: "38.0"
   apt:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Since we have a shallow clone of the repository, it might be the case that the latest tag (which we need for publishing the build artifacts) might not be in the current history.


**What is the new behavior?**
The clone in incrementally deepened until a tag is found (or a max depth is reached).


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```


**Other information**:
An alternative is to create a deeper clone from the beginning and hope that the latest tag in present (as done in #14193).