### PR TITLE
refactor(aio): move SearchService initialisation into SearchBoxComponent

### DIFF
--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -4,11 +4,9 @@ import { By } from '@angular/platform-browser';
 import { AppComponent } from './app.component';
 import { AppModule } from './app.module';
 import { GaService } from 'app/shared/ga.service';
-import { SearchService } from 'app/search/search.service';
 import { SearchResultsComponent } from 'app/search/search-results/search-results.component';
 import { SearchBoxComponent } from 'app/search/search-box/search-box.component';
 import { AutoScrollService } from 'app/shared/auto-scroll.service';
-import { MockSearchService } from 'testing/search.service';
 import { LocationService } from 'app/shared/location.service';
 import { MockLocationService } from 'testing/location.service';
 import { Logger } from 'app/shared/logger.service';
@@ -24,7 +22,6 @@ describe('AppComponent', () => {
       imports: [ AppModule ],
       providers: [
         { provide: APP_BASE_HREF, useValue: '/' },
-        { provide: SearchService, useClass: MockSearchService },
         { provide: GaService, useClass: TestGaService },
         { provide: LocationService, useFactory: () => new MockLocationService(initialUrl) },
         { provide: Logger, useClass: MockLogger }
@@ -90,14 +87,6 @@ describe('AppComponent', () => {
       component.onDocRendered(null);
       expect(scrollService.scroll).toHaveBeenCalledWith(jasmine.any(HTMLElement));
     });
-  });
-
-  describe('initialisation', () => {
-    it('should initialize the search worker', inject([SearchService], (searchService: SearchService) => {
-      fixture.detectChanges(); // triggers ngOnInit
-      expect(searchService.initWorker).toHaveBeenCalled();
-      expect(searchService.loadIndex).toHaveBeenCalled();
-    }));
   });
 
   describe('click intercepting', () => {

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -6,7 +6,6 @@ import { LocationService } from 'app/shared/location.service';
 import { DocumentService, DocumentContents } from 'app/documents/document.service';
 import { DocViewerComponent } from 'app/layout/doc-viewer/doc-viewer.component';
 import { NavigationService, NavigationViews, NavigationNode, VersionInfo } from 'app/navigation/navigation.service';
-import { SearchService } from 'app/search/search.service';
 import { SearchResultsComponent } from 'app/search/search-results/search-results.component';
 import { AutoScrollService } from 'app/shared/auto-scroll.service';
 
@@ -40,8 +39,7 @@ export class AppComponent implements OnInit {
               gaService: GaService,
               navigationService: NavigationService,
               private autoScroll: AutoScrollService,
-              private locationService: LocationService,
-              private searchService: SearchService) {
+              private locationService: LocationService) {
     this.currentDocument = documentService.currentDocument;
     locationService.currentUrl.subscribe(url => gaService.locationChanged(url));
     this.navigationViews = navigationService.navigationViews;
@@ -50,9 +48,6 @@ export class AppComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.searchService.initWorker('app/search/search-worker.js');
-    this.searchService.loadIndex();
-
     this.onResize(window.innerWidth);
 
     // The url changed, so scroll to the anchor in the hash fragment.

--- a/aio/src/app/search/search-box/search-box.component.spec.ts
+++ b/aio/src/app/search/search-box/search-box.component.spec.ts
@@ -30,6 +30,12 @@ describe('SearchBoxComponent', () => {
   });
 
   describe('initialisation', () => {
+    it('should initialize the search worker', inject([SearchService], (searchService: SearchService) => {
+      fixture.detectChanges(); // triggers ngOnInit
+      expect(searchService.initWorker).toHaveBeenCalled();
+      expect(searchService.loadIndex).toHaveBeenCalled();
+    }));
+
     it('should get the current search query from the location service', inject([LocationService], (location: MockLocationService) => {
       location.search.and.returnValue({ search: 'initial search' });
       spyOn(component, 'onSearch');

--- a/aio/src/app/search/search-box/search-box.component.ts
+++ b/aio/src/app/search/search-box/search-box.component.ts
@@ -25,6 +25,9 @@ export class SearchBoxComponent implements OnInit {
   constructor(private searchService: SearchService, private locationService: LocationService) { }
 
   ngOnInit() {
+    this.searchService.initWorker('app/search/search-worker.js');
+    this.searchService.loadIndex();
+
     const query = this.locationService.search()['search'];
     if (query) {
       this.searchBox.nativeElement.value = query;


### PR DESCRIPTION
The AppComponent really doesn't need to know about the search service.

A great suggestion by @wardbell 