### PR TITLE
feat(compiler): open the serializer API for i18n

### DIFF
--- a/modules/@angular/compiler-cli/integrationtest/src/messages.fr.json
+++ b/modules/@angular/compiler-cli/integrationtest/src/messages.fr.json
@@ -1,0 +1,5 @@
+{
+  "76e1eccb1b772fa9f294ef9c146ea6d0efa8a2d4": "Traduisez moi",
+  "65cc4ab3b4c438e07c89be2b677d08369fb62da2": "Bienvenue",
+  "63a85808f03b8181e36a952e0fa38202c2304862": "other-3rdP-component"
+}

--- a/modules/@angular/compiler-cli/integrationtest/test/basic_spec.ts
+++ b/modules/@angular/compiler-cli/integrationtest/test/basic_spec.ts
@@ -15,6 +15,7 @@ import {createComponent} from './util';
 
 describe('template codegen output', () => {
   const outDir = 'src';
+  const genDir = 'gen_custom_serializer/src';
 
   it('should lower Decorators without reflect-metadata', () => {
     const jsOutput = path.join(outDir, 'basic.js');
@@ -87,6 +88,14 @@ describe('template codegen output', () => {
       const pElement = containerElement.children.find((c: any) => c.name == 'p');
       const pText = pElement.children.map((c: any) => c.data).join('').trim();
       expect(pText).toBe('tervetuloa');
+    });
+
+    describe('with custom serializer', () => {
+      it('should generate translated factories', () => {
+        const jsOutput = path.join(genDir, 'basic.ngfactory.ts');
+        expect(fs.existsSync(jsOutput)).toBeTruthy();
+        expect(fs.readFileSync(jsOutput, {encoding: 'utf-8'})).toContain('Bienvenue');
+      });
     });
   });
 });

--- a/modules/@angular/compiler-cli/integrationtest/test/custom_serializer.ts
+++ b/modules/@angular/compiler-cli/integrationtest/test/custom_serializer.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Container, Icu, IcuPlaceholder, Message, Node, Placeholder, Serializer, TagPlaceholder, Text, Visitor, digest} from '@angular/compiler';
+
+class CustomSerializer extends Serializer {
+  constructor() { super(); }
+
+  write(messages: Message[]): string {
+    const visitor = new _WriteVisitor();
+    let result: {[id: string]: string} = {};
+    messages.forEach(message => { result[message.id] = visitor.serialize(message.nodes); });
+    return JSON.stringify(result);
+  }
+
+  load(content: string, url: string):
+      {locale: string | null, i18nNodesByMsgId: {[msgId: string]: Node[]}} {
+    const data = JSON.parse(content);
+    const i18nNodesByMsgId: {[msgId: string]: Node[]} = {};
+    Object.keys(data).forEach(
+        msgId => { i18nNodesByMsgId[msgId] = [new Text(data[msgId], null)]; });
+    return {locale: null, i18nNodesByMsgId: i18nNodesByMsgId};
+  }
+
+  digest(message: Message): string { return digest(message); }
+
+  getExtension(): string { return 'json'; }
+}
+
+class _WriteVisitor implements Visitor {
+  visitText(text: Text, context?: any): string { return text.value; }
+  visitContainer(container: Container, context?: any): string { return ''; }
+  visitIcu(icu: Icu, context?: any): string { return ''; }
+  visitTagPlaceholder(ph: TagPlaceholder, context?: any): string { return ''; }
+  visitPlaceholder(ph: Placeholder, context?: any): string { return ''; }
+  visitIcuPlaceholder(ph: IcuPlaceholder, context?: any): string { return ''; }
+  serialize(nodes: Node[]): string { return '' + nodes.map(node => node.visit(this)).join(''); }
+}
+
+module.exports = CustomSerializer;

--- a/modules/@angular/compiler-cli/integrationtest/test/i18n_spec.ts
+++ b/modules/@angular/compiler-cli/integrationtest/test/i18n_spec.ts
@@ -63,6 +63,9 @@ const EXPECTED_XLIFF = `<?xml version="1.0" encoding="UTF-8" ?>
 </xliff>
 `;
 
+const EXPECTED_JSON =
+    `{"76e1eccb1b772fa9f294ef9c146ea6d0efa8a2d4":"translate me","65cc4ab3b4c438e07c89be2b677d08369fb62da2":"Welcome","63a85808f03b8181e36a952e0fa38202c2304862":"other-3rdP-component"}`;
+
 describe('template i18n extraction output', () => {
   const outDir = '';
   const genDir = 'out';
@@ -84,5 +87,12 @@ describe('template i18n extraction output', () => {
   it('should not emit js', () => {
     const genOutput = path.join(genDir, '');
     expect(fs.existsSync(genOutput)).toBeFalsy();
+  });
+
+  it('should extract i18n messages with custom serializer', () => {
+    const jsonOutput = path.join(outDir, 'messages.json');
+    expect(fs.existsSync(jsonOutput)).toBeTruthy();
+    const json = fs.readFileSync(jsonOutput, {encoding: 'utf-8'});
+    expect(json).toEqual(EXPECTED_JSON);
   });
 });

--- a/modules/@angular/compiler-cli/integrationtest/test/test_ngtools_api.ts
+++ b/modules/@angular/compiler-cli/integrationtest/test/test_ngtools_api.ts
@@ -68,6 +68,7 @@ function codeGenTest() {
 
         // i18n options.
         i18nFormat: null,
+        i18nSerializer: null,
         i18nFile: null,
         locale: null,
 
@@ -131,6 +132,7 @@ function i18nTest() {
         compilerOptions: config.parsed.options, program, host,
         angularCompilerOptions: config.ngOptions,
         i18nFormat: 'xlf',
+        i18nSerializer: null,
         readResource: (fileName: string) => {
           readResources.push(fileName);
           return hostContext.readResource(fileName);

--- a/modules/@angular/compiler-cli/integrationtest/tsconfig-custom-serializer.json
+++ b/modules/@angular/compiler-cli/integrationtest/tsconfig-custom-serializer.json
@@ -30,5 +30,8 @@
     "benchmarks/src/tree/ng2_switch/index_aot.ts",
     "benchmarks/src/largetable/ng2/index_aot.ts",
     "benchmarks/src/largetable/ng2_switch/index_aot.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "genDir": "./gen_custom_serializer"
+  }
 }

--- a/modules/@angular/compiler-cli/src/codegen.ts
+++ b/modules/@angular/compiler-cli/src/codegen.ts
@@ -13,11 +13,11 @@
 import * as compiler from '@angular/compiler';
 import {AngularCompilerOptions, NgcCliOptions} from '@angular/tsc-wrapped';
 import {readFileSync} from 'fs';
-import * as path from 'path';
 import * as ts from 'typescript';
 
 import {CompilerHost, CompilerHostContext, ModuleResolutionHostAdapter} from './compiler_host';
 import {PathMappedCompilerHost} from './path_mapped_compiler_host';
+import {getI18nSerializer} from './utils';
 
 const GENERATED_META_FILES = /\.json$/;
 
@@ -71,10 +71,17 @@ export class CodeGenerator {
       }
       transContent = readFileSync(transFile, 'utf8');
     }
+
+    let serializer: compiler.Serializer;
+    const serializerPath = cliOptions.i18nSerializer;
+    if (serializerPath) {
+      serializer = getI18nSerializer(serializerPath);
+    }
     const {compiler: aotCompiler} = compiler.createAotCompiler(ngCompilerHost, {
       debug: options.debug === true,
       translations: transContent,
       i18nFormat: cliOptions.i18nFormat,
+      i18nSerializer: serializer,
       locale: cliOptions.locale
     });
     return new CodeGenerator(options, program, tsCompilerHost, aotCompiler, ngCompilerHost);

--- a/modules/@angular/compiler-cli/src/extract_i18n.ts
+++ b/modules/@angular/compiler-cli/src/extract_i18n.ts
@@ -22,7 +22,8 @@ import {Extractor} from './extractor';
 function extract(
     ngOptions: tsc.AngularCompilerOptions, cliOptions: tsc.I18nExtractionCliOptions,
     program: ts.Program, host: ts.CompilerHost): Promise<void> {
-  return Extractor.create(ngOptions, program, host).extract(cliOptions.i18nFormat);
+  return Extractor.create(ngOptions, program, host)
+      .extract(cliOptions.i18nFormat, cliOptions.i18nSerializer);
 }
 
 // Entry point

--- a/modules/@angular/compiler-cli/src/ngtools_api.ts
+++ b/modules/@angular/compiler-cli/src/ngtools_api.ts
@@ -33,6 +33,7 @@ export interface NgTools_InternalApi_NG2_CodeGen_Options {
 
   // i18n options.
   i18nFormat: string;
+  i18nSerializer: string;
   i18nFile: string;
   locale: string;
 
@@ -59,6 +60,7 @@ export interface NgTools_InternalApi_NG2_ExtractI18n_Options {
   host: ts.CompilerHost;
   angularCompilerOptions: AngularCompilerOptions;
   i18nFormat: string;
+  i18nSerializer: string;
   readResource: (fileName: string) => Promise<string>;
   // Every new property under this line should be optional.
 }
@@ -91,6 +93,7 @@ export class NgTools_InternalApi_NG_2 {
         new CustomLoaderModuleResolutionHostAdapter(options.readResource, options.host);
     const cliOptions: NgcCliOptions = {
       i18nFormat: options.i18nFormat,
+      i18nSerializer: options.i18nSerializer,
       i18nFile: options.i18nFile,
       locale: options.locale,
       basePath: options.basePath
@@ -145,6 +148,6 @@ export class NgTools_InternalApi_NG_2 {
     const extractor = Extractor.create(
         options.angularCompilerOptions, options.program, options.host, hostContext);
 
-    return extractor.extract(options.i18nFormat);
+    return extractor.extract(options.i18nFormat, options.i18nSerializer);
   }
 }

--- a/modules/@angular/compiler-cli/src/utils.ts
+++ b/modules/@angular/compiler-cli/src/utils.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * @module
+ * @description
+ * Entry point for all public APIs of the common package.
+ */
+
+import {Serializer} from '@angular/compiler';
+import * as path from 'path';
+
+export function getI18nSerializer(serializerPath: string): Serializer {
+  let serializerClass: any = null;
+  if (serializerPath.startsWith('.')) {
+    const fullPath = path.join(process.cwd(), serializerPath);
+    serializerClass = require(path.relative(__dirname, fullPath));
+  } else if (serializerPath.startsWith('/')) {
+    serializerClass = require(path.relative(__dirname, serializerPath));
+  } else {
+    serializerClass = require(serializerPath);
+  }
+  return serializerClass ? new serializerClass() : null;
+}

--- a/modules/@angular/compiler/src/aot/compiler_factory.ts
+++ b/modules/@angular/compiler/src/aot/compiler_factory.ts
@@ -55,8 +55,8 @@ export function createAotCompiler(compilerHost: AotCompilerHost, options: AotCom
   StaticAndDynamicReflectionCapabilities.install(staticReflector);
   const console = new Console();
   const htmlParser = new I18NHtmlParser(
-      new HtmlParser(), translations, options.i18nFormat, MissingTranslationStrategy.Warning,
-      console);
+      new HtmlParser(), translations, options.i18nFormat, options.i18nSerializer,
+      MissingTranslationStrategy.Warning, console);
   const config = new CompilerConfig({
     genDebugInfo: options.debug === true,
     defaultEncapsulation: ViewEncapsulation.Emulated,

--- a/modules/@angular/compiler/src/aot/compiler_options.ts
+++ b/modules/@angular/compiler/src/aot/compiler_options.ts
@@ -5,10 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {Serializer} from '../i18n/index';
 
 export interface AotCompilerOptions {
   debug?: boolean;
   locale?: string;
   i18nFormat?: string;
+  i18nSerializer?: Serializer;
   translations?: string;
 }

--- a/modules/@angular/compiler/src/i18n/i18n_html_parser.ts
+++ b/modules/@angular/compiler/src/i18n/i18n_html_parser.ts
@@ -28,10 +28,11 @@ export class I18NHtmlParser implements HtmlParser {
 
   constructor(
       private _htmlParser: HtmlParser, translations?: string, translationsFormat?: string,
+      serializer?: Serializer,
       missingTranslation: MissingTranslationStrategy = MissingTranslationStrategy.Warning,
       console?: Console) {
     if (translations) {
-      const serializer = createSerializer(translationsFormat);
+      serializer = serializer || createSerializer(translationsFormat);
       this._translationBundle =
           TranslationBundle.load(translations, 'i18n', serializer, missingTranslation, console);
     }

--- a/modules/@angular/compiler/src/i18n/index.ts
+++ b/modules/@angular/compiler/src/i18n/index.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+export * from './digest';
 export {Extractor, ExtractorHost} from './extractor';
+export * from './i18n_ast';
 export {I18NHtmlParser} from './i18n_html_parser';
 export {MessageBundle} from './message_bundle';
 export {Serializer} from './serializers/serializer';

--- a/modules/@angular/compiler/src/i18n/serializers/serializer.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/serializer.ts
@@ -22,6 +22,9 @@ export abstract class Serializer {
   // Creates a name mapper, see `PlaceholderMapper`
   // Returning `null` means that no name mapping is used.
   createNameMapper(message: i18n.Message): PlaceholderMapper { return null; }
+
+  // Returns the file extension to be used by the serializer
+  getExtension(): string { return ''; }
 }
 
 /**

--- a/modules/@angular/compiler/src/i18n/serializers/xliff.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/xliff.ts
@@ -92,6 +92,8 @@ export class Xliff extends Serializer {
   }
 
   digest(message: i18n.Message): string { return digest(message); }
+
+  getExtension(): string { return 'xlf'; }
 }
 
 class _WriteVisitor implements i18n.Visitor {

--- a/modules/@angular/compiler/src/i18n/serializers/xmb.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/xmb.ts
@@ -81,6 +81,8 @@ export class Xmb extends Serializer {
   createNameMapper(message: i18n.Message): PlaceholderMapper {
     return new SimplePlaceholderMapper(message, toPublicName);
   }
+
+  getExtension(): string { return 'xmb'; }
 }
 
 class _Visitor implements i18n.Visitor {

--- a/modules/@angular/compiler/src/i18n/serializers/xtb.ts
+++ b/modules/@angular/compiler/src/i18n/serializers/xtb.ts
@@ -57,6 +57,8 @@ export class Xtb extends Serializer {
   createNameMapper(message: i18n.Message): PlaceholderMapper {
     return new SimplePlaceholderMapper(message, toPublicName);
   }
+
+  getExtension(): string { return 'xtb'; }
 }
 
 function createLazyProperty(messages: any, id: string, valueFn: () => any) {

--- a/modules/@angular/compiler/src/jit/compiler_factory.ts
+++ b/modules/@angular/compiler/src/jit/compiler_factory.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {COMPILER_OPTIONS, Compiler, CompilerFactory, CompilerOptions, Inject, InjectionToken, MissingTranslationStrategy, Optional, PLATFORM_INITIALIZER, PlatformRef, Provider, ReflectiveInjector, TRANSLATIONS, TRANSLATIONS_FORMAT, Type, ViewEncapsulation, createPlatformFactory, isDevMode, platformCore} from '@angular/core';
+import {COMPILER_OPTIONS, Compiler, CompilerFactory, CompilerOptions, Inject, InjectionToken, MissingTranslationStrategy, Optional, PLATFORM_INITIALIZER, PlatformRef, Provider, ReflectiveInjector, TRANSLATIONS, TRANSLATIONS_FORMAT, TRANSLATIONS_SERIALIZER, Type, ViewEncapsulation, createPlatformFactory, isDevMode, platformCore} from '@angular/core';
 
 import {AnimationParser} from '../animation/animation_parser';
 import {CompilerConfig, USE_VIEW_ENGINE} from '../config';
@@ -66,14 +66,16 @@ export const COMPILER_PROVIDERS: Array<any|Type<any>|{[k: string]: any}|any[]> =
   },
   {
     provide: i18n.I18NHtmlParser,
-    useFactory: (parser: HtmlParser, translations: string, format: string, config: CompilerConfig,
-                 console: Console) =>
-                    new i18n.I18NHtmlParser(
-                        parser, translations, format, config.missingTranslation, console),
+    useFactory:
+        (parser: HtmlParser, translations: string, format: string, serializer: i18n.Serializer,
+         config: CompilerConfig, console: Console) =>
+            new i18n.I18NHtmlParser(
+                parser, translations, format, serializer, config.missingTranslation, console),
     deps: [
       baseHtmlParser,
       [new Optional(), new Inject(TRANSLATIONS)],
       [new Optional(), new Inject(TRANSLATIONS_FORMAT)],
+      [new Optional(), new Inject(TRANSLATIONS_SERIALIZER)],
       [CompilerConfig],
       [Console],
     ]

--- a/modules/@angular/compiler/test/i18n/integration_custom_spec.ts
+++ b/modules/@angular/compiler/test/i18n/integration_custom_spec.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Container, Icu, IcuPlaceholder, Message, Node, Placeholder, ResourceLoader, Serializer, TagPlaceholder, Text, Visitor, digest} from '@angular/compiler';
+import {MessageBundle} from '@angular/compiler/src/i18n/message_bundle';
+import {HtmlParser} from '@angular/compiler/src/ml_parser/html_parser';
+import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/interpolation_config';
+import {Component, DebugElement, TRANSLATIONS, TRANSLATIONS_SERIALIZER} from '@angular/core';
+import {TestBed, async} from '@angular/core/testing';
+import {By} from '@angular/platform-browser/src/dom/debug/by';
+import {stringifyElement} from '@angular/platform-browser/testing/browser_util';
+import {expect} from '@angular/platform-browser/testing/matchers';
+
+import {SpyResourceLoader} from '../spies';
+
+export function main() {
+  describe('i18n integration spec with custom serializer', () => {
+
+    beforeEach(async(() => {
+      TestBed.configureCompiler({
+        providers: [
+          {provide: ResourceLoader, useClass: SpyResourceLoader},
+          {provide: TRANSLATIONS, useValue: JSON_TB},
+          {provide: TRANSLATIONS_SERIALIZER, useClass: CustomSerializer},
+        ]
+      });
+
+      TestBed.configureTestingModule({declarations: [I18nComponent]});
+    }));
+
+    it('should extract from templates', () => {
+      const catalog = new MessageBundle(new HtmlParser, [], {});
+      const serializer = new CustomSerializer();
+      catalog.updateFromTemplate(HTML, '', DEFAULT_INTERPOLATION_CONFIG);
+
+      expect(catalog.write(serializer)).toContain(JSON_MB);
+    });
+
+    it('should translate templates', () => {
+      const tb = TestBed.overrideTemplate(I18nComponent, HTML).createComponent(I18nComponent);
+      const el = tb.debugElement;
+
+      expectHtml(el, 'h1').toBe('<h1>attributs i18n sur les balises</h1>');
+    });
+  });
+}
+
+function expectHtml(el: DebugElement, cssSelector: string): any {
+  return expect(stringifyElement(el.query(By.css(cssSelector)).nativeElement));
+}
+
+@Component({
+  selector: 'i18n-cmp',
+  template: '',
+})
+class I18nComponent {
+}
+
+class CustomSerializer extends Serializer {
+  write(messages: Message[]): string {
+    const visitor = new _WriteVisitor();
+    let result: {[id: string]: string} = {};
+    messages.forEach(message => { result[message.id] = visitor.serialize(message.nodes); });
+    return JSON.stringify(result);
+  }
+
+  load(content: string, url: string):
+      {locale: string | null, i18nNodesByMsgId: {[msgId: string]: Node[]}} {
+    const data = JSON.parse(content);
+    const i18nNodesByMsgId: {[msgId: string]: Node[]} = {};
+    Object.keys(data).forEach(
+        msgId => { i18nNodesByMsgId[msgId] = [new Text(data[msgId], null)]; });
+    return {locale: null, i18nNodesByMsgId: i18nNodesByMsgId};
+  }
+
+  digest(message: Message): string { return digest(message); }
+
+  getExtension(): string { return 'json'; }
+}
+
+class _WriteVisitor implements Visitor {
+  visitText(text: Text, context?: any): string { return text.value; }
+  visitContainer(container: Container, context?: any): string { return ''; }
+  visitIcu(icu: Icu, context?: any): string { return ''; }
+  visitTagPlaceholder(ph: TagPlaceholder, context?: any): string { return ''; }
+  visitPlaceholder(ph: Placeholder, context?: any): string { return ''; }
+  visitIcuPlaceholder(ph: IcuPlaceholder, context?: any): string { return ''; }
+  serialize(nodes: Node[]): string { return '' + nodes.map(node => node.visit(this)).join(''); }
+}
+
+const JSON_TB = `{"3cb04208df1c2f62553ed48e75939cf7107f9dad":"attributs i18n sur les balises"}`;
+
+const JSON_MB = `{"3cb04208df1c2f62553ed48e75939cf7107f9dad":"i18n attribute on tags"}`;
+
+const HTML = `
+<div>
+    <h1 i18n>i18n attribute on tags</h1>
+</div>
+`;

--- a/modules/@angular/core/src/core.ts
+++ b/modules/@angular/core/src/core.ts
@@ -25,7 +25,7 @@ export {DebugElement, DebugNode, asNativeElements, getDebugNode} from './debug/d
 export {GetTestability, Testability, TestabilityRegistry, setTestabilityGetter} from './testability/testability';
 export * from './change_detection';
 export * from './platform_core_providers';
-export {TRANSLATIONS, TRANSLATIONS_FORMAT, LOCALE_ID, MissingTranslationStrategy} from './i18n/tokens';
+export {TRANSLATIONS, TRANSLATIONS_FORMAT, TRANSLATIONS_SERIALIZER, LOCALE_ID, MissingTranslationStrategy} from './i18n/tokens';
 export {ApplicationModule} from './application_module';
 export {wtfCreateScope, wtfLeave, wtfStartTimeRange, wtfEndTimeRange, WtfScopeFn} from './profile/profile';
 export {Type} from './type';

--- a/modules/@angular/core/src/i18n/tokens.ts
+++ b/modules/@angular/core/src/i18n/tokens.ts
@@ -26,6 +26,11 @@ export const TRANSLATIONS_FORMAT = new InjectionToken<string>('TranslationsForma
 /**
  * @experimental i18n support is experimental.
  */
+export const TRANSLATIONS_SERIALIZER = new InjectionToken<string>('TranslationsSerializer');
+
+/**
+ * @experimental i18n support is experimental.
+ */
 export enum MissingTranslationStrategy {
   Error,
   Warning,

--- a/scripts/ci-lite/offline_compiler_test.sh
+++ b/scripts/ci-lite/offline_compiler_test.sh
@@ -47,9 +47,11 @@ cp -v package.json $TMP
   node ./node_modules/@angular/tsc-wrapped/src/main -p third_party_src/tsconfig-build.json
 
   ./node_modules/.bin/ngc -p tsconfig-build.json --i18nFile=src/messages.fi.xlf --locale=fi --i18nFormat=xlf
+  ./node_modules/.bin/ngc -p tsconfig-custom-serializer.json --i18nFile=src/messages.fr.json --locale=fr --i18nSerializer=./test/custom_serializer
 
   ./node_modules/.bin/ng-xi18n -p tsconfig-xi18n.json --i18nFormat=xlf
   ./node_modules/.bin/ng-xi18n -p tsconfig-xi18n.json --i18nFormat=xmb
+  ./node_modules/.bin/ng-xi18n -p tsconfig-build.json --i18nSerializer=./test/custom_serializer
 
   node test/test_summaries.js
   node test/test_ngtools_api.js

--- a/tools/@angular/tsc-wrapped/src/cli_options.ts
+++ b/tools/@angular/tsc-wrapped/src/cli_options.ts
@@ -12,22 +12,33 @@ export class CliOptions {
 
 export class I18nExtractionCliOptions extends CliOptions {
   public i18nFormat: string;
+  public i18nSerializer: string;
 
-  constructor({i18nFormat = null}: {i18nFormat?: string}) {
+  constructor({i18nFormat = null,
+               i18nSerializer = null}: {i18nFormat?: string, i18nSerializer?: string}) {
     super({});
     this.i18nFormat = i18nFormat;
+    this.i18nSerializer = i18nSerializer;
   }
 }
 
 export class NgcCliOptions extends CliOptions {
   public i18nFormat: string;
+  public i18nSerializer: string;
   public i18nFile: string;
   public locale: string;
 
-  constructor({i18nFormat = null, i18nFile = null, locale = null, basePath = null}:
-                  {i18nFormat?: string, i18nFile?: string, locale?: string, basePath?: string}) {
+  constructor({i18nFormat = null, i18nSerializer = null, i18nFile = null, locale = null,
+               basePath = null}: {
+    i18nFormat?: string,
+    i18nSerializer?: string,
+    i18nFile?: string,
+    locale?: string,
+    basePath?: string
+  }) {
     super({basePath: basePath});
     this.i18nFormat = i18nFormat;
+    this.i18nSerializer = i18nSerializer;
     this.i18nFile = i18nFile;
     this.locale = locale;
   }

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -1007,6 +1007,9 @@ export declare const TRANSLATIONS: InjectionToken<string>;
 export declare const TRANSLATIONS_FORMAT: InjectionToken<string>;
 
 /** @experimental */
+export declare const TRANSLATIONS_SERIALIZER: InjectionToken<string>;
+
+/** @experimental */
 export declare function trigger(name: string, animation: AnimationMetadata[]): AnimationEntryMetadata;
 
 /** @experimental */


### PR DESCRIPTION
This PR opens the serializer API of i18n, in order to allow developers to do something like this:
```
  ./node_modules/.bin/ng-xi18n --i18nSerializer=./custom_serializer
 ./node_modules/.bin/ngc --i18nFile=src/messages.fr.json --locale=fr --i18nSerializer=./custom_serializer
```

The serializer is loaded with a `require()`, so the path can be relative, absolute or a dependency.
