### PR TITLE
fix(forms): remove equalsTo validator

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -60,30 +60,6 @@ const EMAIL_REGEXP =
  */
 export class Validators {
   /**
-   * Validator that compares the value of the given FormControls
-   */
-  static equalsTo(...fieldPaths: string[]): ValidatorFn {
-    return function(control: FormControl): {[key: string]: any} {
-      if (fieldPaths.length < 1) {
-        throw new Error('You must compare to at least 1 other field');
-      }
-
-      for (let fieldName of fieldPaths) {
-        let field = (<FormGroup>control.parent).get(fieldName);
-        if (!field) {
-          throw new Error(
-              `Field: ${fieldName} undefined, are you sure that ${fieldName} exists in the group`);
-        }
-
-        if (field.value !== control.value) {
-          return {'equalsTo': {'unequalField': fieldName}};
-        }
-      }
-      return null;
-    };
-  }
-
-  /**
    * Validator that requires controls to have a non-empty value.
    */
   static required(control: AbstractControl): {[key: string]: boolean} {

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -38,44 +38,6 @@ export function main() {
   }
 
   describe('Validators', () => {
-    describe('equalsTo', () => {
-      it('should not error when equal', () => {
-        let group = new FormGroup({f1: new FormControl('a'), f2: new FormControl('a')});
-        let validator = Validators.equalsTo('f2');
-        expect(validator(group.controls['f1'])).toBeNull();
-      });
-
-      it('should error when not equal', () => {
-        let group = new FormGroup({f1: new FormControl('a'), f2: new FormControl('b')});
-        let validator = Validators.equalsTo('f2');
-        expect(validator(group.controls['f1'])).toEqual({equalsTo: {unequalField: 'f2'}});
-      });
-
-      it('should throw if passed a form control', () => {
-        let validator = Validators.equalsTo('f1', 'f2');
-        // cast it to any so we don't get TS errors
-        expect(() => validator(<any>new FormGroup({f1: new FormControl('')}))).toThrow();
-      });
-
-      it('should throw if passed a form array', () => {
-        let validator = Validators.equalsTo('f1', 'f2');
-        // cast it to any so we don't get TS errors
-        expect(() => validator(<any>new FormArray([]))).toThrow();
-      });
-
-      it('should throw if not passed any field to compare', () => {
-        let validator = Validators.equalsTo();
-        expect(() => validator(new FormControl('a'))).toThrow();
-      });
-
-      it('should throw if field passed does not exist in the group', () => {
-        let group = new FormGroup({f1: new FormControl('a'), f2: new FormControl('b')});
-        let validator = Validators.equalsTo('f3', 'f4');
-        // cast it to any so we don't get TS errors
-        expect(() => validator(new FormControl('a'))).toThrow();
-      });
-    });
-
     describe('required', () => {
       it('should error on an empty string',
          () => { expect(Validators.required(new FormControl(''))).toEqual({'required': true}); });

--- a/tools/public_api_guard/forms/typings/forms.d.ts
+++ b/tools/public_api_guard/forms/typings/forms.d.ts
@@ -554,7 +554,6 @@ export declare class Validators {
     static email(control: AbstractControl): {
         [key: string]: boolean;
     };
-    static equalsTo(...fieldPaths: string[]): ValidatorFn;
     static maxLength(maxLength: number): ValidatorFn;
     static minLength(minLength: number): ValidatorFn;
     static nullValidator(c: AbstractControl): {


### PR DESCRIPTION
We are removing the equalsTo validator introduced in 4.0.0.beta.6 because upon review, the concept is inconsistent with and breaks the guarantees of the validation model. 

This validator introduces dependencies between sibling controls. This is problematic because our validation model propagates changes up the tree. If you change the value of a form control in the UI, the form control in question is validated, then its parent, and its parent, and so on. Its siblings are not re-validated as their values have not changed. This allows us to skip checking subtrees that haven't updated and keep validation fast.

Because of this, the validator doesn't work as expected.  If you add the equalsTo validator onto control "one", when you change the value of control "two" in the UI, the validation status of control "one" will not be re-calculated.  Only changes initiated in control "one" itself will actually update its validation status. Even if you add another equalsTo validator on control "two", it will still not be validated on changes to control "one" and both controls' validation statuses will often be incorrect (see plunker here: http://plnkr.co/edit/4gcrKXs47nf6NTbJHJPw?p=preview). 

Validating between sibling controls  is something that is already possible in the framework with group validators. We generally recommend moving up a level to validate between sibling controls.  As validation propagates up, the group will always be updated when the value of any of its descendants changes.

Based on these mismatches, this validator does not belong at the framework level. 