### PR TITLE
docs: clarify querying all descendants

### DIFF
--- a/packages/examples/core/di/ts/contentChildren/content_children_example.ts
+++ b/packages/examples/core/di/ts/contentChildren/content_children_example.ts
@@ -17,13 +17,20 @@ export class Pane {
 @Component({
   selector: 'tab',
   template: `
-    <div>panes: {{serializedPanes}}</div> 
+    <div class="top-level">Top level panes: {{serializedPanes}}</div> 
+    <div class="nested">Arbitrary nested panes: {{serializedNestedPanes}}</div>
   `
 })
 export class Tab {
-  @ContentChildren(Pane) panes: QueryList<Pane>;
+  @ContentChildren(Pane) topLevelPanes: QueryList<Pane>;
+  @ContentChildren(Pane, {descendants: true}) arbitraryNestedPanes: QueryList<Pane>;
 
-  get serializedPanes(): string { return this.panes ? this.panes.map(p => p.id).join(', ') : ''; }
+  get serializedPanes(): string {
+    return this.topLevelPanes ? this.topLevelPanes.map(p => p.id).join(', ') : '';
+  }
+  get serializedNestedPanes(): string {
+    return this.arbitraryNestedPanes ? this.arbitraryNestedPanes.map(p => p.id).join(', ') : '';
+  }
 }
 
 @Component({
@@ -32,7 +39,12 @@ export class Tab {
     <tab>
       <pane id="1"></pane>
       <pane id="2"></pane>
-      <pane id="3" *ngIf="shouldShow"></pane>
+      <pane id="3" *ngIf="shouldShow">
+        <tab>
+          <pane id="3_1"></pane>
+          <pane id="3_2"></pane>
+        </tab>
+      </pane>
     </tab>
     
     <button (click)="show()">Show 3</button>

--- a/packages/examples/core/di/ts/contentChildren/e2e_test/content_children_spec.ts
+++ b/packages/examples/core/di/ts/contentChildren/e2e_test/content_children_spec.ts
@@ -12,19 +12,29 @@ import {verifyNoBrowserErrors} from '../../../../../_common/e2e_util';
 describe('contentChildren example', () => {
   afterEach(verifyNoBrowserErrors);
   let button: ElementFinder;
-  let result: ElementFinder;
+  let resultTopLevel: ElementFinder;
+  let resultNested: ElementFinder;
 
   beforeEach(() => {
     browser.get('/core/di/ts/contentChildren/index.html');
     button = element(by.css('button'));
-    result = element(by.css('div'));
+    resultTopLevel = element(by.css('.top-level'));
+    resultNested = element(by.css('.nested'));
   });
 
   it('should query content children', () => {
-    expect(result.getText()).toEqual('panes: 1, 2');
+    expect(resultTopLevel.getText()).toEqual('Top level panes: 1, 2');
 
     button.click();
 
-    expect(result.getText()).toEqual('panes: 1, 2, 3');
+    expect(resultTopLevel.getText()).toEqual('Top level panes: 1, 2, 3');
+  });
+
+  it('should query nested content children', () => {
+    expect(resultNested.getText()).toEqual('Arbitrary nested panes: 1, 2');
+
+    button.click();
+
+    expect(resultNested.getText()).toEqual('Arbitrary nested panes: 1, 2, 3, 3_1, 3_2');
   });
 });


### PR DESCRIPTION
Updated example to illustrate @ContentChildren default behaviour (only query direct children), and how to query for nested elements/all descendants.
PR Close #14417

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Example in docs updated
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

