### PR TITLE
feat(compiler-cli): add option to ng-xi18n in order to specifiy the o…

### DIFF
--- a/modules/@angular/compiler-cli/integrationtest/test/i18n_spec.ts
+++ b/modules/@angular/compiler-cli/integrationtest/test/i18n_spec.ts
@@ -68,7 +68,7 @@ describe('template i18n extraction output', () => {
   const genDir = 'out';
 
   it('should extract i18n messages as xmb', () => {
-    const xmbOutput = path.join(outDir, 'messages.xmb');
+    const xmbOutput = path.join(outDir, 'custom_file.xmb');
     expect(fs.existsSync(xmbOutput)).toBeTruthy();
     const xmb = fs.readFileSync(xmbOutput, {encoding: 'utf-8'});
     expect(xmb).toEqual(EXPECTED_XMB);

--- a/modules/@angular/compiler-cli/integrationtest/test/test_ngtools_api.ts
+++ b/modules/@angular/compiler-cli/integrationtest/test/test_ngtools_api.ts
@@ -131,6 +131,7 @@ function i18nTest() {
         compilerOptions: config.parsed.options, program, host,
         angularCompilerOptions: config.ngOptions,
         i18nFormat: 'xlf',
+        outFile: null,
         readResource: (fileName: string) => {
           readResources.push(fileName);
           return hostContext.readResource(fileName);

--- a/modules/@angular/compiler-cli/src/extract_i18n.ts
+++ b/modules/@angular/compiler-cli/src/extract_i18n.ts
@@ -22,7 +22,8 @@ import {Extractor} from './extractor';
 function extract(
     ngOptions: tsc.AngularCompilerOptions, cliOptions: tsc.I18nExtractionCliOptions,
     program: ts.Program, host: ts.CompilerHost): Promise<void> {
-  return Extractor.create(ngOptions, program, host).extract(cliOptions.i18nFormat);
+  return Extractor.create(ngOptions, program, host)
+      .extract(cliOptions.i18nFormat, cliOptions.outFile);
 }
 
 // Entry point

--- a/modules/@angular/compiler-cli/src/extractor.ts
+++ b/modules/@angular/compiler-cli/src/extractor.ts
@@ -27,7 +27,7 @@ export class Extractor {
       public host: ts.CompilerHost, private ngCompilerHost: CompilerHost,
       private program: ts.Program) {}
 
-  extract(formatName: string): Promise<void> {
+  extract(formatName: string, outFile?: string): Promise<void> {
     // Checks the format and returns the extension
     const ext = this.getExtension(formatName);
 
@@ -35,7 +35,7 @@ export class Extractor {
 
     return promiseBundle.then(bundle => {
       const content = this.serialize(bundle, ext);
-      const dstPath = path.join(this.options.genDir, `messages.${ext}`);
+      const dstPath = path.join(this.options.genDir, `${outFile || ('messages.' + ext)}`);
       this.host.writeFile(dstPath, content, false);
     });
   }

--- a/modules/@angular/compiler-cli/src/ngtools_api.ts
+++ b/modules/@angular/compiler-cli/src/ngtools_api.ts
@@ -59,6 +59,7 @@ export interface NgTools_InternalApi_NG2_ExtractI18n_Options {
   host: ts.CompilerHost;
   angularCompilerOptions: AngularCompilerOptions;
   i18nFormat: string;
+  outFile: string;
   readResource: (fileName: string) => Promise<string>;
   // Every new property under this line should be optional.
 }
@@ -145,6 +146,6 @@ export class NgTools_InternalApi_NG_2 {
     const extractor = Extractor.create(
         options.angularCompilerOptions, options.program, options.host, hostContext);
 
-    return extractor.extract(options.i18nFormat);
+    return extractor.extract(options.i18nFormat, options.outFile);
   }
 }

--- a/scripts/ci-lite/offline_compiler_test.sh
+++ b/scripts/ci-lite/offline_compiler_test.sh
@@ -52,7 +52,7 @@ cp -v package.json $TMP
   ./node_modules/.bin/ngc -p tsconfig-build.json --i18nFile=src/messages.fi.xlf --locale=fi --i18nFormat=xlf
 
   ./node_modules/.bin/ng-xi18n -p tsconfig-xi18n.json --i18nFormat=xlf
-  ./node_modules/.bin/ng-xi18n -p tsconfig-xi18n.json --i18nFormat=xmb
+  ./node_modules/.bin/ng-xi18n -p tsconfig-xi18n.json --i18nFormat=xmb --outFile=custom_file.xmb
 
   node test/test_summaries.js
   node test/test_ngtools_api.js

--- a/tools/@angular/tsc-wrapped/src/cli_options.ts
+++ b/tools/@angular/tsc-wrapped/src/cli_options.ts
@@ -12,10 +12,13 @@ export class CliOptions {
 
 export class I18nExtractionCliOptions extends CliOptions {
   public i18nFormat: string;
+  public outFile: string;
 
-  constructor({i18nFormat = null}: {i18nFormat?: string}) {
+  constructor({i18nFormat = null,
+               outFile = null}: {i18nFormat?: string, outFile?: string}) {
     super({});
     this.i18nFormat = i18nFormat;
+    this.outFile = outFile;
   }
 }
 


### PR DESCRIPTION
…utput file name

Fixes #11416

The output folder can already be specified with the `genDir` option.
The file extension depends on the format used.
The only missing part was being able to customize the file name.