### PR TITLE
ci: fix `getLatestLabel`

### DIFF
--- a/scripts/publish/publish-build-artifacts.sh
+++ b/scripts/publish/publish-build-artifacts.sh
@@ -18,7 +18,6 @@ function getLatestTag {
 
     # Increase the clone depth and look for a tag.
     depth=$((depth + 50))
-    echo "Looking for latest tag at depth $depth..."
     git fetch --depth=$depth
     latestTag=`git describe --tags --abbrev=0 || echo NOT_FOUND`
   done


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
`getLatestLabel` is broken when iteratively trying to deepen the clone.
Returns: `Looking for latest tag at depth 100...\n4.0.0-beta.7`


**What is the new behavior?**
`getLatestLabel` works correctly when iteratively trying to deepen the clone.
Returns: `4.0.0-beta.7`


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```