### PR TITLE
fix(core): use presence of .subscribe to detect observables rather than Symbol.observable

### DIFF
--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -16,7 +16,6 @@ export default {
     'rxjs/Subject': 'Rx',
     'rxjs/Observer': 'Rx',
     'rxjs/Subscription': 'Rx',
-    'rxjs/symbol/observable': 'Rx.Symbol.observable',
     'rxjs/observable/merge': 'Rx.Observable',
     'rxjs/operator/share': 'Rx.Observable.prototype'
   }

--- a/packages/core/src/util/lang.ts
+++ b/packages/core/src/util/lang.ts
@@ -7,7 +7,6 @@
  */
 
 import {Observable} from 'rxjs/Observable';
-import {$$observable as symbolObservable} from 'rxjs/symbol/observable';
 
 /**
  * Determine if the argument is shaped like a Promise
@@ -22,7 +21,8 @@ export function isPromise(obj: any): obj is Promise<any> {
  * Determine if the argument is an Observable
  */
 export function isObservable(obj: any | Observable<any>): obj is Observable<any> {
-  return !!(obj && obj[symbolObservable]);
+  // TODO use Symbol.observable when https://github.com/ReactiveX/rxjs/issues/2415 will be resolved
+  return !!obj && typeof obj.subscribe === 'function';
 }
 
 // TODO(misko): replace with Object.assign once we require ES6.

--- a/packages/core/test/util/lang_spec.ts
+++ b/packages/core/test/util/lang_spec.ts
@@ -30,6 +30,9 @@ export function main() {
   describe('isObservable', () => {
     it('should be true for an Observable', () => expect(isObservable(of (true))).toEqual(true));
 
+    it('should be true if the argument is the object with subscribe function',
+       () => expect(isObservable({subscribe: () => {}})).toEqual(true));
+
     it('should be false if the argument is undefined',
        () => expect(isObservable(undefined)).toEqual(false));
 
@@ -40,8 +43,5 @@ export function main() {
 
     it('should be false if the argument is a function',
        () => expect(isObservable(() => {})).toEqual(false));
-
-    it('should be false if the argument is the object with subscribe function',
-       () => expect(isObservable({subscribe: () => {}})).toEqual(false));
   });
 }


### PR DESCRIPTION
Fixes #14298
Fixes #14473
Fixes #14926

cc @jasonaden