### PR TITLE
ci: skip root pullapproval for packages directory

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -40,6 +40,7 @@ groups:
           - "aio/*"
           - "integration/*"
           - "modules/*"
+          - "packages/*"
           - "tools/*"
     users:
       - IgorMinar


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] CI related changes
```

**What is the current behavior?** (You can also link to an open issue here)

Changes in `packages` directory require root approval

**What is the new behavior?**

Changes in `packages` only need approval from their respective groups.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
