### PR TITLE
feat(upgrade): allow setting the angularjs lib at runtime

### DIFF
--- a/packages/upgrade/src/common/angular1.ts
+++ b/packages/upgrade/src/common/angular1.ts
@@ -201,6 +201,7 @@ function noNg() {
   throw new Error('AngularJS v1.x is not loaded!');
 }
 
+
 let angular: {
   bootstrap: (e: Element, modules: (string | IInjectable)[], config: IAngularBootstrapConfig) =>
                  void,
@@ -208,27 +209,62 @@ let angular: {
   element: (e: Element | string) => IAugmentedJQuery,
   version: {major: number}, resumeBootstrap?: () => void,
   getTestability: (e: Element) => ITestabilityService
-} = <any>{
-  bootstrap: noNg,
-  module: noNg,
-  element: noNg,
-  version: noNg,
-  resumeBootstrap: noNg,
-  getTestability: noNg
 };
-
 
 try {
   if (window.hasOwnProperty('angular')) {
-    angular = (<any>window).angular;
+    setAngularLib((<any>window).angular);
   }
 } catch (e) {
-  // ignore in CJS mode.
+  setAngularLib(<any>{
+    bootstrap: noNg,
+    module: noNg,
+    element: noNg,
+    version: noNg,
+    resumeBootstrap: noNg,
+    getTestability: noNg
+  });
 }
 
-export const bootstrap = angular.bootstrap;
-export const module = angular.module;
-export const element = angular.element;
+/**
+ * Resets the AngularJS library.
+ *
+ * Used when angularjs is loaded lazily, and not available on `window`.
+ *
+ * @stable
+ */
+export function setAngularLib(ng: any): void {
+  angular = ng;
+}
+
+/**
+ * Returns the current version of the AngularJS library.
+ *
+ * @stable
+ */
+export function getAngularLib(): any {
+  return angular;
+}
+
+export function bootstrap(
+    e: Element, modules: (string | IInjectable)[], config: IAngularBootstrapConfig): void {
+  angular.bootstrap(e, modules, config);
+}
+
+export function module(prefix: string, dependencies?: string[]): IModule {
+  return angular.module(prefix, dependencies);
+}
+
+export function element(e: Element | string): IAugmentedJQuery {
+  return angular.element(e);
+}
+
+export function resumeBootstrap(): void {
+  angular.resumeBootstrap();
+}
+
+export function getTestability(e: Element): ITestabilityService {
+  return angular.getTestability(e);
+}
+
 export const version = angular.version;
-export const resumeBootstrap = angular.resumeBootstrap;
-export const getTestability = angular.getTestability;

--- a/packages/upgrade/static/public_api.ts
+++ b/packages/upgrade/static/public_api.ts
@@ -12,6 +12,7 @@
  * Entry point for all public APIs of the upgrade/static package, allowing
  * Angular 1 and Angular 2+ to run side by side in the same application.
  */
+export {getAngularLib, setAngularLib} from './src/common/angular1';
 export {downgradeComponent} from './src/common/downgrade_component';
 export {downgradeInjectable} from './src/common/downgrade_injectable';
 export {VERSION} from './src/common/version';

--- a/tools/public_api_guard/upgrade/static.d.ts
+++ b/tools/public_api_guard/upgrade/static.d.ts
@@ -9,6 +9,12 @@ export declare function downgradeComponent(info: {
 /** @experimental */
 export declare function downgradeInjectable(token: any): Function;
 
+/** @stable */
+export declare function getAngularLib(): any;
+
+/** @stable */
+export declare function setAngularLib(ng: any): void;
+
 /** @experimental */
 export declare class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     constructor(name: string, elementRef: ElementRef, injector: Injector);


### PR DESCRIPTION
This PR adds an ability to reset the angularjs library, which is often needed when Angular
is loaded lazily using RequireJS.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Currently it is not possible to reset the angular lib at runtime when using ngupgrade. This is problematic for many apps that load angularjs lazily. 

**What is the new behavior?**

Now it is possible.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

