### PR TITLE
fix(platform-server): render styles in app component instead of <head>

### DIFF
--- a/modules/@angular/platform-server/src/server_renderer.ts
+++ b/modules/@angular/platform-server/src/server_renderer.ts
@@ -47,6 +47,7 @@ export class ServerRenderer implements Renderer {
     if (componentProto.encapsulation === ViewEncapsulation.Native) {
       throw new Error('Native encapsulation is not supported on the server!');
     }
+    this._rootRenderer.sharedStylesHost.addStyles(this._styles);
     if (this.componentProto.encapsulation === ViewEncapsulation.Emulated) {
       this._contentAttr = shimContentAttribute(styleShimId);
       this._hostAttr = shimHostAttribute(styleShimId);

--- a/modules/@angular/platform-server/src/styles_host.ts
+++ b/modules/@angular/platform-server/src/styles_host.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ApplicationRef, Inject, Injectable} from '@angular/core';
+import {DOCUMENT} from '@angular/platform-browser';
+
+import {Parse5DomAdapter} from './parse5_adapter';
+import {SharedStylesHost, getDOM} from './private_import_platform-browser';
+
+@Injectable()
+export class ServerStylesHost extends SharedStylesHost {
+  private root: any = null;
+  private buffer: string[] = [];
+
+  constructor(@Inject(DOCUMENT) private doc: any, private appRef: ApplicationRef) { super(); }
+
+  private _addStyle(style: string): void {
+    let adapter: Parse5DomAdapter = getDOM() as Parse5DomAdapter;
+    const el = adapter.createElement('style');
+    adapter.setText(el, style);
+    adapter.appendChild(this.root, el);
+  }
+
+  onStylesAdded(additions: Set<string>) {
+    if (!this.root) {
+      additions.forEach(style => this.buffer.push(style));
+    } else {
+      additions.forEach(style => this._addStyle(style));
+    }
+  }
+
+  rootComponentIsReady(): void {
+    if (!!this.root) {
+      return;
+    }
+    this.root = this.appRef.components[0].location.nativeElement;
+    this.buffer.forEach(style => this._addStyle(style));
+    this.buffer = null;
+  }
+}

--- a/modules/@angular/platform-server/test/integration_spec.ts
+++ b/modules/@angular/platform-server/test/integration_spec.ts
@@ -29,6 +29,14 @@ class MyServerApp {
 class ExampleModule {
 }
 
+@Component({selector: 'app', template: `Works!`, styles: [':host { color: red; }']})
+class MyStylesApp {
+}
+
+@NgModule({declarations: [MyStylesApp], imports: [ServerModule], bootstrap: [MyStylesApp]})
+class ExampleStylesModule {
+}
+
 export function main() {
   if (getDOM().supportsDOMEvents()) return;  // NODE only
 
@@ -41,6 +49,17 @@ export function main() {
          const body = writeBody('<app></app>');
          platformDynamicServer().bootstrapModule(ExampleModule).then(() => {
            expect(getDOM().getText(body)).toEqual('Works!');
+         });
+       }));
+
+    it('adds styles to the root component', async(() => {
+         const body = writeBody('<app></app>');
+         platformDynamicServer().bootstrapModule(ExampleStylesModule).then(() => {
+           const app = body.children[0];
+           expect(app.children.length).toBe(2);
+           const style = app.children[1];
+           expect(style.type).toBe('style');
+           expect(style.children[0].data).toContain('color: red');
          });
        }));
 


### PR DESCRIPTION
This ensures when the tree is serialized to the client and the app is later bootstrapped,
the <style> tags created during server-side rendering are destroyed.