### PR TITLE
feat(aio): wire up doc fetching to get generated JSON files

### DIFF
--- a/aio/src/app/nav-engine/doc.service.ts
+++ b/aio/src/app/nav-engine/doc.service.ts
@@ -34,7 +34,7 @@ export class DocService {
       return of(cached);
     }
 
-    return this.fileService.getDocFile(docId)
+    return this.fileService.fetchDoc(docId)
       .switchMap(doc => {
         this.logger.log(`Fetched document for '${docId}'`);
         return doc.content ? of(doc) :
@@ -47,7 +47,7 @@ export class DocService {
   getNotFound(): Observable<string> {
     if (this.notFoundContent) { return of(this.notFoundContent); }
     const nfDocId = 'not-found';
-    return this.fileService.getDocFile(nfDocId)
+    return this.fileService.fetchDoc(nfDocId)
       .map(doc => {
         this.logger.log(`Fetched "not found" document for '${nfDocId}'`);
         this.notFoundContent = doc.content;

--- a/aio/src/app/nav-engine/nav-map.service.ts
+++ b/aio/src/app/nav-engine/nav-map.service.ts
@@ -24,7 +24,7 @@ export class NavMapService {
     docFetchingService: DocFetchingService,
     private http: Http,
     private logger: Logger) {
-      this.getDocPath = docFetchingService.getPath.bind(docFetchingService);
+      this.getDocPath = docFetchingService.getPathFor.bind(docFetchingService);
     }
 
   get navMap(): Observable<NavMap> {

--- a/aio/src/content/navmap.json
+++ b/aio/src/content/navmap.json
@@ -16,37 +16,37 @@
     "tooltip": "The Tour of Heroes tutorial takes you through the steps of creating an Angular application in TypeScript.",
     "children": [
       {
-        "docId": " tutorial/",
+        "docId": "tutorial/",
         "navTitle": "Introduction",
         "tooltip": "Introduction to the Tour of Heroes tutorial"
       },
       {
-        "docId": "tutorial/toh-1",
+        "docId": "tutorial/toh-pt1",
         "navTitle": "The hero editor",
         "tooltip": "Build a simple hero editor"
       },
       {
-        "docId": "tutorial/toh-2",
+        "docId": "tutorial/toh-pt2",
         "navTitle": "Master/detail",
         "tooltip": "Build a master/detail page with a list of heroes."
       },
       {
-        "docId": "tutorial/toh-3",
+        "docId": "tutorial/toh-pt3",
         "navTitle": "Multiple components",
         "tooltip": "Refactor the master/detail view into separate components."
       },
       {
-        "docId": "tutorial/toh-4",
+        "docId": "tutorial/toh-pt4",
         "navTitle": "Services",
         "tooltip": "Create a reusable service to manage hero data."
       },
       {
-        "docId": "tutorial/toh-5",
+        "docId": "tutorial/toh-pt5",
         "navTitle": "Routing",
         "tooltip": "Add the Angular router and navigate among the views."
       },
       {
-        "docId": "tutorial/toh-6",
+        "docId": "tutorial/toh-pt6",
         "navTitle": "HTTP",
         "tooltip": "Use HTTP to retrieve and save hero data."
       }


### PR DESCRIPTION
WIP do not merge

This show the initial wiring of the generated docs. You can go and navigate around.
There are plenty of issues that need to be addressed:

* the top nav links are now wrong - since they expect HTML.
  * we will either need to generate these files or change the way that the doc fetching works to make it more clevel
* all the images for the guides are missing - the guide docs are looking for paths starting with `resources` but since our other images are in `assets` we need to change the migrator to convert these urls
* I think we can simplify the architecture of the app. There is a lot of intercoupling between the services. The doc view seems to have too much to do in my view; the nav-map and nav-engine services could be amalgamated.
* I think the top nav should be driven by the nav-map rather than hard coded in the component template
* the API docs are not yet in any navigation
* the search needs to be implemented
* other stuff ...