### PR TITLE
fix(tsc-wrapped): validate metadata in static members of a class

### DIFF
--- a/tools/@angular/tsc-wrapped/src/collector.ts
+++ b/tools/@angular/tsc-wrapped/src/collector.ts
@@ -576,6 +576,16 @@ function validateMetadata(
       Object.getOwnPropertyNames(classData.members)
           .forEach(name => classData.members[name].forEach((m) => validateMember(classData, m)));
     }
+    if (classData.statics) {
+      Object.getOwnPropertyNames(classData.statics).forEach(name => {
+        const staticMember = classData.statics[name];
+        if (isFunctionMetadata(staticMember)) {
+          validateExpression(staticMember.value);
+        } else {
+          validateExpression(staticMember);
+        }
+      });
+    }
   }
 
   function validateFunction(functionDeclaration: FunctionMetadata) {

--- a/tools/@angular/tsc-wrapped/test/collector.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/collector.spec.ts
@@ -28,6 +28,7 @@ describe('Collector', () => {
       '/promise.ts',
       '/unsupported-1.ts',
       '/unsupported-2.ts',
+      '/unsupported-3.ts',
       'class-arity.ts',
       'import-star.ts',
       'exported-classes.ts',
@@ -621,9 +622,15 @@ describe('Collector', () => {
     });
 
     it('should throw for references to unexpected types', () => {
-      const unsupported1 = program.getSourceFile('/unsupported-2.ts');
-      expect(() => collector.getMetadata(unsupported1, true))
+      const unsupported2 = program.getSourceFile('/unsupported-2.ts');
+      expect(() => collector.getMetadata(unsupported2, true))
           .toThrowError(/Reference to non-exported class/);
+    });
+
+    it('should throw for errors in a static method', () => {
+      const unsupported3 = program.getSourceFile('/unsupported-3.ts');
+      expect(() => collector.getMetadata(unsupported3, true))
+          .toThrowError(/Reference to a non-exported class/);
     });
   });
 
@@ -909,6 +916,15 @@ const FILES: Directory = {
     @Injectable()
     export class Bar {
       constructor(private f: Foo) {}
+    }
+  `,
+  'unsupported-3.ts': `
+    class Foo {}
+
+    export class SomeClass {
+      static someStatic() {
+        return Foo;
+      }
     }
   `,
   'import-star.ts': `


### PR DESCRIPTION
Fixes #13481

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

With the `ngc` option `strictMetadataEmit` set, errors in static members of a class were not validated for errors.

**What is the new behavior?**

`strictMetadataEmit` validates static members of collected classes.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
