### PR TITLE
fix(compiler-cli): fix flat module import on Windows

### DIFF
--- a/modules/@angular/compiler-cli/src/compiler_host.ts
+++ b/modules/@angular/compiler-cli/src/compiler_host.ts
@@ -271,7 +271,8 @@ export class CompilerHost implements AotCompilerHost {
     if (DTS.test(filePath)) {
       // Check for a bundle index.
       if (this.hasBundleIndex(filePath)) {
-        return this.bundleIndexNames.has(filePath);
+        const normalFilePath = path.normalize(filePath);
+        return this.bundleIndexNames.has(normalFilePath);
       }
     }
     return true;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

On windows `ngc` does not correctly detect it should using the flat module metadata bundle and gets into an invalid state.

**What is the new behavior?**

On windows `ngc` correctly detects it should use the flat module metadata.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
