### PR TITLE
fix(aio): selectedNodes should work for URLs ending with a slash

### DIFF
--- a/aio/src/app/navigation/navigation.service.spec.ts
+++ b/aio/src/app/navigation/navigation.service.spec.ts
@@ -82,7 +82,7 @@ describe('NavigationService', () => {
     const nodeTree: NavigationNode[] = [
       { title: 'a', children: [
         { url: 'b', title: 'b', children: [
-          { url: 'c', title: 'c' },
+          { url: 'c/', title: 'c' },
           { url: 'd', title: 'd' }
         ] },
         { url: 'e', title: 'e' }
@@ -123,6 +123,21 @@ describe('NavigationService', () => {
     it('should be an empty array if no navigation node matches the current location', () => {
       location.urlSubject.next('g');
       expect(currentNodes).toEqual([]);
+    });
+
+    it('should ignore trailing slashes on URLs in the navmap', () => {
+      location.urlSubject.next('c');
+      expect(currentNodes).toEqual([
+        nodeTree[0].children[0].children[0],
+        nodeTree[0].children[0],
+        nodeTree[0]
+      ]);
+      location.urlSubject.next('c/');
+      expect(currentNodes).toEqual([
+        nodeTree[0].children[0].children[0],
+        nodeTree[0].children[0],
+        nodeTree[0]
+      ]);
     });
   });
 

--- a/aio/src/app/navigation/navigation.service.ts
+++ b/aio/src/app/navigation/navigation.service.ts
@@ -108,7 +108,11 @@ export class NavigationService {
     const selectedNodes = combineLatest(
       navigationViews.map(this.computeUrlToNodesMap),
       this.location.currentUrl,
-      (navMap, url) => navMap[url] || [])
+      (navMap, url) => {
+        // strip trailing slashes from the currentUrl - they are not relevant to matching against the navMap
+        url = url.replace(/\/$/, '');
+        return navMap[url] || [];
+      })
       .publishReplay(1);
     selectedNodes.connect();
     return selectedNodes;
@@ -127,9 +131,10 @@ export class NavigationService {
 
     function walkNodes(node: NavigationNode, ancestors: NavigationNode[] = []) {
       const nodes = [node, ...ancestors];
+      // only map to this node if it has a url associated with it
       if (node.url) {
-        // only map to this node if it has a url associated with it
-        navMap[node.url] = nodes;
+        // Strip off trailing slashes from nodes in the navMap - they are not relevant to matching
+        navMap[node.url.replace(/\/$/, '')] = nodes;
       }
       if (node.children) {
         node.children.forEach(child => walkNodes(child, nodes));


### PR DESCRIPTION
The mapping was not accounting for the fact that URLs with or without
a trailing slash are actually the same node.
