### PR TITLE
fix(platform-server): fix get/set title for parse5 adapter

### DIFF
--- a/packages/platform-server/src/parse5_adapter.ts
+++ b/packages/platform-server/src/parse5_adapter.ts
@@ -491,8 +491,10 @@ export class Parse5DomAdapter extends DomAdapter {
     return newDoc;
   }
   getBoundingClientRect(el: any): any { return {left: 0, top: 0, width: 0, height: 0}; }
-  getTitle(doc: Document): string { return doc.title || ''; }
-  setTitle(doc: Document, newTitle: string) { doc.title = newTitle; }
+  getTitle(doc: Document): string { return this.getText(this.getTitleNode(doc)) || ''; }
+  setTitle(doc: Document, newTitle: string) {
+    this.setText(this.getTitleNode(doc), newTitle || '');
+  }
   isTemplateElement(el: any): boolean {
     return this.isElementNode(el) && this.tagName(el) === 'template';
   }
@@ -591,6 +593,16 @@ export class Parse5DomAdapter extends DomAdapter {
   getCookie(name: string): string { throw new Error('not implemented'); }
   setCookie(name: string, value: string) { throw new Error('not implemented'); }
   animate(element: any, keyframes: any[], options: any): any { throw new Error('not implemented'); }
+  private getTitleNode(doc: Document) {
+    let title = this.querySelector(doc, 'title');
+
+    if (!title) {
+      title = <HTMLTitleElement>this.createElement('title');
+      this.appendChild(this.querySelector(doc, 'head'), title);
+    }
+
+    return title;
+  }
 }
 
 // TODO: build a proper list, this one is all the keys of a HTMLInputElement


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Fixes https://github.com/angular/angular/issues/14936

Currently, setting and getting the title on platform-server is broken and untested.

**What is the new behavior?**

Getting and setting the title will function and be tested

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
