### PR TITLE
perf(compiler-cli): faster annotations lookup

### DIFF
--- a/modules/@angular/compiler-cli/src/ngtools_impl.ts
+++ b/modules/@angular/compiler-cli/src/ngtools_impl.ts
@@ -166,11 +166,11 @@ function _extractLazyRoutesFromStaticModule(
  * @private
  */
 function _getNgModuleMetadata(staticSymbol: StaticSymbol, reflector: StaticReflector): NgModule {
-  const ngModules = reflector.annotations(staticSymbol).filter((s: any) => s instanceof NgModule);
-  if (ngModules.length === 0) {
+  const ngModule = reflector.annotations(staticSymbol).find((s: any) => s instanceof NgModule);
+  if (!ngModule) {
     throw new Error(`${staticSymbol.name} is not an NgModule`);
   }
-  return ngModules[0];
+  return ngModule;
 }
 
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Currently, when looking up the `NgModule` annotations, Angular filters through the entire list of annotations and afterwards picks the first one in the list.


**What is the new behavior?**
The new behavior will stop looking after the first match and return it.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

