### PR TITLE
docs(forms): broken link NG_VALIDATORS replace by an example

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -24,6 +24,20 @@ function isEmptyInputValue(value: any): boolean {
  *
  * Provide this using `multi: true` to add validators.
  *
+ * ### Example
+ *
+ * ```typescript
+ * @Directive({
+ *   selector: '[custom-validator]',
+ *   providers: [{provide: NG_VALIDATORS, useExisting: CustomValidatorDirective, multi: true}]
+ * })
+ * class CustomValidatorDirective implements Validator {
+ *   validate(control: AbstractControl): ValidationErrors | null {
+ *     return {"custom": true};
+ *   }
+ * }
+ * ```
+ *
  * @stable
  */
 export const NG_VALIDATORS = new InjectionToken<Array<Validator|Function>>('NgValidators');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ X ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Broken link in NG_VALIDATORS jsdoc
see https://angular.io/docs/ts/latest/api/forms/index/NG_VALIDATORS-let.html

**What is the new behavior?**
replace link by a use case


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ X ] No
```


