### PR TITLE
fix(core): provide `NgModuleRef` in `ViewContainerRef.createComponent`.

### DIFF
--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -9,6 +9,7 @@
 import {Injector} from '../di/injector';
 import {ComponentFactory, ComponentRef} from './component_factory';
 import {ElementRef} from './element_ref';
+import {NgModuleRef} from './ng_module_factory';
 import {TemplateRef} from './template_ref';
 import {EmbeddedViewRef, ViewRef} from './view_ref';
 
@@ -83,7 +84,7 @@ export abstract class ViewContainerRef {
    */
   abstract createComponent<C>(
       componentFactory: ComponentFactory<C>, index?: number, injector?: Injector,
-      projectableNodes?: any[][]): ComponentRef<C>;
+      projectableNodes?: any[][], ngModule?: NgModuleRef<any>): ComponentRef<C>;
 
   /**
    * Inserts a View identified by a {@link ViewRef} into the container at the specified `index`.

--- a/packages/core/src/view/provider.ts
+++ b/packages/core/src/view/provider.ts
@@ -356,7 +356,7 @@ export function resolveDep(
   }
   const tokenKey = depDef.tokenKey;
 
-  if (depDef.flags & DepFlags.SkipSelf) {
+  if (elDef && (depDef.flags & DepFlags.SkipSelf)) {
     allowPrivateServices = false;
     elDef = elDef.parent;
   }

--- a/packages/core/test/view/services_spec.ts
+++ b/packages/core/test/view/services_spec.ts
@@ -83,7 +83,6 @@ export function main() {
 
         expect(debugCtx.renderNode).toBe(asElementData(compView, 0).renderElement);
       });
-
     });
   });
 }

--- a/tools/public_api_guard/core/core.d.ts
+++ b/tools/public_api_guard/core/core.d.ts
@@ -1086,7 +1086,7 @@ export declare abstract class ViewContainerRef {
     readonly abstract length: number;
     readonly abstract parentInjector: Injector;
     abstract clear(): void;
-    abstract createComponent<C>(componentFactory: ComponentFactory<C>, index?: number, injector?: Injector, projectableNodes?: any[][]): ComponentRef<C>;
+    abstract createComponent<C>(componentFactory: ComponentFactory<C>, index?: number, injector?: Injector, projectableNodes?: any[][], ngModule?: NgModuleRef<any>): ComponentRef<C>;
     abstract createEmbeddedView<C>(templateRef: TemplateRef<C>, context?: C, index?: number): EmbeddedViewRef<C>;
     abstract detach(index?: number): ViewRef;
     abstract get(index: number): ViewRef;


### PR DESCRIPTION
This is needed to support the corner cases:
- usage of a `ComponentFactory` that was created on the fly via `Compiler`
- overwriting of the `NgModuleRef` that is associated to a 
  `ComponentFactory` by the `ComponentFactoryResolver` from
  which it was read.

Fixes #15241

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

