### PR TITLE
fix(platform-server): don't setup Testability and TestabilityRegistry…

### DIFF
--- a/modules/@angular/core/src/application_ref.ts
+++ b/modules/@angular/core/src/application_ref.ts
@@ -433,9 +433,7 @@ export class ApplicationRef_ extends ApplicationRef {
       private _zone: NgZone, private _console: Console, private _injector: Injector,
       private _exceptionHandler: ErrorHandler,
       private _componentFactoryResolver: ComponentFactoryResolver,
-      private _initStatus: ApplicationInitStatus,
-      @Optional() private _testabilityRegistry: TestabilityRegistry,
-      @Optional() private _testability: Testability) {
+      private _initStatus: ApplicationInitStatus) {
     super();
     this._enforceNoNewChanges = isDevMode();
 

--- a/modules/@angular/platform-server/src/server.ts
+++ b/modules/@angular/platform-server/src/server.ts
@@ -8,7 +8,7 @@
 
 import {PlatformLocation, ɵPLATFORM_SERVER_ID as PLATFORM_SERVER_ID} from '@angular/common';
 import {platformCoreDynamic} from '@angular/compiler';
-import {Injectable, InjectionToken, Injector, NgModule, PLATFORM_ID, PLATFORM_INITIALIZER, PlatformRef, Provider, RendererFactoryV2, RootRenderer, createPlatformFactory, isDevMode, platformCore, ɵALLOW_MULTIPLE_PLATFORMS as ALLOW_MULTIPLE_PLATFORMS} from '@angular/core';
+import {Injectable, InjectionToken, Injector, NgModule, PLATFORM_ID, PLATFORM_INITIALIZER, PlatformRef, Provider, RendererFactoryV2, RootRenderer, Testability, createPlatformFactory, isDevMode, platformCore, ɵALLOW_MULTIPLE_PLATFORMS as ALLOW_MULTIPLE_PLATFORMS} from '@angular/core';
 import {HttpModule} from '@angular/http';
 import {BrowserModule, DOCUMENT, ɵSharedStylesHost as SharedStylesHost, ɵgetDOM as getDOM} from '@angular/platform-browser';
 
@@ -52,7 +52,11 @@ export const SERVER_RENDER_PROVIDERS: Provider[] = [
 @NgModule({
   exports: [BrowserModule],
   imports: [HttpModule],
-  providers: [SERVER_RENDER_PROVIDERS, SERVER_HTTP_PROVIDERS],
+  providers: [
+    SERVER_RENDER_PROVIDERS,
+    SERVER_HTTP_PROVIDERS,
+    {provide: Testability, useValue: null},
+  ],
 })
 export class ServerModule {
 }


### PR DESCRIPTION
… on the server

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently Testability and TestabilityRegistry setup global objects related to Testability. This leaks objects when it is setup for server applications.

**What is the new behavior?**
Don't inject/use Testability in server application by overriding the binding in ServerModule.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

