### PR TITLE
build: check yarn version in `check-environment`

### DIFF
--- a/aio/gulpfile.js
+++ b/aio/gulpfile.js
@@ -13,8 +13,9 @@
 // NOTE: we are getting the value from the parent `angular/angular` package.json not the `/aio` one.
 const engines = require('../package.json').engines;
 require('../tools/check-environment')({
+  requiredNodeVersion: engines.node,
   requiredNpmVersion: engines.npm,
-  requiredNodeVersion: engines.node
+  requiredYarnVersion: engines.yarn
 });
 
 const gulp = require('gulp');
@@ -32,3 +33,4 @@ gulp.task('doc-gen-test', loadTask('docs', 'test'));
 gulp.task('docs-app', loadTask('docs-app'));
 gulp.task('docs-app-test', () => {});
 gulp.task('docs-test', ['doc-gen-test', 'docs-app-test']);
+gulp.task('check-env', () => { /* this is a noop because the env test ran already above */ });

--- a/aio/package.json
+++ b/aio/package.json
@@ -7,16 +7,17 @@
   "license": "MIT",
   "angular-cli": {},
   "scripts": {
-    "ng": "ng",
-    "start": "ng serve",
-    "build": "ng build",
-    "test": "ng test",
-    "lint": "ng lint",
+    "ng": "yarn run check-env && ng",
+    "start": "yarn run check-env && ng serve",
+    "build": "yarn run check-env && ng build",
+    "test": "yarn run check-env && ng test",
+    "lint": "yarn run check-env && ng lint",
     "pree2e": "webdriver-manager update --standalone false --gecko false",
-    "e2e": "ng e2e --no-webdriver-update",
+    "e2e": "yarn run check-env && ng e2e --no-webdriver-update",
     "deploy-staging": "firebase use staging --token \"$FIREBASE_TOKEN\" && yarn run ~~deploy",
-    "pre~~deploy": "ng build --prod",
-    "~~deploy": "firebase deploy --message \"Commit: $TRAVIS_COMMIT\" --non-interactive --token \"$FIREBASE_TOKEN\""
+    "pre~~deploy": "yarn run check-env && ng build --prod",
+    "~~deploy": "firebase deploy --message \"Commit: $TRAVIS_COMMIT\" --non-interactive --token \"$FIREBASE_TOKEN\"",
+    "check-env": "gulp check-env"
   },
   "private": true,
   "dependencies": {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,8 +12,11 @@
 // THIS CHECK SHOULD BE THE FIRST THING IN THIS FILE
 // This is to ensure that we catch env issues before we error while requiring other dependencies.
 const engines = require('./package.json').engines;
-require('./tools/check-environment')(
-    {requiredNpmVersion: engines.npm, requiredNodeVersion: engines.node});
+require('./tools/check-environment')({
+  requiredNodeVersion: engines.node,
+  requiredNpmVersion: engines.npm,
+  requiredYarnVersion: engines.yarn
+});
 
 const gulp = require('gulp');
 
@@ -37,3 +40,4 @@ gulp.task('check-cycle', loadTask('check-cycle'));
 gulp.task('serve', loadTask('serve', 'default'));
 gulp.task('serve-examples', loadTask('serve', 'examples'));
 gulp.task('changelog', loadTask('changelog'));
+gulp.task('check-env', () => {/* this is a noop because the env test ran already above */});

--- a/package.json
+++ b/package.json
@@ -8,15 +8,17 @@
   "bugs": "https://github.com/angular/angular/issues",
   "license": "MIT",
   "engines": {
-    "node": ">= 6.9.5 < 7.0.0",
-    "npm": ">=3.10.7 <4.0.0"
+    "node": ">=6.9.5 <7.0.0",
+    "npm": ">=3.10.7 <4.0.0",
+    "yarn": ">=0.19.1 <0.21.0"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git"
   },
   "scripts": {
-    "postinstall": "node tools/npm/copy-npm-shrinkwrap && webdriver-manager update"
+    "postinstall": "node tools/npm/copy-npm-shrinkwrap && webdriver-manager update",
+    "check-env": "gulp check-env"
   },
   "dependencies": {
     "core-js": "^2.4.1",

--- a/tools/check-environment.js
+++ b/tools/check-environment.js
@@ -54,30 +54,46 @@ try {
 }
 
 function checkEnvironment(reqs) {
-  exec('npm --version', function(e, stdout) {
-    var foundNpmVersion = semver.clean(stdout);
-    var foundNodeVersion = process.version;
-    var issues = [];
+  exec('npm --version', function(npmErr, npmStdout) {
+    exec('yarn --version', function(yarnErr, yarnStdout) {
+      var foundNodeVersion = process.version;
+      var foundNpmVersion = semver.clean(npmStdout);
+      var foundYarnVersion = !yarnErr && semver.clean(yarnStdout);
+      var issues = [];
 
 
-    if (!semver.satisfies(foundNodeVersion, reqs.requiredNodeVersion)) {
-      issues.push(
-          'You are running unsupported node version. Found: ' + foundNodeVersion + ' Expected: ' +
-          reqs.requiredNodeVersion + '. Use nvm to update your node version.');
-    }
+      if (!semver.satisfies(foundNodeVersion, reqs.requiredNodeVersion)) {
+        issues.push(
+            'You are running unsupported node version. Found: ' + foundNodeVersion + ' Expected: ' +
+            reqs.requiredNodeVersion + '. Use nvm to update your node version.');
+      }
 
-    if (!semver.satisfies(foundNpmVersion, reqs.requiredNpmVersion)) {
-      issues.push(
-          'You are running unsupported npm version. Found: ' + foundNpmVersion + ' Expected: ' +
-          reqs.requiredNpmVersion + '. Run: npm update -g npm');
-    }
+      if (!semver.satisfies(foundNpmVersion, reqs.requiredNpmVersion)) {
+        issues.push(
+            'You are running unsupported npm version. Found: ' + foundNpmVersion + ' Expected: ' +
+            reqs.requiredNpmVersion + '. Run: npm update -g npm');
+      }
 
-    if (!checkNodeModules()) {
-      issues.push(
-          'Your node_modules directory is stale or out of sync with npm-shrinkwrap.json. Run: npm install');
-    }
+      if (yarnErr) {
+        issues.push(
+            'You don\'t have yarn globally installed. This is required if you want to work on ' +
+            'certain areas, such as `aio/` and `integration/`. Installation instructions: ' +
+            'https://yarnpkg.com/lang/en/docs/install/');
+      } else if (!semver.satisfies(foundYarnVersion, reqs.requiredYarnVersion)) {
+        issues.push(
+            'You are running unsupported yarn version. Found: ' + foundYarnVersion + ' Expected: ' +
+            reqs.requiredYarnVersion + '. This is required if you want to work on ' +
+            'certain areas, such as `aio/` and `integration/`. See: ' +
+            'https://yarnpkg.com/lang/en/docs/install/');
+      }
 
-    printWarning(issues);
+      if (!checkNodeModules()) {
+        issues.push(
+            'Your node_modules directory is stale or out of sync with npm-shrinkwrap.json. Run: npm install');
+      }
+
+      printWarning(issues);
+    })
   });
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Global yarn is used in certain "areas" (`aio/`, `integration/`), but there is no version check in `check-environment`.


**What is the new behavior?**
The yarn version is checked (same as node and npm).


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```


**Other information**:
Discussed in https://github.com/angular/angular/pull/14382#discussion_r100620839.