### PR TITLE
docs: fix spelling

### DIFF
--- a/packages/compiler/src/ml_parser/icu_ast_expander.ts
+++ b/packages/compiler/src/ml_parser/icu_ast_expander.ts
@@ -102,7 +102,7 @@ function _expandPluralForm(ast: html.Expansion, errors: ParseError[]): html.Elem
       'ng-container', [switchAttr], children, ast.sourceSpan, ast.sourceSpan, ast.sourceSpan);
 }
 
-// ICU messages (excluding plural form) are expanded to `NgSwitch`  and `NgSwitychCase`s
+// ICU messages (excluding plural form) are expanded to `NgSwitch`  and `NgSwitchCase`s
 function _expandDefaultForm(ast: html.Expansion, errors: ParseError[]): html.Element {
   const children = ast.cases.map(c => {
     const expansionResult = expandNodes(c.expression);

--- a/packages/compiler/src/output/path_util.ts
+++ b/packages/compiler/src/output/path_util.ts
@@ -26,7 +26,7 @@ export abstract class ImportResolver {
   abstract getImportAs(symbol: StaticSymbol): StaticSymbol /*|null*/;
 
   /**
-   * Determine the airty of a type.
+   * Determine the arity of a type.
    */
   abstract getTypeArity(symbol: StaticSymbol): number /*|null*/;
 }

--- a/packages/compiler/test/aot/compiler_spec.ts
+++ b/packages/compiler/test/aot/compiler_spec.ts
@@ -416,7 +416,7 @@ describe('compiler (bundled Angular)', () => {
        })));
   });
 
-  describe('Bundled libary', () => {
+  describe('Bundled library', () => {
     let host: MockCompilerHost;
     let aotHost: MockAotCompilerHost;
     let libraryFiles: Map<string, string>;

--- a/packages/compiler/test/aot/summary_serializer_spec.ts
+++ b/packages/compiler/test/aot/summary_serializer_spec.ts
@@ -137,7 +137,7 @@ export function main() {
              .toBe(symbolCache.get('/tmp/external.d.ts', 'SomeExternalPipe'));
        });
 
-    it('should automatically add the metadata of referenced symbols that are not in the soure files',
+    it('should automatically add the metadata of referenced symbols that are not in the source files',
        () => {
          init();
          const externalSerialized = serializeSummaries(
@@ -196,7 +196,7 @@ export function main() {
          // been serialized as well.
          expect(summaries[2].symbol).toBe(symbolCache.get('/tmp/non_summary.d.ts', 'external'));
          expect(summaries[2].metadata).toEqual('b');
-         // SomService is a transitive dep, but sould have been serialized as well.
+         // SomService is a transitive dep, but should have been serialized as well.
          expect(summaries[3].symbol).toBe(symbolCache.get('/tmp/external_svc.d.ts', 'SomeService'));
          expect(summaries[3].type.type.reference)
              .toBe(symbolCache.get('/tmp/external_svc.d.ts', 'SomeService'));

--- a/packages/compiler/test/directive_normalizer_spec.ts
+++ b/packages/compiler/test/directive_normalizer_spec.ts
@@ -305,7 +305,7 @@ export function main() {
     });
 
     describe('normalizeLoadedTemplate', () => {
-      it('should store the viewEncapsulationin the result',
+      it('should store the viewEncapsulation in the result',
          inject([DirectiveNormalizer], (normalizer: DirectiveNormalizer) => {
 
            const viewEncapsulation = ViewEncapsulation.Native;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

1. File `ml_parser/icu_ast_expander.ts` wrong word `NgSwitychCase`
2. File `output/path_util.ts` wrong word `airty`
3. File `test/aot/compiler_spec.ts` wrong word `libary`
4. File `test/aot/summary_serializer_spec.ts` wrong word `soure`
5. File `test/directive_normalizer_spec.ts` wrong word `viewEncapsulationin`

**What is the new behavior?**
1. Should be `NgSwitchCase`
2. Should be `arity`
3. Should be `library`
4. Should be `source`
5. Should be `viewEncapsulation in`


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:

Spelling mistakes