### PR TITLE
fix(compilation): fix upgrade component Closure optimization.

### DIFF
--- a/modules/@angular/upgrade/src/static/upgrade_component.ts
+++ b/modules/@angular/upgrade/src/static/upgrade_component.ts
@@ -355,7 +355,8 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
       controllerType: angular.IController, $scope: angular.IScope,
       $element: angular.IAugmentedJQuery, controllerAs: string) {
     // TODO: Document that we do not pre-assign bindings on the controller instance
-    const locals = {$scope, $element};
+    // Quoted properties below so that this code can be optimized with Closure Compiler.
+    const locals = {'$scope': $scope, '$element': $element};
     const controller = this.$controller(controllerType, locals, null, controllerAs);
     $element.data(controllerKey(this.directive.name), controller);
     return controller;


### PR DESCRIPTION
$scope and $element are passed to AngularJS, which is not optimized together with the app. That means properties must be quoted to prevent reanming.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

Breaks when optimized using Closure Compiler.

**What is the new behavior?**

Survives optimization :-)

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
