### PR TITLE
feat(aio): expand nav menu branch of select item on page load

### DIFF
--- a/aio/src/app/layout/nav-item/nav-item.component.ts
+++ b/aio/src/app/layout/nav-item/nav-item.component.ts
@@ -17,6 +17,7 @@ export class NavItemComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (changes['selectedNodes'] || changes['node']) {
       this.isSelected = this.selectedNodes.indexOf(this.node) !== -1;
+      this.isExpanded = this.isExpanded || this.isSelected;
     }
     this.setClasses();
   }


### PR DESCRIPTION
When load the page with an item specified in the address bar (e.g., `CORE | Dependency Injection | Hierarchical Injection`), the left nav branch is open for that selected item.

Previously, on page load, all nav branches would be closed and only the top level header for the selected item would be visibly selected (e.g., `CORE`).

Does not affect the expanded state of other left nav branches which are as they were when arrived on the page.

It does expand nav branches as you press browser back/forward buttons and see previously selected items from other branches. This seems desirable to me.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```
