### PR TITLE
ci: remove unused import from integration test

### DIFF
--- a/packages/compiler-cli/integrationtest/src/module.ts
+++ b/packages/compiler-cli/integrationtest/src/module.ts
@@ -20,7 +20,7 @@ import {MultipleComponentsMyComp, NextComp} from './a/multiple_components';
 import {AnimateCmp} from './animate';
 import {BasicComp} from './basic';
 import {ComponentUsingThirdParty} from './comp_using_3rdp';
-import {CUSTOM, Named} from './custom_token';
+import {CUSTOM} from './custom_token';
 import {CompWithAnalyzeEntryComponentsProvider, CompWithEntryComponents} from './entry_components';
 import {CompConsumingEvents, CompUsingPipes, CompWithProviders, CompWithReferences, DirPublishingEvents, ModuleUsingCustomElements} from './features';
 import {CompUsingRootModuleDirectiveAndPipe, SomeDirectiveInRootModule, SomeLibModule, SomePipeInRootModule, SomeService} from './module_fixtures';


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] CI related changes
```

**What is the current behavior?** (You can also link to an open issue here)

Integration tests are failing due to an unused import.

**What is the new behavior?**

Unused import removed.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
