### PR TITLE
feat(common): NgTemplateOutlet use internal template if none is provided

### DIFF
--- a/modules/@angular/common/src/directives/ng_template_outlet.ts
+++ b/modules/@angular/common/src/directives/ng_template_outlet.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, EmbeddedViewRef, Input, OnChanges, SimpleChanges, TemplateRef, ViewContainerRef} from '@angular/core';
+import {Directive, EmbeddedViewRef, Input, OnChanges, Optional, SimpleChanges, TemplateRef, ViewContainerRef} from '@angular/core';
 
 /**
  * @ngModule CommonModule
@@ -16,6 +16,12 @@ import {Directive, EmbeddedViewRef, Input, OnChanges, SimpleChanges, TemplateRef
  * @howToUse
  * ```
  * <ng-container *ngTemplateOutlet="templateRefExp; context: contextExp"></ng-container>
+ * ```
+ *
+ * ```
+ * <ng-container *ngTemplateOutlet="let item; context: itemContext">
+ *     {{item.name}}
+ * </ng-container>
  * ```
  *
  * @description
@@ -35,12 +41,24 @@ import {Directive, EmbeddedViewRef, Input, OnChanges, SimpleChanges, TemplateRef
 @Directive({selector: '[ngTemplateOutlet]'})
 export class NgTemplateOutlet implements OnChanges {
   private _viewRef: EmbeddedViewRef<any>;
+  private _injectedTemplateRef: TemplateRef<any>;
 
   @Input() public ngTemplateOutletContext: Object;
 
-  @Input() public ngTemplateOutlet: TemplateRef<any>;
+  @Input()
+  public set ngTemplateOutlet(value: TemplateRef<any>) {
+    if (value) {
+      this._templateRef = value;
+    } else {
+      this._templateRef = this._injectedTemplateRef;
+    }
+  }
 
-  constructor(private _viewContainerRef: ViewContainerRef) {}
+  constructor(
+      private _viewContainerRef: ViewContainerRef,
+      @Optional() private _templateRef: TemplateRef<any>) {
+    this._injectedTemplateRef = _templateRef;
+  }
 
   /**
    * @deprecated v4.0.0 - Renamed to ngTemplateOutletContext.
@@ -53,9 +71,9 @@ export class NgTemplateOutlet implements OnChanges {
       this._viewContainerRef.remove(this._viewContainerRef.indexOf(this._viewRef));
     }
 
-    if (this.ngTemplateOutlet) {
+    if (this._templateRef) {
       this._viewRef = this._viewContainerRef.createEmbeddedView(
-          this.ngTemplateOutlet, this.ngTemplateOutletContext);
+          this._templateRef, this.ngTemplateOutletContext);
     }
   }
 }

--- a/modules/@angular/common/test/directives/ng_template_outlet_spec.ts
+++ b/modules/@angular/common/test/directives/ng_template_outlet_spec.ts
@@ -47,9 +47,9 @@ export function main() {
          detectChangesAndExpectText('foo');
        }));
 
-    it('should clear content if TemplateRef becomes `null`', async(() => {
+    it('should show its child template if TemplateRef becomes `null`', async(() => {
          const template = `<tpl-refs #refs="tplRefs"><template>foo</template></tpl-refs>` +
-             `<ng-container [ngTemplateOutlet]="currentTplRef"></ng-container>`;
+             `<ng-container *ngTemplateOutlet="currentTplRef">bar</ng-container>`;
          fixture = createTestComponent(template);
          fixture.detectChanges();
          const refs = fixture.debugElement.children[0].references['refs'];
@@ -58,7 +58,7 @@ export function main() {
          detectChangesAndExpectText('foo');
 
          setTplRef(null);
-         detectChangesAndExpectText('');
+         detectChangesAndExpectText('bar');
        }));
 
     it('should swap content if TemplateRef changes', async(() => {
@@ -114,6 +114,15 @@ export function main() {
 
          fixture.componentInstance.context = {shawshank: 'was here'};
          detectChangesAndExpectText('was here');
+       }));
+
+    it('should be compatible with star (*) syntax bindings', async(() => {
+         const template =
+             `<ng-container *ngTemplateOutlet="let item; let myFoo = foo; context: context">{{item}}-{{myFoo}}</ng-container>`;
+         fixture = createTestComponent(template);
+
+         fixture.componentInstance.context = {$implicit: 'the_implicit', foo: 'the_foo'};
+         detectChangesAndExpectText('the_implicit-the_foo');
        }));
   });
 }

--- a/tools/public_api_guard/common/typings/common.d.ts
+++ b/tools/public_api_guard/common/typings/common.d.ts
@@ -212,7 +212,7 @@ export declare class NgTemplateOutlet implements OnChanges {
     /** @deprecated */ ngOutletContext: Object;
     ngTemplateOutlet: TemplateRef<any>;
     ngTemplateOutletContext: Object;
-    constructor(_viewContainerRef: ViewContainerRef);
+    constructor(_viewContainerRef: ViewContainerRef, _templateRef: TemplateRef<any>);
     ngOnChanges(changes: SimpleChanges): void;
 }
 


### PR DESCRIPTION
This allows ngTemplateOutlet to be used with variable bindings from
the template micro-syntax.

BREAKING CHANGE:
- A template with the `NgTemplateOutlet` directive will now render its
  own content if the template provided to `[ngTemplateOutlet]` is
  `null`. This also applies to elements that use the `*ngTemplateOutlet`
  syntax.
  Before this change, this content would never render, so adding child
  nodes to a template with `NgTemplateOutlet` had no effect unless
  combined with another directive.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

A recent addition to `NgTemplateOutlet` was better compatibility with star-syntax.
However, only a portion of this syntax is supported, since the template must be passed
through the `ngTemplateOutlet` input.

**What is the new behavior?**

If `NgTemplateOutlet` is applied to a template (or applied using star-syntax), and the
value of the `ngTemplateOutlet` input is not defined, `NgTemplateOutlet` will default to
the injected `TemplateRef<any>` from the template it is defined on. This also allows for
use of the star microsyntax to create variable bindings on this template. This allows for the
following:

```html
<ng-container *ngTemplateOutlet="let item = item; context: someContext">
    <div>{{item.name}}</div>
    <div>{{item.price}}</div>
</ng-container>
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

`NgTemplateOutlet` will now behave differently if the following three conditions are true:

* The directive is applied to a `<template>`, or applied using star (\*) expansion.
* The template or element that the attribute appears on has child nodes.
* The value passed to the `ngTemplateOutlet` input is falsy.

Before this change, nothing would be rendered under those conditions. Now, the template
that `NgTemplateOutlet` is defined on will be used and bound to the provided context.

**Other information**:

