### PR TITLE
fix(compiler): add an empty content for source file of non mapped code.

### DIFF
--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -98,7 +98,10 @@ export class EmitterVisitorContext {
     let firstOffsetMapped = false;
     const mapFirstOffsetIfNeeded = () => {
       if (!firstOffsetMapped) {
-        map.addSource(sourceFilePath).addMapping(0, sourceFilePath, 0, 0);
+        // Add a single space so that tools won't try to load the file from disk.
+        // Note: We are using virtual urls like `ng:///`, so we have to
+        // provide a content here.
+        map.addSource(sourceFilePath, ' ').addMapping(0, sourceFilePath, 0, 0);
         firstOffsetMapped = true;
       }
     };

--- a/packages/compiler/test/aot/compiler_spec.ts
+++ b/packages/compiler/test/aot/compiler_spec.ts
@@ -188,7 +188,7 @@ describe('compiler (unbundled Angular)', () => {
              // for the mapping to the original source file we don't store the source code
              // as we want to keep whatever TypeScript / ... produced for them.
              const sourceIndex = sourceMap.sources.indexOf(ngComponentPath);
-             expect(sourceMap.sourcesContent[sourceIndex]).toBe(null);
+             expect(sourceMap.sourcesContent[sourceIndex]).toBe(' ');
            });
          }));
 

--- a/packages/compiler/test/output/js_emitter_node_only_spec.ts
+++ b/packages/compiler/test/output/js_emitter_node_only_spec.ts
@@ -57,7 +57,7 @@ export function main() {
         const sm = emitSourceMap(someVar.toStmt(), [], '/* MyPreamble \n */');
 
         expect(sm.sources).toEqual([someSourceFilePath, 'in.js']);
-        expect(sm.sourcesContent).toEqual([null, ';;;var']);
+        expect(sm.sourcesContent).toEqual([' ', ';;;var']);
         expect(originalPositionFor(sm, {line: 3, column: 0}))
             .toEqual({line: 1, column: 3, source: 'in.js'});
       });

--- a/packages/compiler/test/output/ts_emitter_node_only_spec.ts
+++ b/packages/compiler/test/output/ts_emitter_node_only_spec.ts
@@ -62,7 +62,7 @@ export function main() {
         const sm = emitSourceMap(someVar.toStmt(), [], '/* MyPreamble \n */');
 
         expect(sm.sources).toEqual([someSourceFilePath, 'in.js']);
-        expect(sm.sourcesContent).toEqual([null, ';;;var']);
+        expect(sm.sourcesContent).toEqual([' ', ';;;var']);
         expect(originalPositionFor(sm, {line: 3, column: 0}))
             .toEqual({line: 1, column: 3, source: 'in.js'});
       });

--- a/packages/core/test/linker/source_map_integration_node_only_spec.ts
+++ b/packages/core/test/linker/source_map_integration_node_only_spec.ts
@@ -128,7 +128,7 @@ export function main() {
            expect(sourceMap.sources).toEqual([
              'ng:///DynamicTestModule/MyComp.ngfactory.js', ngUrl
            ]);
-           expect(sourceMap.sourcesContent).toEqual([null, template]);
+           expect(sourceMap.sourcesContent).toEqual([' ', template]);
          }));
 
 


### PR DESCRIPTION
Before this when using ngc, tools tried to load `ng://…<component>.ts`
if `…<component>.ts` was the source file of a template.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

