### PR TITLE
docs(core): fix typo and example in InjectionToken doc

### DIFF
--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -42,8 +42,8 @@ export class OpaqueToken {
  * runtime representation) such as when injecting an interface, callable type, array or
  * parametrized type.
  *
- * `InjectionToken` is parametrize on `T` which is the type of object which will be returned by the
- * `Injector`. This provides additional level of type safety.
+ * `InjectionToken` is parameterized on `T` which is the type of object which will be returned by
+ * the `Injector`. This provides additional level of type safety.
  *
  * ```
  * interface MyInterface {...}
@@ -53,7 +53,7 @@ export class OpaqueToken {
  *
  * ### Example
  *
- * {@example core/di/ts/injector_spec.ts region='Injector'}
+ * {@example core/di/ts/injector_spec.ts region='InjectionToken'}
  *
  * @stable
  */


### PR DESCRIPTION
The doc included an example that didn't use InjectionToken.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: fix of the documentation
```

**What is the current behavior?** (You can also link to an open issue here)

The InjectionToken doc has a typo, and contains an example that is not related to InjectionToken

**What is the new behavior?**

The typo isn't there anymore, and contains an example that is related to InjectionToken

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```