### PR TITLE
fix(compiler): use attribute id to merge translations

### DIFF
--- a/packages/compiler/src/i18n/extractor_merger.ts
+++ b/packages/compiler/src/i18n/extractor_merger.ts
@@ -347,12 +347,13 @@ class _Visitor implements html.Visitor {
   // translate the attributes of an element and remove i18n specific attributes
   private _translateAttributes(el: html.Element): html.Attribute[] {
     const attributes = el.attrs;
-    const i18nAttributeMeanings: {[name: string]: string} = {};
+    const i18nParsedMessageMeta:
+        {[name: string]: {meaning: string, description: string, id: string}} = {};
 
     attributes.forEach(attr => {
       if (attr.name.startsWith(_I18N_ATTR_PREFIX)) {
-        i18nAttributeMeanings[attr.name.slice(_I18N_ATTR_PREFIX.length)] =
-            _parseMessageMeta(attr.value).meaning;
+        i18nParsedMessageMeta[attr.name.slice(_I18N_ATTR_PREFIX.length)] =
+            _parseMessageMeta(attr.value);
       }
     });
 
@@ -364,9 +365,9 @@ class _Visitor implements html.Visitor {
         return;
       }
 
-      if (attr.value && attr.value != '' && i18nAttributeMeanings.hasOwnProperty(attr.name)) {
-        const meaning = i18nAttributeMeanings[attr.name];
-        const message: i18n.Message = this._createI18nMessage([attr], meaning, '', '');
+      if (attr.value && attr.value != '' && i18nParsedMessageMeta.hasOwnProperty(attr.name)) {
+        let {meaning, description, id} = i18nParsedMessageMeta[attr.name];
+        const message: i18n.Message = this._createI18nMessage([attr], meaning, description, id);
         const nodes = this._translations.get(message);
         if (nodes) {
           if (nodes.length == 0) {
@@ -375,14 +376,16 @@ class _Visitor implements html.Visitor {
             const value = (nodes[0] as html.Text).value;
             translatedAttributes.push(new html.Attribute(attr.name, value, attr.sourceSpan));
           } else {
+            id = id || this._translations.digest(message);
             this._reportError(
                 el,
-                `Unexpected translation for attribute "${attr.name}" (id="${this._translations.digest(message)}")`);
+                `Unexpected translation for attribute "${attr.name}" (id="${id}")`);
           }
         } else {
+          id = id || this._translations.digest(message);
           this._reportError(
               el,
-              `Translation unavailable for attribute "${attr.name}" (id="${this._translations.digest(message)}")`);
+              `Translation unavailable for attribute "${attr.name}" (id="${id}")`);
         }
       } else {
         translatedAttributes.push(attr);

--- a/packages/compiler/test/i18n/extractor_merger_spec.ts
+++ b/packages/compiler/test/i18n/extractor_merger_spec.ts
@@ -430,6 +430,11 @@ export function main() {
         expect(fakeTranslate(HTML)).toEqual('<p title="**foo**"></p>');
       });
 
+      it('should merge attributes with ids', () => {
+        const HTML = `<p i18n-title="@@id" title="foo"></p>`;
+        expect(fakeTranslate(HTML)).toEqual('<p title="**foo**"></p>');
+      });
+
       it('should merge nested attributes', () => {
         const HTML = `<div>{count, plural, =0 {<p i18n-title title="foo"></p>}}</div>`;
         expect(fakeTranslate(HTML))


### PR DESCRIPTION
**What kind of change does this PR introduce?**
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)
We extracted ids from i18n attributes but forgot to use them when merging the translations, resulting in an error about missing translations even when they were correctly defined.

See #15234


**What is the new behavior?**
We use the id (if existing) to merge attribute translations


**Does this PR introduce a breaking change?**
```
[x] No
```