### PR TITLE
fix(forms): make composition event buffering configurable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,9 +12,9 @@ PACKAGES=(core
   compiler
   common
   animations
-  forms
   platform-browser
   platform-browser-dynamic
+  forms
   http
   platform-server
   platform-webworker

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",
-    "@angular/common": "0.0.0-PLACEHOLDER"
+    "@angular/common": "0.0.0-PLACEHOLDER",
+    "@angular/platform-browser": "0.0.0-PLACEHOLDER"
   },
   "repository": {
     "type": "git",

--- a/packages/forms/rollup.config.js
+++ b/packages/forms/rollup.config.js
@@ -15,6 +15,7 @@ export default {
     '@angular/core': 'ng.core',
     '@angular/common': 'ng.common',
     '@angular/compiler': 'ng.compiler',
+    '@angular/platform-browser': 'ng.platformBrowser',
     'rxjs/Observable': 'Rx',
     'rxjs/Subject': 'Rx',
     'rxjs/observable/fromPromise': 'Rx.Observable',

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, EventEmitter, Host, HostListener, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges, forwardRef} from '@angular/core';
+import {Directive, EventEmitter, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges, forwardRef} from '@angular/core';
 
 import {FormControl} from '../model';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
@@ -114,7 +114,6 @@ export class NgModel extends NgControl implements OnChanges,
   _control = new FormControl();
   /** @internal */
   _registered = false;
-  private _composing = false;
   viewModel: any;
 
   @Input() name: string;
@@ -123,15 +122,6 @@ export class NgModel extends NgControl implements OnChanges,
   @Input('ngModelOptions') options: {name?: string, standalone?: boolean};
 
   @Output('ngModelChange') update = new EventEmitter();
-
-  @HostListener('compositionstart')
-  compositionStart(): void { this._composing = true; }
-
-  @HostListener('compositionend')
-  compositionEnd(): void {
-    this._composing = false;
-    this.update.emit(this.viewModel);
-  }
 
   constructor(@Optional() @Host() parent: ControlContainer,
               @Optional() @Self() @Inject(NG_VALIDATORS) validators: Array<Validator|ValidatorFn>,
@@ -176,7 +166,7 @@ export class NgModel extends NgControl implements OnChanges,
 
               viewToModelUpdate(newValue: any): void {
                 this.viewModel = newValue;
-                !this._composing && this.update.emit(newValue);
+                this.update.emit(newValue);
               }
 
               private _setUpControl(): void {

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -23,7 +23,7 @@ export {AbstractFormGroupDirective} from './directives/abstract_form_group_direc
 export {CheckboxControlValueAccessor} from './directives/checkbox_value_accessor';
 export {ControlContainer} from './directives/control_container';
 export {ControlValueAccessor, NG_VALUE_ACCESSOR} from './directives/control_value_accessor';
-export {DefaultValueAccessor} from './directives/default_value_accessor';
+export {COMPOSITION_BUFFER_MODE, DefaultValueAccessor} from './directives/default_value_accessor';
 export {Form} from './directives/form_interface';
 export {NgControl} from './directives/ng_control';
 export {NgControlStatus, NgControlStatusGroup} from './directives/ng_control_status';

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -44,7 +44,7 @@ export function main() {
   describe('Form Directives', () => {
     let defaultAccessor: DefaultValueAccessor;
 
-    beforeEach(() => { defaultAccessor = new DefaultValueAccessor(null, null); });
+    beforeEach(() => { defaultAccessor = new DefaultValueAccessor(null, null, null); });
 
     describe('shared', () => {
       describe('selectValueAccessor', () => {

--- a/packages/forms/tsconfig-build.json
+++ b/packages/forms/tsconfig-build.json
@@ -13,7 +13,8 @@
       "@angular/common": ["../../dist/packages/common"],
       "@angular/common/testing": ["../../dist/packages/common/testing"],
       "@angular/compiler": ["../../dist/packages/compiler"],
-      "@angular/compiler/testing": ["../../dist/packages/compiler/testing"]
+      "@angular/compiler/testing": ["../../dist/packages/compiler/testing"],
+      "@angular/platform-browser": ["../../dist/packages/platform-browser"]
     },
     "rootDir": ".",
     "sourceMap": true,

--- a/packages/platform-webworker/src/web_workers/worker/worker_adapter.ts
+++ b/packages/platform-webworker/src/web_workers/worker/worker_adapter.ts
@@ -150,7 +150,7 @@ export class WorkerDomAdapter extends DomAdapter {
   getLocation(): Location { throw 'not implemented'; }
   getBaseHref(doc: Document): string { throw 'not implemented'; }
   resetBaseElement(): void { throw 'not implemented'; }
-  getUserAgent(): string { throw 'not implemented'; }
+  getUserAgent(): string { return 'Fake user agent'; }
   setData(element: any, name: string, value: string) { throw 'not implemented'; }
   getComputedStyle(element: any): any { throw 'not implemented'; }
   getData(element: any, name: string): string { throw 'not implemented'; }

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -121,6 +121,9 @@ export declare class CheckboxRequiredValidator extends RequiredValidator {
     validate(c: AbstractControl): ValidationErrors | null;
 }
 
+/** @experimental */
+export declare const COMPOSITION_BUFFER_MODE: InjectionToken<boolean>;
+
 /** @stable */
 export declare class ControlContainer extends AbstractControlDirective {
     readonly formDirective: Form;
@@ -140,7 +143,10 @@ export interface ControlValueAccessor {
 export declare class DefaultValueAccessor implements ControlValueAccessor {
     onChange: (_: any) => void;
     onTouched: () => void;
-    constructor(_renderer: Renderer, _elementRef: ElementRef);
+    constructor(_renderer: Renderer, _elementRef: ElementRef, _compositionMode: boolean);
+    _compositionEnd(value: any): void;
+    _compositionStart(): void;
+    _handleInput(value: any): void;
     registerOnChange(fn: (_: any) => void): void;
     registerOnTouched(fn: () => void): void;
     setDisabledState(isDisabled: boolean): void;
@@ -426,8 +432,6 @@ export declare class NgModel extends NgControl implements OnChanges, OnDestroy {
     readonly validator: ValidatorFn;
     viewModel: any;
     constructor(parent: ControlContainer, validators: Array<Validator | ValidatorFn>, asyncValidators: Array<AsyncValidator | AsyncValidatorFn>, valueAccessors: ControlValueAccessor[]);
-    compositionEnd(): void;
-    compositionStart(): void;
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     viewToModelUpdate(newValue: any): void;


### PR DESCRIPTION
This commit fixes a regression where `ngModel` no longer syncs letter by letter on Android devices, and instead syncs at the end of every word. This broke when we introduced buffering of IME events so IMEs like Pinyin keyboards or Katakana keyboards wouldn't display composition strings. Unfortunately, iOS devices and Android devices have opposite event behavior. Whereas iOS devices fire composition events for IME keyboards only, Android fires composition events for Latin-language keyboards. For this reason, languages like English don't work as expected on Android if we always buffer. So to support both platforms, composition string buffering will only be turned on by default for non-Android devices.

However, we have also added a `COMPOSITION_BUFFER_MODE` token to make this configurable by the application, because in some cases, apps might might still want to receive intermediate values. For example, some inputs begin searching behavior based on Latin letters before a character selection is made.

As a provider, this is fairly flexible. If you want to turn composition buffering off, simply provide the token at the top level:

```ts
providers: [
   {provide: COMPOSITION_BUFFER_MODE, useValue: false}
]
```

Or, if you want to change the mode  based on locale or platform, you can use a factory:

```ts
import {shouldUseBuffering} from 'my/lib';

....
providers: [
   {provide: COMPOSITION_BUFFER_MODE, useFactory: shouldUseBuffering}
]
```

Closes #15079.