### PR TITLE
feat(compiler): generate shallow imports for compiler generated references

### DIFF
--- a/modules/@angular/compiler-cli/src/compiler_host.ts
+++ b/modules/@angular/compiler-cli/src/compiler_host.ts
@@ -18,6 +18,7 @@ const NODE_MODULES = '/node_modules/';
 const IS_GENERATED = /\.(ngfactory|ngstyle)$/;
 const GENERATED_FILES = /\.ngfactory\.ts$|\.ngstyle\.ts$/;
 const GENERATED_OR_DTS_FILES = /\.d\.ts$|\.ngfactory\.ts$|\.ngstyle\.ts$/;
+const SHALLOW_IMPORT = /^(\w+|(\@\w+\/\w+))$/;
 
 export interface CompilerHostContext extends ts.ModuleResolutionHost {
   readResource(fileName: string): Promise<string>;
@@ -132,6 +133,9 @@ export class CompilerHost implements AotCompilerHost {
         if (!this.isGenDirChildOfRootDir) {
           // assume that they are on top of each other.
           importedFile = importedFile.replace(this.basePath, this.genDir);
+        }
+        if (SHALLOW_IMPORT.test(importedFile)) {
+          return importedFile;
         }
         return this.dotRelative(containingDir, importedFile);
       }

--- a/modules/@angular/compiler/src/aot/static_reflection_capabilities.ts
+++ b/modules/@angular/compiler/src/aot/static_reflection_capabilities.ts
@@ -42,8 +42,8 @@ export class StaticAndDynamicReflectionCapabilities {
   setter(name: string): SetterFn { return this.dynamicDelegate.setter(name); }
   method(name: string): MethodFn { return this.dynamicDelegate.method(name); }
   importUri(type: any): string { return this.staticDelegate.importUri(type); }
-  resolveIdentifier(name: string, moduleUrl: string, runtime: any) {
-    return this.staticDelegate.resolveIdentifier(name, moduleUrl);
+  resolveIdentifier(name: string, moduleUrl: string, members: string[], runtime: any) {
+    return this.staticDelegate.resolveIdentifier(name, moduleUrl, members);
   }
   resolveEnum(enumIdentifier: any, name: string): any {
     if (isStaticType(enumIdentifier)) {

--- a/modules/@angular/compiler/src/aot/static_reflector.ts
+++ b/modules/@angular/compiler/src/aot/static_reflector.ts
@@ -57,8 +57,16 @@ export class StaticReflector implements ReflectorReader {
     return staticSymbol ? staticSymbol.filePath : null;
   }
 
-  resolveIdentifier(name: string, moduleUrl: string): StaticSymbol {
-    return this.findDeclaration(moduleUrl, name);
+  resolveIdentifier(name: string, moduleUrl: string, members: string[]): StaticSymbol {
+    const importSymbol = this.getStaticSymbol(moduleUrl, name);
+    const rootSymbol = this.findDeclaration(moduleUrl, name);
+    if (importSymbol != rootSymbol) {
+      this.symbolResolver.recordImportAs(rootSymbol, importSymbol);
+    }
+    if (members && members.length) {
+      return this.getStaticSymbol(rootSymbol.filePath, rootSymbol.name, members);
+    }
+    return rootSymbol;
   }
 
   findDeclaration(moduleUrl: string, name: string, containingFile?: string): StaticSymbol {
@@ -77,7 +85,8 @@ export class StaticReflector implements ReflectorReader {
 
   resolveEnum(enumIdentifier: any, name: string): any {
     const staticSymbol: StaticSymbol = enumIdentifier;
-    return this.getStaticSymbol(staticSymbol.filePath, staticSymbol.name, [name]);
+    const members = (staticSymbol.members || []).concat(name);
+    return this.getStaticSymbol(staticSymbol.filePath, staticSymbol.name, members);
   }
 
   public annotations(type: StaticSymbol): any[] {

--- a/modules/@angular/compiler/src/aot/static_symbol_resolver.ts
+++ b/modules/@angular/compiler/src/aot/static_symbol_resolver.ts
@@ -127,6 +127,12 @@ export class StaticSymbolResolver {
     return (resolvedSymbol && resolvedSymbol.metadata && resolvedSymbol.metadata.arity) || null;
   }
 
+  recordImportAs(sourceSymbol: StaticSymbol, targetSymbol: StaticSymbol) {
+    sourceSymbol.assertNoMembers();
+    targetSymbol.assertNoMembers();
+    this.importAs.set(sourceSymbol, targetSymbol);
+  }
+
   private _resolveSymbolMembers(staticSymbol: StaticSymbol): ResolvedStaticSymbol {
     const members = staticSymbol.members;
     const baseResolvedSymbol =

--- a/modules/@angular/compiler/src/identifiers.ts
+++ b/modules/@angular/compiler/src/identifiers.ts
@@ -6,448 +6,392 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ANALYZE_FOR_ENTRY_COMPONENTS, ChangeDetectionStrategy, ChangeDetectorRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, ElementRef, Injector, LOCALE_ID, NgModuleFactory, QueryList, RenderComponentType, Renderer, SecurityContext, SimpleChange, TRANSLATIONS_FORMAT, TemplateRef, ViewContainerRef, ViewEncapsulation} from '@angular/core';
+import {ANALYZE_FOR_ENTRY_COMPONENTS, ChangeDetectionStrategy, ChangeDetectorRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, ElementRef, Injector, LOCALE_ID, NgModuleFactory, QueryList, RenderComponentType, Renderer, SecurityContext, SimpleChange, TRANSLATIONS_FORMAT, TemplateRef, ViewContainerRef, ViewEncapsulation, ɵAnimationGroupPlayer, ɵAnimationKeyframe, ɵAnimationSequencePlayer, ɵAnimationStyles, ɵAnimationTransition, ɵAppView, ɵChangeDetectorStatus, ɵCodegenComponentFactoryResolver, ɵComponentRef_, ɵDebugAppView, ɵDebugContext, ɵNgModuleInjector, ɵNoOpAnimationPlayer, ɵStaticNodeDebugInfo, ɵTemplateRef_, ɵValueUnwrapper, ɵViewContainer, ɵViewType, ɵbalanceAnimationKeyframes, ɵclearStyles, ɵcollectAndResolveStyles, ɵdevModeEqual, ɵprepareFinalAnimationStyles, ɵreflector, ɵregisterModuleFactory, ɵrenderStyles, ɵviewEngine, ɵview_utils} from '@angular/core';
 
 import {CompileIdentifierMetadata, CompileTokenMetadata} from './compile_metadata';
-import {AnimationGroupPlayer, AnimationKeyframe, AnimationSequencePlayer, AnimationStyles, AnimationTransition, AppView, ChangeDetectorStatus, CodegenComponentFactoryResolver, ComponentRef_, DebugAppView, DebugContext, NgModuleInjector, NoOpAnimationPlayer, StaticNodeDebugInfo, TemplateRef_, ValueUnwrapper, ViewContainer, ViewType, balanceAnimationKeyframes, clearStyles, collectAndResolveStyles, devModeEqual, prepareFinalAnimationStyles, reflector, registerModuleFactory, renderStyles, viewEngine, view_utils} from './private_import_core';
 
-const APP_VIEW_MODULE_URL = assetUrl('core', 'linker/view');
+const CORE = assetUrl('core');
 const VIEW_UTILS_MODULE_URL = assetUrl('core', 'linker/view_utils');
-const VIEW_ENGINE_MODULE_URL = assetUrl('core', 'view/index');
-const CD_MODULE_URL = assetUrl('core', 'change_detection/change_detection');
-
-const ANIMATION_STYLE_UTIL_ASSET_URL = assetUrl('core', 'animation/animation_style_util');
 
 export interface IdentifierSpec {
   name: string;
   moduleUrl: string;
+  member?: string;
   runtime: any;
 }
 
 export class Identifiers {
   static ANALYZE_FOR_ENTRY_COMPONENTS: IdentifierSpec = {
     name: 'ANALYZE_FOR_ENTRY_COMPONENTS',
-    moduleUrl: assetUrl('core', 'metadata/di'),
+    moduleUrl: CORE,
     runtime: ANALYZE_FOR_ENTRY_COMPONENTS
   };
-  static ViewUtils: IdentifierSpec = {
-    name: 'ViewUtils',
-    moduleUrl: assetUrl('core', 'linker/view_utils'),
-    runtime: view_utils.ViewUtils
-  };
-  static AppView:
-      IdentifierSpec = {name: 'AppView', moduleUrl: APP_VIEW_MODULE_URL, runtime: AppView};
-  static DebugAppView: IdentifierSpec = {
-    name: 'DebugAppView',
-    moduleUrl: APP_VIEW_MODULE_URL,
-    runtime: DebugAppView
-  };
-  static ViewContainer: IdentifierSpec = {
-    name: 'ViewContainer',
-    moduleUrl: assetUrl('core', 'linker/view_container'),
-    runtime: ViewContainer
-  };
-  static ElementRef: IdentifierSpec = {
-    name: 'ElementRef',
-    moduleUrl: assetUrl('core', 'linker/element_ref'),
-    runtime: ElementRef
-  };
-  static ViewContainerRef: IdentifierSpec = {
-    name: 'ViewContainerRef',
-    moduleUrl: assetUrl('core', 'linker/view_container_ref'),
-    runtime: ViewContainerRef
-  };
-  static ChangeDetectorRef: IdentifierSpec = {
-    name: 'ChangeDetectorRef',
-    moduleUrl: assetUrl('core', 'change_detection/change_detector_ref'),
-    runtime: ChangeDetectorRef
-  };
-  static RenderComponentType: IdentifierSpec = {
-    name: 'RenderComponentType',
-    moduleUrl: assetUrl('core', 'render/api'),
-    runtime: RenderComponentType
-  };
-  static QueryList: IdentifierSpec = {
-    name: 'QueryList',
-    moduleUrl: assetUrl('core', 'linker/query_list'),
-    runtime: QueryList
-  };
-  static TemplateRef: IdentifierSpec = {
-    name: 'TemplateRef',
-    moduleUrl: assetUrl('core', 'linker/template_ref'),
-    runtime: TemplateRef
-  };
-  static TemplateRef_: IdentifierSpec = {
-    name: 'TemplateRef_',
-    moduleUrl: assetUrl('core', 'linker/template_ref'),
-    runtime: TemplateRef_
-  };
+  static ViewUtils: IdentifierSpec =
+      {name: 'ɵview_utils', moduleUrl: CORE, member: 'ViewUtils', runtime: ɵview_utils.ViewUtils};
+  static AppView: IdentifierSpec = {name: 'ɵAppView', moduleUrl: CORE, runtime: ɵAppView};
+  static DebugAppView:
+      IdentifierSpec = {name: 'ɵDebugAppView', moduleUrl: CORE, runtime: ɵDebugAppView};
+  static ViewContainer:
+      IdentifierSpec = {name: 'ɵViewContainer', moduleUrl: CORE, runtime: ɵViewContainer};
+  static ElementRef: IdentifierSpec = {name: 'ElementRef', moduleUrl: CORE, runtime: ElementRef};
+  static ViewContainerRef:
+      IdentifierSpec = {name: 'ViewContainerRef', moduleUrl: CORE, runtime: ViewContainerRef};
+  static ChangeDetectorRef:
+      IdentifierSpec = {name: 'ChangeDetectorRef', moduleUrl: CORE, runtime: ChangeDetectorRef};
+  static RenderComponentType:
+      IdentifierSpec = {name: 'RenderComponentType', moduleUrl: CORE, runtime: RenderComponentType};
+  static QueryList: IdentifierSpec = {name: 'QueryList', moduleUrl: CORE, runtime: QueryList};
+  static TemplateRef: IdentifierSpec = {name: 'TemplateRef', moduleUrl: CORE, runtime: TemplateRef};
+  static TemplateRef_:
+      IdentifierSpec = {name: 'ɵTemplateRef_', moduleUrl: CORE, runtime: ɵTemplateRef_};
   static CodegenComponentFactoryResolver: IdentifierSpec = {
-    name: 'CodegenComponentFactoryResolver',
-    moduleUrl: assetUrl('core', 'linker/component_factory_resolver'),
-    runtime: CodegenComponentFactoryResolver
+    name: 'ɵCodegenComponentFactoryResolver',
+    moduleUrl: CORE,
+    runtime: ɵCodegenComponentFactoryResolver
   };
   static ComponentFactoryResolver: IdentifierSpec = {
     name: 'ComponentFactoryResolver',
-    moduleUrl: assetUrl('core', 'linker/component_factory_resolver'),
+    moduleUrl: CORE,
     runtime: ComponentFactoryResolver
   };
-  static ComponentFactory: IdentifierSpec = {
-    name: 'ComponentFactory',
-    runtime: ComponentFactory,
-    moduleUrl: assetUrl('core', 'linker/component_factory')
-  };
+  static ComponentFactory:
+      IdentifierSpec = {name: 'ComponentFactory', moduleUrl: CORE, runtime: ComponentFactory};
   static ComponentRef_: IdentifierSpec = {
-    name: 'ComponentRef_',
-    runtime: ComponentRef_,
-    moduleUrl: assetUrl('core', 'linker/component_factory')
+    name: 'ɵComponentRef_',
+    moduleUrl: CORE,
+    runtime: ɵComponentRef_,
   };
-  static ComponentRef: IdentifierSpec = {
-    name: 'ComponentRef',
-    runtime: ComponentRef,
-    moduleUrl: assetUrl('core', 'linker/component_factory')
-  };
-  static NgModuleFactory: IdentifierSpec = {
-    name: 'NgModuleFactory',
-    runtime: NgModuleFactory,
-    moduleUrl: assetUrl('core', 'linker/ng_module_factory')
-  };
+  static ComponentRef:
+      IdentifierSpec = {name: 'ComponentRef', moduleUrl: CORE, runtime: ComponentRef};
+  static NgModuleFactory:
+      IdentifierSpec = {name: 'NgModuleFactory', moduleUrl: CORE, runtime: NgModuleFactory};
   static NgModuleInjector: IdentifierSpec = {
-    name: 'NgModuleInjector',
-    runtime: NgModuleInjector,
-    moduleUrl: assetUrl('core', 'linker/ng_module_factory')
+    name: 'ɵNgModuleInjector',
+    moduleUrl: CORE,
+    runtime: ɵNgModuleInjector,
   };
   static RegisterModuleFactoryFn: IdentifierSpec = {
-    name: 'registerModuleFactory',
-    runtime: registerModuleFactory,
-    moduleUrl: assetUrl('core', 'linker/ng_module_factory_loader')
+    name: 'ɵregisterModuleFactory',
+    moduleUrl: CORE,
+    runtime: ɵregisterModuleFactory,
   };
   static ValueUnwrapper:
-      IdentifierSpec = {name: 'ValueUnwrapper', moduleUrl: CD_MODULE_URL, runtime: ValueUnwrapper};
-  static Injector: IdentifierSpec = {
-    name: 'Injector',
-    moduleUrl: assetUrl('core', 'di/injector'),
-    runtime: Injector
-  };
-  static ViewEncapsulation: IdentifierSpec = {
-    name: 'ViewEncapsulation',
-    moduleUrl: assetUrl('core', 'metadata/view'),
-    runtime: ViewEncapsulation
-  };
-  static ViewType: IdentifierSpec = {
-    name: 'ViewType',
-    moduleUrl: assetUrl('core', 'linker/view_type'),
-    runtime: ViewType
-  };
+      IdentifierSpec = {name: 'ɵValueUnwrapper', moduleUrl: CORE, runtime: ɵValueUnwrapper};
+  static Injector: IdentifierSpec = {name: 'Injector', moduleUrl: CORE, runtime: Injector};
+  static ViewEncapsulation:
+      IdentifierSpec = {name: 'ViewEncapsulation', moduleUrl: CORE, runtime: ViewEncapsulation};
+  static ViewType: IdentifierSpec = {name: 'ɵViewType', moduleUrl: CORE, runtime: ɵViewType};
   static ChangeDetectionStrategy: IdentifierSpec = {
     name: 'ChangeDetectionStrategy',
-    moduleUrl: CD_MODULE_URL,
+    moduleUrl: CORE,
     runtime: ChangeDetectionStrategy
   };
   static StaticNodeDebugInfo: IdentifierSpec = {
-    name: 'StaticNodeDebugInfo',
-    moduleUrl: assetUrl('core', 'linker/debug_context'),
-    runtime: StaticNodeDebugInfo
+    name: 'ɵStaticNodeDebugInfo',
+    moduleUrl: CORE,
+    runtime: ɵStaticNodeDebugInfo
   };
-  static DebugContext: IdentifierSpec = {
-    name: 'DebugContext',
-    moduleUrl: assetUrl('core', 'linker/debug_context'),
-    runtime: DebugContext
-  };
-  static Renderer: IdentifierSpec = {
-    name: 'Renderer',
-    moduleUrl: assetUrl('core', 'render/api'),
-    runtime: Renderer
-  };
+  static DebugContext:
+      IdentifierSpec = {name: 'ɵDebugContext', moduleUrl: CORE, runtime: ɵDebugContext};
+  static Renderer: IdentifierSpec = {name: 'Renderer', moduleUrl: CORE, runtime: Renderer};
   static SimpleChange:
-      IdentifierSpec = {name: 'SimpleChange', moduleUrl: CD_MODULE_URL, runtime: SimpleChange};
+      IdentifierSpec = {name: 'SimpleChange', moduleUrl: CORE, runtime: SimpleChange};
   static ChangeDetectorStatus: IdentifierSpec = {
-    name: 'ChangeDetectorStatus',
-    moduleUrl: CD_MODULE_URL,
-    runtime: ChangeDetectorStatus
+    name: 'ɵChangeDetectorStatus',
+    moduleUrl: CORE,
+    runtime: ɵChangeDetectorStatus
   };
   static checkBinding: IdentifierSpec = {
-    name: 'checkBinding',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.checkBinding
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'checkBinding',
+    runtime: ɵview_utils.checkBinding
   };
   static checkBindingChange: IdentifierSpec = {
-    name: 'checkBindingChange',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.checkBindingChange
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'checkBindingChange',
+    runtime: ɵview_utils.checkBindingChange
   };
   static checkRenderText: IdentifierSpec = {
-    name: 'checkRenderText',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.checkRenderText
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'checkRenderText',
+    runtime: ɵview_utils.checkRenderText
   };
   static checkRenderProperty: IdentifierSpec = {
-    name: 'checkRenderProperty',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.checkRenderProperty
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'checkRenderProperty',
+    runtime: ɵview_utils.checkRenderProperty
   };
   static checkRenderAttribute: IdentifierSpec = {
-    name: 'checkRenderAttribute',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.checkRenderAttribute
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'checkRenderAttribute',
+    runtime: ɵview_utils.checkRenderAttribute
   };
   static checkRenderClass: IdentifierSpec = {
-    name: 'checkRenderClass',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.checkRenderClass
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'checkRenderClass',
+    runtime: ɵview_utils.checkRenderClass
   };
   static checkRenderStyle: IdentifierSpec = {
-    name: 'checkRenderStyle',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.checkRenderStyle
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'checkRenderStyle',
+    runtime: ɵview_utils.checkRenderStyle
   };
   static devModeEqual:
-      IdentifierSpec = {name: 'devModeEqual', moduleUrl: CD_MODULE_URL, runtime: devModeEqual};
+      IdentifierSpec = {name: 'ɵdevModeEqual', moduleUrl: CORE, runtime: ɵdevModeEqual};
   static inlineInterpolate: IdentifierSpec = {
-    name: 'inlineInterpolate',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.inlineInterpolate
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'inlineInterpolate',
+    runtime: ɵview_utils.inlineInterpolate
   };
   static interpolate: IdentifierSpec = {
-    name: 'interpolate',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.interpolate
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'interpolate',
+    runtime: ɵview_utils.interpolate
   };
   static castByValue: IdentifierSpec = {
-    name: 'castByValue',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.castByValue
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'castByValue',
+    runtime: ɵview_utils.castByValue
   };
   static EMPTY_ARRAY: IdentifierSpec = {
-    name: 'EMPTY_ARRAY',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.EMPTY_ARRAY
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'EMPTY_ARRAY',
+    runtime: ɵview_utils.EMPTY_ARRAY
   };
-  static EMPTY_MAP: IdentifierSpec = {
-    name: 'EMPTY_MAP',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.EMPTY_MAP
-  };
+  static EMPTY_MAP: IdentifierSpec =
+      {name: 'ɵview_utils', moduleUrl: CORE, member: 'EMPTY_MAP', runtime: ɵview_utils.EMPTY_MAP};
   static createRenderElement: IdentifierSpec = {
-    name: 'createRenderElement',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.createRenderElement
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'createRenderElement',
+    runtime: ɵview_utils.createRenderElement
   };
   static selectOrCreateRenderHostElement: IdentifierSpec = {
-    name: 'selectOrCreateRenderHostElement',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.selectOrCreateRenderHostElement
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'selectOrCreateRenderHostElement',
+    runtime: ɵview_utils.selectOrCreateRenderHostElement
   };
   static pureProxies: IdentifierSpec[] = [
     null,
-    {name: 'pureProxy1', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.pureProxy1},
-    {name: 'pureProxy2', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.pureProxy2},
-    {name: 'pureProxy3', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.pureProxy3},
-    {name: 'pureProxy4', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.pureProxy4},
-    {name: 'pureProxy5', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.pureProxy5},
-    {name: 'pureProxy6', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.pureProxy6},
-    {name: 'pureProxy7', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.pureProxy7},
-    {name: 'pureProxy8', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.pureProxy8},
-    {name: 'pureProxy9', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.pureProxy9},
-    {name: 'pureProxy10', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.pureProxy10},
+    {name: 'ɵview_utils', moduleUrl: CORE, member: 'pureProxy1', runtime: ɵview_utils.pureProxy1},
+    {name: 'ɵview_utils', moduleUrl: CORE, member: 'pureProxy2', runtime: ɵview_utils.pureProxy2},
+    {name: 'ɵview_utils', moduleUrl: CORE, member: 'pureProxy3', runtime: ɵview_utils.pureProxy3},
+    {name: 'ɵview_utils', moduleUrl: CORE, member: 'pureProxy4', runtime: ɵview_utils.pureProxy4},
+    {name: 'ɵview_utils', moduleUrl: CORE, member: 'pureProxy5', runtime: ɵview_utils.pureProxy5},
+    {name: 'ɵview_utils', moduleUrl: CORE, member: 'pureProxy6', runtime: ɵview_utils.pureProxy6},
+    {name: 'ɵview_utils', moduleUrl: CORE, member: 'pureProxy7', runtime: ɵview_utils.pureProxy7},
+    {name: 'ɵview_utils', moduleUrl: CORE, member: 'pureProxy8', runtime: ɵview_utils.pureProxy8},
+    {name: 'ɵview_utils', moduleUrl: CORE, member: 'pureProxy9', runtime: ɵview_utils.pureProxy9},
+    {name: 'ɵview_utils', moduleUrl: CORE, member: 'pureProxy10', runtime: ɵview_utils.pureProxy10},
   ];
   static SecurityContext: IdentifierSpec = {
     name: 'SecurityContext',
-    moduleUrl: assetUrl('core', 'security'),
+    moduleUrl: CORE,
     runtime: SecurityContext,
   };
-  static AnimationKeyframe: IdentifierSpec = {
-    name: 'AnimationKeyframe',
-    moduleUrl: assetUrl('core', 'animation/animation_keyframe'),
-    runtime: AnimationKeyframe
-  };
-  static AnimationStyles: IdentifierSpec = {
-    name: 'AnimationStyles',
-    moduleUrl: assetUrl('core', 'animation/animation_styles'),
-    runtime: AnimationStyles
-  };
+  static AnimationKeyframe:
+      IdentifierSpec = {name: 'ɵAnimationKeyframe', moduleUrl: CORE, runtime: ɵAnimationKeyframe};
+  static AnimationStyles:
+      IdentifierSpec = {name: 'ɵAnimationStyles', moduleUrl: CORE, runtime: ɵAnimationStyles};
   static NoOpAnimationPlayer: IdentifierSpec = {
-    name: 'NoOpAnimationPlayer',
-    moduleUrl: assetUrl('core', 'animation/animation_player'),
-    runtime: NoOpAnimationPlayer
+    name: 'ɵNoOpAnimationPlayer',
+    moduleUrl: CORE,
+    runtime: ɵNoOpAnimationPlayer
   };
   static AnimationGroupPlayer: IdentifierSpec = {
-    name: 'AnimationGroupPlayer',
-    moduleUrl: assetUrl('core', 'animation/animation_group_player'),
-    runtime: AnimationGroupPlayer
+    name: 'ɵAnimationGroupPlayer',
+    moduleUrl: CORE,
+    runtime: ɵAnimationGroupPlayer
   };
   static AnimationSequencePlayer: IdentifierSpec = {
-    name: 'AnimationSequencePlayer',
-    moduleUrl: assetUrl('core', 'animation/animation_sequence_player'),
-    runtime: AnimationSequencePlayer
+    name: 'ɵAnimationSequencePlayer',
+    moduleUrl: CORE,
+    runtime: ɵAnimationSequencePlayer
   };
   static prepareFinalAnimationStyles: IdentifierSpec = {
-    name: 'prepareFinalAnimationStyles',
-    moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL,
-    runtime: prepareFinalAnimationStyles
+    name: 'ɵprepareFinalAnimationStyles',
+    moduleUrl: CORE,
+    runtime: ɵprepareFinalAnimationStyles
   };
   static balanceAnimationKeyframes: IdentifierSpec = {
-    name: 'balanceAnimationKeyframes',
-    moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL,
-    runtime: balanceAnimationKeyframes
+    name: 'ɵbalanceAnimationKeyframes',
+    moduleUrl: CORE,
+    runtime: ɵbalanceAnimationKeyframes
   };
-  static clearStyles: IdentifierSpec = {
-    name: 'clearStyles',
-    moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL,
-    runtime: clearStyles
-  };
-  static renderStyles: IdentifierSpec = {
-    name: 'renderStyles',
-    moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL,
-    runtime: renderStyles
-  };
+  static clearStyles:
+      IdentifierSpec = {name: 'ɵclearStyles', moduleUrl: CORE, runtime: ɵclearStyles};
+  static renderStyles:
+      IdentifierSpec = {name: 'ɵrenderStyles', moduleUrl: CORE, runtime: ɵrenderStyles};
   static collectAndResolveStyles: IdentifierSpec = {
-    name: 'collectAndResolveStyles',
-    moduleUrl: ANIMATION_STYLE_UTIL_ASSET_URL,
-    runtime: collectAndResolveStyles
+    name: 'ɵcollectAndResolveStyles',
+    moduleUrl: CORE,
+    runtime: ɵcollectAndResolveStyles
   };
-  static LOCALE_ID: IdentifierSpec = {
-    name: 'LOCALE_ID',
-    moduleUrl: assetUrl('core', 'i18n/tokens'),
-    runtime: LOCALE_ID
-  };
-  static TRANSLATIONS_FORMAT: IdentifierSpec = {
-    name: 'TRANSLATIONS_FORMAT',
-    moduleUrl: assetUrl('core', 'i18n/tokens'),
-    runtime: TRANSLATIONS_FORMAT
-  };
+  static LOCALE_ID: IdentifierSpec = {name: 'LOCALE_ID', moduleUrl: CORE, runtime: LOCALE_ID};
+  static TRANSLATIONS_FORMAT:
+      IdentifierSpec = {name: 'TRANSLATIONS_FORMAT', moduleUrl: CORE, runtime: TRANSLATIONS_FORMAT};
   static setBindingDebugInfo: IdentifierSpec = {
-    name: 'setBindingDebugInfo',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.setBindingDebugInfo
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'setBindingDebugInfo',
+    runtime: ɵview_utils.setBindingDebugInfo
   };
   static setBindingDebugInfoForChanges: IdentifierSpec = {
-    name: 'setBindingDebugInfoForChanges',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.setBindingDebugInfoForChanges
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'setBindingDebugInfoForChanges',
+    runtime: ɵview_utils.setBindingDebugInfoForChanges
   };
   static AnimationTransition: IdentifierSpec = {
-    name: 'AnimationTransition',
-    moduleUrl: assetUrl('core', 'animation/animation_transition'),
-    runtime: AnimationTransition
+    name: 'ɵAnimationTransition',
+    moduleUrl: CORE,
+    runtime: ɵAnimationTransition
   };
 
   // This is just the interface!
   static InlineArray:
       IdentifierSpec = {name: 'InlineArray', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: null};
   static inlineArrays: IdentifierSpec[] = [
-    {name: 'InlineArray2', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.InlineArray2},
-    {name: 'InlineArray2', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.InlineArray2},
-    {name: 'InlineArray4', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.InlineArray4},
-    {name: 'InlineArray8', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.InlineArray8},
-    {name: 'InlineArray16', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.InlineArray16},
+    {
+      name: 'ɵview_utils',
+      moduleUrl: CORE,
+      member: 'InlineArray2',
+      runtime: ɵview_utils.InlineArray2
+    },
+    {
+      name: 'ɵview_utils',
+      moduleUrl: CORE,
+      member: 'InlineArray2',
+      runtime: ɵview_utils.InlineArray2
+    },
+    {
+      name: 'ɵview_utils',
+      moduleUrl: CORE,
+      member: 'InlineArray4',
+      runtime: ɵview_utils.InlineArray4
+    },
+    {
+      name: 'ɵview_utils',
+      moduleUrl: CORE,
+      member: 'InlineArray8',
+      runtime: ɵview_utils.InlineArray8
+    },
+    {
+      name: 'ɵview_utils',
+      moduleUrl: CORE,
+      member: 'InlineArray16',
+      runtime: ɵview_utils.InlineArray16
+    },
   ];
   static EMPTY_INLINE_ARRAY: IdentifierSpec = {
-    name: 'EMPTY_INLINE_ARRAY',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.EMPTY_INLINE_ARRAY
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'EMPTY_INLINE_ARRAY',
+    runtime: ɵview_utils.EMPTY_INLINE_ARRAY
   };
   static InlineArrayDynamic: IdentifierSpec = {
-    name: 'InlineArrayDynamic',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.InlineArrayDynamic
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'InlineArrayDynamic',
+    runtime: ɵview_utils.InlineArrayDynamic
   };
   static subscribeToRenderElement: IdentifierSpec = {
-    name: 'subscribeToRenderElement',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.subscribeToRenderElement
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'subscribeToRenderElement',
+    runtime: ɵview_utils.subscribeToRenderElement
   };
   static createRenderComponentType: IdentifierSpec = {
-    name: 'createRenderComponentType',
-    moduleUrl: VIEW_UTILS_MODULE_URL,
-    runtime: view_utils.createRenderComponentType
+    name: 'ɵview_utils',
+    moduleUrl: CORE,
+    member: 'createRenderComponentType',
+    runtime: ɵview_utils.createRenderComponentType
   };
-  static noop:
-      IdentifierSpec = {name: 'noop', moduleUrl: VIEW_UTILS_MODULE_URL, runtime: view_utils.noop};
 
-  static viewDef: IdentifierSpec = {
-    name: 'viewDef',
-    moduleUrl: VIEW_ENGINE_MODULE_URL,
-    runtime: viewEngine.viewDef
-  };
-  static elementDef: IdentifierSpec = {
-    name: 'elementDef',
-    moduleUrl: VIEW_ENGINE_MODULE_URL,
-    runtime: viewEngine.elementDef
-  };
-  static anchorDef: IdentifierSpec = {
-    name: 'anchorDef',
-    moduleUrl: VIEW_ENGINE_MODULE_URL,
-    runtime: viewEngine.anchorDef
-  };
-  static textDef: IdentifierSpec = {
-    name: 'textDef',
-    moduleUrl: VIEW_ENGINE_MODULE_URL,
-    runtime: viewEngine.textDef
-  };
+
+  static noop: IdentifierSpec =
+      {name: 'ɵview_utils', moduleUrl: CORE, member: 'noop', runtime: ɵview_utils.noop};
+
+  static viewDef: IdentifierSpec =
+      {name: 'ɵviewEngine', moduleUrl: CORE, member: 'viewDef', runtime: ɵviewEngine.viewDef};
+  static elementDef: IdentifierSpec =
+      {name: 'ɵviewEngine', moduleUrl: CORE, member: 'elementDef', runtime: ɵviewEngine.elementDef};
+  static anchorDef: IdentifierSpec =
+      {name: 'ɵviewEngine', moduleUrl: CORE, member: 'anchorDef', runtime: ɵviewEngine.anchorDef};
+  static textDef: IdentifierSpec =
+      {name: 'ɵviewEngine', moduleUrl: CORE, member: 'textDef', runtime: ɵviewEngine.textDef};
   static directiveDef: IdentifierSpec = {
-    name: 'directiveDef',
-    moduleUrl: VIEW_ENGINE_MODULE_URL,
-    runtime: viewEngine.directiveDef
+    name: 'ɵviewEngine',
+    moduleUrl: CORE,
+    member: 'directiveDef',
+    runtime: ɵviewEngine.directiveDef
   };
   static providerDef: IdentifierSpec = {
-    name: 'providerDef',
-    moduleUrl: VIEW_ENGINE_MODULE_URL,
-    runtime: viewEngine.providerDef
+    name: 'ɵviewEngine',
+    moduleUrl: CORE,
+    member: 'providerDef',
+    runtime: ɵviewEngine.providerDef
   };
-  static queryDef: IdentifierSpec = {
-    name: 'queryDef',
-    moduleUrl: VIEW_ENGINE_MODULE_URL,
-    runtime: viewEngine.queryDef
-  };
+  static queryDef: IdentifierSpec =
+      {name: 'ɵviewEngine', moduleUrl: CORE, member: 'queryDef', runtime: ɵviewEngine.queryDef};
   static pureArrayDef: IdentifierSpec = {
-    name: 'pureArrayDef',
-    moduleUrl: VIEW_ENGINE_MODULE_URL,
-    runtime: viewEngine.pureArrayDef
+    name: 'ɵviewEngine',
+    moduleUrl: CORE,
+    member: 'pureArrayDef',
+    runtime: ɵviewEngine.pureArrayDef
   };
   static pureObjectDef: IdentifierSpec = {
-    name: 'pureObjectDef',
-    moduleUrl: VIEW_ENGINE_MODULE_URL,
-    runtime: viewEngine.pureObjectDef
+    name: 'ɵviewEngine',
+    moduleUrl: CORE,
+    member: 'pureObjectDef',
+    runtime: ɵviewEngine.pureObjectDef
   };
   static purePipeDef: IdentifierSpec = {
-    name: 'purePipeDef',
-    moduleUrl: VIEW_ENGINE_MODULE_URL,
-    runtime: viewEngine.purePipeDef
+    name: 'ɵviewEngine',
+    moduleUrl: CORE,
+    member: 'purePipeDef',
+    runtime: ɵviewEngine.purePipeDef
   };
-  static pipeDef: IdentifierSpec = {
-    name: 'pipeDef',
-    moduleUrl: VIEW_ENGINE_MODULE_URL,
-    runtime: viewEngine.pipeDef
-  };
-  static nodeValue: IdentifierSpec = {
-    name: 'nodeValue',
-    moduleUrl: VIEW_ENGINE_MODULE_URL,
-    runtime: viewEngine.nodeValue
-  };
+  static pipeDef: IdentifierSpec =
+      {name: 'ɵviewEngine', moduleUrl: CORE, member: 'pipeDef', runtime: ɵviewEngine.pipeDef};
+  static nodeValue: IdentifierSpec =
+      {name: 'ɵviewEngine', moduleUrl: CORE, member: 'nodeValue', runtime: ɵviewEngine.nodeValue};
   static unwrapValue: IdentifierSpec = {
-    name: 'unwrapValue',
-    moduleUrl: VIEW_ENGINE_MODULE_URL,
-    runtime: viewEngine.unwrapValue
+    name: 'ɵviewEngine',
+    moduleUrl: CORE,
+    member: 'unwrapValue',
+    runtime: ɵviewEngine.unwrapValue
   };
 }
 
 export function assetUrl(pkg: string, path: string = null, type: string = 'src'): string {
   if (path == null) {
-    return `@angular/${pkg}/index`;
+    return `@angular/${pkg}`;
   } else {
     return `@angular/${pkg}/${type}/${path}`;
   }
 }
 
 export function resolveIdentifier(identifier: IdentifierSpec) {
-  return reflector.resolveIdentifier(identifier.name, identifier.moduleUrl, identifier.runtime);
+  let name = identifier.name;
+  let members = identifier.member && [identifier.member];
+  return ɵreflector.resolveIdentifier(name, identifier.moduleUrl, members, identifier.runtime);
 }
 
 export function createIdentifier(identifier: IdentifierSpec): CompileIdentifierMetadata {
-  const reference =
-      reflector.resolveIdentifier(identifier.name, identifier.moduleUrl, identifier.runtime);
-  return {reference: reference};
+  return {reference: resolveIdentifier(identifier)};
 }
 
 export function identifierToken(identifier: CompileIdentifierMetadata): CompileTokenMetadata {
@@ -460,6 +404,6 @@ export function createIdentifierToken(identifier: IdentifierSpec): CompileTokenM
 
 export function createEnumIdentifier(
     enumType: IdentifierSpec, name: string): CompileIdentifierMetadata {
-  const resolvedEnum = reflector.resolveEnum(resolveIdentifier(enumType), name);
+  const resolvedEnum = ɵreflector.resolveEnum(resolveIdentifier(enumType), name);
   return {reference: resolvedEnum};
 }

--- a/modules/@angular/compiler/test/aot/test_util.ts
+++ b/modules/@angular/compiler/test/aot/test_util.ts
@@ -41,15 +41,18 @@ export const settings: ts.CompilerOptions = {
   types: []
 };
 
+export interface EmitterOptions { emitMetadata: boolean; }
+
 export class EmittingCompilerHost implements ts.CompilerHost {
   private angularSourcePath: string|undefined;
   private nodeModulesPath: string|undefined;
+  private addedFiles = new Map<string, string>();
   private writtenFiles = new Map<string, string>();
   private scriptNames: string[];
   private root = '/';
   private collector = new MetadataCollector();
 
-  constructor(scriptNames: string[]) {
+  constructor(scriptNames: string[], private options: EmitterOptions) {
     const moduleFilename = module.filename.replace(/\\/g, '/');
     const distIndex = moduleFilename.indexOf('/dist/all');
     if (distIndex >= 0) {
@@ -59,11 +62,25 @@ export class EmittingCompilerHost implements ts.CompilerHost {
 
       // Rewrite references to scripts with '@angular' to its corresponding location in
       // the source tree.
-      this.scriptNames = scriptNames.map(
-          f => f.startsWith('@angular/') ? path.join(this.angularSourcePath, f) : f);
+      this.scriptNames = scriptNames.map(f => this.effectiveName(f));
 
       this.root = root;
     }
+  }
+
+  public addScript(fileName: string, content: string) {
+    const scriptName = this.effectiveName(fileName);
+    this.addedFiles.set(scriptName, content);
+    this.scriptNames.push(scriptName);
+  }
+
+  public override(fileName: string, content: string) {
+    const scriptName = this.effectiveName(fileName);
+    this.addedFiles.set(scriptName, content);
+  }
+
+  public addWrittenFile(fileName: string, content: string) {
+    this.writtenFiles.set(this.effectiveName(fileName), content);
   }
 
   public getWrittenFiles(): {name: string, content: string}[] {
@@ -74,10 +91,19 @@ export class EmittingCompilerHost implements ts.CompilerHost {
 
   public get written(): Map<string, string> { return this.writtenFiles; }
 
+  public effectiveName(fileName: string): string {
+    return fileName.startsWith('@angular/') ? path.join(this.angularSourcePath, fileName) :
+                                              fileName;
+  }
+
   // ts.ModuleResolutionHost
-  fileExists(fileName: string): boolean { return fs.existsSync(fileName); }
+  fileExists(fileName: string): boolean {
+    return this.addedFiles.has(fileName) || fs.existsSync(fileName);
+  }
 
   readFile(fileName: string): string {
+    const result = this.addedFiles.get(fileName);
+    if (result) return result;
     let basename = path.basename(fileName);
     if (/^lib.*\.d\.ts$/.test(basename)) {
       let libPath = ts.getDefaultLibFilePath(settings);
@@ -106,7 +132,7 @@ export class EmittingCompilerHost implements ts.CompilerHost {
       onError?: (message: string) => void): ts.SourceFile {
     const content = this.readFile(fileName);
     if (content) {
-      return ts.createSourceFile(fileName, content, languageVersion);
+      return ts.createSourceFile(fileName, content, languageVersion, /* setParentNodes */ true);
     }
   }
 
@@ -115,11 +141,13 @@ export class EmittingCompilerHost implements ts.CompilerHost {
   writeFile: ts.WriteFileCallback =
       (fileName: string, data: string, writeByteOrderMark: boolean,
        onError?: (message: string) => void, sourceFiles?: ts.SourceFile[]) => {
-        this.writtenFiles.set(fileName, data);
-        if (sourceFiles && sourceFiles.length && DTS.test(fileName)) {
+        this.addWrittenFile(fileName, data);
+        if (this.options.emitMetadata && sourceFiles && sourceFiles.length && DTS.test(fileName)) {
           const metadataFilePath = fileName.replace(DTS, '.metadata.json');
           const metadata = this.collector.getMetadata(sourceFiles[0]);
-          if (metadata) this.writtenFiles.set(metadataFilePath, JSON.stringify(metadata));
+          if (metadata) {
+            this.addWrittenFile(metadataFilePath, JSON.stringify(metadata));
+          }
         }
       }
 

--- a/modules/@angular/core/src/codegen_private_exports.ts
+++ b/modules/@angular/core/src/codegen_private_exports.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as view_utils from './linker/view_utils';
+import * as viewEngine from './view/index';
+
+export {AnimationGroupPlayer as ɵAnimationGroupPlayer} from './animation/animation_group_player';
+export {AnimationKeyframe as ɵAnimationKeyframe} from './animation/animation_keyframe';
+export {NoOpAnimationPlayer as ɵNoOpAnimationPlayer} from './animation/animation_player';
+export {AnimationSequencePlayer as ɵAnimationSequencePlayer} from './animation/animation_sequence_player';
+export {balanceAnimationKeyframes as ɵbalanceAnimationKeyframes, clearStyles as ɵclearStyles, collectAndResolveStyles as ɵcollectAndResolveStyles, prepareFinalAnimationStyles as ɵprepareFinalAnimationStyles, renderStyles as ɵrenderStyles} from './animation/animation_style_util';
+export {AnimationStyles as ɵAnimationStyles} from './animation/animation_styles';
+export {AnimationTransition as ɵAnimationTransition} from './animation/animation_transition';
+export {ValueUnwrapper as ɵValueUnwrapper, devModeEqual as ɵdevModeEqual} from './change_detection/change_detection_util';
+export {ChangeDetectorStatus as ɵChangeDetectorStatus} from './change_detection/constants';
+export {ComponentRef_ as ɵComponentRef_} from './linker/component_factory';
+export {CodegenComponentFactoryResolver as ɵCodegenComponentFactoryResolver} from './linker/component_factory_resolver';
+export {DebugContext as ɵDebugContext, StaticNodeDebugInfo as ɵStaticNodeDebugInfo} from './linker/debug_context';
+export {NgModuleInjector as ɵNgModuleInjector} from './linker/ng_module_factory';
+export {registerModuleFactory as ɵregisterModuleFactory} from './linker/ng_module_factory_loader';
+export {TemplateRef_ as ɵTemplateRef_} from './linker/template_ref';
+export {AppView as ɵAppView, DebugAppView as ɵDebugAppView} from './linker/view';
+export {ViewContainer as ɵViewContainer} from './linker/view_container';
+export {ViewType as ɵViewType} from './linker/view_type';
+export {reflector as ɵreflector} from './reflection/reflection';
+export {view_utils as ɵview_utils};
+export {viewEngine as ɵviewEngine};

--- a/modules/@angular/core/src/core.ts
+++ b/modules/@angular/core/src/core.ts
@@ -39,3 +39,4 @@ export {AnimationStyles} from './animation/animation_styles';
 export {AnimationKeyframe} from './animation/animation_keyframe';
 export {Sanitizer, SecurityContext} from './security';
 export {TransitionFactory, TransitionInstruction, Trigger} from './triggers';
+export * from './codegen_private_exports';

--- a/modules/@angular/core/src/reflection/platform_reflection_capabilities.ts
+++ b/modules/@angular/core/src/reflection/platform_reflection_capabilities.ts
@@ -20,6 +20,6 @@ export interface PlatformReflectionCapabilities {
   setter(name: string): SetterFn;
   method(name: string): MethodFn;
   importUri(type: Type<any>): string;
-  resolveIdentifier(name: string, moduleUrl: string, runtime: any): any;
+  resolveIdentifier(name: string, moduleUrl: string, members: string[], runtime: any): any;
   resolveEnum(enumIdentifier: any, name: string): any;
 }

--- a/modules/@angular/core/src/reflection/reflection_capabilities.ts
+++ b/modules/@angular/core/src/reflection/reflection_capabilities.ts
@@ -227,7 +227,9 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
     return `./${stringify(type)}`;
   }
 
-  resolveIdentifier(name: string, moduleUrl: string, runtime: any): any { return runtime; }
+  resolveIdentifier(name: string, moduleUrl: string, members: string[], runtime: any): any {
+    return runtime;
+  }
   resolveEnum(enumIdentifier: any, name: string): any { return enumIdentifier[name]; }
 }
 

--- a/modules/@angular/core/src/reflection/reflector.ts
+++ b/modules/@angular/core/src/reflection/reflector.ts
@@ -49,8 +49,8 @@ export class Reflector extends ReflectorReader {
 
   importUri(type: any): string { return this.reflectionCapabilities.importUri(type); }
 
-  resolveIdentifier(name: string, moduleUrl: string, runtime: any): any {
-    return this.reflectionCapabilities.resolveIdentifier(name, moduleUrl, runtime);
+  resolveIdentifier(name: string, moduleUrl: string, members: string[], runtime: any): any {
+    return this.reflectionCapabilities.resolveIdentifier(name, moduleUrl, members, runtime);
   }
 
   resolveEnum(identifier: any, name: string): any {

--- a/modules/@angular/core/src/reflection/reflector_reader.ts
+++ b/modules/@angular/core/src/reflection/reflector_reader.ts
@@ -15,6 +15,6 @@ export abstract class ReflectorReader {
   abstract annotations(typeOrFunc: /*Type*/ any): any[];
   abstract propMetadata(typeOrFunc: /*Type*/ any): {[key: string]: any[]};
   abstract importUri(typeOrFunc: /*Type*/ any): string;
-  abstract resolveIdentifier(name: string, moduleUrl: string, runtime: any): any;
+  abstract resolveIdentifier(name: string, moduleUrl: string, members: string[], runtime: any): any;
   abstract resolveEnum(identifier: any, name: string): any;
 }

--- a/tools/gulp-tasks/public-api.js
+++ b/tools/gulp-tasks/public-api.js
@@ -23,7 +23,7 @@ const publicApiArgs = [
   '--rootDir',
   'dist/packages-dist',
   '--stripExportPattern',
-  '^__',
+  '^(__|ɵ)',
   '--allowModuleIdentifiers',
   'jasmine',
   '--allowModuleIdentifiers',


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Feature
```

**What is the current behavior?** (You can also link to an open issue here)

Compiler generated references to symbols in `@angular/core`, such as `AppView<T>`, generate a deep import to the module that declared the file (.e.g. `import * as import7 from '@angular/core/src/linker/view';`).

**What is the new behavior?**

Compiler generated reference to symbols in `@angular/core` generate a shallow import (e.g. `import * as import1 from '@angular/core`;`).

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
