### PR TITLE
build: use `ts-api-guardian` v0.2.1

### DIFF
--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -6146,7 +6146,7 @@
       "dev": true
     },
     "ts-api-guardian": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dev": true,
       "dependencies": {
         "diff": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8988,9 +8988,9 @@
       "dev": true
     },
     "ts-api-guardian": {
-      "version": "0.2.0",
-      "from": "ts-api-guardian@0.2.0",
-      "resolved": "https://registry.npmjs.org/ts-api-guardian/-/ts-api-guardian-0.2.0.tgz",
+      "version": "0.2.1",
+      "from": "ts-api-guardian@0.2.1",
+      "resolved": "https://registry.npmjs.org/ts-api-guardian/-/ts-api-guardian-0.2.1.tgz",
       "dev": true,
       "dependencies": {
         "diff": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "source-map": "^0.5.6",
     "source-map-support": "^0.4.2",
     "systemjs": "0.18.10",
-    "ts-api-guardian": "^0.2.0",
+    "ts-api-guardian": "^0.2.1",
     "tsickle": "^0.21.1",
     "tslint": "^4.1.1",
     "tslint-eslint-rules": "^3.1.0",
@@ -97,5 +97,4 @@
     "yargs": "^3.31.0",
     "yarn": "^0.19.1"
   }
-
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Build related changes
```

**What is the new behavior?**

Updates `ts-api-guardian` which now allows stripped exports to be aliases. 

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
