### PR TITLE
feat(aio): hide sidenav when current doc is not in sidenav menu

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -29,7 +29,7 @@
       "tooltip": "The Tour of Heroes tutorial takes you through the steps of creating an Angular application in TypeScript.",
       "children": [
         {
-          "url": "tutorial/",
+          "url": "tutorial",
           "title": "Introduction",
           "tooltip": "Introduction to the Tour of Heroes tutorial"
         },
@@ -211,7 +211,6 @@
         },
 
         {
-          "url": "guide/directives",
           "title": "Directives",
           "tooltip": "Learn how directives modify the layout and behavior of elements.",
           "children": [
@@ -384,7 +383,7 @@
     },
 
     {
-      "url": "resources/",
+      "url": "resources",
       "title": "Resources",
       "children": [
         {

--- a/aio/e2e/app.e2e-spec.ts
+++ b/aio/e2e/app.e2e-spec.ts
@@ -22,12 +22,13 @@ describe('site App', function() {
 
     // navigate to a different page
     page.getLink('features').click();
+    expect(page.getDocViewerText()).toMatch(/Features/i);
 
-    // check that we can navigate to the tutorial page via a link in the navigation
-    const heading = page.getNavHeading(/tutorial/i);
-    expect(heading.getText()).toMatch(/tutorial/i);
-    heading.click();
-    page.getLink('tutorial/').click();
+    // Show the menu; the tutorial section should be fully open from previous visit
+    page.docsMenuButton.click();
+
+    // Navigate to the tutorial introduction via a link in the sidenav
+    page.getNavItem(/introduction/i).click();
     expect(page.getDocViewerText()).toMatch(/Tutorial: Tour of Heroes/i);
   });
 

--- a/aio/e2e/app.po.ts
+++ b/aio/e2e/app.po.ts
@@ -4,6 +4,7 @@ const githubRegex = /https:\/\/github.com\/angular\/angular\//;
 
 export class SitePage {
   links = element.all(by.css('md-toolbar a'));
+  docsMenuButton = element(by.css('button.hamburger'));
   docViewer = element(by.css('aio-doc-viewer'));
   codeExample = element.all(by.css('aio-doc-viewer pre > code'));
   ghLink = this.docViewer
@@ -11,7 +12,7 @@ export class SitePage {
     .filter((a: ElementFinder) => a.getAttribute('href').then(href => githubRegex.test(href)))
     .first();
   gaReady: promise.Promise<any>;
-  getNavHeading(pattern: RegExp) {
+  getNavItem(pattern: RegExp) {
     return element.all(by.css('aio-nav-item a'))
                   .filter(element => element.getText().then(text => pattern.test(text)))
                   .first();

--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -23,11 +23,4 @@
 
 <aio-search-results #searchResults></aio-search-results>
 
-<footer>
-  <div class="footer">
-    <p>Powered by Google ©2010-2017. Code licensed under an <a href="/license">MIT-style License</a>.</p>
-    <p>Documentation licensed under <a href="http://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.
-    </p>
-    <p class="version-info">Version Info | {{ version | async }}</p>
-  </div>
-</footer>
+<aio-footer></aio-footer>

--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -1,14 +1,13 @@
 <md-toolbar color="primary" class="app-toolbar">
-  <button *ngIf="isHamburgerVisible" class="hamburger" md-button (click)="sidenav.toggle()"><md-icon>menu</md-icon></button>
+  <button *ngIf="isHamburgerVisible" class="hamburger" md-button (click)="sidenav.toggle()" title="Docs menu"><md-icon>menu</md-icon></button>
   <aio-top-menu *ngIf="isSideBySide" [nodes]="(navigationViews | async)?.TopBar" [homeImageUrl]="homeImageUrl"></aio-top-menu>
   <aio-search-box class="search-container" #searchBox></aio-search-box>
   <span class="fill-remaining-space"></span>
 </md-toolbar>
 
 <md-sidenav-container class="sidenav-container">
-
-  <md-sidenav #sidenav class="sidenav" [opened]="isSideBySide" [mode] = "isSideBySide ? 'side' : 'over'">
-    <aio-top-menu *ngIf="!isSideBySide" class="small" [nodes]="(navigationViews | async)?.TopBar" [homeImageUrl]="homeImageUrl"></aio-top-menu> 
+  <md-sidenav #sidenav class="sidenav" [opened]="isSideBySide && isSideNavNode" [mode]="isSideBySide ? 'side' : 'over'">
+    <aio-top-menu *ngIf="!isSideBySide" class="small" [nodes]="(navigationViews | async)?.TopBar" [homeImageUrl]="homeImageUrl"></aio-top-menu>
     <aio-nav-menu [nodes]="(navigationViews | async)?.SideNav" [selectedNodes]="selectedNodes | async"></aio-nav-menu>
   </md-sidenav>
 

--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -1,19 +1,24 @@
 <md-toolbar color="primary" class="app-toolbar">
-  <button *ngIf="isHamburgerVisible" class="hamburger" md-button (click)="sidenav.toggle()" title="Docs menu"><md-icon>menu</md-icon></button>
-  <aio-top-menu *ngIf="isSideBySide" [nodes]="(navigationViews | async)?.TopBar" [homeImageUrl]="homeImageUrl"></aio-top-menu>
+  <button *ngIf="isHamburgerVisible" class="hamburger" md-button
+    (click)="sidenav.toggle()" title="Docs menu">
+    <md-icon>menu</md-icon>
+  </button>
+  <aio-top-menu *ngIf="isSideBySide"></aio-top-menu>
   <aio-search-box class="search-container" #searchBox></aio-search-box>
   <span class="fill-remaining-space"></span>
 </md-toolbar>
 
 <md-sidenav-container class="sidenav-container">
-  <md-sidenav #sidenav class="sidenav" [opened]="isSideBySide && isSideNavNode" [mode]="isSideBySide ? 'side' : 'over'">
-    <aio-top-menu *ngIf="!isSideBySide" class="small" [nodes]="(navigationViews | async)?.TopBar" [homeImageUrl]="homeImageUrl"></aio-top-menu>
-    <aio-nav-menu [nodes]="(navigationViews | async)?.SideNav" [selectedNodes]="selectedNodes | async"></aio-nav-menu>
+
+  <md-sidenav #sidenav class="sidenav" [opened]="isOpened" [mode]="mode">
+    <aio-top-menu *ngIf="!isSideBySide" class="small"></aio-top-menu>
+    <aio-nav-menu (isSideNavDoc)="isSideNavDoc=$event"></aio-nav-menu>
   </md-sidenav>
 
   <section class="sidenav-content">
     <aio-doc-viewer [doc]="currentDocument | async" (docRendered)="onDocRendered($event)"></aio-doc-viewer>
   </section>
+
 </md-sidenav-container>
 
 <aio-search-results #searchResults></aio-search-results>
@@ -23,6 +28,6 @@
     <p>Powered by Google ©2010-2017. Code licensed under an <a href="/license">MIT-style License</a>.</p>
     <p>Documentation licensed under <a href="http://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.
     </p>
-    <p class="version-info">Version Info | {{ (versionInfo | async)?.full }}</p>
+    <p class="version-info">Version Info | {{ version | async }}</p>
   </div>
 </footer>

--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -12,7 +12,7 @@
 
   <md-sidenav #sidenav class="sidenav" [opened]="isOpened" [mode]="mode">
     <aio-top-menu *ngIf="!isSideBySide" class="small"></aio-top-menu>
-    <aio-nav-menu (isSideNavDoc)="isSideNavDoc=$event"></aio-nav-menu>
+    <aio-nav-menu></aio-nav-menu>
   </md-sidenav>
 
   <section class="sidenav-content">

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -71,7 +71,6 @@ describe('AppComponent', () => {
 
     it('should have sidenav open when doc in the sidenav (guide/pipes)', () => {
       locationService.urlSubject.next('guide/pipes');
-      expect(component.isSideNavDoc).toBe(true, 'isSideNavDoc');
 
       fixture.detectChanges();
       const sidenav = fixture.debugElement.query(By.css('md-sidenav')).nativeElement;
@@ -80,7 +79,6 @@ describe('AppComponent', () => {
 
     it('should have sidenav closed when doc not in the sidenav (api)', () => {
       locationService.urlSubject.next('api');
-      expect(component.isSideNavDoc).toBe(false, 'isSideNavNode');
 
       fixture.detectChanges();
       const sidenav = fixture.debugElement.query(By.css('md-sidenav')).nativeElement;

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -48,17 +48,6 @@ describe('AppComponent', () => {
     expect(component).toBeDefined();
   });
 
-  describe('google analytics', () => {
-    it('should call gaService.locationChanged with initial URL', () => {
-      const { locationChanged } = TestBed.get(GaService) as TestGaService;
-      expect(locationChanged.calls.count()).toBe(1, 'gaService.locationChanged');
-      const args = locationChanged.calls.first().args;
-      expect(args[0]).toBe(initialUrl);
-    });
-
-    // Todo: add test to confirm tracking URL when navigate.
-  });
-
   describe('isHamburgerVisible', () => {
     console.log('PENDING: AppComponent isHamburgerVisible');
   });

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -82,7 +82,7 @@ describe('AppComponent', () => {
 
     it('should have sidenav open when doc in the sidenav (guide/pipes)', () => {
       locationService.urlSubject.next('guide/pipes');
-      expect(component.isSideNavNode).toBe(true, 'isSideNavNode');
+      expect(component.isSideNavDoc).toBe(true, 'isSideNavDoc');
 
       fixture.detectChanges();
       const sidenav = fixture.debugElement.query(By.css('md-sidenav')).nativeElement;
@@ -91,7 +91,7 @@ describe('AppComponent', () => {
 
     it('should have sidenav closed when doc not in the sidenav (api)', () => {
       locationService.urlSubject.next('api');
-      expect(component.isSideNavNode).toBe(false, 'isSideNavNode');
+      expect(component.isSideNavDoc).toBe(false, 'isSideNavNode');
 
       fixture.detectChanges();
       const sidenav = fixture.debugElement.query(By.css('md-sidenav')).nativeElement;

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -1,11 +1,13 @@
 import { Component, ElementRef, HostListener, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
+
 import { Observable } from 'rxjs/Observable';
+import 'rxjs/operator/map';
 
 import { GaService } from 'app/shared/ga.service';
 import { LocationService } from 'app/shared/location.service';
 import { DocumentService, DocumentContents } from 'app/documents/document.service';
 import { DocViewerComponent } from 'app/layout/doc-viewer/doc-viewer.component';
-import { NavigationService, NavigationViews, NavigationNode, VersionInfo } from 'app/navigation/navigation.service';
+import { NavigationService, VersionInfo } from 'app/navigation/navigation.service';
 import { SearchService } from 'app/search/search.service';
 import { SearchResultsComponent } from 'app/search/search-results/search-results.component';
 import { AutoScrollService } from 'app/shared/auto-scroll.service';
@@ -16,16 +18,15 @@ import { AutoScrollService } from 'app/shared/auto-scroll.service';
 })
 export class AppComponent implements OnInit {
   readonly sideBySideWidth = 600;
-  readonly homeImageUrl = 'assets/images/logos/standard/logo-nav.png';
 
   isHamburgerVisible = true; // always ... for now
-  isSideNavNode = false;
   isSideBySide = false;
+  isSideNavDoc = false;
+  get mode() { return this.isSideBySide ? 'side' : 'over'; }
+  get isOpened() { return this.isSideBySide && this.isSideNavDoc; }
 
   currentDocument: Observable<DocumentContents>;
-  navigationViews: Observable<NavigationViews>;
-  selectedNodes: Observable<NavigationNode[]>;
-  versionInfo: Observable<VersionInfo>;
+  version: Observable<string>;
 
   @ViewChildren('searchBox, searchResults', { read: ElementRef })
   searchElements: QueryList<ElementRef>;
@@ -33,21 +34,18 @@ export class AppComponent implements OnInit {
   @ViewChild(SearchResultsComponent)
   searchResults: SearchResultsComponent;
 
-  // We need the doc-viewer element for scrolling the contents
+  // Need the doc-viewer element for scrolling the contents
   @ViewChild(DocViewerComponent, { read: ElementRef })
   docViewer: ElementRef;
 
   constructor(documentService: DocumentService,
-              gaService: GaService,
-              navigationService: NavigationService,
-              private autoScroll: AutoScrollService,
+              private autoScrollService: AutoScrollService,
+              private gaService: GaService,
               private locationService: LocationService,
+              navigationService: NavigationService,
               private searchService: SearchService) {
     this.currentDocument = documentService.currentDocument;
-    locationService.currentUrl.subscribe(url => gaService.locationChanged(url));
-    this.navigationViews = navigationService.navigationViews;
-    this.selectedNodes = navigationService.selectedNodes;
-    this.versionInfo = navigationService.versionInfo;
+    this.version = navigationService.versionInfo.map(info => info.full);
   }
 
   ngOnInit() {
@@ -56,20 +54,21 @@ export class AppComponent implements OnInit {
 
     this.onResize(window.innerWidth);
 
-    // The url changed, so scroll to the anchor in the hash fragment.
-    // This subscription is needed when navigating between anchors within a document
-    // and the document itself has not changed
-    this.locationService.currentUrl.subscribe(url => this.autoScroll.scroll(this.docViewer.nativeElement.offsetParent));
-
-    // The current doc is in side nav if there are selected nodes
-    this.selectedNodes.subscribe(nodes => this.isSideNavNode = !!nodes.length );
+    this.locationService.currentUrl.subscribe(url => {
+      this.gaService.locationChanged(url);
+      this.autoScroll(); // scroll even if only the hash fragment changed
+    });
   }
 
   onDocRendered(doc: DocumentContents) {
-    // A new document has been rendered, so scroll to the anchor in the hash fragment.
     // This handler is needed because the subscription to the `currentUrl` in `ngOnInit`
     // gets triggered too early before the doc-viewer has finished rendering the doc
-    this.autoScroll.scroll(this.docViewer.nativeElement.offsetParent);
+    this.autoScroll();
+  }
+
+  // Scroll to the anchor in the hash fragment.
+  autoScroll() {
+    this.autoScrollService.scroll(this.docViewer.nativeElement.offsetParent);
   }
 
   @HostListener('window:resize', ['$event.target.innerWidth'])

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -7,6 +7,7 @@ import { AutoScrollService } from 'app/shared/auto-scroll.service';
 import { DocumentService, DocumentContents } from 'app/documents/document.service';
 import { DocViewerComponent } from 'app/layout/doc-viewer/doc-viewer.component';
 import { LocationService } from 'app/shared/location.service';
+import { NavMenuComponent } from 'app/layout/nav-menu/nav-menu.component';
 import { SearchService } from 'app/search/search.service';
 import { SearchResultsComponent } from 'app/search/search-results/search-results.component';
 
@@ -15,22 +16,24 @@ import { SearchResultsComponent } from 'app/search/search-results/search-results
   templateUrl: './app.component.html',
 })
 export class AppComponent implements OnInit {
-  readonly sideBySideWidth = 600;
+  private readonly sideBySideWidth = 600;
 
   isHamburgerVisible = true; // always ... for now
   isSideBySide = false;
-  isSideNavDoc = false;
+
   get mode() { return this.isSideBySide ? 'side' : 'over'; }
-  get isOpened() { return this.isSideBySide && this.isSideNavDoc; }
+  get isOpened() { return this.isSideBySide && this.navMenu.isSideNavDoc; }
 
   currentDocument: Observable<DocumentContents>;
-  version: Observable<string>;
 
   @ViewChildren('searchBox, searchResults', { read: ElementRef })
   searchElements: QueryList<ElementRef>;
 
   @ViewChild(SearchResultsComponent)
   searchResults: SearchResultsComponent;
+
+  @ViewChild(NavMenuComponent)
+  navMenu: NavMenuComponent;
 
   // Need the doc-viewer element for scrolling the contents
   @ViewChild(DocViewerComponent, { read: ElementRef })

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -3,14 +3,12 @@ import { Component, ElementRef, HostListener, OnInit, QueryList, ViewChild, View
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/operator/map';
 
-import { GaService } from 'app/shared/ga.service';
-import { LocationService } from 'app/shared/location.service';
+import { AutoScrollService } from 'app/shared/auto-scroll.service';
 import { DocumentService, DocumentContents } from 'app/documents/document.service';
 import { DocViewerComponent } from 'app/layout/doc-viewer/doc-viewer.component';
-import { NavigationService, VersionInfo } from 'app/navigation/navigation.service';
+import { LocationService } from 'app/shared/location.service';
 import { SearchService } from 'app/search/search.service';
 import { SearchResultsComponent } from 'app/search/search-results/search-results.component';
-import { AutoScrollService } from 'app/shared/auto-scroll.service';
 
 @Component({
   selector: 'aio-shell',
@@ -40,12 +38,9 @@ export class AppComponent implements OnInit {
 
   constructor(documentService: DocumentService,
               private autoScrollService: AutoScrollService,
-              private gaService: GaService,
               private locationService: LocationService,
-              navigationService: NavigationService,
               private searchService: SearchService) {
     this.currentDocument = documentService.currentDocument;
-    this.version = navigationService.versionInfo.map(info => info.full);
   }
 
   ngOnInit() {
@@ -55,7 +50,6 @@ export class AppComponent implements OnInit {
     this.onResize(window.innerWidth);
 
     this.locationService.currentUrl.subscribe(url => {
-      this.gaService.locationChanged(url);
       this.autoScroll(); // scroll even if only the hash fragment changed
     });
   }

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -19,6 +19,7 @@ export class AppComponent implements OnInit {
   readonly homeImageUrl = 'assets/images/logos/standard/logo-nav.png';
 
   isHamburgerVisible = true; // always ... for now
+  isSideNavNode = false;
   isSideBySide = false;
 
   currentDocument: Observable<DocumentContents>;
@@ -59,6 +60,9 @@ export class AppComponent implements OnInit {
     // This subscription is needed when navigating between anchors within a document
     // and the document itself has not changed
     this.locationService.currentUrl.subscribe(url => this.autoScroll.scroll(this.docViewer.nativeElement.offsetParent));
+
+    // The current doc is in side nav if there are selected nodes
+    this.selectedNodes.subscribe(nodes => this.isSideNavNode = !!nodes.length );
   }
 
   onDocRendered(doc: DocumentContents) {

--- a/aio/src/app/app.module.ts
+++ b/aio/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { NavigationService } from 'app/navigation/navigation.service';
 import { DocumentService } from 'app/documents/document.service';
 import { SearchService } from 'app/search/search.service';
 import { TopMenuComponent } from 'app/layout/top-menu/top-menu.component';
+import { FooterComponent } from 'app/layout/footer/footer.component';
 import { NavMenuComponent } from 'app/layout/nav-menu/nav-menu.component';
 import { NavItemComponent } from 'app/layout/nav-item/nav-item.component';
 import { SearchResultsComponent } from './search/search-results/search-results.component';
@@ -46,6 +47,7 @@ import { AutoScrollService } from 'app/shared/auto-scroll.service';
     AppComponent,
     embeddedComponents,
     DocViewerComponent,
+    FooterComponent,
     TopMenuComponent,
     NavMenuComponent,
     NavItemComponent,

--- a/aio/src/app/documents/document.service.ts
+++ b/aio/src/app/documents/document.service.ts
@@ -3,6 +3,9 @@ import { Http, Response } from '@angular/http';
 
 import { Observable } from 'rxjs/Observable';
 import { AsyncSubject } from 'rxjs/AsyncSubject';
+import { of } from 'rxjs/observable/of';
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/switchMap';
 
 import { DocumentContents } from './document-contents';
@@ -51,7 +54,7 @@ export class DocumentService {
             // using `getDocument` means that we can fetch the 404 doc contents from the server and cache it
             return this.getDocument(FILE_NOT_FOUND_URL);
           } else {
-            return Observable.of({ title: 'Not Found', contents: 'Document not found' });
+            return of({ title: 'Not Found', contents: 'Document not found' });
           }
         } else {
           throw error;

--- a/aio/src/app/layout/footer/footer.component.ts
+++ b/aio/src/app/layout/footer/footer.component.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { NavigationService } from 'app/navigation/navigation.service';
+
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/operator/map';
+
+@Component({
+  selector: 'aio-footer',
+  template: `
+  <footer>
+    <div class="footer">
+      <p>Powered by Google ©2010-2017. Code licensed under an <a href="/license">MIT-style License</a>.</p>
+      <p>Documentation licensed under <a href="http://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.
+      </p>
+      <p class="version-info">Version Info | {{ version | async }}</p>
+    </div>
+  </footer>`
+})
+export class FooterComponent {
+  version: Observable<string>;
+
+  constructor(navigationService: NavigationService) {
+    this.version = navigationService.versionInfo.map(info => info.full);
+  }
+}

--- a/aio/src/app/layout/nav-menu/nav-menu.component.spec.ts
+++ b/aio/src/app/layout/nav-menu/nav-menu.component.spec.ts
@@ -4,7 +4,7 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { NavMenuComponent } from './nav-menu.component';
-import { NavigationService, NavigationViews, NavigationNode } from 'app/navigation/navigation.service';
+import { CurrentNode, NavigationService, NavigationViews, NavigationNode } from 'app/navigation/navigation.service';
 
 
 describe('NavMenuComponent', () => {
@@ -49,5 +49,5 @@ class TestNavigationService {
   };
 
   navigationViews = new BehaviorSubject<NavigationViews>(this.navJson);
-  selectedNodes = new BehaviorSubject<NavigationNode[]>([]);
+  currentNode = new BehaviorSubject<CurrentNode>(undefined);
 }

--- a/aio/src/app/layout/nav-menu/nav-menu.component.ts
+++ b/aio/src/app/layout/nav-menu/nav-menu.component.ts
@@ -1,15 +1,37 @@
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
-import { NavigationNode } from 'app/navigation/navigation.service';
+import { Component, EventEmitter, Output, OnInit, OnDestroy } from '@angular/core';
+import { NavigationService, NavigationViews, NavigationNode } from 'app/navigation/navigation.service';
+
+import { Subject } from 'rxjs/Subject';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/takeUntil';
 
 @Component({
   selector: 'aio-nav-menu',
-  template: `<aio-nav-item *ngFor="let node of nodes" [selectedNodes]="selectedNodes" [node]="node"></aio-nav-item>`
+  template: `
+  <aio-nav-item *ngFor="let node of nodes | async" [node]="node" [selectedNodes]="selectedNodes | async">
+  </aio-nav-item>`
 })
-export class NavMenuComponent {
+export class NavMenuComponent implements OnInit, OnDestroy {
+  @Output()
+  isSideNavDoc = new EventEmitter<boolean>();
 
-  @Input()
-  selectedNodes: NavigationNode[];
+  nodes: Observable<NavigationNode[]>;
+  selectedNodes: Observable<NavigationNode[]>;
+  onDestroy = new Subject();
 
-  @Input()
-  nodes: NavigationNode[];
+  constructor(navigationService: NavigationService) {
+    this.nodes = navigationService.navigationViews.map(views => views.SideNav).takeUntil(this.onDestroy);
+    this.selectedNodes = navigationService.selectedNodes.takeUntil(this.onDestroy);
+  }
+
+  ngOnInit() {
+    // The current doc is in side nav if there are selected nodes
+    this.selectedNodes.subscribe(nodes => this.isSideNavDoc.emit(!!nodes.length));
+  }
+
+  // Component never destroyed but future proof it
+  ngOnDestroy() {
+    this.onDestroy.next();
+  }
 }

--- a/aio/src/app/layout/nav-menu/nav-menu.component.ts
+++ b/aio/src/app/layout/nav-menu/nav-menu.component.ts
@@ -1,10 +1,12 @@
 import { Component, EventEmitter, OnInit, OnDestroy } from '@angular/core';
-import { NavigationService, NavigationViews, NavigationNode } from 'app/navigation/navigation.service';
+import { CurrentNode, NavigationService, NavigationViews, NavigationNode } from 'app/navigation/navigation.service';
 
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/takeUntil';
+
+const sideNav = 'SideNav';
 
 @Component({
   selector: 'aio-nav-menu',
@@ -19,8 +21,13 @@ export class NavMenuComponent implements OnInit, OnDestroy {
   onDestroy = new Subject();
 
   constructor(navigationService: NavigationService) {
-    this.nodes = navigationService.navigationViews.map(views => views.SideNav).takeUntil(this.onDestroy);
-    this.selectedNodes = navigationService.selectedNodes.takeUntil(this.onDestroy);
+    this.nodes = navigationService.navigationViews
+      .map(views => views[sideNav])
+      .takeUntil(this.onDestroy);
+
+    this.selectedNodes = navigationService.currentNode
+      .map(current => current && current.view === sideNav ? current.nodes : [])
+      .takeUntil(this.onDestroy);
   }
 
   ngOnInit() {

--- a/aio/src/app/layout/nav-menu/nav-menu.component.ts
+++ b/aio/src/app/layout/nav-menu/nav-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output, OnInit, OnDestroy } from '@angular/core';
+import { Component, EventEmitter, OnInit, OnDestroy } from '@angular/core';
 import { NavigationService, NavigationViews, NavigationNode } from 'app/navigation/navigation.service';
 
 import { Subject } from 'rxjs/Subject';
@@ -13,9 +13,7 @@ import 'rxjs/add/operator/takeUntil';
   </aio-nav-item>`
 })
 export class NavMenuComponent implements OnInit, OnDestroy {
-  @Output()
-  isSideNavDoc = new EventEmitter<boolean>();
-
+  isSideNavDoc = false;
   nodes: Observable<NavigationNode[]>;
   selectedNodes: Observable<NavigationNode[]>;
   onDestroy = new Subject();
@@ -27,7 +25,7 @@ export class NavMenuComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     // The current doc is in side nav if there are selected nodes
-    this.selectedNodes.subscribe(nodes => this.isSideNavDoc.emit(!!nodes.length));
+    this.selectedNodes.subscribe(nodes => this.isSideNavDoc = !!nodes.length);
   }
 
   // Component never destroyed but future proof it

--- a/aio/src/app/layout/top-menu/top-menu.component.scss
+++ b/aio/src/app/layout/top-menu/top-menu.component.scss
@@ -1,0 +1,30 @@
+.fill-remaining-space {
+  flex: 1 1 auto;
+}
+
+.nav-link {
+  margin-right: 10px;
+  margin-left: 20px;
+  cursor: pointer;
+}
+
+.nav-link.home img {
+  position: relative;
+  margin-top: -15px;
+  top: 12px;
+  height: 36px;
+}
+
+@media (max-width: 700px) {
+  .nav-link {
+    margin-right: 8px;
+    margin-left: 0px;
+  }
+}
+@media (max-width: 600px) {
+  .nav-link {
+    font-size: 80%;
+    margin-right: 8px;
+    margin-left: 0px;
+  }
+}

--- a/aio/src/app/layout/top-menu/top-menu.component.spec.ts
+++ b/aio/src/app/layout/top-menu/top-menu.component.spec.ts
@@ -1,29 +1,26 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
-import { NavMenuComponent } from './nav-menu.component';
+import { TopMenuComponent } from './top-menu.component';
 import { NavigationService, NavigationViews, NavigationNode } from 'app/navigation/navigation.service';
 
-
-describe('NavMenuComponent', () => {
-  let component: NavMenuComponent;
-  let fixture: ComponentFixture<NavMenuComponent>;
+describe('TopMenuComponent', () => {
+  let component: TopMenuComponent;
+  let fixture: ComponentFixture<TopMenuComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ NavMenuComponent ],
+      declarations: [ TopMenuComponent ],
       providers: [
         {provide: NavigationService, useClass: TestNavigationService }
-      ],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+      ]
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(NavMenuComponent);
+    fixture = TestBed.createComponent(TopMenuComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
@@ -36,18 +33,11 @@ describe('NavMenuComponent', () => {
 //// Test Helpers ////
 class TestNavigationService {
   navJson = {
-    SideNav:  [
-      { title: 'a', children: [
-        { url: 'b', title: 'b', children: [
-          { url: 'c', title: 'c' },
-          { url: 'd', title: 'd' }
-        ] },
-        { url: 'e', title: 'e' }
-      ] },
-      { url: 'f', title: 'f' }
-    ]
+    TopBar: [
+      {url: 'api', title: 'API' },
+      {url: 'features', title: 'Features' }
+    ],
   };
 
   navigationViews = new BehaviorSubject<NavigationViews>(this.navJson);
-  selectedNodes = new BehaviorSubject<NavigationNode[]>([]);
 }

--- a/aio/src/app/layout/top-menu/top-menu.component.ts
+++ b/aio/src/app/layout/top-menu/top-menu.component.ts
@@ -4,6 +4,8 @@ import { NavigationService, NavigationViews, NavigationNode } from 'app/navigati
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/operator/map';
 
+const topBar = 'TopBar';
+
 @Component({
   selector: 'aio-top-menu',
   template: `
@@ -19,6 +21,6 @@ export class TopMenuComponent {
   nodes: Observable<NavigationNode[]>;
 
   constructor(navigationService: NavigationService) {
-    this.nodes = navigationService.navigationViews.map(views => views.TopBar);
+    this.nodes = navigationService.navigationViews.map(views => views[topBar]);
   }
 }

--- a/aio/src/app/layout/top-menu/top-menu.component.ts
+++ b/aio/src/app/layout/top-menu/top-menu.component.ts
@@ -1,50 +1,24 @@
-import { Component, Input } from '@angular/core';
-import { NavigationNode } from 'app/navigation/navigation.service';
+import { Component } from '@angular/core';
+import { NavigationService, NavigationViews, NavigationNode } from 'app/navigation/navigation.service';
+
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/operator/map';
 
 @Component({
   selector: 'aio-top-menu',
   template: `
     <ul role="navigation">
-    <li><a class="nav-link home" href="/"><img src="{{ homeImageUrl }}" title="Home" alt="Home"></a></li>
-    <li *ngFor="let node of nodes"><a class="nav-link" [href]="node.path || node.url">{{ node.title }}</a></li>
+      <li><a class="nav-link home" href="/"><img src="{{ homeImageUrl }}" title="Home" alt="Home"></a></li>
+      <li *ngFor="let node of nodes | async"><a class="nav-link" [href]="node.path || node.url">{{ node.title }}</a></li>
     </ul>`,
-  styles: [`
-    .fill-remaining-space {
-      flex: 1 1 auto;
-    }
-
-    .nav-link {
-      margin-right: 10px;
-      margin-left: 20px;
-      cursor: pointer;
-    }
-
-    .nav-link.home img {
-      position: relative;
-      margin-top: -15px;
-      top: 12px;
-      height: 36px;
-    }
-
-    @media (max-width: 700px) {
-      .nav-link {
-        margin-right: 8px;
-        margin-left: 0px;
-      }
-    }
-    @media (max-width: 600px) {
-      .nav-link {
-        font-size: 80%;
-        margin-right: 8px;
-        margin-left: 0px;
-      }
-    }`
-  ]
+  styleUrls: ['top-menu.component.scss']
 })
 export class TopMenuComponent {
-  @Input()
-  nodes: NavigationNode[];
 
-  @Input()
-  homeImageUrl: string;
+  readonly homeImageUrl = 'assets/images/logos/standard/logo-nav.png';
+  nodes: Observable<NavigationNode[]>;
+
+  constructor(navigationService: NavigationService) {
+    this.nodes = navigationService.navigationViews.map(views => views.TopBar);
+  }
 }

--- a/aio/src/app/navigation/navigation.service.spec.ts
+++ b/aio/src/app/navigation/navigation.service.spec.ts
@@ -79,16 +79,24 @@ describe('NavigationService', () => {
   describe('selectedNodes', () => {
     let service: NavigationService, location: MockLocationService;
     let currentNodes: NavigationNode[];
-    const nodeTree: NavigationNode[] = [
-      { title: 'a', children: [
-        { url: 'b', title: 'b', children: [
-          { url: 'c', title: 'c' },
-          { url: 'd', title: 'd' }
+
+    const sideNavNodes: NavigationNode[] = [
+        { title: 'a', children: [
+          { url: 'b', title: 'b', children: [
+            { url: 'c', title: 'c' },
+            { url: 'd', title: 'd' }
+          ] },
+          { url: 'e', title: 'e' }
         ] },
-        { url: 'e', title: 'e' }
-      ] },
-      { url: 'f', title: 'f' }
-    ];
+        { url: 'f', title: 'f' }
+      ];
+
+    const navJson = {
+      TopMenu: [ { url: 'api/url', title: 'api' }],
+      SideNav: sideNavNodes,
+      __versionInfo: {}
+    };
+
 
     beforeEach(() => {
       location = injector.get(LocationService);
@@ -97,30 +105,35 @@ describe('NavigationService', () => {
       service.selectedNodes.subscribe(nodes => currentNodes = nodes);
 
       const backend = injector.get(ConnectionBackend);
-      backend.connectionsArray[0].mockRespond(createResponse({ nav: nodeTree }));
+      backend.connectionsArray[0].mockRespond(createResponse(navJson));
     });
 
-    it('should list the navigation node that matches the current location, and all its ancestors', () => {
+    it('should list the side navigation node that matches the current location, and all its ancestors', () => {
       location.urlSubject.next('b');
       expect(currentNodes).toEqual([
-        nodeTree[0].children[0],
-        nodeTree[0]
+        sideNavNodes[0].children[0],
+        sideNavNodes[0]
       ]);
 
       location.urlSubject.next('d');
       expect(currentNodes).toEqual([
-        nodeTree[0].children[0].children[1],
-        nodeTree[0].children[0],
-        nodeTree[0]
+        sideNavNodes[0].children[0].children[1],
+        sideNavNodes[0].children[0],
+        sideNavNodes[0]
       ]);
 
       location.urlSubject.next('f');
       expect(currentNodes).toEqual([
-        nodeTree[1]
+        sideNavNodes[1]
       ]);
     });
 
-    it('should be an empty array if no navigation node matches the current location', () => {
+    it('should be an empty array if the current location is a top menu node', () => {
+      location.urlSubject.next('api/url');
+      expect(currentNodes).toEqual([]);
+    });
+
+    it('should be an empty array if no side navigation node matches the current location', () => {
       location.urlSubject.next('g');
       expect(currentNodes).toEqual([]);
     });

--- a/aio/src/app/navigation/navigation.service.spec.ts
+++ b/aio/src/app/navigation/navigation.service.spec.ts
@@ -92,7 +92,7 @@ describe('NavigationService', () => {
       ];
 
     const navJson = {
-      TopMenu: [ { url: 'api/url', title: 'api' }],
+      TopBar: [ { url: 'api/url', title: 'api' }],
       SideNav: sideNavNodes,
       __versionInfo: {}
     };

--- a/aio/src/app/navigation/navigation.service.ts
+++ b/aio/src/app/navigation/navigation.service.ts
@@ -15,6 +15,8 @@ export { NavigationNode } from './navigation-node';
 export type NavigationResponse = {__versionInfo: VersionInfo } & { [name: string]: NavigationNode[]|VersionInfo };
 
 export interface NavigationViews {
+  SideNav?: NavigationNode[];
+  TopBar?: NavigationNode[];
   [name: string]: NavigationNode[];
 }
 
@@ -38,7 +40,6 @@ export interface VersionInfo {
 }
 
 const navigationPath = 'content/navigation.json';
-const sideNavNode = 'SideNav';
 
 @Injectable()
 export class NavigationService {
@@ -121,7 +122,7 @@ export class NavigationService {
    */
   private computeUrlToSideNavNodesMap(navigation: NavigationViews) {
     const navMap: NavigationMap = {};
-    navigation[sideNavNode].forEach(node => walkNodes(node));
+    navigation.SideNav.forEach(node => walkNodes(node));
     return navMap;
 
     function walkNodes(node: NavigationNode, ancestors: NavigationNode[] = []) {

--- a/aio/src/app/navigation/navigation.service.ts
+++ b/aio/src/app/navigation/navigation.service.ts
@@ -12,7 +12,6 @@ import { LocationService } from 'app/shared/location.service';
 import { NavigationNode } from './navigation-node';
 export { NavigationNode } from './navigation-node';
 
-
 export type NavigationResponse = {__versionInfo: VersionInfo } & { [name: string]: NavigationNode[]|VersionInfo };
 
 export interface NavigationViews {
@@ -39,7 +38,7 @@ export interface VersionInfo {
 }
 
 const navigationPath = 'content/navigation.json';
-
+const sideNavNode = 'SideNav';
 
 @Injectable()
 export class NavigationService {
@@ -106,7 +105,7 @@ export class NavigationService {
    */
   private getSelectedNodes(navigationViews: Observable<NavigationViews>) {
     const selectedNodes = combineLatest(
-      navigationViews.map(this.computeUrlToNodesMap),
+      navigationViews.map(this.computeUrlToSideNavNodesMap),
       this.location.currentUrl,
       (navMap, url) => navMap[url] || [])
       .publishReplay(1);
@@ -118,11 +117,11 @@ export class NavigationService {
    * Compute a mapping from URL to an array of nodes, where the first node in the array
    * is the one that matches the URL and the rest are the ancestors of that node.
    *
-   * @param navigation A collection of navigation nodes that are to be mapped
+   * @param navigation A collection of SideNav navigation nodes that are to be mapped
    */
-  private computeUrlToNodesMap(navigation: NavigationViews) {
+  private computeUrlToSideNavNodesMap(navigation: NavigationViews) {
     const navMap: NavigationMap = {};
-    Object.keys(navigation).forEach(key => navigation[key].forEach(node => walkNodes(node)));
+    navigation[sideNavNode].forEach(node => walkNodes(node));
     return navMap;
 
     function walkNodes(node: NavigationNode, ancestors: NavigationNode[] = []) {

--- a/aio/src/app/navigation/navigation.service.ts
+++ b/aio/src/app/navigation/navigation.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
+
 import { Observable } from 'rxjs/Observable';
 import { AsyncSubject } from 'rxjs/AsyncSubject';
 import { combineLatest } from 'rxjs/observable/combineLatest';
-import 'rxjs/add/operator/publishReplay';
 import 'rxjs/add/operator/publishLast';
+import 'rxjs/add/operator/publishReplay';
 
 import { Logger } from 'app/shared/logger.service';
 import { LocationService } from 'app/shared/location.service';
@@ -15,13 +16,17 @@ export { NavigationNode } from './navigation-node';
 export type NavigationResponse = {__versionInfo: VersionInfo } & { [name: string]: NavigationNode[]|VersionInfo };
 
 export interface NavigationViews {
-  SideNav?: NavigationNode[];
-  TopBar?: NavigationNode[];
   [name: string]: NavigationNode[];
 }
 
-export interface NavigationMap {
-  [url: string]: NavigationNode;
+/**
+ *  Navigation information about a node at specific URL
+ *  view: 'SideNav' | 'TopBar'
+ *  nodes: the node and its ancestor nodes within that view
+ */
+export interface CurrentNode {
+  view: 'SideNav' | 'TopBar';
+  nodes: NavigationNode[];
 }
 
 export interface VersionInfo {
@@ -55,16 +60,18 @@ export class NavigationService {
   versionInfo: Observable<VersionInfo>;
 
   /**
-   * An observable array of nodes that indicate which nodes in the `navigationViews` match the current URL location
+   * An observable of the current node with info about the
+   * node (if any) that matches the current URL location
+   * including its navigation view and its ancestor nodes in that view
    */
-  selectedNodes: Observable<NavigationNode[]>;
+  currentNode: Observable<CurrentNode>;
 
   constructor(private http: Http, private location: LocationService, private logger: Logger) {
     const navigationInfo = this.fetchNavigationInfo();
     // The version information is packaged inside the navigation response to save us an extra request.
     this.versionInfo = this.getVersionInfo(navigationInfo);
     this.navigationViews = this.getNavigationViews(navigationInfo);
-    this.selectedNodes = this.getSelectedNodes(this.navigationViews);
+    this.currentNode = this.getCurrentNode(this.navigationViews);
   }
 
   /**
@@ -99,40 +106,41 @@ export class NavigationService {
   }
 
   /**
-   * Get an observable that will list the nodes that are currently selected
+   * Get an observable of the current SelectedNode
    * We use `publishReplay(1)` because otherwise subscribers will have to wait until the next
    * URL change before they receive an emission.
    * See above for discussion of using `connect`.
    */
-  private getSelectedNodes(navigationViews: Observable<NavigationViews>) {
-    const selectedNodes = combineLatest(
-      navigationViews.map(this.computeUrlToSideNavNodesMap),
+  private getCurrentNode(navigationViews: Observable<NavigationViews>): Observable<CurrentNode> {
+    const currentNode = combineLatest(
+      navigationViews.map(this.computeUrlToNavNodesMap),
       this.location.currentUrl,
-      (navMap, url) => navMap[url] || [])
+      (navMap, url) => navMap[url])
       .publishReplay(1);
-    selectedNodes.connect();
-    return selectedNodes;
+    currentNode.connect();
+    return currentNode;
   }
 
   /**
    * Compute a mapping from URL to an array of nodes, where the first node in the array
    * is the one that matches the URL and the rest are the ancestors of that node.
    *
-   * @param navigation A collection of SideNav navigation nodes that are to be mapped
+   * @param navigation - A collection of navigation nodes that are to be mapped
    */
-  private computeUrlToSideNavNodesMap(navigation: NavigationViews) {
-    const navMap: NavigationMap = {};
-    navigation.SideNav.forEach(node => walkNodes(node));
+  private computeUrlToNavNodesMap(navigation: NavigationViews) {
+    const navMap = {};
+    Object.keys(navigation)
+      .forEach(key => navigation[key].forEach(node => walkNodes(key, node)));
     return navMap;
 
-    function walkNodes(node: NavigationNode, ancestors: NavigationNode[] = []) {
+    function walkNodes(view: string, node: NavigationNode, ancestors: NavigationNode[] = []) {
       const nodes = [node, ...ancestors];
       if (node.url) {
         // only map to this node if it has a url associated with it
-        navMap[node.url] = nodes;
+        navMap[node.url] = {view, nodes};
       }
       if (node.children) {
-        node.children.forEach(child => walkNodes(child, nodes));
+        node.children.forEach(child => walkNodes(view, child, nodes));
       }
     }
   }

--- a/aio/src/app/search/search-box/search-box.component.html
+++ b/aio/src/app/search/search-box/search-box.component.html
@@ -1,5 +1,0 @@
-<input #searchBox
-    placeholder="Search"
-    (keyup)="onSearch($event.target.value, $event.which)"
-    (focus)="onSearch($event.target.value)"
-    (click)="onSearch($event.target.value)">

--- a/aio/src/app/search/search-box/search-box.component.spec.ts
+++ b/aio/src/app/search/search-box/search-box.component.spec.ts
@@ -1,5 +1,4 @@
 import { async, ComponentFixture, TestBed, inject } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { SearchBoxComponent } from './search-box.component';
 import { SearchService } from '../search.service';
@@ -17,8 +16,7 @@ describe('SearchBoxComponent', () => {
       providers: [
         { provide: SearchService, useFactory: () => new MockSearchService() },
         { provide: LocationService, useFactory: () => new MockLocationService('') }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
+      ]
     })
     .compileComponents();
   }));

--- a/aio/src/app/search/search-box/search-box.component.ts
+++ b/aio/src/app/search/search-box/search-box.component.ts
@@ -16,7 +16,11 @@ import { LocationService } from 'app/shared/location.service';
  */
 @Component({
   selector: 'aio-search-box',
-  templateUrl: './search-box.component.html',
+  template: `<input #searchBox
+    placeholder="Search"
+    (keyup)="onSearch($event.target.value, $event.which)"
+    (focus)="onSearch($event.target.value)"
+    (click)="onSearch($event.target.value)">`
 })
 export class SearchBoxComponent implements OnInit {
 

--- a/aio/src/app/shared/location.service.spec.ts
+++ b/aio/src/app/shared/location.service.spec.ts
@@ -1,12 +1,9 @@
 import { ReflectiveInjector } from '@angular/core';
 import { Location, LocationStrategy, PlatformLocation } from '@angular/common';
 import { MockLocationStrategy } from '@angular/common/testing';
-import { LocationService } from './location.service';
 
-class MockPlatformLocation {
-  pathname = 'a/b/c';
-  replaceState = jasmine.createSpy('PlatformLocation.replaceState');
-}
+import { GaService } from 'app/shared/ga.service';
+import { LocationService } from './location.service';
 
 describe('LocationService', () => {
 
@@ -16,6 +13,7 @@ describe('LocationService', () => {
     injector = ReflectiveInjector.resolveAndCreate([
         LocationService,
         Location,
+        { provide: GaService, useClass: TestGaService },
         { provide: LocationStrategy, useClass: MockLocationStrategy },
         { provide: PlatformLocation, useClass: MockPlatformLocation }
     ]);
@@ -341,4 +339,58 @@ describe('LocationService', () => {
       });
     });
   });
+
+  describe('google analytics - GaService#locationChanged', () => {
+
+    let gaLocationChanged: jasmine.Spy;
+    let location: Location;
+    let service: LocationService;
+
+    beforeEach(() => {
+      const gaService = injector.get(GaService);
+      gaLocationChanged = gaService.locationChanged;
+      location = injector.get(Location);
+      service = injector.get(LocationService);
+    });
+
+    it('should call locationChanged with initial URL', () => {
+      const initialUrl = stripLeadingSlashes(location.path(true));
+
+      expect(gaLocationChanged.calls.count()).toBe(1, 'gaService.locationChanged');
+      const args = gaLocationChanged.calls.first().args;
+      expect(args[0]).toBe(initialUrl);
+    });
+
+    it('should call locationChanged when `go` to a page', () => {
+      service.go('some-new-url');
+      expect(gaLocationChanged.calls.count()).toBe(2, 'gaService.locationChanged');
+      const args = gaLocationChanged.calls.argsFor(1);
+      expect(args[0]).toBe('some-new-url');
+    });
+
+    it('should call locationChanged when window history changes', () => {
+     const locationStrategy: MockLocationStrategy = injector.get(LocationStrategy);
+     locationStrategy.simulatePopState('/next-url');
+
+      expect(gaLocationChanged.calls.count()).toBe(2, 'gaService.locationChanged');
+      const args = gaLocationChanged.calls.argsFor(1);
+      expect(args[0]).toBe('next-url');
+    });
+
+  });
+
 });
+
+/// Test Helpers ///
+class MockPlatformLocation {
+  pathname = 'a/b/c';
+  replaceState = jasmine.createSpy('PlatformLocation.replaceState');
+}
+
+function stripLeadingSlashes(url: string) {
+  return url.replace(/^\/+/, '');
+}
+
+class TestGaService {
+  locationChanged = jasmine.createSpy('locationChanged');
+}

--- a/aio/src/app/shared/location.service.ts
+++ b/aio/src/app/shared/location.service.ts
@@ -1,19 +1,28 @@
 import { Injectable } from '@angular/core';
 import { Location, PlatformLocation } from '@angular/common';
+
 import { Observable } from 'rxjs/Observable';
-import { ReplaySubject } from 'rxjs/ReplaySubject';
+import { Subject } from 'rxjs/Subject';
+import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/publishReplay';
+
+import { GaService } from 'app/shared/ga.service';
 
 @Injectable()
 export class LocationService {
 
   private readonly urlParser = document.createElement('a');
-  private urlSubject = new ReplaySubject<string>(1);
-  currentUrl = this.urlSubject.asObservable();
+  private urlSubject = new Subject<string>();
+  currentUrl = this.urlSubject
+    .do(url => this.gaService.locationChanged(url))
+    .publishReplay(1);
 
   constructor(
+    private gaService: GaService,
     private location: Location,
     private platformLocation: PlatformLocation) {
 
+    this.currentUrl.connect();
     const initialUrl = this.stripLeadingSlashes(location.path(true));
     this.urlSubject.next(initialUrl);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```
Igor requested this feature. He only wants the sidenav to appear when looking at guide pages. Marketing and API pages should use the whole screen.

Shows the left sidenav when the current doc is in the left nav (e.g., core or tutorial pages).
Hides the nav when the current doc is _not_ in the left nav (e.g. a marketing page or the API page).

To make this work, I changed `NavigationService` so that ONLY sidenav nodes can be in `selectedNodes`.  There is no good reason to have top menu nodes among `selectedNodes` because only `nav-items` use that feature.

This change makes the logic simple: if the current doc has "selected nodes", it's in the left sidenav; otherwise it is not.

The show/hide sidenav is now the intersection of selected node and screen width.