### PR TITLE
build(aio): correctly render decorator docs

### DIFF
--- a/docs/templates/includes/_metadata.html
+++ b/docs/templates/includes/_metadata.html
@@ -1,8 +1,8 @@
-{% if doc.metadataDoc and doc.metadataDoc.members.length %}
+{% if doc.members.length %}
 <section class="meta-data">
   <h2>Metadata Properties</h2>
   <div class="description">
-    {% for metadata in doc.metadataDoc.members %}{% if not metadata.internal %}
+    {% for metadata in doc.members %}{% if not metadata.internal %}
     <div class="metadata-member">
       <a name="{$ metadata.name $}-anchor" class="anchor-offset"></a>
       <pre class="prettyprint no-bg" ng-class="{ 'anchor-focused': appCtrl.isApiDocMemberFocused('{$ metadata.name $}') }">

--- a/tools/docs/angular.io-package/processors/mergeDecoratorDocs.spec.js
+++ b/tools/docs/angular.io-package/processors/mergeDecoratorDocs.spec.js
@@ -2,7 +2,7 @@ var testPackage = require('../../helpers/test-package');
 var Dgeni = require('dgeni');
 
 describe('mergeDecoratorDocs processor', function() {
-  var dgeni, injector, processor, decoratorDoc, otherDoc;
+  var dgeni, injector, processor, decoratorDoc, decoratorDocWithTypeAssertion, otherDoc;
 
   beforeEach(function() {
     dgeni = new Dgeni([testPackage('angular.io-package')]);
@@ -13,9 +13,8 @@ describe('mergeDecoratorDocs processor', function() {
       name: 'X',
       docType: 'var',
       exportSymbol: {
-        valueDeclaration: {
-          initializer: {expression: {text: 'makeDecorator'}, arguments: [{text: 'XMetadata'}]}
-        }
+        valueDeclaration:
+            {initializer: {expression: {text: 'makeDecorator'}, arguments: [{text: 'X'}]}}
       }
     };
 
@@ -25,11 +24,8 @@ describe('mergeDecoratorDocs processor', function() {
       exportSymbol: {
         valueDeclaration: {
           initializer: {
-            expression: {
-              type: {},
-              expression: {text: 'makeDecorator'},
-              arguments: [{text: 'YMetadata'}]
-            }
+            expression:
+                {type: {}, expression: {text: 'makeDecorator'}, arguments: [{text: 'Y'}]}
           }
         }
       }
@@ -55,7 +51,7 @@ describe('mergeDecoratorDocs processor', function() {
 
   it('should extract the "type" of the decorator meta data', function() {
     processor.$process([decoratorDoc, decoratorDocWithTypeAssertion, otherDoc]);
-    expect(decoratorDoc.decoratorType).toEqual('XMetadata');
-    expect(decoratorDocWithTypeAssertion.decoratorType).toEqual('YMetadata');
+    expect(decoratorDoc.decoratorType).toEqual('X');
+    expect(decoratorDocWithTypeAssertion.decoratorType).toEqual('Y');
   });
 });


### PR DESCRIPTION
This commit updates the doc-gen to account
for the changes to the codebase for decorators.

There are actually three kinds of calls that create decorators:

* makeDecorator
* makePropDecorator
* makeParamDecorator

Also, the actual documentation for each
decorator is split between two exported symbols:

* `interface [DecoratorName]` contains the metadata fields
* interface [DecoratorName]Decorator` contains a
  "call member" which holds the general description of the decorator.

This processor now identifies all three decorator types, and pulls the
description of the callMember onto the main decorator doc description.

(There are some outstanding interfaces in the angular/angular project that
need to be re-exported from `/angular/modules/@angular/core/src/metadata.ts`
to ensure that the doc-gen is able to access them.)

Closes https://github.com/angular/angular.io/pull/2349

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

