### PR TITLE
fix(platform-server): fix an exception when HostListener('window:scroll') is used on the server

### DIFF
--- a/packages/platform-server/src/parse5_adapter.ts
+++ b/packages/platform-server/src/parse5_adapter.ts
@@ -27,11 +27,26 @@ function _notImplemented(methodName: string) {
   return new Error('This method is not implemented in Parse5DomAdapter: ' + methodName);
 }
 
+function _getElement(el: any, name: string) {
+  for (let i = 0; i < el.childNodes.length; i++) {
+    let node = el.childNodes[i];
+    if (node.name === name) {
+      return node;
+    }
+  }
+  return null;
+}
+
 /**
  * Parses a document string to a Document object.
  */
 export function parseDocument(html: string) {
-  return parse5.parse(html, {treeAdapter: parse5.treeAdapters.htmlparser2});
+  let doc = parse5.parse(html, {treeAdapter: parse5.treeAdapters.htmlparser2});
+  let docElement = _getElement(doc, 'html');
+  doc['head'] = _getElement(docElement, 'head');
+  doc['body'] = _getElement(docElement, 'body');
+  doc['_window'] = {};
+  return doc;
 }
 
 

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {APP_BASE_HREF, PlatformLocation, isPlatformServer} from '@angular/common';
-import {ApplicationRef, CompilerFactory, Component, NgModule, NgModuleRef, NgZone, PLATFORM_ID, PlatformRef, destroyPlatform, getPlatform} from '@angular/core';
+import {ApplicationRef, CompilerFactory, Component, HostListener, NgModule, NgModuleRef, NgZone, PLATFORM_ID, PlatformRef, destroyPlatform, getPlatform} from '@angular/core';
 import {TestBed, async, inject} from '@angular/core/testing';
 import {Http, HttpModule, Response, ResponseOptions, XHRBackend} from '@angular/http';
 import {MockBackend, MockConnection} from '@angular/http/testing';
@@ -56,6 +56,9 @@ class TitleAppModule {
 @Component({selector: 'app', template: '{{text}}'})
 class MyAsyncServerApp {
   text = '';
+
+  @HostListener('window:scroll')
+  track() { console.error('scroll'); }
 
   ngOnInit() {
     Promise.resolve(null).then(() => setTimeout(() => { this.text = 'Works!'; }, 10));
@@ -141,7 +144,13 @@ export function main() {
          platform.bootstrapModule(ExampleModule).then((moduleRef) => {
            expect(isPlatformServer(moduleRef.injector.get(PLATFORM_ID))).toBe(true);
            const doc = moduleRef.injector.get(DOCUMENT);
+
+           expect(doc.head).toBe(getDOM().querySelector(doc, 'head'));
+           expect(doc.body).toBe(getDOM().querySelector(doc, 'body'));
+           expect((<any>doc)._window).toEqual({});
+
            expect(getDOM().getText(doc)).toEqual('Works!');
+
            platform.destroy();
          });
        }));


### PR DESCRIPTION
Fixes #15000 

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Trying to bootstrap when a component has @HostListener("window:scroll") causes an exception on the server

**What is the new behavior?**
No exception


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```