### PR TITLE
feat(common): added typed overloaded for `AsyncPipe.transform()`

### DIFF
--- a/modules/@angular/common/src/pipes/async_pipe.ts
+++ b/modules/@angular/common/src/pipes/async_pipe.ts
@@ -82,6 +82,9 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
     }
   }
 
+  transform<T>(obj: Observable<T>): T|null;
+  transform<T>(obj: Promise<T>): T|null;
+  transform<T>(obj: EventEmitter<T>): T|null;
   transform(obj: Observable<any>|Promise<any>|EventEmitter<any>): any {
     if (!this._obj) {
       if (obj) {
@@ -93,7 +96,7 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
 
     if (obj !== this._obj) {
       this._dispose();
-      return this.transform(obj);
+      return this.transform(obj as any);
     }
 
     if (this._latestValue === this._latestReturnedValue) {

--- a/tools/public_api_guard/common/index.d.ts
+++ b/tools/public_api_guard/common/index.d.ts
@@ -5,7 +5,9 @@ export declare const APP_BASE_HREF: InjectionToken<string>;
 export declare class AsyncPipe implements OnDestroy, PipeTransform {
     constructor(_ref: ChangeDetectorRef);
     ngOnDestroy(): void;
-    transform(obj: Observable<any> | Promise<any> | EventEmitter<any>): any;
+    transform<T>(obj: EventEmitter<T>): T | null;
+    transform<T>(obj: Promise<T>): T | null;
+    transform<T>(obj: Observable<T>): T | null;
 }
 
 /** @stable */


### PR DESCRIPTION
BREAKING CHANGE: Classes that derive from `AsyncPipe` and override
`transform()` might not compile correctly. Use of  `async` pipe in
templates is unaffected.

Mitigation: Update derived classes of `AsyncPipe` that override
`transform()` to include the type parameter overloads.

Related to #12398

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Feature
```

**What is the current behavior?** (You can also link to an open issue here)

The type of `AsyncPipe.transform()` is `any` for which no type information can be inferred.

**What is the new behavior?**

The type of `AsyncPipe.transform()` can be used to infer the type of the result from the event, promise or observable the transform is used to simplify. 

**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

See the commit message.

