### PR TITLE
build(aio): fix paths to "index" pages

### DIFF
--- a/aio/e2e/app.e2e-spec.ts
+++ b/aio/e2e/app.e2e-spec.ts
@@ -10,9 +10,25 @@ describe('site App', function() {
   });
 
   it('should show features text after clicking "Features"', () => {
-    page.featureLink.click().then(() => {
+    page.getLink('features').click().then(() => {
       expect(page.getDocViewerText()).toMatch(/Progressive web apps/i);
     });
+  });
+
+  it('should show the tutorial index page at `/tutorial/`', () => {
+    // check that we can navigate directly to the tutorial page
+    page.navigateTo('tutorial/');
+    expect(page.getDocViewerText()).toMatch(/Tutorial: Tour of Heroes/i);
+
+    // navigate to a different page
+    page.getLink('features').click();
+
+    // check that we can navigate to the tutorial page via a link in the navigation
+    const heading = page.getNavHeading(/tutorial/i);
+    expect(heading.getText()).toMatch(/tutorial/i);
+    heading.click();
+    page.getLink('tutorial/').click();
+    expect(page.getDocViewerText()).toMatch(/Tutorial: Tour of Heroes/i);
   });
 
   it('should convert a doc with a code-example');

--- a/aio/e2e/app.po.ts
+++ b/aio/e2e/app.po.ts
@@ -10,10 +10,15 @@ export class SitePage {
     .all(by.css('a'))
     .filter((a: ElementFinder) => a.getAttribute('href').then(href => githubRegex.test(href)))
     .first();
-  featureLink = element(by.css('md-toolbar a[href="features"]'));
   gaReady: promise.Promise<any>;
-  ga = () => browser.executeScript('return window["gaCalls"]') as promise.Promise<any[][]>;
-  locationPath = () => browser.executeScript('return document.location.pathname') as promise.Promise<string>;
+  getNavHeading(pattern: RegExp) {
+    return element.all(by.css('aio-nav-item a'))
+                  .filter(element => element.getText().then(text => pattern.test(text)))
+                  .first();
+  }
+  getLink(path) { return element(by.css(`a[href="${path}"]`)); }
+  ga() { return browser.executeScript('return window["gaCalls"]') as promise.Promise<any[][]>; }
+  locationPath() { return browser.executeScript('return document.location.pathname') as promise.Promise<string>; }
 
   navigateTo(pageUrl = '') {
     return browser.get('/' + pageUrl).then(_ => this.replaceGa(_));

--- a/aio/src/app/documents/document.service.spec.ts
+++ b/aio/src/app/documents/document.service.spec.ts
@@ -155,5 +155,12 @@ describe('DocumentService', () => {
 
       expect(backend.connectionsArray[0].request.url).toEqual(CONTENT_URL_PREFIX + 'index.json');
     });
+
+    it('should map the "folder" locations to the correct document request', () => {
+      const { service, backend, location } = getServices('guide/');
+      service.currentDocument.subscribe();
+
+      expect(backend.connectionsArray[0].request.url).toEqual(CONTENT_URL_PREFIX + 'guide.json');
+    });
   });
 });

--- a/aio/src/app/documents/document.service.ts
+++ b/aio/src/app/documents/document.service.ts
@@ -63,8 +63,11 @@ export class DocumentService {
 
   private computePath(url: string) {
     url = url.match(/[^#?]*/)[0]; // strip off fragment and query
-    url = '/' + url;
-    url = url.endsWith('/') ? url + 'index' : url;
-    return 'content/docs' + url + '.json';
+    url = url.replace(/\/$/, ''); // strip off trailing slash
+    if (url === '') {
+      // deal with root url
+      url = 'index';
+    }
+    return 'content/docs/' + url + '.json';
   }
 }

--- a/aio/transforms/angular.io-package/index.js
+++ b/aio/transforms/angular.io-package/index.js
@@ -266,7 +266,11 @@ module.exports =
               outputPathTemplate: '${moduleDoc.moduleFolder}/${name}.json',
             },
             {docTypes: ['example-region'], getOutputPath: function() {}},
-            {docTypes: ['content'], pathTemplate: '${id}', outputPathTemplate: '${path}.json'},
+            {
+              docTypes: ['content'],
+              getPath: (doc) => `${doc.id.replace(/\/index$/, '')}`,
+              outputPathTemplate: '${path}.json'
+            },
             {docTypes: ['navigation-map'], pathTemplate: '${id}', outputPathTemplate: '../${id}.json'}
           ];
         })


### PR DESCRIPTION
Content pages like `tutorial/index.md` were being mapped to `tutorial.index.json`,
which meant that they could only be rendered if you browsed to `/tutorial/index`.

This didn't sit well so now these pages are mapped to `tutorial.json`, which
means that you browser to them via `/tutorial/` or just `/tutorial`.

Fixed #15335
