### PR TITLE
[4.x only - already in 2.x] fix(http): Make ResponseOptionsArgs an interface (#14607)

### DIFF
--- a/packages/http/src/interfaces.ts
+++ b/packages/http/src/interfaces.ts
@@ -68,9 +68,11 @@ export interface RequestArgs extends RequestOptionsArgs { url: string; }
  *
  * @experimental
  */
-export type ResponseOptionsArgs = {
-  body?: string | Object | FormData | ArrayBuffer | Blob; status?: number; statusText?: string;
+export interface ResponseOptionsArgs {
+  body?: string|Object|FormData|ArrayBuffer|Blob;
+  status?: number;
+  statusText?: string;
   headers?: Headers;
   type?: ResponseType;
   url?: string;
-};
+}

--- a/tools/public_api_guard/http/typings/http.d.ts
+++ b/tools/public_api_guard/http/typings/http.d.ts
@@ -197,14 +197,14 @@ export declare class ResponseOptions {
 }
 
 /** @experimental */
-export declare type ResponseOptionsArgs = {
+export interface ResponseOptionsArgs {
     body?: string | Object | FormData | ArrayBuffer | Blob;
+    headers?: Headers;
     status?: number;
     statusText?: string;
-    headers?: Headers;
     type?: ResponseType;
     url?: string;
-};
+}
 
 /** @experimental */
 export declare enum ResponseType {


### PR DESCRIPTION
original PR #13708

This commit had been revert in master due to a failure in g3 (the root cause was an other change)

@IgorMinar Do we want to merge this one ?