### PR TITLE
feat(forms): equalsTo validator accepts form control

### DIFF
--- a/modules/@angular/forms/src/validators.ts
+++ b/modules/@angular/forms/src/validators.ts
@@ -62,23 +62,34 @@ const EMAIL_REGEXP =
  */
 export class Validators {
   /**
-   * Validator that compares the value of the given FormControls
+   * Validator that compares the value of the given FormControls,
+   * provided directly or as a path in the parent group.
    */
-  static equalsTo(...fieldPaths: string[]): ValidatorFn {
+  static equalsTo(...fields: Array<string|AbstractControl>): ValidatorFn {
+    if (fields.length < 1) {
+      throw new Error('You must compare to at least 1 other field');
+    }
     return function(control: FormControl): {[key: string]: any} {
-      if (fieldPaths.length < 1) {
-        throw new Error('You must compare to at least 1 other field');
-      }
-
-      for (let fieldName of fieldPaths) {
-        let field = (<FormGroup>control.parent).get(fieldName);
-        if (!field) {
-          throw new Error(
-              `Field: ${fieldName} undefined, are you sure that ${fieldName} exists in the group`);
-        }
-
-        if (field.value !== control.value) {
-          return {'equalsTo': {'unequalField': fieldName}};
+      for (let fieldToCompare of fields) {
+        if (typeof fieldToCompare === 'string') {
+          const field = (<FormGroup>control.parent).get(fieldToCompare);
+          if (!field) {
+            throw new Error(
+                `Field: ${fieldToCompare} used in the equalsTo validator is undefined. Are you sure that ${fieldToCompare} exists in the group?`);
+          }
+          if (field.value !== control.value) {
+            return {'equalsTo': {'unequalField': fieldToCompare}};
+          }
+        } else {
+          if (fieldToCompare.value !== control.value) {
+            const controls = (<FormGroup>control.parent).controls;
+            const fieldName = Object.keys(controls).find(name => controls[name] === fieldToCompare);
+            if (!fieldName) {
+              throw new Error(
+                  `A field was added to the equalsTo validator, but was not found in the parent group. Are you sure that it exists in the group?`);
+            }
+            return {'equalsTo': {'unequalField': fieldName}};
+          }
         }
       }
       return null;

--- a/modules/@angular/forms/test/validators_spec.ts
+++ b/modules/@angular/forms/test/validators_spec.ts
@@ -40,37 +40,57 @@ export function main() {
   describe('Validators', () => {
     describe('equalsTo', () => {
       it('should not error when equal', () => {
-        let group = new FormGroup({f1: new FormControl('a'), f2: new FormControl('a')});
-        let validator = Validators.equalsTo('f2');
+        const group = new FormGroup({f1: new FormControl('a'), f2: new FormControl('a')});
+        const validator = Validators.equalsTo('f2');
+        expect(validator(group.controls['f1'])).toBeNull();
+      });
+
+      it('should not error when equal with controls', () => {
+        const f2 = new FormControl('a');
+        const group = new FormGroup({f1: new FormControl('a'), f2});
+        const validator = Validators.equalsTo(f2);
         expect(validator(group.controls['f1'])).toBeNull();
       });
 
       it('should error when not equal', () => {
-        let group = new FormGroup({f1: new FormControl('a'), f2: new FormControl('b')});
-        let validator = Validators.equalsTo('f2');
+        const group = new FormGroup({f1: new FormControl('a'), f2: new FormControl('b')});
+        const validator = Validators.equalsTo('f2');
         expect(validator(group.controls['f1'])).toEqual({equalsTo: {unequalField: 'f2'}});
       });
 
-      it('should throw if passed a form control', () => {
-        let validator = Validators.equalsTo('f1', 'f2');
+      it('should not error when not equal with controls', () => {
+        const f2 = new FormControl('b');
+        const group = new FormGroup({f1: new FormControl('a'), f2});
+        const validator = Validators.equalsTo(f2);
+        expect(validator(group.controls['f1'])).toEqual({equalsTo: {unequalField: 'f2'}});
+      });
+
+      it('should not throw if passed a form control', () => {
+        const f1 = new FormControl('a');
+        const f2 = new FormControl('a');
+        const group = new FormGroup({f1, f2});
+        const validator = Validators.equalsTo(f2);
+        expect(validator(f1)).toBeNull();
+      });
+
+      it('should throw if passed a form group', () => {
+        const validator = Validators.equalsTo('f1', 'f2');
         // cast it to any so we don't get TS errors
         expect(() => validator(<any>new FormGroup({f1: new FormControl('')}))).toThrow();
       });
 
       it('should throw if passed a form array', () => {
-        let validator = Validators.equalsTo('f1', 'f2');
+        const validator = Validators.equalsTo('f1', 'f2');
         // cast it to any so we don't get TS errors
         expect(() => validator(<any>new FormArray([]))).toThrow();
       });
 
-      it('should throw if not passed any field to compare', () => {
-        let validator = Validators.equalsTo();
-        expect(() => validator(new FormControl('a'))).toThrow();
-      });
+      it('should throw if not passed any field to compare',
+         () => { expect(() => Validators.equalsTo()).toThrow(); });
 
       it('should throw if field passed does not exist in the group', () => {
-        let group = new FormGroup({f1: new FormControl('a'), f2: new FormControl('b')});
-        let validator = Validators.equalsTo('f3', 'f4');
+        const group = new FormGroup({f1: new FormControl('a'), f2: new FormControl('b')});
+        const validator = Validators.equalsTo('f3', 'f4');
         // cast it to any so we don't get TS errors
         expect(() => validator(new FormControl('a'))).toThrow();
       });

--- a/tools/public_api_guard/forms/typings/forms.d.ts
+++ b/tools/public_api_guard/forms/typings/forms.d.ts
@@ -554,7 +554,7 @@ export declare class Validators {
     static email(control: AbstractControl): {
         [key: string]: boolean;
     };
-    static equalsTo(...fieldPaths: string[]): ValidatorFn;
+    static equalsTo(...fields: Array<string | AbstractControl>): ValidatorFn;
     static maxLength(maxLength: number): ValidatorFn;
     static minLength(minLength: number): ValidatorFn;
     static nullValidator(c: AbstractControl): {


### PR DESCRIPTION
`Validators.equalsTo` only accepted `string[]`, it now accepts `(string|AbstractControl)[]`.
It allows to add the validator before adding the control to a group.

    const f1 = new FormControl('a');
    const f2 = new FormControl('a', Validators.equalTo(f1));
    const group = new FormGroup({f1, f2});

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
See #14770 

```
const f1 = new FormControl('a');
const f2 = new FormControl('a', Validators.equalTo('f1')); // breaks
const group = new FormGroup({f1, f2});
```

This breaks with `Cannot read property 'get' of undefined`


**What is the new behavior?**
Allows

```
const f1 = new FormControl('a');
const f2 = new FormControl('a', Validators.equalTo(f1));
const group = new FormGroup({f1, f2});
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

