### PR TITLE
fix(compiler): don’t throw for empty array literal in assignments

### DIFF
--- a/modules/@angular/compiler/src/expression_parser/ast.ts
+++ b/modules/@angular/compiler/src/expression_parser/ast.ts
@@ -321,7 +321,7 @@ export class AstTransformer implements AstVisitor {
   }
 
   visitPropertyWrite(ast: PropertyWrite, context: any): AST {
-    return new PropertyWrite(ast.span, ast.receiver.visit(this), ast.name, ast.value);
+    return new PropertyWrite(ast.span, ast.receiver.visit(this), ast.name, ast.value.visit(this));
   }
 
   visitSafePropertyRead(ast: SafePropertyRead, context: any): AST {

--- a/modules/@angular/core/test/linker/change_detection_integration_spec.ts
+++ b/modules/@angular/core/test/linker/change_detection_integration_spec.ts
@@ -621,6 +621,14 @@ export function main() {
              expect(ctx.componentInstance.a).toEqual(2);
            }));
 
+        it('should support empty literals', fakeAsync(() => {
+             const ctx = _bindSimpleProp('(event)="a=[{},[]]"');
+             const childEl = ctx.debugElement.children[0];
+             childEl.triggerEventHandler('event', 'EVENT');
+
+             expect(ctx.componentInstance.a).toEqual([{}, []]);
+           }));
+
         it('should throw when trying to assign to a local', fakeAsync(() => {
              expect(() => {
                _bindSimpleProp('(event)="$event=1"');


### PR DESCRIPTION
Closes #14782
