### PR TITLE
feat(platform-browser): add support for css props

### DIFF
--- a/modules/@angular/platform-browser/src/dom/dom_renderer.ts
+++ b/modules/@angular/platform-browser/src/dom/dom_renderer.ts
@@ -245,6 +245,8 @@ export class DomRenderer implements Renderer {
   setElementStyle(renderElement: HTMLElement, styleName: string, styleValue: string): void {
     if (isPresent(styleValue)) {
       (renderElement.style as any)[styleName] = stringify(styleValue);
+    } else if (styleName.startsWith('--')) {
+      (renderElement.style as any).setProperty(styleName, styleValue);
     } else {
       // IE requires '' instead of null
       // see https://github.com/angular/angular/issues/7916


### PR DESCRIPTION
add support for custom css properties by use of the setProperty function
when using the renderer to setElementStyle

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently when using the renderer to setElementStyle using a custom css prop (eg: `--my-prop`) it isn't added, due to the need to use `el.styles.setProperty()`.


**What is the new behavior?**
If the `styleName` begins with two dashes, `--`, then we can assume it is a css property, and assign it as so.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
This all stemmed from a conversation with @robwormald on [gitter](https://gitter.im/angular/angular?at=589949096018ccd6527d592c)
