### PR TITLE
ci(aio): correctly detect PRs and skip deploying to staging

### DIFF
--- a/scripts/ci-lite/deploy_aio_staging.sh
+++ b/scripts/ci-lite/deploy_aio_staging.sh
@@ -3,8 +3,8 @@
 set -ex -o pipefail
 
 # Only deploy if this Travis job is for the upstream master branch
-if [[ ! ${TRAVIS} || ${CI_MODE} != "aio" || ${TRAVIS_PULL_REQUEST} || ${TRAVIS_BRANCH} != "master" ]]; then
-  echo 0;
+if [[ $TRAVIS != "true" || $CI_MODE != "aio" || $TRAVIS_PULL_REQUEST != "false" || $TRAVIS_BRANCH != "master" ]]; then
+  exit 0;
 fi
 
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
1. Non-PRs are incorrectly categorized as PRs, because `$TRAVIS_PULL_REQUEST` will be set to `"false"`, which is a truthy value.
2. The script does not exit when it should (because it does `echo 0` instead of `exit 0`). 


**What is the new behavior?**
1. Non-PRs are correctly detect (by verifying that `$TRAVIS_PULL_REQUEST == "false"`).
2. The cript exists when it should not deploy.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```


**Other information**:
The actual behavior of the script was (and remains) correct, because the two bugs above (kind of) cancelled each other out. The script would always try to deploy (for both PRs and non-PRs), but since the encrypted `$FIREBASE_TOKEN` (which is required for successfully deploying to staging) was only available in non-PR builds, deploying would fail on all PR builds. 😥 