### PR TITLE
fix(compiler): allow single quotes into named interpolations

### DIFF
--- a/packages/compiler/src/i18n/i18n_parser.ts
+++ b/packages/compiler/src/i18n/i18n_parser.ts
@@ -161,8 +161,9 @@ class _I18nVisitor implements html.Visitor {
   }
 }
 
-const _CUSTOM_PH_EXP = /\/\/[\s\S]*i18n[\s\S]*\([\s\S]*ph[\s\S]*=[\s\S]*"([\s\S]*?)"[\s\S]*\)/g;
+const _CUSTOM_PH_EXP =
+    /\/\/[\s\S]*i18n[\s\S]*\([\s\S]*ph[\s\S]*=[\s\S]*("|')([\s\S]*?)\1[\s\S]*\)/g;
 
 function _extractPlaceholderName(input: string): string {
-  return input.split(_CUSTOM_PH_EXP)[1];
+  return input.split(_CUSTOM_PH_EXP)[2];
 }

--- a/packages/compiler/test/i18n/i18n_parser_spec.ts
+++ b/packages/compiler/test/i18n/i18n_parser_spec.ts
@@ -125,6 +125,12 @@ export function main() {
             .toEqual([
               [['[before, <ph name="TEST"> exp //i18n(ph="teSt") </ph>, after]'], 'm', 'd'],
             ]);
+
+        expect(
+            _humanizeMessages('<div i18n=\'m|d\'>before{{ exp //i18n(ph=\'teSt\') }}after</div>'))
+            .toEqual([
+              [[`[before, <ph name="TEST"> exp //i18n(ph='teSt') </ph>, after]`], 'm', 'd'],
+            ]);
       });
     });
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
```
[x] Bugfix
```

**What is the current behavior?**
The regex that extract named interpolations for i18n placeholders only allowed double quotes.
See #15318


**What is the new behavior?**
This PR adds the ability to use single quotes.


**Does this PR introduce a breaking change?**
```
[x] No
```