### PR TITLE
fix: discard undefined property value

### DIFF
--- a/packages/animations/browser/src/render/web_animations/web_animations_player.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_player.ts
@@ -36,7 +36,11 @@ export class WebAnimationsPlayer implements AnimationPlayer {
     this.previousStyles = {};
     previousPlayers.forEach(player => {
       let styles = player._captureStyles();
-      Object.keys(styles).forEach(prop => this.previousStyles[prop] = styles[prop]);
+      Object.keys(styles).forEach(prop => {
+        if (styles[prop] !== undefined) {
+          this.previousStyles[prop] = styles[prop];
+        }
+      });
     });
   }
 


### PR DESCRIPTION
This was causing the browser to throw an exception in the call to animate()

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
With md-tooltip, sometimes an exception is thrown in the call to element.animate() due to an undefined property value.


**What is the new behavior?**
No exception is thrown because the property with the undefined value is discarded.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

