### PR TITLE
feat(aio): add and test FileLoaderService w/ XHR, Webpack, Http

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -71,7 +71,7 @@
       "tooltip": "A gentle introduction to Angular.",
       "children": [
         {
-          "url": "guide/docs-overview",
+          "url": "guide/",
           "title": "Overview",
           "tooltip": "How to read and use this documentation."
         },

--- a/aio/src/app/app.module.ts
+++ b/aio/src/app/app.module.ts
@@ -1,6 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { HttpModule } from '@angular/http';
 
 import { Location, LocationStrategy, PathLocationStrategy } from '@angular/common';
 
@@ -19,6 +18,12 @@ import { AppComponent } from 'app/app.component';
 import { ApiService } from 'app/embedded/api/api.service';
 import { DocViewerComponent } from 'app/layout/doc-viewer/doc-viewer.component';
 import { embeddedComponents, EmbeddedComponents } from 'app/embedded';
+
+import { HttpModule } from '@angular/http';
+import { FileLoaderProviders } from 'app/shared/file-loader-http.service';
+// import { FileLoaderProviders } from 'app/shared/file-loader-webpack.service';
+// import { FileLoaderProviders } from 'app/shared/file-loader-xhr.service';
+
 import { GaService } from 'app/shared/ga.service';
 import { Logger } from 'app/shared/logger.service';
 import { LocationService } from 'app/shared/location.service';
@@ -35,7 +40,7 @@ import { AutoScrollService } from 'app/shared/auto-scroll.service';
 @NgModule({
   imports: [
     BrowserModule,
-    HttpModule,
+    HttpModule,  // <- Delete if we use a non-Http FileLoaderService
     MdButtonModule,
     MdIconModule,
     MdInputModule,
@@ -55,6 +60,7 @@ import { AutoScrollService } from 'app/shared/auto-scroll.service';
   providers: [
     ApiService,
     EmbeddedComponents,
+    FileLoaderProviders,
     GaService,
     Logger,
     Location,

--- a/aio/src/app/documents/document.service.spec.ts
+++ b/aio/src/app/documents/document.service.spec.ts
@@ -1,39 +1,32 @@
 import { ReflectiveInjector } from '@angular/core';
-import { Http, ConnectionBackend, RequestOptions, BaseRequestOptions, Response, ResponseOptions } from '@angular/http';
 
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
-import { MockBackend } from '@angular/http/testing';
+import { FileLoaderService } from 'app/shared/file-loader.service';
+import { TestFileLoaderService } from 'testing/file-loader.service';
 import { LocationService } from 'app/shared/location.service';
 import { MockLocationService } from 'testing/location.service';
 import { Logger } from 'app/shared/logger.service';
 import { MockLogger } from 'testing/logger.service';
 import { DocumentService, DocumentContents } from './document.service';
 
-
-const CONTENT_URL_PREFIX = 'content/docs/';
-
-function createResponse(body: any) {
-  return new Response(new ResponseOptions({ body: JSON.stringify(body) }));
-}
+const CONTENT_URL_PREFIX = 'docs/';
 
 function createInjector(initialUrl: string) {
   return ReflectiveInjector.resolveAndCreate([
       DocumentService,
       { provide: LocationService, useFactory: () => new MockLocationService(initialUrl) },
-      { provide: ConnectionBackend, useClass: MockBackend },
-      { provide: RequestOptions, useClass: BaseRequestOptions },
-      { provide: Logger, useClass: MockLogger },
-      Http,
+        { provide: FileLoaderService, useClass: TestFileLoaderService },
+      { provide: Logger, useClass: MockLogger }
   ]);
 }
 
 function getServices(initialUrl: string = '') {
   const injector = createInjector(initialUrl);
   return {
-    backend: injector.get(ConnectionBackend) as MockBackend,
+    loader: injector.get(FileLoaderService) as TestFileLoaderService,
     location: injector.get(LocationService) as MockLocationService,
     service: injector.get(DocumentService) as DocumentService,
     logger: injector.get(Logger) as MockLogger
@@ -50,58 +43,58 @@ describe('DocumentService', () => {
   describe('currentDocument', () => {
 
     it('should fetch a document for the initial location url', () => {
-      const { service, backend } = getServices('initial/url');
-      const connections = backend.connectionsArray;
+      const { service, loader } = getServices('initial/url');
+      const connections = loader.connectionsArray;
       service.currentDocument.subscribe();
 
       expect(connections.length).toEqual(1);
-      expect(connections[0].request.url).toEqual(CONTENT_URL_PREFIX + 'initial/url.json');
-      expect(backend.connectionsArray[0].request.url).toEqual(CONTENT_URL_PREFIX + 'initial/url.json');
+      expect(connections[0].url).toEqual(CONTENT_URL_PREFIX + 'initial/url.json');
+      expect(loader.connectionsArray[0].url).toEqual(CONTENT_URL_PREFIX + 'initial/url.json');
     });
 
     it('should emit a document each time the location changes', () => {
       let latestDocument: DocumentContents;
       const doc0 = { title: 'doc 0' };
       const doc1 = { title: 'doc 1' };
-      const { service, backend, location } = getServices('initial/url');
-      const connections = backend.connectionsArray;
+      const { service, loader, location } = getServices('initial/url');
+      const connections = loader.connectionsArray;
 
       service.currentDocument.subscribe(doc => latestDocument = doc);
       expect(latestDocument).toBeUndefined();
 
-      connections[0].mockRespond(createResponse(doc0));
+      connections[0].mockRespond(doc0);
       expect(latestDocument).toEqual(doc0);
 
       location.urlSubject.next('new/url');
-      connections[1].mockRespond(createResponse(doc1));
+      connections[1].mockRespond(doc1);
       expect(latestDocument).toEqual(doc1);
     });
 
     it('should emit the not-found document if the document is not found on the server', () => {
-      const { service, backend } = getServices('missing/url');
-      const connections = backend.connectionsArray;
+      const { service, loader } = getServices('missing/url');
+      const connections = loader.connectionsArray;
       service.currentDocument.subscribe();
 
-      connections[0].mockError(new Response(new ResponseOptions({ status: 404, statusText: 'NOT FOUND'})) as any);
+      connections[0].mockRespond(undefined, { status: 404, statusText: 'NOT FOUND'});
       expect(connections.length).toEqual(2);
-      expect(connections[1].request.url).toEqual(CONTENT_URL_PREFIX + 'file-not-found.json');
+      expect(connections[1].url).toEqual(CONTENT_URL_PREFIX + 'file-not-found.json');
     });
 
     it('should emit a hard-coded not-found document if the not-found document is not found on the server', () => {
       let currentDocument: DocumentContents;
       const notFoundDoc = { title: 'Not Found', contents: 'Document not found' };
       const nextDoc = { title: 'Next Doc' };
-      const { service, backend, location } = getServices('file-not-found');
-      const connections = backend.connectionsArray;
+      const { service, loader, location } = getServices('file-not-found');
+      const connections = loader.connectionsArray;
       service.currentDocument.subscribe(doc => currentDocument = doc);
 
-      connections[0].mockError(new Response(new ResponseOptions({ status: 404, statusText: 'NOT FOUND'})) as any);
+      connections[0].mockRespond(null, { status: 404, statusText: 'NOT FOUND'});
       expect(connections.length).toEqual(1);
       expect(currentDocument).toEqual(notFoundDoc);
 
       // now check that we haven't killed the currentDocument observable sequence
       location.urlSubject.next('new/url');
-      connections[1].mockRespond(createResponse(nextDoc));
+      connections[1].mockRespond(nextDoc);
       expect(currentDocument).toEqual(nextDoc);
     });
 
@@ -111,27 +104,27 @@ describe('DocumentService', () => {
 
       const doc0 = { title: 'doc 0' };
       const doc1 = { title: 'doc 1' };
-      const { service, backend, location } = getServices('url/0');
-      const connections = backend.connectionsArray;
+      const { service, loader, location } = getServices('url/0');
+      const connections = loader.connectionsArray;
 
       subscription = service.currentDocument.subscribe(doc => latestDocument = doc);
       expect(connections.length).toEqual(1);
-      connections[0].mockRespond(createResponse(doc0));
+      connections[0].mockRespond(doc0);
       expect(latestDocument).toEqual(doc0);
       subscription.unsubscribe();
 
       // modify the response so we can check that future subscriptions do not trigger another request
-      connections[0].response.next(createResponse({ title: 'error 0' }));
+      connections[0].mockRespond({ title: 'error 0' });
 
       subscription = service.currentDocument.subscribe(doc => latestDocument = doc);
       location.urlSubject.next('url/1');
       expect(connections.length).toEqual(2);
-      connections[1].mockRespond(createResponse(doc1));
+      connections[1].mockRespond(doc1);
       expect(latestDocument).toEqual(doc1);
       subscription.unsubscribe();
 
       // modify the response so we can check that future subscriptions do not trigger another request
-      connections[1].response.next(createResponse({ title: 'error 1' }));
+      connections[1].mockRespond({ title: 'error 1' });
 
       subscription = service.currentDocument.subscribe(doc => latestDocument = doc);
       location.urlSubject.next('url/0');
@@ -150,10 +143,10 @@ describe('DocumentService', () => {
   describe('computeMap', () => {
     it('should map the "empty" location to the correct document request', () => {
       let latestDocument: DocumentContents;
-      const { service, backend } = getServices();
+      const { service, loader } = getServices();
       service.currentDocument.subscribe(doc => latestDocument = doc);
 
-      expect(backend.connectionsArray[0].request.url).toEqual(CONTENT_URL_PREFIX + 'index.json');
+      expect(loader.connectionsArray[0].url).toEqual(CONTENT_URL_PREFIX + 'index.json');
     });
 
     it('should map the "folder" locations to the correct document request', () => {

--- a/aio/src/app/documents/document.service.ts
+++ b/aio/src/app/documents/document.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Http, Response } from '@angular/http';
+import { FileLoaderService, Response } from 'app/shared/file-loader.service';
 
 import { Observable } from 'rxjs/Observable';
 import { AsyncSubject } from 'rxjs/AsyncSubject';
@@ -23,7 +23,7 @@ export class DocumentService {
 
   constructor(
     private logger: Logger,
-    private http: Http,
+    private loader: FileLoaderService,
     location: LocationService) {
     // Whenever the URL changes we try to get the appropriate doc
     this.currentDocument = location.currentUrl.switchMap(url => this.getDocument(url));
@@ -41,8 +41,8 @@ export class DocumentService {
   private fetchDocument(path: string) {
     this.logger.log('fetching document from', path);
     const subject = new AsyncSubject();
-    this.http
-      .get(path)
+    this.loader
+      .load(path)
       .map(res => res.json())
       .catch((error: Response) => {
         if (error.status === 404) {
@@ -63,11 +63,8 @@ export class DocumentService {
 
   private computePath(url: string) {
     url = url.match(/[^#?]*/)[0]; // strip off fragment and query
-    url = url.replace(/\/$/, ''); // strip off trailing slash
-    if (url === '') {
-      // deal with root url
-      url = 'index';
-    }
-    return 'content/docs/' + url + '.json';
+    url = '/' + url;
+    url = url.endsWith('/') ? url + 'index' : url;
+    return 'docs' + url + '.json';
   }
 }

--- a/aio/src/app/embedded/api/api.service.ts
+++ b/aio/src/app/embedded/api/api.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { Http } from '@angular/http';
 
 import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { Subject } from 'rxjs/Subject';
@@ -7,6 +6,7 @@ import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/takeUntil';
 
+import { FileLoaderService } from 'app/shared/file-loader.service';
 import { Logger } from 'app/shared/logger.service';
 
 export interface ApiItem {
@@ -29,7 +29,7 @@ export interface ApiSection {
 @Injectable()
 export class ApiService implements OnDestroy {
 
-  private apiBase = 'content/docs/api/';
+  private apiBase = 'docs/api/';
   private apiListJsonDefault = 'api-list.json';
   private firstTime = true;
   private onDestroy = new Subject();
@@ -53,7 +53,7 @@ export class ApiService implements OnDestroy {
     return this._sections;
   };
 
-  constructor(private http: Http, private logger: Logger) { }
+  constructor(private loader: FileLoaderService, private logger: Logger) { }
 
   ngOnDestroy() {
     this.onDestroy.next();
@@ -69,7 +69,7 @@ export class ApiService implements OnDestroy {
   fetchSections(src?: string) {
     // TODO: get URL by configuration?
     const url = this.apiBase + (src || this.apiListJsonDefault);
-    this.http.get(url)
+    this.loader.load(url)
       .takeUntil(this.onDestroy)
       .map(response => response.json())
       .do(() => this.logger.log(`Got API sections from ${url}`))

--- a/aio/src/app/navigation/navigation.service.spec.ts
+++ b/aio/src/app/navigation/navigation.service.spec.ts
@@ -1,6 +1,7 @@
 import { ReflectiveInjector } from '@angular/core';
-import { Http, ConnectionBackend, RequestOptions, BaseRequestOptions, Response, ResponseOptions } from '@angular/http';
-import { MockBackend } from '@angular/http/testing';
+import { FileLoaderService } from 'app/shared/file-loader.service';
+import { TestFileLoaderService } from 'testing/file-loader.service';
+
 import { NavigationService, NavigationViews, NavigationNode, VersionInfo } from 'app/navigation/navigation.service';
 import { LocationService } from 'app/shared/location.service';
 import { MockLocationService } from 'testing/location.service';
@@ -10,17 +11,11 @@ describe('NavigationService', () => {
 
   let injector: ReflectiveInjector;
 
-  function createResponse(body: any) {
-    return new Response(new ResponseOptions({ body: JSON.stringify(body) }));
-  }
-
   beforeEach(() => {
     injector = ReflectiveInjector.resolveAndCreate([
         NavigationService,
         { provide: LocationService, useFactory: () => new MockLocationService('a') },
-        { provide: ConnectionBackend, useClass: MockBackend },
-        { provide: RequestOptions, useClass: BaseRequestOptions },
-        Http,
+        { provide: FileLoaderService, useClass: TestFileLoaderService },
         Logger
     ]);
   });
@@ -31,39 +26,43 @@ describe('NavigationService', () => {
   });
 
   describe('navigationViews', () => {
-    let service: NavigationService, backend: MockBackend;
+    let service: NavigationService;
+    let loader: TestFileLoaderService;
 
     beforeEach(() => {
-      backend = injector.get(ConnectionBackend);
+      loader = injector.get(FileLoaderService);
       service = injector.get(NavigationService);
     });
 
     it('should make a single connection to the server', () => {
-      expect(backend.connectionsArray.length).toEqual(1);
-      expect(backend.connectionsArray[0].request.url).toEqual('content/navigation.json');
+      expect(loader.connectionsArray.length).toEqual(1);
+      expect(loader.connectionsArray[0].url).toBe('navigation.json');
     });
 
     it('should expose the server response', () => {
       const viewsEvents: NavigationViews[] = [];
+      const json = { TopBar: [ { url: 'a' }] };
       service.navigationViews.subscribe(views => viewsEvents.push(views));
 
       expect(viewsEvents).toEqual([]);
-      backend.connectionsArray[0].mockRespond(createResponse({ TopBar: [ { url: 'a' }] }));
-      expect(viewsEvents).toEqual([{ TopBar: [ { url: 'a' }] }]);
-
+      loader.connectionsArray[0].mockRespond(json);
+      expect(viewsEvents).toEqual([json]);
     });
 
     it('should return the same object to all subscribers', () => {
+
+      const json = { TopBar: [ { url: 'a' }] };
+
       let views1: NavigationViews;
       service.navigationViews.subscribe(views => views1 = views);
 
       let views2: NavigationViews;
       service.navigationViews.subscribe(views => views2 = views);
 
-      backend.connectionsArray[0].mockRespond(createResponse({ TopBar: [{ url: 'a' }] }));
+      loader.connectionsArray[0].mockRespond(json);
 
       // modify the response so we can check that future subscriptions do not trigger another request
-      backend.connectionsArray[0].response.next(createResponse({ TopBar: [{ url: 'error 1' }] }));
+      loader.connectionsArray[0].mockRespond({ TopBar: [{ url: 'error 1' }] });
 
       let views3: NavigationViews;
       service.navigationViews.subscribe(views => views3 = views);
@@ -77,7 +76,9 @@ describe('NavigationService', () => {
   });
 
   describe('selectedNodes', () => {
-    let service: NavigationService, location: MockLocationService;
+    let service: NavigationService;
+    let loader: TestFileLoaderService;
+    let location: MockLocationService;
     let currentNodes: NavigationNode[];
     const nodeTree: NavigationNode[] = [
       { title: 'a', children: [
@@ -96,8 +97,8 @@ describe('NavigationService', () => {
       service = injector.get(NavigationService);
       service.selectedNodes.subscribe(nodes => currentNodes = nodes);
 
-      const backend = injector.get(ConnectionBackend);
-      backend.connectionsArray[0].mockRespond(createResponse({ nav: nodeTree }));
+      loader = injector.get(FileLoaderService);
+      loader.connectionsArray[0].mockRespond({ nav: nodeTree });
     });
 
     it('should list the navigation node that matches the current location, and all its ancestors', () => {
@@ -127,16 +128,18 @@ describe('NavigationService', () => {
   });
 
   describe('versionInfo', () => {
-    let service: NavigationService, versionInfo: VersionInfo;
+    let loader: TestFileLoaderService;
+    let service: NavigationService;
+    let versionInfo: VersionInfo;
 
     beforeEach(() => {
       service = injector.get(NavigationService);
       service.versionInfo.subscribe(info => versionInfo = info);
 
-      const backend = injector.get(ConnectionBackend);
-      backend.connectionsArray[0].mockRespond(createResponse({
+      loader = injector.get(FileLoaderService);
+      loader.connectionsArray[0].mockRespond({
         __versionInfo: { raw: '4.0.0' }
-      }));
+      });
     });
 
     it('should extract the version info', () => {

--- a/aio/src/app/shared/file-loader-http.service.ts
+++ b/aio/src/app/shared/file-loader-http.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { Http, Headers, Response, ResponseOptions, ResponseType} from '@angular/http';
+export { Response }
+
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/throw';
+
+import { FileLoaderService} from './file-loader.service';
+
+
+@Injectable()
+export class HttpFileLoaderService {
+
+  constructor(private http: Http) {}
+
+  load(path: string) {
+    if (!path) {
+      const options = {
+        url: path, status: 400, statusText: 'Bad Request', body: 'No url',
+        type: ResponseType.Default, headers: new Headers()
+      };
+      const resp = new Response(new ResponseOptions(options));
+      return Observable.throw(resp);
+    }
+    return this.http.get('content/' + path);
+  }
+}
+
+export const FileLoaderProviders = [
+  { provide: FileLoaderService, useClass: HttpFileLoaderService }
+];

--- a/aio/src/app/shared/file-loader-webpack.service.ts
+++ b/aio/src/app/shared/file-loader-webpack.service.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+
+import { FileLoaderService, Response } from './file-loader.service';
+export { Response }
+
+declare const System: { import: (string) => Promise<Response> };
+
+// tslint:disable-next-line:class-name
+class Response_ implements Response {
+    ok: boolean;
+    url: string;
+    status: number;
+    statusText: string;
+    json: () => any;
+    text: () => string;
+
+    constructor({url, status, statusText, body}: {
+      url?: string,
+      status?: number,
+      statusText?: string,
+      body?: any
+    }) {
+      this.url = url || '';
+      this.status = status || 0;
+      this.ok = this.status >= 200 && this.status < 300;
+      this.statusText = statusText || (this.ok ? 'ok' : '');
+
+      if (typeof body === 'string') {
+        this.json = () => JSON.parse(body || '{}');
+        this.text = () => body;
+      } else {
+        this.json = () => body;
+        this.text = () => JSON.stringify(body);
+      }
+    }
+
+    toString() {
+      return `${this.status}: ${this.url}`;
+    };
+}
+
+@Injectable()
+export class WebpackFileLoaderService {
+
+  load(path: string) {
+    let url: string;
+
+    return new Observable<Response>(observer => {
+      try {
+        if (!path) {
+          observer.error(
+            new Response_({url: path, status: 400, statusText: 'Bad Request', body: 'No url'})
+          );
+          return;
+        }
+
+        const jsonIx = path.lastIndexOf('.json');
+        if (jsonIx > - 1) { path = path.substr(0, jsonIx); }
+        url = 'content/' + path + '.json';
+
+        // note: System.import arg must be literals exactly like the following.
+        // The prefix must be relative to the app root folder.
+        System.import('../../content/' + path + '.json').then(
+          text => {
+            observer.next(new Response_({url, body: text}));
+            observer.complete();
+          },
+          errorHandler
+        );
+      } catch (err) {
+        errorHandler(err);
+      }
+
+      function errorHandler(err: any) {
+        const respArgs = (err && /Cannot find/.test(err.message)) ?
+          { url, status: 404, statusText: 'Not Found' } :
+          { url, status: 500, statusText: 'Server or application error', body: err };
+          observer.error(new Response_(respArgs));
+      }
+    });
+
+  }
+}
+
+export const FileLoaderProviders = [
+  { provide: FileLoaderService, useClass: WebpackFileLoaderService }
+];

--- a/aio/src/app/shared/file-loader-xhr.service.ts
+++ b/aio/src/app/shared/file-loader-xhr.service.ts
@@ -1,0 +1,100 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+
+import { FileLoaderService, Response } from './file-loader.service';
+export { Response }
+
+/**
+ * All possible states in which a connection can be, based on
+ * [States](http://www.w3.org/TR/XMLHttpRequest/#states) from the `XMLHttpRequest` spec
+ */
+enum ReadyState {
+    Unsent = 0,
+    Open = 1,
+    HeadersReceived = 2,
+    Loading = 3,
+    Done = 4
+}
+
+// tslint:disable-next-line:class-name
+class Response_ implements Response {
+    ok: boolean;
+    url: string;
+    status: number;
+    statusText: string;
+    private _body: string;
+
+    json(): any {
+      return JSON.parse(this._body || '{}');
+    };
+
+    text(): string { return (this._body || '').toString(); }
+
+    constructor({url, status, statusText, body}: {
+      url?: string,
+      status?: number,
+      statusText?: string,
+      body?: any
+    }) {
+      this.url = url || '';
+      this.status = status || 0;
+      this._body = body;
+      this.ok = this.status >= 200 && this.status < 300;
+      this.statusText = statusText || (this.ok ? 'ok' : '');
+    }
+
+    toString() {
+      return `${this.status}: ${this.url}`;
+    };
+}
+
+@Injectable()
+export class XhrFileLoaderService {
+  load(path: string) {
+    return new Observable<Response>(observer => {
+      if (!path) {
+        observer.error(
+          new Response_({url: path, status: 400, statusText: 'Bad Request', body: 'No url'})
+        );
+        return;
+      }
+
+      let xhr = new XMLHttpRequest();
+      xhr.onload = complete;
+      xhr.onerror = failed;
+      xhr.open('GET', 'content/' + path);
+      xhr.send();
+
+      function complete (evt) {
+        const { responseURL, status, statusText, responseText: body } = evt.srcElement;
+        const resp: Response = new Response_({url: responseURL, status, statusText, body});
+        if (resp.ok) {
+          observer.next(resp);
+          observer.complete();
+        } else {
+          observer.error(resp);
+        }
+      }
+
+      function failed(evt) {
+        // Todo: learn about error events, what causes them, and whether this is right.
+        const { responseURL, status, statusText, responseText: body } = evt.srcElement;
+        const resp: Response = new Response_({url: responseURL, status, statusText, body});
+        observer.error(resp);
+      }
+
+      function unsubscribe() {
+          if (xhr && xhr.readyState < 4) {
+            xhr.abort();
+          }
+          xhr = undefined;
+      }
+
+      return { unsubscribe };
+    });
+  }
+}
+
+export const FileLoaderProviders = [
+  { provide: FileLoaderService, useClass: XhrFileLoaderService }
+];

--- a/aio/src/app/shared/file-loader.service.spec.ts
+++ b/aio/src/app/shared/file-loader.service.spec.ts
@@ -1,0 +1,119 @@
+import { HttpFileLoaderService as FileLoaderService } from './file-loader-http.service';
+// import { WebpackFileLoaderService as FileLoaderService } from './file-loader-webpack.service';
+// import { XhrFileLoaderService as FileLoaderService } from './file-loader-xhr.service';
+
+import 'rxjs/add/operator/map';
+
+describe('FileLoaderService', () => {
+
+  const navJsonUrl = 'navigation.json';
+
+  let service: FileLoaderService;
+
+  beforeEach(() => {
+    // service = new FileLoaderService();
+    service = createHttpFileLoaderService();
+  });
+
+  it(`should get '${navJsonUrl}'`, done => {
+    const req = service.load(navJsonUrl);
+    req.subscribe(
+      resp => {
+        expect(resp.text().length).toBeGreaterThan(0, 'expect text');
+      },
+      err => {
+        fail(err);
+        done();
+      },
+      done
+    );
+
+  }, 500);
+
+  it(`should get navigation JSON from '${navJsonUrl}'`, done => {
+    const req = service.load(navJsonUrl).map(resp => resp.json());
+
+    req.subscribe(
+      data => {
+        expect(data['SideNav']).toBeDefined('expect SideNav JSON');
+        expect(data['TopBar']).toBeDefined('expect TopBar JSON');
+      },
+      err => {
+        fail(err);
+        done();
+      },
+      done
+    );
+  }, 500);
+
+  it(`should 404 for bad URL`, done => {
+    const req = service.load('this/is/bad');
+    req.subscribe(
+      resp => {
+        throw new Error('Should fail but got a success response');
+      },
+      err => {
+        expect(err).toBeDefined();
+        expect(err.status).toBe(404, 'status 404 - Not Found');
+        done();
+      },
+      () => {
+        throw new Error('Should fail and not complete');
+      }
+    );
+  }, 500);
+
+  it(`should 400 for empty URL`, done => {
+    const req = service.load(undefined);
+    req.subscribe(
+      resp => {
+        throw new Error('Should fail but got a success response');
+      },
+      err => {
+        expect(err).toBeDefined();
+        expect(err.status).toBe(400, 'status 400 - Bad Request');
+        done();
+      },
+      () => {
+        throw new Error('Should fail and not complete');
+      }
+    );
+  }, 500);
+});
+
+/// HELPERS BELOW ARE ONLY FOR HTTP VERSION OF FileLoaderService
+
+// These imports needed only by the TestHttp class
+import { Http, Headers, Response, ResponseOptions, ResponseType} from '@angular/http';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
+import 'rxjs/add/observable/throw';
+
+function createHttpFileLoaderService() {
+  return new FileLoaderService(<Http> <any> new TestHttp());
+}
+
+class TestHttp {
+
+  get = jasmine.createSpy('get').and.callFake((url: string) => {
+
+    if (url && url.indexOf('navigation.json') > -1) {
+      const options = {
+        url,  status: 200, statusText: 'ok',
+        type: ResponseType.Default, headers: new Headers(),
+        body: '{ "SideNav": {}, "TopBar": {} }'
+      };
+      const resp = new Response(new ResponseOptions(options));
+      return of(resp);
+
+    // any other url is 404-Not found
+    } else {
+      const options = {
+        url,  status: 404, statusText: 'Not Found',
+        type: ResponseType.Default, headers: new Headers()
+      };
+      const resp = new Response(new ResponseOptions(options));
+      return Observable.throw(resp);
+    }
+  });
+}

--- a/aio/src/app/shared/file-loader.service.ts
+++ b/aio/src/app/shared/file-loader.service.ts
@@ -1,0 +1,47 @@
+import { Observable } from 'rxjs/Observable';
+
+/*
+ * The Response interface is based on the Angular http module response
+ * which is inspired by the Response constructor defined in the
+ * [Fetch Spec](https://fetch.spec.whatwg.org/#response-class),
+ * but certain properties and methods are missing and
+ * the body can be accessed many times.
+ */
+export interface Response {
+    /**
+     * True if the response's status is within 200-299
+     */
+    ok: boolean;
+    /**
+     * URL of response.
+     *
+     * Defaults to empty string.
+     */
+    url: string;
+    /**
+     * Status code returned by server.
+     *
+     * Defaults to 200.
+     */
+    status: number;
+    /**
+     * Text representing the corresponding reason phrase to the `status`, as defined in [ietf rfc 2616
+     * section 6.1.1](https://tools.ietf.org/html/rfc2616#section-6.1.1)
+     *
+     * Defaults to "OK"
+     */
+    statusText: string;
+
+    /**
+     * Attempts to return body as parsed `JSON` object, or raises an exception.
+     */
+    json(): any ;
+    /**
+     * Returns the body as a string, presuming `toString()` can be called on the response body.
+     */
+    text(): string;
+}
+
+export abstract class FileLoaderService {
+  abstract load(url: string): Observable<Response>;
+}

--- a/aio/src/testing/file-loader.service.ts
+++ b/aio/src/testing/file-loader.service.ts
@@ -1,0 +1,59 @@
+import { FileLoaderService, Response } from 'app/shared/file-loader.service';
+
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import { Observer } from 'rxjs/Observer';
+
+export class TestConnection {
+    constructor(
+      public url: string,
+      private observer: Observer<Response>
+    ) { }
+
+    mockRespond(body: any, options = {}) {
+      body = options['body'] || body;
+
+      let json: () => any;
+      let text: () => string;
+
+      if (typeof body === 'string') {
+        json = () => JSON.parse(body || '{}');
+        text = () => body;
+      } else {
+        json = () => body;
+        text = () => JSON.stringify(body);
+      }
+
+      const response = {...{
+          ok: true,
+          url: this.url,
+          status: 200,
+          statusText: 'ok',
+          text,
+          json
+      }, ...options};
+
+      response.ok = response.status >= 200 && response.status < 300;
+
+      if (response.ok) {
+        this.observer.next(response);
+        this.observer.complete();
+      } else {
+        this.observer.error(response);
+      }
+    }
+}
+
+export class TestFileLoaderService {
+  private connectionSubject = new Subject<TestConnection>();
+  connections = this.connectionSubject as Observable<TestConnection>;
+  connectionsArray: TestConnection[] = [];
+
+  load(url: string) {
+    return new Observable(observer => {
+      const connection = new TestConnection(url, observer);
+      this.connectionsArray.push(connection);
+      this.connectionSubject.next(connection);
+    });
+  }
+}


### PR DESCRIPTION
This is an archive PR that shows `FileLoaderService` implementations in three ways: with XHR, Webpack (System.import), and Http.

It was a corrected, rebased version of PR #15203

The webpack way never worked ... and wouldn't per Rob Wormald. But it is an interesting start and we might be able to revive it some day.

We went with Http in PR #15409

This PR was closed almost immediately.
