### PR TITLE
fix(core): DebugElement shouldn't hang browser when used with Jasmine

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -140,6 +140,11 @@ export class DebugElement extends DebugNode {
       }
     });
   }
+
+  /** @internal */
+  jasmineToString(): string {
+    return `DebugElement{name=${this.name}, properties=${JSON.stringify(this.properties)}, attributes=${JSON.stringify(this.attributes)}, classes=${JSON.stringify(this.classes)}, styles=${JSON.stringify(this.styles)}}`;
+  }
 }
 
 /**

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -13,6 +13,7 @@ import {ComponentFixture, TestBed, async} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
+import {DebugElement} from '../../src/debug/debug_node';
 
 @Injectable()
 class Logger {
@@ -352,6 +353,11 @@ export function main() {
       fixture.debugElement.children[1].triggerEventHandler('myevent', <Event>{});
       expect(fixture.componentInstance.customed).toBe(true);
 
+    });
+
+    it('should implement jasmineToString', () => {
+      const element = new DebugElement(null, null, null);
+      expect(element.jasmineToString).toBeDefined();
     });
   });
 }


### PR DESCRIPTION
DebugElement is a recursive data structure so the Jasmine PrettyPrinter is
taking a while to print out it. To pre-empt any recursing we implement
jasmineToString method. (https://github.com/jasmine/jasmine/issues/1288)

Closes #14235