### PR TITLE
fix(core): view engine - fix perf regressions

### DIFF
--- a/modules/@angular/core/src/view/errors.ts
+++ b/modules/@angular/core/src/view/errors.ts
@@ -7,12 +7,12 @@
  */
 
 import {ERROR_DEBUG_CONTEXT, ERROR_ORIGINAL_ERROR, getDebugContext} from '../errors';
-import {DebugContext, EntryAction, ViewState} from './types';
+import {DebugContext, ViewState} from './types';
 
 export function expressionChangedAfterItHasBeenCheckedError(
     context: DebugContext, oldValue: any, currValue: any, isFirstCheck: boolean): Error {
   let msg =
-      `Expression has changed after it was checked. Previous value: '${oldValue}'. Current value: '${currValue}'.`;
+      `ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked. Previous value: '${oldValue}'. Current value: '${currValue}'.`;
   if (isFirstCheck) {
     msg +=
         ` It seems like the view has been created after its parent and its children have been dirty checked.` +
@@ -39,6 +39,6 @@ export function isViewDebugError(err: Error): boolean {
   return !!getDebugContext(err);
 }
 
-export function viewDestroyedError(action: EntryAction): Error {
-  return new Error(`View has been used after destroy for ${EntryAction[action]}`);
+export function viewDestroyedError(action: string): Error {
+  return new Error(`ViewDestroyedError: Attempt to use a destroyed view: ${action}`);
 }

--- a/modules/@angular/core/src/view/index.ts
+++ b/modules/@angular/core/src/view/index.ts
@@ -11,16 +11,11 @@ export {ngContentDef} from './ng_content';
 export {directiveDef, providerDef} from './provider';
 export {pureArrayDef, pureObjectDef, purePipeDef} from './pure_expression';
 export {queryDef} from './query';
+export {createComponentFactory} from './refs';
+export {initServicesIfNeeded} from './services';
 export {textDef} from './text';
-export {rootRenderNodes, setCurrentNode} from './util';
-export {checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createEmbeddedView, createRootView, destroyView, viewDef} from './view';
+export {rootRenderNodes} from './util';
+export {viewDef} from './view';
 export {attachEmbeddedView, detachEmbeddedView, moveEmbeddedView} from './view_attach';
+
 export * from './types';
-
-import {createRefs} from './refs';
-import {Refs} from './types';
-
-Refs.setInstance(createRefs());
-
-export const createComponentFactory: typeof Refs.createComponentFactory =
-    Refs.createComponentFactory;

--- a/modules/@angular/core/src/view/ng_content.ts
+++ b/modules/@angular/core/src/view/ng_content.ts
@@ -46,13 +46,6 @@ export function appendNgContent(view: ViewData, renderHost: any, def: NodeDef) {
     return;
   }
   const ngContentIndex = def.ngContent.index;
-  if (view.renderer) {
-    const projectedNodes: any[] = [];
-    visitProjectedRenderNodes(
-        view, ngContentIndex, RenderNodeAction.Collect, undefined, undefined, projectedNodes);
-    view.renderer.projectNodes(parentEl, projectedNodes);
-  } else {
-    visitProjectedRenderNodes(
-        view, ngContentIndex, RenderNodeAction.AppendChild, parentEl, undefined, undefined);
-  }
+  visitProjectedRenderNodes(
+      view, ngContentIndex, RenderNodeAction.AppendChild, parentEl, undefined, undefined);
 }

--- a/modules/@angular/core/src/view/pure_expression.ts
+++ b/modules/@angular/core/src/view/pure_expression.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {resolveDep, tokenKey} from './provider';
-import {BindingDef, BindingType, DepDef, DepFlags, NodeData, NodeDef, NodeType, ProviderData, PureExpressionData, PureExpressionType, ViewData, asPureExpressionData} from './types';
-import {checkAndUpdateBinding, unwrapValue} from './util';
+import {BindingDef, BindingType, DepDef, DepFlags, NodeData, NodeDef, NodeType, ProviderData, PureExpressionData, PureExpressionType, Services, ViewData, asPureExpressionData} from './types';
+import {checkAndUpdateBinding, tokenKey, unwrapValue} from './util';
 
 export function purePipeDef(pipeToken: any, argCount: number): NodeDef {
   return _pureExpressionDef(
@@ -64,7 +63,7 @@ function _pureExpressionDef(
 
 export function createPureExpression(view: ViewData, def: NodeDef): PureExpressionData {
   const pipe = def.pureExpression.pipeDep ?
-      resolveDep(view, def.index, def.parent, def.pureExpression.pipeDep) :
+      Services.resolveDep(view, def.index, def.parent, def.pureExpression.pipeDep) :
       undefined;
   return {value: undefined, pipe};
 }
@@ -98,6 +97,7 @@ export function checkAndUpdatePureExpressionInline(
       if (checkAndUpdateBinding(view, def, 0, v0)) changed = true;
   }
 
+  const data = asPureExpressionData(view, def.index);
   if (changed) {
     v0 = unwrapValue(v0);
     v1 = unwrapValue(v1);
@@ -110,7 +110,6 @@ export function checkAndUpdatePureExpressionInline(
     v8 = unwrapValue(v8);
     v9 = unwrapValue(v9);
 
-    const data = asPureExpressionData(view, def.index);
     let value: any;
     switch (def.pureExpression.type) {
       case PureExpressionType.Array:
@@ -202,6 +201,7 @@ export function checkAndUpdatePureExpressionInline(
     }
     data.value = value;
   }
+  return data.value;
 }
 
 export function checkAndUpdatePureExpressionDynamic(view: ViewData, def: NodeDef, values: any[]) {
@@ -214,8 +214,8 @@ export function checkAndUpdatePureExpressionDynamic(view: ViewData, def: NodeDef
       changed = true;
     }
   }
+  const data = asPureExpressionData(view, def.index);
   if (changed) {
-    const data = asPureExpressionData(view, def.index);
     let value: any;
     switch (def.pureExpression.type) {
       case PureExpressionType.Array:
@@ -240,4 +240,5 @@ export function checkAndUpdatePureExpressionDynamic(view: ViewData, def: NodeDef
     }
     data.value = value;
   }
+  return data.value;
 }

--- a/modules/@angular/core/src/view/query.ts
+++ b/modules/@angular/core/src/view/query.ts
@@ -11,7 +11,8 @@ import {QueryList} from '../linker/query_list';
 import {TemplateRef} from '../linker/template_ref';
 import {ViewContainerRef} from '../linker/view_container_ref';
 
-import {NodeDef, NodeFlags, NodeType, QueryBindingDef, QueryBindingType, QueryDef, QueryValueType, Refs, ViewData, asElementData, asProviderData, asQueryList} from './types';
+import {createTemplateRef, createViewContainerRef} from './refs';
+import {NodeDef, NodeFlags, NodeType, QueryBindingDef, QueryBindingType, QueryDef, QueryValueType, Services, ViewData, asElementData, asProviderData, asQueryList} from './types';
 import {declaredViewContainer} from './util';
 
 export function queryDef(
@@ -158,10 +159,10 @@ export function getQueryValue(view: ViewData, nodeDef: NodeDef, queryId: string)
         value = new ElementRef(asElementData(view, nodeDef.index).renderElement);
         break;
       case QueryValueType.TemplateRef:
-        value = Refs.createTemplateRef(view, nodeDef);
+        value = createTemplateRef(view, nodeDef);
         break;
       case QueryValueType.ViewContainerRef:
-        value = Refs.createViewContainerRef(view, nodeDef.index);
+        value = createViewContainerRef(view, nodeDef.index);
         break;
       case QueryValueType.Provider:
         value = asProviderData(view, nodeDef.index).instance;

--- a/modules/@angular/core/src/view/refs.ts
+++ b/modules/@angular/core/src/view/refs.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {isDevMode} from '../application_ref';
 import {ChangeDetectorRef} from '../change_detection/change_detection';
 import {Injectable, Injector} from '../di';
 import {ComponentFactory, ComponentRef} from '../linker/component_factory';
@@ -13,67 +14,32 @@ import {ElementRef} from '../linker/element_ref';
 import {TemplateRef} from '../linker/template_ref';
 import {ViewContainerRef} from '../linker/view_container_ref';
 import {EmbeddedViewRef, ViewRef} from '../linker/view_ref';
-import {RenderComponentType, Renderer, RootRenderer} from '../render/api';
+import * as v1renderer from '../render/api';
 import {Sanitizer, SecurityContext} from '../security';
 import {Type} from '../type';
 
-import {resolveDep, tokenKey} from './provider';
-import {getQueryValue} from './query';
-import {DebugContext, DepFlags, ElementData, NodeData, NodeDef, NodeType, Refs, RootData, ViewData, ViewDefinition, ViewDefinitionFactory, ViewState, asElementData, asProviderData} from './types';
-import {findElementDef, isComponentView, parentDiIndex, renderNode, resolveViewDefinition, rootRenderNodes} from './util';
-import {checkAndUpdateView, checkNoChangesView, createEmbeddedView, createRootView, destroyView} from './view';
-import {attachEmbeddedView, detachEmbeddedView, moveEmbeddedView} from './view_attach';
+import {DirectDomRenderer, LegacyRendererAdapter} from './renderer';
+import {ArgumentType, BindingType, DebugContext, DepFlags, ElementData, NodeCheckFn, NodeData, NodeDef, NodeType, RendererV2, RootData, Services, ViewData, ViewDefinition, ViewDefinitionFactory, ViewState, asElementData, asProviderData} from './types';
+import {findElementDef, isComponentView, parentDiIndex, renderNode, resolveViewDefinition, rootRenderNodes, tokenKey} from './util';
 
 const EMPTY_CONTEXT = new Object();
 
-export function createRefs() {
-  return new Refs_();
-}
-
-export class Refs_ implements Refs {
-  createComponentFactory(selector: string, viewDefFactory: ViewDefinitionFactory):
-      ComponentFactory<any> {
-    return new ComponentFactory_(selector, viewDefFactory);
-  }
-  createViewRef(data: ViewData): ViewRef { return new ViewRef_(data); }
-  createViewContainerRef(view: ViewData, elIndex: number): ViewContainerRef {
-    return new ViewContainerRef_(view, elIndex);
-  }
-  createTemplateRef(parentView: ViewData, def: NodeDef): TemplateRef<any> {
-    return new TemplateRef_(parentView, def);
-  }
-  createInjector(view: ViewData, elIndex: number): Injector { return new Injector_(view, elIndex); }
-  createDebugContext(view: ViewData, nodeIndex: number): DebugContext {
-    return new DebugContext_(view, nodeIndex);
-  }
+export function createComponentFactory(
+    selector: string, componentType: Type<any>,
+    viewDefFactory: ViewDefinitionFactory): ComponentFactory<any> {
+  return new ComponentFactory_(selector, componentType, viewDefFactory);
 }
 
 class ComponentFactory_ implements ComponentFactory<any> {
   /**
-   * Only needed so that we can implement ComponentFactory
+   * We are not renaming this field as the old ComponentFactory is using it.
    * @internal */
   _viewClass: any;
 
-  private _viewDef: ViewDefinition;
-  private _componentNodeIndex: number;
-
-  constructor(public selector: string, viewDefFactory: ViewDefinitionFactory) {
-    const viewDef = this._viewDef = resolveViewDefinition(viewDefFactory);
-    const len = viewDef.nodes.length;
-    for (let i = 0; i < len; i++) {
-      const nodeDef = viewDef.nodes[i];
-      if (nodeDef.provider && nodeDef.provider.component) {
-        this._componentNodeIndex = i;
-        break;
-      }
-    }
-    if (this._componentNodeIndex == null) {
-      throw new Error(`Illegal State: Could not find a component in the view definition!`);
-    }
-  }
-
-  get componentType(): Type<any> {
-    return this._viewDef.nodes[this._componentNodeIndex].provider.value;
+  constructor(
+      public selector: string, public componentType: Type<any>,
+      _viewDefFactory: ViewDefinitionFactory) {
+    this._viewClass = _viewDefFactory;
   }
 
   /**
@@ -82,29 +48,28 @@ class ComponentFactory_ implements ComponentFactory<any> {
   create(
       injector: Injector, projectableNodes: any[][] = null,
       rootSelectorOrNode: string|any = null): ComponentRef<any> {
-    if (!projectableNodes) {
-      projectableNodes = [];
+    const viewDef = resolveViewDefinition(this._viewClass);
+    let componentNodeIndex: number;
+    const len = viewDef.nodes.length;
+    for (let i = 0; i < len; i++) {
+      const nodeDef = viewDef.nodes[i];
+      if (nodeDef.provider && nodeDef.provider.component) {
+        componentNodeIndex = i;
+        break;
+      }
     }
-    if (!rootSelectorOrNode) {
-      rootSelectorOrNode = this.selector;
+    if (componentNodeIndex == null) {
+      throw new Error(`Illegal State: Could not find a component in the view definition!`);
     }
-    const renderer = injector.get(RootRenderer);
-    const sanitizer = injector.get(Sanitizer);
-
-    const root: RootData =
-        {injector, projectableNodes, selectorOrNode: rootSelectorOrNode, sanitizer, renderer};
-
-    const view = createRootView(root, this._viewDef, EMPTY_CONTEXT);
-    const component = asProviderData(view, this._componentNodeIndex).instance;
-    return new ComponentRef_(view, component);
+    const view = Services.createRootView(
+        injector, projectableNodes || [], rootSelectorOrNode, viewDef, EMPTY_CONTEXT);
+    const component = asProviderData(view, componentNodeIndex).instance;
+    return new ComponentRef_(view, new ViewRef_(view), component);
   }
 }
 
 class ComponentRef_ implements ComponentRef<any> {
-  private _viewRef: ViewRef_;
-  constructor(private _view: ViewData, private _component: any) {
-    this._viewRef = new ViewRef_(_view);
-  }
+  constructor(private _view: ViewData, private _viewRef: ViewRef, private _component: any) {}
   get location(): ElementRef { return new ElementRef(asElementData(this._view, 0).renderElement); }
   get injector(): Injector { return new Injector_(this._view, 0); }
   get instance(): any { return this._component; };
@@ -114,6 +79,10 @@ class ComponentRef_ implements ComponentRef<any> {
 
   destroy(): void { this._viewRef.destroy(); }
   onDestroy(callback: Function): void { this._viewRef.onDestroy(callback); }
+}
+
+export function createViewContainerRef(view: ViewData, elIndex: number): ViewContainerRef {
+  return new ViewContainerRef_(view, elIndex);
 }
 
 class ViewContainerRef_ implements ViewContainerRef {
@@ -139,8 +108,8 @@ class ViewContainerRef_ implements ViewContainerRef {
   clear(): void {
     const len = this._data.embeddedViews.length;
     for (let i = len - 1; i >= 0; i--) {
-      const view = detachEmbeddedView(this._data, i);
-      destroyView(view);
+      const view = Services.detachEmbeddedView(this._data, i);
+      Services.destroyView(view);
     }
   }
 
@@ -166,13 +135,13 @@ class ViewContainerRef_ implements ViewContainerRef {
 
   insert(viewRef: ViewRef, index?: number): ViewRef {
     const viewData = (<ViewRef_>viewRef)._view;
-    attachEmbeddedView(this._data, index, viewData);
+    Services.attachEmbeddedView(this._data, index, viewData);
     return viewRef;
   }
 
   move(viewRef: ViewRef_, currentIndex: number): ViewRef {
     const previousIndex = this._data.embeddedViews.indexOf(viewRef._view);
-    moveEmbeddedView(this._data, previousIndex, currentIndex);
+    Services.moveEmbeddedView(this._data, previousIndex, currentIndex);
     return viewRef;
   }
 
@@ -181,15 +150,19 @@ class ViewContainerRef_ implements ViewContainerRef {
   }
 
   remove(index?: number): void {
-    const viewData = detachEmbeddedView(this._data, index);
-    destroyView(viewData);
+    const viewData = Services.detachEmbeddedView(this._data, index);
+    Services.destroyView(viewData);
   }
 
   detach(index?: number): ViewRef {
     const view = this.get(index);
-    detachEmbeddedView(this._data, index);
+    Services.detachEmbeddedView(this._data, index);
     return view;
   }
+}
+
+export function createChangeDetectorRef(view: ViewData): ChangeDetectorRef {
+  return new ViewRef_(view);
 }
 
 class ViewRef_ implements EmbeddedViewRef<any> {
@@ -206,20 +179,24 @@ class ViewRef_ implements EmbeddedViewRef<any> {
 
   markForCheck(): void { this.reattach(); }
   detach(): void { this._view.state &= ~ViewState.ChecksEnabled; }
-  detectChanges(): void { checkAndUpdateView(this._view); }
-  checkNoChanges(): void { checkNoChangesView(this._view); }
+  detectChanges(): void { Services.checkAndUpdateView(this._view); }
+  checkNoChanges(): void { Services.checkNoChangesView(this._view); }
 
   reattach(): void { this._view.state |= ViewState.ChecksEnabled; }
   onDestroy(callback: Function) { this._view.disposables.push(<any>callback); }
 
-  destroy() { destroyView(this._view); }
+  destroy() { Services.destroyView(this._view); }
+}
+
+export function createTemplateRef(view: ViewData, def: NodeDef): TemplateRef<any> {
+  return new TemplateRef_(view, def);
 }
 
 class TemplateRef_ implements TemplateRef<any> {
   constructor(private _parentView: ViewData, private _def: NodeDef) {}
 
   createEmbeddedView(context: any): EmbeddedViewRef<any> {
-    return new ViewRef_(createEmbeddedView(this._parentView, this._def, context));
+    return new ViewRef_(Services.createEmbeddedView(this._parentView, this._def, context));
   }
 
   get elementRef(): ElementRef {
@@ -227,91 +204,15 @@ class TemplateRef_ implements TemplateRef<any> {
   }
 }
 
+export function createInjector(view: ViewData, elIndex: number): Injector {
+  return new Injector_(view, elIndex);
+}
+
 class Injector_ implements Injector {
   constructor(private view: ViewData, private elIndex: number) {}
   get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND): any {
-    return resolveDep(
+    return Services.resolveDep(
         this.view, undefined, this.elIndex,
         {flags: DepFlags.None, token, tokenKey: tokenKey(token)}, notFoundValue);
-  }
-}
-
-class DebugContext_ implements DebugContext {
-  private nodeDef: NodeDef;
-  private elDef: NodeDef;
-  constructor(public view: ViewData, public nodeIndex: number) {
-    if (nodeIndex == null) {
-      this.nodeIndex = nodeIndex = view.parentIndex;
-      this.view = view = view.parent;
-    }
-    this.nodeDef = view.def.nodes[nodeIndex];
-    this.elDef = findElementDef(view, nodeIndex);
-  }
-  get injector(): Injector { return new Injector_(this.view, this.elDef.index); }
-  get component(): any { return this.view.component; }
-  get providerTokens(): any[] {
-    const tokens: any[] = [];
-    if (this.elDef) {
-      for (let i = this.elDef.index + 1; i <= this.elDef.index + this.elDef.childCount; i++) {
-        const childDef = this.view.def.nodes[i];
-        if (childDef.type === NodeType.Provider) {
-          tokens.push(childDef.provider.token);
-        } else {
-          i += childDef.childCount;
-        }
-      }
-    }
-    return tokens;
-  }
-  get references(): {[key: string]: any} {
-    const references: {[key: string]: any} = {};
-    if (this.elDef) {
-      collectReferences(this.view, this.elDef, references);
-
-      for (let i = this.elDef.index + 1; i <= this.elDef.index + this.elDef.childCount; i++) {
-        const childDef = this.view.def.nodes[i];
-        if (childDef.type === NodeType.Provider) {
-          collectReferences(this.view, childDef, references);
-        } else {
-          i += childDef.childCount;
-        }
-      }
-    }
-    return references;
-  }
-  get context(): any { return this.view.context; }
-  get source(): string {
-    if (this.nodeDef.type === NodeType.Text) {
-      return this.nodeDef.text.source;
-    } else {
-      return this.elDef.element.source;
-    }
-  }
-  get componentRenderElement() {
-    const elData = findHostElement(this.view);
-    return elData ? elData.renderElement : undefined;
-  }
-  get renderNode(): any {
-    let nodeDef = this.nodeDef.type === NodeType.Text ? this.nodeDef : this.elDef;
-    return renderNode(this.view, nodeDef);
-  }
-}
-
-function findHostElement(view: ViewData): ElementData {
-  while (view && !isComponentView(view)) {
-    view = view.parent;
-  }
-  if (view.parent) {
-    const hostData = asElementData(view.parent, view.parentIndex);
-    return hostData;
-  }
-  return undefined;
-}
-
-function collectReferences(view: ViewData, nodeDef: NodeDef, references: {[key: string]: any}) {
-  for (let queryId in nodeDef.matchedQueries) {
-    if (queryId.startsWith('#')) {
-      references[queryId.slice(1)] = getQueryValue(view, nodeDef, queryId);
-    }
   }
 }

--- a/modules/@angular/core/src/view/renderer.ts
+++ b/modules/@angular/core/src/view/renderer.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ViewEncapsulation} from '../metadata/view';
+import * as v1 from '../render/api';
+
+import {DebugContext, RendererV2} from './types';
+
+export class DirectDomRenderer implements RendererV2 {
+  createElement(name: string): any { return document.createElement(name); }
+  createComment(value: string): any { return document.createComment(value); }
+  createText(value: string): any { return document.createTextNode(value); }
+  appendChild(parent: any, newChild: any): void { parent.appendChild(newChild); }
+  insertBefore(parent: any, newChild: any, refChild: any): void {
+    if (parent) {
+      parent.insertBefore(newChild, refChild);
+    }
+  }
+  removeChild(parent: any, oldChild: any): void {
+    if (parent) {
+      parent.removeChild(oldChild);
+    }
+  }
+  selectRootElement(selectorOrNode: string|any, debugInfo?: DebugContext): any {
+    let el: any;
+    if (typeof selectorOrNode === 'string') {
+      el = document.querySelector(selectorOrNode);
+    } else {
+      el = selectorOrNode;
+    }
+    el.textContent = '';
+    return el;
+  }
+  parentNode(node: any): any { return node.parentNode; }
+  nextSibling(node: any): any { return node.nextSiblibng; }
+  setAttribute(el: any, name: string, value: string): void { return el.setAttribute(name, value); }
+  removeAttribute(el: any, name: string): void { el.removeAttribute(name); }
+  addClass(el: any, name: string): void { el.classList.add(name); }
+  removeClass(el: any, name: string): void { el.classList.remove(name); }
+  setStyle(el: any, style: string, value: any): void { el.style[style] = value; }
+  removeStyle(el: any, style: string): void {
+    // IE requires '' instead of null
+    // see https://github.com/angular/angular/issues/7916
+    (el.style as any)[style] = '';
+  }
+  setProperty(el: any, name: string, value: any): void { el[name] = value; }
+  setText(node: any, value: string): void { node.nodeValue = value; }
+  listen(target: any, eventName: string, callback: (event: any) => boolean): () => void {
+    let renderTarget: any;
+    switch (target) {
+      case 'window':
+        renderTarget = window;
+        break;
+      case 'document':
+        renderTarget = document;
+        break;
+      default:
+        renderTarget = target;
+    }
+    const closure = (event: any) => {
+      if (callback(event) === false) {
+        event.preventDefault();
+      }
+    };
+    renderTarget.addEventListener(eventName, closure);
+    return () => renderTarget.removeEventListener(eventName, closure);
+  }
+}
+
+const EMPTY_V1_RENDER_COMPONENT_TYPE =
+    new v1.RenderComponentType('EMPTY', '', 0, ViewEncapsulation.None, [], {});
+
+/**
+ * A temporal implementation of `Renderer` until we migrated our current renderer
+ * in all packages to the new API.
+ *
+ * Note that this is not complete, e.g. does not support shadow dom, view encapsulation, ...!
+ */
+export class LegacyRendererAdapter implements RendererV2 {
+  private _delegate: v1.Renderer;
+  constructor(rootDelegate: v1.RootRenderer) {
+    this._delegate = rootDelegate.renderComponent(EMPTY_V1_RENDER_COMPONENT_TYPE);
+  }
+  createElement(name: string, debugInfo?: DebugContext): any {
+    return this._delegate.createElement(null, name, debugInfo);
+  }
+  createComment(value: string, debugInfo?: DebugContext): any {
+    return this._delegate.createTemplateAnchor(null, debugInfo);
+  }
+  createText(value: string, debugInfo?: DebugContext): any {
+    return this._delegate.createText(null, value, debugInfo);
+  }
+  appendChild(parent: any, newChild: any): void { this._delegate.projectNodes(parent, [newChild]); }
+  insertBefore(parent: any, newChild: any, refChild: any): void {
+    const beforeSibling = refChild.nextSiblingOf ? refChild.nextSiblingOf : refChild;
+    this._delegate.attachViewAfter(beforeSibling, [newChild]);
+  }
+  removeChild(parent: any, oldChild: any): void {
+    if (parent) {
+      this._delegate.detachView([oldChild]);
+    }
+  }
+  selectRootElement(selectorOrNode: any, debugInfo?: DebugContext): any {
+    return this._delegate.selectRootElement(selectorOrNode, debugInfo);
+  }
+  parentNode(node: any): any { return {parentOf: node}; }
+  nextSibling(node: any): any { return {nextSiblingOf: node}; }
+  setAttribute(el: any, name: string, value: string): void {
+    this._delegate.setElementAttribute(el, name, value);
+  }
+  removeAttribute(el: any, name: string): void {
+    this._delegate.setElementAttribute(el, name, null);
+  }
+  addClass(el: any, name: string): void { this._delegate.setElementClass(el, name, true); }
+  removeClass(el: any, name: string): void { this._delegate.setElementClass(el, name, false); }
+  setStyle(el: any, style: string, value: any): void {
+    this._delegate.setElementStyle(el, style, value);
+  }
+  removeStyle(el: any, style: string): void { this._delegate.setElementStyle(el, style, null); }
+  setProperty(el: any, name: string, value: any): void {
+    this._delegate.setElementProperty(el, name, value);
+  }
+  setText(node: any, value: string): void { this._delegate.setText(node, value); }
+  listen(target: any, eventName: string, callback: (event: any) => boolean): () => void {
+    if (typeof target === 'string') {
+      return <any>this._delegate.listenGlobal(target, eventName, callback);
+    } else {
+      return <any>this._delegate.listen(target, eventName, callback);
+    }
+  }
+}

--- a/modules/@angular/core/src/view/services.ts
+++ b/modules/@angular/core/src/view/services.ts
@@ -1,0 +1,360 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {isDevMode} from '../application_ref';
+import {Injectable, Injector} from '../di';
+import {looseIdentical} from '../facade/lang';
+import {ElementRef} from '../linker/element_ref';
+import * as v1renderer from '../render/api';
+import {Sanitizer, SecurityContext} from '../security';
+import {Type} from '../type';
+
+import {isViewDebugError, viewDestroyedError, viewWrappedDebugError} from './errors';
+import {resolveDep} from './provider';
+import {getQueryValue} from './query';
+import {createInjector} from './refs';
+import {DirectDomRenderer, LegacyRendererAdapter} from './renderer';
+import {ArgumentType, BindingType, DebugContext, DepFlags, ElementData, NodeCheckFn, NodeData, NodeDef, NodeType, RendererV2, RootData, Services, ViewData, ViewDefinition, ViewDefinitionFactory, ViewState, asElementData, asProviderData} from './types';
+import {checkBinding, findElementDef, isComponentView, parentDiIndex, renderNode, resolveViewDefinition, rootRenderNodes} from './util';
+import {checkAndUpdateView, checkNoChangesView, createEmbeddedView, createRootView, destroyView} from './view';
+import {attachEmbeddedView, detachEmbeddedView, moveEmbeddedView} from './view_attach';
+
+let initialized = false;
+
+export function initServicesIfNeeded() {
+  if (initialized) {
+    return;
+  }
+  initialized = true;
+  const services = isDevMode() ? createDebugServices() : createProdServices();
+  Services.setCurrentNode = services.setCurrentNode;
+  Services.createRootView = services.createRootView;
+  Services.createEmbeddedView = services.createEmbeddedView;
+  Services.checkAndUpdateView = services.checkAndUpdateView;
+  Services.checkNoChangesView = services.checkNoChangesView;
+  Services.destroyView = services.destroyView;
+  Services.attachEmbeddedView = services.attachEmbeddedView,
+  Services.detachEmbeddedView = services.detachEmbeddedView,
+  Services.moveEmbeddedView = services.moveEmbeddedView;
+  Services.resolveDep = services.resolveDep;
+  Services.createDebugContext = services.createDebugContext;
+  Services.handleEvent = services.handleEvent;
+  Services.updateView = services.updateView;
+}
+
+function createProdServices() {
+  return {
+    setCurrentNode: () => {},
+    createRootView: createProdRootView,
+    createEmbeddedView: createEmbeddedView,
+    checkAndUpdateView: checkAndUpdateView,
+    checkNoChangesView: checkNoChangesView,
+    destroyView: destroyView,
+    attachEmbeddedView: attachEmbeddedView,
+    detachEmbeddedView: detachEmbeddedView,
+    moveEmbeddedView: moveEmbeddedView,
+    resolveDep: resolveDep,
+    createDebugContext: (view: ViewData, nodeIndex: number) => new DebugContext_(view, nodeIndex),
+    handleEvent: (view: ViewData, nodeIndex: number, eventName: string, event: any) =>
+                     view.def.handleEvent(view, nodeIndex, eventName, event),
+    updateView: (check: NodeCheckFn, view: ViewData) => view.def.update(check, view)
+  };
+}
+
+function createDebugServices() {
+  return {
+    setCurrentNode: debugSetCurrentNode,
+    createRootView: debugCreateRootView,
+    createEmbeddedView: debugCreateEmbeddedView,
+    checkAndUpdateView: debugCheckAndUpdateView,
+    checkNoChangesView: debugCheckNoChangesView,
+    destroyView: debugDestroyView,
+    attachEmbeddedView: attachEmbeddedView,
+    detachEmbeddedView: detachEmbeddedView,
+    moveEmbeddedView: moveEmbeddedView,
+    resolveDep: resolveDep,
+    createDebugContext: (view: ViewData, nodeIndex: number) => new DebugContext_(view, nodeIndex),
+    handleEvent: debugHandleEvent,
+    updateView: debugUpdateView
+  };
+}
+
+function createProdRootView(
+    injector: Injector, projectableNodes: any[][], rootSelectorOrNode: string | any,
+    def: ViewDefinition, context?: any): ViewData {
+  return createRootView(
+      createRootData(injector, projectableNodes, rootSelectorOrNode), def, context);
+}
+
+function debugCreateRootView(
+    injector: Injector, projectableNodes: any[][], rootSelectorOrNode: string | any,
+    def: ViewDefinition, context?: any): ViewData {
+  const root = createRootData(injector, projectableNodes, rootSelectorOrNode);
+  const debugRoot: RootData = {
+    injector: root.injector,
+    projectableNodes: root.projectableNodes,
+    element: root.element,
+    renderer: new DebugRenderer(root.renderer),
+    sanitizer: root.sanitizer
+  };
+  return callWithDebugContext('create', createRootView, null, [debugRoot, def, context]);
+}
+
+function createRootData(
+    injector: Injector, projectableNodes: any[][], rootSelectorOrNode: any): RootData {
+  const sanitizer = injector.get(Sanitizer);
+  // TODO(tbosch): once the new renderer interface is implemented via platform-browser,
+  // just get it via the injector and drop LegacyRendererAdapter and DirectDomRenderer.
+  const renderer = isDevMode() ? new LegacyRendererAdapter(injector.get(v1renderer.RootRenderer)) :
+                                 new DirectDomRenderer();
+  const rootElement =
+      rootSelectorOrNode ? renderer.selectRootElement(rootSelectorOrNode) : undefined;
+  return {injector, projectableNodes, element: rootElement, sanitizer, renderer};
+}
+
+function debugCreateEmbeddedView(parent: ViewData, anchorDef: NodeDef, context?: any): ViewData {
+  return callWithDebugContext('create', createEmbeddedView, null, [parent, anchorDef, context]);
+}
+
+function debugCheckAndUpdateView(view: ViewData) {
+  return callWithDebugContext('detectChanges', checkAndUpdateView, null, [view]);
+}
+
+function debugCheckNoChangesView(view: ViewData) {
+  return callWithDebugContext('checkNoChanges', checkNoChangesView, null, [view]);
+}
+
+function debugDestroyView(view: ViewData) {
+  return callWithDebugContext('destroyView', destroyView, null, [view]);
+}
+
+
+let _currentAction: string;
+let _currentView: ViewData;
+let _currentNodeIndex: number;
+
+function debugSetCurrentNode(view: ViewData, nodeIndex: number) {
+  _currentView = view;
+  _currentNodeIndex = nodeIndex;
+}
+
+function debugHandleEvent(view: ViewData, nodeIndex: number, eventName: string, event: any) {
+  if (view.state & ViewState.Destroyed) {
+    throw viewDestroyedError(_currentAction);
+  }
+  debugSetCurrentNode(view, nodeIndex);
+  return callWithDebugContext(
+      'handleEvent', view.def.handleEvent, null, [view, nodeIndex, eventName, event]);
+}
+
+function debugUpdateView(check: NodeCheckFn, view: ViewData) {
+  if (view.state & ViewState.Destroyed) {
+    throw viewDestroyedError(_currentAction);
+  }
+  debugSetCurrentNode(view, nextNodeIndexWithBinding(view, 0));
+  return view.def.update(debugCheckFn, view);
+
+  function debugCheckFn(
+      view: ViewData, nodeIndex: number, argStyle: ArgumentType, v0?: any, v1?: any, v2?: any,
+      v3?: any, v4?: any, v5?: any, v6?: any, v7?: any, v8?: any, v9?: any) {
+    const values = argStyle === ArgumentType.Dynamic ? v0 : [].slice.call(arguments, 3);
+    const nodeDef = view.def.nodes[nodeIndex];
+    for (let i = 0; i < nodeDef.bindings.length; i++) {
+      const binding = nodeDef.bindings[i];
+      const value = values[i];
+      if ((binding.type === BindingType.ElementProperty ||
+           binding.type === BindingType.ProviderProperty) &&
+          checkBinding(view, nodeDef, i, value)) {
+        const elIndex = nodeDef.type === NodeType.Provider ? nodeDef.parent : nodeDef.index;
+        setBindingDebugInfo(
+            view.root.renderer, asElementData(view, elIndex).renderElement, binding.nonMinifiedName,
+            value);
+      }
+    }
+    const result = check(view, nodeIndex, <any>argStyle, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9);
+
+    debugSetCurrentNode(view, nextNodeIndexWithBinding(view, nodeIndex));
+    return result;
+  };
+}
+
+function setBindingDebugInfo(renderer: RendererV2, renderNode: any, propName: string, value: any) {
+  try {
+    renderer.setAttribute(
+        renderNode, `ng-reflect-${camelCaseToDashCase(propName)}`, value ? value.toString() : null);
+  } catch (e) {
+    renderer.setAttribute(
+        renderNode, `ng-reflect-${camelCaseToDashCase(propName)}`,
+        '[ERROR] Exception while trying to serialize the value');
+  }
+}
+
+const CAMEL_CASE_REGEXP = /([A-Z])/g;
+
+function camelCaseToDashCase(input: string): string {
+  return input.replace(CAMEL_CASE_REGEXP, (...m: any[]) => '-' + m[1].toLowerCase());
+}
+
+function nextNodeIndexWithBinding(view: ViewData, nodeIndex: number): number {
+  for (let i = nodeIndex; i < view.def.nodes.length; i++) {
+    const nodeDef = view.def.nodes[i];
+    if (nodeDef.bindings && nodeDef.bindings.length) {
+      return i;
+    }
+  }
+  return undefined;
+}
+
+
+class DebugRenderer implements RendererV2 {
+  constructor(private _delegate: RendererV2) {}
+  createElement(name: string): any {
+    return this._delegate.createElement(name, getCurrentDebugContext());
+  }
+  createComment(value: string): any {
+    return this._delegate.createComment(value, getCurrentDebugContext());
+  }
+  createText(value: string): any {
+    return this._delegate.createText(value, getCurrentDebugContext());
+  }
+  appendChild(parent: any, newChild: any): void {
+    return this._delegate.appendChild(parent, newChild);
+  }
+  insertBefore(parent: any, newChild: any, refChild: any): void {
+    return this._delegate.insertBefore(parent, newChild, refChild);
+  }
+  removeChild(parent: any, oldChild: any): void {
+    return this._delegate.removeChild(parent, oldChild);
+  }
+  selectRootElement(selectorOrNode: string|any): any {
+    return this._delegate.selectRootElement(selectorOrNode, getCurrentDebugContext());
+  }
+  parentNode(node: any): any { return this._delegate.parentNode(node); }
+  nextSibling(node: any): any { return this._delegate.nextSibling(node); }
+  setAttribute(el: any, name: string, value: string): void {
+    return this._delegate.setAttribute(el, name, value);
+  }
+  removeAttribute(el: any, name: string): void { return this._delegate.removeAttribute(el, name); }
+  addClass(el: any, name: string): void { return this._delegate.addClass(el, name); }
+  removeClass(el: any, name: string): void { return this._delegate.removeClass(el, name); }
+  setStyle(el: any, style: string, value: any): void {
+    return this._delegate.setStyle(el, style, value);
+  }
+  removeStyle(el: any, style: string): void { return this._delegate.removeStyle(el, style); }
+  setProperty(el: any, name: string, value: any): void {
+    return this._delegate.setProperty(el, name, value);
+  }
+  setText(node: any, value: string): void { return this._delegate.setText(node, value); }
+  listen(target: 'window'|'document'|any, eventName: string, callback: (event: any) => boolean):
+      () => void {
+    return this._delegate.listen(target, eventName, callback);
+  }
+}
+
+class DebugContext_ implements DebugContext {
+  private nodeDef: NodeDef;
+  private elDef: NodeDef;
+  constructor(public view: ViewData, public nodeIndex: number) {
+    if (nodeIndex == null) {
+      this.nodeIndex = nodeIndex = view.parentIndex;
+      this.view = view = view.parent;
+    }
+    this.nodeDef = view.def.nodes[nodeIndex];
+    this.elDef = findElementDef(view, nodeIndex);
+  }
+  get injector(): Injector { return createInjector(this.view, this.elDef.index); }
+  get component(): any { return this.view.component; }
+  get providerTokens(): any[] {
+    const tokens: any[] = [];
+    if (this.elDef) {
+      for (let i = this.elDef.index + 1; i <= this.elDef.index + this.elDef.childCount; i++) {
+        const childDef = this.view.def.nodes[i];
+        if (childDef.type === NodeType.Provider) {
+          tokens.push(childDef.provider.token);
+        } else {
+          i += childDef.childCount;
+        }
+      }
+    }
+    return tokens;
+  }
+  get references(): {[key: string]: any} {
+    const references: {[key: string]: any} = {};
+    if (this.elDef) {
+      collectReferences(this.view, this.elDef, references);
+
+      for (let i = this.elDef.index + 1; i <= this.elDef.index + this.elDef.childCount; i++) {
+        const childDef = this.view.def.nodes[i];
+        if (childDef.type === NodeType.Provider) {
+          collectReferences(this.view, childDef, references);
+        } else {
+          i += childDef.childCount;
+        }
+      }
+    }
+    return references;
+  }
+  get context(): any { return this.view.context; }
+  get source(): string {
+    if (this.nodeDef.type === NodeType.Text) {
+      return this.nodeDef.text.source;
+    } else {
+      return this.elDef.element.source;
+    }
+  }
+  get componentRenderElement() {
+    const elData = findHostElement(this.view);
+    return elData ? elData.renderElement : undefined;
+  }
+  get renderNode(): any {
+    let nodeDef = this.nodeDef.type === NodeType.Text ? this.nodeDef : this.elDef;
+    return renderNode(this.view, nodeDef);
+  }
+}
+
+function findHostElement(view: ViewData): ElementData {
+  while (view && !isComponentView(view)) {
+    view = view.parent;
+  }
+  if (view.parent) {
+    const hostData = asElementData(view.parent, view.parentIndex);
+    return hostData;
+  }
+  return undefined;
+}
+
+function collectReferences(view: ViewData, nodeDef: NodeDef, references: {[key: string]: any}) {
+  for (let queryId in nodeDef.matchedQueries) {
+    if (queryId.startsWith('#')) {
+      references[queryId.slice(1)] = getQueryValue(view, nodeDef, queryId);
+    }
+  }
+}
+
+function callWithDebugContext(action: string, fn: any, self: any, args: any[]) {
+  const oldAction = _currentAction;
+  const oldView = _currentView;
+  const oldNodeIndex = _currentNodeIndex;
+  try {
+    _currentAction = action;
+    const result = fn.apply(self, args);
+    _currentView = oldView;
+    _currentNodeIndex = oldNodeIndex;
+    _currentAction = oldAction;
+    return result;
+  } catch (e) {
+    if (isViewDebugError(e) || !_currentView) {
+      throw e;
+    }
+    throw viewWrappedDebugError(e, getCurrentDebugContext());
+  }
+}
+
+function getCurrentDebugContext() {
+  return new DebugContext_(_currentView, _currentNodeIndex);
+}

--- a/modules/@angular/core/src/view/text.ts
+++ b/modules/@angular/core/src/view/text.ts
@@ -9,7 +9,7 @@
 import {isDevMode} from '../application_ref';
 import {looseIdentical} from '../facade/lang';
 
-import {BindingDef, BindingType, DebugContext, NodeData, NodeDef, NodeFlags, NodeType, Refs, RootData, TextData, ViewData, ViewFlags, asElementData, asTextData} from './types';
+import {BindingDef, BindingType, DebugContext, NodeData, NodeDef, NodeFlags, NodeType, RootData, Services, TextData, ViewData, ViewFlags, asElementData, asTextData} from './types';
 import {checkAndUpdateBinding, sliceErrorStack, unwrapValue} from './util';
 
 export function textDef(ngContentIndex: number, constants: string[]): NodeDef {
@@ -53,14 +53,10 @@ export function createText(view: ViewData, renderHost: any, def: NodeDef): TextD
   const parentNode =
       def.parent != null ? asElementData(view, def.parent).renderElement : renderHost;
   let renderNode: any;
-  if (view.renderer) {
-    const debugContext = isDevMode() ? Refs.createDebugContext(view, def.index) : undefined;
-    renderNode = view.renderer.createText(parentNode, def.text.prefix, debugContext);
-  } else {
-    renderNode = document.createTextNode(def.text.prefix);
-    if (parentNode) {
-      parentNode.appendChild(renderNode);
-    }
+  const renderer = view.root.renderer;
+  renderNode = renderer.createText(def.text.prefix);
+  if (parentNode) {
+    renderer.appendChild(parentNode, renderNode);
   }
   return {renderText: renderNode};
 }
@@ -121,11 +117,7 @@ export function checkAndUpdateTextInline(
     }
     value = def.text.prefix + value;
     const renderNode = asTextData(view, def.index).renderText;
-    if (view.renderer) {
-      view.renderer.setText(renderNode, value);
-    } else {
-      renderNode.nodeValue = value;
-    }
+    view.root.renderer.setText(renderNode, value);
   }
 }
 
@@ -146,11 +138,7 @@ export function checkAndUpdateTextDynamic(view: ViewData, def: NodeDef, values: 
     }
     value = def.text.prefix + value;
     const renderNode = asTextData(view, def.index).renderText;
-    if (view.renderer) {
-      view.renderer.setText(renderNode, value);
-    } else {
-      renderNode.nodeValue = value;
-    }
+    view.root.renderer.setText(renderNode, value);
   }
 }
 

--- a/modules/@angular/core/src/view/view_attach.ts
+++ b/modules/@angular/core/src/view/view_attach.ts
@@ -83,27 +83,16 @@ export function moveEmbeddedView(
 function renderAttachEmbeddedView(elementData: ElementData, prevView: ViewData, view: ViewData) {
   const prevRenderNode =
       prevView ? renderNode(prevView, prevView.def.lastRootNode) : elementData.renderElement;
-  if (view.renderer) {
-    view.renderer.attachViewAfter(prevRenderNode, rootRenderNodes(view));
-  } else {
-    const parentNode = prevRenderNode.parentNode;
-    const nextSibling = prevRenderNode.nextSibling;
-    if (parentNode) {
-      const action = nextSibling ? RenderNodeAction.InsertBefore : RenderNodeAction.AppendChild;
-      visitRootRenderNodes(view, action, parentNode, nextSibling, undefined);
-    }
-  }
+  const parentNode = view.root.renderer.parentNode(prevRenderNode);
+  const nextSibling = view.root.renderer.nextSibling(prevRenderNode);
+  // Note: We can't check if `nextSibling` is present, as on WebWorkers it will always be!
+  // However, browsers automatically do `appendChild` when there is no `nextSibling`.
+  visitRootRenderNodes(view, RenderNodeAction.InsertBefore, parentNode, nextSibling, undefined);
 }
 
 function renderDetachEmbeddedView(elementData: ElementData, view: ViewData) {
-  if (view.renderer) {
-    view.renderer.detachView(rootRenderNodes(view));
-  } else {
-    const parentNode = elementData.renderElement.parentNode;
-    if (parentNode) {
-      visitRootRenderNodes(view, RenderNodeAction.RemoveChild, parentNode, null, undefined);
-    }
-  }
+  const parentNode = view.root.renderer.parentNode(elementData.renderElement);
+  visitRootRenderNodes(view, RenderNodeAction.RemoveChild, parentNode, null, undefined);
 }
 
 function addToArray(arr: any[], index: number, value: any) {

--- a/modules/@angular/core/test/view/anchor_spec.ts
+++ b/modules/@angular/core/test/view/anchor_spec.ts
@@ -7,40 +7,22 @@
  */
 
 import {Injector, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation, getDebugNode} from '@angular/core';
-import {DebugContext, NodeDef, NodeFlags, RootData, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createRootView, elementDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
+import {DebugContext, NodeDef, NodeFlags, RootData, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, elementDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
 import {inject} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
-import {createRootData, isBrowser, setupAndCheckRenderer} from './helper';
+import {createRootView, isBrowser} from './helper';
 
 export function main() {
-  if (isBrowser()) {
-    defineTests({directDom: true, viewFlags: ViewFlags.DirectDom});
-  }
-  defineTests({directDom: false, viewFlags: 0});
-}
-
-function defineTests(config: {directDom: boolean, viewFlags: number}) {
-  describe(`View Anchor, directDom: ${config.directDom}`, () => {
-    setupAndCheckRenderer(config);
-
-    let rootData: RootData;
-    let renderComponentType: RenderComponentType;
-
-    beforeEach(() => {
-      rootData = createRootData();
-      renderComponentType =
-          new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
-    });
-
+  describe(`View Anchor`, () => {
     function compViewDef(
         nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn): ViewDefinition {
-      return viewDef(config.viewFlags, nodes, update, handleEvent, renderComponentType);
+      return viewDef(ViewFlags.None, nodes, update, handleEvent);
     }
 
     function createAndGetRootNodes(
         viewDef: ViewDefinition, ctx?: any): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(rootData, viewDef, ctx);
+      const view = createRootView(viewDef, ctx);
       const rootNodes = rootRenderNodes(view);
       return {rootNodes, view};
     }
@@ -69,14 +51,12 @@ function defineTests(config: {directDom: boolean, viewFlags: number}) {
         expect(getDOM().childNodes(rootNodes[0]).length).toBe(1);
       });
 
-      if (!config.directDom) {
-        it('should add debug information to the renderer', () => {
-          const someContext = new Object();
-          const {view, rootNodes} = createAndGetRootNodes(
-              compViewDef([anchorDef(NodeFlags.None, null, null, 0)]), someContext);
-          expect(getDebugNode(rootNodes[0]).nativeNode).toBe(asElementData(view, 0).renderElement);
-        });
-      }
+      it('should add debug information to the renderer', () => {
+        const someContext = new Object();
+        const {view, rootNodes} = createAndGetRootNodes(
+            compViewDef([anchorDef(NodeFlags.None, null, null, 0)]), someContext);
+        expect(getDebugNode(rootNodes[0]).nativeNode).toBe(asElementData(view, 0).renderElement);
+      });
     });
   });
 }

--- a/modules/@angular/core/test/view/helper.ts
+++ b/modules/@angular/core/test/view/helper.ts
@@ -7,7 +7,7 @@
  */
 
 import {Injector, RootRenderer, Sanitizer} from '@angular/core';
-import {RootData, checkNodeDynamic, checkNodeInline} from '@angular/core/src/view/index';
+import {ArgumentType, NodeCheckFn, RootData, Services, ViewData, ViewDefinition, initServicesIfNeeded} from '@angular/core/src/view/index';
 import {TestBed} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
@@ -15,53 +15,25 @@ export function isBrowser() {
   return getDOM().supportsDOMEvents();
 }
 
-export function setupAndCheckRenderer(config: {directDom: boolean}) {
-  let rootRenderer: any;
-  if (config.directDom) {
-    beforeEach(() => {
-      rootRenderer = <any>{
-        renderComponent: jasmine.createSpy('renderComponent')
-                             .and.throwError('Renderer should not have been called!')
-      };
-      TestBed.configureTestingModule(
-          {providers: [{provide: RootRenderer, useValue: rootRenderer}]});
-    });
-    afterEach(() => { expect(rootRenderer.renderComponent).not.toHaveBeenCalled(); });
-  } else {
-    beforeEach(() => {
-      rootRenderer = TestBed.get(RootRenderer);
-      spyOn(rootRenderer, 'renderComponent').and.callThrough();
-    });
-    afterEach(() => { expect(rootRenderer.renderComponent).toHaveBeenCalled(); });
+export const ARG_TYPE_VALUES = [ArgumentType.Inline, ArgumentType.Dynamic];
+
+export function checkNodeInlineOrDynamic(
+    check: NodeCheckFn, view: ViewData, nodeIndex: number, argType: ArgumentType,
+    values: any[]): any {
+  switch (argType) {
+    case ArgumentType.Inline:
+      return (<any>check)(view, nodeIndex, argType, ...values);
+    case ArgumentType.Dynamic:
+      return check(view, nodeIndex, argType, values);
   }
 }
 
-export enum InlineDynamic {
-  Inline,
-  Dynamic
-}
-
-export const INLINE_DYNAMIC_VALUES = [InlineDynamic.Inline, InlineDynamic.Dynamic];
-
-export function checkNodeInlineOrDynamic(inlineDynamic: InlineDynamic, values: any[]): any {
-  switch (inlineDynamic) {
-    case InlineDynamic.Inline:
-      return (<any>checkNodeInline)(...values);
-    case InlineDynamic.Dynamic:
-      return checkNodeDynamic(values);
-  }
-}
-
-export function createRootData(projectableNodes?: any[][], rootSelectorOrNode?: any): RootData {
-  const injector = TestBed.get(Injector);
-  const renderer = injector.get(RootRenderer);
-  const sanitizer = injector.get(Sanitizer);
-  projectableNodes = projectableNodes || [];
-  return <RootData>{
-    injector,
-    projectableNodes,
-    selectorOrNode: rootSelectorOrNode, sanitizer, renderer
-  };
+export function createRootView(
+    def: ViewDefinition, context?: any, projectableNodes?: any[][],
+    rootSelectorOrNode?: any): ViewData {
+  initServicesIfNeeded();
+  return Services.createRootView(
+      TestBed.get(Injector), projectableNodes || [], rootSelectorOrNode, def, context);
 }
 
 export let removeNodes: Node[];

--- a/modules/@angular/core/test/view/pure_expression_spec.ts
+++ b/modules/@angular/core/test/view/pure_expression_spec.ts
@@ -7,29 +7,21 @@
  */
 
 import {Injector, PipeTransform, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation, WrappedValue} from '@angular/core';
-import {NodeDef, NodeFlags, RootData, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asProviderData, asPureExpressionData, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createRootView, directiveDef, elementDef, pureArrayDef, pureObjectDef, purePipeDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
+import {ArgumentType, NodeDef, NodeFlags, RootData, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asProviderData, asPureExpressionData, directiveDef, elementDef, pureArrayDef, pureObjectDef, purePipeDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
 import {inject} from '@angular/core/testing';
 
-import {INLINE_DYNAMIC_VALUES, InlineDynamic, checkNodeInlineOrDynamic, createRootData} from './helper';
+import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, createRootView} from './helper';
 
 export function main() {
   describe(`View Pure Expressions`, () => {
-    let rootData: RootData;
-    let renderComponentType: RenderComponentType;
-
-    beforeEach(() => {
-      rootData = createRootData();
-      renderComponentType =
-          new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
-    });
-
     function compViewDef(
-        nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn): ViewDefinition {
-      return viewDef(ViewFlags.None, nodes, update, handleEvent, renderComponentType);
+        nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn,
+        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
+      return viewDef(viewFlags, nodes, update, handleEvent);
     }
 
     function createAndGetRootNodes(viewDef: ViewDefinition): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(rootData, viewDef);
+      const view = createRootView(viewDef);
       const rootNodes = rootRenderNodes(view);
       return {rootNodes, view};
     }
@@ -40,8 +32,8 @@ export function main() {
 
     describe('pure arrays', () => {
 
-      INLINE_DYNAMIC_VALUES.forEach((inlineDynamic) => {
-        it(`should support ${InlineDynamic[inlineDynamic]} bindings`, () => {
+      ARG_TYPE_VALUES.forEach((inlineDynamic) => {
+        it(`should support ${ArgumentType[inlineDynamic]} bindings`, () => {
           let values: any[];
 
           const {view, rootNodes} = createAndGetRootNodes(compViewDef(
@@ -49,55 +41,52 @@ export function main() {
                 elementDef(NodeFlags.None, null, null, 2, 'span'), pureArrayDef(2),
                 directiveDef(NodeFlags.None, null, 0, Service, [], {data: [0, 'data']})
               ],
-              (view) => {
-                setCurrentNode(view, 1);
-                const pureValue = checkNodeInlineOrDynamic(inlineDynamic, values);
-                setCurrentNode(view, 2);
-                checkNodeInlineOrDynamic(inlineDynamic, [pureValue]);
+              (check, view) => {
+                const pureValue = checkNodeInlineOrDynamic(check, view, 1, inlineDynamic, values);
+                checkNodeInlineOrDynamic(check, view, 2, inlineDynamic, [pureValue]);
               }));
           const service = asProviderData(view, 2).instance;
 
           values = [1, 2];
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           const arr0 = service.data;
           expect(arr0).toEqual([1, 2]);
 
           // instance should not change
           // if the values don't change
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           expect(service.data).toBe(arr0);
 
           values = [3, 2];
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           const arr1 = service.data;
           expect(arr1).not.toBe(arr0);
           expect(arr1).toEqual([3, 2]);
         });
 
-        it(`should unwrap values with ${InlineDynamic[inlineDynamic]}`, () => {
+        it(`should unwrap values with ${ArgumentType[inlineDynamic]}`, () => {
           let bindingValue: any;
           const {view, rootNodes} = createAndGetRootNodes(compViewDef(
               [
                 elementDef(NodeFlags.None, null, null, 1, 'span'),
                 pureArrayDef(1),
               ],
-              (view) => {
-                setCurrentNode(view, 1);
-                checkNodeInlineOrDynamic(inlineDynamic, [bindingValue]);
+              (check, view) => {
+                checkNodeInlineOrDynamic(check, view, 1, inlineDynamic, [bindingValue]);
               }));
 
           const exprData = asPureExpressionData(view, 1);
 
           bindingValue = 'v1';
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           const v1Arr = exprData.value;
           expect(v1Arr).toEqual(['v1']);
 
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           expect(exprData.value).toBe(v1Arr);
 
           bindingValue = WrappedValue.wrap('v1');
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           expect(exprData.value).not.toBe(v1Arr);
           expect(exprData.value).toEqual(['v1']);
         });
@@ -106,8 +95,8 @@ export function main() {
     });
 
     describe('pure objects', () => {
-      INLINE_DYNAMIC_VALUES.forEach((inlineDynamic) => {
-        it(`should support ${InlineDynamic[inlineDynamic]} bindings`, () => {
+      ARG_TYPE_VALUES.forEach((inlineDynamic) => {
+        it(`should support ${ArgumentType[inlineDynamic]} bindings`, () => {
           let values: any[];
 
           const {view, rootNodes} = createAndGetRootNodes(compViewDef(
@@ -115,55 +104,52 @@ export function main() {
                 elementDef(NodeFlags.None, null, null, 2, 'span'), pureObjectDef(['a', 'b']),
                 directiveDef(NodeFlags.None, null, 0, Service, [], {data: [0, 'data']})
               ],
-              (view) => {
-                setCurrentNode(view, 1);
-                const pureValue = checkNodeInlineOrDynamic(inlineDynamic, values);
-                setCurrentNode(view, 2);
-                checkNodeInlineOrDynamic(inlineDynamic, [pureValue]);
+              (check, view) => {
+                const pureValue = checkNodeInlineOrDynamic(check, view, 1, inlineDynamic, values);
+                checkNodeInlineOrDynamic(check, view, 2, inlineDynamic, [pureValue]);
               }));
           const service = asProviderData(view, 2).instance;
 
           values = [1, 2];
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           const obj0 = service.data;
           expect(obj0).toEqual({a: 1, b: 2});
 
           // instance should not change
           // if the values don't change
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           expect(service.data).toBe(obj0);
 
           values = [3, 2];
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           const obj1 = service.data;
           expect(obj1).not.toBe(obj0);
           expect(obj1).toEqual({a: 3, b: 2});
         });
 
-        it(`should unwrap values with ${InlineDynamic[inlineDynamic]}`, () => {
+        it(`should unwrap values with ${ArgumentType[inlineDynamic]}`, () => {
           let bindingValue: any;
           const {view, rootNodes} = createAndGetRootNodes(compViewDef(
               [
                 elementDef(NodeFlags.None, null, null, 1, 'span'),
                 pureObjectDef(['a']),
               ],
-              (view) => {
-                setCurrentNode(view, 1);
-                checkNodeInlineOrDynamic(inlineDynamic, [bindingValue]);
+              (check, view) => {
+                checkNodeInlineOrDynamic(check, view, 1, inlineDynamic, [bindingValue]);
               }));
 
           const exprData = asPureExpressionData(view, 1);
 
           bindingValue = 'v1';
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           const v1Obj = exprData.value;
           expect(v1Obj).toEqual({'a': 'v1'});
 
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           expect(exprData.value).toBe(v1Obj);
 
           bindingValue = WrappedValue.wrap('v1');
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           expect(exprData.value).not.toBe(v1Obj);
           expect(exprData.value).toEqual({'a': 'v1'});
         });
@@ -171,8 +157,8 @@ export function main() {
     });
 
     describe('pure pipes', () => {
-      INLINE_DYNAMIC_VALUES.forEach((inlineDynamic) => {
-        it(`should support ${InlineDynamic[inlineDynamic]} bindings`, () => {
+      ARG_TYPE_VALUES.forEach((inlineDynamic) => {
+        it(`should support ${ArgumentType[inlineDynamic]} bindings`, () => {
           class SomePipe implements PipeTransform {
             transform(v1: any, v2: any) { return [v1 + 10, v2 + 20]; }
           }
@@ -185,32 +171,30 @@ export function main() {
                 directiveDef(NodeFlags.None, null, 0, SomePipe, []), purePipeDef(SomePipe, 2),
                 directiveDef(NodeFlags.None, null, 0, Service, [], {data: [0, 'data']})
               ],
-              (view) => {
-                setCurrentNode(view, 2);
-                const pureValue = checkNodeInlineOrDynamic(inlineDynamic, values);
-                setCurrentNode(view, 3);
-                checkNodeInlineOrDynamic(inlineDynamic, [pureValue]);
+              (check, view) => {
+                const pureValue = checkNodeInlineOrDynamic(check, view, 2, inlineDynamic, values);
+                checkNodeInlineOrDynamic(check, view, 3, inlineDynamic, [pureValue]);
               }));
           const service = asProviderData(view, 3).instance;
 
           values = [1, 2];
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           const obj0 = service.data;
           expect(obj0).toEqual([11, 22]);
 
           // instance should not change
           // if the values don't change
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           expect(service.data).toBe(obj0);
 
           values = [3, 2];
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           const obj1 = service.data;
           expect(obj1).not.toBe(obj0);
           expect(obj1).toEqual([13, 22]);
         });
 
-        it(`should unwrap values with ${InlineDynamic[inlineDynamic]}`, () => {
+        it(`should unwrap values with ${ArgumentType[inlineDynamic]}`, () => {
           let bindingValue: any;
           let transformSpy = jasmine.createSpy('transform');
 
@@ -224,21 +208,20 @@ export function main() {
                 directiveDef(NodeFlags.None, null, 0, SomePipe, []),
                 purePipeDef(SomePipe, 1),
               ],
-              (view) => {
-                setCurrentNode(view, 2);
-                checkNodeInlineOrDynamic(inlineDynamic, [bindingValue]);
+              (check, view) => {
+                checkNodeInlineOrDynamic(check, view, 2, inlineDynamic, [bindingValue]);
               }));
 
           bindingValue = 'v1';
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           expect(transformSpy).toHaveBeenCalledWith('v1');
 
           transformSpy.calls.reset();
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           expect(transformSpy).not.toHaveBeenCalled();
 
           bindingValue = WrappedValue.wrap('v1');
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
           expect(transformSpy).toHaveBeenCalledWith('v1');
         });
       });

--- a/modules/@angular/core/test/view/query_spec.ts
+++ b/modules/@angular/core/test/view/query_spec.ts
@@ -8,26 +8,18 @@
 
 import {ElementRef, Injector, QueryList, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, TemplateRef, ViewContainerRef, ViewEncapsulation, getDebugNode} from '@angular/core';
 import {getDebugContext} from '@angular/core/src/errors';
-import {BindingType, DebugContext, NodeDef, NodeFlags, QueryBindingType, QueryValueType, RootData, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, asProviderData, attachEmbeddedView, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createEmbeddedView, createRootView, destroyView, detachEmbeddedView, directiveDef, elementDef, queryDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
+import {BindingType, DebugContext, NodeDef, NodeFlags, QueryBindingType, QueryValueType, RootData, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, asProviderData, attachEmbeddedView, detachEmbeddedView, directiveDef, elementDef, queryDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
 import {inject} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
-import {createRootData} from './helper';
+import {createRootView} from './helper';
 
 export function main() {
   describe(`Query Views`, () => {
-    let rootData: RootData;
-    let renderComponentType: RenderComponentType;
-
-    beforeEach(() => {
-      rootData = createRootData();
-      renderComponentType =
-          new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
-    });
-
     function compViewDef(
-        nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn): ViewDefinition {
-      return viewDef(ViewFlags.None, nodes, update, handleEvent, renderComponentType);
+        nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn,
+        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
+      return viewDef(viewFlags, nodes, update, handleEvent);
     }
 
     function embeddedViewDef(nodes: NodeDef[], update?: ViewUpdateFn): ViewDefinition {
@@ -36,7 +28,7 @@ export function main() {
 
     function createAndGetRootNodes(
         viewDef: ViewDefinition, context: any = null): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(rootData, viewDef, context);
+      const view = createRootView(viewDef, context);
       const rootNodes = rootRenderNodes(view);
       return {rootNodes, view};
     }
@@ -79,7 +71,7 @@ export function main() {
         const qs: QueryService = asProviderData(view, 1).instance;
         expect(qs.a).toBeUndefined();
 
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         const as = qs.a.toArray();
         expect(as.length).toBe(2);
@@ -97,7 +89,7 @@ export function main() {
           aServiceProvider(),
         ]));
 
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         const qs: QueryService = asProviderData(view, 3).instance;
         expect(qs.a.length).toBe(0);
@@ -114,7 +106,7 @@ export function main() {
           ])),
         ]));
 
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         const comp: QueryService = asProviderData(view, 1).instance;
         const compView = asProviderData(view, 1).componentView;
@@ -131,7 +123,7 @@ export function main() {
           aServiceProvider(),
         ]));
 
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
         const comp: QueryService = asProviderData(view, 1).instance;
         expect(comp.a.length).toBe(0);
       });
@@ -153,9 +145,9 @@ export function main() {
           ...contentQueryProviders(),
         ]));
 
-        const childView = createEmbeddedView(view, view.def.nodes[3]);
+        const childView = Services.createEmbeddedView(view, view.def.nodes[3]);
         attachEmbeddedView(asElementData(view, 3), 0, childView);
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         // queries on parent elements of anchors
         const qs1: QueryService = asProviderData(view, 1).instance;
@@ -185,11 +177,11 @@ export function main() {
           anchorDef(NodeFlags.HasEmbeddedViews, null, null, 0),
         ]));
 
-        const childView = createEmbeddedView(view, view.def.nodes[3]);
+        const childView = Services.createEmbeddedView(view, view.def.nodes[3]);
         // attach at a different place than the one where the template was defined
         attachEmbeddedView(asElementData(view, 7), 0, childView);
 
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         // query on the declaration place
         const qs1: QueryService = asProviderData(view, 1).instance;
@@ -215,19 +207,19 @@ export function main() {
                   ])),
         ]));
 
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         const qs: QueryService = asProviderData(view, 1).instance;
         expect(qs.a.length).toBe(0);
 
-        const childView = createEmbeddedView(view, view.def.nodes[3]);
+        const childView = Services.createEmbeddedView(view, view.def.nodes[3]);
         attachEmbeddedView(asElementData(view, 3), 0, childView);
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         expect(qs.a.length).toBe(1);
 
         detachEmbeddedView(asElementData(view, 3), 0);
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         expect(qs.a.length).toBe(0);
       });
@@ -247,20 +239,20 @@ export function main() {
           ])),
         ]));
 
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         const comp: QueryService = asProviderData(view, 1).instance;
         expect(comp.a.length).toBe(0);
 
         const compView = asProviderData(view, 1).componentView;
-        const childView = createEmbeddedView(compView, compView.def.nodes[0]);
+        const childView = Services.createEmbeddedView(compView, compView.def.nodes[0]);
         attachEmbeddedView(asElementData(compView, 0), 0, childView);
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         expect(comp.a.length).toBe(1);
 
         detachEmbeddedView(asElementData(compView, 0), 0);
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         expect(comp.a.length).toBe(0);
       });
@@ -280,7 +272,7 @@ export function main() {
           aServiceProvider(),
         ]));
 
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         const qs: QueryService = asProviderData(view, 1).instance;
         expect(qs.a instanceof QueryList).toBeTruthy();
@@ -303,7 +295,7 @@ export function main() {
           aServiceProvider(),
         ]));
 
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         const qs: QueryService = asProviderData(view, 1).instance;
         expect(qs.a).toBe(asProviderData(view, 3).instance);
@@ -322,7 +314,7 @@ export function main() {
           queryDef(NodeFlags.HasContentQuery, 'query1', {'a': QueryBindingType.First}),
         ]));
 
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         const qs: QueryService = asProviderData(view, 1).instance;
         expect(qs.a.nativeElement).toBe(asElementData(view, 0).renderElement);
@@ -341,7 +333,7 @@ export function main() {
           queryDef(NodeFlags.HasContentQuery, 'query1', {'a': QueryBindingType.First}),
         ]));
 
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         const qs: QueryService = asProviderData(view, 1).instance;
         expect(qs.a.createEmbeddedView).toBeTruthy();
@@ -358,7 +350,7 @@ export function main() {
           queryDef(NodeFlags.HasContentQuery, 'query1', {'a': QueryBindingType.First}),
         ]));
 
-        checkAndUpdateView(view);
+        Services.checkAndUpdateView(view);
 
         const qs: QueryService = asProviderData(view, 1).instance;
         expect(qs.a.createEmbeddedView).toBeTruthy();
@@ -380,22 +372,22 @@ export function main() {
                   ])),
         ]));
 
-        checkAndUpdateView(view);
-        checkNoChangesView(view);
+        Services.checkAndUpdateView(view);
+        Services.checkNoChangesView(view);
 
-        const childView = createEmbeddedView(view, view.def.nodes[3]);
+        const childView = Services.createEmbeddedView(view, view.def.nodes[3]);
         attachEmbeddedView(asElementData(view, 3), 0, childView);
 
         let err: any;
         try {
-          checkNoChangesView(view);
+          Services.checkNoChangesView(view);
         } catch (e) {
           err = e;
         }
         expect(err).toBeTruthy();
         expect(err.message)
             .toBe(
-                `Expression has changed after it was checked. Previous value: 'Query query1 not dirty'. Current value: 'Query query1 dirty'.`);
+                `ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked. Previous value: 'Query query1 not dirty'. Current value: 'Query query1 dirty'.`);
         const debugCtx = getDebugContext(err);
         expect(debugCtx.view).toBe(view);
         expect(debugCtx.nodeIndex).toBe(2);
@@ -416,7 +408,7 @@ export function main() {
 
         let err: any;
         try {
-          checkAndUpdateView(view);
+          Services.checkAndUpdateView(view);
         } catch (e) {
           err = e;
         }

--- a/modules/@angular/core/test/view/services_spec.ts
+++ b/modules/@angular/core/test/view/services_spec.ts
@@ -7,31 +7,23 @@
  */
 
 import {Injector, RenderComponentType, RootRenderer, Sanitizer, SecurityContext, ViewEncapsulation, getDebugNode} from '@angular/core';
-import {DebugContext, NodeDef, NodeFlags, QueryValueType, Refs, RootData, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, asProviderData, asTextData, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, createRootView, directiveDef, elementDef, rootRenderNodes, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
+import {DebugContext, NodeDef, NodeFlags, QueryValueType, RootData, Services, ViewData, ViewDefinition, ViewFlags, ViewHandleEventFn, ViewUpdateFn, anchorDef, asElementData, asProviderData, asTextData, directiveDef, elementDef, rootRenderNodes, textDef, viewDef} from '@angular/core/src/view/index';
 import {inject} from '@angular/core/testing';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 
-import {createRootData, isBrowser, setupAndCheckRenderer} from './helper';
+import {createRootView, isBrowser} from './helper';
 
 export function main() {
-  describe('View References', () => {
-    let rootData: RootData;
-    let renderComponentType: RenderComponentType;
-
-    beforeEach(() => {
-      rootData = createRootData();
-      renderComponentType =
-          new RenderComponentType('1', 'someUrl', 0, ViewEncapsulation.None, [], {});
-    });
-
+  describe('View Services', () => {
     function compViewDef(
-        nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn): ViewDefinition {
-      return viewDef(ViewFlags.None, nodes, update, handleEvent, renderComponentType);
+        nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn,
+        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
+      return viewDef(viewFlags, nodes, update, handleEvent);
     }
 
     function createAndGetRootNodes(
         viewDef: ViewDefinition, context: any = null): {rootNodes: any[], view: ViewData} {
-      const view = createRootView(rootData, viewDef, context);
+      const view = createRootView(viewDef, context);
       const rootNodes = rootRenderNodes(view);
       return {rootNodes, view};
     }
@@ -58,7 +50,7 @@ export function main() {
         const view = createViewWithData();
         const compView = asProviderData(view, 1).componentView;
 
-        const debugCtx = Refs.createDebugContext(compView, 0);
+        const debugCtx = Services.createDebugContext(compView, 0);
 
         expect(debugCtx.componentRenderElement).toBe(asElementData(view, 0).renderElement);
         expect(debugCtx.renderNode).toBe(asElementData(compView, 0).renderElement);
@@ -75,7 +67,7 @@ export function main() {
         const view = createViewWithData();
         const compView = asProviderData(view, 1).componentView;
 
-        const debugCtx = Refs.createDebugContext(compView, 2);
+        const debugCtx = Services.createDebugContext(compView, 2);
 
         expect(debugCtx.componentRenderElement).toBe(asElementData(view, 0).renderElement);
         expect(debugCtx.renderNode).toBe(asTextData(compView, 2).renderText);
@@ -89,7 +81,7 @@ export function main() {
         const view = createViewWithData();
         const compView = asProviderData(view, 1).componentView;
 
-        const debugCtx = Refs.createDebugContext(compView, 1);
+        const debugCtx = Services.createDebugContext(compView, 1);
 
         expect(debugCtx.renderNode).toBe(asElementData(compView, 0).renderElement);
       });

--- a/modules/@angular/core/test/view/view_def_spec.ts
+++ b/modules/@angular/core/test/view/view_def_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NodeFlags, QueryValueType, ViewData, ViewDefinition, ViewFlags, anchorDef, checkAndUpdateView, checkNoChangesView, checkNodeDynamic, checkNodeInline, directiveDef, elementDef, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
+import {NodeFlags, QueryValueType, ViewData, ViewDefinition, ViewFlags, anchorDef, directiveDef, elementDef, textDef, viewDef} from '@angular/core/src/view/index';
 
 export function main() {
   describe('viewDef', () => {

--- a/modules/benchmarks/src/tree/ng2_next/tree.ts
+++ b/modules/benchmarks/src/tree/ng2_next/tree.ts
@@ -8,7 +8,7 @@
 
 import {NgIf} from '@angular/common';
 import {Component, ComponentFactory, ComponentRef, Injector, NgModule, RootRenderer, Sanitizer, TemplateRef, ViewContainerRef, ViewEncapsulation} from '@angular/core';
-import {BindingType, NodeFlags, ViewData, ViewDefinition, ViewFlags, anchorDef, checkNodeInline, createComponentFactory, directiveDef, elementDef, setCurrentNode, textDef, viewDef} from '@angular/core/src/view/index';
+import {ArgumentType, BindingType, NodeFlags, ViewData, ViewDefinition, ViewFlags, anchorDef, createComponentFactory, directiveDef, elementDef, initServicesIfNeeded, textDef, viewDef} from '@angular/core/src/view/index';
 import {DomSanitizerImpl, SafeStyle} from '@angular/platform-browser/src/security/dom_sanitization_service';
 
 import {TreeNode, emptyTree} from '../util';
@@ -21,7 +21,7 @@ export class TreeComponent {
   get bgColor() { return this.data.depth % 2 ? trustedEmptyColor : trustedGreyColor; }
 }
 
-let viewFlags = ViewFlags.DirectDom;
+let viewFlags = ViewFlags.None;
 
 function TreeComponent_Host(): ViewDefinition {
   return viewDef(viewFlags, [
@@ -38,10 +38,9 @@ function TreeComponent_0(): ViewDefinition {
         directiveDef(
             NodeFlags.None, null, 0, TreeComponent, [], {data: [0, 'data']}, null, TreeComponent_0),
       ],
-      (view: ViewData) => {
+      (check, view) => {
         const cmp = view.component;
-        setCurrentNode(view, 1);
-        checkNodeInline(cmp.data.left);
+        check(view, 1, ArgumentType.Inline, cmp.data.left);
       });
 
   const TreeComponent_2: ViewDefinition = viewDef(
@@ -51,10 +50,9 @@ function TreeComponent_0(): ViewDefinition {
         directiveDef(
             NodeFlags.None, null, 0, TreeComponent, [], {data: [0, 'data']}, null, TreeComponent_0),
       ],
-      (view: ViewData) => {
+      (check, view) => {
         const cmp = view.component;
-        setCurrentNode(view, 1);
-        checkNodeInline(cmp.data.right);
+        check(view, 1, ArgumentType.Inline, cmp.data.left);
       });
 
   return viewDef(
@@ -71,16 +69,12 @@ function TreeComponent_0(): ViewDefinition {
         directiveDef(
             NodeFlags.None, null, 0, NgIf, [ViewContainerRef, TemplateRef], {ngIf: [0, 'ngIf']}),
       ],
-      (view: ViewData) => {
+      (check, view) => {
         const cmp = view.component;
-        setCurrentNode(view, 0);
-        checkNodeInline(cmp.bgColor);
-        setCurrentNode(view, 1);
-        checkNodeInline(cmp.data.value);
-        setCurrentNode(view, 3);
-        checkNodeInline(cmp.data.left != null);
-        setCurrentNode(view, 5);
-        checkNodeInline(cmp.data.right != null);
+        check(view, 0, ArgumentType.Inline, cmp.bgColor);
+        check(view, 1, ArgumentType.Inline, cmp.data.value);
+        check(view, 3, ArgumentType.Inline, cmp.data.left != null);
+        check(view, 5, ArgumentType.Inline, cmp.data.right != null);
       });
 }
 
@@ -90,10 +84,11 @@ export class AppModule implements Injector {
   componentRef: ComponentRef<TreeComponent>;
 
   constructor() {
+    initServicesIfNeeded();
     this.sanitizer = new DomSanitizerImpl();
     trustedEmptyColor = this.sanitizer.bypassSecurityTrustStyle('');
     trustedGreyColor = this.sanitizer.bypassSecurityTrustStyle('grey');
-    this.componentFactory = createComponentFactory('#root', TreeComponent_Host);
+    this.componentFactory = createComponentFactory('#root', TreeComponent, TreeComponent_Host);
   }
 
   get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND): any {
@@ -106,6 +101,8 @@ export class AppModule implements Injector {
     return Injector.NULL.get(token, notFoundValue);
   }
 
-  bootstrap() { this.componentRef = this.componentFactory.create(this); }
+  bootstrap() {
+    this.componentRef = this.componentFactory.create(this, [], this.componentFactory.selector);
+  }
   tick() { this.componentRef.changeDetectorRef.detectChanges(); }
 }

--- a/modules/benchmarks/src/util.ts
+++ b/modules/benchmarks/src/util.ts
@@ -41,22 +41,9 @@ export function bindAction(selector: string, callback: () => void) {
 
 export function profile(create: () => void, destroy: () => void, name: string) {
   return function() {
-    window.console.profile(name + ' w GC');
+    window.console.profile(name);
     let duration = 0;
     let count = 0;
-    while (count++ < 150) {
-      (<any>window)['gc']();
-      const start = window.performance.now();
-      create();
-      duration += window.performance.now() - start;
-      destroy();
-    }
-    window.console.profileEnd();
-    window.console.log(`Iterations: ${count}; time: ${duration / count} ms / iteration`);
-
-    window.console.profile(name + ' w/o GC');
-    duration = 0;
-    count = 0;
     while (count++ < 150) {
       const start = window.performance.now();
       create();


### PR DESCRIPTION
- Make sure `NodeDef`s don’t fall into dictionary mode.
- Use strategy pattern to add debug information / checks, instead of constantly checking for `isDevMode`.
- introduce a very light weight `RendererV2` interface to not have duplicate
  code paths for direct and non direct rendering

The strategy pattern is implemented via the new `Services` object.

Part of #14013
