### PR TITLE
fix(forms): useless update value first time

### DIFF
--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -36,7 +36,6 @@ export function setUpControl(control: FormControl, dir: NgControl): void {
 
   control.validator = Validators.compose([control.validator, dir.validator]);
   control.asyncValidator = Validators.composeAsync([control.asyncValidator, dir.asyncValidator]);
-  dir.valueAccessor.writeValue(control.value);
 
   // view -> model
   dir.valueAccessor.registerOnChange((newValue: any) => {
@@ -128,7 +127,7 @@ export function isPropertyUpdated(changes: {[key: string]: any}, viewModel: any)
   if (!changes.hasOwnProperty('model')) return false;
   const change = changes['model'];
 
-  if (change.isFirstChange()) return true;
+  if (change.isFirstChange()) return change.currentValue !== '';
   return !looseIdentical(viewModel, change.currentValue);
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When a field with ngModel is used, the first onChange write always the input value. It shouldn't be writed when there is no value to ngModel.


**What is the new behavior?**
When there is no value to ngModel directive, the input field is not updated.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

