### PR TITLE
fix(compiler): always use `ng://` prefix for sourcemap urls

### DIFF
--- a/packages/compiler/src/aot/compiler.ts
+++ b/packages/compiler/src/aot/compiler.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CompileDirectiveMetadata, CompileIdentifierMetadata, CompileNgModuleMetadata, CompileProviderMetadata, componentFactoryName, createHostComponentMeta, flatten, identifierName, templateSourceUrl} from '../compile_metadata';
+import {CompileDirectiveMetadata, CompileIdentifierMetadata, CompileNgModuleMetadata, CompileProviderMetadata, componentFactoryName, createHostComponentMeta, flatten, identifierName, sourceUrl, templateSourceUrl} from '../compile_metadata';
 import {CompilerConfig} from '../config';
 import {Identifiers, createIdentifier, createIdentifierToken} from '../identifiers';
 import {CompileMetadataResolver} from '../metadata_resolver';
@@ -217,7 +217,7 @@ export class AotCompiler {
     return new GeneratedFile(
         srcFileUrl, genFileUrl,
         this._outputEmitter.emitStatements(
-            srcFileUrl, genFileUrl, statements, exportedVars, this._genFilePreamble));
+            sourceUrl(srcFileUrl), genFileUrl, statements, exportedVars, this._genFilePreamble));
   }
 }
 

--- a/packages/core/test/linker/source_map_integration_node_only_spec.ts
+++ b/packages/core/test/linker/source_map_integration_node_only_spec.ts
@@ -73,36 +73,36 @@ export function main() {
     }
 
     describe('inline templates', () => {
-      const templateUrl = 'ng:///DynamicTestModule/MyComp.html';
+      const ngUrl = 'ng:///DynamicTestModule/MyComp.html';
 
       function templateDecorator(template: string) { return {template}; }
 
-      declareTests({templateUrl, templateDecorator});
+      declareTests({ngUrl, templateDecorator});
     });
 
     describe('external templates', () => {
-      const templateUrl = 'http://localhost:1234:some/url.html';
+      const ngUrl = 'ng:///some/url.html';
+      const templateUrl = 'http://localhost:1234/some/url.html';
 
       function templateDecorator(template: string) {
         resourceLoader.expect(templateUrl, template);
         return {templateUrl};
       }
 
-      declareTests({templateUrl, templateDecorator});
+      declareTests({ngUrl, templateDecorator});
     });
 
-    function declareTests({templateUrl, templateDecorator}: {
-      templateUrl: string,
-      templateDecorator: (template: string) => { [key: string]: any }
-    }) {
+    function declareTests(
+        {ngUrl, templateDecorator}:
+            {ngUrl: string, templateDecorator: (template: string) => { [key: string]: any }}) {
       it('should use the right source url in html parse errors', fakeAsync(() => {
            @Component({...templateDecorator('<div>\n  </error>')})
            class MyComp {
            }
 
            expect(() => compileAndCreateComponent(MyComp))
-               .toThrowError(new RegExp(
-                   `Template parse errors[\\s\\S]*${templateUrl.replace('$', '\\$')}@1:2`));
+               .toThrowError(
+                   new RegExp(`Template parse errors[\\s\\S]*${ngUrl.replace('$', '\\$')}@1:2`));
          }));
 
       it('should use the right source url in template parse errors', fakeAsync(() => {
@@ -111,8 +111,8 @@ export function main() {
            }
 
            expect(() => compileAndCreateComponent(MyComp))
-               .toThrowError(new RegExp(
-                   `Template parse errors[\\s\\S]*${templateUrl.replace('$', '\\$')}@1:7`));
+               .toThrowError(
+                   new RegExp(`Template parse errors[\\s\\S]*${ngUrl.replace('$', '\\$')}@1:7`));
          }));
 
       it('should create a sourceMap for templates', fakeAsync(() => {
@@ -126,7 +126,7 @@ export function main() {
 
            const sourceMap = getSourceMap('ng:///DynamicTestModule/MyComp.ngfactory.js');
            expect(sourceMap.sources).toEqual([
-             'ng:///DynamicTestModule/MyComp.ngfactory.js', templateUrl
+             'ng:///DynamicTestModule/MyComp.ngfactory.js', ngUrl
            ]);
            expect(sourceMap.sourcesContent).toEqual([null, template]);
          }));
@@ -155,7 +155,7 @@ export function main() {
            expect(getSourcePositionForStack(getErrorLoggerStack(error))).toEqual({
              line: 2,
              column: 4,
-             source: templateUrl,
+             source: ngUrl,
            });
          }));
 
@@ -179,13 +179,13 @@ export function main() {
            expect(getSourcePositionForStack(error.stack)).toEqual({
              line: 2,
              column: 12,
-             source: templateUrl,
+             source: ngUrl,
            });
            // The error should be logged from the element
            expect(getSourcePositionForStack(getErrorLoggerStack(error))).toEqual({
              line: 2,
              column: 4,
-             source: templateUrl,
+             source: ngUrl,
            });
          }));
 
@@ -209,13 +209,13 @@ export function main() {
            expect(getSourcePositionForStack(error.stack)).toEqual({
              line: 2,
              column: 12,
-             source: templateUrl,
+             source: ngUrl,
            });
            // The error should be logged from the element
            expect(getSourcePositionForStack(getErrorLoggerStack(error))).toEqual({
              line: 2,
              column: 4,
-             source: templateUrl,
+             source: ngUrl,
            });
 
          }));


### PR DESCRIPTION
Fixes:
- In G3, filePaths don’t start with a `/` and therefore became relative.
- Always using the `ng://` prefix groups angular resources in the same
  way for AOT and JIT.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

