### PR TITLE
test(aio): remove unnecessary hack from e2e tests

### DIFF
--- a/aio/e2e/app.e2e-spec.ts
+++ b/aio/e2e/app.e2e-spec.ts
@@ -3,34 +3,20 @@ import { SitePage } from './app.po';
 describe('site App', function() {
   let page: SitePage;
 
-  beforeAll(done => {
-    // Hack:  CI has been failing on first test so
-    // buying time by giving the browser a wake-up call.
-    // Todo:  Find and fix the root cause for flakes.
-    new SitePage().navigateTo().then(done);
-  });
-
   beforeEach(() => {
     page = new SitePage();
+    page.navigateTo();
   });
 
   it('should show features text after clicking "Features"', () => {
-    page.navigateTo()
-      .then(() => {
-        return page.featureLink.click();
-      })
-      .then(() => {
-        expect(page.getDocViewerText()).toContain('Progressive web apps');
-      });
+    page.featureLink.click().then(() => {
+      expect(page.getDocViewerText()).toContain('Progressive web apps');
+    });
   });
 
   it('should convert code-example in pipe.html', () => {
-    page.navigateTo()
-      .then(() => {
-        return page.datePipeLink.click();
-      })
-      .then(() => {
-        expect(page.codeExample.count()).toBeGreaterThan(0, 'should have code-example content');
-      });
+    page.datePipeLink.click().then(() => {
+      expect(page.codeExample.count()).toBeGreaterThan(0, 'should have code-example content');
+    });
   });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Test related changes
```

**What is the current behavior?** (You can also link to an open issue here)
Hack to warm up browser before running the actual e2e tests.
Flakey-ness.


**What is the new behavior?**
No hack to warm up browser before running the actual e2e tests.
(Hopefully) No flakey-ness.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```


**Other information**:
My theory is that the flake (that made the "warm-up" hack necessary) was related to the use of `fetch()` and the fact that `Zone` does not have a task scheduled, while `fetch()` is fetching stuff. Now that we use `Http` (which at the moment relies on `XMLHttpRequest`), `Zone` is aware of the pending task and as a result `Testability` does not prematurely report as stable to protractor.

The "warm-up" hack was added in #14294 with [6ac593d][1] (before switching to `Http`) and the switch to `Http` happened with [48393a0][2] (as part of the same PR, but _after_ having added the "warm-up" hack). 

[1]: https://github.com/angular/angular/pull/14294/commits/6ac593d38e76f9f1123abfeb4780e0227f47eed2
[2]: https://github.com/angular/angular/pull/14294/commits/48393a0eeef07b4fff0e0cad0dda1523037cef13

So it all adds up. Yay! :confetti_ball: