### PR TITLE
refactor: change remaining `<template>` to `<ng-template>`

### DIFF
--- a/modules/@angular/common/src/directives/ng_plural.ts
+++ b/modules/@angular/common/src/directives/ng_plural.ts
@@ -21,9 +21,9 @@ import {SwitchView} from './ng_switch';
  * @howToUse
  * ```
  * <some-element [ngPlural]="value">
- *   <template ngPluralCase="=0">there is nothing</template>
- *   <template ngPluralCase="=1">there is one</template>
- *   <template ngPluralCase="few">there are a few</template>
+ *   <ng-template ngPluralCase="=0">there is nothing</ng-template>
+ *   <ng-template ngPluralCase="=1">there is one</ng-template>
+ *   <ng-template ngPluralCase="few">there are a few</ng-template>
  * </some-element>
  * ```
  *
@@ -89,8 +89,8 @@ export class NgPlural {
  * @howToUse
  * ```
  * <some-element [ngPlural]="value">
- *   <template ngPluralCase="=0">...</template>
- *   <template ngPluralCase="other">...</template>
+ *   <ng-template ngPluralCase="=0">...</ng-template>
+ *   <ng-template ngPluralCase="other">...</ng-template>
  * </some-element>
  *```
  *

--- a/modules/@angular/common/test/directives/ng_for_spec.ts
+++ b/modules/@angular/common/test/directives/ng_for_spec.ts
@@ -352,7 +352,7 @@ export function main() {
          }));
 
       it('should support injecting `NgFor` and get an instance of `NgForOf`', async(() => {
-           const template = `<template ngFor [ngForOf]='items' let-item test></template>`;
+           const template = `<ng-template ngFor [ngForOf]='items' let-item test></ng-template>`;
            fixture = createTestComponent(template);
            const testDirective = fixture.debugElement.childNodes[0].injector.get(TestDirective);
            const ngForOf = fixture.debugElement.childNodes[0].injector.get(NgForOf);

--- a/modules/@angular/common/test/directives/ng_plural_spec.ts
+++ b/modules/@angular/common/test/directives/ng_plural_spec.ts
@@ -50,8 +50,8 @@ export function main() {
     it('should display the template according to the exact numeric value', async(() => {
          const template = '<div>' +
              '<ul [ngPlural]="switchValue">' +
-             '<template ngPluralCase="0"><li>you have no messages.</li></template>' +
-             '<template ngPluralCase="1"><li>you have one message.</li></template>' +
+             '<ng-template ngPluralCase="0"><li>you have no messages.</li></ng-template>' +
+             '<ng-template ngPluralCase="1"><li>you have one message.</li></ng-template>' +
              '</ul></div>';
 
          fixture = createTestComponent(template);

--- a/modules/@angular/core/test/linker/integration_spec.ts
+++ b/modules/@angular/core/test/linker/integration_spec.ts
@@ -532,7 +532,8 @@ function declareTests({useJit, viewEngine}: {useJit: boolean, viewEngine: boolea
         it('should assign the TemplateRef to a user-defined variable', () => {
           const fixture =
               TestBed.configureTestingModule({declarations: [MyComp]})
-                  .overrideComponent(MyComp, {set: {template: '<template ref-alice></template>'}})
+                  .overrideComponent(
+                      MyComp, {set: {template: '<ng-template ref-alice></ng-template>'}})
                   .createComponent(MyComp);
 
           const value = fixture.debugElement.childNodes[0].references['alice'];


### PR DESCRIPTION
I forgot to update the newly introduced one after I rebased the original PR.