### PR TITLE
feat(compiler): remove the need to add bootstrap components into declarations

### DIFF
--- a/modules/@angular/compiler/src/metadata_resolver.ts
+++ b/modules/@angular/compiler/src/metadata_resolver.ts
@@ -480,8 +480,13 @@ export class CompileMetadataResolver {
     // Note: This will be modified later, so we rely on
     // getting a new instance every time!
     const transitiveModule = this._getTransitiveNgModuleMetadata(importedModules, exportedModules);
-    if (meta.declarations) {
-      flattenAndDedupeArray(meta.declarations).forEach((declaredType) => {
+    if (meta.declarations || meta.bootstrap) {
+      const declarations = flattenArray(meta.declarations);
+      const bootstrapTypes = flattenArray(meta.bootstrap);
+      const validTypes = bootstrapTypes.filter(
+          type => type && this.isDirective(type) && !this._ngModuleOfTypes.has(type));
+      declarations.push(...validTypes);
+      dedupeArray(declarations).forEach((declaredType) => {
         if (!isValidType(declaredType)) {
           this._reportError(
               syntaxError(

--- a/modules/@angular/compiler/test/metadata_resolver_spec.ts
+++ b/modules/@angular/compiler/test/metadata_resolver_spec.ts
@@ -367,6 +367,41 @@ export function main() {
 
          expect(() => resolver.getNgModuleMetadata(ModuleWithComponentInBootstrap)).not.toThrow();
        }));
+
+    it('should include bootstrap components in declarations',
+       inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
+
+         @Component({template: ''})
+         class MyComp {
+         }
+
+         @NgModule({bootstrap: [MyComp]})
+         class MyModule {
+         }
+
+         const modMeta = resolver.getNgModuleMetadata(MyModule);
+         expect(modMeta.declaredDirectives.length).toBe(1);
+         expect(modMeta.declaredDirectives[0].reference).toBe(MyComp);
+       }));
+
+    it(`should not include bootstrap cmp in declarations if it's already declared by another module`,
+       inject([CompileMetadataResolver], (resolver: CompileMetadataResolver) => {
+
+         @Component({template: ''})
+         class MyComp {
+         }
+
+         @NgModule({declarations: [MyComp], exports: [MyComp]})
+         class ModuleA {
+         }
+
+         @NgModule({imports: [ModuleA], bootstrap: [MyComp]})
+         class ModuleB {
+         }
+
+         const modMeta = resolver.getNgModuleMetadata(ModuleB);
+         expect(modMeta.declaredDirectives.length).toBe(0);
+       }));
   });
 
   it('should dedupe declarations in NgModule',


### PR DESCRIPTION
Closes #10631

Before:
```
@NgModule({
  declarations: [App, Start, Contact, About],
  bootstrap: [App],
})
export class AppModule {
}
```
After:
```
@NgModule({
  declarations: [Start, Contact, About],
  bootstrap: [App],
})
export class AppModule {
}
```