### PR TITLE
build(aio): `yarn test --sourcemap=false` for faster dev/test cycles

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -10,7 +10,7 @@
     "ng": "yarn check-env && ng",
     "start": "yarn check-env && ng serve",
     "build": "yarn check-env && yarn docs && ng build -prod -sm",
-    "test": "yarn check-env && ng test",
+    "test": "yarn check-env && ng test --sourcemap=false",
     "lint": "yarn check-env && ng lint",
     "pree2e": "webdriver-manager update --standalone false --gecko false",
     "e2e": "yarn check-env && ng e2e --no-webdriver-update",


### PR DESCRIPTION
The `yarn test` command should run `ng test --sourcemap=false` which (today) makes the dev/test cycle faster. Probably no significant effect on CI because the _first_ build/test is pretty quick. Slowness arises with rebuilds during dev iteration.

See https://github.com/angular/angular-cli/issues/5423

FWIW, `yarn test -- --sm=true` will restore testing-w-sourcemaps

FYI - A forthcoming CLI RC _may_ default to `ng test --sourcemap=false`. Or they may solve the root cause. If they solve it, we'll want to revert because it's nice to have sourcemaps _if they are (nearly) free_.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```
