### PR TITLE
fix(http): Request should use search if params are absent

### DIFF
--- a/modules/@angular/http/src/base_request_options.ts
+++ b/modules/@angular/http/src/base_request_options.ts
@@ -7,13 +7,11 @@
  */
 
 import {Injectable} from '@angular/core';
-
 import {RequestMethod, ResponseContentType} from './enums';
 import {Headers} from './headers';
 import {normalizeMethodName} from './http_utils';
 import {RequestOptionsArgs} from './interfaces';
 import {URLSearchParams} from './url_search_params';
-
 
 /**
  * Creates a request options object to be optionally provided when instantiating a

--- a/modules/@angular/http/src/interfaces.ts
+++ b/modules/@angular/http/src/interfaces.ts
@@ -58,11 +58,6 @@ export interface RequestOptionsArgs {
 }
 
 /**
- * Required structure when constructing new Request();
- */
-export interface RequestArgs extends RequestOptionsArgs { url: string; }
-
-/**
  * Interface for options to construct a Response, based on
  * [ResponseInit](https://fetch.spec.whatwg.org/#responseinit) from the Fetch spec.
  *

--- a/modules/@angular/http/src/static_request.ts
+++ b/modules/@angular/http/src/static_request.ts
@@ -6,12 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {RequestOptions} from './base_request_options';
 import {Body} from './body';
 import {ContentType, RequestMethod, ResponseContentType} from './enums';
 import {Headers} from './headers';
 import {normalizeMethodName} from './http_utils';
-import {RequestArgs} from './interfaces';
 import {URLSearchParams} from './url_search_params';
+
 
 
 // TODO(jeffbcross): properly implement body accessors
@@ -71,10 +72,12 @@ export class Request extends Body {
   withCredentials: boolean;
   /** Buffer to store the response */
   responseType: ResponseContentType;
-  constructor(requestOptions: RequestArgs) {
+  constructor(requestOptions: RequestOptions) {
     super();
-    // TODO: assert that url is present
     const url = requestOptions.url;
+    if (url == null) {
+      throw new Error(`url must not be ${url}`);
+    }
     this.url = requestOptions.url;
     if (requestOptions.params) {
       const params = requestOptions.params.toString();

--- a/modules/@angular/http/test/static_request_spec.ts
+++ b/modules/@angular/http/test/static_request_spec.ts
@@ -7,11 +7,11 @@
  */
 
 import {describe, expect, it} from '@angular/core/testing/testing_internal';
-
 import {RequestOptions} from '../src/base_request_options';
 import {ContentType} from '../src/enums';
 import {Headers} from '../src/headers';
 import {ArrayBuffer, Request} from '../src/static_request';
+import {URLSearchParams} from '../src/url_search_params';
 
 export function main() {
   describe('Request', () => {
@@ -107,6 +107,11 @@ export function main() {
       const req = new Request(reqOptions);
 
       expect(req.text()).toEqual('');
+    });
+
+    it('should throw when url is null', () => {
+      const reqOptions = new RequestOptions({url: null, method: 'GET'});
+      expect(() => new Request(reqOptions)).toThrowError('url must not be null');
     });
   });
 }

--- a/tools/public_api_guard/http/typings/http.d.ts
+++ b/tools/public_api_guard/http/typings/http.d.ts
@@ -117,7 +117,7 @@ export declare class Request extends Body {
     responseType: ResponseContentType;
     url: string;
     withCredentials: boolean;
-    constructor(requestOptions: RequestArgs);
+    constructor(requestOptions: RequestOptions);
     detectContentType(): ContentType;
     detectContentTypeFromBody(): ContentType;
     getBody(): any;


### PR DESCRIPTION
When `Request` object is created using `RequestArgs` instead of `RequestOptions` `search` parameter is ignored. For example:
```
let requestArgs: RequestArgs = {
 search: config.requestParams || null,
};
let req =  new Request(requestArgs);
```