### PR TITLE
fix(platform-server): correctly implement get href in parse5 adapter

### DIFF
--- a/packages/platform-server/src/parse5_adapter.ts
+++ b/packages/platform-server/src/parse5_adapter.ts
@@ -505,7 +505,7 @@ export class Parse5DomAdapter extends DomAdapter {
   isShadowRoot(node: any): boolean { return this.getShadowRoot(node) == node; }
   importIntoDoc(node: any): any { return this.clone(node); }
   adoptNode(node: any): any { return node; }
-  getHref(el: any): string { return el.href; }
+  getHref(el: any): string { return this.getAttribute(el, 'href'); }
   resolveAndSetHref(el: any, baseUrl: string, href: string) {
     if (href == null) {
       el.href = baseUrl;

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {PlatformLocation, isPlatformServer} from '@angular/common';
+import {APP_BASE_HREF, PlatformLocation, isPlatformServer} from '@angular/common';
 import {ApplicationRef, CompilerFactory, Component, NgModule, NgModuleRef, NgZone, PLATFORM_ID, PlatformRef, destroyPlatform, getPlatform} from '@angular/core';
 import {TestBed, async, inject} from '@angular/core/testing';
 import {Http, HttpModule, Response, ResponseOptions, XHRBackend} from '@angular/http';
@@ -167,6 +167,19 @@ export function main() {
            const title = getDOM().querySelector(doc, 'title');
            expect(getDOM().getText(title)).toBe('Test App Title');
            expect(state.renderToString()).toContain('<title>Test App Title</title>');
+         });
+       }));
+
+    it('should get base href from document', async(() => {
+         const platform = platformDynamicServer([{
+           provide: INITIAL_CONFIG,
+           useValue:
+               {document: '<html><head><base href="/"></head><body><app></app></body></html>'}
+         }]);
+         platform.bootstrapModule(ExampleModule).then((moduleRef) => {
+           const location = moduleRef.injector.get(PlatformLocation);
+           expect(location.getBaseHrefFromDOM()).toEqual('/');
+           platform.destroy();
          });
        }));
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Fixes https://github.com/angular/angular/issues/15021

**What is the new behavior?**

The base href should be detected.

Other places where href's are grabbed should also work on platform-server.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
