### PR TITLE
build(integration): fix tests

### DIFF
--- a/integration/hello_world__closure/package.json
+++ b/integration/hello_world__closure/package.json
@@ -23,7 +23,7 @@
     "protractor": "file:../../node_modules/protractor"
   },
   "scripts": {
-    "test": "ngc && ./bundle.sh && concurrently \"npm run serve\" \"npm run protractor\" --kill-others --success first",
+    "test": "ngc && ./bundle.sh && concurrently \"PATH=$PATH yarn run serve\" \"PATH=$PATH yarn run protractor\" --kill-others --success first",
     "serve": "lite-server -c e2e/browser.config.json",
     "preprotractor": "tsc -p e2e",
     "protractor": "protractor e2e/protractor.config.js"

--- a/integration/run_tests.sh
+++ b/integration/run_tests.sh
@@ -18,7 +18,7 @@ for testDir in $(ls | grep -v rxjs | grep -v node_modules) ; do
     cd $testDir
     # Workaround for https://github.com/yarnpkg/yarn/issues/2256
     rm -f yarn.lock
-    ../../node_modules/.bin/yarn
-    ../../node_modules/.bin/yarn test || exit 1
+    yarn
+    yarn test || exit 1
   )
 done

--- a/scripts/ci-lite/build.sh
+++ b/scripts/ci-lite/build.sh
@@ -19,6 +19,17 @@ node dist/tools/@angular/tsc-wrapped/src/main -p modules/@angular/platform-brows
 node dist/tools/@angular/tsc-wrapped/src/main -p modules/@angular/router/tsconfig-build.json
 node dist/tools/@angular/tsc-wrapped/src/main -p modules/@angular/forms/tsconfig-build.json
 
+if [[ ${CI_MODE} == "e2e" ]]; then
+  echo 'travis_fold:start:BUILD.integration'
+
+  # Build integration
+  cd "`dirname $0`/../../integration"
+  ./build_rxjs_es6.sh
+  cd -
+
+  echo 'travis_fold:end:BUILD.integration'
+fi
+
 if [[ ${CI_MODE} == "aio" ]]; then
   echo 'travis_fold:start:BUILD.aio'
 

--- a/scripts/ci-lite/install.sh
+++ b/scripts/ci-lite/install.sh
@@ -32,21 +32,21 @@ node tools/npm/check-node-modules --purge || npm install
 echo 'travis_fold:end:install.node_modules'
 
 
-if [[ ${TRAVIS} && ${CI_MODE} == "aio" ]]; then
-
-  # angular.io: Install version of yarn that we are locked against
-  echo 'travis_fold:start:install.aio.yarn'
+if [[ ${TRAVIS} && (${CI_MODE} == "e2e" || ${CI_MODE} == "aio") ]]; then
+  # Install version of yarn that we are locked against
+  echo 'travis_fold:start:install.yarn'
   curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version "${YARN_VERSION}"
-  echo 'travis_fold:end:install.aio.yarn'
+  echo 'travis_fold:end:install.yarn'
+fi
 
 
+if [[ ${TRAVIS} && ${CI_MODE} == "aio" ]]; then
   # angular.io: Install all yarn dependencies according to angular.io/yarn.lock
   echo 'travis_fold:start:install.aio.node_modules'
   cd "`dirname $0`/../../angular.io"
   yarn install
   cd -
   echo 'travis_fold:end:install.aio.node_modules'
-
 fi
 
 

--- a/scripts/ci-lite/test_e2e.sh
+++ b/scripts/ci-lite/test_e2e.sh
@@ -7,7 +7,7 @@ if [[ ${TRAVIS} && ${CI_MODE} != "e2e" ]]; then
 fi
 
 
-echo 'travis_fold:start:test.js'
+echo 'travis_fold:start:test.e2e'
 
 # Setup environment
 cd `dirname $0`
@@ -15,26 +15,32 @@ source ./env.sh
 cd ../..
 
 
-echo 'travis_fold:start:test.buildPackages'
-
+echo 'travis_fold:start:test.e2e.buildPackages'
 ./build.sh
+echo 'travis_fold:end:test.e2e.buildPackages'
 
-echo 'travis_fold:end:test.buildPackages'
 
 if [[ ${TRAVIS} ]]; then
+  echo 'travis_fold:start:test.e2e.localChrome'
   sh -e /etc/init.d/xvfb start
+  echo 'travis_fold:end:test.e2e.localChrome'
 fi
 
-./integration/build_rxjs_es6.sh
+
+echo 'travis_fold:start:test.e2e.integration'
 ./integration/run_tests.sh
 #TODO(alexeagle): move offline_compiler_test to integration/
 ./scripts/ci-lite/offline_compiler_test.sh
+echo 'travis_fold:end:test.e2e.integration'
 
+
+echo 'travis_fold:start:test.e2e.apiAndCircularDeps'
 $(npm bin)/gulp public-api:enforce
-
 $(npm bin)/gulp check-cycle
+echo 'travis_fold:end:test.e2e.apiAndCircularDeps'
 
-echo 'travis_fold:start:test.e2e.localChrome'
+
+echo 'travis_fold:start:test.e2e.protractor'
 cd dist/
 $(npm bin)/gulp serve &
 $(npm bin)/gulp serve-examples &
@@ -42,9 +48,10 @@ cd ..
 NODE_PATH=$NODE_PATH:./dist/all $(npm bin)/protractor ./protractor-e2e.conf.js --bundles=true
 NODE_PATH=$NODE_PATH:./dist/all $(npm bin)/protractor ./protractor-examples-e2e.conf.js --bundles=true
 NODE_PATH=$NODE_PATH:./dist/all $(npm bin)/protractor ./protractor-perf.conf.js --bundles=true --dryrun
-echo 'travis_fold:end:test.e2e.localChrome'
+echo 'travis_fold:end:test.e2e.protractor'
 
-echo 'travis_fold:end:test.js'
+echo 'travis_fold:end:test.e2e'
+
 
 if [[ ${TRAVIS} ]]; then
   ./scripts/publish/publish-build-artifacts.sh


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The `integration/` tests are failing, because `concurrently "foo"` does not inherit the `PATH` env var ([more info][1]).


**What is the new behavior?**
The `integration/` tests pass, by setting the `PATH` env var explicitly: `concurrently "PATH=$PATH foo"`.
(There might be a better long-term solution, but this seem to work for now.)


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```


**Other information**:
This commit also includes some minor refactoring of the `integration/` tests scripts:
- Move build-related operations to `ci-lite/build.sh` (for consistency).
- Use `yarn run ...` instead of `npm run ...` inside package.json scripts.
- Use global `yarn` (since we are already using it for `aio/`).
- Fix some `travis_fold` statements.

[1]: https://github.com/kimmobrunfeldt/concurrently/issues/61#issuecomment-252081610