### PR TITLE
feat(aio): add FileLoaderService in Http, XHR and Webpack favors

### DIFF
--- a/aio/e2e/app.e2e-spec.ts
+++ b/aio/e2e/app.e2e-spec.ts
@@ -17,6 +17,14 @@ describe('site App', function() {
 
   it('should convert a doc with a code-example');
 
+  describe('api-docs', () => {
+    it('should show a link to github', () => {
+      page.navigateTo('api/common/NgClass');
+      expect(page.ghLink.getAttribute('href'))
+          .toMatch(/https:\/\/github.com\/angular\/angular\/tree\/.+\/packages\/common\/src\/directives\/ng_class\.ts/);
+    });
+  });
+
   describe('google analytics', () => {
     beforeEach(done => page.gaReady.then(done));
 

--- a/aio/e2e/app.po.ts
+++ b/aio/e2e/app.po.ts
@@ -1,16 +1,22 @@
-import { browser, element, by, promise } from 'protractor';
+import { browser, element, by, promise, ElementFinder } from 'protractor';
+
+const githubRegex = /https:\/\/github.com\/angular\/angular\//;
 
 export class SitePage {
   links = element.all(by.css('md-toolbar a'));
   docViewer = element(by.css('aio-doc-viewer'));
   codeExample = element.all(by.css('aio-doc-viewer pre > code'));
+  ghLink = this.docViewer
+    .all(by.css('a'))
+    .filter((a: ElementFinder) => a.getAttribute('href').then(href => githubRegex.test(href)))
+    .first();
   featureLink = element(by.css('md-toolbar a[href="features"]'));
   gaReady: promise.Promise<any>;
   ga = () => browser.executeScript('return window["gaCalls"]') as promise.Promise<any[][]>;
   locationPath = () => browser.executeScript('return document.location.pathname') as promise.Promise<string>;
 
-  navigateTo() {
-    return browser.get('/').then(_ => this.replaceGa(_));
+  navigateTo(pageUrl = '') {
+    return browser.get('/' + pageUrl).then(_ => this.replaceGa(_));
   }
 
   getDocViewerText() {

--- a/aio/package.json
+++ b/aio/package.json
@@ -58,7 +58,7 @@
     "codelyzer": "~2.0.0-beta.4",
     "concurrently": "^3.4.0",
     "dgeni": "^0.4.7",
-    "dgeni-packages": "^0.16.8",
+    "dgeni-packages": "0.17.0",
     "entities": "^1.1.1",
     "firebase-tools": "^3.2.1",
     "gulp": "^3.9.1",

--- a/aio/package.json
+++ b/aio/package.json
@@ -43,7 +43,7 @@
     "@angular/platform-browser-dynamic": "next",
     "@angular/platform-server": "next",
     "@angular/router": "next",
-    "@angular/service-worker": "^1.0.0-beta.6",
+    "@angular/service-worker": "^1.0.0-beta.7",
     "core-js": "^2.4.1",
     "rxjs": "^5.1.0",
     "ts-helpers": "^1.1.1",

--- a/aio/src/app/app.module.ts
+++ b/aio/src/app/app.module.ts
@@ -19,7 +19,9 @@ import { ApiService } from 'app/embedded/api/api.service';
 import { DocViewerComponent } from 'app/layout/doc-viewer/doc-viewer.component';
 import { embeddedComponents, EmbeddedComponents } from 'app/embedded';
 
-import { FileLoaderProviders } from 'app/shared/file-loader-webpack.service';
+import { HttpModule } from '@angular/http';
+import { FileLoaderProviders } from 'app/shared/file-loader-http.service';
+// import { FileLoaderProviders } from 'app/shared/file-loader-webpack.service';
 // import { FileLoaderProviders } from 'app/shared/file-loader-xhr.service';
 
 import { GaService } from 'app/shared/ga.service';
@@ -38,6 +40,7 @@ import { AutoScrollService } from 'app/shared/auto-scroll.service';
 @NgModule({
   imports: [
     BrowserModule,
+    HttpModule,  // <- Delete if we use a non-Http FileLoaderService
     MdButtonModule,
     MdIconModule,
     MdInputModule,

--- a/aio/src/app/app.module.ts
+++ b/aio/src/app/app.module.ts
@@ -1,6 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { HttpModule } from '@angular/http';
 
 import { Location, LocationStrategy, PathLocationStrategy } from '@angular/common';
 
@@ -19,6 +18,10 @@ import { AppComponent } from 'app/app.component';
 import { ApiService } from 'app/embedded/api/api.service';
 import { DocViewerComponent } from 'app/layout/doc-viewer/doc-viewer.component';
 import { embeddedComponents, EmbeddedComponents } from 'app/embedded';
+
+// import { FileLoaderProviders } from 'app/shared/file-loader-webpack.service';
+import { FileLoaderProviders } from 'app/shared/file-loader-xhr.service';
+
 import { GaService } from 'app/shared/ga.service';
 import { Logger } from 'app/shared/logger.service';
 import { LocationService } from 'app/shared/location.service';
@@ -35,7 +38,6 @@ import { AutoScrollService } from 'app/shared/auto-scroll.service';
 @NgModule({
   imports: [
     BrowserModule,
-    HttpModule,
     MdButtonModule,
     MdIconModule,
     MdInputModule,
@@ -55,6 +57,7 @@ import { AutoScrollService } from 'app/shared/auto-scroll.service';
   providers: [
     ApiService,
     EmbeddedComponents,
+    FileLoaderProviders,
     GaService,
     Logger,
     Location,

--- a/aio/src/app/app.module.ts
+++ b/aio/src/app/app.module.ts
@@ -19,8 +19,8 @@ import { ApiService } from 'app/embedded/api/api.service';
 import { DocViewerComponent } from 'app/layout/doc-viewer/doc-viewer.component';
 import { embeddedComponents, EmbeddedComponents } from 'app/embedded';
 
-// import { FileLoaderProviders } from 'app/shared/file-loader-webpack.service';
-import { FileLoaderProviders } from 'app/shared/file-loader-xhr.service';
+import { FileLoaderProviders } from 'app/shared/file-loader-webpack.service';
+// import { FileLoaderProviders } from 'app/shared/file-loader-xhr.service';
 
 import { GaService } from 'app/shared/ga.service';
 import { Logger } from 'app/shared/logger.service';

--- a/aio/src/app/documents/document.service.spec.ts
+++ b/aio/src/app/documents/document.service.spec.ts
@@ -1,39 +1,32 @@
 import { ReflectiveInjector } from '@angular/core';
-import { Http, ConnectionBackend, RequestOptions, BaseRequestOptions, Response, ResponseOptions } from '@angular/http';
 
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
-import { MockBackend } from '@angular/http/testing';
+import { FileLoaderService } from 'app/shared/file-loader.service';
+import { TestFileLoaderService } from 'testing/file-loader.service';
 import { LocationService } from 'app/shared/location.service';
 import { MockLocationService } from 'testing/location.service';
 import { Logger } from 'app/shared/logger.service';
 import { MockLogger } from 'testing/logger.service';
 import { DocumentService, DocumentContents } from './document.service';
 
-
-const CONTENT_URL_PREFIX = 'content/docs/';
-
-function createResponse(body: any) {
-  return new Response(new ResponseOptions({ body: JSON.stringify(body) }));
-}
+const CONTENT_URL_PREFIX = 'docs/';
 
 function createInjector(initialUrl: string) {
   return ReflectiveInjector.resolveAndCreate([
       DocumentService,
       { provide: LocationService, useFactory: () => new MockLocationService(initialUrl) },
-      { provide: ConnectionBackend, useClass: MockBackend },
-      { provide: RequestOptions, useClass: BaseRequestOptions },
-      { provide: Logger, useClass: MockLogger },
-      Http,
+        { provide: FileLoaderService, useClass: TestFileLoaderService },
+      { provide: Logger, useClass: MockLogger }
   ]);
 }
 
 function getServices(initialUrl: string = '') {
   const injector = createInjector(initialUrl);
   return {
-    backend: injector.get(ConnectionBackend) as MockBackend,
+    loader: injector.get(FileLoaderService) as TestFileLoaderService,
     location: injector.get(LocationService) as MockLocationService,
     service: injector.get(DocumentService) as DocumentService,
     logger: injector.get(Logger) as MockLogger
@@ -50,58 +43,58 @@ describe('DocumentService', () => {
   describe('currentDocument', () => {
 
     it('should fetch a document for the initial location url', () => {
-      const { service, backend } = getServices('initial/url');
-      const connections = backend.connectionsArray;
+      const { service, loader } = getServices('initial/url');
+      const connections = loader.connectionsArray;
       service.currentDocument.subscribe();
 
       expect(connections.length).toEqual(1);
-      expect(connections[0].request.url).toEqual(CONTENT_URL_PREFIX + 'initial/url.json');
-      expect(backend.connectionsArray[0].request.url).toEqual(CONTENT_URL_PREFIX + 'initial/url.json');
+      expect(connections[0].url).toEqual(CONTENT_URL_PREFIX + 'initial/url.json');
+      expect(loader.connectionsArray[0].url).toEqual(CONTENT_URL_PREFIX + 'initial/url.json');
     });
 
     it('should emit a document each time the location changes', () => {
       let latestDocument: DocumentContents;
       const doc0 = { title: 'doc 0' };
       const doc1 = { title: 'doc 1' };
-      const { service, backend, location } = getServices('initial/url');
-      const connections = backend.connectionsArray;
+      const { service, loader, location } = getServices('initial/url');
+      const connections = loader.connectionsArray;
 
       service.currentDocument.subscribe(doc => latestDocument = doc);
       expect(latestDocument).toBeUndefined();
 
-      connections[0].mockRespond(createResponse(doc0));
+      connections[0].mockRespond(doc0);
       expect(latestDocument).toEqual(doc0);
 
       location.urlSubject.next('new/url');
-      connections[1].mockRespond(createResponse(doc1));
+      connections[1].mockRespond(doc1);
       expect(latestDocument).toEqual(doc1);
     });
 
     it('should emit the not-found document if the document is not found on the server', () => {
-      const { service, backend } = getServices('missing/url');
-      const connections = backend.connectionsArray;
+      const { service, loader } = getServices('missing/url');
+      const connections = loader.connectionsArray;
       service.currentDocument.subscribe();
 
-      connections[0].mockError(new Response(new ResponseOptions({ status: 404, statusText: 'NOT FOUND'})) as any);
+      connections[0].mockRespond(undefined, { status: 404, statusText: 'NOT FOUND'});
       expect(connections.length).toEqual(2);
-      expect(connections[1].request.url).toEqual(CONTENT_URL_PREFIX + 'file-not-found.json');
+      expect(connections[1].url).toEqual(CONTENT_URL_PREFIX + 'file-not-found.json');
     });
 
     it('should emit a hard-coded not-found document if the not-found document is not found on the server', () => {
       let currentDocument: DocumentContents;
       const notFoundDoc = { title: 'Not Found', contents: 'Document not found' };
       const nextDoc = { title: 'Next Doc' };
-      const { service, backend, location } = getServices('file-not-found');
-      const connections = backend.connectionsArray;
+      const { service, loader, location } = getServices('file-not-found');
+      const connections = loader.connectionsArray;
       service.currentDocument.subscribe(doc => currentDocument = doc);
 
-      connections[0].mockError(new Response(new ResponseOptions({ status: 404, statusText: 'NOT FOUND'})) as any);
+      connections[0].mockRespond(null, { status: 404, statusText: 'NOT FOUND'});
       expect(connections.length).toEqual(1);
       expect(currentDocument).toEqual(notFoundDoc);
 
       // now check that we haven't killed the currentDocument observable sequence
       location.urlSubject.next('new/url');
-      connections[1].mockRespond(createResponse(nextDoc));
+      connections[1].mockRespond(nextDoc);
       expect(currentDocument).toEqual(nextDoc);
     });
 
@@ -111,27 +104,27 @@ describe('DocumentService', () => {
 
       const doc0 = { title: 'doc 0' };
       const doc1 = { title: 'doc 1' };
-      const { service, backend, location } = getServices('url/0');
-      const connections = backend.connectionsArray;
+      const { service, loader, location } = getServices('url/0');
+      const connections = loader.connectionsArray;
 
       subscription = service.currentDocument.subscribe(doc => latestDocument = doc);
       expect(connections.length).toEqual(1);
-      connections[0].mockRespond(createResponse(doc0));
+      connections[0].mockRespond(doc0);
       expect(latestDocument).toEqual(doc0);
       subscription.unsubscribe();
 
       // modify the response so we can check that future subscriptions do not trigger another request
-      connections[0].response.next(createResponse({ title: 'error 0' }));
+      connections[0].mockRespond({ title: 'error 0' });
 
       subscription = service.currentDocument.subscribe(doc => latestDocument = doc);
       location.urlSubject.next('url/1');
       expect(connections.length).toEqual(2);
-      connections[1].mockRespond(createResponse(doc1));
+      connections[1].mockRespond(doc1);
       expect(latestDocument).toEqual(doc1);
       subscription.unsubscribe();
 
       // modify the response so we can check that future subscriptions do not trigger another request
-      connections[1].response.next(createResponse({ title: 'error 1' }));
+      connections[1].mockRespond({ title: 'error 1' });
 
       subscription = service.currentDocument.subscribe(doc => latestDocument = doc);
       location.urlSubject.next('url/0');
@@ -150,10 +143,10 @@ describe('DocumentService', () => {
   describe('computeMap', () => {
     it('should map the "empty" location to the correct document request', () => {
       let latestDocument: DocumentContents;
-      const { service, backend } = getServices();
+      const { service, loader } = getServices();
       service.currentDocument.subscribe(doc => latestDocument = doc);
 
-      expect(backend.connectionsArray[0].request.url).toEqual(CONTENT_URL_PREFIX + 'index.json');
+      expect(loader.connectionsArray[0].url).toEqual(CONTENT_URL_PREFIX + 'index.json');
     });
   });
 });

--- a/aio/src/app/documents/document.service.ts
+++ b/aio/src/app/documents/document.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Http, Response } from '@angular/http';
+import { FileLoaderService, Response } from 'app/shared/file-loader.service';
 
 import { Observable } from 'rxjs/Observable';
 import { AsyncSubject } from 'rxjs/AsyncSubject';
@@ -23,7 +23,7 @@ export class DocumentService {
 
   constructor(
     private logger: Logger,
-    private http: Http,
+    private loader: FileLoaderService,
     location: LocationService) {
     // Whenever the URL changes we try to get the appropriate doc
     this.currentDocument = location.currentUrl.switchMap(url => this.getDocument(url));
@@ -41,8 +41,8 @@ export class DocumentService {
   private fetchDocument(path: string) {
     this.logger.log('fetching document from', path);
     const subject = new AsyncSubject();
-    this.http
-      .get(path)
+    this.loader
+      .load(path)
       .map(res => res.json())
       .catch((error: Response) => {
         if (error.status === 404) {
@@ -65,6 +65,6 @@ export class DocumentService {
     url = url.match(/[^#?]*/)[0]; // strip off fragment and query
     url = '/' + url;
     url = url.endsWith('/') ? url + 'index' : url;
-    return 'content/docs' + url + '.json';
+    return 'docs' + url + '.json';
   }
 }

--- a/aio/src/app/embedded/api/api.service.ts
+++ b/aio/src/app/embedded/api/api.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { Http } from '@angular/http';
 
 import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { Subject } from 'rxjs/Subject';
@@ -7,6 +6,7 @@ import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/takeUntil';
 
+import { FileLoaderService } from 'app/shared/file-loader.service';
 import { Logger } from 'app/shared/logger.service';
 
 export interface ApiItem {
@@ -29,7 +29,7 @@ export interface ApiSection {
 @Injectable()
 export class ApiService implements OnDestroy {
 
-  private apiBase = 'content/docs/api/';
+  private apiBase = 'docs/api/';
   private apiListJsonDefault = 'api-list.json';
   private firstTime = true;
   private onDestroy = new Subject();
@@ -53,7 +53,7 @@ export class ApiService implements OnDestroy {
     return this._sections;
   };
 
-  constructor(private http: Http, private logger: Logger) { }
+  constructor(private loader: FileLoaderService, private logger: Logger) { }
 
   ngOnDestroy() {
     this.onDestroy.next();
@@ -69,7 +69,7 @@ export class ApiService implements OnDestroy {
   fetchSections(src?: string) {
     // TODO: get URL by configuration?
     const url = this.apiBase + (src || this.apiListJsonDefault);
-    this.http.get(url)
+    this.loader.load(url)
       .takeUntil(this.onDestroy)
       .map(response => response.json())
       .do(() => this.logger.log(`Got API sections from ${url}`))

--- a/aio/src/app/layout/nav-item/nav-item.component.ts
+++ b/aio/src/app/layout/nav-item/nav-item.component.ts
@@ -17,6 +17,7 @@ export class NavItemComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (changes['selectedNodes'] || changes['node']) {
       this.isSelected = this.selectedNodes.indexOf(this.node) !== -1;
+      this.isExpanded = this.isExpanded || this.isSelected;
     }
     this.setClasses();
   }

--- a/aio/src/app/navigation/navigation.service.ts
+++ b/aio/src/app/navigation/navigation.service.ts
@@ -11,12 +11,13 @@ import { LocationService } from 'app/shared/location.service';
 
 import { NavigationNode } from './navigation-node';
 export { NavigationNode } from './navigation-node';
+import { FileLoaderService } from 'app/shared/file-loader.service';
 
 export interface NavigationViews {
   [name: string]: NavigationNode[];
 }
 
-const navigationPath = 'content/navigation.json';
+const navigationPath = 'navigation.json';
 
 @Injectable()
 export class NavigationService {
@@ -30,7 +31,7 @@ export class NavigationService {
    */
   selectedNodes = this.getSelectedNodes();
 
-  constructor(private http: Http, private location: LocationService, private logger: Logger) { }
+  constructor(private loader: FileLoaderService, private location: LocationService, private logger: Logger) { }
 
   /**
    * Get an observable that fetches the `NavigationViews` from the server.
@@ -44,7 +45,7 @@ export class NavigationService {
    * We are not storing the subscription from connecting as we do not expect this service to be destroyed.
    */
   private fetchNavigationViews(): Observable<NavigationViews> {
-    const navigationViews = this.http.get(navigationPath)
+    const navigationViews = this.loader.load(navigationPath)
              .map(res => res.json() as NavigationViews)
              .publishLast();
     navigationViews.connect();

--- a/aio/src/app/shared/file-loader-http.service.ts
+++ b/aio/src/app/shared/file-loader-http.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { Http, Headers, Response, ResponseOptions, ResponseType} from '@angular/http';
+export { Response }
+
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/throw';
+
+import { FileLoaderService} from './file-loader.service';
+
+
+@Injectable()
+export class HttpFileLoaderService {
+
+  constructor(private http: Http) {}
+
+  load(path: string) {
+    if (!path) {
+      const options = {
+        url: path, status: 400, statusText: 'Bad Request', body: 'No url',
+        type: ResponseType.Default, headers: new Headers()
+      };
+      const resp = new Response(new ResponseOptions(options));
+      return Observable.throw(resp);
+    }
+    return this.http.get('content/' + path);
+  }
+}
+
+export const FileLoaderProviders = [
+  { provide: FileLoaderService, useClass: HttpFileLoaderService }
+];

--- a/aio/src/app/shared/file-loader-webpack.service.ts
+++ b/aio/src/app/shared/file-loader-webpack.service.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+
+import { FileLoaderService, Response } from './file-loader.service';
+export { Response }
+
+declare const System: { import: (string) => Promise<Response> };
+
+// tslint:disable-next-line:class-name
+class Response_ implements Response {
+    ok: boolean;
+    url: string;
+    status: number;
+    statusText: string;
+    json: () => any;
+    text: () => string;
+
+    constructor({url, status, statusText, body}: {
+      url?: string,
+      status?: number,
+      statusText?: string,
+      body?: any
+    }) {
+      this.url = url || '';
+      this.status = status || 0;
+      this.ok = this.status >= 200 && this.status < 300;
+      this.statusText = statusText || (this.ok ? 'ok' : '');
+
+      if (typeof body === 'string') {
+        this.json = () => JSON.parse(body || '{}');
+        this.text = () => body;
+      } else {
+        this.json = () => body;
+        this.text = () => JSON.stringify(body);
+      }
+    }
+
+    toString() {
+      return `${this.status}: ${this.url}`;
+    };
+}
+
+@Injectable()
+export class WebpackFileLoaderService {
+
+  load(path: string) {
+    let url: string;
+
+    return new Observable<Response>(observer => {
+      try {
+        if (!path) {
+          observer.error(
+            new Response_({url: path, status: 400, statusText: 'Bad Request', body: 'No url'})
+          );
+          return;
+        }
+
+        const jsonIx = path.lastIndexOf('.json');
+        if (jsonIx > - 1) { path = path.substr(0, jsonIx); }
+        url = 'content/' + path + '.json';
+
+        // note: System.import arg must be literals exactly like the following.
+        // The prefix must be relative to the app root folder.
+        System.import('../../content/' + path + '.json').then(
+          text => {
+            observer.next(new Response_({url, body: text}));
+            observer.complete();
+          },
+          errorHandler
+        );
+      } catch (err) {
+        errorHandler(err);
+      }
+
+      function errorHandler(err: any) {
+        const respArgs = (err && /Cannot find/.test(err.message)) ?
+          { url, status: 404, statusText: 'Not Found' } :
+          { url, status: 500, statusText: 'Server or application error', body: err };
+          observer.error(new Response_(respArgs));
+      }
+    });
+
+  }
+}
+
+export const FileLoaderProviders = [
+  { provide: FileLoaderService, useClass: WebpackFileLoaderService }
+];

--- a/aio/src/app/shared/file-loader-xhr.service.ts
+++ b/aio/src/app/shared/file-loader-xhr.service.ts
@@ -1,0 +1,102 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+
+import { FileLoaderService, Response } from './file-loader.service';
+export { Response }
+
+/**
+ * All possible states in which a connection can be, based on
+ * [States](http://www.w3.org/TR/XMLHttpRequest/#states) from the `XMLHttpRequest` spec
+ */
+enum ReadyState {
+    Unsent = 0,
+    Open = 1,
+    HeadersReceived = 2,
+    Loading = 3,
+    Done = 4
+}
+
+// tslint:disable-next-line:class-name
+class Response_ implements Response {
+    ok: boolean;
+    url: string;
+    status: number;
+    statusText: string;
+    private _body: string;
+
+    json(): any {
+      return JSON.parse(this._body || '{}');
+    };
+
+    text(): string { return (this._body || '').toString(); }
+
+    constructor({url, status, statusText, body}: {
+      url?: string,
+      status?: number,
+      statusText?: string,
+      body?: any
+    }) {
+      this.url = url || '';
+      this.status = status || 0;
+      this._body = body;
+      this.ok = this.status >= 200 && this.status < 300;
+      this.statusText = statusText || (this.ok ? 'ok' : '');
+    }
+
+    toString() {
+      return `${this.status}: ${this.url}`;
+    };
+}
+
+const fileRoot = 'content/';
+
+@Injectable()
+export class XhrFileLoaderService {
+  load(url: string) {
+    return new Observable<Response>(observer => {
+      if (!url) {
+        observer.error(
+          new Response_({url, status: 400, statusText: 'Bad Request', body: 'No url'})
+        );
+        return;
+      }
+
+      let xhr = new XMLHttpRequest();
+      xhr.onload = complete;
+      xhr.onerror = failed;
+      xhr.open('GET', fileRoot + url);
+      xhr.send();
+
+      function complete (evt) {
+        const { responseURL, status, statusText, responseText: body } = evt.srcElement;
+        const resp: Response = new Response_({url: responseURL, status, statusText, body});
+        if (resp.ok) {
+          observer.next(resp);
+          observer.complete();
+        } else {
+          observer.error(resp);
+        }
+      }
+
+      function failed(evt) {
+        // Todo: learn about error events, what causes them, and whether this is right.
+        const { responseURL, status, statusText, responseText: body } = evt.srcElement;
+        const resp: Response = new Response_({url: responseURL, status, statusText, body});
+        observer.error(resp);
+      }
+
+      function unsubscribe() {
+          if (xhr && xhr.readyState < 4) {
+            xhr.abort();
+          }
+          xhr = undefined;
+      }
+
+      return { unsubscribe };
+    });
+  }
+}
+
+export const FileLoaderProviders = [
+  { provide: FileLoaderService, useClass: XhrFileLoaderService }
+];

--- a/aio/src/app/shared/file-loader-xhr.service.ts
+++ b/aio/src/app/shared/file-loader-xhr.service.ts
@@ -48,15 +48,13 @@ class Response_ implements Response {
     };
 }
 
-const fileRoot = 'content/';
-
 @Injectable()
 export class XhrFileLoaderService {
-  load(url: string) {
+  load(path: string) {
     return new Observable<Response>(observer => {
-      if (!url) {
+      if (!path) {
         observer.error(
-          new Response_({url, status: 400, statusText: 'Bad Request', body: 'No url'})
+          new Response_({url: path, status: 400, statusText: 'Bad Request', body: 'No url'})
         );
         return;
       }
@@ -64,7 +62,7 @@ export class XhrFileLoaderService {
       let xhr = new XMLHttpRequest();
       xhr.onload = complete;
       xhr.onerror = failed;
-      xhr.open('GET', fileRoot + url);
+      xhr.open('GET', 'content/' + path);
       xhr.send();
 
       function complete (evt) {

--- a/aio/src/app/shared/file-loader.service.spec.ts
+++ b/aio/src/app/shared/file-loader.service.spec.ts
@@ -1,5 +1,5 @@
-// import { WebpackFileLoaderService as FileLoaderService } from './file-loader-webpack.service';
-import { XhrFileLoaderService as FileLoaderService } from './file-loader-xhr.service';
+import { WebpackFileLoaderService as FileLoaderService } from './file-loader-webpack.service';
+// import { XhrFileLoaderService as FileLoaderService } from './file-loader-xhr.service';
 
 import 'rxjs/add/operator/map';
 

--- a/aio/src/app/shared/file-loader.service.spec.ts
+++ b/aio/src/app/shared/file-loader.service.spec.ts
@@ -1,4 +1,5 @@
-import { WebpackFileLoaderService as FileLoaderService } from './file-loader-webpack.service';
+import { HttpFileLoaderService as FileLoaderService } from './file-loader-http.service';
+// import { WebpackFileLoaderService as FileLoaderService } from './file-loader-webpack.service';
 // import { XhrFileLoaderService as FileLoaderService } from './file-loader-xhr.service';
 
 import 'rxjs/add/operator/map';
@@ -10,7 +11,8 @@ describe('FileLoaderService', () => {
   let service: FileLoaderService;
 
   beforeEach(() => {
-    service = new FileLoaderService();
+    // service = new FileLoaderService();
+    service = createHttpFileLoaderService();
   });
 
   it(`should get '${navJsonUrl}'`, done => {
@@ -79,9 +81,39 @@ describe('FileLoaderService', () => {
   }, 500);
 });
 
-//// Helpers /////
-class TestLogger {
-  log = jasmine.createSpy('log');
-  error = jasmine.createSpy('error');
-  warn = jasmine.createSpy('warn');
+/// HELPERS BELOW ARE ONLY FOR HTTP VERSION OF FileLoaderService
+
+// These imports needed only by the TestHttp class
+import { Http, Headers, Response, ResponseOptions, ResponseType} from '@angular/http';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
+import 'rxjs/add/observable/throw';
+
+function createHttpFileLoaderService() {
+  return new FileLoaderService(<Http> <any> new TestHttp());
+}
+
+class TestHttp {
+
+  get = jasmine.createSpy('get').and.callFake((url: string) => {
+
+    if (url && url.indexOf('navigation.json') > -1) {
+      const options = {
+        url,  status: 200, statusText: 'ok',
+        type: ResponseType.Default, headers: new Headers(),
+        body: '{ "SideNav": {}, "TopBar": {} }'
+      };
+      const resp = new Response(new ResponseOptions(options));
+      return of(resp);
+
+    // any other url is 404-Not found
+    } else {
+      const options = {
+        url,  status: 404, statusText: 'Not Found',
+        type: ResponseType.Default, headers: new Headers()
+      };
+      const resp = new Response(new ResponseOptions(options));
+      return Observable.throw(resp);
+    }
+  });
 }

--- a/aio/src/app/shared/file-loader.service.spec.ts
+++ b/aio/src/app/shared/file-loader.service.spec.ts
@@ -1,0 +1,87 @@
+// import { WebpackFileLoaderService as FileLoaderService } from './file-loader-webpack.service';
+import { XhrFileLoaderService as FileLoaderService } from './file-loader-xhr.service';
+
+import 'rxjs/add/operator/map';
+
+describe('FileLoaderService', () => {
+
+  const navJsonUrl = 'navigation.json';
+
+  let service: FileLoaderService;
+
+  beforeEach(() => {
+    service = new FileLoaderService();
+  });
+
+  it(`should get '${navJsonUrl}'`, done => {
+    const req = service.load(navJsonUrl);
+    req.subscribe(
+      resp => {
+        expect(resp.text().length).toBeGreaterThan(0, 'expect text');
+      },
+      err => {
+        fail(err);
+        done();
+      },
+      done
+    );
+
+  }, 500);
+
+  it(`should get navigation JSON from '${navJsonUrl}'`, done => {
+    const req = service.load(navJsonUrl).map(resp => resp.json());
+
+    req.subscribe(
+      data => {
+        expect(data['SideNav']).toBeDefined('expect SideNav JSON');
+        expect(data['TopBar']).toBeDefined('expect TopBar JSON');
+      },
+      err => {
+        fail(err);
+        done();
+      },
+      done
+    );
+  }, 500);
+
+  it(`should 404 for bad URL`, done => {
+    const req = service.load('this/is/bad');
+    req.subscribe(
+      resp => {
+        throw new Error('Should fail but got a success response');
+      },
+      err => {
+        expect(err).toBeDefined();
+        expect(err.status).toBe(404, 'status 404 - Not Found');
+        done();
+      },
+      () => {
+        throw new Error('Should fail and not complete');
+      }
+    );
+  }, 500);
+
+  it(`should 400 for empty URL`, done => {
+    const req = service.load(undefined);
+    req.subscribe(
+      resp => {
+        throw new Error('Should fail but got a success response');
+      },
+      err => {
+        expect(err).toBeDefined();
+        expect(err.status).toBe(400, 'status 400 - Bad Request');
+        done();
+      },
+      () => {
+        throw new Error('Should fail and not complete');
+      }
+    );
+  }, 500);
+});
+
+//// Helpers /////
+class TestLogger {
+  log = jasmine.createSpy('log');
+  error = jasmine.createSpy('error');
+  warn = jasmine.createSpy('warn');
+}

--- a/aio/src/app/shared/file-loader.service.ts
+++ b/aio/src/app/shared/file-loader.service.ts
@@ -1,0 +1,47 @@
+import { Observable } from 'rxjs/Observable';
+
+/*
+ * The Response interface is based on the Angular http module response
+ * which is inspired by the Response constructor defined in the
+ * [Fetch Spec](https://fetch.spec.whatwg.org/#response-class),
+ * but certain properties and methods are missing and
+ * the body can be accessed many times.
+ */
+export interface Response {
+    /**
+     * True if the response's status is within 200-299
+     */
+    ok: boolean;
+    /**
+     * URL of response.
+     *
+     * Defaults to empty string.
+     */
+    url: string;
+    /**
+     * Status code returned by server.
+     *
+     * Defaults to 200.
+     */
+    status: number;
+    /**
+     * Text representing the corresponding reason phrase to the `status`, as defined in [ietf rfc 2616
+     * section 6.1.1](https://tools.ietf.org/html/rfc2616#section-6.1.1)
+     *
+     * Defaults to "OK"
+     */
+    statusText: string;
+
+    /**
+     * Attempts to return body as parsed `JSON` object, or raises an exception.
+     */
+    json(): any ;
+    /**
+     * Returns the body as a string, presuming `toString()` can be called on the response body.
+     */
+    text(): string;
+}
+
+export abstract class FileLoaderService {
+  abstract load(url: string): Observable<Response>;
+}

--- a/aio/src/testing/file-loader.service.ts
+++ b/aio/src/testing/file-loader.service.ts
@@ -1,0 +1,59 @@
+import { FileLoaderService, Response } from 'app/shared/file-loader.service';
+
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import { Observer } from 'rxjs/Observer';
+
+export class TestConnection {
+    constructor(
+      public url: string,
+      private observer: Observer<Response>
+    ) { }
+
+    mockRespond(body: any, options = {}) {
+      body = options['body'] || body;
+
+      let json: () => any;
+      let text: () => string;
+
+      if (typeof body === 'string') {
+        json = () => JSON.parse(body || '{}');
+        text = () => body;
+      } else {
+        json = () => body;
+        text = () => JSON.stringify(body);
+      }
+
+      const response = {...{
+          ok: true,
+          url: this.url,
+          status: 200,
+          statusText: 'ok',
+          text,
+          json
+      }, ...options};
+
+      response.ok = response.status >= 200 && response.status < 300;
+
+      if (response.ok) {
+        this.observer.next(response);
+        this.observer.complete();
+      } else {
+        this.observer.error(response);
+      }
+    }
+}
+
+export class TestFileLoaderService {
+  private connectionSubject = new Subject<TestConnection>();
+  connections = this.connectionSubject as Observable<TestConnection>;
+  connectionsArray: TestConnection[] = [];
+
+  load(url: string) {
+    return new Observable(observer => {
+      const connection = new TestConnection(url, observer);
+      this.connectionsArray.push(connection);
+      this.connectionSubject.next(connection);
+    });
+  }
+}

--- a/aio/tools/prerender/constants.js
+++ b/aio/tools/prerender/constants.js
@@ -4,7 +4,7 @@
 const path = require('path');
 
 // Constants
-const BROWSER_INSTANCES = 7;
+const BROWSER_INSTANCES = 3;
 
 const PORT = 4201;
 const BASE_URL = `http://localhost:${PORT}`;

--- a/aio/transforms/templates/lib/githubLinks.html
+++ b/aio/transforms/templates/lib/githubLinks.html
@@ -1,5 +1,5 @@
 {% macro githubHref(doc, versionInfo) -%}
-https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInfo.repo $}/tree/{$ versionInfo.currentVersion.isSnapshot and versionInfo.currentVersion.SHA or versionInfo.currentVersion.raw $}/modules/{$ doc.fileInfo.projectRelativePath $}#L{$ doc.location.start.line+1 $}-L{$ doc.location.end.line+1 $}
+https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInfo.repo $}/tree/{$ versionInfo.currentVersion.isSnapshot and versionInfo.currentVersion.SHA or versionInfo.currentVersion.raw $}/packages/{$ doc.fileInfo.projectRelativePath $}#L{$ doc.location.start.line+1 $}-L{$ doc.location.end.line+1 $}
 {%- endmacro %}
 
 {% macro githubViewLink(doc, versionInfo) -%}

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -1598,9 +1598,9 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-dgeni-packages@^0.16.8:
-  version "0.16.8"
-  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.16.8.tgz#e0596f1902ef76799576bed7bcc1d69943f853a3"
+dgeni-packages@0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.17.0.tgz#b2e5117670e99109f664703af26a460a5064d6cc"
   dependencies:
     canonical-path "0.0.2"
     catharsis "^0.8.1"
@@ -5595,15 +5595,7 @@ sha.js@^2.3.6:
   dependencies:
     inherits "^2.0.1"
 
-shelljs@^0.7.0:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.6.tgz#379cccfb56b91c8601e4793356eb5382924de9ad"
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
-shelljs@^0.7.7:
+shelljs@^0.7.0, shelljs@^0.7.7:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
   dependencies:
@@ -6910,10 +6902,6 @@ zip-stream@~0.6.0:
     lodash "~3.10.1"
     readable-stream "~1.0.26"
 
-zone.js@0.7.8:
+zone.js@0.7.8, zone.js@^0.7.2:
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.7.8.tgz#4f3fe8834d44597f2639053a0fa438df34fffded"
-
-zone.js@^0.7.2:
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.7.7.tgz#0d7b7ae7f68012d03438b8a18f5763441bbf9620"

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -3,8 +3,8 @@
 
 
 "@angular/animations@next":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-4.0.0-rc.2.tgz#b4818712cfb576e831cf9d108754463f00c111b9"
+  version "4.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-4.0.0-rc.4.tgz#e9c56b0b5e4ed0351f3ef14c27e525daa5c2af11"
 
 "@angular/cli@^1.0.0-rc.0":
   version "1.0.0-rc.0"
@@ -74,8 +74,8 @@
     zone.js "^0.7.2"
 
 "@angular/common@next":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@angular/common/-/common-4.0.0-rc.2.tgz#69f68639270d71b2e8c552e4fa939975fcb88304"
+  version "4.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-4.0.0-rc.4.tgz#603b397da87b3f57c67aef8b063609099f9a20d8"
 
 "@angular/compiler-cli@>=2.3.1 <5.0.0 || >=4.0.0-beta <5.0.0", "@angular/compiler-cli@next":
   version "4.0.0-rc.2"
@@ -86,47 +86,47 @@
     reflect-metadata "^0.1.2"
 
 "@angular/compiler@>=2.3.1 <5.0.0 || >=4.0.0-beta <5.0.0", "@angular/compiler@next":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-4.0.0-rc.2.tgz#643e199e6792413f42cf149a9cf1672284787c11"
+  version "4.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-4.0.0-rc.4.tgz#8ffc413a4c7a6070a3054033988e60e3070cedd2"
 
 "@angular/core@>=2.3.1 <5.0.0 || >=4.0.0-beta <5.0.0", "@angular/core@next":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-4.0.0-rc.2.tgz#59535050e5d0e6141417186eee571296f8e9c3d0"
+  version "4.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-4.0.0-rc.4.tgz#e2eb34dcaed9c2929cf5df8853590c4e2809e01c"
 
 "@angular/forms@next":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-4.0.0-rc.2.tgz#6d9df97783b6023d652d97369db13d6ad6c7fa9e"
+  version "4.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-4.0.0-rc.4.tgz#407404e50965d3a94216615a898096c5cbca3f1e"
 
 "@angular/http@next":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@angular/http/-/http-4.0.0-rc.2.tgz#145ecd17f483b97e7750bb9e00b60e48ff82b67a"
+  version "4.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/http/-/http-4.0.0-rc.4.tgz#5dc307d8bf10d89c604a76addbcf71e017e685af"
 
 "@angular/material@https://github.com/angular/material2-builds":
   version "2.0.0-beta.2"
   resolved "https://github.com/angular/material2-builds#d7f549850cfd94b31bb624e2702b61305fd6337d"
 
 "@angular/platform-browser-dynamic@next":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.0.0-rc.2.tgz#f2bbab322706dc6361d46647e1e2b7c26f036a1c"
+  version "4.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.0.0-rc.4.tgz#0dae36b9758cf1c131c4076cfd33bc11813870e1"
 
 "@angular/platform-browser@next":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-4.0.0-rc.2.tgz#bcca05ce85d320ee0b257640f15479b59fed20f0"
+  version "4.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-4.0.0-rc.4.tgz#abb5eba57fe29dcf8bd8acc037a1709ce7281f1d"
 
 "@angular/platform-server@next":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@angular/platform-server/-/platform-server-4.0.0-rc.2.tgz#3b09f4e2f2dc1b7d723fbbdc6b99117019c0f9de"
+  version "4.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/platform-server/-/platform-server-4.0.0-rc.4.tgz#ca96dc1e7fb8023d0e8b3f8bbd855d53fbf90c69"
   dependencies:
     parse5 "^3.0.1"
     xhr2 "^0.1.4"
 
 "@angular/router@next":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@angular/router/-/router-4.0.0-rc.2.tgz#66fc5be012caa38441314d0a0b9c9b6a723c471a"
+  version "4.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/router/-/router-4.0.0-rc.4.tgz#d1f9700ac68ae16c4ba410b5f9651448213b867e"
 
-"@angular/service-worker@^1.0.0-beta.6":
-  version "1.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@angular/service-worker/-/service-worker-1.0.0-beta.6.tgz#ae3ca0b43ab1cbd572a191b2ef3e1b787f71ed1e"
+"@angular/service-worker@^1.0.0-beta.7":
+  version "1.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@angular/service-worker/-/service-worker-1.0.0-beta.7.tgz#e8edd2e993948caffc2d45d6935667f9b5a3c221"
   dependencies:
     base64-js "^1.1.2"
     jshashes "^1.0.5"


### PR DESCRIPTION
**Review but do not merge**. This PR presents a set of alternatives. We'll pick one.

For file loading by doc viewer, replaces direct calls to `http` with calls to `FileLoaderService` which abstracts the file fetching process.

It could be implemented with `http`, or `fetch`, or webpack's `System.import` (if we could get it to work ... see PR #15196), or XHR. 

This PR happens to implement with three file loaders: Http, Webpack,  and XHR.
The webpack one does NOT work. Rob thinks it can be made to work.

Each version is in its own commit. The Http is the 3rd commit and is enabled in that commit.

If any BUT the Http version were used, we could remove `Http` from the application to help make it smaller per request of @IgorMinar .

Todos:
- [ ] Pick the flavor to go with for now
- [ ] Extract that one into a separate PR, squash, remove the other flavors, and merge THAT PR
- [ ] Close this one for historical reasons so we can revisit if we want to revive the other techniques.


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```
