### PR TITLE
docs(router): document the value format for Params.

### DIFF
--- a/modules/@angular/router/src/shared.ts
+++ b/modules/@angular/router/src/shared.ts
@@ -21,10 +21,14 @@ export const PRIMARY_OUTLET = 'primary';
 /**
  * A collection of parameters.
  *
+ * Values are either `string`s (for single URL params like `?foo=bar` => `{foo: 'bar'}`), or
+ * `string[]` for repeated parameters (for repeated URL params like `?foo=bar&foo=baz` => `{foo:
+ * ['bar', 'baz']}`).
+ *
  * @stable
  */
 export type Params = {
-  [key: string]: any
+  [key: string]: any  // actually string|string[], but cannot change due to backwards compatibility.
 };
 
 const NAVIGATION_CANCELING_ERROR = 'ngNavigationCancelingError';


### PR DESCRIPTION
This was previously just strings, but after #11373 can also contain arrays of strings.

Sadly the type declaration cannot be changed for backwards compatibility.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: docs
```
