### PR TITLE
fix(compiler-cli): import shallow import to @angular/upgrade/static correctly

### DIFF
--- a/modules/@angular/compiler-cli/src/compiler_host.ts
+++ b/modules/@angular/compiler-cli/src/compiler_host.ts
@@ -18,7 +18,7 @@ const NODE_MODULES = '/node_modules/';
 const IS_GENERATED = /\.(ngfactory|ngstyle)$/;
 const GENERATED_FILES = /\.ngfactory\.ts$|\.ngstyle\.ts$/;
 const GENERATED_OR_DTS_FILES = /\.d\.ts$|\.ngfactory\.ts$|\.ngstyle\.ts$/;
-const SHALLOW_IMPORT = /^((\w|-)+|(@(\w|-)+\/(\w|-)+))$/;
+const SHALLOW_IMPORT = /^((\w|-)+|(@(\w|-)+(\/(\w|-)+)+))$/;
 
 export interface CompilerHostContext extends ts.ModuleResolutionHost {
   readResource(fileName: string): Promise<string>;

--- a/modules/@angular/compiler-cli/test/aot_host_spec.ts
+++ b/modules/@angular/compiler-cli/test/aot_host_spec.ts
@@ -135,6 +135,18 @@ describe('CompilerHost', () => {
         .toEqual('@angular/core');
   });
 
+  it('should be able to produce an import to a shallow import', () => {
+    expect(hostNestedGenDir.fileNameToModuleName('@angular/core', '/tmp/project/src/main.ts'))
+        .toEqual('@angular/core');
+    expect(hostNestedGenDir.fileNameToModuleName(
+               '@angular/upgrade/static', '/tmp/project/src/main.ts'))
+        .toEqual('@angular/upgrade/static');
+    expect(hostNestedGenDir.fileNameToModuleName('myLibrary', '/tmp/project/src/main.ts'))
+        .toEqual('myLibrary');
+    expect(hostNestedGenDir.fileNameToModuleName('lib23-43', '/tmp/project/src/main.ts'))
+        .toEqual('lib23-43');
+  });
+
   it('should be able to produce an import from main to a sub-directory', () => {
     expect(hostNestedGenDir.fileNameToModuleName('lib/utils.ts', 'main.ts')).toEqual('./lib/utils');
   });


### PR DESCRIPTION
Fixes #14648

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

The import of `@angular/upgrade/static` is treated as a relative import when it should be a shallow import.

**What is the new behavior?**

Import of `@angular/upgrade/static` is correctly generated.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
