### PR TITLE
fix(compiler-cli): support declared modules

### DIFF
--- a/modules/@angular/compiler-cli/integrationtest/src/basic.ts
+++ b/modules/@angular/compiler-cli/integrationtest/src/basic.ts
@@ -9,6 +9,7 @@
 import {NgFor, NgIf} from '@angular/common';
 import {Component, Inject, LOCALE_ID, TRANSLATIONS_FORMAT} from '@angular/core';
 
+import {Worker} from 'cluster';
 
 @Component({
   selector: 'basic',
@@ -22,7 +23,7 @@ export class BasicComp {
   ctxArr: any[] = [];
   constructor(
       @Inject(LOCALE_ID) public localeId: string,
-      @Inject(TRANSLATIONS_FORMAT) public translationsFormat: string) {
+      @Inject(TRANSLATIONS_FORMAT) public translationsFormat: string, public worker: Worker) {
     this.ctxProp = 'initialValue';
   }
 }

--- a/modules/@angular/compiler-cli/integrationtest/src/module.ts
+++ b/modules/@angular/compiler-cli/integrationtest/src/module.ts
@@ -11,6 +11,8 @@ import {FormsModule} from '@angular/forms';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {ServerModule} from '@angular/platform-server';
 import {MdButtonModule} from '@angular2-material/button';
+// Used to test declared modules.
+import {Worker} from 'cluster';
 // Note: don't refer to third_party_src as we want to test that
 // we can compile components from node_modules!
 import {ThirdpartyModule} from 'third_party/module';
@@ -24,6 +26,10 @@ import {CompConsumingEvents, CompUsingPipes, CompWithProviders, CompWithReferenc
 import {CompUsingRootModuleDirectiveAndPipe, SomeDirectiveInRootModule, SomeLibModule, SomePipeInRootModule, SomeService} from './module_fixtures';
 import {CompWithNgContent, ProjectingComp} from './projection';
 import {CompForChildQuery, CompWithChildQuery, CompWithDirectiveChild, DirectiveForQuery} from './queries';
+
+export function getWorker(): Worker|null {
+  return null;
+}
 
 @NgModule({
   declarations: [
@@ -58,7 +64,7 @@ import {CompForChildQuery, CompWithChildQuery, CompWithDirectiveChild, Directive
     SomeLibModule.withProviders(),
     ThirdpartyModule,
   ],
-  providers: [SomeService],
+  providers: [SomeService, {provide: Worker, useFactory: getWorker}],
   entryComponents: [
     AnimateCmp,
     BasicComp,

--- a/modules/@angular/compiler-cli/integrationtest/tsconfig-build.json
+++ b/modules/@angular/compiler-cli/integrationtest/tsconfig-build.json
@@ -1,7 +1,5 @@
 {
   "angularCompilerOptions": {
-    // For TypeScript 1.8, we have to lay out generated files
-    // in the same source directory with your code.
     "genDir": ".",
     "debug": true
   },

--- a/modules/@angular/compiler-cli/integrationtest/tsconfig-xi18n.json
+++ b/modules/@angular/compiler-cli/integrationtest/tsconfig-xi18n.json
@@ -1,34 +1,6 @@
 {
-  "angularCompilerOptions": {
-    // For TypeScript 1.8, we have to lay out generated files
-    // in the same source directory with your code.
-    "genDir": ".",
-    "debug": true
-  },
-
+  "extends": "./tsconfig-build",
   "compilerOptions": {
-    "target": "es5",
-    "experimentalDecorators": true,
-    "noImplicitAny": true,
-    "moduleResolution": "node",
-    "outDir": "./out",
-    "rootDir": "",
-    "declaration": true,
-    "lib": ["es6", "dom"],
-    "baseUrl": ".",
-    // Prevent scanning up the directory tree for types
-    "typeRoots": ["node_modules/@types"]
-  },
-
-  "files": [
-    "src/module",
-    "src/bootstrap",
-    "test/all_spec",
-    "test/test_ngtools_api",
-    "test/test_summaries",
-    "benchmarks/src/tree/ng2/index_aot.ts",
-    "benchmarks/src/tree/ng2_switch/index_aot.ts",
-    "benchmarks/src/largetable/ng2/index_aot.ts",
-    "benchmarks/src/largetable/ng2_switch/index_aot.ts"
-  ]
+    "outDir": "./out"
+  }
 }

--- a/modules/@angular/compiler-cli/test/aot_host_spec.ts
+++ b/modules/@angular/compiler-cli/test/aot_host_spec.ts
@@ -23,7 +23,7 @@ describe('CompilerHost', () => {
     context = new MockAotContext('/tmp/src', clone(FILES));
     const host = new MockCompilerHost(context);
     program = ts.createProgram(
-        ['main.ts'], {
+        ['main.ts', 'declared-module.ts'], {
           module: ts.ModuleKind.CommonJS,
         },
         host);
@@ -202,6 +202,12 @@ describe('CompilerHost', () => {
       {__symbolic: 'module', version: 3, metadata: {}, exports: [{from: './lib/utils'}]}
     ]);
   });
+
+  it('should be able to detect a declared module', () => {
+    const fileName = hostNestedGenDir.moduleNameToFileName('some/module', '/tmp/src/main.ts');
+    const moduleName = hostNestedGenDir.fileNameToModuleName(fileName, '/tmp/src/main.ts');
+    expect(moduleName).toEqual('some/module');
+  });
 });
 
 const dummyModule = 'export let foo: any[];';
@@ -220,6 +226,11 @@ const FILES: Entry = {
         import * as u from './lib/utils';
         import * as cs from './lib/collections';
         import * as u2 from './lib2/utils2';
+      `,
+      'declared-module.ts': `
+        declare module 'some/module' {
+          export class AmbientClass {}
+        }
       `,
       'lib': {
         'utils.ts': dummyModule,


### PR DESCRIPTION
Fixes #13072

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

References to classes in a declared module fail to resolve and produce a error.

**What is the new behavior?**

References to declared modules are detected and are no encoded to generated an import to the declared module.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
