### PR TITLE
fix(core): allow to use the `Renderer` outside of views.

### DIFF
--- a/modules/@angular/core/src/view/services.ts
+++ b/modules/@angular/core/src/view/services.ts
@@ -411,7 +411,7 @@ function callWithDebugContext(action: DebugAction, fn: any, self: any, args: any
 }
 
 export function getCurrentDebugContext(): DebugContext {
-  return new DebugContext_(_currentView, _currentNodeIndex);
+  return _currentView ? new DebugContext_(_currentView, _currentNodeIndex) : null;
 }
 
 
@@ -440,23 +440,30 @@ class DebugRendererV2 implements RendererV2 {
 
   createElement(name: string, namespace?: string): any {
     const el = this.delegate.createElement(name, namespace);
-    const debugEl = new DebugElement(el, null, getCurrentDebugContext());
-    debugEl.name = name;
-    indexDebugNode(debugEl);
+    const debugCtx = getCurrentDebugContext();
+    if (debugCtx) {
+      const debugEl = new DebugElement(el, null, debugCtx);
+      debugEl.name = name;
+      indexDebugNode(debugEl);
+    }
     return el;
   }
 
   createComment(value: string): any {
     const comment = this.delegate.createComment(value);
-    const debugEl = new DebugNode(comment, null, getCurrentDebugContext());
-    indexDebugNode(debugEl);
+    const debugCtx = getCurrentDebugContext();
+    if (debugCtx) {
+      indexDebugNode(new DebugNode(comment, null, debugCtx));
+    }
     return comment;
   }
 
   createText(value: string): any {
     const text = this.delegate.createText(value);
-    const debugEl = new DebugNode(text, null, getCurrentDebugContext());
-    indexDebugNode(debugEl);
+    const debugCtx = getCurrentDebugContext();
+    if (debugCtx) {
+      indexDebugNode(new DebugNode(text, null, debugCtx));
+    }
     return text;
   }
 
@@ -491,8 +498,10 @@ class DebugRendererV2 implements RendererV2 {
 
   selectRootElement(selectorOrNode: string|any): any {
     const el = this.delegate.selectRootElement(selectorOrNode);
-    const debugEl = new DebugElement(el, null, getCurrentDebugContext());
-    indexDebugNode(debugEl);
+    const debugCtx = getCurrentDebugContext();
+    if (debugCtx) {
+      indexDebugNode(new DebugElement(el, null, debugCtx));
+    }
     return el;
   }
 

--- a/modules/@angular/core/test/linker/regression_integration_spec.ts
+++ b/modules/@angular/core/test/linker/regression_integration_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ANALYZE_FOR_ENTRY_COMPONENTS, Component, InjectionToken, Injector, Pipe, PipeTransform, Provider} from '@angular/core';
+import {ANALYZE_FOR_ENTRY_COMPONENTS, Component, InjectionToken, Injector, Pipe, PipeTransform, Provider, RendererV2} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/matchers';
 
@@ -208,6 +208,19 @@ function declareTests({useJit}: {useJit: boolean}) {
           {declarations: [HeroComponent, VillianComponent, MainComponent]});
       const fixture = TestBed.createComponent(MainComponent);
       expect(fixture.nativeElement).toHaveText('I was saved by my hero from a villian.');
+    });
+
+    it('should allow to use the renderer outside of views', () => {
+      @Component({template: ''})
+      class MyComp {
+        constructor(public renderer: RendererV2) {}
+      }
+
+      TestBed.configureTestingModule({declarations: [MyComp]});
+      const ctx = TestBed.createComponent(MyComp);
+
+      const txtNode = ctx.componentInstance.renderer.createText('test');
+      expect(txtNode).toHaveText('test');
     });
   });
 }


### PR DESCRIPTION
Fixes #14872
