### PR TITLE
docs: changelog - fix else example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ We’ve made changes under to hood to what AOT generated code looks like. These 
 Our template binding syntax now supports a couple helpful changes. You can now use an if/else style syntax, and assign local variables such as when unrolling an observable.
 
 ```
-<div #loading>Loading...</div>
+<ng-template #loading>Loading...</ng-template>
 <div *ngIf="userObservable | async; else loading; let user">
   {{ user.name }}
 </div>


### PR DESCRIPTION
The else syntax needs a `ng-template`.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
Fix rc.1 changelog
```

**What is the current behavior?** (You can also link to an open issue here)
The changelog uses a broken example of the new `else` syntax:

    <div #loading>Loading...</div>
    <div *ngIf="userObservable | async; else loading; let user">
      {{ user.name }}
    </div>

This currently can't work (the loading div will always be displayed).

**What is the new behavior?**

Use a proper `ng-template` in the changelog

    <ng-template #loading>Loading...</ng-template>
    <div *ngIf="userObservable | async; else loading; let user">
      {{ user.name }}
    </div>



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

