### PR TITLE
fix: these are instructions to install rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ The following is a list of known issues that will be fixed in the next rcs.
 - legacy UMD bundles don't have correct RxJS mappings when running in ES5 mode without a module system
 
 
-## Installing RC.0
+## Installing RC.1
 We have two main ways to update. If you have an existing project, you should be able to run:
 
 `npm install @angular/{common,compiler,compiler-cli,core,forms,http,platform-browser,platform-browser-dynamic,platform-server,router,animations}@next --save`


### PR DESCRIPTION
fixed typo (reference to installing rc.0 rather than)
see `npm view @angular/core dist-tags`