### PR TITLE
refactor: use object spread operator rather than merge

### DIFF
--- a/packages/compiler/src/directive_resolver.ts
+++ b/packages/compiler/src/directive_resolver.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, Directive, HostBinding, HostListener, Input, Output, Query, Type, resolveForwardRef, ɵReflectorReader, ɵmerge as merge, ɵreflector, ɵstringify as stringify} from '@angular/core';
+import {Component, Directive, HostBinding, HostListener, Input, Output, Query, Type, resolveForwardRef, ɵReflectorReader, ɵreflector, ɵstringify as stringify} from '@angular/core';
 import {CompilerInjectable} from './injectable';
 import {splitAtColon} from './util';
 
@@ -124,8 +124,8 @@ export class DirectiveResolver {
         this._dedupeBindings(directive.inputs ? directive.inputs.concat(inputs) : inputs);
     const mergedOutputs =
         this._dedupeBindings(directive.outputs ? directive.outputs.concat(outputs) : outputs);
-    const mergedHost = directive.host ? merge(directive.host, host) : host;
-    const mergedQueries = directive.queries ? merge(directive.queries, queries) : queries;
+    const mergedHost = directive.host ? {...directive.host, ...host} : host;
+    const mergedQueries = directive.queries ? {...directive.queries, ...queries} : queries;
 
     if (directive instanceof Component) {
       return new Component({

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -25,5 +25,5 @@ export {GetterFn as ɵGetterFn, MethodFn as ɵMethodFn, SetterFn as ɵSetterFn} 
 export {DirectRenderer as ɵDirectRenderer, RenderDebugInfo as ɵRenderDebugInfo} from './render/api';
 export {global as ɵglobal, looseIdentical as ɵlooseIdentical, stringify as ɵstringify} from './util';
 export {makeDecorator as ɵmakeDecorator} from './util/decorators';
-export {isObservable as ɵisObservable, isPromise as ɵisPromise, merge as ɵmerge} from './util/lang';
+export {isObservable as ɵisObservable, isPromise as ɵisPromise} from './util/lang';
 export {NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from './view/provider';

--- a/packages/core/src/util/lang.ts
+++ b/packages/core/src/util/lang.ts
@@ -24,18 +24,3 @@ export function isObservable(obj: any | Observable<any>): obj is Observable<any>
   // TODO use Symbol.observable when https://github.com/ReactiveX/rxjs/issues/2415 will be resolved
   return !!obj && typeof obj.subscribe === 'function';
 }
-
-// TODO(misko): replace with Object.assign once we require ES6.
-export function merge<V>(m1: {[key: string]: V}, m2: {[key: string]: V}): {[key: string]: V} {
-  const m: {[key: string]: V} = {};
-
-  for (const k of Object.keys(m1)) {
-    m[k] = m1[k];
-  }
-
-  for (const k of Object.keys(m2)) {
-    m[k] = m2[k];
-  }
-
-  return m;
-}

--- a/packages/core/testing/src/testing_internal.ts
+++ b/packages/core/testing/src/testing_internal.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵisPromise as isPromise, ɵmerge as merge} from '@angular/core';
+import {ɵisPromise as isPromise} from '@angular/core';
 import {global} from '@angular/core/src/util';
 
 import {AsyncTestCompleter} from './async_test_completer';
@@ -196,7 +196,7 @@ export class SpyObject {
       object = new SpyObject();
     }
 
-    const m = merge(config, overrides);
+    const m = {...config, ...overrides};
     Object.keys(m).forEach(key => { object.spy(key).and.returnValue(m[key]); });
     return object;
   }

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectionToken, ɵisObservable as isObservable, ɵisPromise as isPromise, ɵmerge as merge} from '@angular/core';
+import {InjectionToken, ɵisObservable as isObservable, ɵisPromise as isPromise} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {forkJoin} from 'rxjs/observable/forkJoin';
 import {fromPromise} from 'rxjs/observable/fromPromise';
@@ -188,7 +188,7 @@ function _executeAsyncValidators(control: AbstractControl, validators: AsyncVali
 function _mergeErrors(arrayOfErrors: ValidationErrors[]): ValidationErrors|null {
   const res: {[key: string]: any} =
       arrayOfErrors.reduce((res: ValidationErrors | null, errors: ValidationErrors | null) => {
-        return errors != null ? merge(res, errors) : res;
+        return errors != null ? {...res, ...errors} : res;
       }, {});
   return Object.keys(res).length === 0 ? null : res;
 }

--- a/packages/platform-browser/src/dom/debug/ng_probe.ts
+++ b/packages/platform-browser/src/dom/debug/ng_probe.ts
@@ -38,7 +38,7 @@ export function _createNgProbe(extraTokens: NgProbeToken[], coreTokens: core.NgP
   const tokens = (extraTokens || []).concat(coreTokens || []);
   getDOM().setGlobalVar(INSPECT_GLOBAL_NAME, inspectNativeElement);
   getDOM().setGlobalVar(
-      CORE_TOKENS_GLOBAL_NAME, core.ɵmerge(CORE_TOKENS, _ngProbeTokensToMap(tokens || [])));
+      CORE_TOKENS_GLOBAL_NAME, {...CORE_TOKENS, ..._ngProbeTokensToMap(tokens || [])});
   return () => inspectNativeElement;
 }
 


### PR DESCRIPTION
Object spread operator was introduced in Typescript 2.1 so we no longer need to use neither `Object.assign` not custom `merge` function.