### PR TITLE
fix(platform-browser): By.css should work with all element types

### DIFF
--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -290,13 +290,9 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   getTitle(doc: Document): string { return document.title; }
   setTitle(doc: Document, newTitle: string) { document.title = newTitle || ''; }
   elementMatches(n: any, selector: string): boolean {
-    if (n instanceof HTMLElement) {
-      return n.matches && n.matches(selector) ||
-          n.msMatchesSelector && n.msMatchesSelector(selector) ||
-          n.webkitMatchesSelector && n.webkitMatchesSelector(selector);
-    }
-
-    return false;
+    return n.matches && n.matches(selector) ||
+        n.msMatchesSelector && n.msMatchesSelector(selector) ||
+        n.webkitMatchesSelector && n.webkitMatchesSelector(selector);
   }
   isTemplateElement(el: Node): boolean {
     return el instanceof HTMLElement && el.nodeName == 'TEMPLATE';


### PR DESCRIPTION
Closes #15164

Before this change `By.css` only worked with `HTMLElement`s