### PR TITLE
feat(core): allow to provide multiple default testing modules

### DIFF
--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -69,7 +69,7 @@ export class TestBed implements Injector {
    *
    * @experimental
    */
-  static initTestEnvironment(ngModule: Type<any>, platform: PlatformRef): TestBed {
+  static initTestEnvironment(ngModule: Type<any>|Type<any>[], platform: PlatformRef): TestBed {
     const testBed = getTestBed();
     testBed.initTestEnvironment(ngModule, platform);
     return testBed;
@@ -179,7 +179,7 @@ export class TestBed implements Injector {
    *
    * @experimental
    */
-  initTestEnvironment(ngModule: Type<any>, platform: PlatformRef) {
+  initTestEnvironment(ngModule: Type<any>|Type<any>[], platform: PlatformRef) {
     if (this.platform || this.ngModule) {
       throw new Error('Cannot set base providers because it has already been called');
     }
@@ -219,7 +219,7 @@ export class TestBed implements Injector {
 
   platform: PlatformRef = null;
 
-  ngModule: Type<any> = null;
+  ngModule: Type<any>|Type<any>[] = null;
 
   configureCompiler(config: {providers?: any[], useJit?: boolean}) {
     this._assertNotInstantiated('TestBed.configureCompiler', 'configure the compiler');

--- a/test-main.js
+++ b/test-main.js
@@ -66,11 +66,15 @@ System.config({
 // method and kick off Karma (Jasmine).
 System.import('@angular/core/testing')
     .then(function(coreTesting) {
-      return System.import('@angular/platform-browser-dynamic/testing')
-          .then(function(browserTesting) {
+      return Promise
+          .all([
+            System.import('@angular/platform-browser-dynamic/testing'),
+            System.import('@angular/platform-browser/animations')
+          ])
+          .then(function(mods) {
             coreTesting.TestBed.initTestEnvironment(
-                browserTesting.BrowserDynamicTestingModule,
-                browserTesting.platformBrowserDynamicTesting());
+                [mods[0].BrowserDynamicTestingModule, mods[1].NoopAnimationsModule],
+                mods[0].platformBrowserDynamicTesting());
           });
     })
     .then(function() {

--- a/tools/public_api_guard/core/typings/testing/index.d.ts
+++ b/tools/public_api_guard/core/typings/testing/index.d.ts
@@ -58,7 +58,7 @@ export declare function resetFakeAsyncZone(): void;
 
 /** @stable */
 export declare class TestBed implements Injector {
-    ngModule: Type<any>;
+    ngModule: Type<any> | Type<any>[];
     platform: PlatformRef;
     compileComponents(): Promise<any>;
     configureCompiler(config: {
@@ -69,7 +69,7 @@ export declare class TestBed implements Injector {
     createComponent<T>(component: Type<T>): ComponentFixture<T>;
     execute(tokens: any[], fn: Function, context?: any): any;
     get(token: any, notFoundValue?: any): any;
-    /** @experimental */ initTestEnvironment(ngModule: Type<any>, platform: PlatformRef): void;
+    /** @experimental */ initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef): void;
     overrideComponent(component: Type<any>, override: MetadataOverride<Component>): void;
     overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): void;
     overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): void;
@@ -84,7 +84,7 @@ export declare class TestBed implements Injector {
     static configureTestingModule(moduleDef: TestModuleMetadata): typeof TestBed;
     static createComponent<T>(component: Type<T>): ComponentFixture<T>;
     static get(token: any, notFoundValue?: any): any;
-    /** @experimental */ static initTestEnvironment(ngModule: Type<any>, platform: PlatformRef): TestBed;
+    /** @experimental */ static initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef): TestBed;
     static overrideComponent(component: Type<any>, override: MetadataOverride<Component>): typeof TestBed;
     static overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): typeof TestBed;
     static overrideModule(ngModule: Type<any>, override: MetadataOverride<NgModule>): typeof TestBed;


### PR DESCRIPTION
This can be used to e.g. add the NoopAnimationsModule by default:

```
TestBed.initTestEnvironment([
  BrowserDynamicTestingModule,
  NoopAnimationsModule
], platformBrowserDynamicTesting());
```
