### PR TITLE
refactor: remove old compiler options

### DIFF
--- a/modules/@angular/compiler-cli/src/codegen.ts
+++ b/modules/@angular/compiler-cli/src/codegen.ts
@@ -72,7 +72,6 @@ export class CodeGenerator {
       transContent = readFileSync(transFile, 'utf8');
     }
     const {compiler: aotCompiler} = compiler.createAotCompiler(ngCompilerHost, {
-      debug: options.debug === true,
       translations: transContent,
       i18nFormat: cliOptions.i18nFormat,
       locale: cliOptions.locale,

--- a/modules/@angular/compiler/src/aot/compiler_factory.ts
+++ b/modules/@angular/compiler/src/aot/compiler_factory.ts
@@ -54,9 +54,7 @@ export function createAotCompiler(compilerHost: AotCompilerHost, options: AotCom
       new HtmlParser(), translations, options.i18nFormat, MissingTranslationStrategy.Warning,
       console);
   const config = new CompilerConfig({
-    genDebugInfo: options.debug === true,
     defaultEncapsulation: ViewEncapsulation.Emulated,
-    logBindingUpdate: false,
     useJit: false,
     enableLegacyTemplate: options.enableLegacyTemplate !== false,
   });

--- a/modules/@angular/compiler/src/aot/compiler_options.ts
+++ b/modules/@angular/compiler/src/aot/compiler_options.ts
@@ -7,7 +7,6 @@
  */
 
 export interface AotCompilerOptions {
-  debug?: boolean;
   locale?: string;
   i18nFormat?: string;
   translations?: string;

--- a/modules/@angular/compiler/src/config.ts
+++ b/modules/@angular/compiler/src/config.ts
@@ -20,31 +20,17 @@ export class CompilerConfig {
   public useJit: boolean;
   public missingTranslation: MissingTranslationStrategy;
 
-  private _genDebugInfo: boolean;
-  private _logBindingUpdate: boolean;
-
   constructor(
-      {defaultEncapsulation = ViewEncapsulation.Emulated, genDebugInfo, logBindingUpdate,
-       useJit = true, missingTranslation, enableLegacyTemplate}: {
+      {defaultEncapsulation = ViewEncapsulation.Emulated, useJit = true, missingTranslation,
+       enableLegacyTemplate}: {
         defaultEncapsulation?: ViewEncapsulation,
-        genDebugInfo?: boolean,
-        logBindingUpdate?: boolean,
         useJit?: boolean,
         missingTranslation?: MissingTranslationStrategy,
         enableLegacyTemplate?: boolean,
       } = {}) {
     this.defaultEncapsulation = defaultEncapsulation;
-    this._genDebugInfo = genDebugInfo;
-    this._logBindingUpdate = logBindingUpdate;
     this.useJit = useJit;
     this.missingTranslation = missingTranslation;
     this.enableLegacyTemplate = enableLegacyTemplate !== false;
-  }
-
-  get genDebugInfo(): boolean {
-    return this._genDebugInfo === void 0 ? isDevMode() : this._genDebugInfo;
-  }
-  get logBindingUpdate(): boolean {
-    return this._logBindingUpdate === void 0 ? isDevMode() : this._logBindingUpdate;
   }
 }

--- a/modules/@angular/compiler/src/i18n/extractor.ts
+++ b/modules/@angular/compiler/src/i18n/extractor.ts
@@ -97,12 +97,8 @@ export class Extractor {
     const staticReflector = new StaticReflector(staticSymbolResolver);
     StaticAndDynamicReflectionCapabilities.install(staticReflector);
 
-    const config = new CompilerConfig({
-      genDebugInfo: false,
-      defaultEncapsulation: ViewEncapsulation.Emulated,
-      logBindingUpdate: false,
-      useJit: false
-    });
+    const config =
+        new CompilerConfig({defaultEncapsulation: ViewEncapsulation.Emulated, useJit: false});
 
     const normalizer = new DirectiveNormalizer(
         {get: (url: string) => host.loadResource(url)}, urlResolver, htmlParser, config);

--- a/modules/@angular/compiler/src/jit/compiler_factory.ts
+++ b/modules/@angular/compiler/src/jit/compiler_factory.ts
@@ -112,15 +112,11 @@ export class JitCompilerFactory implements CompilerFactory {
         useFactory: () => {
           return new CompilerConfig({
             // let explicit values from the compiler options overwrite options
-            // from the app providers. E.g. important for the testing platform.
-            genDebugInfo: opts.useDebug,
-            // let explicit values from the compiler options overwrite options
             // from the app providers
             useJit: opts.useJit,
             // let explicit values from the compiler options overwrite options
             // from the app providers
             defaultEncapsulation: opts.defaultEncapsulation,
-            logBindingUpdate: opts.useDebug,
             missingTranslation: opts.missingTranslation,
             enableLegacyTemplate: opts.enableLegacyTemplate,
           });
@@ -150,7 +146,6 @@ export const platformCoreDynamic = createPlatformFactory(platformCore, 'coreDyna
 
 function _mergeOptions(optionsArr: CompilerOptions[]): CompilerOptions {
   return {
-    useDebug: _lastDefined(optionsArr.map(options => options.useDebug)),
     useJit: _lastDefined(optionsArr.map(options => options.useJit)),
     defaultEncapsulation: _lastDefined(optionsArr.map(options => options.defaultEncapsulation)),
     providers: _mergeArrays(optionsArr.map(options => options.providers)),

--- a/modules/@angular/core/src/linker/compiler.ts
+++ b/modules/@angular/core/src/linker/compiler.ts
@@ -93,6 +93,9 @@ export class Compiler {
  * @experimental
  */
 export type CompilerOptions = {
+  /**
+   * @deprecated since v4 this option has no effect anymore.
+   */
   useDebug?: boolean,
   useJit?: boolean,
   defaultEncapsulation?: ViewEncapsulation,

--- a/modules/@angular/language-service/src/typescript_host.ts
+++ b/modules/@angular/language-service/src/typescript_host.ts
@@ -107,14 +107,9 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
       const urlResolver = createOfflineCompileUrlResolver();
       const htmlParser = new DummyHtmlParser();
       // This tracks the CompileConfig in codegen.ts. Currently these options
-      // are hard-coded except for genDebugInfo which is not applicable as we
-      // never generate code.
-      const config = new CompilerConfig({
-        genDebugInfo: false,
-        defaultEncapsulation: ViewEncapsulation.Emulated,
-        logBindingUpdate: false,
-        useJit: false
-      });
+      // are hard-coded.
+      const config =
+          new CompilerConfig({defaultEncapsulation: ViewEncapsulation.Emulated, useJit: false});
       const directiveNormalizer =
           new DirectiveNormalizer(resourceLoader, urlResolver, htmlParser, config);
 

--- a/tools/@angular/tsc-wrapped/src/options.ts
+++ b/tools/@angular/tsc-wrapped/src/options.ts
@@ -76,7 +76,7 @@ interface Options extends ts.CompilerOptions {
   // Print extra information while running the compiler
   trace?: boolean;
 
-  // Whether to embed debug information in the compiled templates
+  /** @deprecated since v4 this option has no effect anymore. */
   debug?: boolean;
 
   // Whether to enable support for <template> and the template attribute (true by default)

--- a/tools/public_api_guard/core/typings/core.d.ts
+++ b/tools/public_api_guard/core/typings/core.d.ts
@@ -205,7 +205,7 @@ export declare abstract class CompilerFactory {
 
 /** @experimental */
 export declare type CompilerOptions = {
-    useDebug?: boolean;
+    /** @deprecated */ useDebug?: boolean;
     useJit?: boolean;
     defaultEncapsulation?: ViewEncapsulation;
     providers?: any[];


### PR DESCRIPTION
DEPRECATION
- `CompilerOptions.debug` has no effect any more, as the compiler
  always produces the same code independent of debug mode.
