### PR TITLE
fix(compiler-cli): ngtools should accept `useFactory` (lazy routes)

### DIFF
--- a/packages/compiler-cli/src/ngtools_impl.ts
+++ b/packages/compiler-cli/src/ngtools_impl.ts
@@ -182,7 +182,11 @@ function _collectRoutes(
     providers: any[], reflector: StaticReflector, ROUTES: StaticSymbol): Route[] {
   return providers.reduce((routeList: Route[], p: any) => {
     if (p.provide === ROUTES) {
-      return routeList.concat(p.useValue);
+      if (p.useFactory != null) {
+        return routeList.concat(p.useFactory);
+      } else {
+        return routeList.concat(p.useValue);
+      }
     } else if (Array.isArray(p)) {
       return routeList.concat(_collectRoutes(p, reflector, ROUTES));
     } else {


### PR DESCRIPTION
Add the required functionality to `_collectRoutes` function of `ngtools_impl.ts`, so that the `ngtools` respect provided factories with `p.useFactory` (as well as provided values with `useValue`).

Closes #15305

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Providing a factory method (`useFactory`) for the DI token `ROUTES` causes the discovery of lazy-routes to fail. Further details are documented on #15305.

**What is the new behavior?**
With this PR, it's possible to provide a factory method for the DI token `ROUTES`, and **`@ngtools/webpack`** accepts the values provided by the factory with `useFactory` (as well as provided values with `useValue`).


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
For these changes, **no tests** and **documents** have been **added** or **changed**. Actually, there were already no specific tests and documents found to evaluate/document the current and new behavior.
