### PR TITLE
feat(aio): temporarily include content folder among production assets

### DIFF
--- a/aio/angular-cli.json
+++ b/aio/angular-cli.json
@@ -9,6 +9,7 @@
       "outDir": "dist",
       "assets": [
         "assets",
+        "content",
         "favicon.ico"
       ],
       "index": "index.html",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The `contents` folder is not copied to output during `ng serve -prod` presumably because it was not listed among the assets in `angular-cli.json#assets`.  That means that its contents were not delivered from the staging site.

This PR guesses that adding the `content` folder to `angular-cli.json#assets` will solve the problem.

**What is the new behavior?**

The site works again when served from staging.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
