### PR TITLE
fix(core): don’t recreate `TemplateRef` when used as a reference.

### DIFF
--- a/packages/core/src/view/provider.ts
+++ b/packages/core/src/view/provider.ts
@@ -14,7 +14,7 @@ import {ViewContainerRef} from '../linker/view_container_ref';
 import {ViewEncapsulation} from '../metadata/view';
 import {Renderer as RendererV1, Renderer2, RendererFactory2, RendererType2} from '../render/api';
 
-import {createChangeDetectorRef, createInjector, createRendererV1, createTemplateRef, createViewContainerRef} from './refs';
+import {createChangeDetectorRef, createInjector, createRendererV1} from './refs';
 import {BindingDef, BindingType, DepDef, DepFlags, DisposableFn, NodeData, NodeDef, NodeFlags, OutputDef, OutputType, ProviderData, QueryBindingType, QueryDef, QueryValueType, RootData, Services, ViewData, ViewDefinition, ViewFlags, ViewState, asElementData, asProviderData} from './types';
 import {checkBinding, dispatchEvent, filterQueryId, isComponentView, splitMatchedQueriesDsl, tokenKey, viewParentEl} from './util';
 
@@ -356,10 +356,10 @@ export function resolveDep(
         case ElementRefTokenKey:
           return new ElementRef(asElementData(view, elDef.index).renderElement);
         case ViewContainerRefTokenKey:
-          return createViewContainerRef(view, elDef);
+          return asElementData(view, elDef.index).viewContainer;
         case TemplateRefTokenKey: {
           if (elDef.element.template) {
-            return createTemplateRef(view, elDef);
+            return asElementData(view, elDef.index).template;
           }
           break;
         }

--- a/packages/core/src/view/query.ts
+++ b/packages/core/src/view/query.ts
@@ -11,7 +11,6 @@ import {QueryList} from '../linker/query_list';
 import {TemplateRef} from '../linker/template_ref';
 import {ViewContainerRef} from '../linker/view_container_ref';
 
-import {createTemplateRef, createViewContainerRef} from './refs';
 import {NodeDef, NodeFlags, QueryBindingDef, QueryBindingType, QueryDef, QueryValueType, Services, ViewData, asElementData, asProviderData, asQueryList} from './types';
 import {declaredViewContainer, filterQueryId, isEmbeddedView, viewParentEl} from './util';
 
@@ -141,8 +140,8 @@ function calcQueryValues(
         (nodeDef.element.template.nodeMatchedQueries & queryDef.filterId) === queryDef.filterId) {
       // check embedded views that were attached at the place of their template.
       const elementData = asElementData(view, i);
-      const embeddedViews = elementData.embeddedViews;
-      if (embeddedViews) {
+      if (nodeDef.flags & NodeFlags.EmbeddedViews) {
+        const embeddedViews = elementData.viewContainer._embeddedViews;
         for (let k = 0; k < embeddedViews.length; k++) {
           const embeddedView = embeddedViews[k];
           const dvc = declaredViewContainer(embeddedView);
@@ -151,7 +150,7 @@ function calcQueryValues(
           }
         }
       }
-      const projectedViews = elementData.projectedViews;
+      const projectedViews = elementData.template._projectedViews;
       if (projectedViews) {
         for (let k = 0; k < projectedViews.length; k++) {
           const projectedView = projectedViews[k];
@@ -180,10 +179,10 @@ export function getQueryValue(
         value = new ElementRef(asElementData(view, nodeDef.index).renderElement);
         break;
       case QueryValueType.TemplateRef:
-        value = createTemplateRef(view, nodeDef);
+        value = asElementData(view, nodeDef.index).template;
         break;
       case QueryValueType.ViewContainerRef:
-        value = createViewContainerRef(view, nodeDef);
+        value = asElementData(view, nodeDef.index).viewContainer;
         break;
       case QueryValueType.Provider:
         value = asProviderData(view, nodeDef.index).instance;

--- a/packages/core/src/view/types.ts
+++ b/packages/core/src/view/types.ts
@@ -355,12 +355,18 @@ export function asTextData(view: ViewData, index: number): TextData {
 export interface ElementData {
   renderElement: any;
   componentView: ViewData;
-  embeddedViews: ViewData[];
+  viewContainer: ViewContainerData;
+  template: TemplateData;
+}
+
+export interface ViewContainerData extends ViewContainerRef { _embeddedViews: ViewData[]; }
+
+export interface TemplateData extends TemplateRef<any> {
   // views that have been created from the template
   // of this element,
   // but inserted into the embeddedViews of another element.
   // By default, this is undefined.
-  projectedViews: ViewData[];
+  _projectedViews: ViewData[];
 }
 
 /**

--- a/packages/core/src/view/util.ts
+++ b/packages/core/src/view/util.ts
@@ -293,11 +293,9 @@ function visitRenderNode(
     const rn = renderNode(view, nodeDef);
     execRenderNodeAction(view, rn, action, parentNode, nextSibling, target);
     if (nodeDef.flags & NodeFlags.EmbeddedViews) {
-      const embeddedViews = asElementData(view, nodeDef.index).embeddedViews;
-      if (embeddedViews) {
-        for (let k = 0; k < embeddedViews.length; k++) {
-          visitRootRenderNodes(embeddedViews[k], action, parentNode, nextSibling, target);
-        }
+      const embeddedViews = asElementData(view, nodeDef.index).viewContainer._embeddedViews;
+      for (let k = 0; k < embeddedViews.length; k++) {
+        visitRootRenderNodes(embeddedViews[k], action, parentNode, nextSibling, target);
       }
     }
     if (nodeDef.flags & NodeFlags.TypeElement && !nodeDef.element.name) {

--- a/packages/core/src/view/view_attach.ts
+++ b/packages/core/src/view/view_attach.ts
@@ -11,7 +11,7 @@ import {RenderNodeAction, declaredViewContainer, isComponentView, renderNode, ro
 
 export function attachEmbeddedView(
     parentView: ViewData, elementData: ElementData, viewIndex: number, view: ViewData) {
-  let embeddedViews = elementData.embeddedViews;
+  let embeddedViews = elementData.viewContainer._embeddedViews;
   if (viewIndex == null) {
     viewIndex = embeddedViews.length;
   }
@@ -19,9 +19,9 @@ export function attachEmbeddedView(
   addToArray(embeddedViews, viewIndex, view);
   const dvcElementData = declaredViewContainer(view);
   if (dvcElementData && dvcElementData !== elementData) {
-    let projectedViews = dvcElementData.projectedViews;
+    let projectedViews = dvcElementData.template._projectedViews;
     if (!projectedViews) {
-      projectedViews = dvcElementData.projectedViews = [];
+      projectedViews = dvcElementData.template._projectedViews = [];
     }
     projectedViews.push(view);
   }
@@ -33,7 +33,7 @@ export function attachEmbeddedView(
 }
 
 export function detachEmbeddedView(elementData: ElementData, viewIndex: number): ViewData {
-  const embeddedViews = elementData.embeddedViews;
+  const embeddedViews = elementData.viewContainer._embeddedViews;
   if (viewIndex == null || viewIndex >= embeddedViews.length) {
     viewIndex = embeddedViews.length - 1;
   }
@@ -46,7 +46,7 @@ export function detachEmbeddedView(elementData: ElementData, viewIndex: number):
 
   const dvcElementData = declaredViewContainer(view);
   if (dvcElementData && dvcElementData !== elementData) {
-    const projectedViews = dvcElementData.projectedViews;
+    const projectedViews = dvcElementData.template._projectedViews;
     removeFromArray(projectedViews, projectedViews.indexOf(view));
   }
 
@@ -59,7 +59,7 @@ export function detachEmbeddedView(elementData: ElementData, viewIndex: number):
 
 export function moveEmbeddedView(
     elementData: ElementData, oldViewIndex: number, newViewIndex: number): ViewData {
-  const embeddedViews = elementData.embeddedViews;
+  const embeddedViews = elementData.viewContainer._embeddedViews;
   const view = embeddedViews[oldViewIndex];
   removeFromArray(embeddedViews, oldViewIndex);
   if (newViewIndex == null) {

--- a/packages/core/test/view/embedded_view_spec.ts
+++ b/packages/core/test/view/embedded_view_spec.ts
@@ -101,7 +101,7 @@ export function main() {
 
       moveEmbeddedView(viewContainerData, 0, 1);
 
-      expect(viewContainerData.embeddedViews).toEqual([childView1, childView0]);
+      expect(viewContainerData.viewContainer._embeddedViews).toEqual([childView1, childView0]);
       // 2 anchors + 2 elements
       const rootChildren = getDOM().childNodes(rootNodes[0]);
       expect(rootChildren.length).toBe(4);

--- a/packages/core/test/view/ng_content_spec.ts
+++ b/packages/core/test/view/ng_content_spec.ts
@@ -96,7 +96,7 @@ export function main() {
       const anchor = asElementData(view, 2);
       expect((getDOM().childNodes(getDOM().firstChild(rootNodes[0]))[0]))
           .toBe(anchor.renderElement);
-      const embeddedView = anchor.embeddedViews[0];
+      const embeddedView = anchor.viewContainer._embeddedViews[0];
       expect((getDOM().childNodes(getDOM().firstChild(rootNodes[0]))[1]))
           .toBe(asTextData(embeddedView, 0).renderText);
     });

--- a/packages/core/test/view/query_spec.ts
+++ b/packages/core/test/view/query_spec.ts
@@ -353,7 +353,8 @@ export function main() {
         }
 
         const {view} = createAndGetRootNodes(compViewDef([
-          anchorDef(NodeFlags.None, [[someQueryId, QueryValueType.ViewContainerRef]], null, 2),
+          anchorDef(
+              NodeFlags.EmbeddedViews, [[someQueryId, QueryValueType.ViewContainerRef]], null, 2),
           directiveDef(NodeFlags.None, null, 1, QueryService, []),
           queryDef(
               NodeFlags.TypeContentQuery | NodeFlags.DynamicQuery, someQueryId,


### PR DESCRIPTION
This was a regression introduced in v4 rc.0.

Fixes #14873
