### PR TITLE
caretaker squash: fix: spelling errors

### DIFF
--- a/packages/animations/browser/src/dsl/animation_timeline_visitor.ts
+++ b/packages/animations/browser/src/dsl/animation_timeline_visitor.ts
@@ -51,7 +51,7 @@ import {AnimationTimelineInstruction, createTimelineInstruction} from './animati
  * [TimelineBuilder]
  * This class is responsible for tracking the styles and building a series of keyframe objects for a
  * timeline between a start and end time. The builder starts off with an initial timeline and each
- * time the AST comes across a `group()`, `keyframes()` or a combination of the two wihtin a
+ * time the AST comes across a `group()`, `keyframes()` or a combination of the two within a
  * `sequence()` then it will generate a sub timeline for each step as well as a new one after
  * they are complete.
  *
@@ -83,7 +83,7 @@ import {AnimationTimelineInstruction, createTimelineInstruction} from './animati
  * from all previous keyframes up until where it is first used. For the timeline keyframe generation
  * to properly fill in the style it will place the previous value (the value from the parent
  * timeline) or a default value of `*` into the backFill object. Given that each of the keyframe
- * styles are objects that prototypically inhert from the backFill object, this means that if a
+ * styles are objects that prototypically inherited from the backFill object, this means that if a
  * value is added into the backFill then it will automatically propagate any missing values to all
  * keyframes. Therefore the missing `height` value will be properly filled into the already
  * processed keyframes.
@@ -92,7 +92,7 @@ import {AnimationTimelineInstruction, createTimelineInstruction} from './animati
  * styles present within the sub-timeline do not accidentally seep into the previous/future timeline
  * keyframes
  *
- * (For prototypically-inherited contents to be detected a `for(i in obj)` loop must be used.)
+ * (For prototypically inherited contents to be detected a `for(i in obj)` loop must be used.)
  *
  * [Validation]
  * The code in this file is not responsible for validation. That functionality happens with within

--- a/packages/benchpress/src/metric/perflog_metric.ts
+++ b/packages/benchpress/src/metric/perflog_metric.ts
@@ -272,7 +272,7 @@ export class PerflogMetric extends Metric {
       } else if (this._receivedData && name === 'receivedData' && ph === 'I') {
         result['receivedData'] += event['args']['encodedDataLength'];
       }
-      if (ph === 'B' && name === _MARK_NAME_FRAME_CAPUTRE) {
+      if (ph === 'B' && name === _MARK_NAME_FRAME_CAPTURE) {
         if (frameCaptureStartEvent) {
           throw new Error('can capture frames only once per benchmark run');
         }
@@ -281,7 +281,7 @@ export class PerflogMetric extends Metric {
               'found start event for frame capture, but frame capture was not requested in benchpress');
         }
         frameCaptureStartEvent = event;
-      } else if (ph === 'E' && name === _MARK_NAME_FRAME_CAPUTRE) {
+      } else if (ph === 'E' && name === _MARK_NAME_FRAME_CAPTURE) {
         if (!frameCaptureStartEvent) {
           throw new Error('missing start event for frame capture');
         }
@@ -366,6 +366,6 @@ const _MICRO_ITERATIONS_REGEX = /(.+)\*(\d+)$/;
 const _MAX_RETRY_COUNT = 20;
 const _MARK_NAME_PREFIX = 'benchpress';
 
-const _MARK_NAME_FRAME_CAPUTRE = 'frameCapture';
+const _MARK_NAME_FRAME_CAPTURE = 'frameCapture';
 // using 17ms as a somewhat looser threshold, instead of 16.6666ms
 const _FRAME_TIME_SMOOTH_THRESHOLD = 17;

--- a/packages/common/src/directives/index.ts
+++ b/packages/common/src/directives/index.ts
@@ -55,6 +55,6 @@ export const COMMON_DIRECTIVES: Provider[] = [
 ];
 
 /**
- * A colletion of deprecated directives that are no longer part of the core module.
+ * A collection of deprecated directives that are no longer part of the core module.
  */
 export const COMMON_DEPRECATED_DIRECTIVES: Provider[] = [NgFor];


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
1. File `animation_timeline_visitor.ts` contained wrong words `wihtin`, `inhert` and `prototypically-inherited`

2. File `perflog_metric.ts` contained constant variable with a wrong spelling `_MARK_NAME_FRAME_CAPUTRE`

3. File `directives/index.ts` contained wrong word `colletion`

**What is the new behavior?**
1. Should be `within`, `inherited` and `prototypically inherited`
2. Should be `_MARK_NAME_FRAME_CAPTURE`
3. Should be `collection`

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:

Spelling errors