### PR TITLE
perf(upgrade): unregister `$doCheck` watcher when destroying upgraded component

### DIFF
--- a/modules/@angular/upgrade/src/static/upgrade_component.ts
+++ b/modules/@angular/upgrade/src/static/upgrade_component.ts
@@ -100,6 +100,8 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
   private controllerInstance: IControllerInstance = null;
   private bindingDestination: IBindingDestination = null;
 
+  private unregisterDoCheckWatcher: Function;
+
   /**
    * Create a new `UpgradeComponent` instance. You should not normally need to do this.
    * Instead you should derive a new class from this one and call the super constructor
@@ -173,7 +175,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     if (this.controllerInstance && isFunction(this.controllerInstance.$doCheck)) {
       const callDoCheck = () => this.controllerInstance.$doCheck();
 
-      this.$componentScope.$parent.$watch(callDoCheck);
+      this.unregisterDoCheckWatcher = this.$componentScope.$parent.$watch(callDoCheck);
       callDoCheck();
     }
 
@@ -236,6 +238,9 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
   }
 
   ngOnDestroy() {
+    if (isFunction(this.unregisterDoCheckWatcher)) {
+      this.unregisterDoCheckWatcher();
+    }
     if (this.controllerInstance && isFunction(this.controllerInstance.$onDestroy)) {
       this.controllerInstance.$onDestroy();
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Watchers registered on the parent scope for `$doCheck()` hooks on upgraded components, do not get unregistered when the component is destroyed (e.g. via a structural directive).


**What is the new behavior?**
All necessary watchers get unregistered when the upgraded component is destroyed.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```