### PR TITLE
fix(upgrade): pass correct values to `ngOnChanges` for interpolation bindings

### DIFF
--- a/modules/@angular/upgrade/src/angular_js.ts
+++ b/modules/@angular/upgrade/src/angular_js.ts
@@ -8,6 +8,8 @@
 
 export type Ng1Token = string;
 
+export type Ng1Expression = string | Function;
+
 export interface IAnnotatedFunction extends Function { $inject?: Ng1Token[]; }
 
 export type IInjectable = (Ng1Token | Function)[] | IAnnotatedFunction;
@@ -45,9 +47,7 @@ export interface IRootScopeService {
   $watch(expr: any, fn?: (a1?: any, a2?: any) => void): Function;
   $on(event: string, fn?: (event?: any, ...args: any[]) => void): Function;
   $destroy(): any;
-  $apply(): any;
-  $apply(exp: string): any;
-  $apply(exp: Function): any;
+  $apply(exp?: Ng1Expression): any;
   $digest(): any;
   $evalAsync(): any;
   $on(event: string, fn?: (event?: any, ...args: any[]) => void): Function;

--- a/modules/@angular/upgrade/src/aot/downgrade_component_adapter.ts
+++ b/modules/@angular/upgrade/src/aot/downgrade_component_adapter.ts
@@ -57,16 +57,15 @@ export class DowngradeComponentAdapter {
       let expr: any /** TODO #9100 */ = null;
 
       if (attrs.hasOwnProperty(input.attr)) {
-        const observeFn = ((prop: any /** TODO #9100 */) => {
+        const observeFn = (prop => {
           let prevValue = INITIAL_VALUE;
-          return (value: any /** TODO #9100 */) => {
-            if (this.inputChanges !== null) {
-              this.inputChangeCount++;
-              this.inputChanges[prop] =
-                  new Ng1Change(value, prevValue === INITIAL_VALUE ? value : prevValue);
-              prevValue = value;
+          return (currValue: any) => {
+            if (prevValue === INITIAL_VALUE) {
+              prevValue = currValue;
             }
-            this.component[prop] = value;
+
+            this.updateInput(prop, prevValue, currValue);
+            prevValue = currValue;
           };
         })(input.prop);
         attrs.$observe(input.attr, observeFn);
@@ -82,14 +81,8 @@ export class DowngradeComponentAdapter {
       }
       if (expr != null) {
         const watchFn =
-            ((prop: any /** TODO #9100 */) =>
-                 (value: any /** TODO #9100 */, prevValue: any /** TODO #9100 */) => {
-                   if (this.inputChanges != null) {
-                     this.inputChangeCount++;
-                     this.inputChanges[prop] = new Ng1Change(prevValue, value);
-                   }
-                   this.component[prop] = value;
-                 })(input.prop);
+            (prop => (currValue: any, prevValue: any) =>
+                 this.updateInput(prop, prevValue, currValue))(input.prop);
         this.componentScope.$watch(expr, watchFn);
       }
     }
@@ -170,6 +163,15 @@ export class DowngradeComponentAdapter {
       this.componentScope.$destroy();
       this.componentRef.destroy();
     });
+  }
+
+  private updateInput(prop: string, prevValue: any, currValue: any) {
+    if (this.inputChanges) {
+      this.inputChangeCount++;
+      this.inputChanges[prop] = new Ng1Change(prevValue, currValue);
+    }
+
+    this.component[prop] = currValue;
   }
 }
 

--- a/modules/@angular/upgrade/src/downgrade_ng2_adapter.ts
+++ b/modules/@angular/upgrade/src/downgrade_ng2_adapter.ts
@@ -49,16 +49,15 @@ export class DowngradeNg2ComponentAdapter {
       const input = inputs[i];
       let expr: any /** TODO #9100 */ = null;
       if (attrs.hasOwnProperty(input.attr)) {
-        const observeFn = ((prop: any /** TODO #9100 */) => {
+        const observeFn = (prop => {
           let prevValue = INITIAL_VALUE;
-          return (value: any /** TODO #9100 */) => {
-            if (this.inputChanges !== null) {
-              this.inputChangeCount++;
-              this.inputChanges[prop] =
-                  new Ng1Change(value, prevValue === INITIAL_VALUE ? value : prevValue);
-              prevValue = value;
+          return (currValue: any) => {
+            if (prevValue === INITIAL_VALUE) {
+              prevValue = currValue;
             }
-            this.component[prop] = value;
+
+            this.updateInput(prop, prevValue, currValue);
+            prevValue = currValue;
           };
         })(input.prop);
         attrs.$observe(input.attr, observeFn);
@@ -73,14 +72,8 @@ export class DowngradeNg2ComponentAdapter {
       }
       if (expr != null) {
         const watchFn =
-            ((prop: any /** TODO #9100 */) =>
-                 (value: any /** TODO #9100 */, prevValue: any /** TODO #9100 */) => {
-                   if (this.inputChanges != null) {
-                     this.inputChangeCount++;
-                     this.inputChanges[prop] = new Ng1Change(prevValue, value);
-                   }
-                   this.component[prop] = value;
-                 })(input.prop);
+            (prop => (currValue: any, prevValue: any) =>
+                 this.updateInput(prop, prevValue, currValue))(input.prop);
         this.componentScope.$watch(expr, watchFn);
       }
     }
@@ -150,6 +143,15 @@ export class DowngradeNg2ComponentAdapter {
       this.componentScope.$destroy();
       this.componentRef.destroy();
     });
+  }
+
+  private updateInput(prop: string, prevValue: any, currValue: any) {
+    if (this.inputChanges) {
+      this.inputChangeCount++;
+      this.inputChanges[prop] = new Ng1Change(prevValue, currValue);
+    }
+
+    this.component[prop] = currValue;
   }
 }
 

--- a/modules/@angular/upgrade/test/aot/integration/downgrade_component_spec.ts
+++ b/modules/@angular/upgrade/test/aot/integration/downgrade_component_spec.ts
@@ -13,7 +13,7 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import * as angular from '@angular/upgrade/src/angular_js';
 import {UpgradeModule, downgradeComponent} from '@angular/upgrade/static';
 
-import {bootstrap, html, multiTrim} from '../test_helpers';
+import {$apply, bootstrap, html, multiTrim} from '../test_helpers';
 
 export function main() {
   describe('downgrade ng2 component', () => {
@@ -22,15 +22,18 @@ export function main() {
     afterEach(() => destroyPlatform());
 
     it('should bind properties, events', async(() => {
-
-         const ng1Module = angular.module('ng1', []).run(($rootScope: angular.IScope) => {
-           $rootScope['dataA'] = 'A';
-           $rootScope['dataB'] = 'B';
-           $rootScope['modelA'] = 'initModelA';
-           $rootScope['modelB'] = 'initModelB';
-           $rootScope['eventA'] = '?';
-           $rootScope['eventB'] = '?';
-         });
+         const ng1Module =
+             angular.module('ng1', []).value('$exceptionHandler', (err: any) => {
+                                        throw err;
+                                      }).run(($rootScope: angular.IScope) => {
+               $rootScope['name'] = 'world';
+               $rootScope['dataA'] = 'A';
+               $rootScope['dataB'] = 'B';
+               $rootScope['modelA'] = 'initModelA';
+               $rootScope['modelB'] = 'initModelB';
+               $rootScope['eventA'] = '?';
+               $rootScope['eventB'] = '?';
+             });
 
          @Component({
            selector: 'ng2',
@@ -94,9 +97,10 @@ export function main() {
                  break;
                case 1:
                  assertChange('twoWayA', 'newA');
+                 assertChange('twoWayB', 'newB');
                  break;
                case 2:
-                 assertChange('twoWayB', 'newB');
+                 assertChange('interpolate', 'Hello everyone');
                  break;
                default:
                  throw new Error('Called too many times! ' + JSON.stringify(changes));
@@ -125,7 +129,7 @@ export function main() {
 
          const element = html(`
            <div>
-             <ng2 literal="Text" interpolate="Hello {{'world'}}"
+             <ng2 literal="Text" interpolate="Hello {{name}}"
                  bind-one-way-a="dataA" [one-way-b]="dataB"
                  bindon-two-way-a="modelA" [(two-way-b)]="modelB"
                  on-event-a='eventA=$event' (event-b)="eventB=$event"></ng2>
@@ -138,6 +142,14 @@ export function main() {
                    'ignore: -; ' +
                    'literal: Text; interpolate: Hello world; ' +
                    'oneWayA: A; oneWayB: B; twoWayA: newA; twoWayB: newB; (2) | ' +
+                   'modelA: newA; modelB: newB; eventA: aFired; eventB: bFired;');
+
+           $apply(upgrade, 'name = "everyone"');
+           expect(multiTrim(document.body.textContent))
+               .toEqual(
+                   'ignore: -; ' +
+                   'literal: Text; interpolate: Hello everyone; ' +
+                   'oneWayA: A; oneWayB: B; twoWayA: newA; twoWayB: newB; (3) | ' +
                    'modelA: newA; modelB: newB; eventA: aFired; eventB: bFired;');
          });
        }));

--- a/modules/@angular/upgrade/test/aot/integration/upgrade_component_spec.ts
+++ b/modules/@angular/upgrade/test/aot/integration/upgrade_component_spec.ts
@@ -13,7 +13,7 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import * as angular from '@angular/upgrade/src/angular_js';
 import {UpgradeComponent, UpgradeModule, downgradeComponent} from '@angular/upgrade/static';
 
-import {bootstrap, digest, html, multiTrim} from '../test_helpers';
+import {$digest, bootstrap, html, multiTrim} from '../test_helpers';
 
 export function main() {
   describe('upgrade ng1 component', () => {
@@ -530,7 +530,7 @@ export function main() {
 
              ng2ComponentInstance.dataA = 'foo2';
              ng2ComponentInstance.dataB = 'bar2';
-             digest(adapter);
+             $digest(adapter);
              tick();
 
              expect(multiTrim(element.textContent))
@@ -605,7 +605,7 @@ export function main() {
 
              ng2ComponentInstance.dataA = {value: 'foo2'};
              ng2ComponentInstance.dataB = {value: 'bar2'};
-             digest(adapter);
+             $digest(adapter);
              tick();
 
              expect(multiTrim(element.textContent))
@@ -682,7 +682,7 @@ export function main() {
 
              ng2ComponentInstance.dataA = {value: 'foo2'};
              ng2ComponentInstance.dataB = {value: 'bar2'};
-             digest(adapter);
+             $digest(adapter);
              tick();
 
              expect(multiTrim(element.textContent))
@@ -929,7 +929,7 @@ export function main() {
 
              ng1Controller1.outputA({value: 'foo again'});
              ng1Controller2.outputB('bar again');
-             digest(adapter);
+             $digest(adapter);
              tick();
 
              expect(ng1Controller0.inputA).toEqual({value: 'foo again'});
@@ -1010,7 +1010,7 @@ export function main() {
                  .toBe('ng1 - Data: [4,5] - Length: 2 | ng2 - Data: 4,5 - Length: 2');
 
              ng1Controller.$scope.outputA(6);
-             digest(adapter);
+             $digest(adapter);
              tick();
 
              expect(ng1Controller.$scope.inputA).toEqual([4, 5, 6]);
@@ -1858,7 +1858,7 @@ export function main() {
 
              // Change: Re-assign `data`
              ng2ComponentInstance.data = {foo: 'baz'};
-             digest(adapter);
+             $digest(adapter);
              tick();
 
              expect(scopeOnChanges.calls.count()).toBe(2);
@@ -1879,7 +1879,7 @@ export function main() {
 
              // No change: Update internal property
              ng2ComponentInstance.data.foo = 'qux';
-             digest(adapter);
+             $digest(adapter);
              tick();
 
              expect(scopeOnChanges.calls.count()).toBe(2);
@@ -1888,7 +1888,7 @@ export function main() {
 
              // Change: Re-assign `data` (even if it looks the same)
              ng2ComponentInstance.data = {foo: 'qux'};
-             digest(adapter);
+             $digest(adapter);
              tick();
 
              expect(scopeOnChanges.calls.count()).toBe(3);
@@ -2008,7 +2008,7 @@ export function main() {
 
              // Change: Re-assign `data`
              ng2ComponentInstance.data = {foo: 'baz'};
-             digest(adapter);
+             $digest(adapter);
              tick();
 
              expect(scopeOnChangesA.calls.count()).toBe(2);
@@ -2029,7 +2029,7 @@ export function main() {
 
              // No change: Update internal property
              ng2ComponentInstance.data.foo = 'qux';
-             digest(adapter);
+             $digest(adapter);
              tick();
 
              expect(scopeOnChangesA.calls.count()).toBe(2);
@@ -2039,7 +2039,7 @@ export function main() {
 
              // Change: Re-assign `data` (even if it looks the same)
              ng2ComponentInstance.data = {foo: 'qux'};
-             digest(adapter);
+             $digest(adapter);
              tick();
 
              expect(scopeOnChangesA.calls.count()).toBe(3);
@@ -2631,7 +2631,7 @@ export function main() {
            expect(scopeDestroyListener).not.toHaveBeenCalled();
 
            ng2ComponentAInstance.destroyIt = true;
-           digest(adapter);
+           $digest(adapter);
 
            expect(scopeDestroyListener).toHaveBeenCalled();
          });
@@ -2795,7 +2795,7 @@ export function main() {
            // (Should not propagate upwards.)
            ng2ComponentBInstance.ng2BInputA = 'foo2';
            ng2ComponentBInstance.ng2BInputC = 'baz2';
-           digest(adapter);
+           $digest(adapter);
            tick();
 
            expect(multiTrim(document.body.textContent))
@@ -2805,7 +2805,7 @@ export function main() {
            // (Should propagate all the way up to `ng1ADataC` and back all the way down to
            // `ng2BInputC`.)
            ng2ComponentBInstance.ng2BOutputC.emit('baz3');
-           digest(adapter);
+           $digest(adapter);
            tick();
 
            expect(multiTrim(document.body.textContent))
@@ -2815,7 +2815,7 @@ export function main() {
            // (Should not propagate upwards, only downwards.)
            ng1ControllerXInstance.ng1XInputA = 'foo4';
            ng1ControllerXInstance.ng1XInputB = {value: 'bar4'};
-           digest(adapter);
+           $digest(adapter);
            tick();
 
            expect(multiTrim(document.body.textContent))
@@ -2824,7 +2824,7 @@ export function main() {
            // Update `ng1XInputC`.
            // (Should propagate upwards and downwards.)
            ng1ControllerXInstance.ng1XInputC = {value: 'baz5'};
-           digest(adapter);
+           $digest(adapter);
            tick();
 
            expect(multiTrim(document.body.textContent))
@@ -2833,7 +2833,7 @@ export function main() {
            // Update a property on `ng1XInputC`.
            // (Should propagate upwards and downwards.)
            ng1ControllerXInstance.ng1XInputC.value = 'baz6';
-           digest(adapter);
+           $digest(adapter);
            tick();
 
            expect(multiTrim(document.body.textContent))
@@ -2842,7 +2842,7 @@ export function main() {
            // Emit from `ng1XOutputA`.
            // (Should propagate upwards to `ng1ADataA` and back all the way down to `ng2BInputA`.)
            (ng1ControllerXInstance as any).ng1XOutputA({value: 'foo7'});
-           digest(adapter);
+           $digest(adapter);
            tick();
 
            expect(multiTrim(document.body.textContent))
@@ -2852,7 +2852,7 @@ export function main() {
            // (Should propagate upwards to `ng1ADataB`, but not downwards,
            //  since `ng1XInputB` has been re-assigned (i.e. `ng2ADataB !== ng1XInputB`).)
            (ng1ControllerXInstance as any).ng1XOutputB('bar8');
-           digest(adapter);
+           $digest(adapter);
            tick();
 
            expect(multiTrim(document.body.textContent))
@@ -2863,7 +2863,7 @@ export function main() {
            ng2ComponentAInstance.ng2ADataA = {value: 'foo9'};
            ng2ComponentAInstance.ng2ADataB = {value: 'bar9'};
            ng2ComponentAInstance.ng2ADataC = {value: 'baz9'};
-           digest(adapter);
+           $digest(adapter);
            tick();
 
            expect(multiTrim(document.body.textContent))

--- a/modules/@angular/upgrade/test/aot/test_helpers.ts
+++ b/modules/@angular/upgrade/test/aot/test_helpers.ts
@@ -21,11 +21,6 @@ export function bootstrap(
   });
 }
 
-export function digest(adapter: UpgradeModule) {
-  const $rootScope = adapter.$injector.get($ROOT_SCOPE) as angular.IRootScopeService;
-  $rootScope.$digest();
-}
-
 export function html(html: string): Element {
   // Don't return `body` itself, because using it as a `$rootElement` for ng1
   // will attach `$injector` to it and that will affect subsequent tests.
@@ -42,4 +37,14 @@ export function html(html: string): Element {
 
 export function multiTrim(text: string): string {
   return text.replace(/\n/g, '').replace(/\s\s+/g, ' ').trim();
+}
+
+export function $apply(adapter: UpgradeModule, exp: angular.Ng1Expression) {
+  const $rootScope = adapter.$injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+  $rootScope.$apply(exp);
+}
+
+export function $digest(adapter: UpgradeModule) {
+  const $rootScope = adapter.$injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+  $rootScope.$digest();
 }

--- a/modules/@angular/upgrade/test/upgrade_spec.ts
+++ b/modules/@angular/upgrade/test/upgrade_spec.ts
@@ -291,9 +291,11 @@ export function main() {
 
       it('should bind properties, events', async(() => {
            const adapter: UpgradeAdapter = new UpgradeAdapter(forwardRef(() => Ng2Module));
-           const ng1Module = angular.module('ng1', []);
+           const ng1Module =
+               angular.module('ng1', []).value('$exceptionHandler', (err: any) => { throw err; });
 
            ng1Module.run(($rootScope: any) => {
+             $rootScope.name = 'world';
              $rootScope.dataA = 'A';
              $rootScope.dataB = 'B';
              $rootScope.modelA = 'initModelA';
@@ -364,9 +366,10 @@ export function main() {
                    break;
                  case 1:
                    assertChange('twoWayA', 'newA');
+                   assertChange('twoWayB', 'newB');
                    break;
                  case 2:
-                   assertChange('twoWayB', 'newB');
+                   assertChange('interpolate', 'Hello everyone');
                    break;
                  default:
                    throw new Error('Called too many times! ' + JSON.stringify(changes));
@@ -381,7 +384,7 @@ export function main() {
                              }).Class({constructor: function() {}});
 
            const element = html(`<div>
-              <ng2 literal="Text" interpolate="Hello {{'world'}}"
+              <ng2 literal="Text" interpolate="Hello {{name}}"
                    bind-one-way-a="dataA" [one-way-b]="dataB"
                    bindon-two-way-a="modelA" [(two-way-b)]="modelB"
                    on-event-a='eventA=$event' (event-b)="eventB=$event"></ng2>
@@ -394,6 +397,15 @@ export function main() {
                      'literal: Text; interpolate: Hello world; ' +
                      'oneWayA: A; oneWayB: B; twoWayA: newA; twoWayB: newB; (2) | ' +
                      'modelA: newA; modelB: newB; eventA: aFired; eventB: bFired;');
+
+             ref.ng1RootScope.$apply('name = "everyone"');
+             expect(multiTrim(document.body.textContent))
+                 .toEqual(
+                     'ignore: -; ' +
+                     'literal: Text; interpolate: Hello everyone; ' +
+                     'oneWayA: A; oneWayB: B; twoWayA: newA; twoWayB: newB; (3) | ' +
+                     'modelA: newA; modelB: newB; eventA: aFired; eventB: bFired;');
+
              ref.dispose();
            });
 


### PR DESCRIPTION
_This is the same as #14301, but for the 2.4.x branch._

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The `previousValue` and `currentValue` arguments passed to the `SimpleChange` constructor are swapped for interpolation bindings.


**What is the new behavior?**
The `previousValue` and `currentValue` arguments passed to the `SimpleChange` constructor are in correct order.
This commit also refactors the code, so that interpolation bindings and property bindings share the same implementation, and fixes some broken tests (that hide failures by allowing the `$exceptionHandler` to swallow thrown exceptions).


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
