### PR TITLE
test: pin down @types/* dependencies in typings test

### DIFF
--- a/tools/typings-test/test.sh
+++ b/tools/typings-test/test.sh
@@ -18,7 +18,7 @@ cp -R -v tools/typings-test/* $TMP
   # create package.json so that npm install doesn't pollute any parent node_modules's directory
   npm init --yes
   npm install ${LINKABLE_PKGS[*]}
-  npm install @types/es6-promise @types/es6-collections @types/jasmine rxjs@5.0.0-beta.11
+  npm install @types/es6-promise@0.0.32 @types/es6-collections@0.5.29 @types/jasmine@2.5.41 rxjs@5.0.0-beta.11
   npm install typescript@1.8.10
   $(npm bin)/tsc --version
   $(npm bin)/tsc -p tsconfig.json


### PR DESCRIPTION
This is needed because the latest versions are no longer compatible with typescript 1.8 which results in build errors:
https://travis-ci.org/angular/angular/jobs/202752040#L3863
