### PR TITLE
build: Removed unused yargs variable in map_sources

### DIFF
--- a/scripts/build/map_sources.js
+++ b/scripts/build/map_sources.js
@@ -1,12 +1,9 @@
-
 var path = require('path');
 var sorcery = require('sorcery');
-var yargs = require('yargs');
 
 var argv = require('yargs')
   .alias('f', 'file')
   .argv;
-
 
 sorcery.load(argv.file).then(function(chain) {
   chain.write();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Unused `yargs` variable in `scripts/build/map_sources.js`


**What is the new behavior?**
Removed unused `yargs` variable in `scripts/build/map_sources.js` as the `yargs` module is used directly via require.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
