### PR TITLE
feat(core): add a PLATFORM_NAME token that provides the name of the current platform

### DIFF
--- a/modules/@angular/common/src/common.ts
+++ b/modules/@angular/common/src/common.ts
@@ -16,4 +16,5 @@ export {NgLocaleLocalization, NgLocalization} from './localization';
 export {CommonModule, DeprecatedCommonModule} from './common_module';
 export {NgClass, NgFor, NgForOf, NgIf, NgPlural, NgPluralCase, NgStyle, NgSwitch, NgSwitchCase, NgSwitchDefault, NgTemplateOutlet, NgComponentOutlet} from './directives/index';
 export {AsyncPipe, DatePipe, I18nPluralPipe, I18nSelectPipe, JsonPipe, LowerCasePipe, CurrencyPipe, DecimalPipe, PercentPipe, SlicePipe, UpperCasePipe, TitleCasePipe} from './pipes/index';
+export {PLATFORM_BROWSER_ID as ɵPLATFORM_BROWSER_ID, PLATFORM_SERVER_ID as ɵPLATFORM_SERVER_ID, PLATFORM_WORKER_APP_ID as ɵPLATFORM_WORKER_APP_ID, PLATFORM_WORKER_UI_ID as ɵPLATFORM_WORKER_UI_ID, isPlatformBrowser, isPlatformServer, isPlatformWorkerApp, isPlatformWorkerUi} from './platform_id';
 export {VERSION} from './version';

--- a/modules/@angular/common/src/platform_id.ts
+++ b/modules/@angular/common/src/platform_id.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export const PLATFORM_BROWSER_ID = 'browser';
+export const PLATFORM_SERVER_ID = 'server';
+export const PLATFORM_WORKER_APP_ID = 'browserWorkerApp';
+export const PLATFORM_WORKER_UI_ID = 'browserWorkerUi';
+
+/**
+ * Returns whether a platform id represents a browser platform.
+ * @experimental
+ */
+export function isPlatformBrowser(platformId: Object): boolean {
+  return platformId === PLATFORM_BROWSER_ID;
+}
+
+/**
+ * Returns whether a platform id represents a server platform.
+ * @experimental
+ */
+export function isPlatformServer(platformId: Object): boolean {
+  return platformId === PLATFORM_SERVER_ID;
+}
+
+/**
+ * Returns whether a platform id represents a web worker app platform.
+ * @experimental
+ */
+export function isPlatformWorkerApp(platformId: Object): boolean {
+  return platformId === PLATFORM_WORKER_APP_ID;
+}
+
+/**
+ * Returns whether a platform id represents a web worker UI platform.
+ * @experimental
+ */
+export function isPlatformWorkerUi(platformId: Object): boolean {
+  return platformId === PLATFORM_WORKER_UI_ID;
+}

--- a/modules/@angular/core/src/application_tokens.ts
+++ b/modules/@angular/core/src/application_tokens.ts
@@ -47,6 +47,12 @@ function _randomChar(): string {
 export const PLATFORM_INITIALIZER = new InjectionToken<Array<() => void>>('Platform Initializer');
 
 /**
+ * A token that indicates an opaque platform id.
+ * @experimental
+ */
+export const PLATFORM_ID = new InjectionToken<Object>('Platform ID');
+
+/**
  * All callbacks provided via this token will be called for every component that is bootstrapped.
  * Signature of the callback:
  *

--- a/modules/@angular/core/src/core.ts
+++ b/modules/@angular/core/src/core.ts
@@ -16,7 +16,7 @@ export * from './version';
 export * from './util';
 export * from './di';
 export {createPlatform, assertPlatform, destroyPlatform, getPlatform, PlatformRef, ApplicationRef, enableProdMode, isDevMode, createPlatformFactory, NgProbeToken} from './application_ref';
-export {APP_ID, PACKAGE_ROOT_URL, PLATFORM_INITIALIZER, APP_BOOTSTRAP_LISTENER} from './application_tokens';
+export {APP_ID, PACKAGE_ROOT_URL, PLATFORM_INITIALIZER, PLATFORM_ID, APP_BOOTSTRAP_LISTENER} from './application_tokens';
 export {APP_INITIALIZER, ApplicationInitStatus} from './application_init';
 export * from './zone';
 export * from './render';

--- a/modules/@angular/core/src/platform_core_providers.ts
+++ b/modules/@angular/core/src/platform_core_providers.ts
@@ -7,6 +7,7 @@
  */
 
 import {PlatformRef, PlatformRef_, createPlatformFactory} from './application_ref';
+import {PLATFORM_ID} from './application_tokens';
 import {Console} from './console';
 import {Provider} from './di';
 import {Reflector, reflector} from './reflection/reflection';
@@ -18,6 +19,8 @@ function _reflector(): Reflector {
 }
 
 const _CORE_PLATFORM_PROVIDERS: Provider[] = [
+  // Set a default platform name for platforms that don't set it explicitly.
+  {provide: PLATFORM_ID, useValue: 'unknown'},
   PlatformRef_,
   {provide: PlatformRef, useExisting: PlatformRef_},
   {provide: Reflector, useFactory: _reflector, deps: []},

--- a/modules/@angular/platform-browser-dynamic/src/platform_providers.ts
+++ b/modules/@angular/platform-browser-dynamic/src/platform_providers.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
 import {ResourceLoader} from '@angular/compiler';
-import {COMPILER_OPTIONS, Provider} from '@angular/core';
+import {COMPILER_OPTIONS, PLATFORM_ID, Provider} from '@angular/core';
 
 import {ɵINTERNAL_BROWSER_PLATFORM_PROVIDERS as INTERNAL_BROWSER_PLATFORM_PROVIDERS} from '@angular/platform-browser';
 
@@ -20,4 +21,5 @@ export const INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS: Provider[] = [
     useValue: {providers: [{provide: ResourceLoader, useClass: ResourceLoaderImpl}]},
     multi: true
   },
+  {provide: PLATFORM_ID, useValue: PLATFORM_BROWSER_ID},
 ];

--- a/modules/@angular/platform-browser/src/browser.ts
+++ b/modules/@angular/platform-browser/src/browser.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CommonModule, PlatformLocation} from '@angular/common';
-import {APP_ID, ApplicationModule, ErrorHandler, ModuleWithProviders, NgModule, Optional, PLATFORM_INITIALIZER, PlatformRef, Provider, RendererFactoryV2, RootRenderer, Sanitizer, SkipSelf, Testability, createPlatformFactory, platformCore} from '@angular/core';
+import {CommonModule, PlatformLocation, ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
+import {APP_ID, ApplicationModule, ErrorHandler, ModuleWithProviders, NgModule, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, PlatformRef, Provider, RendererFactoryV2, RootRenderer, Sanitizer, SkipSelf, Testability, createPlatformFactory, platformCore} from '@angular/core';
 
 import {AnimationDriver} from '../src/dom/animation_driver';
 import {WebAnimationsDriver} from '../src/dom/web_animations_driver';
@@ -30,6 +30,7 @@ import {DomSharedStylesHost, SharedStylesHost} from './dom/shared_styles_host';
 import {DomSanitizer, DomSanitizerImpl} from './security/dom_sanitization_service';
 
 export const INTERNAL_BROWSER_PLATFORM_PROVIDERS: Provider[] = [
+  {provide: PLATFORM_ID, useValue: PLATFORM_BROWSER_ID},
   {provide: PLATFORM_INITIALIZER, useValue: initDomAdapter, multi: true},
   {provide: PlatformLocation, useClass: BrowserPlatformLocation},
   {provide: DOCUMENT, useFactory: _document, deps: []},

--- a/modules/@angular/platform-browser/test/browser/bootstrap_spec.ts
+++ b/modules/@angular/platform-browser/test/browser/bootstrap_spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_INITIALIZER, CUSTOM_ELEMENTS_SCHEMA, Compiler, Component, Directive, ErrorHandler, Inject, Input, LOCALE_ID, NgModule, OnDestroy, PLATFORM_INITIALIZER, Pipe, Provider, VERSION, createPlatformFactory} from '@angular/core';
+import {isPlatformBrowser} from '@angular/common';
+import {APP_INITIALIZER, CUSTOM_ELEMENTS_SCHEMA, Compiler, Component, Directive, ErrorHandler, Inject, Input, LOCALE_ID, NgModule, OnDestroy, PLATFORM_ID, PLATFORM_INITIALIZER, Pipe, Provider, VERSION, createPlatformFactory} from '@angular/core';
 import {ApplicationRef, destroyPlatform} from '@angular/core/src/application_ref';
 import {Console} from '@angular/core/src/console';
 import {ComponentRef} from '@angular/core/src/linker/component_factory';
@@ -221,6 +222,15 @@ export function main() {
       const refPromise = bootstrap(HelloRootCmp, testProviders);
       expect(refPromise).not.toBe(null);
     });
+
+    it('should set platform name to browser',
+       inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+         const refPromise = bootstrap(HelloRootCmp, testProviders);
+         refPromise.then((ref) => {
+           expect(isPlatformBrowser(ref.injector.get(PLATFORM_ID))).toBe(true);
+           async.done();
+         });
+       }));
 
     it('should display hello world', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          const refPromise = bootstrap(HelloRootCmp, testProviders);

--- a/modules/@angular/platform-server/src/server.ts
+++ b/modules/@angular/platform-server/src/server.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {PlatformLocation} from '@angular/common';
+import {PlatformLocation, ɵPLATFORM_SERVER_ID as PLATFORM_SERVER_ID} from '@angular/common';
 import {platformCoreDynamic} from '@angular/compiler';
-import {Injectable, InjectionToken, Injector, NgModule, PLATFORM_INITIALIZER, PlatformRef, Provider, RendererFactoryV2, RootRenderer, createPlatformFactory, isDevMode, platformCore, ɵALLOW_MULTIPLE_PLATFORMS as ALLOW_MULTIPLE_PLATFORMS, ɵDebugDomRootRenderer as DebugDomRootRenderer} from '@angular/core';
+import {Injectable, InjectionToken, Injector, NgModule, PLATFORM_ID, PLATFORM_INITIALIZER, PlatformRef, Provider, RendererFactoryV2, RootRenderer, createPlatformFactory, isDevMode, platformCore, ɵALLOW_MULTIPLE_PLATFORMS as ALLOW_MULTIPLE_PLATFORMS, ɵDebugDomRootRenderer as DebugDomRootRenderer} from '@angular/core';
 import {HttpModule} from '@angular/http';
 import {BrowserModule, DOCUMENT, ɵSharedStylesHost as SharedStylesHost, ɵgetDOM as getDOM} from '@angular/platform-browser';
+
 import {SERVER_HTTP_PROVIDERS} from './http';
 import {ServerPlatformLocation} from './location';
 import {Parse5DomAdapter, parseDocument} from './parse5_adapter';
@@ -25,6 +26,7 @@ function notSupported(feature: string): Error {
 
 export const INTERNAL_SERVER_PLATFORM_PROVIDERS: Array<any /*Type | Provider | any[]*/> = [
   {provide: DOCUMENT, useFactory: _document, deps: [Injector]},
+  {provide: PLATFORM_ID, useValue: PLATFORM_SERVER_ID},
   {provide: PLATFORM_INITIALIZER, useFactory: initParse5Adapter, multi: true, deps: [Injector]},
   {provide: PlatformLocation, useClass: ServerPlatformLocation}, PlatformState,
   // Add special provider that allows multiple instances of platformServer* to be created.

--- a/modules/@angular/platform-server/test/integration_spec.ts
+++ b/modules/@angular/platform-server/test/integration_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {PlatformLocation} from '@angular/common';
+import {PlatformLocation, isPlatformServer} from '@angular/common';
 import {USE_VIEW_ENGINE} from '@angular/compiler/src/config';
-import {ApplicationRef, CompilerFactory, Component, NgModule, NgModuleRef, NgZone, PlatformRef, destroyPlatform, getPlatform} from '@angular/core';
+import {ApplicationRef, CompilerFactory, Component, NgModule, NgModuleRef, NgZone, PLATFORM_ID, PlatformRef, destroyPlatform, getPlatform} from '@angular/core';
 import {TestBed, async, inject} from '@angular/core/testing';
 import {Http, HttpModule, Response, ResponseOptions, XHRBackend} from '@angular/http';
 import {MockBackend, MockConnection} from '@angular/http/testing';
@@ -137,6 +137,7 @@ function declareTests({viewEngine}: {viewEngine: boolean}) {
              [{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
 
          platform.bootstrapModule(ExampleModule).then((moduleRef) => {
+           expect(isPlatformServer(moduleRef.injector.get(PLATFORM_ID))).toBe(true);
            const doc = moduleRef.injector.get(DOCUMENT);
            expect(getDOM().getText(doc)).toEqual('Works!');
            platform.destroy();

--- a/modules/@angular/platform-webworker-dynamic/package.json
+++ b/modules/@angular/platform-webworker-dynamic/package.json
@@ -9,6 +9,7 @@
   "author": "angular",
   "license": "MIT",
   "peerDependencies": {
+    "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER",

--- a/modules/@angular/platform-webworker-dynamic/src/platform-webworker-dynamic.ts
+++ b/modules/@angular/platform-webworker-dynamic/src/platform-webworker-dynamic.ts
@@ -6,17 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ɵPLATFORM_WORKER_UI_ID as PLATFORM_WORKER_UI_ID} from '@angular/common';
 import {ResourceLoader, platformCoreDynamic} from '@angular/compiler';
-import {COMPILER_OPTIONS, PlatformRef, Provider, createPlatformFactory} from '@angular/core';
+import {COMPILER_OPTIONS, PLATFORM_ID, PlatformRef, Provider, createPlatformFactory} from '@angular/core';
 import {ɵResourceLoaderImpl as ResourceLoaderImpl} from '@angular/platform-browser-dynamic';
 export {VERSION} from './version';
 
 /**
  * @experimental API related to bootstrapping are still under review.
  */
-export const platformWorkerAppDynamic = createPlatformFactory(
-    platformCoreDynamic, 'workerAppDynamic', [{
-      provide: COMPILER_OPTIONS,
-      useValue: {providers: [{provide: ResourceLoader, useClass: ResourceLoaderImpl}]},
-      multi: true
-    }]);
+export const platformWorkerAppDynamic =
+    createPlatformFactory(platformCoreDynamic, 'workerAppDynamic', [
+      {
+        provide: COMPILER_OPTIONS,
+        useValue: {providers: [{provide: ResourceLoader, useClass: ResourceLoaderImpl}]},
+        multi: true
+      },
+      {provide: PLATFORM_ID, useValue: PLATFORM_WORKER_UI_ID}
+    ]);

--- a/modules/@angular/platform-webworker/package.json
+++ b/modules/@angular/platform-webworker/package.json
@@ -9,6 +9,7 @@
   "author": "angular",
   "license": "MIT",
   "peerDependencies": {
+    "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER"
   },

--- a/modules/@angular/platform-webworker/src/worker_app.ts
+++ b/modules/@angular/platform-webworker/src/worker_app.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CommonModule} from '@angular/common';
-import {APP_INITIALIZER, ApplicationModule, ErrorHandler, NgModule, NgZone, PlatformRef, Provider, RendererFactoryV2, RootRenderer, createPlatformFactory, platformCore} from '@angular/core';
+import {CommonModule, ɵPLATFORM_WORKER_APP_ID as PLATFORM_WORKER_APP_ID} from '@angular/common';
+import {APP_INITIALIZER, ApplicationModule, ErrorHandler, NgModule, NgZone, PLATFORM_ID, PlatformRef, Provider, RendererFactoryV2, RootRenderer, createPlatformFactory, platformCore} from '@angular/core';
 import {DOCUMENT, ɵBROWSER_SANITIZATION_PROVIDERS as BROWSER_SANITIZATION_PROVIDERS} from '@angular/platform-browser';
 import {ON_WEB_WORKER} from './web_workers/shared/api';
 import {ClientMessageBrokerFactory, ClientMessageBrokerFactory_} from './web_workers/shared/client_message_broker';
@@ -24,7 +24,8 @@ import {WorkerDomAdapter} from './web_workers/worker/worker_adapter';
 /**
  * @experimental
  */
-export const platformWorkerApp = createPlatformFactory(platformCore, 'workerApp');
+export const platformWorkerApp = createPlatformFactory(
+    platformCore, 'workerApp', [{provide: PLATFORM_ID, useValue: PLATFORM_WORKER_APP_ID}]);
 
 export function errorHandler(): ErrorHandler {
   return new ErrorHandler();

--- a/modules/@angular/platform-webworker/src/worker_render.ts
+++ b/modules/@angular/platform-webworker/src/worker_render.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ErrorHandler, Injectable, InjectionToken, Injector, NgZone, PLATFORM_INITIALIZER, PlatformRef, Provider, RendererFactoryV2, RootRenderer, Testability, createPlatformFactory, isDevMode, platformCore, ɵAPP_ID_RANDOM_PROVIDER as APP_ID_RANDOM_PROVIDER} from '@angular/core';
+import {CommonModule, ɵPLATFORM_WORKER_UI_ID as PLATFORM_WORKER_UI_ID} from '@angular/common';
+import {ErrorHandler, Injectable, InjectionToken, Injector, NgZone, PLATFORM_ID, PLATFORM_INITIALIZER, PlatformRef, Provider, RendererFactoryV2, RootRenderer, Testability, createPlatformFactory, isDevMode, platformCore, ɵAPP_ID_RANDOM_PROVIDER as APP_ID_RANDOM_PROVIDER} from '@angular/core';
 import {AnimationDriver, DOCUMENT, EVENT_MANAGER_PLUGINS, EventManager, HAMMER_GESTURE_CONFIG, HammerGestureConfig, ɵBROWSER_SANITIZATION_PROVIDERS as BROWSER_SANITIZATION_PROVIDERS, ɵBrowserDomAdapter as BrowserDomAdapter, ɵBrowserGetTestability as BrowserGetTestability, ɵDomEventsPlugin as DomEventsPlugin, ɵDomRendererFactoryV2 as DomRendererFactoryV2, ɵDomRootRenderer as DomRootRenderer, ɵDomRootRenderer_ as DomRootRenderer_, ɵDomSharedStylesHost as DomSharedStylesHost, ɵHammerGesturesPlugin as HammerGesturesPlugin, ɵKeyEventsPlugin as KeyEventsPlugin, ɵSharedStylesHost as SharedStylesHost, ɵWebAnimationsDriver as WebAnimationsDriver, ɵgetDOM as getDOM} from '@angular/platform-browser';
 
 import {ON_WEB_WORKER} from './web_workers/shared/api';
@@ -87,6 +88,7 @@ export const _WORKER_UI_PLATFORM_PROVIDERS: Provider[] = [
     multi: true,
     deps: [Injector]
   },
+  {provide: PLATFORM_ID, useValue: PLATFORM_WORKER_UI_ID},
   {provide: MessageBus, useFactory: messageBusFactory, deps: [WebWorkerInstance]},
 ];
 

--- a/tools/public_api_guard/common/typings/common.d.ts
+++ b/tools/public_api_guard/common/typings/common.d.ts
@@ -64,6 +64,18 @@ export declare class I18nSelectPipe implements PipeTransform {
     }): string;
 }
 
+/** @experimental */
+export declare function isPlatformBrowser(platformId: Object): boolean;
+
+/** @experimental */
+export declare function isPlatformServer(platformId: Object): boolean;
+
+/** @experimental */
+export declare function isPlatformWorkerApp(platformId: Object): boolean;
+
+/** @experimental */
+export declare function isPlatformWorkerUi(platformId: Object): boolean;
+
 /** @stable */
 export declare class JsonPipe implements PipeTransform {
     transform(value: any): string;

--- a/tools/public_api_guard/core/typings/core.d.ts
+++ b/tools/public_api_guard/core/typings/core.d.ts
@@ -744,6 +744,9 @@ export interface PipeTransform {
 }
 
 /** @experimental */
+export declare const PLATFORM_ID: InjectionToken<Object>;
+
+/** @experimental */
 export declare const PLATFORM_INITIALIZER: InjectionToken<(() => void)[]>;
 
 /** @experimental */


### PR DESCRIPTION
Users can use isPlatformBrowser, isPlatformServer, isPlatformWorkerApp and isPlatformWorkerUi from '@angular/common' to check the Platform Id object they get back.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the new behavior?**
We now provide a PLATFOR_NAME at the platform level. User code can inject this token to have conditional logic based on whether it is running on 'server' or 'browser'.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
