### PR TITLE
Update example to show querying all descendants

### DIFF
--- a/packages/examples/core/di/ts/contentChildren/content_children_example.ts
+++ b/packages/examples/core/di/ts/contentChildren/content_children_example.ts
@@ -17,13 +17,16 @@ export class Pane {
 @Component({
   selector: 'tab',
   template: `
-    <div>panes: {{serializedPanes}}</div> 
+    <div>panes: {{serializedPanes}}</div>
+    <div>allPanes: {{serializedAllPanes}}</div>
   `
 })
 export class Tab {
   @ContentChildren(Pane) panes: QueryList<Pane>;
+  @ContentChildren(Pane, { descendants: true }) allPanes: QueryList<Pane>;
 
   get serializedPanes(): string { return this.panes ? this.panes.map(p => p.id).join(', ') : ''; }
+  get serializedAllPanes(): string { return this.allPanes ? this.allPanes.map(p => p.id).join(', ') : ''; }
 }
 
 @Component({
@@ -32,7 +35,12 @@ export class Tab {
     <tab>
       <pane id="1"></pane>
       <pane id="2"></pane>
-      <pane id="3" *ngIf="shouldShow"></pane>
+      <pane id="3" *ngIf="shouldShow">
+        <tab>
+          <pane id="3_1"></pane>
+          <pane id="3_2"></pane>
+        </tab>
+      </pane>
     </tab>
     
     <button (click)="show()">Show 3</button>


### PR DESCRIPTION
Updated example to illustrate @ContentChildren default behaviour (only query direct children), and how to query for nested elements/all descendants.
PR Close #14417

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Example in docs updated
```

**What is the current behavior?** (You can also link to an open issue here)
Example didn't make it clear that the default behaviour of ContentChildren was to only query direct children.


**What is the new behavior?**
Added an equally simple example of query for nested elements/all descendants.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

