### PR TITLE
fix(compiler-cli): self referencing routes cause a stack overflow

### DIFF
--- a/packages/compiler-cli/integrationtest/ngtools_src/feature3/recursive-feature.module.ts
+++ b/packages/compiler-cli/integrationtest/ngtools_src/feature3/recursive-feature.module.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, NgModule} from '@angular/core';
+import {RouterModule} from '@angular/router';
+
+@Component({selector: 'recursive-feature-comp', template: 'recursive feature!'})
+export class RecursiveFeatureComponent {
+}
+
+@NgModule({
+  imports: [RouterModule.forChild([
+    {path: '', component: RecursiveFeatureComponent, pathMatch: 'full'},
+    {path: ':name', loadChildren: './recursive-feature.module#RecursiveFeatureModule'}
+  ])],
+  declarations: [RecursiveFeatureComponent]
+})
+export class RecursiveFeatureModule {
+}

--- a/packages/compiler-cli/integrationtest/ngtools_src/lazy.module.ts
+++ b/packages/compiler-cli/integrationtest/ngtools_src/lazy.module.ts
@@ -17,7 +17,8 @@ export class LazyComponent {
   imports: [RouterModule.forChild([
     {path: '', component: LazyComponent, pathMatch: 'full'},
     {path: 'feature', loadChildren: './feature/feature.module#FeatureModule'},
-    {path: 'lazy-feature', loadChildren: './feature/lazy-feature.module#LazyFeatureModule'}
+    {path: 'lazy-feature', loadChildren: './feature/lazy-feature.module#LazyFeatureModule'},
+    {path: 'recursive-feature', loadChildren: './feature3/recursive-feature.module#RecursiveFeatureModule'}
   ])],
   declarations: [LazyComponent]
 })

--- a/packages/compiler-cli/integrationtest/ngtools_src/lazy.module.ts
+++ b/packages/compiler-cli/integrationtest/ngtools_src/lazy.module.ts
@@ -18,6 +18,7 @@ export class LazyComponent {
     {path: '', component: LazyComponent, pathMatch: 'full'},
     {path: 'feature', loadChildren: './feature/feature.module#FeatureModule'},
     {path: 'lazy-feature', loadChildren: './feature/lazy-feature.module#LazyFeatureModule'}
+    {path: 'recursive-feature', loadChildren: './feature3/recursive-feature.module#RecursiveFeatureModule'}
   ])],
   declarations: [LazyComponent]
 })

--- a/packages/compiler-cli/src/ngtools_impl.ts
+++ b/packages/compiler-cli/src/ngtools_impl.ts
@@ -71,6 +71,11 @@ export function listLazyRoutesOfModule(
           LazyRouteMap {
             const route: string = lazyRoute.routeDef.toString();
             _assertRoute(allRoutes, lazyRoute);
+
+            if (route in allRoutes) {
+                return allRoutes;
+            }
+
             allRoutes[route] = lazyRoute;
 
             // StaticReflector does not support discovering annotations like `NgModule` on default


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

See: https://github.com/angular/angular/issues/15376


**What is the new behavior?**

Stack overflow no longer occurs. Self referencing routes render correctly.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
I have been unable to compile the angular codebase and execute the new test changes so please consider this when reviewing! I'm hoping that the new test demonstrates the specific route configuration that is causing the issue above.

I have made the same correction against our original code base and this has resolved the problem.