### PR TITLE
feat(platform-browser): add Title#setPrefix and Title#setSuffix

### DIFF
--- a/modules/@angular/platform-browser/src/browser/title.ts
+++ b/modules/@angular/platform-browser/src/browser/title.ts
@@ -24,6 +24,9 @@ import {DOCUMENT} from '../dom/dom_tokens';
  */
 @Injectable()
 export class Title {
+  private prefix: string = '';
+  private suffix: string = '';
+
   constructor(@Inject(DOCUMENT) private _doc: any) {}
   /**
    * Get the title of the current HTML document.
@@ -35,5 +38,19 @@ export class Title {
    * Set the title of the current HTML document.
    * @param newTitle
    */
-  setTitle(newTitle: string) { getDOM().setTitle(this._doc, newTitle); }
+  setTitle(newTitle: string) {
+    getDOM().setTitle(this._doc, `${this.prefix} ${newTitle || ''} ${this.suffix}`.trim());
+  }
+
+  /**
+   * Set the title's prefix.
+   * @param newPrefix
+   */
+  setPrefix(newPrefix: string) { this.prefix = newPrefix; }
+
+  /**
+   * Set the title's suffix.
+   * @param newSuffix
+   */
+  setSuffix(newSuffix: string) { this.suffix = newSuffix; }
 }

--- a/modules/@angular/platform-browser/test/browser/title_spec.ts
+++ b/modules/@angular/platform-browser/test/browser/title_spec.ts
@@ -16,9 +16,12 @@ export function main() {
   describe('title service', () => {
     const doc = getDOM().createHtmlDocument();
     const initialTitle = getDOM().getTitle(doc);
-    const titleService = new Title(doc);
+    let titleService = new Title(doc);
 
-    afterEach(() => { getDOM().setTitle(doc, initialTitle); });
+    afterEach(() => {
+      getDOM().setTitle(doc, initialTitle);
+      titleService = new Title(doc);
+    });
 
     it('should allow reading initial title',
        () => { expect(titleService.getTitle()).toEqual(initialTitle); });
@@ -27,6 +30,20 @@ export function main() {
       titleService.setTitle('test title');
       expect(getDOM().getTitle(doc)).toEqual('test title');
       expect(titleService.getTitle()).toEqual('test title');
+    });
+
+    it('should set a title with prefix', () => {
+      titleService.setPrefix('prefix');
+      titleService.setTitle('test title');
+      expect(getDOM().getTitle(doc)).toEqual('prefix test title');
+      expect(titleService.getTitle()).toEqual('prefix test title');
+    });
+
+    it('should set a title with suffix', () => {
+      titleService.setSuffix('suffix');
+      titleService.setTitle('test title');
+      expect(getDOM().getTitle(doc)).toEqual('test title suffix');
+      expect(titleService.getTitle()).toEqual('test title suffix');
     });
 
     it('should reset title to empty string if title not provided', () => {

--- a/tools/public_api_guard/platform-browser/typings/platform-browser.d.ts
+++ b/tools/public_api_guard/platform-browser/typings/platform-browser.d.ts
@@ -116,6 +116,8 @@ export interface SafeUrl extends SafeValue {
 export declare class Title {
     constructor(_doc: any);
     getTitle(): string;
+    setPrefix(newPrefix: string): void;
+    setSuffix(newSuffix: string): void;
     setTitle(newTitle: string): void;
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
[Title](https://github.com/angular/angular/blob/master/modules/%40angular/platform-browser/src/browser/title.ts#L26-L38) has only `setTitle` and `getTitle` methods. 

**What is the new behavior?**
Added `setPrefix` and `setSuffix`.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
[This](https://gist.github.com/Falci/e395ddd3f977fc204e499aaa31b198ff) is my current workaround that produces the same result.
