### PR TITLE
fix(core): ErrorHandler should not rethrow an error by default (#15077)

### DIFF
--- a/packages/core/src/error_handler.ts
+++ b/packages/core/src/error_handler.ts
@@ -42,12 +42,12 @@ export class ErrorHandler {
    */
   _console: Console = console;
 
-  /**
-   * @internal
-   */
-  rethrowError: boolean;
-
-  constructor(rethrowError: boolean = true) { this.rethrowError = rethrowError; }
+  constructor(
+      /**
+       * @deprecated since v4.0 parameter no longer has an effect, as ErrorHandler will never
+       * rethrow.
+       */
+      deprecatedParameter?: boolean) {}
 
   handleError(error: any): void {
     const originalError = this._findOriginalError(error);
@@ -63,10 +63,6 @@ export class ErrorHandler {
     if (context) {
       errorLogger(this._console, 'ERROR CONTEXT', context);
     }
-
-    // We rethrow exceptions, so operations like 'bootstrap' will result in an error
-    // when an error happens. If we do not rethrow, bootstrap will always succeed.
-    if (this.rethrowError) throw error;
   }
 
   /** @internal */

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -52,7 +52,7 @@ export function main() {
       } else {
         options = providersOrOptions || {};
       }
-      const errorHandler = new ErrorHandler(false);
+      const errorHandler = new ErrorHandler();
       errorHandler._console = mockConsole as any;
 
       const platformModule = getDOM().supportsDOMEvents() ? BrowserModule : ServerModule;

--- a/packages/core/test/error_handler_spec.ts
+++ b/packages/core/test/error_handler_spec.ts
@@ -18,7 +18,7 @@ class MockConsole {
 export function main() {
   function errorToString(error: any) {
     const logger = new MockConsole();
-    const errorHandler = new ErrorHandler(false);
+    const errorHandler = new ErrorHandler();
     errorHandler._console = logger as any;
     errorHandler.handleError(error);
     return logger.res.map(line => line.join('#')).join('\n');
@@ -61,7 +61,7 @@ ERROR CONTEXT#Context`);
     it('should use the error logger on the error', () => {
       const err = new Error('test');
       const console = new MockConsole();
-      const errorHandler = new ErrorHandler(false);
+      const errorHandler = new ErrorHandler();
       errorHandler._console = console as any;
       const logger = jasmine.createSpy('logger');
       (err as any)[ERROR_LOGGER] = logger;

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -159,7 +159,7 @@ export function main() {
     it('should throw if bootstrapped Directive is not a Component',
        inject([AsyncTestCompleter], (done: AsyncTestCompleter) => {
          const logger = new MockConsole();
-         const errorHandler = new ErrorHandler(false);
+         const errorHandler = new ErrorHandler();
          errorHandler._console = logger as any;
          expect(
              () => bootstrap(
@@ -171,7 +171,7 @@ export function main() {
     it('should throw if no element is found',
        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
          const logger = new MockConsole();
-         const errorHandler = new ErrorHandler(false);
+         const errorHandler = new ErrorHandler();
          errorHandler._console = logger as any;
          bootstrap(NonExistentComp, [
            {provide: ErrorHandler, useValue: errorHandler}
@@ -187,7 +187,7 @@ export function main() {
       it('should forward the error to promise when bootstrap fails',
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
            const logger = new MockConsole();
-           const errorHandler = new ErrorHandler(false);
+           const errorHandler = new ErrorHandler();
            errorHandler._console = logger as any;
 
            const refPromise =
@@ -202,7 +202,7 @@ export function main() {
       it('should invoke the default exception handler when bootstrap fails',
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
            const logger = new MockConsole();
-           const errorHandler = new ErrorHandler(false);
+           const errorHandler = new ErrorHandler();
            errorHandler._console = logger as any;
 
            const refPromise =

--- a/tools/public_api_guard/core/typings/core.d.ts
+++ b/tools/public_api_guard/core/typings/core.d.ts
@@ -383,7 +383,8 @@ export declare function enableProdMode(): void;
 
 /** @stable */
 export declare class ErrorHandler {
-    constructor(rethrowError?: boolean);
+    constructor(
+        deprecatedParameter?: boolean);
     handleError(error: any): void;
 }
 


### PR DESCRIPTION
ErrorHandler can not throw errors because it will unsubscribe itself from
the error stream.

Zones captures errors and feed it into NgZone, which than has a Rx Observable
to feed it into ErrorHandler. If the ErroHandler throws, then Rx will teardown
the observable which in essence causes the ErrorHandler to be removed from the
error handling. This implies that the ErrorHandler can never throw errors.

Closes #14949
Closes #15182
Closes #14316
