### PR TITLE
fix(aio): use cleanUrls option rather than bruteforce rewriting rule

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -4,11 +4,6 @@
   },
   "hosting": {
     "public": "dist",
-    "rewrites": [
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
-    ]
+    "cleanUrls": true
   }
 }


### PR DESCRIPTION
the cleanUrls option is smarter and looks at headers and mime type to route requests correctly.
