### PR TITLE
build(tsc-wrapped): update tsickle to version 0.21.6

### DIFF
--- a/npm-shrinkwrap.clean.json
+++ b/npm-shrinkwrap.clean.json
@@ -6166,7 +6166,7 @@
       }
     },
     "tsickle": {
-      "version": "0.21.5",
+      "version": "0.21.6",
       "dev": true
     },
     "tslint": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9016,9 +9016,9 @@
       }
     },
     "tsickle": {
-      "version": "0.21.5",
-      "from": "tsickle@0.21.5",
-      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.21.5.tgz",
+      "version": "0.21.6",
+      "from": "tsickle@0.21.6",
+      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.21.6.tgz",
       "dev": true
     },
     "tslint": {

--- a/tools/@angular/tsc-wrapped/test/main.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/main.spec.ts
@@ -284,8 +284,45 @@ describe('tsc-wrapped', () => {
     // Provide a file called test.ts that has an inline source map
     // which says that it was transpiled from a file other_test.ts
     // with exactly the same content.
+    const inputSourceMap =
+        `{"version":3,"sources":["other_test.ts"],"names":[],"mappings":"AAAA,MAAM,EAAE,EAAE,CAAC","file":"../test.ts","sourceRoot":""}`;
+    const encodedSourceMap = new Buffer(inputSourceMap, 'utf8').toString('base64');
     write('test.ts', `const x = 3;
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm90aGVyX3Rlc3QudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsTUFBTSxFQUFFLEVBQUUsQ0FBQyIsImZpbGUiOiIuLi90ZXN0LnRzIiwic291cmNlUm9vdCI6IiJ9`);
+//# sourceMappingURL=data:application/json;base64,${encodedSourceMap}`);
+
+    main(basePath, {basePath})
+        .then(() => {
+          const out = readOut('js.map');
+          expect(out).toContain('"sources":["other_test.ts"]');
+          done();
+        })
+        .catch(e => done.fail(e));
+  });
+
+  it(`should accept input source maps that don't match the file name`, (done) => {
+    write('tsconfig.json', `{
+      "compilerOptions": {
+        "experimentalDecorators": true,
+        "types": [],
+        "outDir": "built",
+        "declaration": true,
+        "moduleResolution": "node",
+        "target": "es2015",
+        "sourceMap": true
+      },
+      "angularCompilerOptions": {
+        "annotateForClosureCompiler": true
+      },
+      "files": ["test.ts"]
+    }`);
+    // Provide a file called test.ts that has an inline source map
+    // which says that it was transpiled from a file other_test.ts
+    // with exactly the same content.
+    const inputSourceMap =
+        `{"version":3,"sources":["other_test.ts"],"names":[],"mappings":"AAAA,MAAM,EAAE,EAAE,CAAC","file":"test.ts","sourceRoot":""}`;
+    const encodedSourceMap = new Buffer(inputSourceMap, 'utf8').toString('base64');
+    write('test.ts', `const x = 3;
+//# sourceMappingURL=data:application/json;base64,${encodedSourceMap}`);
 
     main(basePath, {basePath})
         .then(() => {


### PR DESCRIPTION
Update tsickle to version 0.21.6 which fixes a bug where input source maps which specified filenames differently than the names supplied to tsc didn't get composed with tsc's source maps.  Also adds a test that the bug was fixed.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

