### PR TITLE
feat(core): Remove ChangeDetectorRef Paramter from KeyValueDifferFactory and IterableDifferFactory

### DIFF
--- a/modules/@angular/common/src/directives/ng_class.ts
+++ b/modules/@angular/common/src/directives/ng_class.ts
@@ -69,9 +69,9 @@ export class NgClass implements DoCheck {
 
     if (this._rawClass) {
       if (isListLikeIterable(this._rawClass)) {
-        this._iterableDiffer = this._iterableDiffers.find(this._rawClass).create(null);
+        this._iterableDiffer = this._iterableDiffers.find(this._rawClass).create();
       } else {
-        this._keyValueDiffer = this._keyValueDiffers.find(this._rawClass).create(null);
+        this._keyValueDiffer = this._keyValueDiffers.find(this._rawClass).create();
       }
     }
   }

--- a/modules/@angular/common/src/directives/ng_for_of.ts
+++ b/modules/@angular/common/src/directives/ng_for_of.ts
@@ -112,7 +112,7 @@ export class NgForOf<T> implements DoCheck,
 
   constructor(
       private _viewContainer: ViewContainerRef, private _template: TemplateRef<NgForOfRow<T>>,
-      private _differs: IterableDiffers, private _cdr: ChangeDetectorRef) {}
+      private _differs: IterableDiffers) {}
 
   @Input()
   set ngForTemplate(value: TemplateRef<NgForOfRow<T>>) {
@@ -130,7 +130,7 @@ export class NgForOf<T> implements DoCheck,
       const value = changes['ngForOf'].currentValue;
       if (!this._differ && value) {
         try {
-          this._differ = this._differs.find(value).create(this._cdr, this.ngForTrackBy);
+          this._differ = this._differs.find(value).create(this.ngForTrackBy);
         } catch (e) {
           throw new Error(
               `Cannot find a differ supporting object '${value}' of type '${getTypeNameForDebugging(value)}'. NgFor only supports binding to Iterables such as Arrays.`);

--- a/modules/@angular/common/src/directives/ng_style.ts
+++ b/modules/@angular/common/src/directives/ng_style.ts
@@ -42,7 +42,7 @@ export class NgStyle implements DoCheck {
   set ngStyle(v: {[key: string]: string}) {
     this._ngStyle = v;
     if (!this._differ && v) {
-      this._differ = this._differs.find(v).create(null);
+      this._differ = this._differs.find(v).create();
     }
   }
 

--- a/modules/@angular/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/modules/@angular/core/src/change_detection/differs/default_iterable_differ.ts
@@ -8,9 +8,9 @@
 
 import {isListLikeIterable, iterateListLike} from '../../facade/collection';
 import {isBlank, looseIdentical, stringify} from '../../facade/lang';
+import {ChangeDetectorRef} from '../change_detector_ref';
 
 import {IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, NgIterable, TrackByFunction} from './iterable_differs';
-import {ChangeDetectorRef} from '../change_detector_ref';
 
 
 export class DefaultIterableDifferFactory implements IterableDifferFactory {
@@ -22,8 +22,10 @@ export class DefaultIterableDifferFactory implements IterableDifferFactory {
   /**
    * @deprecated v4.0.0 - ChangeDetectorRef is not used and is no longer a parameter
    */
-  create<V>(cdRefOrTrackBy?: ChangeDetectorRef|TrackByFunction<any>, trackByFn?: TrackByFunction<any>): DefaultIterableDiffer<V> {
-    return new DefaultIterableDiffer<V>(trackByFn || <TrackByFunction<any>> cdRefOrTrackBy);
+  create<V>(
+      cdRefOrTrackBy?: ChangeDetectorRef|TrackByFunction<any>,
+      trackByFn?: TrackByFunction<any>): DefaultIterableDiffer<V> {
+    return new DefaultIterableDiffer<V>(trackByFn || <TrackByFunction<any>>cdRefOrTrackBy);
   }
 }
 

--- a/modules/@angular/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/modules/@angular/core/src/change_detection/differs/default_iterable_differ.ts
@@ -10,13 +10,20 @@ import {isListLikeIterable, iterateListLike} from '../../facade/collection';
 import {isBlank, looseIdentical, stringify} from '../../facade/lang';
 
 import {IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, NgIterable, TrackByFunction} from './iterable_differs';
+import {ChangeDetectorRef} from '../change_detector_ref';
 
 
 export class DefaultIterableDifferFactory implements IterableDifferFactory {
   constructor() {}
   supports(obj: Object): boolean { return isListLikeIterable(obj); }
-  create<V>(trackByFn?: TrackByFunction<any>): DefaultIterableDiffer<V> {
-    return new DefaultIterableDiffer<V>(trackByFn);
+
+  create<V>(trackByFn?: TrackByFunction<any>): DefaultIterableDiffer<V>;
+
+  /**
+   * @deprecated v4.0.0 - ChangeDetectorRef is not used and is no longer a parameter
+   */
+  create<V>(cdRefOrTrackBy?: ChangeDetectorRef|TrackByFunction<any>, trackByFn?: TrackByFunction<any>): DefaultIterableDiffer<V> {
+    return new DefaultIterableDiffer<V>(trackByFn || <TrackByFunction<any>> cdRefOrTrackBy);
   }
 }
 

--- a/modules/@angular/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/modules/@angular/core/src/change_detection/differs/default_iterable_differ.ts
@@ -16,7 +16,7 @@ import {IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFac
 export class DefaultIterableDifferFactory implements IterableDifferFactory {
   constructor() {}
   supports(obj: Object): boolean { return isListLikeIterable(obj); }
-  create<V>(cdRef: ChangeDetectorRef, trackByFn?: TrackByFunction<any>): DefaultIterableDiffer<V> {
+  create<V>(cdRef?: ChangeDetectorRef, trackByFn?: TrackByFunction<any>): DefaultIterableDiffer<V> {
     return new DefaultIterableDiffer<V>(trackByFn);
   }
 }

--- a/modules/@angular/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/modules/@angular/core/src/change_detection/differs/default_iterable_differ.ts
@@ -16,7 +16,7 @@ import {IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFac
 export class DefaultIterableDifferFactory implements IterableDifferFactory {
   constructor() {}
   supports(obj: Object): boolean { return isListLikeIterable(obj); }
-  create<V>(cdRef?: ChangeDetectorRef, trackByFn?: TrackByFunction<any>): DefaultIterableDiffer<V> {
+  create<V>(trackByFn?: TrackByFunction<any>): DefaultIterableDiffer<V> {
     return new DefaultIterableDiffer<V>(trackByFn);
   }
 }

--- a/modules/@angular/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/modules/@angular/core/src/change_detection/differs/default_iterable_differ.ts
@@ -8,7 +8,6 @@
 
 import {isListLikeIterable, iterateListLike} from '../../facade/collection';
 import {isBlank, looseIdentical, stringify} from '../../facade/lang';
-import {ChangeDetectorRef} from '../change_detector_ref';
 
 import {IterableChangeRecord, IterableChanges, IterableDiffer, IterableDifferFactory, NgIterable, TrackByFunction} from './iterable_differs';
 

--- a/modules/@angular/core/src/change_detection/differs/default_keyvalue_differ.ts
+++ b/modules/@angular/core/src/change_detection/differs/default_keyvalue_differ.ts
@@ -8,7 +8,6 @@
 
 import {StringMapWrapper} from '../../facade/collection';
 import {isJsObject, looseIdentical, stringify} from '../../facade/lang';
-import {ChangeDetectorRef} from '../change_detector_ref';
 
 import {KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory} from './keyvalue_differs';
 

--- a/modules/@angular/core/src/change_detection/differs/default_keyvalue_differ.ts
+++ b/modules/@angular/core/src/change_detection/differs/default_keyvalue_differ.ts
@@ -17,7 +17,7 @@ export class DefaultKeyValueDifferFactory<K, V> implements KeyValueDifferFactory
   constructor() {}
   supports(obj: any): boolean { return obj instanceof Map || isJsObject(obj); }
 
-  create<K, V>(cdRef: ChangeDetectorRef): KeyValueDiffer<K, V> {
+  create<K, V>(): KeyValueDiffer<K, V> {
     return new DefaultKeyValueDiffer<K, V>();
   }
 }

--- a/modules/@angular/core/src/change_detection/differs/default_keyvalue_differ.ts
+++ b/modules/@angular/core/src/change_detection/differs/default_keyvalue_differ.ts
@@ -16,9 +16,7 @@ export class DefaultKeyValueDifferFactory<K, V> implements KeyValueDifferFactory
   constructor() {}
   supports(obj: any): boolean { return obj instanceof Map || isJsObject(obj); }
 
-  create<K, V>(): KeyValueDiffer<K, V> {
-    return new DefaultKeyValueDiffer<K, V>();
-  }
+  create<K, V>(): KeyValueDiffer<K, V> { return new DefaultKeyValueDiffer<K, V>(); }
 }
 
 export class DefaultKeyValueDiffer<K, V> implements KeyValueDiffer<K, V>, KeyValueChanges<K, V> {

--- a/modules/@angular/core/src/change_detection/differs/default_keyvalue_differ.ts
+++ b/modules/@angular/core/src/change_detection/differs/default_keyvalue_differ.ts
@@ -8,9 +8,9 @@
 
 import {StringMapWrapper} from '../../facade/collection';
 import {isJsObject, looseIdentical, stringify} from '../../facade/lang';
+import {ChangeDetectorRef} from '../change_detector_ref';
 
 import {KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory} from './keyvalue_differs';
-import {ChangeDetectorRef} from '../change_detector_ref';
 
 
 export class DefaultKeyValueDifferFactory<K, V> implements KeyValueDifferFactory {
@@ -22,7 +22,9 @@ export class DefaultKeyValueDifferFactory<K, V> implements KeyValueDifferFactory
   /**
    * @deprecated v4.0.0 - ChangeDetectorRef is not used and is no longer a parameter
    */
-  create<K, V>(cd?: ChangeDetectorRef): KeyValueDiffer<K, V> { return new DefaultKeyValueDiffer<K, V>(); }
+  create<K, V>(cd?: ChangeDetectorRef): KeyValueDiffer<K, V> {
+    return new DefaultKeyValueDiffer<K, V>();
+  }
 }
 
 export class DefaultKeyValueDiffer<K, V> implements KeyValueDiffer<K, V>, KeyValueChanges<K, V> {

--- a/modules/@angular/core/src/change_detection/differs/default_keyvalue_differ.ts
+++ b/modules/@angular/core/src/change_detection/differs/default_keyvalue_differ.ts
@@ -10,13 +10,19 @@ import {StringMapWrapper} from '../../facade/collection';
 import {isJsObject, looseIdentical, stringify} from '../../facade/lang';
 
 import {KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory} from './keyvalue_differs';
+import {ChangeDetectorRef} from '../change_detector_ref';
 
 
 export class DefaultKeyValueDifferFactory<K, V> implements KeyValueDifferFactory {
   constructor() {}
   supports(obj: any): boolean { return obj instanceof Map || isJsObject(obj); }
 
-  create<K, V>(): KeyValueDiffer<K, V> { return new DefaultKeyValueDiffer<K, V>(); }
+  create<K, V>(): DefaultKeyValueDiffer<K, V>;
+
+  /**
+   * @deprecated v4.0.0 - ChangeDetectorRef is not used and is no longer a parameter
+   */
+  create<K, V>(cd?: ChangeDetectorRef): KeyValueDiffer<K, V> { return new DefaultKeyValueDiffer<K, V>(); }
 }
 
 export class DefaultKeyValueDiffer<K, V> implements KeyValueDiffer<K, V>, KeyValueChanges<K, V> {

--- a/modules/@angular/core/src/change_detection/differs/iterable_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/iterable_differs.ts
@@ -8,7 +8,6 @@
 
 import {Optional, Provider, SkipSelf} from '../../di';
 import {getTypeNameForDebugging, isPresent} from '../../facade/lang';
-import {ChangeDetectorRef} from '../change_detector_ref';
 
 /**
  * A type describing supported interable types.

--- a/modules/@angular/core/src/change_detection/differs/iterable_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/iterable_differs.ts
@@ -8,6 +8,7 @@
 
 import {Optional, Provider, SkipSelf} from '../../di';
 import {getTypeNameForDebugging, isPresent} from '../../facade/lang';
+import { ChangeDetectorRef } from '../change_detector_ref';
 
 /**
  * A type describing supported interable types.
@@ -137,6 +138,11 @@ export interface TrackByFunction<T> { (index: number, item: T): any; }
 export interface IterableDifferFactory {
   supports(objects: any): boolean;
   create<V>(trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
+
+  /**
+   * @deprecated v4.0.0 - ChangeDetectorRef is not used and is no longer a parameter
+   */
+  create<V>(_cdr?: ChangeDetectorRef|TrackByFunction<V>, trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
 }
 
 /**

--- a/modules/@angular/core/src/change_detection/differs/iterable_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/iterable_differs.ts
@@ -137,7 +137,7 @@ export interface TrackByFunction<T> { (index: number, item: T): any; }
  */
 export interface IterableDifferFactory {
   supports(objects: any): boolean;
-  create<V>(cdRef: ChangeDetectorRef, trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
+  create<V>(cdRef?: ChangeDetectorRef, trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
 }
 
 /**

--- a/modules/@angular/core/src/change_detection/differs/iterable_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/iterable_differs.ts
@@ -137,7 +137,7 @@ export interface TrackByFunction<T> { (index: number, item: T): any; }
  */
 export interface IterableDifferFactory {
   supports(objects: any): boolean;
-  create<V>(cdRef?: ChangeDetectorRef, trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
+  create<V>(trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
 }
 
 /**

--- a/modules/@angular/core/src/change_detection/differs/iterable_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/iterable_differs.ts
@@ -8,7 +8,7 @@
 
 import {Optional, Provider, SkipSelf} from '../../di';
 import {getTypeNameForDebugging, isPresent} from '../../facade/lang';
-import { ChangeDetectorRef } from '../change_detector_ref';
+import {ChangeDetectorRef} from '../change_detector_ref';
 
 /**
  * A type describing supported interable types.
@@ -142,7 +142,8 @@ export interface IterableDifferFactory {
   /**
    * @deprecated v4.0.0 - ChangeDetectorRef is not used and is no longer a parameter
    */
-  create<V>(_cdr?: ChangeDetectorRef|TrackByFunction<V>, trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
+  create<V>(_cdr?: ChangeDetectorRef|TrackByFunction<V>, trackByFn?: TrackByFunction<V>):
+      IterableDiffer<V>;
 }
 
 /**

--- a/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
@@ -7,6 +7,7 @@
  */
 
 import {Optional, Provider, SkipSelf} from '../../di';
+import {ChangeDetectorRef} from '@angular/core/src/change_detection/change_detector_ref';
 
 
 /**
@@ -108,6 +109,11 @@ export interface KeyValueDifferFactory {
    * Create a `KeyValueDiffer`.
    */
   create<K, V>(): KeyValueDiffer<K, V>;
+
+  /**
+   * @deprecated v4.0.0 - ChangeDetectorRef is not used and is no longer a parameter
+   */
+  create<K, V>(_cdr?: ChangeDetectorRef): KeyValueDiffer<K, V>;
 }
 
 /**

--- a/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Optional, Provider, SkipSelf} from '../../di';
 import {ChangeDetectorRef} from '@angular/core/src/change_detection/change_detector_ref';
+
+import {Optional, Provider, SkipSelf} from '../../di';
+
 
 
 /**

--- a/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
@@ -7,7 +7,6 @@
  */
 
 import {Optional, Provider, SkipSelf} from '../../di';
-import {ChangeDetectorRef} from '../change_detector_ref';
 
 
 /**

--- a/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef} from '@angular/core/src/change_detection/change_detector_ref';
+import {ChangeDetectorRef} from '../change_detector_ref';
 
 import {Optional, Provider, SkipSelf} from '../../di';
 

--- a/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef} from '../change_detector_ref';
-
 import {Optional, Provider, SkipSelf} from '../../di';
+import {ChangeDetectorRef} from '../change_detector_ref';
 
 
 

--- a/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/modules/@angular/core/src/change_detection/differs/keyvalue_differs.ts
@@ -108,7 +108,7 @@ export interface KeyValueDifferFactory {
   /**
    * Create a `KeyValueDiffer`.
    */
-  create<K, V>(cdRef: ChangeDetectorRef): KeyValueDiffer<K, V>;
+  create<K, V>(): KeyValueDiffer<K, V>;
 }
 
 /**

--- a/tools/public_api_guard/common/index.d.ts
+++ b/tools/public_api_guard/common/index.d.ts
@@ -137,7 +137,7 @@ export declare class NgForOf<T> implements DoCheck, OnChanges {
     ngForOf: NgIterable<T>;
     ngForTemplate: TemplateRef<NgForOfRow<T>>;
     ngForTrackBy: TrackByFunction<T>;
-    constructor(_viewContainer: ViewContainerRef, _template: TemplateRef<NgForOfRow<T>>, _differs: IterableDiffers, _cdr: ChangeDetectorRef);
+    constructor(_viewContainer: ViewContainerRef, _template: TemplateRef<NgForOfRow<T>>, _differs: IterableDiffers);
     ngDoCheck(): void;
     ngOnChanges(changes: SimpleChanges): void;
 }

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -561,7 +561,7 @@ export interface IterableDiffer<V> {
 
 /** @stable */
 export interface IterableDifferFactory {
-    create<V>(cdRef: ChangeDetectorRef, trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
+    create<V>(trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
     supports(objects: any): boolean;
 }
 
@@ -603,7 +603,7 @@ export interface KeyValueDiffer<K, V> {
 
 /** @stable */
 export interface KeyValueDifferFactory {
-    create<K, V>(cdRef: ChangeDetectorRef): KeyValueDiffer<K, V>;
+    create<K, V>(): KeyValueDiffer<K, V>;
     supports(objects: any): boolean;
 }
 

--- a/tools/public_api_guard/core/index.d.ts
+++ b/tools/public_api_guard/core/index.d.ts
@@ -562,6 +562,7 @@ export interface IterableDiffer<V> {
 /** @stable */
 export interface IterableDifferFactory {
     create<V>(trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
+    /** @deprecated */ create<V>(_cdr?: ChangeDetectorRef | TrackByFunction<V>, trackByFn?: TrackByFunction<V>): IterableDiffer<V>;
     supports(objects: any): boolean;
 }
 
@@ -604,6 +605,7 @@ export interface KeyValueDiffer<K, V> {
 /** @stable */
 export interface KeyValueDifferFactory {
     create<K, V>(): KeyValueDiffer<K, V>;
+    /** @deprecated */ create<K, V>(_cdr?: ChangeDetectorRef): KeyValueDiffer<K, V>;
     supports(objects: any): boolean;
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

https://github.com/angular/angular/issues/13961: DifferFactories required a ChangeDetectorRef to be passed into it's create method but did not use it.

**What is the new behavior?**

The ChangeDetectorRef parameter has been removed from the create method and it's arguments have been removed from places that use it.

**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

Applications that have used the Iterable factory will 

**Other information**:

