### PR TITLE
feat(aio): revise sitemap.service with sitemap.json

### DIFF
--- a/aio/e2e/app.po.ts
+++ b/aio/e2e/app.po.ts
@@ -3,7 +3,7 @@ import { browser, element, by } from 'protractor';
 export class SitePage {
 
   links = element.all(by.css('md-toolbar a'));
-  datePipeLink = element(by.css('md-toolbar a[aioNavLink="docs/api/common/DatePipe"]'));
+  datePipeLink = element(by.css('md-toolbar a[aioNavLink="api/common/date-pipe"]'));
   docViewer = element(by.css('aio-doc-viewer'));
   codeExample = element.all(by.css('aio-doc-viewer pre > code'));
   featureLink = element(by.css('md-toolbar a[aioNavLink="features"]'));

--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -3,7 +3,7 @@
     <span><a class="nav-link" aioNavLink="home"> Home </a></span>
     <span><a class="nav-link" aioNavLink="news"> News</a></span>
     <span><a class="nav-link" aioNavLink="features"> Features</a></span>
-    <span><a class="nav-link" aioNavLink="docs/api/common/DatePipe"> DatePipe</a></span>
+    <span><a class="nav-link" aioNavLink="api/common/date-pipe"> DatePipe</a></span>
     <span class="fill-remaining-space"></span>
 </md-toolbar>
 <section class="app-content">

--- a/aio/src/app/doc-viewer/doc-viewer.component.spec.ts
+++ b/aio/src/app/doc-viewer/doc-viewer.component.spec.ts
@@ -4,7 +4,7 @@ import { Component, DebugElement } from '@angular/core';
 
 import { ComponentFactoryResolver, ElementRef, Injector, NgModule, OnInit, ViewChild } from '@angular/core';
 
-import { Doc, DocMetadata } from '../nav-engine';
+import { Doc, NavigationNode } from '../nav-engine';
 import { DocViewerComponent } from '../doc-viewer/doc-viewer.component';
 
 import { embeddedComponents, EmbeddedComponents } from '../embedded';
@@ -101,7 +101,7 @@ class TestComponent {
 //////// Tests //////////////
 
 describe('DocViewerComponent', () => {
-  const mockDocMetadata: DocMetadata = { id: 'mock', title: 'Mock Doc', url: '' };
+  const fakeDocMetadata = { id: 'mock', title: 'Mock Doc', path: '' } as NavigationNode;
   let component: TestComponent;
   let docViewerDE: DebugElement;
   let docViewerEl: HTMLElement;
@@ -135,21 +135,21 @@ describe('DocViewerComponent', () => {
   });
 
   it(('should display nothing when set DocViewer.doc to doc w/o content'), () => {
-    component.docViewer.doc = { metadata: mockDocMetadata, content: '' };
+    component.docViewer.doc = { node: fakeDocMetadata, content: '' };
     expect(docViewerEl.innerHTML).toBe('');
   });
 
   it(('should display simple static content doc'), () => {
     const content = '<p>Howdy, doc viewer</p>';
-    component.docViewer.doc = { metadata: mockDocMetadata, content };
+    component.docViewer.doc = { node: fakeDocMetadata, content };
     expect(docViewerEl.innerHTML).toEqual(content);
   });
 
   it(('should display nothing after reset static content doc'), () => {
     const content = '<p>Howdy, doc viewer</p>';
-    component.docViewer.doc = { metadata: mockDocMetadata, content };
+    component.docViewer.doc = { node: fakeDocMetadata, content };
     fixture.detectChanges();
-    component.docViewer.doc = { metadata: mockDocMetadata, content: '' };
+    component.docViewer.doc = { node: fakeDocMetadata, content: '' };
     expect(docViewerEl.innerHTML).toEqual('');
   });
 
@@ -159,7 +159,7 @@ describe('DocViewerComponent', () => {
       <p><aio-foo></aio-foo></p>
       <p>Below Foo</p>
     `;
-    component.docViewer.doc = { metadata: mockDocMetadata, content };
+    component.docViewer.doc = { node: fakeDocMetadata, content };
     const fooHtml = docViewerEl.querySelector('aio-foo').innerHTML;
     expect(fooHtml).toContain('Foo Component');
   });
@@ -174,7 +174,7 @@ describe('DocViewerComponent', () => {
       </div>
       <p>Below Foo</p>
     `;
-    component.docViewer.doc = { metadata: mockDocMetadata, content };
+    component.docViewer.doc = { node: fakeDocMetadata, content };
     const foos = docViewerEl.querySelectorAll('aio-foo');
     expect(foos.length).toBe(2);
   });
@@ -185,7 +185,7 @@ describe('DocViewerComponent', () => {
       <aio-bar></aio-bar>
       <p>Below Bar</p>
     `;
-    component.docViewer.doc = { metadata: mockDocMetadata, content };
+    component.docViewer.doc = { node: fakeDocMetadata, content };
     const barHtml = docViewerEl.querySelector('aio-bar').innerHTML;
     expect(barHtml).toContain('Bar Component');
   });
@@ -196,7 +196,7 @@ describe('DocViewerComponent', () => {
       <aio-bar>###bar content###</aio-bar>
       <p>Below Bar</p>
     `;
-    component.docViewer.doc = { metadata: mockDocMetadata, content };
+    component.docViewer.doc = { node: fakeDocMetadata, content };
 
     // necessary to trigger projection within ngOnInit
     fixture.detectChanges();
@@ -214,7 +214,7 @@ describe('DocViewerComponent', () => {
       <p><aio-foo></aio-foo></p>
       <p>Bottom</p>
     `;
-    component.docViewer.doc = { metadata: mockDocMetadata, content };
+    component.docViewer.doc = { node: fakeDocMetadata, content };
 
     // necessary to trigger Bar's projection within ngOnInit
     fixture.detectChanges();
@@ -237,7 +237,7 @@ describe('DocViewerComponent', () => {
       <p><aio-foo></aio-foo><p>
       <p>Bottom</p>
     `;
-    component.docViewer.doc = { metadata: mockDocMetadata, content };
+    component.docViewer.doc = { node: fakeDocMetadata, content };
 
     // necessary to trigger Bar's projection within ngOnInit
     fixture.detectChanges();
@@ -261,7 +261,7 @@ describe('DocViewerComponent', () => {
       <p><aio-foo></aio-foo></p>
       <p>Bottom</p>
     `;
-    component.docViewer.doc = { metadata: mockDocMetadata, content };
+    component.docViewer.doc = { node: fakeDocMetadata, content };
 
     // necessary to trigger Bar's projection within ngOnInit
     fixture.detectChanges();
@@ -289,7 +289,7 @@ describe('DocViewerComponent', () => {
       <p><aio-baz>---More baz--</aio-baz></p>
       <p>Bottom</p>
     `;
-    component.docViewer.doc = { metadata: mockDocMetadata, content };
+    component.docViewer.doc = { node: fakeDocMetadata, content };
 
     // necessary to trigger Bar's projection within ngOnInit
     fixture.detectChanges();

--- a/aio/src/app/doc-viewer/doc-viewer.component.ts
+++ b/aio/src/app/doc-viewer/doc-viewer.component.ts
@@ -3,7 +3,7 @@ import {
   DoCheck, ElementRef, Injector, Input, OnDestroy, ViewEncapsulation
 } from '@angular/core';
 
-import { Doc, DocMetadata } from '../nav-engine';
+import { Doc, NavigationNode } from '../nav-engine';
 import { EmbeddedComponents } from '../embedded';
 
 interface EmbeddedComponentFactory {
@@ -105,13 +105,13 @@ export class DocViewerComponent implements DoCheck, OnDestroy {
 
 class DisplayedDoc {
 
-  metadata: DocMetadata;
+  node: NavigationNode;
 
   private embeddedComponents: ComponentRef<any>[] = [];
 
   constructor(doc: Doc) {
     // ignore doc.content ... don't need to keep it around
-    this.metadata = doc.metadata;
+    this.node = doc.node;
   }
 
   addEmbeddedComponent(component: ComponentRef<any>) {

--- a/aio/src/app/nav-engine/doc-fetching.service.ts
+++ b/aio/src/app/nav-engine/doc-fetching.service.ts
@@ -12,6 +12,8 @@ import { Logger } from '../logger.service';
 @Injectable()
 export class DocFetchingService {
 
+  private base = 'content/';
+
   constructor(private http: Http, private logger: Logger) { }
 
   /**
@@ -28,6 +30,8 @@ export class DocFetchingService {
       throw new Error(emsg);
     }
 
+    url = this.base + url;
+
     this.logger.log('fetching document file at ', url);
 
     return this.http.get(url)
@@ -35,7 +39,7 @@ export class DocFetchingService {
       .do(content => this.logger.log('fetched document file at ', url) )
       .catch((error: Response) => {
         if (error.status === 404) {
-          this.logger.error(`Document file not found at '$(url)'`);
+          this.logger.error(`Document file not found at '${url}'`);
           return of('');
         } else {
           throw error;

--- a/aio/src/app/nav-engine/doc.model.ts
+++ b/aio/src/app/nav-engine/doc.model.ts
@@ -1,10 +1,57 @@
-export interface DocMetadata {
-  id: string;    // 'home'
-  title: string; // 'Home'
-  url: string;   // 'assets/documents/home.html'
+export interface Doc {
+  node: NavigationNode;
+  content: string;
 }
 
-export interface Doc {
-  metadata: DocMetadata;
-  content: string;
+/**
+ * UI navigation node that describes a document or container of documents
+ * Each node corresponds to a link in the UI.
+ */
+export interface NavigationNode {
+  /** Id of this node in the navigation map */
+  id: string;
+  /** path to corresponding document in this site; empty string if there is no document. */
+  path: string;
+  /** url to an external web page; path and url are mutually exclusive. */
+  url?: string;
+  /** Title to display at the top of the document page in its header */
+  title: string;
+  /** Title to display in the navigation link; typically shorter */
+  navTitle: string;
+  /** Tooltip for links */
+  tooltip: string;
+  /** Ids of ancestor nodes higher in the hierarchy */
+  ancestorIds: string[];
+  /** true if a path lookup should favor this node over others with the same path */
+  primary?: boolean;
+  /** true if should not be displayed in UI. Can still be loaded directly */
+  hide?: boolean;
+  /** If defined, this node is a container of child nodes */
+  children?: NavigationNode[];
+}
+
+
+/**
+ * Navigation metadata for the site.
+ * - navigationMap: the navigation hierarchy for the UI.
+ * - docs: find node for a given document id.
+ * - paths: find all node for a given HTML path.
+ */
+export interface SiteMap {
+  /**
+   * Map that drives the UI navigation.
+   * Each node correspond to a navigation link in the UI.
+   * Supports unlimited node nesting.
+   */
+  navigationMap: Map<string, NavigationNode>;
+
+  /**
+   * NavigationNode for a document id in the SiteMap.
+   */
+  docs: { [index: string]: NavigationNode; };
+
+  /**
+   * NavigationNodes for an HTML path in the SiteMap.
+   */
+  paths: { [index: string]: NavigationNode[]; };
 }

--- a/aio/src/app/nav-engine/doc.service.ts
+++ b/aio/src/app/nav-engine/doc.service.ts
@@ -5,19 +5,15 @@ import { of } from 'rxjs/observable/of';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/switchMap';
 
-import { Doc, DocMetadata } from './doc.model';
+import { Doc, NavigationNode } from './doc.model';
 import { DocFetchingService } from './doc-fetching.service';
 import { Logger } from '../logger.service';
 
 import { SiteMapService } from './sitemap.service';
 
-interface DocCache {
-  [index: string]: Doc;
-}
-
 @Injectable()
 export class DocService {
-  private cache: DocCache = {};
+  private cache = new Map<string, Doc>();
 
   constructor(
     private fileService: DocFetchingService,
@@ -26,35 +22,37 @@ export class DocService {
     ) { }
 
   /**
-   * Get document for documentId, from cache if found else server.
+   * Get document for id, from cache if found else server.
    * Pass server errors along to caller
    * Caller should interpret empty string content as "404 - file not found"
    */
-  getDoc(documentId: string): Observable<Doc> {
-    let doc = this.cache[documentId];
+  getDoc(id: string): Observable<Doc> {
+    let doc = this.cache.get(id);
     if (doc) {
-      this.logger.log('returned cached content for ', doc.metadata);
-      return of(cloneDoc(doc));
+      this.logger.log('returned cached content for ', doc.node);
+      return of(doc);
     }
 
     return this.siteMapService
-      .getDocMetadata(documentId)
-      .switchMap(metadata => {
+      .getDocMetadata(id)
+      .switchMap(node => {
 
-        return this.fileService.getFile(metadata.url)
+        // document id not found
+        if (!node) {
+          this.logger.error('No metadata for id: ' + id);
+          return of({
+            node: {id, title: '', path: ''},
+            content: ''
+          } as Doc);
+        };
+
+        return this.fileService.getFile(node.path)
           .map(content => {
-            this.logger.log('fetched content for', metadata);
-            doc = { metadata, content };
-            this.cache[metadata.id] = doc;
-            return cloneDoc(doc);
+            this.logger.log('fetched content for', node);
+            doc = { node, content };
+            this.cache.set(node.id, doc);
+            return doc;
           });
       });
   }
-}
-
-function cloneDoc(doc: Doc) {
-  return {
-    metadata: Object.assign({}, doc.metadata),
-    content: doc.content
-  };
 }

--- a/aio/src/app/nav-engine/index.ts
+++ b/aio/src/app/nav-engine/index.ts
@@ -4,7 +4,8 @@ import { NavEngine } from './nav-engine.service';
 import { NavLinkDirective } from './nav-link.directive';
 import { SiteMapService } from './sitemap.service';
 
-export { Doc, DocMetadata } from './doc.model';
+export { Doc, NavigationNode, SiteMap } from './doc.model';
+export { SiteMapService } from './sitemap.service';
 
 export const navDirectives = [
   NavLinkDirective

--- a/aio/src/app/nav-engine/nav-engine.service.spec.ts
+++ b/aio/src/app/nav-engine/nav-engine.service.spec.ts
@@ -5,16 +5,16 @@ import { of } from 'rxjs/observable/of';
 import 'rxjs/add/operator/delay';
 
 import { DocService } from './doc.service';
-import { Doc, DocMetadata } from './doc.model';
+import { Doc, NavigationNode } from './doc.model';
 
 import { NavEngine } from './nav-engine.service';
 
 const fakeDoc: Doc = {
-  metadata: {
+  node: {
     id: 'fake',
     title: 'All about the fake',
-    url: 'assets/documents/fake.html'
-  },
+    path: 'content/documents/fake.html'
+  } as NavigationNode,
   content: 'fake content'
 };
 

--- a/aio/src/app/nav-engine/nav-engine.service.ts
+++ b/aio/src/app/nav-engine/nav-engine.service.ts
@@ -11,12 +11,12 @@ export class NavEngine {
   constructor(private docService: DocService) {}
 
   /**
-   * Navigate sets `currentDoc` to the document for `documentId`.
+   * Navigate sets `currentDoc` to the document for the given `id`.
    * TODO: handle 'Document not found', signaled by empty string content
    * TODO: handle document retrieval error
    */
-  navigate(documentId: string) {
-    this.docService.getDoc(documentId).subscribe(
+  navigate(id: string) {
+    this.docService.getDoc(id).subscribe(
       doc => this.currentDoc = doc
     );
   }

--- a/aio/src/app/nav-engine/sitemap.service.spec.ts
+++ b/aio/src/app/nav-engine/sitemap.service.spec.ts
@@ -1,32 +1,278 @@
 import { fakeAsync, tick } from '@angular/core/testing';
-import { DocMetadata } from './doc.model';
+import { Http, Response } from '@angular/http';
+
+import { of } from 'rxjs/observable/of';
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/delay';
+
+import { NavigationNode, SiteMap } from './doc.model';
 import { SiteMapService } from './sitemap.service';
 
 describe('SiteMapService', () => {
+  let httpSpy: any;
+  let loggerSpy: any;
   let siteMapService: SiteMapService;
 
   beforeEach(() => {
-    siteMapService = new SiteMapService();
+    httpSpy = jasmine.createSpyObj('http', ['get']);
+    httpSpy.get.and.returnValue(of(getFakeSiteMapResponse()).delay(0));
+    loggerSpy = jasmine.createSpyObj('logger', ['log', 'warn', 'error']);
+
+    siteMapService = new SiteMapService(httpSpy, loggerSpy);
   });
 
-  it('should get News metadata', fakeAsync(() => {
-    siteMapService.getDocMetadata('news').subscribe(
-      metadata => expect(metadata.url).toBe('content/news.html')
-    );
-    tick();
-  }));
+  describe('#siteMap', () => {
+    let siteMap: SiteMap;
 
-  it('should calculate expected doc url for unknown id', fakeAsync(() => {
-    siteMapService.getDocMetadata('fizbuz').subscribe(
-      metadata => expect(metadata.url).toBe('content/fizbuz.html')
-    );
-    tick();
-  }));
+    beforeEach(fakeAsync(() => {
+      siteMap = undefined;
+      siteMapService.siteMap.subscribe(map => siteMap = map);
+      tick();
+    }));
 
-  it('should calculate expected index doc url for unknown id ending in /', fakeAsync(() => {
-    siteMapService.getDocMetadata('fizbuz/').subscribe(
-      metadata => expect(metadata.url).toBe('content/fizbuz/index.html')
-    );
-    tick();
-  }));
+    it('should build the sitemap', () => {
+      expect(siteMap).toBeDefined();
+    });
+
+    it('should set the guide node path to "index.html"', () => {
+      const gsSection = siteMap.navigationMap['getting-started'];
+      expect(gsSection).toBeDefined('should have "getting-started" section');
+      const guidePath = gsSection.children[0].path;
+      expect(guidePath).toBe('guide/index.html');
+    });
+
+    it('should not change defined props of id:"guide"', () => {
+      const guideNode = siteMap.docs['guide'];
+      const title = guideNode.title;
+      expect(guideNode).toBeDefined('should have a node for id:"guide"');
+      expect(guideNode.path).toBe('guide/index.html', 'path be guide\'s "index.html"');
+      expect(guideNode.navTitle).not.toBe(title, 'navTitle should NOT be same as title');
+      expect(guideNode.tooltip).not.toBe(title, 'tooltip should NOT be same as title');
+    });
+
+    it('should fill in empty props of id:"foo"', () => {
+      const fooNode = siteMap.docs['foo'];
+      const title = fooNode.title;
+      expect(fooNode).toBeDefined('should have a node for id:"foo"');
+      expect(fooNode.path).toBe('foo.html', 'path should have .html extension');
+      expect(fooNode.navTitle).toBe(title, 'navTitle should be same as title');
+      expect(fooNode.tooltip).toBe(title, 'tooltip should be same as title');
+    });
+  });
+
+  describe('#siteMap.paths', () => {
+    let siteMap: SiteMap;
+
+    beforeEach(fakeAsync(() => {
+      siteMap = undefined;
+      siteMapService.siteMap.subscribe(map => siteMap = map);
+      tick();
+    }));
+
+    // One level
+    it('should have [menu] ancestor for path "foo.html" ', () => {
+      const nodes = siteMap.paths['foo.html'];
+      expect(nodes.length).toBe(1, 'expected one node');
+      expect(nodes[0].ancestorIds).toEqual(['menu']);
+    });
+
+    // guide/quickstart.html appears twice in the navigation map
+    it('should have two node for path "guide/quickstart.html", solo (primary) and under "menu"', () => {
+      const nodes = siteMap.paths['guide/quickstart.html'];
+      expect(nodes.length).toBe(2, 'expected two nodes');
+      expect(nodes[0].ancestorIds).toEqual(['menu'], '1st node ancestors should be "menu"');
+      expect(nodes[1].ancestorIds).toEqual([], '2nd node should be empty');
+      expect(nodes[1].primary).toBe(true, '2nd node ancestors should be primary');
+    });
+
+    // guide/directives.html is both a doc and the "core/directives" section header
+    it('should have [core, directives] ancestors for path "guide/directives.html" ', () => {
+      const nodes = siteMap.paths['guide/directives.html'];
+      expect(nodes.length).toBe(1, 'expected one node');
+      expect(nodes[0].ancestorIds).toEqual(['core', 'directives']);
+    });
+
+    // Path is 3 levels deep in the navigation map
+    it('should have [core, directives] ancestors for path "guide/structural-directives.html"', () => {
+      const nodes = siteMap.paths['guide/structural-directives.html'];
+      expect(nodes.length).toBe(1, 'expected one node');
+      expect(nodes[0].ancestorIds).toEqual(['core', 'directives']);
+    });
+  });
+
+  describe('#getDocMetadata', () => {
+    it('should get news metadata', fakeAsync(() => {
+      siteMapService.getDocMetadata('news').subscribe(
+        metadata => expect(metadata.path).toBe('news.html')
+      );
+      tick();
+    }));
+
+    it('should be case insensitive', fakeAsync(() => {
+      siteMapService.getDocMetadata('NeWs').subscribe(
+        metadata => expect(metadata.path).toBe('news.html')
+      );
+      tick();
+    }));
+
+    it('should get "quide/quickstart" metadata', fakeAsync(() => {
+      siteMapService.getDocMetadata('guide/quickstart').subscribe(
+        metadata => expect(metadata.path).toBe('guide/quickstart.html')
+      );
+      tick();
+    }));
+
+    it('should get metadata by the id:"menu-quickstart"', fakeAsync(() => {
+      siteMapService.getDocMetadata('menu-quickstart').subscribe(
+        metadata => expect(metadata.path).toBe('guide/quickstart.html')
+      );
+      tick();
+    }));
+
+    it('should get deep "guide/structural-directives" metadata', fakeAsync(() => {
+      siteMapService.getDocMetadata('guide/structural-directives').subscribe(
+        metadata => expect(metadata.path).toBe('guide/structural-directives.html')
+      );
+      tick();
+    }));
+
+    it('should calculate metadata for id that begins "api/"', fakeAsync(() => {
+      const apiId = 'api/my/dog/has/fleas';
+      siteMapService.getDocMetadata(apiId).subscribe(
+        metadata => expect(metadata.path).toBe(apiId + '.html')
+      );
+      tick();
+    }));
+  });
+
+  describe('#getDocMetadataForPath', () => {
+    it('should get metadata for path "news.html"', fakeAsync(() => {
+      siteMapService.getDocMetadataForPath('news.html').subscribe(
+        metadata => expect(metadata.id).toBe('news')
+      );
+      tick();
+    }));
+
+    it('should get primary metadata for "quide/quickstart.html"', fakeAsync(() => {
+      siteMapService.getDocMetadataForPath('guide/quickstart.html').subscribe(
+        metadata => {
+          expect(metadata.id).toBe('guide/quickstart');
+        });
+      tick();
+    }));
+
+    it('should be case insensitive', fakeAsync(() => {
+      siteMapService.getDocMetadataForPath('Guide/QuickStart.html').subscribe(
+        metadata => {
+          expect(metadata.id).toBe('guide/quickstart');
+        });
+      tick();
+    }));
+
+    it('should get deep "guide/attribute-directives.html" metadata', fakeAsync(() => {
+      siteMapService.getDocMetadataForPath('guide/attribute-directives.html').subscribe(
+        metadata => expect(metadata.id).toBe('attribute-directives')
+      );
+      tick();
+    }));
+
+    it('should calculate metadata for path that begins "api/"', fakeAsync(() => {
+      const apiId = 'api/my/dog/has/fleas';
+      siteMapService.getDocMetadataForPath(apiId + '.html').subscribe(
+        metadata => expect(metadata.id).toBe(apiId)
+      );
+      tick();
+    }));
+  });
+
 });
+
+//////////////
+function getFakeSiteMapResponse(): Response {
+  // tslint:disable:quotemark
+  const fakeNavMapJson = {
+    "menu": {
+      "id": "menu",
+      "children": [
+        {
+          "path": "news",
+          "title": "News",
+          "tooltip": ""
+        },
+        {
+          "id": "menu-quickstart",
+          "path": "guide/quickstart",
+          "title": "Getting started",
+          "tooltip": ""
+        },
+        {
+          "path": "foo",
+          "title": "Foo"
+        },
+      ]
+    },
+
+    "quickstart": {
+      "path": "guide/quickstart",
+      "primary": true,
+      "title": "Quickstart",
+      "tooltip": "A quick look at an Angular app."
+    },
+
+    "getting-started": {
+      "id": "getting-started",
+      "title": "Getting started",
+      "children": [
+        {
+          "id": "guide",
+          "path": "guide/",
+          "title": "Documentation overview",
+          "navTitle": "Overview",
+          "tooltip": "How to read and use this documentation."
+        },
+        {
+          "path": "guide/setup",
+          "title": "Setup for local development",
+          "navTitle": "Setup",
+          "tooltip": "Install the Angular QuickStart seed for faster, more efficient development on your machine."
+        }
+      ]
+    },
+
+    "core": {
+      "id": "core",
+      "title": "Core",
+      "tooltip": "Learn the core capabilities of Angular",
+      "children": [
+        {
+          "path": "guide/ngmodule",
+          "title": "Angular Modules (NgModule)",
+          "tooltip": "Define application modules with @NgModule."
+        },
+        {
+          "id": "directives",
+          "title": "Directives",
+          "path": "guide/directives",
+          "children": [
+            {
+              "id": "attribute-directives",
+              "path": "guide/attribute-directives",
+              "title": "Attribute directives",
+              "tooltip": "Attribute directives attach behavior to elements."
+            },
+            {
+              "path": "guide/structural-directives",
+              "title": "Structural directives",
+              "tooltip": "Structural directives manipulate the layout of the page."
+            }
+          ]
+        }
+      ]
+    }
+  };
+  // tslint:enable:quotemark
+  return {
+    status: 200,
+    json: () => fakeNavMapJson
+  } as Response;
+}

--- a/aio/src/app/nav-engine/sitemap.service.ts
+++ b/aio/src/app/nav-engine/sitemap.service.ts
@@ -1,38 +1,145 @@
 import { Injectable } from '@angular/core';
+import { Http } from '@angular/http';
 
 import { Observable } from 'rxjs/Observable';
 import { of } from 'rxjs/observable/of';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
+import 'rxjs/add/observable/throw';
 import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/switchMap';
 
-import { DocMetadata } from './doc.model';
+import { Doc, NavigationNode, SiteMap } from './doc.model';
+import { DocFetchingService } from './doc-fetching.service';
+import { Logger } from '../logger.service';
 
-const siteMap: DocMetadata[] = [
-  { 'title': 'Home', 'url': 'content/home.html', id: 'home'},
-  { 'title': 'Features', 'url': 'content/features.html', id: 'features'},
-  { 'title': 'News', 'url': 'content/news.html', id: 'news'}
-];
+const siteMapUrl = 'content/sitemap.json';
 
 @Injectable()
 export class SiteMapService {
-  private siteMap = new BehaviorSubject(siteMap);
 
-  getDocMetadata(id: string) {
-    const missing = () => this.getMissingMetadata(id);
-    return this.siteMap
-      .map(map =>
-        map.find(d => d.id === id) || missing());
+  private siteMapSubject: ReplaySubject<SiteMap>;
+
+  constructor(private http: Http, private logger: Logger) { }
+
+  get siteMap(): Observable<SiteMap> {
+    return (this.siteMapSubject ? this.siteMapSubject : this.createSiteMapSubject()).asObservable() ;
   }
 
-  // Alternative way to calculate metadata. Will it be used?
-  private getMissingMetadata(id: string) {
-
-    const filename = id.startsWith('/') ? id.substring(1) : id; // strip leading '/'
-
-    return {
-      id,
-      title: id,
-      url: `content/${filename}${filename.endsWith('/') ? 'index' : ''}.html`
-    } as DocMetadata;
+  /**
+   * Get metadata for a document with `id` from the SiteMap.
+   * Document ids that begin with 'api/' are special-cased.
+   * Returns undefined if no document metadata for that id.
+   */
+  getDocMetadata(id: string): Observable<NavigationNode> {
+    if (!id) { return Observable.throw('no id'); }
+    id = id.toLocaleLowerCase();
+    return id.startsWith('api/') ?
+      of(generateApiNode(id)) :
+      this.siteMap.map(siteMap => siteMap.docs[id]);
   }
+
+  /**
+   * Get the metadata for a document that matches the path.
+   * If more than one, picks the primary; if no primary, picks the first.
+   * Paths that begin with 'api/' are special-cased.
+   * Returns undefined if no document metadata for that path.
+   */
+  getDocMetadataForPath(path: string): Observable<NavigationNode> {
+    if (!path) { return Observable.throw('no path'); }
+    path = path.toLocaleLowerCase();
+    return path.startsWith('api/') ?
+      of(generateApiNodeForPath(path)) :
+      this.siteMap.map(siteMap => {
+        const nodes = siteMap.paths[path];
+        if (nodes.length > 1) {
+          const primary = nodes.find(node => node.primary);
+          if (primary) { return primary; }
+        }
+        return nodes[0];
+      });
+  }
+
+  private createSiteMapSubject(): ReplaySubject<SiteMap> {
+    this.siteMapSubject = new ReplaySubject<SiteMap>(1);
+
+    this.http.get(siteMapUrl)
+      .map(res => res.json())
+      .do(content => this.logger.log('fetched site map JSON at ', siteMapUrl) )
+      .subscribe(
+        navMap => this.siteMapSubject.next(createSiteMap(navMap))
+      );
+
+    return this.siteMapSubject;
+  }
+}
+
+////// private helper functions ////
+
+function createSiteMap(navMap: Map<string, NavigationNode>) {
+  const siteMap: SiteMap = { navigationMap: navMap, docs: {}, paths: {}};
+
+  // tslint:disable-next-line:forin
+  for (const key in navMap) {
+    adjustNode(navMap[key], siteMap, []);
+  }
+  return siteMap;
+}
+
+// Should never need but don't want to fail for lack of an id. The value is irrelevant.
+let nextNodeId = 1;
+
+// Fill in missing properties of NavigationMetadata from JSON
+// and build siteMap.docs and siteMap.pathIds
+function adjustNode(node: NavigationNode, siteMap: SiteMap, ancestorIds: string[] ) {
+  node.id = node.id || node.path || node.url || '#' + nextNodeId++;
+  node.id = node.id.toLocaleLowerCase();
+  node.title = node.title || node.path || node.url || '';
+  node.navTitle = node.navTitle || node.title;
+  if ( node.tooltip === undefined ) { node.tooltip = node.title; }
+
+  // Set ancestors; include self if this node has children
+  node.ancestorIds = node.children ? ancestorIds.concat(node.id) : ancestorIds;
+
+  if (node.path) {
+    node.path = node.path.toLocaleLowerCase();
+    node.path = addPathExtension(node.path);
+    siteMap.docs[node.id] = node;
+    siteMap.paths[node.path] = (siteMap.paths[node.path] || []).concat(node);
+  }
+
+  if (node.children) {
+    node.children.forEach(e => adjustNode(e, siteMap, ancestorIds.concat(node.id)));
+  }
+}
+
+function generateApiNode(id: string) {
+  const path = addPathExtension(id);
+  return {id, title: id, path, ancestorIds: ['api']} as NavigationNode;
+}
+
+function addPathExtension(path: string) {
+  if (path) {
+    if (path.endsWith('/')) {
+      return path + 'index.html';
+    } else if (!path.endsWith('.html')) {
+      return path + '.html';
+    }
+  }
+  return path;
+}
+
+function generateApiNodeForPath(path: string) {
+  const id = removePathExtension(path);
+  return {id, title: id, path, ancestorIds: ['api']} as NavigationNode;
+}
+
+function removePathExtension(path: string) {
+  if (path) {
+    if (path.endsWith('/index.html')) {
+      return path.substring(0, path.length - 10);
+    } else if (path.endsWith('.html')) {
+      return path.substring(0, path.length - 5);
+    }
+  }
+  return path;
 }

--- a/aio/src/content/api/common/date-pipe.html
+++ b/aio/src/content/api/common/date-pipe.html
@@ -1,0 +1,239 @@
+<header class="hero background-sky"><h1 class="hero-title is-standard-case">DatePipe</h1><span
+    class="badge is-stable">Stable</span>
+  <div class="clear"></div>
+  <h2 class="hero-subtitle">Pipe</h2></header>
+<article class="l-content-small grid-fluid docs-content">
+  <div layout="row" layout-xs="column" class="row-margin">
+    <div flex="20" flex-xs="100"><h2 class="h2-api-docs">What it does</h2></div>
+    <div flex="80" flex-xs="100"><p>Formats a date according to locale rules.</p>
+    </div>
+  </div>
+  <div layout="row" layout-xs="column" class="row-margin">
+    <div flex="20" flex-xs="100"><h2 class="h2-api-docs">How to use</h2></div>
+    <div flex="80" flex-xs="100"><p><code>date_expression | date[:format]</code></p>
+    </div>
+  </div>
+  <div layout="row" layout-xs="column" class="row-margin">
+    <div flex="20" flex-xs="100"><h2 class="h2-api-docs">NgModule</h2></div>
+    <div flex="80" flex-xs="100" class="code-links">CommonModule
+
+    </div>
+  </div>
+  <div layout="row" layout-xs="column" class="row-margin">
+    <div flex="20" flex-xs="100"><h2 class="h2-api-docs">Description</h2></div>
+    <div flex="80" flex-xs="100" class="code-links"><p>Where:</p>
+      <ul>
+        <li><code>expression</code> is a date object or a number (milliseconds since UTC epoch) or
+          an ISO string
+          (<a href="https://www.w3.org/TR/NOTE-datetime">https://www.w3.org/TR/NOTE-datetime</a>).
+        </li>
+        <li><code>format</code> indicates which date/time components to include. The format can be
+          predifined as
+          shown below or custom as shown in the table.
+          <ul>
+            <li><code>&#39;medium&#39;</code>: equivalent to <code>&#39;yMMMdjms&#39;</code> (e.g.
+              <code>Sep 3, 2010, 12:05:08 PM</code> for <code>en-US</code>)
+            </li>
+            <li><code>&#39;short&#39;</code>: equivalent to <code>&#39;yMdjm&#39;</code> (e.g.
+              <code>9/3/2010, 12:05 PM</code> for <code>en-US</code>)
+            </li>
+            <li><code>&#39;fullDate&#39;</code>: equivalent to <code>&#39;yMMMMEEEEd&#39;</code>
+              (e.g. <code>Friday, September 3, 2010</code> for <code>en-US</code>)
+            </li>
+            <li><code>&#39;longDate&#39;</code>: equivalent to <code>&#39;yMMMMd&#39;</code> (e.g.
+              <code>September 3, 2010</code> for <code>en-US</code>)
+            </li>
+            <li><code>&#39;mediumDate&#39;</code>: equivalent to <code>&#39;yMMMd&#39;</code> (e.g.
+              <code>Sep 3, 2010</code> for <code>en-US</code>)
+            </li>
+            <li><code>&#39;shortDate&#39;</code>: equivalent to <code>&#39;yMd&#39;</code> (e.g.
+              <code>9/3/2010</code> for <code>en-US</code>)
+            </li>
+            <li><code>&#39;mediumTime&#39;</code>: equivalent to <code>&#39;jms&#39;</code> (e.g.
+              <code>12:05:08 PM</code> for <code>en-US</code>)
+            </li>
+            <li><code>&#39;shortTime&#39;</code>: equivalent to <code>&#39;jm&#39;</code> (e.g.
+              <code>12:05 PM</code> for <code>en-US</code>)
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <table>
+        <thead>
+        <tr>
+          <th>Component</th>
+          <th style="text-align:center">Symbol</th>
+          <th>Narrow</th>
+          <th>Short Form</th>
+          <th>Long Form</th>
+          <th>Numeric</th>
+          <th>2-digit</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <td>era</td>
+          <td style="text-align:center">G</td>
+          <td>G (A)</td>
+          <td>GGG (AD)</td>
+          <td>GGGG (Anno Domini)</td>
+          <td>-</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>year</td>
+          <td style="text-align:center">y</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+          <td>y (2015)</td>
+          <td>yy (15)</td>
+        </tr>
+        <tr>
+          <td>month</td>
+          <td style="text-align:center">M</td>
+          <td>L (S)</td>
+          <td>MMM (Sep)</td>
+          <td>MMMM (September)</td>
+          <td>M (9)</td>
+          <td>MM (09)</td>
+        </tr>
+        <tr>
+          <td>day</td>
+          <td style="text-align:center">d</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+          <td>d (3)</td>
+          <td>dd (03)</td>
+        </tr>
+        <tr>
+          <td>weekday</td>
+          <td style="text-align:center">E</td>
+          <td>E (S)</td>
+          <td>EEE (Sun)</td>
+          <td>EEEE (Sunday)</td>
+          <td>-</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>hour</td>
+          <td style="text-align:center">j</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+          <td>j (13)</td>
+          <td>jj (13)</td>
+        </tr>
+        <tr>
+          <td>hour12</td>
+          <td style="text-align:center">h</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+          <td>h (1 PM)</td>
+          <td>hh (01 PM)</td>
+        </tr>
+        <tr>
+          <td>hour24</td>
+          <td style="text-align:center">H</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+          <td>H (13)</td>
+          <td>HH (13)</td>
+        </tr>
+        <tr>
+          <td>minute</td>
+          <td style="text-align:center">m</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+          <td>m (5)</td>
+          <td>mm (05)</td>
+        </tr>
+        <tr>
+          <td>second</td>
+          <td style="text-align:center">s</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+          <td>s (9)</td>
+          <td>ss (09)</td>
+        </tr>
+        <tr>
+          <td>timezone</td>
+          <td style="text-align:center">z</td>
+          <td>-</td>
+          <td>-</td>
+          <td>z (Pacific Standard Time)</td>
+          <td>-</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>timezone</td>
+          <td style="text-align:center">Z</td>
+          <td>-</td>
+          <td>Z (GMT-8:00)</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td>timezone</td>
+          <td style="text-align:center">a</td>
+          <td>-</td>
+          <td>a (PM)</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+        </tr>
+        </tbody>
+      </table>
+      <p>In javascript, only the components specified will be respected (not the ordering,
+        punctuations, ...) and details of the formatting will be dependent on the locale.</p>
+      <p>Timezone of the formatted text will be the local system timezone of the end-user&#39;s
+        machine.</p>
+      <p>WARNINGS:</p>
+      <ul>
+        <li>this pipe is marked as pure hence it will not be re-evaluated when the input is mutated.
+          Instead users should treat the date as an immutable object and change the reference when
+          the
+          pipe needs to re-run (this is to avoid reformatting the date on every change detection run
+          which would be an expensive operation).
+        </li>
+        <li>this pipe uses the Internationalization API. Therefore it is only reliable in Chrome and
+          Opera
+          browsers.
+        </li>
+      </ul>
+      <h3 id="examples">Examples</h3>
+      <p>Assuming <code>dateObj</code> is (year: 2015, month: 6, day: 15, hour: 21, minute: 43,
+        second: 11)
+        in the <em>local</em> time and locale is &#39;en-US&#39;:</p>
+      <code-example format="linenums" language="js">{{ dateObj | date }} // output is &#039;Jun 15,
+        2015&#039;
+        {{ dateObj | date:&#039;medium&#039; }} // output is &#039;Jun 15, 2015, 9:43:11 PM&#039;
+        {{ dateObj | date:&#039;shortTime&#039; }} // output is &#039;9:43 PM&#039;
+        {{ dateObj | date:&#039;mmss&#039; }} // output is &#039;43:11&#039;
+      </code-example>
+      <div class="code-example">
+        <code-example language="ts" format="linenums">@Component({
+          selector: &#39;date-pipe&#39;,
+          template: `&lt;div&gt;
+          &lt;p&gt;Today is {{today | date}}&lt;/p&gt;
+          &lt;p&gt;Or if you prefer, {{today | date:&#39;fullDate&#39;}}&lt;/p&gt;
+          &lt;p&gt;The time is {{today | date:&#39;jmZ&#39;}}&lt;/p&gt;
+          &lt;/div&gt;`
+          })
+          export class DatePipeComponent {
+          today: number = Date.now();
+          }
+        </code-example>
+      </div>
+    </div>
+  </div>
+  <p class="location-badge">exported from <a href="index.html">@angular/common/index</a>
+    defined in <a
+        href="https://github.com/angular/angular/tree/2.2.0-beta.1/modules/@angular/common/src/pipes/date_pipe.ts#L12-L116">@angular/common/src/pipes/date_pipe.ts</a>
+  </p></article>

--- a/aio/src/content/sitemap.json
+++ b/aio/src/content/sitemap.json
@@ -1,0 +1,136 @@
+{
+  "menu": {
+    "children": [
+      {
+        "path": "home",
+        "title": "Home",
+        "tooltip": ""
+      },
+      {
+        "path": "features",
+        "title": "Features",
+        "tooltip": ""
+      },
+      {
+        "path": "news",
+        "title": "News",
+        "tooltip": ""
+      },
+      {
+        "id": "menu-quickstart",
+        "path": "guide/quickstart",
+        "title": "Getting started",
+        "tooltip": ""
+      }
+    ]
+  },
+
+  "quickstart": {
+    "path": "guide/quickstart",
+    "primary": true,
+    "title": "Quickstart",
+    "tooltip": "A quick look at an Angular app."
+  },
+
+  "cli-quickstart": {
+    "path": "guide/cli-quickstart",
+    "title": "CLI Quickstart",
+    "tooltip": "A quick look at an Angular app built with the Angular CLI."
+  },
+
+  "tutorial": {
+    "title": "Tutorial",
+    "children": [
+      {
+        "id": " tutorial",
+        "path": "tutorial/",
+        "title": "Tutorial: Tour of Heroes",
+        "navTitle": "Introduction",
+        "tooltip": "The Tour of Heroes tutorial takes you through the steps of creating an Angular application in TypeScript."
+      },
+      {
+        "path": "tutorial/toh-1",
+        "title": "The Hero Editor",
+        "tooltip": "Build a simple hero editor."
+      }
+    ]
+  },
+
+  "getting-started": {
+    "title": "Getting started",
+    "children": [
+      {
+        "path": "guide/docs-overview",
+        "title": "Documentation overview",
+        "navTitle": "Overview",
+        "tooltip": "How to read and use this documentation."
+      },
+      {
+        "path": "guide/setup",
+        "title": "Setup for local development",
+        "navTitle": "Setup",
+        "tooltip": "Install the Angular QuickStart seed for faster, more efficient development on your machine."
+      }
+    ]
+  },
+
+  "core": {
+    "title": "Core",
+    "tooltip": "Learn the core capabilities of Angular",
+    "children": [
+      {
+        "path": "guide/ngmodule",
+        "title": "Angular Modules (NgModule)",
+        "tooltip": "Define application modules with @NgModule."
+      },
+      {
+        "title": "Directives",
+        "children": [
+          {
+            "path": "guide/attribute-directives",
+            "title": "Attribute directives",
+            "tooltip": "Attribute directives attach behavior to elements."
+          },
+          {
+            "path": "guide/structural-directives",
+            "title": "Structural directives",
+            "tooltip": "Structural directives manipulate the layout of the page."
+          }
+        ]
+      },
+      {
+        "path": "guide/pipes",
+        "title": "Pipes",
+        "tooltip": "Pipes transform displayed values within a template."
+      }
+    ]
+  },
+
+  "resources": {
+    "title": "Resources",
+    "children": [
+      {
+        "path": "about",
+        "title": "Moving the web forward",
+        "navTitle": "About",
+        "tooltip": "The people behind Angular"
+      }
+    ]
+  },
+
+  "help": {
+    "title": "Help",
+    "children": [
+      {
+        "url": "http://stackoverflow.com/questions/tagged/angular2.html",
+        "title": "Stack Overflow",
+        "tooltip": "Stack Overflow: where the community answers your technical Angular questions."
+      },
+      {
+        "url": "https://gitter.im/angular/angular.html",
+        "title": "Gitter",
+        "tooltip": "Chat about Angular with other birds of a feather"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```
Replaces #14379

This PR adds "sitemap" metadata based on a realistic variety of navigation hierarchy requirements embodied in a sample version of `sitemap.json`. The real version would be hand-edited by docs team.

This PR explores, through unit tests, how consumers (e.g. NavEngine, the navigation panel, the menu bar) can get docs from metadata and get metadata from a path. The latter capability will be tied into the aio router.

Todo:
- [ ] Confirm terminology
- [ ] Confirm content location and adjust