### PR TITLE
docs(compiler-cli): mention that `.ngsummary.json` files should be gitignore'd

### DIFF
--- a/packages/compiler-cli/README.md
+++ b/packages/compiler-cli/README.md
@@ -78,7 +78,8 @@ twice in code reviews, with the generated version inscrutible by the reviewer.
 
 In TypeScript 1.8, the generated sources will have to be written alongside your originals,
 so set `genDir` to the same location as your files (typicially the same as `rootDir`).
-Add `**/*.ngfactory.ts` to your `.gitignore` or other mechanism for your version control system.
+Add `**/*.ngfactory.ts` and `**/*.ngsummary.json` to your `.gitignore` or other mechanism for your
+version control system.
 
 In TypeScript 1.9 and above, you can add a generated folder into your application,
 such as `codegen`. Using the `rootDirs` option, you can allow relative imports like


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Docs update
```

**What is the current behavior?** (You can also link to an open issue here)
The `compiler-cli` README recommends to gitignore `.ngfactory.ts` files. There is not mention of `.ngsummary.json` files (probably because they didn't exist when the docs were written).
This is confusing as users might think that `.ngsummary.json` files need to be put under version control. 


**What is the new behavior?**
The `compiler-cli` README recommends to gitignore `.ngfactory.ts` **and** `.ngsummary.json` files.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
