### PR TITLE
fix(compiler-cli): adding missing format xliff for the extractor

### DIFF
--- a/packages/compiler-cli/src/extractor.ts
+++ b/packages/compiler-cli/src/extractor.ts
@@ -67,7 +67,7 @@ export class Extractor {
     const format = (formatName || 'xlf').toLowerCase();
 
     if (format === 'xmb') return 'xmb';
-    if (format === 'xlf' || format === 'xlif') return 'xlf';
+    if (format === 'xlf' || format === 'xlif' || format === 'xliff') return 'xlf';
 
     throw new Error('Unsupported format "${formatName}"');
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
```
[x] Bugfix
```

**What is the current behavior?**
To generate XLF files with ng-xi18n we could use the format parameter `xlf` or `xlif`. The real name being `xliff`, not `xlif`, this was most likely a typo.


**What is the new behavior?**
This PR adds the parameter `xliff` as can be expected. I haven't removed `xlif` to avoid breaking changes.


**Does this PR introduce a breaking change?**
```
[x] No
```