### PR TITLE
fix(compiler): look for flat module resources using declaration module path

### DIFF
--- a/packages/compiler-cli/integrationtest/flat_module/public-api.ts
+++ b/packages/compiler-cli/integrationtest/flat_module/public-api.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export * from './src/flat.component';
+export * from './src/flat.module';

--- a/packages/compiler-cli/integrationtest/flat_module/src/flat.component.html
+++ b/packages/compiler-cli/integrationtest/flat_module/src/flat.component.html
@@ -1,0 +1,1 @@
+<div>flat module component</div>

--- a/packages/compiler-cli/integrationtest/flat_module/src/flat.component.ts
+++ b/packages/compiler-cli/integrationtest/flat_module/src/flat.component.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'flat-comp',
+  templateUrl: 'flat.component.html',
+})
+export class FlatComponent {
+}

--- a/packages/compiler-cli/integrationtest/flat_module/src/flat.module.ts
+++ b/packages/compiler-cli/integrationtest/flat_module/src/flat.module.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {NgModule} from '@angular/core';
+
+import {FlatComponent} from './flat.component';
+
+@NgModule({
+  declarations: [
+    FlatComponent,
+  ],
+  exports: [
+    FlatComponent,
+  ]
+})
+export class FlatModule {
+}

--- a/packages/compiler-cli/integrationtest/flat_module/tsconfig-build.json
+++ b/packages/compiler-cli/integrationtest/flat_module/tsconfig-build.json
@@ -1,0 +1,26 @@
+{
+  "angularCompilerOptions": {
+    // For TypeScript 1.8, we have to lay out generated files
+    // in the same source directory with your code.
+    "genDir": "ng",
+    "flatModuleId": "flat_module",
+    "flatModuleOutFile": "index.js",
+    "skipTemplateCodegen": true
+  },
+
+  "compilerOptions": {
+    "target": "es5",
+    "experimentalDecorators": true,
+    "noImplicitAny": true,
+    "moduleResolution": "node",
+    "rootDir": "",
+    "declaration": true,
+    "lib": ["es6", "dom"],
+    "baseUrl": ".",
+    "outDir": "../node_modules/flat_module",
+     // Prevent scanning up the directory tree for types
+    "typeRoots": ["node_modules/@types"]
+ },
+
+ "files": ["public-api.ts"]
+}

--- a/packages/compiler-cli/integrationtest/src/comp_using_flat_module.ts
+++ b/packages/compiler-cli/integrationtest/src/comp_using_flat_module.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'use-flat-module',
+  template: '<flat-comp></flat-comp>',
+})
+export class ComponentUsingFlatModule {
+}

--- a/packages/compiler-cli/integrationtest/src/module.ts
+++ b/packages/compiler-cli/integrationtest/src/module.ts
@@ -10,6 +10,7 @@ import {ApplicationRef, NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {ServerModule} from '@angular/platform-server';
 import {MdButtonModule} from '@angular2-material/button';
+import {FlatModule} from 'flat_module';
 // Note: don't refer to third_party_src as we want to test that
 // we can compile components from node_modules!
 import {ThirdpartyModule} from 'third_party/module';
@@ -18,6 +19,7 @@ import {MultipleComponentsMyComp, NextComp} from './a/multiple_components';
 import {AnimateCmp} from './animate';
 import {BasicComp} from './basic';
 import {ComponentUsingThirdParty} from './comp_using_3rdp';
+import {ComponentUsingFlatModule} from './comp_using_flat_module';
 import {CUSTOM} from './custom_token';
 import {CompWithAnalyzeEntryComponentsProvider, CompWithEntryComponents} from './entry_components';
 import {BindingErrorComp} from './errors';
@@ -48,6 +50,7 @@ import {CompForChildQuery, CompWithChildQuery, CompWithDirectiveChild, Directive
     ProjectingComp,
     SomeDirectiveInRootModule,
     SomePipeInRootModule,
+    ComponentUsingFlatModule,
     ComponentUsingThirdParty,
     BindingErrorComp,
   ],
@@ -58,6 +61,7 @@ import {CompForChildQuery, CompWithChildQuery, CompWithDirectiveChild, Directive
     ModuleUsingCustomElements,
     SomeLibModule.withProviders(),
     ThirdpartyModule,
+    FlatModule,
   ],
   providers: [
     SomeService,
@@ -73,6 +77,7 @@ import {CompForChildQuery, CompWithChildQuery, CompWithDirectiveChild, Directive
     CompWithReferences,
     ProjectingComp,
     ComponentUsingThirdParty,
+    ComponentUsingFlatModule,
     BindingErrorComp,
   ]
 })

--- a/packages/compiler-cli/integrationtest/test/ng_module_spec.ts
+++ b/packages/compiler-cli/integrationtest/test/ng_module_spec.ts
@@ -8,6 +8,7 @@
 import './init';
 
 import {ComponentUsingThirdParty} from '../src/comp_using_3rdp';
+import {ComponentUsingFlatModule} from '../src/comp_using_flat_module';
 import {MainModule} from '../src/module';
 import {CompUsingLibModuleDirectiveAndPipe, CompUsingRootModuleDirectiveAndPipe, SOME_TOKEN, ServiceUsingLibModule, SomeLibModule, SomeService} from '../src/module_fixtures';
 
@@ -42,6 +43,15 @@ describe('NgModule', () => {
          {a: 'b', component: CompUsingLibModuleDirectiveAndPipe}
        ]);
      });
+
+  describe('flat modules', () => {
+    it('should support flat module entryComponents components', () => {
+      // https://github.com/angular/angular/issues/15221
+      const fixture = createComponent(ComponentUsingFlatModule);
+      const bundleComp = fixture.nativeElement.children;
+      expect(bundleComp[0].children[0].children[0].data).toEqual('flat module component');
+    });
+  });
 
   describe('third-party modules', () => {
     // https://github.com/angular/angular/issues/11889

--- a/packages/compiler/src/aot/static_reflection_capabilities.ts
+++ b/packages/compiler/src/aot/static_reflection_capabilities.ts
@@ -42,6 +42,7 @@ export class StaticAndDynamicReflectionCapabilities {
   setter(name: string): ɵSetterFn { return this.dynamicDelegate.setter(name); }
   method(name: string): ɵMethodFn { return this.dynamicDelegate.method(name); }
   importUri(type: any): string { return this.staticDelegate.importUri(type); }
+  resourceUri(type: any): string { return this.staticDelegate.resourceUri(type); }
   resolveIdentifier(name: string, moduleUrl: string, members: string[], runtime: any) {
     return this.staticDelegate.resolveIdentifier(name, moduleUrl, members);
   }

--- a/packages/compiler/src/aot/static_reflector.ts
+++ b/packages/compiler/src/aot/static_reflector.ts
@@ -54,6 +54,11 @@ export class StaticReflector implements ɵReflectorReader {
     return staticSymbol ? staticSymbol.filePath : null;
   }
 
+  resourceUri(typeOrFunc: StaticSymbol): string {
+    const staticSymbol = this.findSymbolDeclaration(typeOrFunc);
+    return this.symbolResolver.getResourcePath(staticSymbol);
+  }
+
   resolveIdentifier(name: string, moduleUrl: string, members: string[]): StaticSymbol {
     const importSymbol = this.getStaticSymbol(moduleUrl, name);
     const rootSymbol = this.findDeclaration(moduleUrl, name);

--- a/packages/compiler/src/metadata_resolver.ts
+++ b/packages/compiler/src/metadata_resolver.ts
@@ -1060,7 +1060,7 @@ function isValidType(value: any): boolean {
 export function componentModuleUrl(
     reflector: ɵReflectorReader, type: Type<any>, cmpMetadata: Component): string {
   if (type instanceof StaticSymbol) {
-    return type.filePath;
+    return reflector.resourceUri(type);
   }
 
   const moduleId = cmpMetadata.moduleId;

--- a/packages/core/src/reflection/platform_reflection_capabilities.ts
+++ b/packages/core/src/reflection/platform_reflection_capabilities.ts
@@ -20,6 +20,7 @@ export interface PlatformReflectionCapabilities {
   setter(name: string): SetterFn;
   method(name: string): MethodFn;
   importUri(type: Type<any>): string;
+  resourceUri(type: Type<any>): string;
   resolveIdentifier(name: string, moduleUrl: string, members: string[], runtime: any): any;
   resolveEnum(enumIdentifier: any, name: string): any;
 }

--- a/packages/core/src/reflection/reflection_capabilities.ts
+++ b/packages/core/src/reflection/reflection_capabilities.ts
@@ -226,6 +226,8 @@ export class ReflectionCapabilities implements PlatformReflectionCapabilities {
     return `./${stringify(type)}`;
   }
 
+  resourceUri(type: any): string { return `./${stringify(type)}`; }
+
   resolveIdentifier(name: string, moduleUrl: string, members: string[], runtime: any): any {
     return runtime;
   }

--- a/packages/core/src/reflection/reflector.ts
+++ b/packages/core/src/reflection/reflector.ts
@@ -49,6 +49,8 @@ export class Reflector extends ReflectorReader {
 
   importUri(type: any): string { return this.reflectionCapabilities.importUri(type); }
 
+  resourceUri(type: any): string { return this.reflectionCapabilities.resourceUri(type); }
+
   resolveIdentifier(name: string, moduleUrl: string, members: string[], runtime: any): any {
     return this.reflectionCapabilities.resolveIdentifier(name, moduleUrl, members, runtime);
   }

--- a/packages/core/src/reflection/reflector_reader.ts
+++ b/packages/core/src/reflection/reflector_reader.ts
@@ -15,6 +15,7 @@ export abstract class ReflectorReader {
   abstract annotations(typeOrFunc: /*Type*/ any): any[];
   abstract propMetadata(typeOrFunc: /*Type*/ any): {[key: string]: any[]};
   abstract importUri(typeOrFunc: /*Type*/ any): string;
+  abstract resourceUri(typeOrFunc: /*Type*/ any): string;
   abstract resolveIdentifier(name: string, moduleUrl: string, members: string[], runtime: any): any;
   abstract resolveEnum(identifier: any, name: string): any;
 }

--- a/scripts/ci/offline_compiler_test.sh
+++ b/scripts/ci/offline_compiler_test.sh
@@ -49,6 +49,12 @@ cp -v package.json $TMP
   # Generate the metadata for the third-party modules
   node ./node_modules/@angular/tsc-wrapped/src/main -p third_party_src/tsconfig-build.json
 
+  # Generate the the bundle modules
+  node ./node_modules/@angular/tsc-wrapped/src/main -p flat_module/tsconfig-build.json
+
+  # Copy the html files from source to the emitted output
+  cp flat_module/src/*.html node_modules/flat_module/src
+
   ./node_modules/.bin/ngc -p tsconfig-build.json --i18nFile=src/messages.fi.xlf --locale=fi --i18nFormat=xlf
 
   ./node_modules/.bin/ng-xi18n -p tsconfig-xi18n.json --i18nFormat=xlf --locale=fr

--- a/tools/@angular/tsc-wrapped/src/schema.ts
+++ b/tools/@angular/tsc-wrapped/src/schema.ts
@@ -25,6 +25,7 @@ export interface ModuleMetadata {
   exports?: ModuleExportMetadata[];
   importAs?: string;
   metadata: {[name: string]: MetadataEntry};
+  origins?: {[name: string]: string};
 }
 export function isModuleMetadata(value: any): value is ModuleMetadata {
   return value && value.__symbolic === 'module';

--- a/tools/@angular/tsc-wrapped/test/bundler_spec.ts
+++ b/tools/@angular/tsc-wrapped/test/bundler_spec.ts
@@ -25,9 +25,21 @@ describe('metadata bundler', () => {
     expect(Object.keys(result.metadata.metadata).sort()).toEqual([
       'ONE_CLASSES', 'One', 'OneMore', 'TWO_CLASSES', 'Two', 'TwoMore', 'ɵa', 'ɵb'
     ]);
+
+    const originalOne = './src/one';
+    const originalTwo = './src/two/index';
+    expect(Object.keys(result.metadata.origins)
+               .sort()
+               .map(name => ({name, value: result.metadata.origins[name]})))
+        .toEqual([
+          {name: 'ONE_CLASSES', value: originalOne}, {name: 'One', value: originalOne},
+          {name: 'OneMore', value: originalOne}, {name: 'TWO_CLASSES', value: originalTwo},
+          {name: 'Two', value: originalTwo}, {name: 'TwoMore', value: originalTwo},
+          {name: 'ɵa', value: originalOne}, {name: 'ɵb', value: originalTwo}
+        ]);
     expect(result.privates).toEqual([
-      {privateName: 'ɵa', name: 'PrivateOne', module: './src/one'},
-      {privateName: 'ɵb', name: 'PrivateTwo', module: './src/two/index'}
+      {privateName: 'ɵa', name: 'PrivateOne', module: originalOne},
+      {privateName: 'ɵb', name: 'PrivateTwo', module: originalTwo}
     ]);
   });
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

See #15221. `ngc` loses the full path of resources and looks for them relative to the flat module index.

**What is the new behavior?**

`ngc` now looks for resources relative to the `.d.ts` file that declares the class.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
