### PR TITLE
Update template_parser.ts

### DIFF
--- a/packages/compiler/src/template_parser/template_parser.ts
+++ b/packages/compiler/src/template_parser/template_parser.ts
@@ -63,6 +63,9 @@ const CLASS_ATTR = 'class';
 
 const TEXT_CSS_SELECTOR = CssSelector.parse('*')[0];
 
+// prevent template deprecation warnings from logging repeatedly.
+let TEMPLATE_DEPRECATION_LOGGED = false;
+
 /**
  * Provides an array of {@link TemplateAstVisitor}s which will be used to transform
  * parsed templates before compilation is invoked, allowing custom expression syntax
@@ -283,7 +286,8 @@ class TemplateParseVisitor implements html.Visitor {
       let prefixToken: string|undefined;
       let normalizedName = this._normalizeAttributeName(attr.name);
 
-      if (this.config.enableLegacyTemplate && normalizedName == TEMPLATE_ATTR) {
+      if (this.config.enableLegacyTemplate && normalizedName == TEMPLATE_ATTR && !TEMPLATE_DEPRECATION_LOGGED) {
+        TEMPLATE_DEPRECATION_LOGGED = true;
         this._reportError(
             `The template attribute is deprecated. Use an ng-template element instead.`,
             attr.sourceSpan, ParseErrorLevel.WARNING);


### PR DESCRIPTION
Prevent Compiler from repeatedly logging warnings to the console when developers use the deprecated `template` tag rather than the new `ng-template`