### PR TITLE
[4.x] fix(core): stringify shouldn't throw when toString returns null/undefined

### DIFF
--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -69,6 +69,11 @@ export function stringify(token: any): string {
   }
 
   const res = token.toString();
+
+  if (res == null) {
+    return '' + res;
+  }
+
   const newLineIndex = res.indexOf('\n');
   return newLineIndex === -1 ? res : res.substring(0, newLineIndex);
 }

--- a/packages/core/test/util_spec.ts
+++ b/packages/core/test/util_spec.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {stringify} from '../src/util';
+
+export function main() {
+  describe('stringify', () => {
+    it('should return string undefined when toString returns undefined',
+       () => expect(stringify({toString: (): any => undefined})).toBe('undefined'));
+
+    it('should return string null when toString returns null',
+       () => expect(stringify({toString: (): any => null})).toBe('null'));
+  });
+}


### PR DESCRIPTION
Fixes #14948