### PR TITLE
fix(tsc-wrapped): use windows friendly path normalization in bundler

### DIFF
--- a/tools/@angular/tsc-wrapped/src/bundler.ts
+++ b/tools/@angular/tsc-wrapped/src/bundler.ts
@@ -517,32 +517,14 @@ export class CompilerHostAdapter implements MetadataBundlerHost {
 
 function resolveModule(importName: string, from: string): string {
   if (importName.startsWith('.') && from) {
-    return normalize(path.join(path.dirname(from), importName));
+    const normalPath = path.normalize(path.join(path.dirname(from), importName));
+    if (!normalPath.startsWith('.') && from.startsWith('.')) {
+      // path.normalize() preserves leading '../' but not './'. This adds it back.
+      return `.${path.sep}${normalPath}`;
+    }
+    return normalPath;
   }
   return importName;
-}
-
-function normalize(path: string): string {
-  const parts = path.split('/');
-  const segments: string[] = [];
-  for (const part of parts) {
-    switch (part) {
-      case '':
-      case '.':
-        continue;
-      case '..':
-        segments.pop();
-        break;
-      default:
-        segments.push(part);
-    }
-  }
-  if (segments.length) {
-    segments.unshift(path.startsWith('/') ? '' : '.');
-    return segments.join('/');
-  } else {
-    return '.';
-  }
 }
 
 function isPrimitive(o: any): o is boolean|string|number {


### PR DESCRIPTION
Fixes #15289

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

The flat module index is (almost) always empty when building on Windows.

**What is the new behavior?**

The flat module index contains the correct data.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
