### PR TITLE
fix(upgrade): Prevent property renaming for $inject.

### DIFF
--- a/modules/@angular/upgrade/src/common/downgrade_component.ts
+++ b/modules/@angular/upgrade/src/common/downgrade_component.ts
@@ -124,7 +124,7 @@ export function downgradeComponent(info: /* ComponentInfo */ {
     };
   };
 
-  directiveFactory.$inject = [$COMPILE, $INJECTOR, $PARSE];
+  directiveFactory['$inject'] = [$COMPILE, $INJECTOR, $PARSE];
   return directiveFactory;
 }
 


### PR DESCRIPTION
fix(upgrade): Prevent property renaming for $inject.

Switch to bracket notation for `directiveFactory.$inject`, otherwise Closure Compiler will (property) rename it, since the output type is `any`.


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
`directiveFactory.$inject` is renamed by Closure Compiler, since the output type is `any`.


**What is the new behavior?**
`directiveFactory['$inject']` is not renamed due to using bracket notation.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
**Other information**:

