### PR TITLE
refactor(aio): refactor the protractor config

### DIFF
--- a/angular.io/protractor.conf.js
+++ b/angular.io/protractor.conf.js
@@ -11,11 +11,14 @@ exports.config = {
     './e2e/**/*.e2e-spec.ts'
   ],
   capabilities: {
-    'browserName': 'chrome'
+    browserName: 'chrome',
+    chromeOptions: {
+      binary: process.env.CHROME_BIN
+    }
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',
-  framework: 'jasmine2',
+  framework: 'jasmine',
   jasmineNodeOpts: {
     showColors: true,
     defaultTimeoutInterval: 30000,
@@ -31,9 +34,3 @@ exports.config = {
     jasmine.getEnv().addReporter(new SpecReporter());
   }
 };
-
-if (process.env.TRAVIS) {
-  exports.config.capabilities.chromeOptions = {
-    binary: process.env.CHROME_BIN
-  };
-}


### PR DESCRIPTION
1. Use `jasmine` as framework instead of `jasmine2`.
   (Since angular/protractor@2bde92b, `jasmine2` is an alias for `jasmine`.)
2. Simplify the `chromeOptions` config by always setting.
   (If `process.env.CHROME_BIN` is not defined, `binary` will be ignored.)


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```