### PR TITLE
feat(compiler): integrate compiler with view engine - change detectio…

### DIFF
--- a/modules/@angular/compiler/src/aot/compiler.ts
+++ b/modules/@angular/compiler/src/aot/compiler.ts
@@ -205,14 +205,14 @@ export class AotCompiler {
     const pipes = ngModule.transitiveModule.pipes.map(
         pipe => this._metadataResolver.getPipeSummary(pipe.reference));
 
-    const parsedTemplate = this._templateParser.parse(
+    const {template: parsedTemplate, pipes: usedPipes} = this._templateParser.parse(
         compMeta, compMeta.template.template, directives, pipes, ngModule.schemas,
         identifierName(compMeta.type));
     const stylesExpr = componentStyles ? o.variable(componentStyles.stylesVar) : o.literalArr([]);
     const compiledAnimations =
         this._animationCompiler.compile(identifierName(compMeta.type), parsedAnimations);
     const viewResult = this._viewCompiler.compileComponent(
-        compMeta, parsedTemplate, stylesExpr, pipes, compiledAnimations);
+        compMeta, parsedTemplate, stylesExpr, usedPipes, compiledAnimations);
     if (componentStyles) {
       targetStatements.push(
           ..._resolveStyleStatements(this._symbolResolver, componentStyles, fileSuffix));

--- a/modules/@angular/compiler/src/compiler_util/render_util.ts
+++ b/modules/@angular/compiler/src/compiler_util/render_util.ts
@@ -13,12 +13,12 @@ import {EMPTY_STATE as EMPTY_ANIMATION_STATE} from '../private_import_core';
 import {BoundElementPropertyAst, BoundEventAst, PropertyBindingType} from '../template_parser/template_ast';
 
 import {isFirstViewCheck} from './binding_util';
-import {ConvertPropertyBindingResult} from './expression_converter';
+import {LegacyConvertPropertyBindingResult} from './expression_converter';
 import {createEnumExpression} from './identifier_util';
 
 export function createCheckRenderBindingStmt(
     view: o.Expression, renderElement: o.Expression, boundProp: BoundElementPropertyAst,
-    oldValue: o.ReadPropExpr, evalResult: ConvertPropertyBindingResult,
+    oldValue: o.ReadPropExpr, evalResult: LegacyConvertPropertyBindingResult,
     securityContextExpression?: o.Expression): o.Statement[] {
   const checkStmts: o.Statement[] = [...evalResult.stmts];
   const securityContext = calcSecurityContext(boundProp, securityContextExpression);
@@ -84,7 +84,7 @@ function calcSecurityContext(
 export function createCheckAnimationBindingStmts(
     view: o.Expression, componentView: o.Expression, boundProp: BoundElementPropertyAst,
     boundOutputs: BoundEventAst[], eventListener: o.Expression, renderElement: o.Expression,
-    oldValue: o.ReadPropExpr, evalResult: ConvertPropertyBindingResult) {
+    oldValue: o.ReadPropExpr, evalResult: LegacyConvertPropertyBindingResult) {
   const detachStmts: o.Statement[] = [];
   const updateStmts: o.Statement[] = [];
 

--- a/modules/@angular/compiler/src/directive_wrapper_compiler.ts
+++ b/modules/@angular/compiler/src/directive_wrapper_compiler.ts
@@ -8,7 +8,7 @@
 
 import {CompileDirectiveMetadata, CompileDirectiveSummary, CompileIdentifierMetadata, dirWrapperClassName, identifierModuleUrl, identifierName} from './compile_metadata';
 import {createCheckBindingField, isFirstViewCheck} from './compiler_util/binding_util';
-import {EventHandlerVars, convertActionBinding, convertPropertyBinding} from './compiler_util/expression_converter';
+import {EventHandlerVars, convertActionBinding, legacyConvertPropertyBinding} from './compiler_util/expression_converter';
 import {createCheckAnimationBindingStmts, createCheckRenderBindingStmt} from './compiler_util/render_util';
 import {CompilerConfig} from './config';
 import {Parser} from './expression_parser/parser';
@@ -253,7 +253,7 @@ function addCheckHostMethod(
   ];
   hostProps.forEach((hostProp, hostPropIdx) => {
     const field = createCheckBindingField(builder);
-    const evalResult = convertPropertyBinding(
+    const evalResult = legacyConvertPropertyBinding(
         builder, null, o.THIS_EXPR.prop(CONTEXT_FIELD_NAME), hostProp.value, field.bindingId);
     if (!evalResult) {
       return;
@@ -285,8 +285,7 @@ function addHandleEventMethod(hostListeners: BoundEventAst[], builder: Directive
   const actionStmts: o.Statement[] = [resultVar.set(o.literal(true)).toDeclStmt(o.BOOL_TYPE)];
   hostListeners.forEach((hostListener, eventIdx) => {
     const evalResult = convertActionBinding(
-        builder, null, o.THIS_EXPR.prop(CONTEXT_FIELD_NAME), hostListener.handler,
-        `sub_${eventIdx}`);
+        null, o.THIS_EXPR.prop(CONTEXT_FIELD_NAME), hostListener.handler, `sub_${eventIdx}`);
     const trueStmts = evalResult.stmts;
     if (evalResult.allowDefault) {
       trueStmts.push(resultVar.set(evalResult.allowDefault.and(resultVar)).toStmt());

--- a/modules/@angular/compiler/src/identifiers.ts
+++ b/modules/@angular/compiler/src/identifiers.ts
@@ -400,10 +400,35 @@ export class Identifiers {
     moduleUrl: VIEW_ENGINE_MODULE_URL,
     runtime: viewEngine.queryDef
   };
+  static pureArrayDef: IdentifierSpec = {
+    name: 'pureArrayDef',
+    moduleUrl: VIEW_ENGINE_MODULE_URL,
+    runtime: viewEngine.pureArrayDef
+  };
+  static pureObjectDef: IdentifierSpec = {
+    name: 'pureObjectDef',
+    moduleUrl: VIEW_ENGINE_MODULE_URL,
+    runtime: viewEngine.pureObjectDef
+  };
+  static purePipeDef: IdentifierSpec = {
+    name: 'purePipeDef',
+    moduleUrl: VIEW_ENGINE_MODULE_URL,
+    runtime: viewEngine.purePipeDef
+  };
+  static pipeDef: IdentifierSpec = {
+    name: 'pipeDef',
+    moduleUrl: VIEW_ENGINE_MODULE_URL,
+    runtime: viewEngine.pipeDef
+  };
   static nodeValue: IdentifierSpec = {
     name: 'nodeValue',
     moduleUrl: VIEW_ENGINE_MODULE_URL,
     runtime: viewEngine.nodeValue
+  };
+  static unwrapValue: IdentifierSpec = {
+    name: 'unwrapValue',
+    moduleUrl: VIEW_ENGINE_MODULE_URL,
+    runtime: viewEngine.unwrapValue
   };
 }
 

--- a/modules/@angular/compiler/src/jit/compiler.ts
+++ b/modules/@angular/compiler/src/jit/compiler.ts
@@ -278,14 +278,14 @@ export class JitCompiler implements Compiler {
         template.directives.map(dir => this._metadataResolver.getDirectiveSummary(dir.reference));
     const pipes = template.ngModule.transitiveModule.pipes.map(
         pipe => this._metadataResolver.getPipeSummary(pipe.reference));
-    const parsedTemplate = this._templateParser.parse(
+    const {template: parsedTemplate, pipes: usedPipes} = this._templateParser.parse(
         compMeta, compMeta.template.template, directives, pipes, template.ngModule.schemas,
         identifierName(compMeta.type));
     const compiledAnimations =
         this._animationCompiler.compile(identifierName(compMeta.type), parsedAnimations);
     const compileResult = this._viewCompiler.compileComponent(
         compMeta, parsedTemplate, ir.variable(stylesCompileResult.componentStylesheet.stylesVar),
-        pipes, compiledAnimations);
+        usedPipes, compiledAnimations);
     const statements = stylesCompileResult.componentStylesheet.statements
                            .concat(...compiledAnimations.map(ca => ca.statements))
                            .concat(compileResult.statements);

--- a/modules/@angular/compiler/src/view_compiler/compile_view.ts
+++ b/modules/@angular/compiler/src/view_compiler/compile_view.ts
@@ -8,7 +8,7 @@
 
 import {AnimationEntryCompileResult} from '../animation/animation_compiler';
 import {CompileDirectiveMetadata, CompilePipeSummary, tokenName, viewClassName} from '../compile_metadata';
-import {EventHandlerVars, NameResolver} from '../compiler_util/expression_converter';
+import {EventHandlerVars, LegacyNameResolver} from '../compiler_util/expression_converter';
 import {CompilerConfig} from '../config';
 import {isPresent} from '../facade/lang';
 import * as o from '../output/output_ast';
@@ -33,7 +33,7 @@ export class CompileViewRootNode {
       public ngContentIndex?: number) {}
 }
 
-export class CompileView implements NameResolver {
+export class CompileView implements LegacyNameResolver {
   public viewType: ViewType;
   public viewQueries: Map<any, CompileQuery[]>;
 

--- a/modules/@angular/compiler/src/view_compiler/event_binder.ts
+++ b/modules/@angular/compiler/src/view_compiler/event_binder.ts
@@ -102,8 +102,8 @@ function generateHandleEventMethod(
   });
   boundEvents.forEach((renderEvent, renderEventIdx) => {
     const evalResult = convertActionBinding(
-        compileElement.view, compileElement.view, compileElement.view.componentContext,
-        renderEvent.handler, `sub_${renderEventIdx}`);
+        compileElement.view, compileElement.view.componentContext, renderEvent.handler,
+        `sub_${renderEventIdx}`);
     const trueStmts = evalResult.stmts;
     if (evalResult.allowDefault) {
       trueStmts.push(resultVar.set(evalResult.allowDefault.and(resultVar)).toStmt());

--- a/modules/@angular/compiler/src/view_compiler/property_binder.ts
+++ b/modules/@angular/compiler/src/view_compiler/property_binder.ts
@@ -9,7 +9,7 @@
 import {SecurityContext} from '@angular/core';
 
 import {createCheckBindingField} from '../compiler_util/binding_util';
-import {convertPropertyBinding} from '../compiler_util/expression_converter';
+import {legacyConvertPropertyBinding} from '../compiler_util/expression_converter';
 import {createEnumExpression} from '../compiler_util/identifier_util';
 import {createCheckAnimationBindingStmts, createCheckRenderBindingStmt} from '../compiler_util/render_util';
 import {DirectiveWrapperExpressions} from '../directive_wrapper_compiler';
@@ -26,7 +26,7 @@ import {getHandleEventMethodName} from './util';
 export function bindRenderText(
     boundText: BoundTextAst, compileNode: CompileNode, view: CompileView): void {
   const valueField = createCheckBindingField(view);
-  const evalResult = convertPropertyBinding(
+  const evalResult = legacyConvertPropertyBinding(
       view, view, view.componentContext, boundText.value, valueField.bindingId);
   if (!evalResult) {
     return null;
@@ -53,7 +53,7 @@ export function bindRenderInputs(
   boundProps.forEach((boundProp) => {
     const bindingField = createCheckBindingField(view);
     view.detectChangesRenderPropertiesMethod.resetDebugInfo(compileElement.nodeIndex, boundProp);
-    const evalResult = convertPropertyBinding(
+    const evalResult = legacyConvertPropertyBinding(
         view, view, compileElement.view.componentContext, boundProp.value, bindingField.bindingId);
     if (!evalResult) {
       return;
@@ -123,7 +123,7 @@ export function bindDirectiveInputs(
     const bindingId = `${compileElement.nodeIndex}_${dirIndex}_${inputIdx}`;
     detectChangesInInputsMethod.resetDebugInfo(compileElement.nodeIndex, input);
     const evalResult =
-        convertPropertyBinding(view, view, view.componentContext, input.value, bindingId);
+        legacyConvertPropertyBinding(view, view, view.componentContext, input.value, bindingId);
     if (!evalResult) {
       return;
     }

--- a/modules/@angular/compiler/src/view_compiler/view_builder.ts
+++ b/modules/@angular/compiler/src/view_compiler/view_builder.ts
@@ -9,7 +9,7 @@
 import {ViewEncapsulation} from '@angular/core';
 
 import {CompileDirectiveSummary, identifierModuleUrl, identifierName} from '../compile_metadata';
-import {createSharedBindingVariablesIfNeeded} from '../compiler_util/expression_converter';
+import {legacyCreateSharedBindingVariablesIfNeeded} from '../compiler_util/expression_converter';
 import {createDiTokenExpression, createInlineArray} from '../compiler_util/identifier_util';
 import {isPresent} from '../facade/lang';
 import {Identifiers, createIdentifier, identifierToken} from '../identifiers';
@@ -586,7 +586,7 @@ function generateDetectChangesMethod(view: CompileView): o.Statement[] {
     stmts.push(new o.IfStmt(o.not(ViewProperties.throwOnChange), afterViewStmts));
   }
 
-  const varStmts = createSharedBindingVariablesIfNeeded(stmts);
+  const varStmts = legacyCreateSharedBindingVariablesIfNeeded(stmts);
   return varStmts.concat(stmts);
 }
 

--- a/modules/@angular/compiler/src/view_compiler_next/view_compiler.ts
+++ b/modules/@angular/compiler/src/view_compiler_next/view_compiler.ts
@@ -10,7 +10,7 @@ import {ChangeDetectionStrategy} from '@angular/core';
 
 import {AnimationEntryCompileResult} from '../animation/animation_compiler';
 import {CompileDiDependencyMetadata, CompileDirectiveMetadata, CompileDirectiveSummary, CompilePipeSummary, CompileProviderMetadata, CompileTokenMetadata, identifierModuleUrl, identifierName, tokenReference} from '../compile_metadata';
-import {EventHandlerVars, NameResolver, convertActionBinding, convertPropertyBinding} from '../compiler_util/expression_converter';
+import {BuiltinConverter, BuiltinConverterFactory, EventHandlerVars, LocalResolver, convertActionBinding, convertPropertyBinding, convertPropertyBindingBuiltins} from '../compiler_util/expression_converter';
 import {CompilerConfig} from '../config';
 import {AST, ASTWithSource, Interpolation} from '../expression_parser/ast';
 import {Identifiers, createIdentifier, resolveIdentifier} from '../identifiers';
@@ -25,6 +25,7 @@ import {ComponentFactoryDependency, ComponentViewDependency, DirectiveWrapperDep
 
 const CLASS_ATTR = 'class';
 const STYLE_ATTR = 'style';
+const IMPLICIT_TEMPLATE_VAR = '\$implicit';
 
 @CompilerInjectable()
 export class ViewCompilerNext extends ViewCompiler {
@@ -35,7 +36,7 @@ export class ViewCompilerNext extends ViewCompiler {
 
   compileComponent(
       component: CompileDirectiveMetadata, template: TemplateAst[], styles: o.Expression,
-      pipes: CompilePipeSummary[],
+      usedPipes: CompilePipeSummary[],
       compiledAnimations: AnimationEntryCompileResult[]): ViewCompileResult {
     const compName = identifierName(component.type) + (component.isHost ? `_Host` : '');
 
@@ -44,7 +45,7 @@ export class ViewCompilerNext extends ViewCompiler {
     const viewBuilderFactory = (parent: ViewBuilder): ViewBuilder => {
       const embeddedViewIndex = embeddedViewCount++;
       const viewName = `view_${compName}_${embeddedViewIndex}`;
-      return new ViewBuilder(parent, viewName, viewBuilderFactory);
+      return new ViewBuilder(parent, viewName, usedPipes, viewBuilderFactory);
     };
 
     const visitor = viewBuilderFactory(null);
@@ -80,20 +81,31 @@ const NODE_INDEX_VAR = o.variable('nodeIndex');
 const EVENT_NAME_VAR = o.variable('eventName');
 const ALLOW_DEFAULT_VAR = o.variable(`allowDefault`);
 
-class ViewBuilder implements TemplateAstVisitor, NameResolver {
+class ViewBuilder implements TemplateAstVisitor, LocalResolver, BuiltinConverterFactory {
   private nodeDefs: o.Expression[] = [];
+  private purePipeNodeIndices: {[pipeName: string]: number} = {};
   private refNodeIndices: {[refName: string]: number} = {};
   private variables: VariableAst[] = [];
   private children: ViewBuilder[] = [];
-  private updateExpressions: UpdateExpression[] = [];
+  private updateDirectivesExpressions: UpdateExpression[] = [];
+  private updateRendererExpressions: UpdateExpression[] = [];
   private handleEventExpressions: HandleEventExpression[] = [];
 
   constructor(
-      private parent: ViewBuilder, public viewName: string,
+      private parent: ViewBuilder, public viewName: string, private usedPipes: CompilePipeSummary[],
       private viewBuilderFactory: ViewBuilderFactory) {}
 
   visitAll(variables: VariableAst[], astNodes: TemplateAst[], elementDepth: number) {
     this.variables = variables;
+    // create the pipes for the pure pipes immediately, so that we know their indices.
+    if (!this.parent) {
+      this.usedPipes.forEach((pipe) => {
+        if (pipe.pure) {
+          this.purePipeNodeIndices[pipe.name] = this._createPipe(pipe);
+        }
+      });
+    }
+
     templateVisitAll(this, astNodes, {elementDepth});
     if (astNodes.length === 0 || (this.parent && hasViewContainer(astNodes[astNodes.length - 1]))) {
       // if the view is empty, or an embedded view has a view container as last root nde,
@@ -108,46 +120,16 @@ class ViewBuilder implements TemplateAstVisitor, NameResolver {
     const compType = o.importType(component.type);
     this.children.forEach((child) => { child.build(component, targetStatements); });
 
-    const updateStmts: o.Statement[] = [];
-    let updateBindingCount = 0;
-    this.updateExpressions
-        .forEach(
-            ({expressions, nodeIndex}) => {
-              const exprs = expressions.map(({context, value}) => {
-                const bindingId = `${updateBindingCount++}`;
-                const {stmts, currValExpr} =
-                    convertPropertyBinding(null, this, context, value, bindingId);
-                updateStmts.push(...stmts);
-                return currValExpr;
-              });
-              if (exprs.length > 10) {
-                updateStmts.push(
-                    CHECK_VAR
-                        .callFn([
-                          VIEW_VAR, o.literal(nodeIndex),
-                          o.literal(viewEngine.ArgumentType.Dynamic), o.literalArr(exprs)
-                        ])
-                        .toStmt());
-              } else {
-                updateStmts.push(
-            CHECK_VAR.callFn((<o.Expression[]>[VIEW_VAR, o.literal(nodeIndex), o.literal(viewEngine.ArgumentType.Inline)]).concat(exprs)).toStmt());
-              }
-            });
-    let updateFn: o.Expression;
-    if (updateStmts.length > 0) {
-      updateFn = o.fn(
-          [new o.FnParam(CHECK_VAR.name), new o.FnParam(VIEW_VAR.name)],
-          [COMP_VAR.set(VIEW_VAR.prop('component')).toDeclStmt(compType), ...updateStmts]);
-    } else {
-      updateFn = o.NULL_EXPR;
-    }
+    const updateDirectivesFn = this._createUpdateFn(this.updateDirectivesExpressions, compType);
+    const updateRendererFn = this._createUpdateFn(this.updateRendererExpressions, compType);
 
     const handleEventStmts: o.Statement[] = [];
     let handleEventBindingCount = 0;
     this.handleEventExpressions.forEach(({expression, context, nodeIndex, eventName}) => {
       const bindingId = `${handleEventBindingCount++}`;
+      const nameResolver = context === COMP_VAR ? this : null;
       const {stmts, allowDefault} =
-          convertActionBinding(null, this, context, expression, bindingId);
+          convertActionBinding(nameResolver, context, expression, bindingId);
       const trueStmts = stmts;
       if (allowDefault) {
         trueStmts.push(ALLOW_DEFAULT_VAR.set(allowDefault.and(ALLOW_DEFAULT_VAR)).toStmt());
@@ -181,11 +163,37 @@ class ViewBuilder implements TemplateAstVisitor, NameResolver {
     const viewFactory = new o.DeclareFunctionStmt(
         this.viewName, [],
         [new o.ReturnStatement(o.importExpr(createIdentifier(Identifiers.viewDef)).callFn([
-          o.literal(viewFlags), o.literalArr(this.nodeDefs), updateFn, handleEventFn
+          o.literal(viewFlags), o.literalArr(this.nodeDefs), updateDirectivesFn, updateRendererFn,
+          handleEventFn
         ]))]);
 
     targetStatements.push(viewFactory);
     return targetStatements;
+  }
+
+  private _createUpdateFn(expressions: UpdateExpression[], compType: o.Type): o.Expression {
+    const updateStmts: o.Statement[] = [];
+    let updateBindingCount = 0;
+    expressions.forEach(({expressions, nodeIndex}) => {
+      const exprs = expressions.map(({context, value}) => {
+        const bindingId = `${updateBindingCount++}`;
+        const nameResolver = context === COMP_VAR ? this : null;
+        const {stmts, currValExpr} =
+            convertPropertyBinding(nameResolver, context, value, bindingId);
+        updateStmts.push(...stmts);
+        return currValExpr;
+      });
+      updateStmts.push(callCheckStmt(nodeIndex, exprs).toStmt());
+    });
+    let updateFn: o.Expression;
+    if (updateStmts.length > 0) {
+      updateFn = o.fn(
+          [new o.FnParam(CHECK_VAR.name), new o.FnParam(VIEW_VAR.name)],
+          [COMP_VAR.set(VIEW_VAR.prop('component')).toDeclStmt(compType), ...updateStmts]);
+    } else {
+      updateFn = o.NULL_EXPR;
+    }
+    return updateFn;
   }
 
   visitNgContent(ast: NgContentAst, context: any): any {}
@@ -199,17 +207,20 @@ class ViewBuilder implements TemplateAstVisitor, NameResolver {
 
   visitBoundText(ast: BoundTextAst, context: any): any {
     const nodeIndex = this.nodeDefs.length;
+    // reserve the space in the nodeDefs array
+    this.nodeDefs.push(null);
+
     const astWithSource = <ASTWithSource>ast.value;
     const inter = <Interpolation>astWithSource.ast;
-    this.updateExpressions.push({
-      nodeIndex,
-      expressions: inter.expressions.map((expr) => { return {context: COMP_VAR, value: expr}; })
-    });
+
+    this._addUpdateExpressions(
+        nodeIndex, inter.expressions.map((expr) => { return {context: COMP_VAR, value: expr}; }),
+        this.updateRendererExpressions);
 
     // textDef(ngContentIndex: number, constants: string[]): NodeDef;
-    this.nodeDefs.push(o.importExpr(createIdentifier(Identifiers.textDef)).callFn([
+    this.nodeDefs[nodeIndex] = o.importExpr(createIdentifier(Identifiers.textDef)).callFn([
       o.NULL_EXPR, o.literalArr(inter.strings.map(s => o.literal(s)))
-    ]));
+    ]);
   }
 
   visitEmbeddedTemplate(ast: EmbeddedTemplateAst, context: {elementDepth: number}): any {
@@ -219,10 +230,11 @@ class ViewBuilder implements TemplateAstVisitor, NameResolver {
 
     const {flags, queryMatchesExpr} = this._visitElementOrTemplate(nodeIndex, ast, context);
 
-    const childCount = this.nodeDefs.length - nodeIndex - 1;
     const childVisitor = this.viewBuilderFactory(this);
     this.children.push(childVisitor);
     childVisitor.visitAll(ast.variables, ast.children, context.elementDepth + 1);
+
+    const childCount = this.nodeDefs.length - nodeIndex - 1;
 
     // anchorDef(
     //   flags: NodeFlags, matchedQueries: [string, QueryValueType][], ngContentIndex: number,
@@ -243,12 +255,9 @@ class ViewBuilder implements TemplateAstVisitor, NameResolver {
 
     templateVisitAll(this, ast.children, {elementDepth: context.elementDepth + 1});
 
-    const childCount = this.nodeDefs.length - nodeIndex - 1;
-
-    ast.inputs.forEach((inputAst) => {
-      hostBindings.push({context: COMP_VAR, value: (<ASTWithSource>inputAst.value).ast});
-    });
-    this.updateExpressions.push({nodeIndex, expressions: hostBindings});
+    ast.inputs.forEach(
+        (inputAst) => { hostBindings.push({context: COMP_VAR, value: inputAst.value}); });
+    this._addUpdateExpressions(nodeIndex, hostBindings, this.updateRendererExpressions);
 
     const inputDefs = elementBindingDefs(ast.inputs);
     ast.directives.forEach(
@@ -257,6 +266,8 @@ class ViewBuilder implements TemplateAstVisitor, NameResolver {
       return target ? o.literalArr([o.literal(target), o.literal(eventName)]) :
                       o.literal(eventName);
     });
+
+    const childCount = this.nodeDefs.length - nodeIndex - 1;
 
     // elementDef(
     //   flags: NodeFlags, matchedQueries: [string, QueryValueType][], ngContentIndex: number,
@@ -355,13 +366,10 @@ class ViewBuilder implements TemplateAstVisitor, NameResolver {
     ast.outputs.forEach(
         (outputAst) => { hostEvents.push({context: COMP_VAR, eventAst: outputAst}); });
     hostEvents.forEach((hostEvent) => {
-      this.handleEventExpressions.push({
-        nodeIndex,
-        context: hostEvent.context,
-        eventName:
-            viewEngine.elementEventFullName(hostEvent.eventAst.target, hostEvent.eventAst.name),
-        expression: (<ASTWithSource>hostEvent.eventAst.handler).ast
-      });
+      this._addHandleEventExpression(
+          nodeIndex, hostEvent.context,
+          viewEngine.elementEventFullName(hostEvent.eventAst.target, hostEvent.eventAst.name),
+          hostEvent.eventAst.handler);
     });
 
     return {
@@ -382,6 +390,22 @@ class ViewBuilder implements TemplateAstVisitor, NameResolver {
     const nodeIndex = this.nodeDefs.length;
     // reserve the space in the nodeDefs array so we can add children
     this.nodeDefs.push(null);
+
+    directiveAst.directive.queries.forEach((query, queryIndex) => {
+      const queryId: QueryId = {elementDepth, directiveIndex, queryIndex};
+      const bindingType =
+          query.first ? viewEngine.QueryBindingType.First : viewEngine.QueryBindingType.All;
+      this.nodeDefs.push(o.importExpr(createIdentifier(Identifiers.queryDef)).callFn([
+        o.literal(viewEngine.NodeFlags.HasContentQuery), o.literal(calcQueryId(queryId)),
+        new o.LiteralMapExpr([new o.LiteralMapEntry(query.propertyName, o.literal(bindingType))])
+      ]));
+    });
+
+    // Note: the operation below might also create new nodeDefs,
+    // but we don't want them to be a child of a directive,
+    // as they might be a provider/pipe on their own.
+    // I.e. we only allow queries as children of directives nodes.
+    const childCount = this.nodeDefs.length - nodeIndex - 1;
 
     const {flags, queryMatchExprs, providerExpr, providerType, depsExpr} =
         this._visitProviderOrDirective(providerAst, queryMatches);
@@ -415,11 +439,10 @@ class ViewBuilder implements TemplateAstVisitor, NameResolver {
       }
     });
     if (directiveAst.inputs.length) {
-      this.updateExpressions.push({
-        nodeIndex,
-        expressions: directiveAst.inputs.map(
-            input => { return {context: COMP_VAR, value: (<ASTWithSource>input.value).ast}; })
-      });
+      this._addUpdateExpressions(
+          nodeIndex,
+          directiveAst.inputs.map((input) => { return {context: COMP_VAR, value: input.value}; }),
+          this.updateDirectivesExpressions);
     }
 
     const dirContextExpr = o.importExpr(createIdentifier(Identifiers.nodeValue)).callFn([
@@ -434,19 +457,6 @@ class ViewBuilder implements TemplateAstVisitor, NameResolver {
     const hostEvents = directiveAst.hostEvents.map(
         (hostEventAst) => { return {context: dirContextExpr, eventAst: hostEventAst}; });
 
-    const childCount = directiveAst.directive.queries.length;
-    directiveAst.directive.queries.forEach((query, queryIndex) => {
-      const queryId: QueryId = {elementDepth, directiveIndex, queryIndex};
-      const bindingType =
-          query.first ? viewEngine.QueryBindingType.First : viewEngine.QueryBindingType.All;
-      // queryDef(
-      //   flags: NodeFlags, id: string, bindings: {[propName: string]: QueryBindingType}): NodeDef
-      //   {
-      this.nodeDefs.push(o.importExpr(createIdentifier(Identifiers.queryDef)).callFn([
-        o.literal(viewEngine.NodeFlags.HasContentQuery), o.literal(calcQueryId(queryId)),
-        new o.LiteralMapExpr([new o.LiteralMapEntry(query.propertyName, o.literal(bindingType))])
-      ]));
-    });
 
     // directiveDef(
     //   flags: NodeFlags, matchedQueries: [string, QueryValueType][], childCount: number, ctor:
@@ -514,10 +524,6 @@ class ViewBuilder implements TemplateAstVisitor, NameResolver {
     return {flags, queryMatchExprs, providerExpr, providerType, depsExpr};
   }
 
-  callPipe(name: string, input: o.Expression, args: o.Expression[]): o.Expression {
-    throw new Error('Pipes are not yet supported!');
-  }
-
   getLocal(name: string): o.Expression {
     if (name == EventHandlerVars.event.name) {
       return EventHandlerVars.event;
@@ -536,10 +542,121 @@ class ViewBuilder implements TemplateAstVisitor, NameResolver {
       // check variables
       const varAst = currBuilder.variables.find((varAst) => varAst.name === name);
       if (varAst) {
-        return currViewExpr.prop('context').prop(varAst.value);
+        const varValue = varAst.value || IMPLICIT_TEMPLATE_VAR;
+        return currViewExpr.prop('context').prop(varValue);
       }
     }
     return null;
+  }
+
+  createLiteralArrayConverter(argCount: number): BuiltinConverter {
+    if (argCount === 0) {
+      const valueExpr = o.importExpr(createIdentifier(Identifiers.EMPTY_ARRAY));
+      return () => valueExpr;
+    }
+
+    const nodeIndex = this.nodeDefs.length;
+    // pureArrayDef(argCount: number): NodeDef;
+    const nodeDef =
+        o.importExpr(createIdentifier(Identifiers.pureArrayDef)).callFn([o.literal(argCount)]);
+    this.nodeDefs.push(nodeDef);
+
+    return (args: o.Expression[]) => callCheckStmt(nodeIndex, args);
+  }
+  createLiteralMapConverter(keys: string[]): BuiltinConverter {
+    if (keys.length === 0) {
+      const valueExpr = o.importExpr(createIdentifier(Identifiers.EMPTY_MAP));
+      return () => valueExpr;
+    }
+
+    const nodeIndex = this.nodeDefs.length;
+    // function pureObjectDef(propertyNames: string[]): NodeDef
+    const nodeDef = o.importExpr(createIdentifier(Identifiers.pureObjectDef)).callFn([o.literalArr(
+        keys.map(key => o.literal(key)))]);
+    this.nodeDefs.push(nodeDef);
+
+    return (args: o.Expression[]) => callCheckStmt(nodeIndex, args);
+  }
+  createPipeConverter(name: string, argCount: number): BuiltinConverter {
+    const pipe = this._findPipe(name);
+    if (pipe.pure) {
+      const nodeIndex = this.nodeDefs.length;
+      // function purePipeDef(argCount: number): NodeDef;
+      const nodeDef =
+          o.importExpr(createIdentifier(Identifiers.purePipeDef)).callFn([o.literal(argCount)]);
+      this.nodeDefs.push(nodeDef);
+
+      // find underlying pipe in the component view
+      let compViewExpr: o.Expression = VIEW_VAR;
+      let compBuilder: ViewBuilder = this;
+      while (compBuilder.parent) {
+        compBuilder = compBuilder.parent;
+        compViewExpr = compViewExpr.prop('parent');
+      }
+      const pipeNodeIndex = compBuilder.purePipeNodeIndices[name];
+      const pipeValueExpr: o.Expression =
+          o.importExpr(createIdentifier(Identifiers.nodeValue)).callFn([
+            compViewExpr, o.literal(pipeNodeIndex)
+          ]);
+
+      return (args: o.Expression[]) =>
+                 callUnwrapValue(callCheckStmt(nodeIndex, [pipeValueExpr].concat(args)));
+    } else {
+      const nodeIndex = this._createPipe(pipe);
+      const nodeValueExpr = o.importExpr(createIdentifier(Identifiers.nodeValue)).callFn([
+        VIEW_VAR, o.literal(nodeIndex)
+      ]);
+
+      return (args: o.Expression[]) => callUnwrapValue(nodeValueExpr.callMethod('transform', args));
+    }
+  }
+
+  private _findPipe(name: string): CompilePipeSummary {
+    return this.usedPipes.find((pipeSummary) => pipeSummary.name === name);
+  }
+
+  private _createPipe(pipe: CompilePipeSummary): number {
+    const nodeIndex = this.nodeDefs.length;
+    let flags = viewEngine.NodeFlags.None;
+    pipe.type.lifecycleHooks.forEach((lifecycleHook) => {
+      // for pipes, we only support ngOnDestroy
+      if (lifecycleHook === LifecycleHooks.OnDestroy) {
+        flags |= lifecycleHookToNodeFlag(lifecycleHook);
+      }
+    });
+
+    const depExprs = pipe.type.diDeps.map(depDef);
+    // function pipeDef(
+    //   flags: NodeFlags, ctor: any, deps: ([DepFlags, any] | any)[]): NodeDef
+    const nodeDef = o.importExpr(createIdentifier(Identifiers.pipeDef)).callFn([
+      o.literal(flags), o.importExpr(pipe.type), o.literalArr(depExprs)
+    ]);
+    this.nodeDefs.push(nodeDef);
+    return nodeIndex;
+  }
+
+  // Attention: This might create new nodeDefs (for pipes and literal arrays and literal maps)!
+  private _addUpdateExpressions(
+      nodeIndex: number, expressions: {context: o.Expression, value: AST}[],
+      target: UpdateExpression[]) {
+    if (expressions.length === 0) {
+      return;
+    }
+    const transformedExpressions = expressions.map(({context, value}) => {
+      if (value instanceof ASTWithSource) {
+        value = value.ast;
+      }
+      return {context, value: convertPropertyBindingBuiltins(this, value)};
+    });
+    target.push({nodeIndex, expressions: transformedExpressions});
+  }
+
+  private _addHandleEventExpression(
+      nodeIndex: number, context: o.Expression, eventName: string, expression: AST) {
+    if (expression instanceof ASTWithSource) {
+      expression = expression.ast;
+    }
+    this.handleEventExpressions.push({nodeIndex, context, eventName, expression});
   }
 
   visitDirective(ast: DirectiveAst, context: {usedEvents: Set<string>}): any {}
@@ -735,4 +852,20 @@ function mergeAttributeValue(attrName: string, attrValue1: string, attrValue2: s
   } else {
     return attrValue2;
   }
+}
+
+function callCheckStmt(nodeIndex: number, exprs: o.Expression[]): o.Expression {
+  if (exprs.length > 10) {
+    return CHECK_VAR.callFn([
+      VIEW_VAR, o.literal(nodeIndex), o.literal(viewEngine.ArgumentType.Dynamic),
+      o.literalArr(exprs)
+    ]);
+  } else {
+    return CHECK_VAR.callFn(
+        [VIEW_VAR, o.literal(nodeIndex), o.literal(viewEngine.ArgumentType.Inline), ...exprs]);
+  }
+}
+
+function callUnwrapValue(expr: o.Expression): o.Expression {
+  return o.importExpr(createIdentifier(Identifiers.unwrapValue)).callFn([expr]);
 }

--- a/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
+++ b/modules/@angular/compiler/test/template_parser/template_parser_spec.ts
@@ -70,7 +70,8 @@ export function main() {
             if (pipes === null) {
               pipes = [];
             }
-            return parser.parse(component, template, directives, pipes, schemas, 'TestComp');
+            return parser.parse(component, template, directives, pipes, schemas, 'TestComp')
+                .template;
           };
     }));
   }
@@ -306,10 +307,10 @@ export function main() {
              isComponent: true,
              template: new CompileTemplateMetadata({interpolation: ['{%', '%}']})
            });
-           expect(humanizeTplAst(parser.parse(component, '{%a%}', [], [], [], 'TestComp'), {
-             start: '{%',
-             end: '%}'
-           })).toEqual([[BoundTextAst, '{% a %}']]);
+           expect(humanizeTplAst(
+                      parser.parse(component, '{%a%}', [], [], [], 'TestComp').template,
+                      {start: '{%', end: '%}'}))
+               .toEqual([[BoundTextAst, '{% a %}']]);
          }));
 
       describe('bound properties', () => {

--- a/modules/@angular/core/src/view/element.ts
+++ b/modules/@angular/core/src/view/element.ts
@@ -10,7 +10,7 @@ import {isDevMode} from '../application_ref';
 import {SecurityContext} from '../security';
 
 import {BindingDef, BindingType, DebugContext, DisposableFn, ElementData, ElementOutputDef, NodeData, NodeDef, NodeFlags, NodeType, QueryValueType, Services, ViewData, ViewDefinition, ViewDefinitionFactory, ViewFlags, asElementData} from './types';
-import {checkAndUpdateBinding, dispatchEvent, elementEventFullName, resolveViewDefinition, sliceErrorStack, unwrapValue} from './util';
+import {checkAndUpdateBinding, dispatchEvent, elementEventFullName, resolveViewDefinition, sliceErrorStack} from './util';
 
 export function anchorDef(
     flags: NodeFlags, matchedQueries: [string, QueryValueType][], ngContentIndex: number,
@@ -209,8 +209,6 @@ function checkAndUpdateElementValue(view: ViewData, def: NodeDef, bindingIdx: nu
   if (!checkAndUpdateBinding(view, def, bindingIdx, value)) {
     return;
   }
-  value = unwrapValue(value);
-
   const binding = def.bindings[bindingIdx];
   const name = binding.name;
   const renderNode = asElementData(view, def.index).renderElement;

--- a/modules/@angular/core/src/view/errors.ts
+++ b/modules/@angular/core/src/view/errors.ts
@@ -31,7 +31,6 @@ export function viewDebugError(msg: string, context: DebugContext): Error {
   const err = new Error(msg);
   (err as any)[ERROR_DEBUG_CONTEXT] = context;
   err.stack = context.source;
-  context.view.state |= ViewState.Errored;
   return err;
 }
 

--- a/modules/@angular/core/src/view/index.ts
+++ b/modules/@angular/core/src/view/index.ts
@@ -8,13 +8,13 @@
 
 export {anchorDef, elementDef} from './element';
 export {ngContentDef} from './ng_content';
-export {directiveDef, providerDef} from './provider';
+export {directiveDef, pipeDef, providerDef} from './provider';
 export {pureArrayDef, pureObjectDef, purePipeDef} from './pure_expression';
 export {queryDef} from './query';
 export {createComponentFactory} from './refs';
 export {initServicesIfNeeded} from './services';
 export {textDef} from './text';
-export {elementEventFullName, nodeValue, rootRenderNodes} from './util';
+export {elementEventFullName, nodeValue, rootRenderNodes, unwrapValue} from './util';
 export {viewDef} from './view';
 export {attachEmbeddedView, detachEmbeddedView, moveEmbeddedView} from './view_attach';
 

--- a/modules/@angular/core/src/view/provider.ts
+++ b/modules/@angular/core/src/view/provider.ts
@@ -15,8 +15,8 @@ import * as v1renderer from '../render/api';
 import {Type} from '../type';
 
 import {createChangeDetectorRef, createInjector, createTemplateRef, createViewContainerRef} from './refs';
-import {BindingDef, BindingType, DepDef, DepFlags, DisposableFn, NodeData, NodeDef, NodeFlags, NodeType, ProviderData, ProviderOutputDef, ProviderType, QueryBindingType, QueryDef, QueryValueType, RootData, Services, ViewData, ViewDefinition, ViewFlags, ViewState, asElementData, asProviderData} from './types';
-import {checkAndUpdateBinding, dispatchEvent, isComponentView, tokenKey, unwrapValue, viewParentDiIndex} from './util';
+import {BindingDef, BindingType, DepDef, DepFlags, DirectiveOutputDef, DisposableFn, NodeData, NodeDef, NodeFlags, NodeType, ProviderData, ProviderType, QueryBindingType, QueryDef, QueryValueType, RootData, Services, ViewData, ViewDefinition, ViewFlags, ViewState, asElementData, asProviderData} from './types';
+import {checkAndUpdateBinding, dispatchEvent, isComponentView, tokenKey, viewParentElIndex} from './util';
 
 const RendererV1TokenKey = tokenKey(v1renderer.Renderer);
 const ElementRefTokenKey = tokenKey(ElementRef);
@@ -31,45 +31,55 @@ export function directiveDef(
     flags: NodeFlags, matchedQueries: [string, QueryValueType][], childCount: number, ctor: any,
     deps: ([DepFlags, any] | any)[], props?: {[name: string]: [number, string]},
     outputs?: {[name: string]: string}, component?: () => ViewDefinition): NodeDef {
-  return _providerDef(
-      flags, matchedQueries, childCount, ProviderType.Class, ctor, ctor, deps, props, outputs,
-      component);
-}
-
-export function providerDef(
-    flags: NodeFlags, matchedQueries: [string, QueryValueType][], type: ProviderType, token: any,
-    value: any, deps: ([DepFlags, any] | any)[]): NodeDef {
-  return _providerDef(flags, matchedQueries, 0, type, token, value, deps);
-}
-
-export function _providerDef(
-    flags: NodeFlags, matchedQueries: [string, QueryValueType][], childCount: number,
-    type: ProviderType, token: any, value: any, deps: ([DepFlags, any] | any)[],
-    props?: {[name: string]: [number, string]}, outputs?: {[name: string]: string},
-    component?: () => ViewDefinition): NodeDef {
-  const matchedQueryDefs: {[queryId: string]: QueryValueType} = {};
-  if (matchedQueries) {
-    matchedQueries.forEach(([queryId, valueType]) => { matchedQueryDefs[queryId] = valueType; });
-  }
-
   const bindings: BindingDef[] = [];
   if (props) {
     for (let prop in props) {
       const [bindingIndex, nonMinifiedName] = props[prop];
       bindings[bindingIndex] = {
-        type: BindingType.ProviderProperty,
+        type: BindingType.DirectiveProperty,
         name: prop, nonMinifiedName,
         securityContext: undefined,
         suffix: undefined
       };
     }
   }
-  const outputDefs: ProviderOutputDef[] = [];
+  const outputDefs: DirectiveOutputDef[] = [];
   if (outputs) {
     for (let propName in outputs) {
       outputDefs.push({propName, eventName: outputs[propName]});
     }
   }
+  return _def(
+      NodeType.Directive, flags, matchedQueries, childCount, ProviderType.Class, ctor, ctor, deps,
+      bindings, outputDefs, component);
+}
+
+export function pipeDef(flags: NodeFlags, ctor: any, deps: ([DepFlags, any] | any)[]): NodeDef {
+  return _def(NodeType.Pipe, flags, null, 0, ProviderType.Class, ctor, ctor, deps);
+}
+
+export function providerDef(
+    flags: NodeFlags, matchedQueries: [string, QueryValueType][], type: ProviderType, token: any,
+    value: any, deps: ([DepFlags, any] | any)[]): NodeDef {
+  return _def(NodeType.Provider, flags, matchedQueries, 0, type, token, value, deps);
+}
+
+export function _def(
+    type: NodeType, flags: NodeFlags, matchedQueries: [string, QueryValueType][],
+    childCount: number, providerType: ProviderType, token: any, value: any,
+    deps: ([DepFlags, any] | any)[], bindings?: BindingDef[], outputs?: DirectiveOutputDef[],
+    component?: () => ViewDefinition): NodeDef {
+  const matchedQueryDefs: {[queryId: string]: QueryValueType} = {};
+  if (matchedQueries) {
+    matchedQueries.forEach(([queryId, valueType]) => { matchedQueryDefs[queryId] = valueType; });
+  }
+  if (!outputs) {
+    outputs = [];
+  }
+  if (!bindings) {
+    bindings = [];
+  }
+
   const depDefs: DepDef[] = deps.map(value => {
     let token: any;
     let flags: DepFlags;
@@ -86,7 +96,7 @@ export function _providerDef(
   }
 
   return {
-    type: NodeType.Provider,
+    type,
     // will bet set by the view definition
     index: undefined,
     reverseChildIndex: undefined,
@@ -99,14 +109,13 @@ export function _providerDef(
     flags,
     matchedQueries: matchedQueryDefs,
     ngContentIndex: undefined, childCount, bindings,
-    disposableCount: outputDefs.length,
+    disposableCount: outputs.length,
     element: undefined,
     provider: {
-      type,
+      type: providerType,
       token,
       tokenKey: tokenKey(token), value,
-      deps: depDefs,
-      outputs: outputDefs, component
+      deps: depDefs, outputs, component
     },
     text: undefined,
     pureExpression: undefined,
@@ -116,96 +125,114 @@ export function _providerDef(
 }
 
 export function createProviderInstance(view: ViewData, def: NodeDef): any {
+  return def.flags & NodeFlags.LazyProvider ? NOT_CREATED : _createProviderInstance(view, def);
+}
+
+export function createPipeInstance(view: ViewData, def: NodeDef): any {
+  // deps are looked up from component.
+  let compView = view;
+  while (compView.parent && !isComponentView(compView)) {
+    compView = compView.parent;
+  }
+  // pipes are always eager and classes!
+  return createClass(
+      compView.parent, compView.parentIndex, viewParentElIndex(compView), def.provider.value,
+      def.provider.deps);
+}
+
+export function createDirectiveInstance(view: ViewData, def: NodeDef): any {
   const providerDef = def.provider;
-  return def.flags & NodeFlags.LazyProvider ? NOT_CREATED : createInstance(view, def);
+  // directives are always eager and classes!
+  const instance = createClass(view, def.index, def.parent, def.provider.value, def.provider.deps);
+  if (providerDef.outputs.length) {
+    for (let i = 0; i < providerDef.outputs.length; i++) {
+      const output = providerDef.outputs[i];
+      const subscription = instance[output.propName].subscribe(
+          eventHandlerClosure(view, def.parent, output.eventName));
+      view.disposables[def.disposableIndex + i] = subscription.unsubscribe.bind(subscription);
+    }
+  }
+  return instance;
 }
 
 function eventHandlerClosure(view: ViewData, index: number, eventName: string) {
   return (event: any) => dispatchEvent(view, index, eventName, event);
 }
 
-export function checkAndUpdateProviderInline(
+export function checkAndUpdateDirectiveInline(
     view: ViewData, def: NodeDef, v0: any, v1: any, v2: any, v3: any, v4: any, v5: any, v6: any,
     v7: any, v8: any, v9: any) {
-  const provider = asProviderData(view, def.index).instance;
+  const providerData = asProviderData(view, def.index);
+  const directive = providerData.instance;
   let changes: SimpleChanges;
   // Note: fallthrough is intended!
   switch (def.bindings.length) {
     case 10:
-      changes = checkAndUpdateProp(view, provider, def, 9, v9, changes);
+      changes = checkAndUpdateProp(view, providerData, def, 9, v9, changes);
     case 9:
-      changes = checkAndUpdateProp(view, provider, def, 8, v8, changes);
+      changes = checkAndUpdateProp(view, providerData, def, 8, v8, changes);
     case 8:
-      changes = checkAndUpdateProp(view, provider, def, 7, v7, changes);
+      changes = checkAndUpdateProp(view, providerData, def, 7, v7, changes);
     case 7:
-      changes = checkAndUpdateProp(view, provider, def, 6, v6, changes);
+      changes = checkAndUpdateProp(view, providerData, def, 6, v6, changes);
     case 6:
-      changes = checkAndUpdateProp(view, provider, def, 5, v5, changes);
+      changes = checkAndUpdateProp(view, providerData, def, 5, v5, changes);
     case 5:
-      changes = checkAndUpdateProp(view, provider, def, 4, v4, changes);
+      changes = checkAndUpdateProp(view, providerData, def, 4, v4, changes);
     case 4:
-      changes = checkAndUpdateProp(view, provider, def, 3, v3, changes);
+      changes = checkAndUpdateProp(view, providerData, def, 3, v3, changes);
     case 3:
-      changes = checkAndUpdateProp(view, provider, def, 2, v2, changes);
+      changes = checkAndUpdateProp(view, providerData, def, 2, v2, changes);
     case 2:
-      changes = checkAndUpdateProp(view, provider, def, 1, v1, changes);
+      changes = checkAndUpdateProp(view, providerData, def, 1, v1, changes);
     case 1:
-      changes = checkAndUpdateProp(view, provider, def, 0, v0, changes);
+      changes = checkAndUpdateProp(view, providerData, def, 0, v0, changes);
   }
   if (changes) {
-    provider.ngOnChanges(changes);
+    directive.ngOnChanges(changes);
   }
   if ((view.state & ViewState.FirstCheck) && (def.flags & NodeFlags.OnInit)) {
-    provider.ngOnInit();
+    directive.ngOnInit();
   }
   if (def.flags & NodeFlags.DoCheck) {
-    provider.ngDoCheck();
+    directive.ngDoCheck();
   }
 }
 
-export function checkAndUpdateProviderDynamic(view: ViewData, def: NodeDef, values: any[]) {
-  const provider = asProviderData(view, def.index).instance;
+export function checkAndUpdateDirectiveDynamic(view: ViewData, def: NodeDef, values: any[]) {
+  const providerData = asProviderData(view, def.index);
+  const directive = providerData.instance;
   let changes: SimpleChanges;
   for (let i = 0; i < values.length; i++) {
-    changes = checkAndUpdateProp(view, provider, def, i, values[i], changes);
+    changes = checkAndUpdateProp(view, providerData, def, i, values[i], changes);
   }
   if (changes) {
-    provider.ngOnChanges(changes);
+    directive.ngOnChanges(changes);
   }
   if ((view.state & ViewState.FirstCheck) && (def.flags & NodeFlags.OnInit)) {
-    provider.ngOnInit();
+    directive.ngOnInit();
   }
   if (def.flags & NodeFlags.DoCheck) {
-    provider.ngDoCheck();
+    directive.ngDoCheck();
   }
 }
 
-function createInstance(view: ViewData, nodeDef: NodeDef): any {
-  const providerDef = nodeDef.provider;
+function _createProviderInstance(view: ViewData, def: NodeDef): any {
+  const providerDef = def.provider;
   let injectable: any;
   switch (providerDef.type) {
     case ProviderType.Class:
-      injectable =
-          createClass(view, nodeDef.index, nodeDef.parent, providerDef.value, providerDef.deps);
+      injectable = createClass(view, def.index, def.parent, providerDef.value, providerDef.deps);
       break;
     case ProviderType.Factory:
-      injectable =
-          callFactory(view, nodeDef.index, nodeDef.parent, providerDef.value, providerDef.deps);
+      injectable = callFactory(view, def.index, def.parent, providerDef.value, providerDef.deps);
       break;
     case ProviderType.UseExisting:
-      injectable = resolveDep(view, nodeDef.index, nodeDef.parent, providerDef.deps[0]);
+      injectable = resolveDep(view, def.index, def.parent, providerDef.deps[0]);
       break;
     case ProviderType.Value:
       injectable = providerDef.value;
       break;
-  }
-  if (providerDef.outputs.length) {
-    for (let i = 0; i < providerDef.outputs.length; i++) {
-      const output = providerDef.outputs[i];
-      const subscription = injectable[output.propName].subscribe(
-          eventHandlerClosure(view, nodeDef.parent, output.eventName));
-      view.disposables[nodeDef.disposableIndex + i] = subscription.unsubscribe.bind(subscription);
-    }
   }
   return injectable;
 }
@@ -291,7 +318,7 @@ export function resolveDep(
     requestNodeIndex = null;
     elIndex = view.def.nodes[elIndex].parent;
     while (elIndex == null && view) {
-      elIndex = viewParentDiIndex(view);
+      elIndex = viewParentElIndex(view);
       view = view.parent;
     }
   }
@@ -334,20 +361,20 @@ export function resolveDep(
         if (providerIndex != null) {
           const providerData = asProviderData(view, providerIndex);
           if (providerData.instance === NOT_CREATED) {
-            providerData.instance = createInstance(view, view.def.nodes[providerIndex]);
+            providerData.instance = _createProviderInstance(view, view.def.nodes[providerIndex]);
           }
           return providerData.instance;
         }
     }
     requestNodeIndex = null;
-    elIndex = viewParentDiIndex(view);
+    elIndex = viewParentElIndex(view);
     view = view.parent;
   }
   return startView.root.injector.get(depDef.token, notFoundValue);
 }
 
 function checkAndUpdateProp(
-    view: ViewData, provider: any, def: NodeDef, bindingIdx: number, value: any,
+    view: ViewData, providerData: ProviderData, def: NodeDef, bindingIdx: number, value: any,
     changes: SimpleChanges): SimpleChanges {
   let change: SimpleChange;
   let changed: boolean;
@@ -361,13 +388,18 @@ function checkAndUpdateProp(
     changed = checkAndUpdateBinding(view, def, bindingIdx, value);
   }
   if (changed) {
-    value = unwrapValue(value);
+    if (def.flags & NodeFlags.HasComponent) {
+      const compView = providerData.componentView;
+      if (compView.def.flags & ViewFlags.OnPush) {
+        compView.state |= ViewState.ChecksEnabled;
+      }
+    }
     const binding = def.bindings[bindingIdx];
     const propName = binding.name;
     // Note: This is still safe with Closure Compiler as
     // the user passed in the property name as an object has to `providerDef`,
     // so Closure Compiler will have renamed the property correctly already.
-    provider[propName] = value;
+    providerData.instance[propName] = value;
     if (change) {
       changes = changes || {};
       changes[binding.nonMinifiedName] = change;
@@ -382,7 +414,7 @@ export function callLifecycleHooksChildrenFirst(view: ViewData, lifecycles: Node
   }
   const len = view.def.nodes.length;
   for (let i = 0; i < len; i++) {
-    // We use the provider post order to call providers of children first.
+    // We use the reverse child oreder to call providers of children first.
     const nodeDef = view.def.reverseChildNodes[i];
     const nodeIndex = nodeDef.index;
     if (nodeDef.flags & lifecycles) {

--- a/modules/@angular/core/src/view/pure_expression.ts
+++ b/modules/@angular/core/src/view/pure_expression.ts
@@ -7,24 +7,22 @@
  */
 
 import {BindingDef, BindingType, DepDef, DepFlags, NodeData, NodeDef, NodeType, ProviderData, PureExpressionData, PureExpressionType, Services, ViewData, asPureExpressionData} from './types';
-import {checkAndUpdateBinding, tokenKey, unwrapValue} from './util';
+import {checkAndUpdateBinding, tokenKey} from './util';
 
-export function purePipeDef(pipeToken: any, argCount: number): NodeDef {
-  return _pureExpressionDef(
-      PureExpressionType.Pipe, new Array(argCount),
-      {token: pipeToken, tokenKey: tokenKey(pipeToken), flags: DepFlags.None});
+export function purePipeDef(argCount: number): NodeDef {
+  // argCount + 1 to include the pipe as first arg
+  return _pureExpressionDef(PureExpressionType.Pipe, new Array(argCount + 1));
 }
 
 export function pureArrayDef(argCount: number): NodeDef {
-  return _pureExpressionDef(PureExpressionType.Array, new Array(argCount), undefined);
+  return _pureExpressionDef(PureExpressionType.Array, new Array(argCount));
 }
 
 export function pureObjectDef(propertyNames: string[]): NodeDef {
-  return _pureExpressionDef(PureExpressionType.Object, propertyNames, undefined);
+  return _pureExpressionDef(PureExpressionType.Object, propertyNames);
 }
 
-function _pureExpressionDef(
-    type: PureExpressionType, propertyNames: string[], pipeDep: DepDef): NodeDef {
+function _pureExpressionDef(type: PureExpressionType, propertyNames: string[]): NodeDef {
   const bindings: BindingDef[] = new Array(propertyNames.length);
   for (let i = 0; i < propertyNames.length; i++) {
     const prop = propertyNames[i];
@@ -55,17 +53,14 @@ function _pureExpressionDef(
     element: undefined,
     provider: undefined,
     text: undefined,
-    pureExpression: {type, pipeDep},
+    pureExpression: {type},
     query: undefined,
     ngContent: undefined
   };
 }
 
 export function createPureExpression(view: ViewData, def: NodeDef): PureExpressionData {
-  const pipe = def.pureExpression.pipeDep ?
-      Services.resolveDep(view, def.index, def.parent, def.pureExpression.pipeDep) :
-      undefined;
-  return {value: undefined, pipe};
+  return {value: undefined};
 }
 
 export function checkAndUpdatePureExpressionInline(
@@ -99,17 +94,6 @@ export function checkAndUpdatePureExpressionInline(
 
   const data = asPureExpressionData(view, def.index);
   if (changed) {
-    v0 = unwrapValue(v0);
-    v1 = unwrapValue(v1);
-    v2 = unwrapValue(v2);
-    v3 = unwrapValue(v3);
-    v4 = unwrapValue(v4);
-    v5 = unwrapValue(v5);
-    v6 = unwrapValue(v6);
-    v7 = unwrapValue(v7);
-    v8 = unwrapValue(v8);
-    v9 = unwrapValue(v9);
-
     let value: any;
     switch (def.pureExpression.type) {
       case PureExpressionType.Array:
@@ -165,36 +149,37 @@ export function checkAndUpdatePureExpressionInline(
         }
         break;
       case PureExpressionType.Pipe:
+        const pipe = v0;
         switch (bindings.length) {
           case 10:
-            value = data.pipe.transform(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9);
+            value = pipe.transform(v1, v2, v3, v4, v5, v6, v7, v8, v9);
             break;
           case 9:
-            value = data.pipe.transform(v0, v1, v2, v3, v4, v5, v6, v7, v8);
+            value = pipe.transform(v1, v2, v3, v4, v5, v6, v7, v8);
             break;
           case 8:
-            value = data.pipe.transform(v0, v1, v2, v3, v4, v5, v6, v7);
+            value = pipe.transform(v1, v2, v3, v4, v5, v6, v7);
             break;
           case 7:
-            value = data.pipe.transform(v0, v1, v2, v3, v4, v5, v6);
+            value = pipe.transform(v1, v2, v3, v4, v5, v6);
             break;
           case 6:
-            value = data.pipe.transform(v0, v1, v2, v3, v4, v5);
+            value = pipe.transform(v1, v2, v3, v4, v5);
             break;
           case 5:
-            value = data.pipe.transform(v0, v1, v2, v3, v4);
+            value = pipe.transform(v1, v2, v3, v4);
             break;
           case 4:
-            value = data.pipe.transform(v0, v1, v2, v3);
+            value = pipe.transform(v1, v2, v3);
             break;
           case 3:
-            value = data.pipe.transform(v0, v1, v2);
+            value = pipe.transform(v1, v2);
             break;
           case 2:
-            value = data.pipe.transform(v0, v1);
+            value = pipe.transform(v1);
             break;
           case 1:
-            value = data.pipe.transform(v0);
+            value = pipe.transform(v0);
             break;
         }
         break;
@@ -219,23 +204,18 @@ export function checkAndUpdatePureExpressionDynamic(view: ViewData, def: NodeDef
     let value: any;
     switch (def.pureExpression.type) {
       case PureExpressionType.Array:
-        value = new Array(values.length);
-        for (let i = 0; i < values.length; i++) {
-          value[i] = unwrapValue(values[i]);
-        }
+        value = values;
         break;
       case PureExpressionType.Object:
         value = {};
         for (let i = 0; i < values.length; i++) {
-          value[bindings[i].name] = unwrapValue(values[i]);
+          value[bindings[i].name] = values[i];
         }
         break;
       case PureExpressionType.Pipe:
-        const params = new Array(values.length);
-        for (let i = 0; i < values.length; i++) {
-          params[i] = unwrapValue(values[i]);
-        }
-        value = (<any>data.pipe.transform)(...params);
+        const pipe = values[0];
+        const params = values.slice(1);
+        value = (<any>pipe.transform)(...params);
         break;
     }
     data.value = value;

--- a/modules/@angular/core/src/view/query.ts
+++ b/modules/@angular/core/src/view/query.ts
@@ -13,7 +13,7 @@ import {ViewContainerRef} from '../linker/view_container_ref';
 
 import {createTemplateRef, createViewContainerRef} from './refs';
 import {NodeDef, NodeFlags, NodeType, QueryBindingDef, QueryBindingType, QueryDef, QueryValueType, Services, ViewData, asElementData, asProviderData, asQueryList} from './types';
-import {declaredViewContainer} from './util';
+import {declaredViewContainer, viewParentElIndex} from './util';
 
 export function queryDef(
     flags: NodeFlags, id: string, bindings: {[propName: string]: QueryBindingType}): NodeDef {
@@ -54,16 +54,18 @@ export function createQuery(): QueryList<any> {
 }
 
 export function dirtyParentQuery(queryId: string, view: ViewData) {
-  let nodeIndex = view.parentIndex;
+  let elIndex = viewParentElIndex(view);
   view = view.parent;
   let queryIdx: number;
   while (view) {
-    const elementDef = view.def.nodes[nodeIndex];
-    queryIdx = elementDef.element.providerIndices[queryId];
-    if (queryIdx != null) {
-      break;
+    if (elIndex != null) {
+      const elementDef = view.def.nodes[elIndex];
+      queryIdx = elementDef.element.providerIndices[queryId];
+      if (queryIdx != null) {
+        break;
+      }
     }
-    nodeIndex = view.parentIndex;
+    elIndex = viewParentElIndex(view);
     view = view.parent;
   }
   if (!view) {

--- a/modules/@angular/core/src/view/refs.ts
+++ b/modules/@angular/core/src/view/refs.ts
@@ -19,8 +19,8 @@ import {Sanitizer, SecurityContext} from '../security';
 import {Type} from '../type';
 
 import {DirectDomRenderer, LegacyRendererAdapter} from './renderer';
-import {ArgumentType, BindingType, DebugContext, DepFlags, ElementData, NodeCheckFn, NodeData, NodeDef, NodeType, RendererV2, RootData, Services, ViewData, ViewDefinition, ViewDefinitionFactory, ViewState, asElementData, asProviderData} from './types';
-import {isComponentView, renderNode, resolveViewDefinition, rootRenderNodes, tokenKey, viewParentDiIndex} from './util';
+import {ArgumentType, BindingType, DebugContext, DepFlags, ElementData, NodeCheckFn, NodeData, NodeDef, NodeFlags, NodeType, RendererV2, RootData, Services, ViewData, ViewDefinition, ViewDefinitionFactory, ViewState, asElementData, asProviderData} from './types';
+import {isComponentView, renderNode, resolveViewDefinition, rootRenderNodes, tokenKey, viewParentElIndex} from './util';
 
 const EMPTY_CONTEXT = new Object();
 
@@ -53,7 +53,7 @@ class ComponentFactory_ implements ComponentFactory<any> {
     const len = viewDef.nodes.length;
     for (let i = 0; i < len; i++) {
       const nodeDef = viewDef.nodes[i];
-      if (nodeDef.provider && nodeDef.provider.component) {
+      if (nodeDef.flags & NodeFlags.HasComponent) {
         componentNodeIndex = i;
         break;
       }
@@ -99,7 +99,7 @@ class ViewContainerRef_ implements ViewContainerRef {
     let view = this._view;
     let elIndex = view.def.nodes[this._elIndex].parent;
     while (elIndex == null && view) {
-      elIndex = viewParentDiIndex(view);
+      elIndex = viewParentElIndex(view);
       view = view.parent;
     }
     return view ? new Injector_(view, elIndex) : this._view.root.injector;

--- a/modules/@angular/core/src/view/text.ts
+++ b/modules/@angular/core/src/view/text.ts
@@ -10,7 +10,7 @@ import {isDevMode} from '../application_ref';
 import {looseIdentical} from '../facade/lang';
 
 import {BindingDef, BindingType, DebugContext, NodeData, NodeDef, NodeFlags, NodeType, RootData, Services, TextData, ViewData, ViewFlags, asElementData, asTextData} from './types';
-import {checkAndUpdateBinding, sliceErrorStack, unwrapValue} from './util';
+import {checkAndUpdateBinding, sliceErrorStack} from './util';
 
 export function textDef(ngContentIndex: number, constants: string[]): NodeDef {
   // skip the call to sliceErrorStack itself + the call to this function.
@@ -18,7 +18,7 @@ export function textDef(ngContentIndex: number, constants: string[]): NodeDef {
   const bindings: BindingDef[] = new Array(constants.length - 1);
   for (let i = 1; i < constants.length; i++) {
     bindings[i - 1] = {
-      type: BindingType.Interpolation,
+      type: BindingType.TextInterpolation,
       name: undefined,
       nonMinifiedName: undefined,
       securityContext: undefined,
@@ -143,7 +143,6 @@ export function checkAndUpdateTextDynamic(view: ViewData, def: NodeDef, values: 
 }
 
 function _addInterpolationPart(value: any, binding: BindingDef): string {
-  value = unwrapValue(value);
   const valueStr = value != null ? value.toString() : '';
   return valueStr + binding.suffix;
 }

--- a/modules/@angular/core/src/view/types.ts
+++ b/modules/@angular/core/src/view/types.ts
@@ -23,7 +23,8 @@ import {Sanitizer, SecurityContext} from '../security';
 export interface ViewDefinition {
   flags: ViewFlags;
   component: ComponentDefinition;
-  update: ViewUpdateFn;
+  updateDirectives: ViewUpdateFn;
+  updateRenderer: ViewUpdateFn;
   handleEvent: ViewHandleEventFn;
   /**
    * Order: Depth first.
@@ -124,7 +125,9 @@ export interface NodeDef {
 export enum NodeType {
   Element,
   Text,
+  Directive,
   Provider,
+  Pipe,
   PureExpression,
   Query,
   NgContent
@@ -163,8 +166,8 @@ export enum BindingType {
   ElementClass,
   ElementStyle,
   ElementProperty,
-  ProviderProperty,
-  Interpolation,
+  DirectiveProperty,
+  TextInterpolation,
   PureExpressionProperty
 }
 
@@ -200,7 +203,7 @@ export interface ProviderDef {
   tokenKey: string;
   value: any;
   deps: DepDef[];
-  outputs: ProviderOutputDef[];
+  outputs: DirectiveOutputDef[];
   // closure to allow recursive components
   component: ViewDefinitionFactory;
 }
@@ -228,7 +231,7 @@ export enum DepFlags {
   Value = 2 << 2
 }
 
-export interface ProviderOutputDef {
+export interface DirectiveOutputDef {
   propName: string;
   eventName: string;
 }
@@ -238,10 +241,7 @@ export interface TextDef {
   source: string;
 }
 
-export interface PureExpressionDef {
-  type: PureExpressionType;
-  pipeDep: DepDef;
-}
+export interface PureExpressionDef { type: PureExpressionType; }
 
 export enum PureExpressionType {
   Array,
@@ -285,8 +285,7 @@ export interface NgContentDef {
 export interface ViewData {
   def: ViewDefinition;
   root: RootData;
-  // index of parent element / anchor. Not the index
-  // of the provider with the component view.
+  // index of component provider / anchor.
   parentIndex: number;
   parent: ViewData;
   component: any;
@@ -385,10 +384,7 @@ export function asProviderData(view: ViewData, index: number): ProviderData {
  *
  * Attention: Adding fields to this is performance sensitive!
  */
-export interface PureExpressionData {
-  value: any;
-  pipe: PipeTransform;
-}
+export interface PureExpressionData { value: any; }
 
 /**
  * Accessor for view.nodes, enforcing that every usage site stays monomorphic.
@@ -493,7 +489,8 @@ export interface Services {
       notFoundValue?: any): any;
   createDebugContext(view: ViewData, nodeIndex: number): DebugContext;
   handleEvent: ViewHandleEventFn;
-  updateView: ViewUpdateFn;
+  updateDirectives: ViewUpdateFn;
+  updateRenderer: ViewUpdateFn;
 }
 
 /**
@@ -513,5 +510,6 @@ export const Services: Services = {
   resolveDep: undefined,
   createDebugContext: undefined,
   handleEvent: undefined,
-  updateView: undefined,
+  updateDirectives: undefined,
+  updateRenderer: undefined,
 };

--- a/modules/@angular/core/test/linker/integration_spec.ts
+++ b/modules/@angular/core/test/linker/integration_spec.ts
@@ -265,7 +265,7 @@ function declareTests({useJit, viewEngine}: {useJit: boolean, viewEngine: boolea
       });
 
       describe('pipes', () => {
-        viewEngine || it('should support pipes in bindings', () => {
+        it('should support pipes in bindings', () => {
           TestBed.configureTestingModule({declarations: [MyComp, MyDir, DoublePipe]});
           const template = '<div my-dir #dir="mydir" [elprop]="ctxProp | double"></div>';
           TestBed.overrideComponent(MyComp, {set: {template}});
@@ -545,7 +545,7 @@ function declareTests({useJit, viewEngine}: {useJit: boolean, viewEngine: boolea
       });
 
       describe('variables', () => {
-        viewEngine || it('should allow to use variables in a for loop', () => {
+        it('should allow to use variables in a for loop', () => {
           TestBed.configureTestingModule({declarations: [MyComp, ChildCompNoTemplate]});
           const template =
               '<template ngFor [ngForOf]="[1]" let-i><child-cmp-no-template #cmp></child-cmp-no-template>{{i}}-{{cmp.ctxProp}}</template>';
@@ -670,31 +670,29 @@ function declareTests({useJit, viewEngine}: {useJit: boolean, viewEngine: boolea
         });
 
         if (getDOM().supportsDOMEvents()) {
-          viewEngine ||
-              it('should be checked when an async pipe requests a check', fakeAsync(() => {
-                   TestBed.configureTestingModule(
-                       {declarations: [MyComp, PushCmpWithAsyncPipe], imports: [CommonModule]});
-                   const template = '<push-cmp-with-async #cmp></push-cmp-with-async>';
-                   TestBed.overrideComponent(MyComp, {set: {template}});
-                   const fixture = TestBed.createComponent(MyComp);
+          it('should be checked when an async pipe requests a check', fakeAsync(() => {
+               TestBed.configureTestingModule(
+                   {declarations: [MyComp, PushCmpWithAsyncPipe], imports: [CommonModule]});
+               const template = '<push-cmp-with-async #cmp></push-cmp-with-async>';
+               TestBed.overrideComponent(MyComp, {set: {template}});
+               const fixture = TestBed.createComponent(MyComp);
 
-                   tick();
+               tick();
 
-                   const cmp: PushCmpWithAsyncPipe =
-                       fixture.debugElement.children[0].references['cmp'];
-                   fixture.detectChanges();
-                   expect(cmp.numberOfChecks).toEqual(1);
+               const cmp: PushCmpWithAsyncPipe = fixture.debugElement.children[0].references['cmp'];
+               fixture.detectChanges();
+               expect(cmp.numberOfChecks).toEqual(1);
 
-                   fixture.detectChanges();
-                   fixture.detectChanges();
-                   expect(cmp.numberOfChecks).toEqual(1);
+               fixture.detectChanges();
+               fixture.detectChanges();
+               expect(cmp.numberOfChecks).toEqual(1);
 
-                   cmp.resolve(2);
-                   tick();
+               cmp.resolve(2);
+               tick();
 
-                   fixture.detectChanges();
-                   expect(cmp.numberOfChecks).toEqual(2);
-                 }));
+               fixture.detectChanges();
+               expect(cmp.numberOfChecks).toEqual(2);
+             }));
         }
       });
 
@@ -897,26 +895,24 @@ function declareTests({useJit, viewEngine}: {useJit: boolean, viewEngine: boolea
         expect(tc.nativeElement.id).toEqual('newId');
       });
 
-      viewEngine ||
-          it('should not use template variables for expressions in hostProperties', () => {
-            @Directive(
-                {selector: '[host-properties]', host: {'[id]': 'id', '[title]': 'unknownProp'}})
-            class DirectiveWithHostProps {
-              id = 'one';
-            }
+      it('should not use template variables for expressions in hostProperties', () => {
+        @Directive({selector: '[host-properties]', host: {'[id]': 'id', '[title]': 'unknownProp'}})
+        class DirectiveWithHostProps {
+          id = 'one';
+        }
 
-            const fixture =
-                TestBed.configureTestingModule({declarations: [MyComp, DirectiveWithHostProps]})
-                    .overrideComponent(MyComp, {
-                      set: {template: `<div *ngFor="let id of ['forId']" host-properties></div>`}
-                    })
-                    .createComponent(MyComp);
-            fixture.detectChanges();
+        const fixture =
+            TestBed.configureTestingModule({declarations: [MyComp, DirectiveWithHostProps]})
+                .overrideComponent(
+                    MyComp,
+                    {set: {template: `<div *ngFor="let id of ['forId']" host-properties></div>`}})
+                .createComponent(MyComp);
+        fixture.detectChanges();
 
-            const tc = fixture.debugElement.children[0];
-            expect(tc.properties['id']).toBe('one');
-            expect(tc.properties['title']).toBe(undefined);
-          });
+        const tc = fixture.debugElement.children[0];
+        expect(tc.properties['id']).toBe('one');
+        expect(tc.properties['title']).toBe(undefined);
+      });
 
       it('should not allow pipes in hostProperties', () => {
         @Directive({selector: '[host-properties]', host: {'[id]': 'id | uppercase'}})
@@ -930,8 +926,7 @@ function declareTests({useJit, viewEngine}: {useJit: boolean, viewEngine: boolea
             .toThrowError(/Host binding expression cannot contain pipes/);
       });
 
-      // TODO: literal array
-      viewEngine || it('should not use template variables for expressions in hostListeners', () => {
+      it('should not use template variables for expressions in hostListeners', () => {
         @Directive({selector: '[host-listener]', host: {'(click)': 'doIt(id, unknownProp)'}})
         class DirectiveWithHostListener {
           id = 'one';

--- a/modules/@angular/core/test/view/anchor_spec.ts
+++ b/modules/@angular/core/test/view/anchor_spec.ts
@@ -16,8 +16,9 @@ import {createRootView, isBrowser} from './helper';
 export function main() {
   describe(`View Anchor`, () => {
     function compViewDef(
-        nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn): ViewDefinition {
-      return viewDef(ViewFlags.None, nodes, update, handleEvent);
+        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
+        handleEvent?: ViewHandleEventFn): ViewDefinition {
+      return viewDef(ViewFlags.None, nodes, updateDirectives, updateRenderer, handleEvent);
     }
 
     function createAndGetRootNodes(

--- a/modules/@angular/core/test/view/component_view_spec.ts
+++ b/modules/@angular/core/test/view/component_view_spec.ts
@@ -16,9 +16,9 @@ import {createRootView, isBrowser, removeNodes} from './helper';
 export function main() {
   describe(`Component Views`, () => {
     function compViewDef(
-        nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn,
-        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
-      return viewDef(viewFlags, nodes, update, handleEvent);
+        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
+        handleEvent?: ViewHandleEventFn, viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
+      return viewDef(viewFlags, nodes, updateDirectives, updateRenderer, handleEvent);
     }
 
     function createAndGetRootNodes(viewDef: ViewDefinition): {rootNodes: any[], view: ViewData} {
@@ -119,7 +119,7 @@ export function main() {
             directiveDef(NodeFlags.None, null, 0, AComp, [], null, null, () => compViewDef(
               [
                 elementDef(NodeFlags.None, null, null, 0, 'span', null, [[BindingType.ElementAttribute, 'a', SecurityContext.NONE]]),
-              ], update
+              ], null, update
             )),
           ]));
         const compView = asProviderData(view, 1).componentView;
@@ -194,7 +194,7 @@ export function main() {
                                     [
                                       elementDef(NodeFlags.None, null, null, 0, 'span', null, null, ['click']),
                                     ],
-                                    update, null, ViewFlags.OnPush)),
+                                    update, null, null, ViewFlags.OnPush)),
                       ],
                       (check, view) => { check(view, 1, ArgumentType.Inline, compInputValue); }));
 
@@ -246,7 +246,7 @@ export function main() {
                   [
                     elementDef(NodeFlags.None, null, null, 0, 'span', null, [[BindingType.ElementAttribute, 'a', SecurityContext.NONE]]),
                   ],
-                  update)),
+                  null, update)),
         ]));
 
         const compView = asProviderData(view, 1).componentView;

--- a/modules/@angular/core/test/view/element_spec.ts
+++ b/modules/@angular/core/test/view/element_spec.ts
@@ -17,9 +17,9 @@ import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, createRootView, isBrowser, re
 export function main() {
   describe(`View Elements`, () => {
     function compViewDef(
-        nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn,
-        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
-      return viewDef(viewFlags, nodes, update, handleEvent);
+        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
+        handleEvent?: ViewHandleEventFn, viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
+      return viewDef(viewFlags, nodes, updateDirectives, updateRenderer, handleEvent);
     }
 
     function createAndGetRootNodes(
@@ -85,7 +85,7 @@ export function main() {
                       [BindingType.ElementProperty, 'value', SecurityContext.NONE]
                     ]),
               ],
-              (check, view) => {
+              null, (check, view) => {
                 checkNodeInlineOrDynamic(check, view, 0, inlineDynamic, ['v1', 'v2']);
               }));
 
@@ -112,7 +112,7 @@ export function main() {
                       [BindingType.ElementAttribute, 'a2', SecurityContext.NONE]
                     ]),
               ],
-              (check, view) => {
+              null, (check, view) => {
                 checkNodeInlineOrDynamic(check, view, 0, inlineDynamic, ['v1', 'v2']);
               }));
 
@@ -159,7 +159,7 @@ export function main() {
                       [BindingType.ElementStyle, 'color', null]
                     ]),
               ],
-              (check, view) => {
+              null, (check, view) => {
                 checkNodeInlineOrDynamic(check, view, 0, inlineDynamic, [10, 'red']);
               }));
 
@@ -168,42 +168,6 @@ export function main() {
           const el = rootNodes[0];
           expect(getDOM().getStyle(el, 'width')).toBe('10px');
           expect(getDOM().getStyle(el, 'color')).toBe('red');
-        });
-      });
-    });
-
-    describe('general binding behavior', () => {
-      ARG_TYPE_VALUES.forEach((inlineDynamic) => {
-        it(`should unwrap values with ${ArgumentType[inlineDynamic]}`, () => {
-          let bindingValue: any;
-
-          const {view, rootNodes} = createAndGetRootNodes(compViewDef(
-              [
-                elementDef(
-                    NodeFlags.None, null, null, 0, 'input', null,
-                    [
-                      [BindingType.ElementProperty, 'someProp', SecurityContext.NONE],
-                    ]),
-              ],
-              (check, view) => {
-                checkNodeInlineOrDynamic(check, view, 0, inlineDynamic, [bindingValue]);
-              }));
-
-          const setterSpy = jasmine.createSpy('set');
-          Object.defineProperty(rootNodes[0], 'someProp', {set: setterSpy});
-
-          bindingValue = 'v1';
-          Services.checkAndUpdateView(view);
-          expect(setterSpy).toHaveBeenCalledWith('v1');
-
-          setterSpy.calls.reset();
-          Services.checkAndUpdateView(view);
-          expect(setterSpy).not.toHaveBeenCalled();
-
-          setterSpy.calls.reset();
-          bindingValue = WrappedValue.wrap('v1');
-          Services.checkAndUpdateView(view);
-          expect(setterSpy).toHaveBeenCalledWith('v1');
         });
       });
     });
@@ -228,7 +192,7 @@ export function main() {
               spyOn(HTMLElement.prototype, 'removeEventListener').and.callThrough();
           const {view, rootNodes} = createAndAttachAndGetRootNodes(compViewDef(
               [elementDef(NodeFlags.None, null, null, 0, 'button', null, null, ['click'])], null,
-              handleEventSpy));
+              null, handleEventSpy));
 
           rootNodes[0].click();
 
@@ -252,7 +216,7 @@ export function main() {
               [elementDef(
                   NodeFlags.None, null, null, 0, 'button', null, null,
                   [['window', 'windowClick']])],
-              null, handleEventSpy));
+              null, null, handleEventSpy));
 
           expect(addListenerSpy).toHaveBeenCalled();
           expect(addListenerSpy.calls.mostRecent().args[0]).toBe('windowClick');
@@ -278,7 +242,7 @@ export function main() {
               [elementDef(
                   NodeFlags.None, null, null, 0, 'button', null, null,
                   [['document', 'documentClick']])],
-              null, handleEventSpy));
+              null, null, handleEventSpy));
 
           expect(addListenerSpy).toHaveBeenCalled();
           expect(addListenerSpy.calls.mostRecent().args[0]).toBe('documentClick');
@@ -302,7 +266,7 @@ export function main() {
 
           const {view, rootNodes} = createAndAttachAndGetRootNodes(compViewDef(
               [elementDef(NodeFlags.None, null, null, 0, 'button', null, null, ['click'])], null,
-              (view, index, eventName, event) => {
+              null, (view, index, eventName, event) => {
                 preventDefaultSpy = spyOn(event, 'preventDefault').and.callThrough();
                 return eventHandlerResult;
               }));
@@ -328,7 +292,7 @@ export function main() {
           const addListenerSpy = spyOn(HTMLElement.prototype, 'addEventListener').and.callThrough();
           const {view, rootNodes} = createAndAttachAndGetRootNodes(compViewDef(
               [elementDef(NodeFlags.None, null, null, 0, 'button', null, null, ['click'])], null,
-              () => { throw new Error('Test'); }));
+              null, () => { throw new Error('Test'); }));
 
           let err: any;
           try {

--- a/modules/@angular/core/test/view/embedded_view_spec.ts
+++ b/modules/@angular/core/test/view/embedded_view_spec.ts
@@ -16,9 +16,9 @@ import {createRootView, isBrowser} from './helper';
 export function main() {
   describe(`Embedded Views`, () => {
     function compViewDef(
-        nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn,
-        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
-      return viewDef(viewFlags, nodes, update, handleEvent);
+        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
+        handleEvent?: ViewHandleEventFn, viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
+      return viewDef(viewFlags, nodes, updateDirectives, updateRenderer, handleEvent);
     }
 
     function embeddedViewDef(nodes: NodeDef[], update?: ViewUpdateFn): ViewDefinitionFactory {

--- a/modules/@angular/core/test/view/ng_content_spec.ts
+++ b/modules/@angular/core/test/view/ng_content_spec.ts
@@ -16,9 +16,9 @@ import {createRootView, isBrowser} from './helper';
 export function main() {
   describe(`View NgContent`, () => {
     function compViewDef(
-        nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn,
-        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
-      return viewDef(viewFlags, nodes, update, handleEvent);
+        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
+        handleEvent?: ViewHandleEventFn, viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
+      return viewDef(viewFlags, nodes, updateDirectives, updateRenderer, handleEvent);
     }
 
     function embeddedViewDef(nodes: NodeDef[], update?: ViewUpdateFn): ViewDefinitionFactory {

--- a/modules/@angular/core/test/view/query_spec.ts
+++ b/modules/@angular/core/test/view/query_spec.ts
@@ -17,9 +17,9 @@ import {createRootView} from './helper';
 export function main() {
   describe(`Query Views`, () => {
     function compViewDef(
-        nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn,
-        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
-      return viewDef(viewFlags, nodes, update, handleEvent);
+        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
+        handleEvent?: ViewHandleEventFn, viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
+      return viewDef(viewFlags, nodes, updateDirectives, updateRenderer, handleEvent);
     }
 
     function embeddedViewDef(nodes: NodeDef[], update?: ViewUpdateFn): ViewDefinitionFactory {

--- a/modules/@angular/core/test/view/services_spec.ts
+++ b/modules/@angular/core/test/view/services_spec.ts
@@ -16,9 +16,9 @@ import {createRootView, isBrowser} from './helper';
 export function main() {
   describe('View Services', () => {
     function compViewDef(
-        nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn,
-        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
-      return viewDef(viewFlags, nodes, update, handleEvent);
+        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
+        handleEvent?: ViewHandleEventFn, viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
+      return viewDef(viewFlags, nodes, updateDirectives, updateRenderer, handleEvent);
     }
 
     function createAndGetRootNodes(

--- a/modules/@angular/core/test/view/text_spec.ts
+++ b/modules/@angular/core/test/view/text_spec.ts
@@ -16,9 +16,9 @@ import {ARG_TYPE_VALUES, checkNodeInlineOrDynamic, createRootView, isBrowser} fr
 export function main() {
   describe(`View Text`, () => {
     function compViewDef(
-        nodes: NodeDef[], update?: ViewUpdateFn, handleEvent?: ViewHandleEventFn,
-        viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
-      return viewDef(viewFlags, nodes, update, handleEvent);
+        nodes: NodeDef[], updateDirectives?: ViewUpdateFn, updateRenderer?: ViewUpdateFn,
+        handleEvent?: ViewHandleEventFn, viewFlags: ViewFlags = ViewFlags.None): ViewDefinition {
+      return viewDef(viewFlags, nodes, updateDirectives, updateRenderer, handleEvent);
     }
 
     function createAndGetRootNodes(
@@ -67,7 +67,7 @@ export function main() {
               [
                 textDef(null, ['0', '1', '2']),
               ],
-              (check, view) => {
+              null, (check, view) => {
                 checkNodeInlineOrDynamic(check, view, 0, inlineDynamic, ['a', 'b']);
               }));
 
@@ -77,41 +77,6 @@ export function main() {
           expect(getDOM().getText(rootNodes[0])).toBe('0a1b2');
         });
 
-        if (isBrowser()) {
-          it(`should unwrap values with ${ArgumentType[inlineDynamic]}`, () => {
-            let bindingValue: any;
-            const setterSpy = jasmine.createSpy('set');
-
-            class FakeTextNode {
-              set nodeValue(value: any) { setterSpy(value); }
-            }
-
-            spyOn(document, 'createTextNode').and.returnValue(new FakeTextNode());
-
-            const {view, rootNodes} = createAndGetRootNodes(compViewDef(
-                [
-                  textDef(null, ['', '']),
-                ],
-                (check, view) => {
-                  checkNodeInlineOrDynamic(check, view, 0, inlineDynamic, [bindingValue]);
-                }));
-
-            Object.defineProperty(rootNodes[0], 'nodeValue', {set: setterSpy});
-
-            bindingValue = 'v1';
-            Services.checkAndUpdateView(view);
-            expect(setterSpy).toHaveBeenCalledWith('v1');
-
-            setterSpy.calls.reset();
-            Services.checkAndUpdateView(view);
-            expect(setterSpy).not.toHaveBeenCalled();
-
-            setterSpy.calls.reset();
-            bindingValue = WrappedValue.wrap('v1');
-            Services.checkAndUpdateView(view);
-            expect(setterSpy).toHaveBeenCalledWith('v1');
-          });
-        }
       });
     });
 

--- a/modules/benchmarks/src/tree/ng2_next/tree.ts
+++ b/modules/benchmarks/src/tree/ng2_next/tree.ts
@@ -75,10 +75,13 @@ function TreeComponent_0(): ViewDefinition {
       ],
       (check, view) => {
         const cmp = view.component;
-        check(view, 0, ArgumentType.Inline, cmp.bgColor);
-        check(view, 1, ArgumentType.Inline, cmp.data.value);
         check(view, 3, ArgumentType.Inline, cmp.data.left != null);
         check(view, 5, ArgumentType.Inline, cmp.data.right != null);
+      },
+      (check, view) => {
+        const cmp = view.component;
+        check(view, 0, ArgumentType.Inline, cmp.bgColor);
+        check(view, 1, ArgumentType.Inline, cmp.data.value);
       });
 }
 


### PR DESCRIPTION
…n tests work

Included refactoring:
- make ViewData.parentIndex point to component provider index
- split NodeType.Provider into Provider / Directive / Pipe
- make purePipe take the real pipe as argument to detect changes
- order change detection:
  1) directive props
  2) renderer props

Part of #14013
