### PR TITLE
fix(compiler): check entry component metadata

### DIFF
--- a/modules/@angular/compiler/src/metadata_resolver.ts
+++ b/modules/@angular/compiler/src/metadata_resolver.ts
@@ -930,7 +930,7 @@ export class CompileMetadataResolver {
 
     extractIdentifiers(provider.useValue, collectedIdentifiers);
     collectedIdentifiers.forEach((identifier) => {
-      const entry = this._getEntryComponentMetadata(identifier.reference);
+      const entry = this._getEntryComponentMetadata(identifier.reference, false);
       if (entry) {
         components.push(entry);
       }
@@ -938,16 +938,21 @@ export class CompileMetadataResolver {
     return components;
   }
 
-  private _getEntryComponentMetadata(dirType: any): cpl.CompileEntryComponentMetadata {
+  private _getEntryComponentMetadata(dirType: any, throwIfNotFound = true):
+      cpl.CompileEntryComponentMetadata {
     const dirMeta = this.getNonNormalizedDirectiveMetadata(dirType);
-    if (dirMeta) {
+    if (dirMeta && dirMeta.metadata.isComponent) {
       return {componentType: dirType, componentFactory: dirMeta.metadata.componentFactory};
     } else {
       const dirSummary =
           <cpl.CompileDirectiveSummary>this._loadSummary(dirType, cpl.CompileSummaryKind.Directive);
-      if (dirSummary) {
+      if (dirSummary && dirSummary.isComponent) {
         return {componentType: dirType, componentFactory: dirSummary.componentFactory};
       }
+    }
+
+    if (throwIfNotFound) {
+      throw new SyntaxError(`${dirType.name} cannot be used as an entry component.`);
     }
   }
 

--- a/modules/@angular/compiler/test/metadata_resolver_spec.ts
+++ b/modules/@angular/compiler/test/metadata_resolver_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {TEST_COMPILER_PROVIDERS} from '@angular/compiler/testing/test_bindings';
-import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, Component, DoCheck, Injectable, NgModule, OnChanges, OnDestroy, OnInit, Pipe, SimpleChanges, ViewEncapsulation} from '@angular/core';
+import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, Component, Directive, DoCheck, Injectable, NgModule, OnChanges, OnDestroy, OnInit, Pipe, SimpleChanges, ViewEncapsulation} from '@angular/core';
 import {LIFECYCLE_HOOKS_VALUES} from '@angular/core/src/metadata/lifecycle_hooks';
 import {TestBed, async, inject} from '@angular/core/testing';
 
@@ -324,6 +324,61 @@ export function main() {
 
          expect(() => resolver.loadNgModuleDirectiveAndPipeMetadata(Module5, true))
              .toThrowError(`['&lbrace;', '}}'] contains unusable interpolation symbol.`);
+       }));
+
+    it(`should throw an error when a Pipe is added to module's bootstrap list`,
+       inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
+
+         @Pipe({name: 'pipe'})
+         class MyPipe {
+         }
+
+         @NgModule({declarations: [MyPipe], bootstrap: [MyPipe]})
+         class ModuleWithPipeInBootstrap {
+         }
+
+         expect(() => resolver.getNgModuleMetadata(ModuleWithPipeInBootstrap))
+             .toThrowError(SyntaxError, `MyPipe cannot be used as an entry component.`);
+       }));
+
+    it(`should throw an error when a Service is added to module's bootstrap list`,
+       inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
+
+         @NgModule({declarations: [], bootstrap: [SimpleService]})
+         class ModuleWithServiceInBootstrap {
+         }
+
+         expect(() => resolver.getNgModuleMetadata(ModuleWithServiceInBootstrap))
+             .toThrowError(SyntaxError, `SimpleService cannot be used as an entry component.`);
+       }));
+
+    it(`should throw an error when a Directive is added to module's bootstrap list`,
+       inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
+
+         @Directive({selector: 'directive'})
+         class MyDirective {
+         }
+
+         @NgModule({declarations: [], bootstrap: [MyDirective]})
+         class ModuleWithDirectiveInBootstrap {
+         }
+
+         expect(() => resolver.getNgModuleMetadata(ModuleWithDirectiveInBootstrap))
+             .toThrowError(SyntaxError, `MyDirective cannot be used as an entry component.`);
+       }));
+
+    it(`should not throw an error when a Component is added to module's bootstrap list`,
+       inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
+
+         @Component({template: ''})
+         class MyComp {
+         }
+
+         @NgModule({declarations: [MyComp], bootstrap: [MyComp]})
+         class ModuleWithComponentInBootstrap {
+         }
+
+         expect(() => resolver.getNgModuleMetadata(ModuleWithComponentInBootstrap)).not.toThrow();
        }));
   });
 

--- a/modules/@angular/platform-browser/test/browser/bootstrap_spec.ts
+++ b/modules/@angular/platform-browser/test/browser/bootstrap_spec.ts
@@ -155,13 +155,12 @@ export function main() {
          const logger = new MockConsole();
          const errorHandler = new ErrorHandler(false);
          errorHandler._console = logger as any;
-         bootstrap(HelloRootDirectiveIsNotCmp, [
-           {provide: ErrorHandler, useValue: errorHandler}
-         ]).catch((e) => {
-           expect(e.message).toBe(
-               `Could not compile '${stringify(HelloRootDirectiveIsNotCmp)}' because it is not a component.`);
-           done.done();
-         });
+         expect(
+             () => bootstrap(
+                 HelloRootDirectiveIsNotCmp, [{provide: ErrorHandler, useValue: errorHandler}]))
+             .toThrowError(
+                 SyntaxError, `HelloRootDirectiveIsNotCmp cannot be used as an entry component.`);
+         done.done();
        }));
 
     it('should throw if no element is found',

--- a/modules/@angular/platform-browser/test/browser/bootstrap_spec.ts
+++ b/modules/@angular/platform-browser/test/browser/bootstrap_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {SyntaxError} from '@angular/compiler';
 import {APP_INITIALIZER, CUSTOM_ELEMENTS_SCHEMA, Compiler, Component, Directive, ErrorHandler, Inject, Input, LOCALE_ID, NgModule, OnDestroy, PLATFORM_INITIALIZER, Pipe, Provider, VERSION, createPlatformFactory} from '@angular/core';
 import {ApplicationRef, destroyPlatform} from '@angular/core/src/application_ref';
 import {Console} from '@angular/core/src/console';


### PR DESCRIPTION
Throw a proper error when a non-component is added to module's bootstrap list.
This avoids adding non-components to entry components and avoids printing stack traces.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```