### PR TITLE
fix(http): expose BrowserJsonp

### DIFF
--- a/modules/@angular/http/src/backends/browser_jsonp.ts
+++ b/modules/@angular/http/src/backends/browser_jsonp.ts
@@ -13,14 +13,15 @@ export const JSONP_HOME = '__ng_jsonp__';
 let _jsonpConnections: {[key: string]: any} = null;
 
 function _getJsonpConnections(): {[key: string]: any} {
-  const w: {[key: string]: any} = typeof window == 'object' ? window : {};
   if (_jsonpConnections === null) {
+    const w: {[key: string]: any} = typeof window == 'object' ? window : {};
     _jsonpConnections = w[JSONP_HOME] = {};
   }
   return _jsonpConnections;
 }
 
 // Make sure not to evaluate this in a non-browser environment!
+/** @experimental */
 @Injectable()
 export class BrowserJsonp {
   // Construct a <script> element with the specified URL
@@ -32,7 +33,7 @@ export class BrowserJsonp {
 
   nextRequestID(): string { return `__req${_nextRequestId++}`; }
 
-  requestCallback(id: string): string { return `${JSONP_HOME}${id}_finished`; }
+  requestCallback(id: string): string { return `${JSONP_HOME}.${id}.finished`; }
 
   exposeConnection(id: string, connection: any): void {
     const connections = _getJsonpConnections();

--- a/modules/@angular/http/src/http_module.ts
+++ b/modules/@angular/http/src/http_module.ts
@@ -44,13 +44,11 @@ export function jsonpFactory(jsonpBackend: JSONPBackend, requestOptions: Request
  */
 @NgModule({
   providers: [
-    // TODO(pascal): use factory type annotations once supported in DI
-    // issue: https://github.com/angular/angular/issues/3183
-    {provide: Http, useFactory: httpFactory, deps: [XHRBackend, RequestOptions]},
     BrowserXhr,
+    XHRBackend,
     {provide: RequestOptions, useClass: BaseRequestOptions},
     {provide: ResponseOptions, useClass: BaseResponseOptions},
-    XHRBackend,
+    {provide: Http, useFactory: httpFactory, deps: [XHRBackend, RequestOptions]},
     {provide: XSRFStrategy, useFactory: _createDefaultCookieXSRFStrategy},
   ],
 })
@@ -64,10 +62,8 @@ export class HttpModule {
  */
 @NgModule({
   providers: [
-    // TODO(pascal): use factory type annotations once supported in DI
-    // issue: https://github.com/angular/angular/issues/3183
-    {provide: Jsonp, useFactory: jsonpFactory, deps: [JSONPBackend, RequestOptions]},
     BrowserJsonp,
+    {provide: Jsonp, useFactory: jsonpFactory, deps: [JSONPBackend, RequestOptions]},
     {provide: RequestOptions, useClass: BaseRequestOptions},
     {provide: ResponseOptions, useClass: BaseResponseOptions},
     {provide: JSONPBackend, useClass: JSONPBackend_},

--- a/modules/@angular/http/src/index.ts
+++ b/modules/@angular/http/src/index.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+export {BrowserJsonp} from './backends/browser_jsonp';
 export {BrowserXhr} from './backends/browser_xhr';
 export {JSONPBackend, JSONPConnection} from './backends/jsonp_backend';
 export {CookieXSRFStrategy, XHRBackend, XHRConnection} from './backends/xhr_backend';

--- a/modules/@angular/http/test/backends/jsonp_backend_spec.ts
+++ b/modules/@angular/http/test/backends/jsonp_backend_spec.ts
@@ -70,12 +70,6 @@ export function main() {
       expect(instance).toBeAnInstanceOf(JSONPConnection);
     });
 
-    it('callback name should not contain dots', () => {
-      const domJsonp = new MockBrowserJsonp();
-      const callback: string = domJsonp.requestCallback(domJsonp.nextRequestID());
-      expect(callback.indexOf('.') === -1).toBeTruthy();
-    });
-
     describe('JSONPConnection', () => {
       it('should use the injected BaseResponseOptions to create the response',
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {

--- a/tools/public_api_guard/http/index.d.ts
+++ b/tools/public_api_guard/http/index.d.ts
@@ -9,6 +9,17 @@ export declare class BaseResponseOptions extends ResponseOptions {
 }
 
 /** @experimental */
+export declare class BrowserJsonp {
+    build(url: string): any;
+    cleanup(node: any): void;
+    exposeConnection(id: string, connection: any): void;
+    nextRequestID(): string;
+    removeConnection(id: string): void;
+    requestCallback(id: string): string;
+    send(node: any): void;
+}
+
+/** @experimental */
 export declare class BrowserXhr {
     constructor();
     build(): any;


### PR DESCRIPTION
Closes #14267

We are exposing `BrowserJsonp` so users can provide their own implementation. Useful for overriding callback names.