### PR TITLE
[2.x] fix(facade): stringify shouldn't throw when toString return null/undefined

### DIFF
--- a/modules/@angular/facade/src/lang.ts
+++ b/modules/@angular/facade/src/lang.ts
@@ -99,6 +99,11 @@ export function stringify(token: any): string {
   }
 
   const res = token.toString();
+
+  if (res == null) {
+    return '' + res;
+  }
+
   const newLineIndex = res.indexOf('\n');
   return newLineIndex === -1 ? res : res.substring(0, newLineIndex);
 }

--- a/modules/@angular/facade/test/lang_spec.ts
+++ b/modules/@angular/facade/test/lang_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NumberWrapper, escapeRegExp} from '../src/lang';
+import {NumberWrapper, escapeRegExp, stringify} from '../src/lang';
 
 export function main() {
   describe('RegExp', () => {
@@ -38,6 +38,22 @@ export function main() {
 
       it('should return false when passing parseable but non numeric',
          () => { expect(NumberWrapper.isNumeric('2a')).toBe(false); });
+    });
+  });
+
+  describe('stringify', () => {
+    it('should return string undefined when toString returns undefined', () => {
+      class Foo {
+        toString(): string { return undefined; }
+      }
+      expect(stringify(new Foo())).toBe('undefined');
+    });
+
+    it('should return string null when toString returns null', () => {
+      class Foo {
+        toString(): string { return null; }
+      }
+      expect(stringify(new Foo())).toBe('null');
     });
   });
 }


### PR DESCRIPTION
Fixes #14948