### PR TITLE
ci: use angular-builds credentials for publishing artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
   global:
     # GITHUB_TOKEN_ANGULAR
     # This is needed for the e2e Travis matrix task to publish packages to github for continuous packages delivery.
-    - secure: "fq/U7VDMWO8O8SnAQkdbkoSe2X92PVqg4d044HmRYVmcf6YbO48+xeGJ8yOk0pCBwl3ISO4Q2ot0x546kxfiYBuHkZetlngZxZCtQiFT9kyId8ZKcYdXaIW9OVdw3Gh3tQyUwDucfkVhqcs52D6NZjyE2aWZ4/d1V4kWRO/LMgo="
+    - secure: "gE4gRM6Ohjaroh6RqDHtrVKyEfafVxZPQe3C2if5hJ13xTAXoHqTFibmTIMaLq/cWkO/DeY6AAzHDWomaJODO1nWwBJFvNj5kw9BqKgojw1uUkkKh7cC9yCUfEXVkJ56lfvRVcs/bJAvjpCBygumnQo1qwosOc0jTFPyB8sF6bQ="
     # FIREBASE_TOKEN
     # This is needed for publishing builds to the "aio-staging" firebase site.
     # TODO(i): the token was generated using the iminar@google account, we should switch to a shared/role-base account.

--- a/scripts/ci/publish-build-artifacts.sh
+++ b/scripts/ci/publish-build-artifacts.sh
@@ -75,6 +75,8 @@ function publishRepo {
     done
 
     (
+      # SECURITY CRITICAL: DO NOT remove the set -x on the following line. Removing it will leak the github credentials to the travis log.
+      set -x
       cd $REPO_DIR && \
       git config credential.helper "store --file=.git/credentials" && \
       echo "https://${GITHUB_TOKEN_ANGULAR}:@github.com" > .git/credentials


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] CI related changes
```

**What is the current behavior?** (You can also link to an open issue here)

CI uses a revoked credential and would leak a new one.

**What is the new behavior?**

CI uses new credentials and no longer leaks the token.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
