### PR TITLE
fix(compiler): improve error messages in aot compiler

### DIFF
--- a/modules/@angular/compiler/src/aot/compiler.ts
+++ b/modules/@angular/compiler/src/aot/compiler.ts
@@ -19,6 +19,7 @@ import * as o from '../output/output_ast';
 import {CompiledStylesheet, StyleCompiler} from '../style_compiler';
 import {SummaryResolver} from '../summary_resolver';
 import {TemplateParser} from '../template_parser/template_parser';
+import {SyntaxError} from '../util';
 import {ViewCompiler} from '../view_compiler/view_compiler';
 
 import {AotCompilerHost} from './compiler_host';
@@ -290,8 +291,9 @@ export function analyzeAndValidateNgModules(
   const result = analyzeNgModules(programStaticSymbols, host, metadataResolver);
   if (result.symbolsMissingModule && result.symbolsMissingModule.length) {
     const messages = result.symbolsMissingModule.map(
-        s => `Cannot determine the module for class ${s.name} in ${s.filePath}!`);
-    throw new Error(messages.join('\n'));
+        s =>
+            `Cannot determine the module for class ${s.name} in ${s.filePath}! Add ${s.name} to the NgModule to fix it.`);
+    throw new SyntaxError(messages.join('\n'));
   }
   return result;
 }


### PR DESCRIPTION
Do not print the stack trace when the component is not declared in the module.

Example: https://gist.github.com/bowenni/2a26b53a7738faddeb0924dfa0031398

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```