### PR TITLE
chore: reenable standalone browser unit test campaigns

### DIFF
--- a/test-main.js
+++ b/test-main.js
@@ -22,10 +22,10 @@ System.config({
     'benchpress/*': 'dist/js/dev/es5/benchpress/*.js',
     '@angular': 'dist/all/@angular',
     'rxjs': 'node_modules/rxjs',
-    'parse5': 'dist/all/empty.js',
-    'url': 'dist/all/empty.js',
-    'xhr2': 'dist/all/empty.js',
-    '@angular/platform-server/src/parse5_adapter': 'dist/all/empty.js',
+    'parse5': 'dist/all/@angular/empty.js',
+    'url': 'dist/all/@angular/empty.js',
+    'xhr2': 'dist/all/@angular/empty.js',
+    '@angular/platform-server/src/parse5_adapter': 'dist/all/@angular/empty.js',
     'angular2/*': 'dist/all/angular2/*.js',
     'angular2/src/alt_router/router_testing_providers':
         'dist/all/angular2/src/alt_router/router_testing_providers.js'


### PR DESCRIPTION
Browser unit test campaigns cannot be run anymore, except if the `modules` folder was transpiled first.

Steps to reproduce:
```
rm -rf dist/
./test.sh browser
```

This raises the following error:
```
Compiling tools...
Watching: packages/tsconfig.json in /Users/mlaval/dev/github/angular_mlaval
=====> node_modules/.bin/tsc --emitDecoratorMetadata --project packages/tsconfig.json --watch
=====> node node_modules/karma/bin/karma start --no-auto-watch --port=9876 karma-js.conf.js
11:36:41 AM - Compilation complete. Watching for file changes.
------------------------------------------------------------------------------
=====> node node_modules/karma/bin/karma run karma-js.conf.js --port=9876
Chrome 56.0.2924 (Mac OS X 10.11.6) ERROR: Error{originalStack: 'Error: XHR error (404 Not Found) loading http://localhost:9876/base/dist/all/empty.js
    at ZoneAwareError (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?2f7b4b3849e68ad7722691d3bde65aff7f530365:672:33)
    at addToError (http://localhost:9876/base/node_modules/systemjs/dist/system.src.js?1c6a6c12fec50a8db7aeebe8e06e2b70135c0615:43:20)
    at linkSetFailed (http://localhost:9876/base/node_modules/systemjs/dist/system.src.js?1c6a6c12fec50a8db7aeebe8e06e2b70135c0615:643:21)
    at http://localhost:9876/base/node_modules/systemjs/dist/system.src.js?1c6a6c12fec50a8db7aeebe8e06e2b70135c0615:440:9
    at ZoneDelegate.invoke (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?2f7b4b3849e68ad7722691d3bde65aff7f530365:229:26)
    at Zone.run (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?2f7b4b3849e68ad7722691d3bde65aff7f530365:113:43)
    at http://localhost:9876/base/node_modules/zone.js/dist/zone.js?2f7b4b3849e68ad7722691d3bde65aff7f530365:509:57
    at ZoneDelegate.invokeTask (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?2f7b4b3849e68ad7722691d3bde65aff7f530365:262:35)
    at Zone.runTask (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?2f7b4b3849e68ad7722691d3bde65aff7f530365:151:47)
    at drainMicroTaskQueue (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?2f7b4b3849e68ad7722691d3bde65aff7f530365:405:35)
    at XMLHttpRequest.ZoneTask.invoke (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?2f7b4b3849e68ad7722691d3bde65aff7f530365:336:25)', zoneAwareStack: 'Error: XHR error (404 Not Found) loading http://localhost:9876/base/dist/all/empty.js
    at addToError (http://localhost:9876/base/node_modules/systemjs/dist/system.src.js?1c6a6c12fec50a8db7aeebe8e06e2b70135c0615:43:20) [<root>]
    at linkSetFailed (http://localhost:9876/base/node_modules/systemjs/dist/system.src.js?1c6a6c12fec50a8db7aeebe8e06e2b70135c0615:643:21) [<root>]
    at http://localhost:9876/base/node_modules/systemjs/dist/system.src.js?1c6a6c12fec50a8db7aeebe8e06e2b70135c0615:440:9 [<root>]
    at Zone.run (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?2f7b4b3849e68ad7722691d3bde65aff7f530365:113:43) [<root> => <root>]
    at http://localhost:9876/base/node_modules/zone.js/dist/zone.js?2f7b4b3849e68ad7722691d3bde65aff7f530365:509:57 [<root>]
    at Zone.runTask (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?2f7b4b3849e68ad7722691d3bde65aff7f530365:151:47) [<root> => <root>]
    at drainMicroTaskQueue (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?2f7b4b3849e68ad7722691d3bde65aff7f530365:405:35) [<root>]
    at XMLHttpRequest.ZoneTask.invoke (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?2f7b4b3849e68ad7722691d3bde65aff7f530365:336:25) [<root>]'}
```

/cc @IgorMinar @jasonaden 