### PR TITLE
fix(compiler-cli): generate correct paths when running at root

### DIFF
--- a/modules/@angular/compiler-cli/test/aot_host_spec.ts
+++ b/modules/@angular/compiler-cli/test/aot_host_spec.ts
@@ -129,6 +129,48 @@ describe('CompilerHost', () => {
     });
   });
 
+  describe('rootHostDir', () => {
+    let hostRootDir: CompilerHost;
+    beforeEach(() => {
+      hostRootDir = new CompilerHost(
+          program, {
+            genDir: '/src/gen/',
+            basePath: '/',
+            skipMetadataEmit: false,
+            strictMetadataEmit: false,
+            skipTemplateCodegen: false,
+            trace: false
+          },
+          context);
+    });
+
+    it('should import node_module from factory', () => {
+      expect(hostRootDir.fileNameToModuleName(
+                 '/node_modules/@angular/core.d.ts', '/src/gen/src/my.ngfactory.ts'))
+          .toEqual('@angular/core');
+    });
+
+    it('should import factory from factory', () => {
+      expect(hostRootDir.fileNameToModuleName('/src/my.other.ngfactory.ts', '/src/my.ngfactory.ts'))
+          .toEqual('./my.other.ngfactory');
+      expect(hostRootDir.fileNameToModuleName(
+                 '/src/my.other.css.ngstyle.ts', '/src/a/my.ngfactory.ts'))
+          .toEqual('../my.other.css.ngstyle');
+      expect(hostRootDir.fileNameToModuleName(
+                 '/src/a/my.other.shim.ngstyle.ts', '/src/my.ngfactory.ts'))
+          .toEqual('./a/my.other.shim.ngstyle');
+    });
+
+    it('should import application from factory', () => {
+      expect(hostRootDir.fileNameToModuleName('/src/my.other.ts', '/src/my.ngfactory.ts'))
+          .toEqual('../../my.other');
+      expect(hostRootDir.fileNameToModuleName('/src/my.other.ts', '/src/a/my.ngfactory.ts'))
+          .toEqual('../../../my.other');
+      expect(hostRootDir.fileNameToModuleName('/src/a/my.other.ts', '/src/my.ngfactory.ts'))
+          .toEqual('../../a/my.other');
+    });
+  });
+
   it('should be able to produce an import from main @angular/core', () => {
     expect(hostNestedGenDir.fileNameToModuleName(
                '/tmp/project/node_modules/@angular/core.d.ts', '/tmp/project/src/main.ts'))


### PR DESCRIPTION
We cannot assume that the normalized base path does not end with a slash: when it is the filesystem root, it actually does (in both Windows & Linux). This fix tries to be more careful when combining paths with the base path.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

When running aot on a project file which is at the filesystem root (and when basePath is not set otherwise), imported paths from generated files to existing sources may be incorrect. Indeed, in the CompilerHost, basePath is replaced by genDir with the assumption that it does not end with a '/', which is actually wrong if it is the root ('/').

**What is the new behavior?**

The paths are correct.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

Adding or correcting docs does not seem applicable here.
Btw, this bug has been around for quite a while as far as I can see.

