### PR TITLE
fix(language-service): tolerate errors in decorators

### DIFF
--- a/modules/@angular/compiler-cli/src/compiler_host.ts
+++ b/modules/@angular/compiler-cli/src/compiler_host.ts
@@ -7,7 +7,7 @@
  */
 
 import {AotCompilerHost, StaticSymbol} from '@angular/compiler';
-import {AngularCompilerOptions, MetadataCollector, ModuleMetadata} from '@angular/tsc-wrapped';
+import {AngularCompilerOptions, CollectorOptions, MetadataCollector, ModuleMetadata} from '@angular/tsc-wrapped';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
@@ -37,7 +37,7 @@ export class CompilerHost implements AotCompilerHost {
 
   constructor(
       protected program: ts.Program, protected options: AngularCompilerOptions,
-      protected context: CompilerHostContext) {
+      protected context: CompilerHostContext, collectorOptions?: CollectorOptions) {
     // normalize the path so that it never ends with '/'.
     this.basePath = path.normalize(path.join(this.options.basePath, '.')).replace(/\\/g, '/');
     this.genDir = path.normalize(path.join(this.options.genDir, '.')).replace(/\\/g, '/');

--- a/modules/@angular/compiler/test/aot/README.md
+++ b/modules/@angular/compiler/test/aot/README.md
@@ -1,2 +1,1 @@
-Tests in this directory are excluded from running in the browser and only running
-in node.
+Tests in this directory are excluded from running in the browser and only run in node.

--- a/modules/@angular/compiler/test/aot/static_symbol_resolver_spec.ts
+++ b/modules/@angular/compiler/test/aot/static_symbol_resolver_spec.ts
@@ -7,9 +7,8 @@
  */
 
 import {StaticSymbol, StaticSymbolCache, StaticSymbolResolver, StaticSymbolResolverHost, Summary, SummaryResolver} from '@angular/compiler';
-import {MetadataCollector} from '@angular/tsc-wrapped';
+import {CollectorOptions, MetadataCollector} from '@angular/tsc-wrapped';
 import * as ts from 'typescript';
-
 
 
 // This matches .ts files but not .d.ts files.
@@ -366,9 +365,11 @@ export class MockSummaryResolver implements SummaryResolver<StaticSymbol> {
 }
 
 export class MockStaticSymbolResolverHost implements StaticSymbolResolverHost {
-  private collector = new MetadataCollector();
+  private collector: MetadataCollector;
 
-  constructor(private data: {[key: string]: any}) {}
+  constructor(private data: {[key: string]: any}, collectorOptions?: CollectorOptions) {
+    this.collector = new MetadataCollector(collectorOptions);
+  }
 
   // In tests, assume that symbols are not re-exported
   moduleNameToFileName(modulePath: string, containingFile?: string): string {

--- a/modules/@angular/language-service/src/reflector_host.ts
+++ b/modules/@angular/language-service/src/reflector_host.ts
@@ -33,7 +33,8 @@ export class ReflectorHost extends CompilerHost {
       options: AngularCompilerOptions) {
     super(
         null, options,
-        new ModuleResolutionHostAdapter(new ReflectorModuleModuleResolutionHost(serviceHost)));
+        new ModuleResolutionHostAdapter(new ReflectorModuleModuleResolutionHost(serviceHost)),
+        {verboseInvalidExpression: true});
   }
 
   protected get program() { return this.getProgram(); }

--- a/tools/@angular/tsc-wrapped/src/collector.ts
+++ b/tools/@angular/tsc-wrapped/src/collector.ts
@@ -37,6 +37,11 @@ export class CollectorOptions {
    * the source.
    */
   quotedNames?: boolean;
+
+  /**
+   * Do not simplify invalid expressions.
+   */
+  verboseInvalidExpression?: boolean;
 }
 
 /**


### PR DESCRIPTION
Fixes #14631

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

Metadata errors caused the language service to produce strange cascading errors causing problems such as reported here: https://github.com/angular/vscode-ng-language-service/issues/10

**What is the new behavior?**

Metadata errors are reported and ignored.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
