### PR TITLE
fix(compiler-cli): allow import of modules ending with .js, .ts, etc.

### DIFF
--- a/modules/@angular/compiler-cli/test/aot_host_spec.ts
+++ b/modules/@angular/compiler-cli/test/aot_host_spec.ts
@@ -20,7 +20,7 @@ describe('CompilerHost', () => {
   let hostSiblingGenDir: CompilerHost;
 
   beforeEach(() => {
-    context = new MockAotContext('/tmp/src', clone(FILES));
+    context = new MockAotContext('/tmp/project/src', clone(FILES));
     const host = new MockCompilerHost(context);
     program = ts.createProgram(
         ['main.ts'], {
@@ -190,6 +190,22 @@ describe('CompilerHost', () => {
       {__symbolic: 'module', version: 3, metadata: {}, exports: [{from: './lib/utils'}]}
     ]);
   });
+
+  it('should find the path to files ending with ".js"', () => {
+    expect(hostNestedGenDir.moduleNameToFileName('./lib/utils.js', '/tmp/project/src/main.ts'))
+        .toEqual('/tmp/project/src/lib/utils.ts');
+  });
+
+  it('should find the path to files ending with ".js"', () => {
+    expect(hostNestedGenDir.moduleNameToFileName('aspect.js', '/tmp/project/src/main.ts'))
+        .toEqual('/tmp/project/src/node_modules/aspect.js/index.d.ts');
+  });
+
+  it('should find the path to files ending with ".ts"', () => {
+    expect(hostNestedGenDir.moduleNameToFileName('aspect.ts', '/tmp/project/src/main.ts'))
+        .toEqual('/tmp/project/src/node_modules/aspect.ts/index.d.ts');
+  });
+
 });
 
 const dummyModule = 'export let foo: any[];';
@@ -201,47 +217,51 @@ const dummyMetadata: ModuleMetadata = {
 };
 const FILES: Entry = {
   'tmp': {
-    'src': {
-      'main.ts': `
-        import * as c from '@angular/core';
-        import * as r from '@angular/router';
-        import * as u from './lib/utils';
-        import * as cs from './lib/collections';
-        import * as u2 from './lib2/utils2';
-      `,
-      'lib': {
-        'utils.ts': dummyModule,
-        'collections.ts': dummyModule,
-      },
-      'lib2': {'utils2.ts': dummyModule},
-      'node_modules': {
-        '@angular': {
-          'core.d.ts': dummyModule,
-          'core.metadata.json':
-              `{"__symbolic":"module", "version": 3, "metadata": {"foo": {"__symbolic": "class"}}}`,
-          'router': {'index.d.ts': dummyModule, 'src': {'providers.d.ts': dummyModule}},
-          'unused.d.ts': dummyModule,
-          'empty.d.ts': 'export declare var a: string;',
-          'empty.metadata.json': '[]',
-        }
-      },
-      'metadata_versions': {
-        'v1.d.ts': `
-          import {ReExport} from './lib/utils2';
-          export {ReExport};
-
-          export {Export} from './lib/utils2';
-
-          export declare class Bar {
-            ngOnInit() {}
-          }
-          export declare class BarChild extends Bar {}
+    'project': {
+      'src': {
+        'main.ts': `
+          import * as c from '@angular/core';
+          import * as r from '@angular/router';
+          import * as u from './lib/utils';
+          import * as cs from './lib/collections';
+          import * as u2 from './lib2/utils2';
         `,
-        'v1.metadata.json':
-            `{"__symbolic":"module", "version": 1, "metadata": {"foo": {"__symbolic": "class"}}}`,
-        'v1_empty.d.ts': `
-          export * from './lib/utils';
-        `
+        'lib': {
+          'utils.ts': dummyModule,
+          'collections.ts': dummyModule,
+        },
+        'lib2': {'utils2.ts': dummyModule},
+        'node_modules': {
+          '@angular': {
+            'core.d.ts': dummyModule,
+            'core.metadata.json':
+                `{"__symbolic":"module", "version": 3, "metadata": {"foo": {"__symbolic": "class"}}}`,
+            'router': {'index.d.ts': dummyModule, 'src': {'providers.d.ts': dummyModule}},
+            'unused.d.ts': dummyModule,
+            'empty.d.ts': 'export declare var a: string;',
+            'empty.metadata.json': '[]',
+          },
+          'aspect.js': {'index.d.ts': dummyModule},
+          'aspect.ts': {'index.d.ts': dummyModule}
+        },
+        'metadata_versions': {
+          'v1.d.ts': `
+            import {ReExport} from './lib/utils2';
+            export {ReExport};
+
+            export {Export} from './lib/utils2';
+
+            export declare class Bar {
+              ngOnInit() {}
+            }
+            export declare class BarChild extends Bar {}
+          `,
+          'v1.metadata.json':
+              `{"__symbolic":"module", "version": 1, "metadata": {"foo": {"__symbolic": "class"}}}`,
+          'v1_empty.d.ts': `
+            export * from './lib/utils';
+          `
+        }
       }
     }
   }


### PR DESCRIPTION
Fix https://github.com/angular/angular/issues/14663

Allow importing node modules which name ends with the strings: `.ts`, `.d`, `.ts`, `.js`, `.jsx`, `.tsx`.

According to https://github.com/Microsoft/TypeScript/issues/4595
TypeScript knows how to handle imports with an extension so relative
imports should not be a problem (as shown in the tests).

If you prefer to keep the replace, another, alternative solution (less clean I suppose) is:

```ts
  moduleNameToFileName(m: string, containingFile: string): string|null {
    // ...
    const original = m;
    m = m.replace(EXT, '');
    const resolve = (m: string) => ts.resolveModuleName(
          m, containingFile.replace(/\\/g, '/'), this.options, this.resolveModuleNameHost)
        .resolvedModule;
    let resolved = resolve(m);
    if (!resolved) {
      resolved = resolve(original);
    }
    return resolved ? this.getCanonicalFileName(resolved.resolvedFileName) : null;
  };

```

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

AoT doesn't  allows import of package names ending with `.js`, `.ts`, etc.

**What is the new behavior?**

AoT allows import of package names ending with `.js`, `.ts`, etc.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
