### PR TITLE
docs(changelog): typo -- missing "of"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -698,7 +698,7 @@ We’ve made changes under the hood to what AOT generated code looks like. These
 
 
 ### Enhanced `*ngIf` syntax
-Our template binding syntax now supports a couple helpful changes. You can now use an if/else style syntax, and assign local variables such as when unrolling an observable.
+Our template binding syntax now supports a couple of helpful changes. You can now use an if/else style syntax, and assign local variables such as when unrolling an observable.
 
 ```
 <ng-template #loading>Loading...</ng-template>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: typo fix in changelog
```

**What is the current behavior?** (You can also link to an open issue here)

 > supports a couple helpful changes

**What is the new behavior?**

 > supports a couple **of** helpful changes

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

