### PR TITLE
build: pin versions in integration/*/package.json

### DIFF
--- a/integration/hello_world__closure/package.json
+++ b/integration/hello_world__closure/package.json
@@ -10,20 +10,19 @@
     "@angular/platform-browser": "file:../../dist/packages-dist-es2015/platform-browser",
     "@angular/platform-server": "file:../../dist/packages-dist-es2015/platform-server",
     "@angular/tsc-wrapped": "file:../../dist/tools/@angular/tsc-wrapped",
-    "google-closure-compiler": "^20161201.0.0",
+    "google-closure-compiler": "20161201.0.0",
     "rxjs": "file:../../node_modules/rxjs",
-    "source-map-explorer": "^1.3.3",
-    "typescript": "~2.1",
-    "zone.js": "^0.7.6"
+    "typescript": "2.1.6",
+    "zone.js": "0.7.6"
   },
   "devDependencies": {
-    "@types/jasmine": "^2.5.41",
-    "concurrently": "^3.1.0",
-    "lite-server": "^2.2.2",
+    "@types/jasmine": "2.5.41",
+    "concurrently": "3.1.0",
+    "lite-server": "2.2.2",
     "protractor": "file:../../node_modules/protractor"
   },
   "scripts": {
-    "test": "ngc && ./bundle.sh && concurrently \"PATH=$PATH yarn run serve\" \"PATH=$PATH yarn run protractor\" --kill-others --success first",
+    "test": "ngc && ./bundle.sh && concurrently \"yarn run serve\" \"yarn run protractor\" --kill-others --success first",
     "serve": "lite-server -c e2e/browser.config.json",
     "preprotractor": "tsc -p e2e",
     "protractor": "protractor e2e/protractor.config.js"

--- a/integration/typings_test_ts21/package.json
+++ b/integration/typings_test_ts21/package.json
@@ -15,11 +15,10 @@
     "@angular/router": "file:../../dist/packages-dist/router",
     "@angular/tsc-wrapped": "file:../../dist/tools/@angular/tsc-wrapped",
     "@angular/upgrade": "file:../../dist/packages-dist/upgrade",
-    "@types/jasmine": "^2.5.41",
+    "@types/jasmine": "2.5.41",
     "rxjs": "file:../../node_modules/rxjs",
-    "source-map-explorer": "^1.3.3",
-    "typescript": "~2.1",
-    "zone.js": "^0.7.6"
+    "typescript": "2.1.6",
+    "zone.js": "0.7.6"
   },
   "scripts": {
     "test": "tsc"


### PR DESCRIPTION
Floating versions can break our CI. This happened with concurrently release last evening.
Ideally we should just check in the yarn.lock file but are blocked on https://github.com/yarnpkg/yarn/issues/2256

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

/cc @IgorMinar 