### PR TITLE
fix(compiler): correctly handle when `toString` is exported

### DIFF
--- a/packages/compiler/src/aot/static_symbol_resolver.ts
+++ b/packages/compiler/src/aot/static_symbol_resolver.ts
@@ -224,7 +224,7 @@ export class StaticSymbolResolver {
           this.recordImportAs(symbol, importSymbol);
         }
 
-        const origin = origins[metadataKey];
+        const origin = origins.hasOwnProperty(metadataKey) && origins[metadataKey];
         if (origin) {
           // If the symbol is from a bundled index, use the declaration location of the
           // symbol so relative references (such as './my.html') will be calculated

--- a/packages/compiler/test/aot/compiler_spec.ts
+++ b/packages/compiler/test/aot/compiler_spec.ts
@@ -577,6 +577,7 @@ const FILES: MockData = {
       `,
       'app.module.ts': `
         import { NgModule }      from '@angular/core';
+        import { toString }      from './utils';
 
         import { AppComponent }  from './app.component';
 
@@ -585,6 +586,12 @@ const FILES: MockData = {
           bootstrap:    [ AppComponent ]
         })
         export class AppModule { }
+      `,
+      // #15420
+      'utils.ts': `
+        export function toString(value: any): string {
+          return  '';
+        }
       `
     }
   }


### PR DESCRIPTION
Fixes #15420

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

#15420

A fix for flat module indexes (90d2518d9aafb7d741d34c95a4a1bef58d352358) broke the non-flat module case where an export matched the name of a method on the `Object` prototype.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```