### PR TITLE
feat(core): view engine - integrate with `ComponentFactory`

### DIFF
--- a/modules/@angular/core/src/linker/component_factory.ts
+++ b/modules/@angular/core/src/linker/component_factory.ts
@@ -95,11 +95,9 @@ export class ComponentFactory<C> {
   /** @internal */
   _viewClass: Type<AppView<any>>;
   constructor(
-      public selector: string, _viewClass: Type<AppView<any>>, private _componentType: Type<any>) {
+      public selector: string, _viewClass: Type<AppView<any>>, public componentType: Type<any>) {
     this._viewClass = _viewClass;
   }
-
-  get componentType(): Type<any> { return this._componentType; }
 
   /**
    * Creates a new component.

--- a/modules/@angular/core/src/view/errors.ts
+++ b/modules/@angular/core/src/view/errors.ts
@@ -35,7 +35,7 @@ export function viewDebugError(msg: string, context: DebugContext): ViewDebugErr
   const err = new Error(msg) as any;
   err.context = context;
   err.stack = context.source;
-  context.view.state = ViewState.Errored;
+  context.view.state |= ViewState.Errored;
   return err;
 }
 

--- a/modules/@angular/core/src/view/index.ts
+++ b/modules/@angular/core/src/view/index.ts
@@ -14,7 +14,13 @@ export {queryDef} from './query';
 export {textDef} from './text';
 export {rootRenderNodes, setCurrentNode} from './util';
 export {checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createEmbeddedView, createRootView, destroyView, viewDef} from './view';
-export {attachEmbeddedView, detachEmbeddedView} from './view_attach';
-
+export {attachEmbeddedView, detachEmbeddedView, moveEmbeddedView} from './view_attach';
 export * from './types';
-export {DefaultServices} from './services';
+
+import {createRefs} from './refs';
+import {Refs} from './types';
+
+Refs.setInstance(createRefs());
+
+export const createComponentFactory: typeof Refs.createComponentFactory =
+    Refs.createComponentFactory;

--- a/modules/@angular/core/src/view/query.ts
+++ b/modules/@angular/core/src/view/query.ts
@@ -11,7 +11,7 @@ import {QueryList} from '../linker/query_list';
 import {TemplateRef} from '../linker/template_ref';
 import {ViewContainerRef} from '../linker/view_container_ref';
 
-import {NodeDef, NodeFlags, NodeType, QueryBindingDef, QueryBindingType, QueryDef, QueryValueType, ViewData, asElementData, asProviderData, asQueryList} from './types';
+import {NodeDef, NodeFlags, NodeType, QueryBindingDef, QueryBindingType, QueryDef, QueryValueType, Refs, ViewData, asElementData, asProviderData, asQueryList} from './types';
 import {declaredViewContainer} from './util';
 
 export function queryDef(
@@ -158,10 +158,10 @@ export function getQueryValue(view: ViewData, nodeDef: NodeDef, queryId: string)
         value = new ElementRef(asElementData(view, nodeDef.index).renderElement);
         break;
       case QueryValueType.TemplateRef:
-        value = view.services.createTemplateRef(view, nodeDef);
+        value = Refs.createTemplateRef(view, nodeDef);
         break;
       case QueryValueType.ViewContainerRef:
-        value = view.services.createViewContainerRef(asElementData(view, nodeDef.index));
+        value = Refs.createViewContainerRef(view, nodeDef.index);
         break;
       case QueryValueType.Provider:
         value = asProviderData(view, nodeDef.index).instance;

--- a/modules/@angular/core/src/view/refs.ts
+++ b/modules/@angular/core/src/view/refs.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ChangeDetectorRef} from '../change_detection/change_detection';
 import {Injectable, Injector} from '../di';
-import {unimplemented} from '../facade/errors';
 import {ComponentFactory, ComponentRef} from '../linker/component_factory';
 import {ElementRef} from '../linker/element_ref';
 import {TemplateRef} from '../linker/template_ref';
@@ -15,44 +15,126 @@ import {ViewContainerRef} from '../linker/view_container_ref';
 import {EmbeddedViewRef, ViewRef} from '../linker/view_ref';
 import {RenderComponentType, Renderer, RootRenderer} from '../render/api';
 import {Sanitizer, SecurityContext} from '../security';
+import {Type} from '../type';
 
-import {createInjector} from './provider';
+import {resolveDep, tokenKey} from './provider';
 import {getQueryValue} from './query';
-import {DebugContext, ElementData, NodeData, NodeDef, NodeType, Services, ViewData, ViewDefinition, ViewState, asElementData} from './types';
-import {findElementDef, isComponentView, renderNode, rootRenderNodes} from './util';
-import {checkAndUpdateView, checkNoChangesView, createEmbeddedView, destroyView} from './view';
-import {attachEmbeddedView, detachEmbeddedView} from './view_attach';
+import {DebugContext, DepFlags, ElementData, NodeData, NodeDef, NodeType, Refs, RootData, ViewData, ViewDefinition, ViewDefinitionFactory, ViewState, asElementData, asProviderData} from './types';
+import {findElementDef, isComponentView, parentDiIndex, renderNode, resolveViewDefinition, rootRenderNodes} from './util';
+import {checkAndUpdateView, checkNoChangesView, createEmbeddedView, createRootView, destroyView} from './view';
+import {attachEmbeddedView, detachEmbeddedView, moveEmbeddedView} from './view_attach';
 
-@Injectable()
-export class DefaultServices implements Services {
-  constructor(private _rootRenderer: RootRenderer, private _sanitizer: Sanitizer) {}
+const EMPTY_CONTEXT = new Object();
 
-  renderComponent(rcp: RenderComponentType): Renderer {
-    return this._rootRenderer.renderComponent(rcp);
-  }
-  sanitize(context: SecurityContext, value: string): string {
-    return this._sanitizer.sanitize(context, value);
+export function createRefs() {
+  return new Refs_();
+}
+
+export class Refs_ implements Refs {
+  createComponentFactory(selector: string, viewDefFactory: ViewDefinitionFactory):
+      ComponentFactory<any> {
+    return new ComponentFactory_(selector, viewDefFactory);
   }
   createViewRef(data: ViewData): ViewRef { return new ViewRef_(data); }
-  createViewContainerRef(data: ElementData): ViewContainerRef {
-    return new ViewContainerRef_(data);
+  createViewContainerRef(view: ViewData, elIndex: number): ViewContainerRef {
+    return new ViewContainerRef_(view, elIndex);
   }
   createTemplateRef(parentView: ViewData, def: NodeDef): TemplateRef<any> {
     return new TemplateRef_(parentView, def);
   }
+  createInjector(view: ViewData, elIndex: number): Injector { return new Injector_(view, elIndex); }
   createDebugContext(view: ViewData, nodeIndex: number): DebugContext {
     return new DebugContext_(view, nodeIndex);
   }
 }
 
+class ComponentFactory_ implements ComponentFactory<any> {
+  /**
+   * Only needed so that we can implement ComponentFactory
+   * @internal */
+  _viewClass: any;
+
+  private _viewDef: ViewDefinition;
+  private _componentNodeIndex: number;
+
+  constructor(public selector: string, viewDefFactory: ViewDefinitionFactory) {
+    const viewDef = this._viewDef = resolveViewDefinition(viewDefFactory);
+    const len = viewDef.nodes.length;
+    for (let i = 0; i < len; i++) {
+      const nodeDef = viewDef.nodes[i];
+      if (nodeDef.provider && nodeDef.provider.component) {
+        this._componentNodeIndex = i;
+        break;
+      }
+    }
+    if (this._componentNodeIndex == null) {
+      throw new Error(`Illegal State: Could not find a component in the view definition!`);
+    }
+  }
+
+  get componentType(): Type<any> {
+    return this._viewDef.nodes[this._componentNodeIndex].provider.value;
+  }
+
+  /**
+   * Creates a new component.
+   */
+  create(
+      injector: Injector, projectableNodes: any[][] = null,
+      rootSelectorOrNode: string|any = null): ComponentRef<any> {
+    if (!projectableNodes) {
+      projectableNodes = [];
+    }
+    if (!rootSelectorOrNode) {
+      rootSelectorOrNode = this.selector;
+    }
+    const renderer = injector.get(RootRenderer);
+    const sanitizer = injector.get(Sanitizer);
+
+    const root: RootData =
+        {injector, projectableNodes, selectorOrNode: rootSelectorOrNode, sanitizer, renderer};
+
+    const view = createRootView(root, this._viewDef, EMPTY_CONTEXT);
+    const component = asProviderData(view, this._componentNodeIndex).instance;
+    return new ComponentRef_(view, component);
+  }
+}
+
+class ComponentRef_ implements ComponentRef<any> {
+  private _viewRef: ViewRef_;
+  constructor(private _view: ViewData, private _component: any) {
+    this._viewRef = new ViewRef_(_view);
+  }
+  get location(): ElementRef { return new ElementRef(asElementData(this._view, 0).renderElement); }
+  get injector(): Injector { return new Injector_(this._view, 0); }
+  get instance(): any { return this._component; };
+  get hostView(): ViewRef { return this._viewRef; };
+  get changeDetectorRef(): ChangeDetectorRef { return this._viewRef; };
+  get componentType(): Type<any> { return <any>this._component.constructor; }
+
+  destroy(): void { this._viewRef.destroy(); }
+  onDestroy(callback: Function): void { this._viewRef.onDestroy(callback); }
+}
+
 class ViewContainerRef_ implements ViewContainerRef {
-  constructor(private _data: ElementData) {}
+  private _data: ElementData;
+  constructor(private _view: ViewData, private _elIndex: number) {
+    this._data = asElementData(_view, _elIndex);
+  }
 
-  get element(): ElementRef { return <ElementRef>unimplemented(); }
+  get element(): ElementRef { return new ElementRef(this._data.renderElement); }
 
-  get injector(): Injector { return <Injector>unimplemented(); }
+  get injector(): Injector { return new Injector_(this._view, this._elIndex); }
 
-  get parentInjector(): Injector { return <Injector>unimplemented(); }
+  get parentInjector(): Injector {
+    let view = this._view;
+    let elIndex = view.def.nodes[this._elIndex].parent;
+    while (elIndex == null && view) {
+      elIndex = parentDiIndex(view);
+      view = view.parent;
+    }
+    return view ? new Injector_(view, elIndex) : this._view.root.injector;
+  }
 
   clear(): void {
     const len = this._data.embeddedViews.length;
@@ -76,7 +158,10 @@ class ViewContainerRef_ implements ViewContainerRef {
   createComponent<C>(
       componentFactory: ComponentFactory<C>, index?: number, injector?: Injector,
       projectableNodes?: any[][]): ComponentRef<C> {
-    return unimplemented();
+    const contextInjector = injector || this.parentInjector;
+    const componentRef = componentFactory.create(contextInjector, projectableNodes);
+    this.insert(componentRef.hostView, index);
+    return componentRef;
   }
 
   insert(viewRef: ViewRef, index?: number): ViewRef {
@@ -85,7 +170,11 @@ class ViewContainerRef_ implements ViewContainerRef {
     return viewRef;
   }
 
-  move(viewRef: ViewRef, currentIndex: number): ViewRef { return unimplemented(); }
+  move(viewRef: ViewRef_, currentIndex: number): ViewRef {
+    const previousIndex = this._data.embeddedViews.indexOf(viewRef._view);
+    moveEmbeddedView(this._data, previousIndex, currentIndex);
+    return viewRef;
+  }
 
   indexOf(viewRef: ViewRef): number {
     return this._data.embeddedViews.indexOf((<ViewRef_>viewRef)._view);
@@ -113,33 +202,17 @@ class ViewRef_ implements EmbeddedViewRef<any> {
 
   get context() { return this._view.context; }
 
-  get destroyed(): boolean { return this._view.state === ViewState.Destroyed; }
+  get destroyed(): boolean { return (this._view.state & ViewState.Destroyed) !== 0; }
 
   markForCheck(): void { this.reattach(); }
-  detach(): void {
-    if (this._view.state === ViewState.ChecksEnabled) {
-      this._view.state = ViewState.ChecksDisabled;
-    }
-  }
-  detectChanges(): void {
-    if (this._view.state !== ViewState.FirstCheck) {
-      checkAndUpdateView(this._view);
-    }
-  }
-  checkNoChanges(): void {
-    if (this._view.state !== ViewState.FirstCheck) {
-      checkNoChangesView(this._view);
-    }
-  }
+  detach(): void { this._view.state &= ~ViewState.ChecksEnabled; }
+  detectChanges(): void { checkAndUpdateView(this._view); }
+  checkNoChanges(): void { checkNoChangesView(this._view); }
 
-  reattach(): void {
-    if (this._view.state === ViewState.ChecksDisabled) {
-      this._view.state = ViewState.ChecksEnabled;
-    }
-  }
-  onDestroy(callback: Function) { unimplemented(); }
+  reattach(): void { this._view.state |= ViewState.ChecksEnabled; }
+  onDestroy(callback: Function) { this._view.disposables.push(<any>callback); }
 
-  destroy() { unimplemented(); }
+  destroy() { destroyView(this._view); }
 }
 
 class TemplateRef_ implements TemplateRef<any> {
@@ -154,6 +227,15 @@ class TemplateRef_ implements TemplateRef<any> {
   }
 }
 
+class Injector_ implements Injector {
+  constructor(private view: ViewData, private elIndex: number) {}
+  get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND): any {
+    return resolveDep(
+        this.view, undefined, this.elIndex,
+        {flags: DepFlags.None, token, tokenKey: tokenKey(token)}, notFoundValue);
+  }
+}
+
 class DebugContext_ implements DebugContext {
   private nodeDef: NodeDef;
   private elDef: NodeDef;
@@ -165,7 +247,7 @@ class DebugContext_ implements DebugContext {
     this.nodeDef = view.def.nodes[nodeIndex];
     this.elDef = findElementDef(view, nodeIndex);
   }
-  get injector(): Injector { return createInjector(this.view, this.elDef.index); }
+  get injector(): Injector { return new Injector_(this.view, this.elDef.index); }
   get component(): any { return this.view.component; }
   get providerTokens(): any[] {
     const tokens: any[] = [];

--- a/modules/@angular/core/src/view/text.ts
+++ b/modules/@angular/core/src/view/text.ts
@@ -9,7 +9,7 @@
 import {isDevMode} from '../application_ref';
 import {looseIdentical} from '../facade/lang';
 
-import {BindingDef, BindingType, DebugContext, NodeData, NodeDef, NodeFlags, NodeType, Services, TextData, ViewData, ViewFlags, asElementData, asTextData} from './types';
+import {BindingDef, BindingType, DebugContext, NodeData, NodeDef, NodeFlags, NodeType, Refs, RootData, TextData, ViewData, ViewFlags, asElementData, asTextData} from './types';
 import {checkAndUpdateBinding, sliceErrorStack, unwrapValue} from './util';
 
 export function textDef(ngContentIndex: number, constants: string[]): NodeDef {
@@ -54,8 +54,7 @@ export function createText(view: ViewData, renderHost: any, def: NodeDef): TextD
       def.parent != null ? asElementData(view, def.parent).renderElement : renderHost;
   let renderNode: any;
   if (view.renderer) {
-    const debugContext =
-        isDevMode() ? view.services.createDebugContext(view, def.index) : undefined;
+    const debugContext = isDevMode() ? Refs.createDebugContext(view, def.index) : undefined;
     renderNode = view.renderer.createText(parentNode, def.text.prefix, debugContext);
   } else {
     renderNode = document.createTextNode(def.text.prefix);

--- a/modules/@angular/core/src/view/util.ts
+++ b/modules/@angular/core/src/view/util.ts
@@ -9,11 +9,15 @@
 import {isDevMode} from '../application_ref';
 import {WrappedValue, devModeEqual} from '../change_detection/change_detection';
 import {SimpleChange} from '../change_detection/change_detection_util';
+import {Injector} from '../di';
 import {looseIdentical} from '../facade/lang';
+import {TemplateRef} from '../linker/template_ref';
+import {ViewContainerRef} from '../linker/view_container_ref';
+import {ViewRef} from '../linker/view_ref';
 import {Renderer} from '../render/api';
 
 import {expressionChangedAfterItHasBeenCheckedError, isViewDebugError, viewDestroyedError, viewWrappedDebugError} from './errors';
-import {ElementData, EntryAction, NodeData, NodeDef, NodeFlags, NodeType, ViewData, ViewDefinition, ViewDefinitionFactory, ViewFlags, ViewState, asElementData, asProviderData, asTextData} from './types';
+import {DebugContext, ElementData, EntryAction, NodeData, NodeDef, NodeFlags, NodeType, Refs, ViewData, ViewDefinition, ViewDefinitionFactory, ViewFlags, ViewState, asElementData, asProviderData, asTextData} from './types';
 
 export function setBindingDebugInfo(
     renderer: Renderer, renderNode: any, propName: string, value: any) {
@@ -36,23 +40,23 @@ function camelCaseToDashCase(input: string): string {
 export function checkBindingNoChanges(
     view: ViewData, def: NodeDef, bindingIdx: number, value: any) {
   const oldValue = view.oldValues[def.bindingIndex + bindingIdx];
-  if (view.state === ViewState.FirstCheck || !devModeEqual(oldValue, value)) {
+  if ((view.state & ViewState.FirstCheck) || !devModeEqual(oldValue, value)) {
     throw expressionChangedAfterItHasBeenCheckedError(
-        view.services.createDebugContext(view, def.index), oldValue, value,
-        view.state === ViewState.FirstCheck);
+        Refs.createDebugContext(view, def.index), oldValue, value,
+        (view.state & ViewState.FirstCheck) !== 0);
   }
 }
 
 export function checkAndUpdateBinding(
     view: ViewData, def: NodeDef, bindingIdx: number, value: any): boolean {
   const oldValues = view.oldValues;
-  if (view.state === ViewState.FirstCheck ||
+  if ((view.state & ViewState.FirstCheck) ||
       !looseIdentical(oldValues[def.bindingIndex + bindingIdx], value)) {
     oldValues[def.bindingIndex + bindingIdx] = value;
     if (def.flags & NodeFlags.HasComponent) {
       const compView = asProviderData(view, def.index).componentView;
-      if (compView.state === ViewState.ChecksDisabled && compView.def.flags & ViewFlags.OnPush) {
-        compView.state = ViewState.ChecksEnabled;
+      if (compView.def.flags & ViewFlags.OnPush) {
+        compView.state |= ViewState.ChecksEnabled;
       }
     }
     return true;
@@ -65,8 +69,8 @@ export function dispatchEvent(
   setCurrentNode(view, nodeIndex);
   let currView = view;
   while (currView) {
-    if (currView.state === ViewState.ChecksDisabled && currView.def.flags & ViewFlags.OnPush) {
-      currView.state = ViewState.ChecksEnabled;
+    if (currView.def.flags & ViewFlags.OnPush) {
+      currView.state |= ViewState.ChecksEnabled;
     }
     currView = currView.parent;
   }
@@ -86,6 +90,20 @@ export function declaredViewContainer(view: ViewData): ElementData {
     return asElementData(parentView, view.parentIndex);
   }
   return undefined;
+}
+
+/**
+ * for component views, this is the same as parentIndex.
+ * for embedded views, this is the index of the parent node
+ * that contains the view container.
+ */
+export function parentDiIndex(view: ViewData): number {
+  if (view.parent) {
+    const parentNodeDef = view.def.nodes[view.parentIndex];
+    return parentNodeDef.element && parentNodeDef.element.template ? parentNodeDef.parent :
+                                                                     parentNodeDef.index;
+  }
+  return view.parentIndex;
 }
 
 export function findElementDef(view: ViewData, nodeIndex: number): NodeDef {
@@ -163,7 +181,7 @@ export function currentAction() {
  * or code of the framework that might throw as a valid use case.
  */
 export function setCurrentNode(view: ViewData, nodeIndex: number) {
-  if (view.state === ViewState.Destroyed) {
+  if (view.state & ViewState.Destroyed) {
     throw viewDestroyedError(_currentAction);
   }
   _currentView = view;
@@ -198,7 +216,7 @@ function callWithTryCatch(fn: (a: any) => any, arg: any): any {
     if (isViewDebugError(e) || !_currentView) {
       throw e;
     }
-    const debugContext = _currentView.services.createDebugContext(_currentView, _currentNodeIndex);
+    const debugContext = Refs.createDebugContext(_currentView, _currentNodeIndex);
     throw viewWrappedDebugError(e, debugContext);
   }
 }
@@ -231,7 +249,7 @@ export function visitProjectedRenderNodes(
     view: ViewData, ngContentIndex: number, action: RenderNodeAction, parentNode: any,
     nextSibling: any, target: any[]) {
   let compView = view;
-  while (!isComponentView(compView)) {
+  while (compView && !isComponentView(compView)) {
     compView = compView.parent;
   }
   const hostView = compView.parent;
@@ -246,6 +264,15 @@ export function visitProjectedRenderNodes(
     // jump to next sibling
     i += nodeDef.childCount;
   }
+  if (!hostView.parent) {
+    // a root view
+    const projectedNodes = view.root.projectableNodes[ngContentIndex];
+    if (projectedNodes) {
+      for (let i = 0; i < projectedNodes.length; i++) {
+        execRenderNodeAction(projectedNodes[i], action, parentNode, nextSibling, target);
+      }
+    }
+  }
 }
 
 function visitRenderNode(
@@ -256,20 +283,7 @@ function visitRenderNode(
         view, nodeDef.ngContent.index, action, parentNode, nextSibling, target);
   } else {
     const rn = renderNode(view, nodeDef);
-    switch (action) {
-      case RenderNodeAction.AppendChild:
-        parentNode.appendChild(rn);
-        break;
-      case RenderNodeAction.InsertBefore:
-        parentNode.insertBefore(rn, nextSibling);
-        break;
-      case RenderNodeAction.RemoveChild:
-        parentNode.removeChild(rn);
-        break;
-      case RenderNodeAction.Collect:
-        target.push(rn);
-        break;
-    }
+    execRenderNodeAction(rn, action, parentNode, nextSibling, target);
     if (nodeDef.flags & NodeFlags.HasEmbeddedViews) {
       const embeddedViews = asElementData(view, nodeDef.index).embeddedViews;
       if (embeddedViews) {
@@ -278,5 +292,23 @@ function visitRenderNode(
         }
       }
     }
+  }
+}
+
+function execRenderNodeAction(
+    renderNode: any, action: RenderNodeAction, parentNode: any, nextSibling: any, target: any[]) {
+  switch (action) {
+    case RenderNodeAction.AppendChild:
+      parentNode.appendChild(renderNode);
+      break;
+    case RenderNodeAction.InsertBefore:
+      parentNode.insertBefore(renderNode, nextSibling);
+      break;
+    case RenderNodeAction.RemoveChild:
+      parentNode.removeChild(renderNode);
+      break;
+    case RenderNodeAction.Collect:
+      target.push(renderNode);
+      break;
   }
 }

--- a/modules/@angular/core/test/view/anchor_spec.ts
+++ b/modules/@angular/core/test/view/anchor_spec.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation, getDebugNode} from '@angular/core';
-import {DebugContext, DefaultServices, NodeDef, NodeFlags, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createRootView, elementDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
+import {Injector, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation, getDebugNode} from '@angular/core';
+import {DebugContext, NodeDef, NodeFlags, RootData, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createRootView, elementDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
 import {inject} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
-import {isBrowser, setupAndCheckRenderer} from './helper';
+import {createRootData, isBrowser, setupAndCheckRenderer} from './helper';
 
 export function main() {
   if (isBrowser()) {
@@ -24,15 +24,14 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
   describe(`View Anchor, directDom: ${config.directDom}`, () => {
     setupAndCheckRenderer(config);
 
-    let services: Services;
+    let rootData: RootData;
     let renderComponentType: RenderComponentType;
 
-    beforeEach(
-        inject([RootRenderer, Sanitizer], (rootRenderer: RootRenderer, sanitizer: Sanitizer) => {
-          services = new DefaultServices(rootRenderer, sanitizer);
-          renderComponentType =
-              new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
-        }));
+    beforeEach(() => {
+      rootData = createRootData();
+      renderComponentType =
+          new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
+    });
 
     function compViewDef(
         nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn): ViewDefinition {
@@ -41,7 +40,7 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
 
     function createAndGetRootNodes(
         viewDef: ViewDefinition, ctx?: any): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(services, () => viewDef, ctx);
+      const view = createRootView(rootData, viewDef, ctx);
       const rootNodes = rootRenderNodes(view);
       return {rootNodes, view};
     }

--- a/modules/@angular/core/test/view/helper.ts
+++ b/modules/@angular/core/test/view/helper.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {RootRenderer} from '@angular/core';
-import {checkNodeDynamic, checkNodeInline} from '@angular/core/src/view/index';
+import {Injector, RootRenderer, Sanitizer} from '@angular/core';
+import {RootData, checkNodeDynamic, checkNodeInline} from '@angular/core/src/view/index';
 import {TestBed} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
@@ -51,3 +51,19 @@ export function checkNodeInlineOrDynamic(inlineDynamic: InlineDynamic, values: a
       return checkNodeDynamic(values);
   }
 }
+
+export function createRootData(projectableNodes?: any[][], rootSelectorOrNode?: any): RootData {
+  const injector = TestBed.get(Injector);
+  const renderer = injector.get(RootRenderer);
+  const sanitizer = injector.get(Sanitizer);
+  projectableNodes = projectableNodes || [];
+  return <RootData>{
+    injector,
+    projectableNodes,
+    selectorOrNode: rootSelectorOrNode, sanitizer, renderer
+  };
+}
+
+export let removeNodes: Node[];
+beforeEach(() => { removeNodes = []; });
+afterEach(() => { removeNodes.forEach((node) => getDOM().remove(node)); });

--- a/modules/@angular/core/test/view/ng_content_spec.ts
+++ b/modules/@angular/core/test/view/ng_content_spec.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {RenderComponentType, RootRenderer, Sanitizer, SecurityContext, TemplateRef, ViewContainerRef, ViewEncapsulation, getDebugNode} from '@angular/core';
-import {DebugContext, DefaultServices, NodeDef, NodeFlags, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, asProviderData, asTextData, attachEmbeddedView, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createEmbeddedView, createRootView, detachEmbeddedView, directiveDef, elementDef, ngContentDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
+import {Injector, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, TemplateRef, ViewContainerRef, ViewEncapsulation, getDebugNode} from '@angular/core';
+import {DebugContext, NodeDef, NodeFlags, RootData, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, asProviderData, asTextData, attachEmbeddedView, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createEmbeddedView, createRootView, detachEmbeddedView, directiveDef, elementDef, ngContentDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
 import {inject} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
-import {isBrowser, setupAndCheckRenderer} from './helper';
+import {createRootData, isBrowser, setupAndCheckRenderer} from './helper';
 
 export function main() {
   if (isBrowser()) {
@@ -24,15 +24,14 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
   describe(`View NgContent, directDom: ${config.directDom}`, () => {
     setupAndCheckRenderer(config);
 
-    let services: Services;
+    let rootData: RootData;
     let renderComponentType: RenderComponentType;
 
-    beforeEach(
-        inject([RootRenderer, Sanitizer], (rootRenderer: RootRenderer, sanitizer: Sanitizer) => {
-          services = new DefaultServices(rootRenderer, sanitizer);
-          renderComponentType =
-              new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
-        }));
+    beforeEach(() => {
+      rootData = createRootData();
+      renderComponentType =
+          new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
+    });
 
     function compViewDef(
         nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn): ViewDefinition {
@@ -57,7 +56,7 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
 
     function createAndGetRootNodes(
         viewDef: ViewDefinition, ctx?: any): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(services, () => viewDef, ctx || {});
+      const view = createRootView(rootData, viewDef, ctx || {});
       const rootNodes = rootRenderNodes(view);
       return {rootNodes, view};
     }
@@ -136,5 +135,18 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
       detachEmbeddedView(asElementData(componentView, 1), 0);
       expect(getDOM().childNodes(getDOM().firstChild(rootNodes[0])).length).toBe(1);
     });
+
+    if (isBrowser()) {
+      it('should use root projectable nodes', () => {
+        rootData.projectableNodes =
+            [[document.createTextNode('a')], [document.createTextNode('b')]];
+
+        const {view, rootNodes} = createAndGetRootNodes(
+            compViewDef(hostElDef([], [ngContentDef(null, 0), ngContentDef(null, 1)])));
+
+        expect(getDOM().childNodes(rootNodes[0])[0]).toBe(rootData.projectableNodes[0][0]);
+        expect(getDOM().childNodes(rootNodes[0])[1]).toBe(rootData.projectableNodes[1][0]);
+      });
+    }
   });
 }

--- a/modules/@angular/core/test/view/pure_expression_spec.ts
+++ b/modules/@angular/core/test/view/pure_expression_spec.ts
@@ -6,23 +6,22 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {PipeTransform, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation, WrappedValue} from '@angular/core';
-import {DefaultServices, NodeDef, NodeFlags, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asProviderData, asPureExpressionData, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createRootView, directiveDef, elementDef, pureArrayDef, pureObjectDef, purePipeDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
+import {Injector, PipeTransform, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation, WrappedValue} from '@angular/core';
+import {NodeDef, NodeFlags, RootData, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asProviderData, asPureExpressionData, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createRootView, directiveDef, elementDef, pureArrayDef, pureObjectDef, purePipeDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
 import {inject} from '@angular/core/testing';
 
-import {INLINE_DYNAMIC_VALUES, InlineDynamic, checkNodeInlineOrDynamic} from './helper';
+import {INLINE_DYNAMIC_VALUES, InlineDynamic, checkNodeInlineOrDynamic, createRootData} from './helper';
 
 export function main() {
   describe(`View Pure Expressions`, () => {
-    let services: Services;
+    let rootData: RootData;
     let renderComponentType: RenderComponentType;
 
-    beforeEach(
-        inject([RootRenderer, Sanitizer], (rootRenderer: RootRenderer, sanitizer: Sanitizer) => {
-          services = new DefaultServices(rootRenderer, sanitizer);
-          renderComponentType =
-              new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
-        }));
+    beforeEach(() => {
+      rootData = createRootData();
+      renderComponentType =
+          new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
+    });
 
     function compViewDef(
         nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn): ViewDefinition {
@@ -30,7 +29,7 @@ export function main() {
     }
 
     function createAndGetRootNodes(viewDef: ViewDefinition): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(services, () => viewDef);
+      const view = createRootView(rootData, viewDef);
       const rootNodes = rootRenderNodes(view);
       return {rootNodes, view};
     }

--- a/modules/@angular/core/test/view/query_spec.ts
+++ b/modules/@angular/core/test/view/query_spec.ts
@@ -6,22 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ElementRef, QueryList, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, TemplateRef, ViewContainerRef, ViewEncapsulation, getDebugNode} from '@angular/core';
-import {BindingType, DebugContext, DefaultServices, NodeDef, NodeFlags, QueryBindingType, QueryValueType, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, asProviderData, attachEmbeddedView, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createEmbeddedView, createRootView, destroyView, detachEmbeddedView, directiveDef, elementDef, queryDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
+import {ElementRef, Injector, QueryList, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, TemplateRef, ViewContainerRef, ViewEncapsulation, getDebugNode} from '@angular/core';
+import {BindingType, DebugContext, NodeDef, NodeFlags, QueryBindingType, QueryValueType, RootData, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, asProviderData, attachEmbeddedView, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createEmbeddedView, createRootView, destroyView, detachEmbeddedView, directiveDef, elementDef, queryDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
 import {inject} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
+import {createRootData} from './helper';
+
 export function main() {
   describe(`Query Views`, () => {
-    let services: Services;
+    let rootData: RootData;
     let renderComponentType: RenderComponentType;
 
-    beforeEach(
-        inject([RootRenderer, Sanitizer], (rootRenderer: RootRenderer, sanitizer: Sanitizer) => {
-          services = new DefaultServices(rootRenderer, sanitizer);
-          renderComponentType =
-              new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
-        }));
+    beforeEach(() => {
+      rootData = createRootData();
+      renderComponentType =
+          new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
+    });
 
     function compViewDef(
         nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn): ViewDefinition {
@@ -34,7 +35,7 @@ export function main() {
 
     function createAndGetRootNodes(
         viewDef: ViewDefinition, context: any = null): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(services, () => viewDef, context);
+      const view = createRootView(rootData, viewDef, context);
       const rootNodes = rootRenderNodes(view);
       return {rootNodes, view};
     }

--- a/modules/@angular/core/test/view/refs_spec.ts
+++ b/modules/@angular/core/test/view/refs_spec.ts
@@ -6,24 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation, getDebugNode} from '@angular/core';
-import {DebugContext, DefaultServices, NodeDef, NodeFlags, QueryValueType, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, asProviderData, asTextData, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createRootView, directiveDef, elementDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
+import {Injector, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation, getDebugNode} from '@angular/core';
+import {DebugContext, NodeDef, NodeFlags, QueryValueType, Refs, RootData, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, asProviderData, asTextData, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createRootView, directiveDef, elementDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
 import {inject} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
-import {isBrowser, setupAndCheckRenderer} from './helper';
+import {createRootData, isBrowser, setupAndCheckRenderer} from './helper';
 
 export function main() {
-  describe('View Services', () => {
-    let services: Services;
+  describe('View References', () => {
+    let rootData: RootData;
     let renderComponentType: RenderComponentType;
 
-    beforeEach(
-        inject([RootRenderer, Sanitizer], (rootRenderer: RootRenderer, sanitizer: Sanitizer) => {
-          services = new DefaultServices(rootRenderer, sanitizer);
-          renderComponentType =
-              new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
-        }));
+    beforeEach(() => {
+      rootData = createRootData();
+      renderComponentType =
+          new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
+    });
 
     function compViewDef(
         nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn): ViewDefinition {
@@ -32,7 +31,7 @@ export function main() {
 
     function createAndGetRootNodes(
         viewDef: ViewDefinition, context: any = null): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(services, () => viewDef, context);
+      const view = createRootView(rootData, viewDef, context);
       const rootNodes = rootRenderNodes(view);
       return {rootNodes, view};
     }
@@ -59,7 +58,7 @@ export function main() {
         const view = createViewWithData();
         const compView = asProviderData(view, 1).componentView;
 
-        const debugCtx = view.services.createDebugContext(compView, 0);
+        const debugCtx = Refs.createDebugContext(compView, 0);
 
         expect(debugCtx.componentRenderElement).toBe(asElementData(view, 0).renderElement);
         expect(debugCtx.renderNode).toBe(asElementData(compView, 0).renderElement);
@@ -76,7 +75,7 @@ export function main() {
         const view = createViewWithData();
         const compView = asProviderData(view, 1).componentView;
 
-        const debugCtx = view.services.createDebugContext(compView, 2);
+        const debugCtx = Refs.createDebugContext(compView, 2);
 
         expect(debugCtx.componentRenderElement).toBe(asElementData(view, 0).renderElement);
         expect(debugCtx.renderNode).toBe(asTextData(compView, 2).renderText);
@@ -90,7 +89,7 @@ export function main() {
         const view = createViewWithData();
         const compView = asProviderData(view, 1).componentView;
 
-        const debugCtx = view.services.createDebugContext(compView, 1);
+        const debugCtx = Refs.createDebugContext(compView, 1);
 
         expect(debugCtx.renderNode).toBe(asElementData(compView, 0).renderElement);
       });

--- a/modules/@angular/core/test/view/text_spec.ts
+++ b/modules/@angular/core/test/view/text_spec.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation, WrappedValue, getDebugNode} from '@angular/core';
-import {DebugContext, DefaultServices, NodeDef, NodeFlags, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asTextData, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createRootView, elementDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
+import {Injector, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation, WrappedValue, getDebugNode} from '@angular/core';
+import {DebugContext, NodeDef, NodeFlags, RootData, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asTextData, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createRootView, elementDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
 import {inject} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
-import {INLINE_DYNAMIC_VALUES, InlineDynamic, checkNodeInlineOrDynamic, isBrowser, setupAndCheckRenderer} from './helper';
+import {INLINE_DYNAMIC_VALUES, InlineDynamic, checkNodeInlineOrDynamic, createRootData, isBrowser, setupAndCheckRenderer} from './helper';
 
 export function main() {
   if (isBrowser()) {
@@ -24,15 +24,14 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
   describe(`View Text, directDom: ${config.directDom}`, () => {
     setupAndCheckRenderer(config);
 
-    let services: Services;
+    let rootData: RootData;
     let renderComponentType: RenderComponentType;
 
-    beforeEach(
-        inject([RootRenderer, Sanitizer], (rootRenderer: RootRenderer, sanitizer: Sanitizer) => {
-          services = new DefaultServices(rootRenderer, sanitizer);
-          renderComponentType =
-              new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
-        }));
+    beforeEach(() => {
+      rootData = createRootData();
+      renderComponentType =
+          new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
+    });
 
     function compViewDef(
         nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn): ViewDefinition {
@@ -41,7 +40,7 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
 
     function createAndGetRootNodes(
         viewDef: ViewDefinition, context?: any): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(services, () => viewDef, context);
+      const view = createRootView(rootData, viewDef, context);
       const rootNodes = rootRenderNodes(view);
       return {rootNodes, view};
     }

--- a/modules/benchmarks/src/tree/ng2_next/index.ts
+++ b/modules/benchmarks/src/tree/ng2_next/index.ts
@@ -43,10 +43,7 @@ export function main() {
   enableProdMode();
   appMod = new AppModule();
   appMod.bootstrap();
-  tree = appMod.rootComp;
-  const rootEl = document.querySelector('#root');
-  rootEl.textContent = '';
-  rootEl.appendChild(appMod.rootEl);
+  tree = appMod.componentRef.instance;
 
   bindAction('#destroyDom', destroyDom);
   bindAction('#createDom', createDom);

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -273,7 +273,7 @@ export interface ComponentDecorator {
 export declare class ComponentFactory<C> {
     componentType: Type<any>;
     selector: string;
-    constructor(selector: string, _viewClass: Type<AppView<any>>, _componentType: Type<any>);
+    constructor(selector: string, _viewClass: Type<AppView<any>>, componentType: Type<any>);
     create(injector: Injector, projectableNodes?: any[][], rootSelectorOrNode?: string | any): ComponentRef<C>;
 }
 


### PR DESCRIPTION
`ComponentFactory`s can now be created from a `ViewDefinitionFactory` via
`RefFactory.createComponentFactory`.

This commit also:
- splits `Services` into `RefFactory` and `RootData`
- changes `ViewState` into a bitmask
- implements `ViewContainerRef.move`
