### PR TITLE
fix(common): Location should strip trailing slash from urls containing query and matrix params

### DIFF
--- a/modules/@angular/common/src/location/location.ts
+++ b/modules/@angular/common/src/location/location.ts
@@ -170,7 +170,7 @@ export class Location {
   /**
    * If url has a trailing slash, remove it, otherwise return url as is.
    */
-  public static stripTrailingSlash(url: string): string { return url.replace(/\/$/, ''); }
+  public static stripTrailingSlash(url: string): string { return url.replace(/\/(?=$|\?|;)/, ''); }
 }
 
 function _stripBaseHref(baseHref: string, url: string): string {

--- a/modules/@angular/common/test/location/location_spec.ts
+++ b/modules/@angular/common/test/location/location_spec.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Location} from '../../src/location/location';
+
+export function main() {
+  describe('Location', () => {
+
+    describe('stripTrailingSlash', () => {
+      describe('should strip trailing slash when url contains', () => {
+        it('no params', () => {
+          expect(Location.stripTrailingSlash('/test')).toBe('/test');
+          expect(Location.stripTrailingSlash('/test/')).toBe('/test');
+        });
+        it('query params',
+           () => expect(Location.stripTrailingSlash('/test/?a=b')).toBe('/test?a=b'));
+        it('matrix params',
+           () => expect(Location.stripTrailingSlash('/test/;a=b')).toBe('/test;a=b'));
+      });
+    });
+
+  });
+}


### PR DESCRIPTION
Closes #14905
