### PR TITLE
build: remove use of alias metadata

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -267,7 +267,7 @@ compilePackage() {
     $NGC -p ${1}/tsconfig-build.json
     echo "======           Create ${1}/../${package_name}.d.ts re-export file for Closure"
     echo "$(cat ${LICENSE_BANNER}) ${N} export * from './${package_name}/index'" > ${2}/../${package_name}.d.ts
-    echo "{\"alias\": \"./${package_name}/index.metadata.json\"}" > ${2}/../${package_name}.metadata.json
+    echo "{\"__symbolic\":\"module\",\"version\":3,\"metadata\":{},\"exports\":[{\"from\":\"./${package_name}/index\"}]}" > ${2}/../${package_name}.metadata.json
   fi
 
   for DIR in ${1}/* ; do

--- a/packages/compiler-cli/src/compiler_host.ts
+++ b/packages/compiler-cli/src/compiler_host.ts
@@ -207,11 +207,7 @@ export class CompilerHost implements AotCompilerHost {
       return metadatas;
     }
     try {
-      let metadataOrMetadatas = JSON.parse(this.context.readFile(filePath));
-      while (metadataOrMetadatas && metadataOrMetadatas.alias) {
-        filePath = path.join(path.dirname(filePath), metadataOrMetadatas.alias);
-        metadataOrMetadatas = JSON.parse(this.context.readFile(filePath));
-      }
+      const metadataOrMetadatas = JSON.parse(this.context.readFile(filePath));
       const metadatas: ModuleMetadata[] = metadataOrMetadatas ?
           (Array.isArray(metadataOrMetadatas) ? metadataOrMetadatas : [metadataOrMetadatas]) :
           [];

--- a/packages/compiler-cli/test/aot_host_spec.ts
+++ b/packages/compiler-cli/test/aot_host_spec.ts
@@ -202,10 +202,6 @@ describe('CompilerHost', () => {
       {__symbolic: 'module', version: 3, metadata: {}, exports: [{from: './lib/utils'}]}
     ]);
   });
-
-  it('should follow metadata aliases', () => {
-    expect(hostNestedGenDir.getMetadataFor('alias/file.d.ts')).toEqual([dummyMetadata]);
-  });
 });
 
 const dummyModule = 'export let foo: any[];';
@@ -240,11 +236,6 @@ const FILES: Entry = {
           'empty.d.ts': 'export declare var a: string;',
           'empty.metadata.json': '[]',
         }
-      },
-      'alias': {
-        'file.d.ts': dummyModule,
-        'file.metadata.json': '{ "alias": "sub/index.metadata.json"}',
-        'sub': {'index.metadata.json': JSON.stringify(dummyMetadata)}
       },
       'metadata_versions': {
         'v1.d.ts': `


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Build related changes
```

**What is the current behavior?** (You can also link to an open issue here)

Uses alias feature of metadata reader. This feature doesn't correctly handle relative references.

**What is the new behavior?**

Removed use of aliases and used re-export instead which does handle relative references.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
