### PR TITLE
docs: in doc comments, replace [aA]ngular2 with Angular

### DIFF
--- a/packages/animations/src/animation_metadata.ts
+++ b/packages/animations/src/animation_metadata.ts
@@ -118,10 +118,10 @@ export interface AnimationSequenceMetadata extends AnimationMetadata { steps: An
 export interface AnimationGroupMetadata extends AnimationMetadata { steps: AnimationMetadata[]; }
 
 /**
- * `trigger` is an animation-specific function that is designed to be used inside of Angular2's
+ * `trigger` is an animation-specific function that is designed to be used inside of Angular's
  animation DSL language. If this information is new, please navigate to the {@link
  Component#animations-anchor component animations metadata page} to gain a better understanding of
- how animations in Angular2 are used.
+ how animations in Angular are used.
  *
  * `trigger` Creates an animation trigger which will a list of {@link state state} and {@link
  transition transition} entries that will be evaluated when the expression bound to the trigger
@@ -173,10 +173,10 @@ export function trigger(name: string, definitions: AnimationMetadata[]): Animati
 }
 
 /**
- * `animate` is an animation-specific function that is designed to be used inside of Angular2's
+ * `animate` is an animation-specific function that is designed to be used inside of Angular's
  * animation DSL language. If this information is new, please navigate to the {@link
  * Component#animations-anchor component animations metadata page} to gain a better understanding of
- * how animations in Angular2 are used.
+ * how animations in Angular are used.
  *
  * `animate` specifies an animation step that will apply the provided `styles` data for a given
  * amount of time based on the provided `timing` expression value. Calls to `animate` are expected
@@ -224,10 +224,10 @@ export function animate(
 }
 
 /**
- * `group` is an animation-specific function that is designed to be used inside of Angular2's
+ * `group` is an animation-specific function that is designed to be used inside of Angular's
  * animation DSL language. If this information is new, please navigate to the {@link
  * Component#animations-anchor component animations metadata page} to gain a better understanding of
- * how animations in Angular2 are used.
+ * how animations in Angular are used.
  *
  * `group` specifies a list of animation steps that are all run in parallel. Grouped animations are
  * useful when a series of styles must be animated/closed off at different statrting/ending times.
@@ -259,10 +259,10 @@ export function group(steps: AnimationMetadata[]): AnimationGroupMetadata {
 }
 
 /**
- * `sequence` is an animation-specific function that is designed to be used inside of Angular2's
+ * `sequence` is an animation-specific function that is designed to be used inside of Angular's
  * animation DSL language. If this information is new, please navigate to the {@link
  * Component#animations-anchor component animations metadata page} to gain a better understanding of
- * how animations in Angular2 are used.
+ * how animations in Angular are used.
  *
  * `sequence` Specifies a list of animation steps that are run one by one. (`sequence` is used by
  * default when an array is passed as animation data into {@link transition transition}.)
@@ -297,10 +297,10 @@ export function sequence(steps: AnimationMetadata[]): AnimationSequenceMetadata 
 }
 
 /**
- * `style` is an animation-specific function that is designed to be used inside of Angular2's
+ * `style` is an animation-specific function that is designed to be used inside of Angular's
  * animation DSL language. If this information is new, please navigate to the {@link
  * Component#animations-anchor component animations metadata page} to gain a better understanding of
- * how animations in Angular2 are used.
+ * how animations in Angular are used.
  *
  * `style` declares a key/value object containing CSS properties/styles that can then be used for
  * {@link state animation states}, within an {@link sequence animation sequence}, or as styling data
@@ -345,10 +345,10 @@ export function style(
 }
 
 /**
- * `state` is an animation-specific function that is designed to be used inside of Angular2's
+ * `state` is an animation-specific function that is designed to be used inside of Angular's
  * animation DSL language. If this information is new, please navigate to the {@link
  * Component#animations-anchor component animations metadata page} to gain a better understanding of
- * how animations in Angular2 are used.
+ * how animations in Angular are used.
  *
  * `state` declares an animation state within the given trigger. When a state is active within a
  * component then its associated styles will persist on the element that the trigger is attached to
@@ -397,10 +397,10 @@ export function state(name: string, styles: AnimationStyleMetadata): AnimationSt
 }
 
 /**
- * `keyframes` is an animation-specific function that is designed to be used inside of Angular2's
+ * `keyframes` is an animation-specific function that is designed to be used inside of Angular's
  * animation DSL language. If this information is new, please navigate to the {@link
  * Component#animations-anchor component animations metadata page} to gain a better understanding of
- * how animations in Angular2 are used.
+ * how animations in Angular are used.
  *
  * `keyframes` specifies a collection of {@link style style} entries each optionally characterized
  * by an `offset` value.
@@ -446,10 +446,10 @@ export function keyframes(steps: AnimationStyleMetadata[]): AnimationKeyframesSe
 }
 
 /**
- * `transition` is an animation-specific function that is designed to be used inside of Angular2's
+ * `transition` is an animation-specific function that is designed to be used inside of Angular's
  * animation DSL language. If this information is new, please navigate to the {@link
  * Component#animations-anchor component animations metadata page} to gain a better understanding of
- * how animations in Angular2 are used.
+ * how animations in Angular are used.
  *
  * `transition` declares the {@link sequence sequence of animation steps} that will be run when the
  * provided `stateChangeExpr` value is satisfied. The `stateChangeExpr` consists of a `state1 =>

--- a/packages/benchpress/index.ts
+++ b/packages/benchpress/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// Must be imported first, because angular2 decorators throws on load.
+// Must be imported first, because Angular decorators throw on load.
 import 'reflect-metadata';
 
 export {InjectionToken, Injector, Provider, ReflectiveInjector} from '@angular/core';

--- a/packages/common/src/localization.ts
+++ b/packages/common/src/localization.ts
@@ -72,7 +72,7 @@ export class NgLocaleLocalization extends NgLocalization {
 }
 
 // This is generated code DO NOT MODIFY
-// see angular2/script/cldr/gen_plural_rules.js
+// see angular/script/cldr/gen_plural_rules.js
 
 /** @experimental */
 export enum Plural {

--- a/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
+++ b/packages/compiler-cli/integrationtest/test/test_ngtools_api.ts
@@ -8,7 +8,7 @@
  */
 /* tslint:disable:no-console  */
 
-// Must be imported first, because angular2 decorators throws on load.
+// Must be imported first, because Angular decorators throw on load.
 import 'reflect-metadata';
 
 import * as path from 'path';

--- a/packages/compiler-cli/integrationtest/test/test_summaries.ts
+++ b/packages/compiler-cli/integrationtest/test/test_summaries.ts
@@ -8,7 +8,7 @@
  */
 /* tslint:disable:no-console  */
 
-// Must be imported first, because angular2 decorators throws on load.
+// Must be imported first, because Angular decorators throw on load.
 import 'reflect-metadata';
 
 import * as path from 'path';

--- a/packages/compiler-cli/src/extract_i18n.ts
+++ b/packages/compiler-cli/src/extract_i18n.ts
@@ -11,7 +11,7 @@
 /**
  * Extract i18n messages from source code
  */
-// Must be imported first, because angular2 decorators throws on load.
+// Must be imported first, because Angular decorators throw on load.
 import 'reflect-metadata';
 
 import * as tsc from '@angular/tsc-wrapped';

--- a/packages/compiler-cli/src/extractor.ts
+++ b/packages/compiler-cli/src/extractor.ts
@@ -10,7 +10,7 @@
 /**
  * Extract i18n messages from source code
  */
-// Must be imported first, because angular2 decorators throws on load.
+// Must be imported first, because Angular decorators throw on load.
 import 'reflect-metadata';
 
 import * as compiler from '@angular/compiler';

--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -8,7 +8,7 @@
  */
 
 
-// Must be imported first, because angular2 decorators throws on load.
+// Must be imported first, because Angular decorators throw on load.
 import 'reflect-metadata';
 
 import * as ts from 'typescript';

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -639,7 +639,7 @@ export interface Component extends Directive {
    * ### DSL Animation Functions
    *
    * Please visit each of the animation DSL functions listed below to gain a better understanding
-   * of how and why they are used for crafting animations in Angular2:
+   * of how and why they are used for crafting animations in Angular:
    *
    * - {@link trigger trigger()}
    * - {@link state state()}

--- a/packages/core/testing/src/before_each.ts
+++ b/packages/core/testing/src/before_each.ts
@@ -7,7 +7,7 @@
  */
 
 /**
- * Public Test Library for unit testing Angular2 Applications. Assumes that you are running
+ * Public Test Library for unit testing Angular applications. Assumes that you are running
  * with Jasmine, Mocha, or a similar framework which exports a beforeEach function and
  * allows tests to be asynchronous by either returning a promise or using a 'done' parameter.
  */

--- a/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
+++ b/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
@@ -35,7 +35,7 @@ class ExternalTemplateComp {
 class BadTemplateUrl {
 }
 
-// Tests for angular2/testing bundle specific to the browser environment.
+// Tests for angular/testing bundle specific to the browser environment.
 // For general tests, see test/testing/testing_public_spec.ts.
 export function main() {
   describe('test APIs for the browser', () => {

--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -52,7 +52,7 @@ export function locationSyncBootstrapListener(ngUpgrade: UpgradeModule) {
 /**
  * @whatItDoes Sets up a location synchronization.
  *
- * History.pushState does not fire onPopState, so the angular2 location
+ * History.pushState does not fire onPopState, so the Angular location
  * doesn't detect it. The workaround is to attach a location change listener
  *
  * @experimental


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Doc comments
```

**What is the current behavior?** (You can also link to an open issue here)

References to "Angular2" or "angular2". Also "decorators throws".

**What is the new behavior?**

Now "Angular" and "decorators throw"

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
