### PR TITLE
fix(language-service): guard access to `Symbol.members`

### DIFF
--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -668,7 +668,7 @@ class TypeScriptSymbolQuery implements SymbolQuery {
   getSpanAt(line: number, column: number): Span { return spanAt(this.source, line, column); }
 
   private getTemplateRefContextType(type: ts.Symbol): ts.Symbol {
-    const constructor = type.members['__constructor'];
+    const constructor = type.members && type.members['__constructor'];
     if (constructor) {
       const constructorDeclaration = constructor.declarations[0] as ts.ConstructorTypeNode;
       for (const parameter of constructorDeclaration.parameters) {


### PR DESCRIPTION
Fixes #15528

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

The language service access TypeScript's `Symbol.members` without checking for `null` or `undefined`.

**What is the new behavior?**

The access is guarded.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```