### PR TITLE
fix(compiler-cli): self referencing routes cause a stack overflow

### DIFF
--- a/packages/compiler-cli/integrationtest/ngtools_src/feature3/recursive-feature.module.ts
+++ b/packages/compiler-cli/integrationtest/ngtools_src/feature3/recursive-feature.module.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, NgModule} from '@angular/core';
+import {RouterModule} from '@angular/router';
+
+@Component({selector: 'recursive-feature-comp', template: 'recursive feature!'})
+export class RecursiveFeatureComponent {
+}
+
+@NgModule({
+  imports: [RouterModule.forChild([
+    {path: '', component: RecursiveFeatureComponent, pathMatch: 'full'},
+    {path: ':name', loadChildren: './recursive-feature.module#RecursiveFeatureModule'}
+  ])],
+  declarations: [RecursiveFeatureComponent]
+})
+export class RecursiveFeatureModule {
+}

--- a/packages/compiler-cli/integrationtest/ngtools_src/lazy.module.ts
+++ b/packages/compiler-cli/integrationtest/ngtools_src/lazy.module.ts
@@ -17,8 +17,10 @@ export class LazyComponent {
   imports: [RouterModule.forChild([
     {path: '', component: LazyComponent, pathMatch: 'full'},
     {path: 'feature', loadChildren: './feature/feature.module#FeatureModule'},
-    {path: 'lazy-feature', loadChildren: './feature/lazy-feature.module#LazyFeatureModule'},
-    {path: 'recursive-feature', loadChildren: './feature3/recursive-feature.module#RecursiveFeatureModule'}
+    {path: 'lazy-feature', loadChildren: './feature/lazy-feature.module#LazyFeatureModule'}, {
+      path: 'recursive-feature',
+      loadChildren: './feature3/recursive-feature.module#RecursiveFeatureModule'
+    }
   ])],
   declarations: [LazyComponent]
 })

--- a/packages/compiler-cli/integrationtest/ngtools_src/lazy.module.ts
+++ b/packages/compiler-cli/integrationtest/ngtools_src/lazy.module.ts
@@ -17,7 +17,10 @@ export class LazyComponent {
   imports: [RouterModule.forChild([
     {path: '', component: LazyComponent, pathMatch: 'full'},
     {path: 'feature', loadChildren: './feature/feature.module#FeatureModule'},
-    {path: 'lazy-feature', loadChildren: './feature/lazy-feature.module#LazyFeatureModule'}
+    {path: 'lazy-feature', loadChildren: './feature/lazy-feature.module#LazyFeatureModule'}, {
+      path: 'recursive-feature',
+      loadChildren: './feature3/recursive-feature.module#RecursiveFeatureModule'
+    }
   ])],
   declarations: [LazyComponent]
 })

--- a/packages/compiler-cli/integrationtest/ngtools_src/lazy.module.ts
+++ b/packages/compiler-cli/integrationtest/ngtools_src/lazy.module.ts
@@ -17,7 +17,8 @@ export class LazyComponent {
   imports: [RouterModule.forChild([
     {path: '', component: LazyComponent, pathMatch: 'full'},
     {path: 'feature', loadChildren: './feature/feature.module#FeatureModule'},
-    {path: 'lazy-feature', loadChildren: './feature/lazy-feature.module#LazyFeatureModule'}
+    {path: 'lazy-feature', loadChildren: './feature/lazy-feature.module#LazyFeatureModule'},
+    {path: 'recursive-feature', loadChildren: './feature3/recursive-feature.module#RecursiveFeatureModule'}
   ])],
   declarations: [LazyComponent]
 })

--- a/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
+++ b/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
@@ -197,8 +197,7 @@ function lazyRoutesTest() {
     './lazy-feature-nested.module#LazyFeatureNestedModule': 'feature/lazy-feature-nested.module.ts',
     './feature3/recursive-feature.module#RecursiveFeatureModule':
         'feature3/recursive-feature.module.ts',
-    './recursive-feature.module#RecursiveFeatureModule':
-        'feature3/recursive-feature.module.ts',
+    './recursive-feature.module#RecursiveFeatureModule': 'feature3/recursive-feature.module.ts',
     'feature2/feature2.module#Feature2Module': 'feature2/feature2.module.ts',
     './default.module': 'feature2/default.module.ts',
     'feature/feature.module#FeatureModule': 'feature/feature.module.ts'

--- a/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
+++ b/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
@@ -195,11 +195,11 @@ function lazyRoutesTest() {
     './feature/lazy-feature.module#LazyFeatureModule': 'feature/lazy-feature.module.ts',
     './feature.module#FeatureModule': 'feature/feature.module.ts',
     './lazy-feature-nested.module#LazyFeatureNestedModule': 'feature/lazy-feature-nested.module.ts',
-    'feature2/feature2.module#Feature2Module': 'feature2/feature2.module.ts',
     './feature3/recursive-feature.module#RecursiveFeatureModule':
         'feature3/recursive-feature.module.ts',
     './recursive-feature.module#RecursiveFeatureModule':
         'feature3/recursive-feature.module.ts',
+    'feature2/feature2.module#Feature2Module': 'feature2/feature2.module.ts',
     './default.module': 'feature2/default.module.ts',
     'feature/feature.module#FeatureModule': 'feature/feature.module.ts'
   };

--- a/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
+++ b/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
@@ -195,6 +195,10 @@ function lazyRoutesTest() {
     './feature/lazy-feature.module#LazyFeatureModule': 'feature/lazy-feature.module.ts',
     './feature.module#FeatureModule': 'feature/feature.module.ts',
     './lazy-feature-nested.module#LazyFeatureNestedModule': 'feature/lazy-feature-nested.module.ts',
+    './feature3/recursive-feature.module#RecursiveFeatureModule':
+        'feature3/recursive-feature.module.ts',
+    './recursive-feature.module#RecursiveFeatureModule':
+        'feature3/recursive-feature.module.ts',
     'feature2/feature2.module#Feature2Module': 'feature2/feature2.module.ts',
     './default.module': 'feature2/default.module.ts',
     'feature/feature.module#FeatureModule': 'feature/feature.module.ts'

--- a/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
+++ b/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
@@ -197,7 +197,8 @@ function lazyRoutesTest() {
     './lazy-feature-nested.module#LazyFeatureNestedModule': 'feature/lazy-feature-nested.module.ts',
     'feature2/feature2.module#Feature2Module': 'feature2/feature2.module.ts',
     './default.module': 'feature2/default.module.ts',
-    'feature/feature.module#FeatureModule': 'feature/feature.module.ts'
+    'feature/feature.module#FeatureModule': 'feature/feature.module.ts',
+    './feature3/recursive-feature.module#RecursiveFeatureModule': 'feature3/recursive-feature.module.ts'
   };
 
   Object.keys(lazyRoutes).forEach((route: string) => {

--- a/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
+++ b/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
@@ -201,7 +201,7 @@ function lazyRoutesTest() {
     './feature3/recursive-feature.module#RecursiveFeatureModule':
         'feature3/recursive-feature.module.ts',
     './recursive-feature.module#RecursiveFeatureModule':
-        './recursive-feature.module.ts'
+        'feature3/recursive-feature.module.ts'
   };
 
   Object.keys(lazyRoutes).forEach((route: string) => {

--- a/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
+++ b/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
@@ -199,7 +199,9 @@ function lazyRoutesTest() {
     './default.module': 'feature2/default.module.ts',
     'feature/feature.module#FeatureModule': 'feature/feature.module.ts',
     './feature3/recursive-feature.module#RecursiveFeatureModule':
-        'feature3/recursive-feature.module.ts'
+        'feature3/recursive-feature.module.ts',
+    './recursive-feature.module#RecursiveFeatureModule':
+        './recursive-feature.module.ts'
   };
 
   Object.keys(lazyRoutes).forEach((route: string) => {

--- a/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
+++ b/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
@@ -198,7 +198,8 @@ function lazyRoutesTest() {
     'feature2/feature2.module#Feature2Module': 'feature2/feature2.module.ts',
     './default.module': 'feature2/default.module.ts',
     'feature/feature.module#FeatureModule': 'feature/feature.module.ts',
-    './feature3/recursive-feature.module#RecursiveFeatureModule': 'feature3/recursive-feature.module.ts'
+    './feature3/recursive-feature.module#RecursiveFeatureModule':
+        'feature3/recursive-feature.module.ts'
   };
 
   Object.keys(lazyRoutes).forEach((route: string) => {

--- a/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
+++ b/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
@@ -196,12 +196,12 @@ function lazyRoutesTest() {
     './feature.module#FeatureModule': 'feature/feature.module.ts',
     './lazy-feature-nested.module#LazyFeatureNestedModule': 'feature/lazy-feature-nested.module.ts',
     'feature2/feature2.module#Feature2Module': 'feature2/feature2.module.ts',
-    './default.module': 'feature2/default.module.ts',
-    'feature/feature.module#FeatureModule': 'feature/feature.module.ts',
     './feature3/recursive-feature.module#RecursiveFeatureModule':
         'feature3/recursive-feature.module.ts',
     './recursive-feature.module#RecursiveFeatureModule':
-        'feature3/recursive-feature.module.ts'
+        'feature3/recursive-feature.module.ts',
+    './default.module': 'feature2/default.module.ts',
+    'feature/feature.module#FeatureModule': 'feature/feature.module.ts'
   };
 
   Object.keys(lazyRoutes).forEach((route: string) => {

--- a/packages/compiler-cli/src/ngtools_impl.ts
+++ b/packages/compiler-cli/src/ngtools_impl.ts
@@ -73,7 +73,7 @@ export function listLazyRoutesOfModule(
             _assertRoute(allRoutes, lazyRoute);
 
             if (route in allRoutes) {
-                return allRoutes;
+              return allRoutes;
             }
 
             allRoutes[route] = lazyRoute;

--- a/packages/compiler-cli/src/ngtools_impl.ts
+++ b/packages/compiler-cli/src/ngtools_impl.ts
@@ -71,6 +71,11 @@ export function listLazyRoutesOfModule(
           LazyRouteMap {
             const route: string = lazyRoute.routeDef.toString();
             _assertRoute(allRoutes, lazyRoute);
+
+            if (route in allRoutes) {
+              return allRoutes;
+            }
+
             allRoutes[route] = lazyRoute;
 
             // StaticReflector does not support discovering annotations like `NgModule` on default

--- a/packages/compiler-cli/src/ngtools_impl.ts
+++ b/packages/compiler-cli/src/ngtools_impl.ts
@@ -71,6 +71,11 @@ export function listLazyRoutesOfModule(
           LazyRouteMap {
             const route: string = lazyRoute.routeDef.toString();
             _assertRoute(allRoutes, lazyRoute);
+
+            if (route in allRoutes) {
+                return allRoutes;
+            }
+
             allRoutes[route] = lazyRoute;
 
             // StaticReflector does not support discovering annotations like `NgModule` on default


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

See: https://github.com/angular/angular/issues/15376


**What is the new behavior?**

Stack overflow no longer occurs. Self referencing routes render correctly.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
I have made the same correction against our original code base and this has resolved the problem.