### PR TITLE
build(aio): ensure API docs are generated in the correct place

### DIFF
--- a/aio/transforms/angular.io-package/index.js
+++ b/aio/transforms/angular.io-package/index.js
@@ -217,11 +217,10 @@ module.exports =
             {
               docTypes: ['module'],
               getPath: function computeModulePath(doc) {
-                doc.moduleFolder =
-                    doc.id.replace(/^@angular\//, API_SEGMENT + '/').replace(/\/index$/, '');
+                doc.moduleFolder = `${API_SEGMENT}/${doc.id.replace(/\/index$/, '')}`;
                 return doc.moduleFolder;
               },
-              outputPathTemplate: '${moduleFolder}/index.json'
+              outputPathTemplate: '${moduleFolder}.json'
             },
             {
               docTypes: EXPORT_DOC_TYPES.concat(['decorator', 'directive', 'pipe']),


### PR DESCRIPTION
The move of the source code from `modules/@angular` to `packages`, caused a problem with the path to the API docs.