### PR TITLE
fix(compiler): support interface types in injectable constuctors

### DIFF
--- a/packages/compiler-cli/integrationtest/src/basic.ts
+++ b/packages/compiler-cli/integrationtest/src/basic.ts
@@ -9,6 +9,7 @@
 import {NgFor, NgIf} from '@angular/common';
 import {Component, Inject, LOCALE_ID, TRANSLATIONS_FORMAT} from '@angular/core';
 
+import {CUSTOM, Named} from './custom_token';
 
 @Component({
   selector: 'basic',
@@ -22,7 +23,8 @@ export class BasicComp {
   ctxArr: any[] = [];
   constructor(
       @Inject(LOCALE_ID) public localeId: string,
-      @Inject(TRANSLATIONS_FORMAT) public translationsFormat: string) {
+      @Inject(TRANSLATIONS_FORMAT) public translationsFormat: string,
+      @Inject(CUSTOM) public custom: Named) {
     this.ctxProp = 'initialValue';
   }
 }

--- a/packages/compiler-cli/integrationtest/src/custom_token.ts
+++ b/packages/compiler-cli/integrationtest/src/custom_token.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InjectionToken} from '@angular/core';
+
+export interface Named { name: string; }
+
+export const CUSTOM = new InjectionToken<Named>('CUSTOM');

--- a/packages/compiler-cli/integrationtest/src/module.ts
+++ b/packages/compiler-cli/integrationtest/src/module.ts
@@ -20,6 +20,7 @@ import {MultipleComponentsMyComp, NextComp} from './a/multiple_components';
 import {AnimateCmp} from './animate';
 import {BasicComp} from './basic';
 import {ComponentUsingThirdParty} from './comp_using_3rdp';
+import {CUSTOM, Named} from './custom_token';
 import {CompWithAnalyzeEntryComponentsProvider, CompWithEntryComponents} from './entry_components';
 import {CompConsumingEvents, CompUsingPipes, CompWithProviders, CompWithReferences, DirPublishingEvents, ModuleUsingCustomElements} from './features';
 import {CompUsingRootModuleDirectiveAndPipe, SomeDirectiveInRootModule, SomeLibModule, SomePipeInRootModule, SomeService} from './module_fixtures';
@@ -75,6 +76,7 @@ export const SERVER_ANIMATIONS_PROVIDERS: Provider[] = [{
   providers: [
     SomeService,
     SERVER_ANIMATIONS_PROVIDERS,
+    {provide: CUSTOM, useValue: {name: 'some name'}},
   ],
   entryComponents: [
     AnimateCmp,

--- a/packages/compiler/test/aot/static_reflector_spec.ts
+++ b/packages/compiler/test/aot/static_reflector_spec.ts
@@ -726,6 +726,31 @@ describe('StaticReflector', () => {
       expect(reflector.annotations(reflector.getStaticSymbol('/tmp/src/main.ts', 'Child')))
           .toEqual([]);
     });
+
+    it('should support constructor parameters with @Inject and an interface type', () => {
+      const data = Object.create(DEFAULT_TEST_DATA);
+      const file = '/tmp/src/inject_interface.ts';
+      data[file] = `
+        import {Injectable, Inject} from '@angular/core';
+        import {F} from './f';
+
+        export interface InjectedInterface {
+
+        }
+
+        export class Token {}
+
+        @Injectable()
+        export class SomeClass {
+          constructor (@Inject(Token) injected: InjectedInterface, t: Token, @Inject(Token) f: F) {}
+        }
+      `;
+
+      init(data);
+
+      expect(reflector.parameters(reflector.getStaticSymbol(file, 'SomeClass'))[0].length)
+          .toEqual(1);
+    });
   });
 
 });

--- a/packages/compiler/test/aot/static_symbol_resolver_spec.ts
+++ b/packages/compiler/test/aot/static_symbol_resolver_spec.ts
@@ -424,7 +424,9 @@ export class MockStaticSymbolResolverHost implements StaticSymbolResolverHost {
             filePath, this.data[filePath], ts.ScriptTarget.ES5, /* setParentNodes */ true);
         const diagnostics: ts.Diagnostic[] = (<any>sf).parseDiagnostics;
         if (diagnostics && diagnostics.length) {
-          throw Error(`Error encountered during parse of file ${filePath}`);
+          const errors = diagnostics.map(d => `(${d.start}-${d.start+d.length}): ${d.messageText}`)
+                             .join('\n   ');
+          throw Error(`Error encountered during parse of file ${filePath}\n${errors}`);
         }
         return [this.collector.getMetadata(sf)];
       }

--- a/tools/@angular/tsc-wrapped/src/bundler.ts
+++ b/tools/@angular/tsc-wrapped/src/bundler.ts
@@ -9,8 +9,8 @@ import * as path from 'path';
 import * as ts from 'typescript';
 
 import {MetadataCollector} from './collector';
+import {ClassMetadata, ConstructorMetadata, FunctionMetadata, MemberMetadata, MetadataArray, MetadataEntry, MetadataError, MetadataImportedSymbolReferenceExpression, MetadataMap, MetadataObject, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleMetadata, VERSION, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isInterfaceMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataImportedSymbolReferenceExpression, isMetadataModuleReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMethodMetadata} from './schema';
 
-import {ClassMetadata, ConstructorMetadata, FunctionMetadata, MemberMetadata, MetadataArray, MetadataEntry, MetadataError, MetadataImportedSymbolReferenceExpression, MetadataMap, MetadataObject, MetadataSymbolicBinaryExpression, MetadataSymbolicCallExpression, MetadataSymbolicExpression, MetadataSymbolicIfExpression, MetadataSymbolicIndexExpression, MetadataSymbolicPrefixExpression, MetadataSymbolicReferenceExpression, MetadataSymbolicSelectExpression, MetadataSymbolicSpreadExpression, MetadataValue, MethodMetadata, ModuleMetadata, VERSION, isClassMetadata, isConstructorMetadata, isFunctionMetadata, isMetadataError, isMetadataGlobalReferenceExpression, isMetadataImportedSymbolReferenceExpression, isMetadataModuleReferenceExpression, isMetadataSymbolicExpression, isMetadataSymbolicReferenceExpression, isMethodMetadata} from './schema';
 
 // The character set used to produce private names.
 const PRIVATE_NAME_CHARS = [
@@ -267,6 +267,9 @@ export class MetadataBundler {
     }
     if (isFunctionMetadata(value)) {
       return this.convertFunction(moduleName, value);
+    }
+    if (isInterfaceMetadata(value)) {
+      return value;
     }
     return this.convertValue(moduleName, value);
   }

--- a/tools/@angular/tsc-wrapped/src/schema.ts
+++ b/tools/@angular/tsc-wrapped/src/schema.ts
@@ -17,7 +17,7 @@
 
 export const VERSION = 3;
 
-export type MetadataEntry = ClassMetadata | FunctionMetadata | MetadataValue;
+export type MetadataEntry = ClassMetadata | InterfaceMetadata | FunctionMetadata | MetadataValue;
 
 export interface ModuleMetadata {
   __symbolic: 'module';
@@ -45,6 +45,11 @@ export interface ClassMetadata {
 }
 export function isClassMetadata(value: any): value is ClassMetadata {
   return value && value.__symbolic === 'class';
+}
+
+export interface InterfaceMetadata { __symbolic: 'interface'; }
+export function isInterfaceMetadata(value: any): value is InterfaceMetadata {
+  return value && value.__symbolic === 'interface';
 }
 
 export interface MetadataMap { [name: string]: MemberMetadata[]; }


### PR DESCRIPTION
Fixes #12631

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

`ngc` will generate an error when an `@Injectable` class uses an interface as a parameter with an `@Inject` parameter.

**What is the new behavior?**

The type of the parameter is ignored and the instance implied by the token is injected into the class.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
