### PR TITLE
feat(core): allow to specify custom selectors for bootstrap components

### DIFF
--- a/modules/@angular/core/src/application_ref.ts
+++ b/modules/@angular/core/src/application_ref.ts
@@ -79,6 +79,21 @@ export class NgProbeToken {
 }
 
 /**
+ * A token which can be used to provide components to bootstrap. Useful when there are multiple
+ * applications on the same page.
+ *
+ * @experimental
+ */
+export const BOOTSTRAP_COMPONENTS =
+    new InjectionToken<BootstrapComponent[]>('Bootstrap Components');
+
+/** @experimental */
+export interface BootstrapComponent {
+  selector: string;
+  type: Type<any>;
+}
+
+/**
  * Creates a platform.
  * Platforms have to be eagerly created via this function.
  *
@@ -331,7 +346,15 @@ export class PlatformRef_ extends PlatformRef {
 
   private _moduleDoBootstrap(moduleRef: NgModuleInjector<any>): void {
     const appRef = moduleRef.injector.get(ApplicationRef);
-    if (moduleRef.bootstrapFactories.length > 0) {
+    const bootstrapComponents: BootstrapComponent[] =
+        moduleRef.injector.get(BOOTSTRAP_COMPONENTS, []);
+    if (bootstrapComponents.length) {
+      bootstrapComponents.forEach((cmp: BootstrapComponent) => {
+        const compFactory = moduleRef.resolveComponentFactory(cmp.type);
+        compFactory.selector = cmp.selector;
+        appRef.bootstrap(compFactory);
+      });
+    } else if (moduleRef.bootstrapFactories.length) {
       moduleRef.bootstrapFactories.forEach((compFactory) => appRef.bootstrap(compFactory));
     } else if (moduleRef.instance.ngDoBootstrap) {
       moduleRef.instance.ngDoBootstrap(appRef);

--- a/modules/@angular/core/src/core.ts
+++ b/modules/@angular/core/src/core.ts
@@ -15,7 +15,7 @@ export * from './metadata';
 export * from './version';
 export * from './util';
 export * from './di';
-export {createPlatform, assertPlatform, destroyPlatform, getPlatform, PlatformRef, ApplicationRef, enableProdMode, isDevMode, createPlatformFactory, NgProbeToken} from './application_ref';
+export {createPlatform, assertPlatform, destroyPlatform, getPlatform, PlatformRef, ApplicationRef, enableProdMode, isDevMode, createPlatformFactory, NgProbeToken, BOOTSTRAP_COMPONENTS, BootstrapComponent} from './application_ref';
 export {APP_ID, PACKAGE_ROOT_URL, PLATFORM_INITIALIZER, PLATFORM_ID, APP_BOOTSTRAP_LISTENER} from './application_tokens';
 export {APP_INITIALIZER, ApplicationInitStatus} from './application_init';
 export * from './zone';

--- a/modules/@angular/core/test/application_ref_spec.ts
+++ b/modules/@angular/core/test/application_ref_spec.ts
@@ -206,7 +206,7 @@ export function main() {
                });
          }));
 
-      it('should error if neither `ngDoBootstrap` nor @NgModule.bootstrap was specified',
+      it('should error if neither `ngDoBootstrap`, nor @NgModule.bootstrap, nor BOOTSTRAP_COMPONENTS was specified',
          async(() => {
            defaultPlatform.bootstrapModule(createModule({ngDoBootstrap: false}))
                .then(() => expect(false).toBe(true), (e) => {

--- a/modules/@angular/platform-browser/test/browser/bootstrap_spec.ts
+++ b/modules/@angular/platform-browser/test/browser/bootstrap_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {isPlatformBrowser} from '@angular/common';
-import {APP_INITIALIZER, CUSTOM_ELEMENTS_SCHEMA, Compiler, Component, Directive, ErrorHandler, Inject, Input, LOCALE_ID, NgModule, OnDestroy, PLATFORM_ID, PLATFORM_INITIALIZER, Pipe, Provider, VERSION, createPlatformFactory} from '@angular/core';
+import {APP_INITIALIZER, BOOTSTRAP_COMPONENTS, CUSTOM_ELEMENTS_SCHEMA, Compiler, Component, Directive, ErrorHandler, Inject, Input, LOCALE_ID, NgModule, OnDestroy, PLATFORM_ID, PLATFORM_INITIALIZER, Pipe, Provider, VERSION, createPlatformFactory} from '@angular/core';
 import {ApplicationRef, destroyPlatform} from '@angular/core/src/application_ref';
 import {Console} from '@angular/core/src/console';
 import {ComponentRef} from '@angular/core/src/linker/component_factory';
@@ -342,6 +342,29 @@ export function main() {
          log.clear();
          p.bootstrapModule(SomeModule).then(() => {
            expect(log.result()).toEqual('app_init1; app_init2');
+           async.done();
+         });
+       }));
+
+    it('should bootstrap components provided via BOOTSTRAP_COMPONENTS',
+       inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+         const components = [
+           {type: HelloRootCmp, selector: 'hello-app'},
+           {type: HelloRootCmp, selector: 'hello-app-2'}
+         ];
+         const providers = [{provide: BOOTSTRAP_COMPONENTS, useValue: components}];
+
+         @NgModule({
+           imports: [BrowserModule],
+           declarations: [HelloRootCmp],
+           entryComponents: [HelloRootCmp]
+         })
+         class TestModule {
+         }
+
+         platformBrowserDynamic(providers).bootstrapModule(TestModule).then(() => {
+           expect(el).toHaveText('hello world!');
+           expect(el2).toHaveText('hello world!');
            async.done();
          });
        }));

--- a/tools/public_api_guard/core/typings/core.d.ts
+++ b/tools/public_api_guard/core/typings/core.d.ts
@@ -171,6 +171,15 @@ export declare const Attribute: AttributeDecorator;
 /** @deprecated */
 export declare const AUTO_STYLE = "*";
 
+/** @experimental */
+export declare const BOOTSTRAP_COMPONENTS: InjectionToken<BootstrapComponent[]>;
+
+/** @experimental */
+export interface BootstrapComponent {
+    selector: string;
+    type: Type<any>;
+}
+
 /** @stable */
 export declare enum ChangeDetectionStrategy {
     OnPush = 0,


### PR DESCRIPTION
Closes #7136
Closes #13035

Usage:
```
const components = [
  {type: AppCmp, selector: 'app'},
  {type: AppCmp, selector: 'app-2'}
];

@NgModule({
  imports: [BrowserModule],
  declarations: [AppCmp],
  entryComponents: [AppCmp]
})
class AppModule {}

platformBrowserDynamic([{provide: BOOTSTRAP_COMPONENTS, useValue: components}]).bootstrapModule(AppModule);
```