### PR TITLE
fix: don't instantiate providers with ngOnDestroy eagerly.

### DIFF
--- a/packages/compiler/src/ng_module_compiler.ts
+++ b/packages/compiler/src/ng_module_compiler.ts
@@ -91,6 +91,7 @@ class _InjectorBuilder implements ClassBuilder {
   getters: o.ClassGetter[] = [];
   methods: o.ClassMethod[] = [];
   ctorStmts: o.Statement[] = [];
+  private _lazyProps = new Map<string, o.Expression>();
   private _tokens: CompileTokenMetadata[] = [];
   private _instances = new Map<any, o.Expression>();
   private _createStmts: o.Statement[] = [];
@@ -110,7 +111,11 @@ class _InjectorBuilder implements ClassBuilder {
         propName, resolvedProvider, providerValueExpressions, resolvedProvider.multiProvider,
         resolvedProvider.eager);
     if (resolvedProvider.lifecycleHooks.indexOf(ɵLifecycleHooks.OnDestroy) !== -1) {
-      this._destroyStmts.push(instance.callMethod('ngOnDestroy', []).toStmt());
+      let callNgOnDestroy: o.Expression = instance.callMethod('ngOnDestroy', []);
+      if (!resolvedProvider.eager) {
+        callNgOnDestroy = this._lazyProps.get(instance.name).and(callNgOnDestroy);
+      }
+      this._destroyStmts.push(callNgOnDestroy.toStmt());
     }
     this._tokens.push(resolvedProvider.token);
     this._instances.set(tokenReference(resolvedProvider.token), instance);
@@ -180,7 +185,7 @@ class _InjectorBuilder implements ClassBuilder {
 
   private _createProviderProperty(
       propName: string, provider: ProviderAst, providerValueExpressions: o.Expression[],
-      isMulti: boolean, isEager: boolean): o.Expression {
+      isMulti: boolean, isEager: boolean): o.ReadPropExpr {
     let resolvedProviderValueExpr: o.Expression;
     let type: o.Type;
     if (isMulti) {
@@ -197,16 +202,17 @@ class _InjectorBuilder implements ClassBuilder {
       this.fields.push(new o.ClassField(propName, type));
       this._createStmts.push(o.THIS_EXPR.prop(propName).set(resolvedProviderValueExpr).toStmt());
     } else {
-      const internalField = `_${propName}`;
-      this.fields.push(new o.ClassField(internalField, type));
+      const internalFieldProp = o.THIS_EXPR.prop(`_${propName}`);
+      this.fields.push(new o.ClassField(internalFieldProp.name, type));
       // Note: Equals is important for JS so that it also checks the undefined case!
       const getterStmts = [
         new o.IfStmt(
-            o.THIS_EXPR.prop(internalField).isBlank(),
-            [o.THIS_EXPR.prop(internalField).set(resolvedProviderValueExpr).toStmt()]),
-        new o.ReturnStatement(o.THIS_EXPR.prop(internalField))
+            internalFieldProp.isBlank(),
+            [internalFieldProp.set(resolvedProviderValueExpr).toStmt()]),
+        new o.ReturnStatement(internalFieldProp)
       ];
       this.getters.push(new o.ClassGetter(propName, getterStmts, type));
+      this._lazyProps.set(propName, internalFieldProp);
     }
     return o.THIS_EXPR.prop(propName);
   }

--- a/packages/compiler/src/provider_analyzer.ts
+++ b/packages/compiler/src/provider_analyzer.ts
@@ -462,9 +462,10 @@ function _resolveProviders(
               (<CompileTypeMetadata>provider.token.identifier).lifecycleHooks ?
           (<CompileTypeMetadata>provider.token.identifier).lifecycleHooks :
           [];
+      const isUseValue = !(provider.useClass || provider.useExisting || provider.useFactory);
       resolvedProvider = new ProviderAst(
-          provider.token, provider.multi, eager || lifecycleHooks.length > 0, [provider],
-          providerType, lifecycleHooks, sourceSpan);
+          provider.token, provider.multi, eager || isUseValue, [provider], providerType,
+          lifecycleHooks, sourceSpan);
       targetProvidersByToken.set(tokenReference(provider.token), resolvedProvider);
     } else {
       if (!provider.multi) {

--- a/packages/core/src/application_module.ts
+++ b/packages/core/src/application_module.ts
@@ -56,4 +56,6 @@ export function _initViewEngine() {
   ]
 })
 export class ApplicationModule {
+  // Inject ApplicationRef to make it eager...
+  constructor(appRef: ApplicationRef) {}
 }

--- a/packages/core/src/view/provider.ts
+++ b/packages/core/src/view/provider.ts
@@ -468,6 +468,9 @@ function callElementProvidersLifecycles(view: ViewData, elDef: NodeDef, lifecycl
 
 function callProviderLifecycles(view: ViewData, index: number, lifecycles: NodeFlags) {
   const provider = asProviderData(view, index).instance;
+  if (provider === NOT_CREATED) {
+    return;
+  }
   Services.setCurrentNode(view, index);
   if (lifecycles & NodeFlags.AfterContentInit) {
     provider.ngAfterContentInit();

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -213,7 +213,13 @@ export class TestBed implements Injector {
     this._imports = [];
     this._schemas = [];
     this._instantiated = false;
-    this._activeFixtures.forEach((fixture) => fixture.destroy());
+    this._activeFixtures.forEach((fixture) => {
+      try {
+        fixture.destroy();
+      } catch (e) {
+        console.error('Error during cleanup of component', fixture.componentInstance);
+      }
+    });
     this._activeFixtures = [];
   }
 

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -123,7 +123,8 @@ export function routerNgProbeToken() {
  */
 @NgModule({declarations: ROUTER_DIRECTIVES, exports: ROUTER_DIRECTIVES})
 export class RouterModule {
-  constructor(@Optional() @Inject(ROUTER_FORROOT_GUARD) guard: any) {}
+  // Note: We are injecting the Router so it gets created eagerly...
+  constructor(@Optional() @Inject(ROUTER_FORROOT_GUARD) guard: any, @Optional() router: Router) {}
 
   /**
    * Creates a module with all the router providers and directives. It also optionally sets up an

--- a/tools/public_api_guard/core/typings/core.d.ts
+++ b/tools/public_api_guard/core/typings/core.d.ts
@@ -121,6 +121,7 @@ export declare class ApplicationInitStatus {
 
 /** @experimental */
 export declare class ApplicationModule {
+    constructor(appRef: ApplicationRef);
 }
 
 /** @stable */

--- a/tools/public_api_guard/router/typings/router.d.ts
+++ b/tools/public_api_guard/router/typings/router.d.ts
@@ -308,7 +308,7 @@ export declare class RouterLinkWithHref implements OnChanges, OnDestroy {
 
 /** @stable */
 export declare class RouterModule {
-    constructor(guard: any);
+    constructor(guard: any, router: Router);
     static forChild(routes: Routes): ModuleWithProviders;
     static forRoot(routes: Routes, config?: ExtraOptions): ModuleWithProviders;
 }


### PR DESCRIPTION
Perviously, any provider that had an ngOnDestroy lifecycle hook would be created eagerly. Now, only classes that are annotated with @Component, @Directive, @Pipe, @NgModule are eager. Providers only become eager if they are either directly or transitively injected into one of the above.

Fixes #14552
