### PR TITLE
fix(compiler): don’t call `check` if we don’t need to

### DIFF
--- a/packages/compiler/test/aot/compiler_spec.ts
+++ b/packages/compiler/test/aot/compiler_spec.ts
@@ -339,6 +339,35 @@ describe('compiler (unbundled Angular)', () => {
          });
        }));
   });
+
+  describe('generated templates', () => {
+    it('should not call `check` for directives without bindings nor ngDoCheck/ngOnInit',
+       async(() => {
+         const FILES: MockData = {
+           app: {
+             'app.ts': `
+                import { NgModule, Component } from '@angular/core';
+
+                @Component({ template: '' })
+                export class AppComponent {}
+
+                @NgModule({ declarations: [ AppComponent ] })
+                export class AppModule { }
+              `
+           }
+         };
+         const host = new MockCompilerHost(['/app/app.ts'], FILES, angularFiles);
+         const aotHost = new MockAotCompilerHost(host);
+         const genFilePreamble = '/* Hello world! */';
+         compile(host, aotHost, expectNoDiagnostics, expectNoDiagnostics, {genFilePreamble})
+             .then((generatedFiles) => {
+               const genFile = generatedFiles.find(
+                   gf => gf.srcFileUrl === '/app/app.ts' && gf.genFileUrl.endsWith('.ts'));
+               expect(genFile.source).not.toContain('check(');
+             });
+
+       }));
+  });
 });
 
 describe('compiler (bundled Angular)', () => {


### PR DESCRIPTION
If a directive has not bindings nor has a `ngDoCheck` / `ngOnInit`
lifecycle hook, don’t generate a `check` call.

This does not have an impact on the behavior, but produces
less code.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

