### PR TITLE
feat(aio): enable deep-linking on deployed apps (until prerendering is done)

### DIFF
--- a/aio/aio-builds-setup/dockerbuild/nginx/aio-builds.conf
+++ b/aio/aio-builds-setup/dockerbuild/nginx/aio-builds.conf
@@ -14,8 +14,12 @@ server {
   disable_symlinks on from=$document_root;
   index            index.html;
 
-  location / {
+  location "~/[^/]+\.[^/]+$" {
     try_files $uri $uri/ =404;
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html =404;
   }
 }
 
@@ -32,13 +36,13 @@ server {
   ssl_certificate_key {{$AIO_LOCALCERTS_DIR}}/{{$AIO_DOMAIN_NAME}}.key;
 
   # Health check
-  location "~^\/health-check\/?$" {
+  location "~^/health-check/?$" {
     add_header Content-Type text/plain;
     return 200 '';
   }
 
   # Upload builds
-  location "~^\/create-build\/(?<pr>[1-9][0-9]*)\/(?<sha>[0-9a-f]{40})\/?$" {
+  location "~^/create-build/(?<pr>[1-9][0-9]*)/(?<sha>[0-9a-f]{40})/?$" {
     if ($request_method != "POST") {
       add_header Allow "POST";
       return 405;

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/nginx.e2e.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/nginx.e2e.ts
@@ -24,21 +24,21 @@ h.runForAllSupportedSchemes((scheme, port) => describe(`nginx (on ${scheme.toUpp
 
     it('should return /index.html', done => {
       const origin = `${scheme}://pr${pr}-${sha9}.${host}`;
-      const bodyegex = new RegExp(`^PR: ${pr} | SHA: ${sha9} | File: /index\\.html$`);
+      const bodyRegex = new RegExp(`^PR: ${pr} | SHA: ${sha9} | File: /index\\.html$`);
 
       Promise.all([
-        h.runCmd(`curl -iL ${origin}/index.html`).then(h.verifyResponse(200, bodyegex)),
-        h.runCmd(`curl -iL ${origin}/`).then(h.verifyResponse(200, bodyegex)),
-        h.runCmd(`curl -iL ${origin}`).then(h.verifyResponse(200, bodyegex)),
+        h.runCmd(`curl -iL ${origin}/index.html`).then(h.verifyResponse(200, bodyRegex)),
+        h.runCmd(`curl -iL ${origin}/`).then(h.verifyResponse(200, bodyRegex)),
+        h.runCmd(`curl -iL ${origin}`).then(h.verifyResponse(200, bodyRegex)),
       ]).then(done);
     });
 
 
     it('should return /foo/bar.js', done => {
-      const bodyegex = new RegExp(`^PR: ${pr} | SHA: ${sha9} | File: /foo/bar\\.js$`);
+      const bodyRegex = new RegExp(`^PR: ${pr} | SHA: ${sha9} | File: /foo/bar\\.js$`);
 
       h.runCmd(`curl -iL ${scheme}://pr${pr}-${sha9}.${host}/foo/bar.js`).
-        then(h.verifyResponse(200, bodyegex)).
+        then(h.verifyResponse(200, bodyRegex)).
         then(done);
     });
 
@@ -51,10 +51,20 @@ h.runForAllSupportedSchemes((scheme, port) => describe(`nginx (on ${scheme.toUpp
     });
 
 
-    it('should respond with 404 for unknown paths', done => {
+    it('should respond with 404 for unknown paths to files', done => {
       h.runCmd(`curl -iL ${scheme}://pr${pr}-${sha9}.${host}/foo/baz.css`).
         then(h.verifyResponse(404)).
         then(done);
+    });
+
+
+    it('should rewrite to \'index.html\' for unknown paths that don\'t look like files', done => {
+      const bodyRegex = new RegExp(`^PR: ${pr} | SHA: ${sha9} | File: /index\\.html$`);
+
+      Promise.all([
+        h.runCmd(`curl -iL ${scheme}://pr${pr}-${sha9}.${host}/foo/baz`).then(h.verifyResponse(200, bodyRegex)),
+        h.runCmd(`curl -iL ${scheme}://pr${pr}-${sha9}.${host}/foo/baz/`).then(h.verifyResponse(200, bodyRegex)),
+      ]).then(done);
     });
 
 
@@ -93,11 +103,11 @@ h.runForAllSupportedSchemes((scheme, port) => describe(`nginx (on ${scheme.toUpp
 
 
     it('should accept SHAs with leading zeros (but not ignore them)', done => {
-      const bodyegex = new RegExp(`^PR: ${pr} | SHA: ${sha0} | File: /index\\.html$`);
+      const bodyRegex = new RegExp(`^PR: ${pr} | SHA: ${sha0} | File: /index\\.html$`);
 
       Promise.all([
         h.runCmd(`curl -iL ${scheme}://pr${pr}-0${sha9}.${host}`).then(h.verifyResponse(404)),
-        h.runCmd(`curl -iL ${scheme}://pr${pr}-${sha0}.${host}`).then(h.verifyResponse(200, bodyegex)),
+        h.runCmd(`curl -iL ${scheme}://pr${pr}-${sha0}.${host}`).then(h.verifyResponse(200, bodyRegex)),
       ]).then(done);
     });
 

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/test/upload-server/build-verifier.spec.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/test/upload-server/build-verifier.spec.ts
@@ -65,8 +65,12 @@ describe('BuildVerifier', () => {
     });
 
 
-    it('should return a promise', () => {
-      expect(bv.verify(pr, createAuthHeader())).toEqual(jasmine.any(Promise));
+    it('should return a promise', done => {
+      const promise = bv.verify(pr, createAuthHeader());
+      promise.then(done);   // Do not complete the test (and release the spies) synchronously
+                            // to avoid running the actual `bvGetPrAuthorTeamMembership()`.
+
+      expect(promise).toEqual(jasmine.any(Promise));
     });
 
 
@@ -194,8 +198,12 @@ describe('BuildVerifier', () => {
     });
 
 
-    it('should return a promise', () => {
-      expect(bv.getPrAuthorTeamMembership(pr)).toEqual(jasmine.any(Promise));
+    it('should return a promise', done => {
+      const promise = bv.getPrAuthorTeamMembership(pr);
+      promise.then(done);   // Do not complete the test (and release the spies) synchronously
+                            // to avoid running the actual `GithubTeams#isMemberBySlug()`.
+
+      expect(promise).toEqual(jasmine.any(Promise));
     });
 
 

--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -4,6 +4,12 @@
   },
   "hosting": {
     "public": "dist",
-    "cleanUrls": true
+    "cleanUrls": true,
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Deep-linking does not work on `ngbuilds.io` (PR previews) or `aio-stading.firebaseapp.com` (staging).
This was intentional, since the ultimate goal is to prerender all pages. Until this isimplemented, though, it is useful to support deep-linking.

**What is the new behavior?**
Deep-linking works on `ngbuilds.io` (PR previews) or `aio-stading.firebaseapp.com` (staging).


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

Other information:
Partly addresses #14922.