### PR TITLE
fix(platform-browser): support HTML template content children

### DIFF
--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -117,17 +117,19 @@ class DefaultDomRenderer2 implements Renderer2 {
 
   createText(value: string): any { return document.createTextNode(value); }
 
-  appendChild(parent: any, newChild: any): void { parent.appendChild(newChild); }
+  appendChild(parent: any, newChild: any): void {
+    this.nodeOrContent(parent).appendChild(newChild);
+  }
 
   insertBefore(parent: any, newChild: any, refChild: any): void {
     if (parent) {
-      parent.insertBefore(newChild, refChild);
+      this.nodeOrContent(parent).insertBefore(newChild, refChild);
     }
   }
 
   removeChild(parent: any, oldChild: any): void {
     if (parent) {
-      parent.removeChild(oldChild);
+      this.nodeOrContent(parent).removeChild(oldChild);
     }
   }
 
@@ -211,6 +213,14 @@ class DefaultDomRenderer2 implements Renderer2 {
     }
     return <() => void>this.eventManager.addEventListener(
                target, event, decoratePreventDefault(callback)) as() => void;
+  }
+
+  private nodeOrContent(parent: any): any {
+    if (parent && parent.content instanceof DocumentFragment) {
+      return parent.content;
+    } else {
+      return parent;
+    }
   }
 }
 

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -104,6 +104,24 @@ export function main() {
            expect(window.getComputedStyle(none).color).toEqual('rgb(0, 255, 0)');
          });
     }
+
+    if (browserDetection.supportsHtmlTemplate) {
+      it('should add and remove children from HTML template content fragment', () => {
+        const template = document.createElement('template');
+        const div = document.createElement('div');
+        const span = document.createElement('span');
+
+        renderer.appendChild(template, div);
+        expect(template.children.length).toBe(0);
+        expect(template.content.children.length).toBe(1);
+
+        renderer.insertBefore(template, span, div);
+        expect(template.content.children).toEqual([span, div]);
+
+        renderer.removeChild(template, div);
+        expect(template.content.children).toEqual([span])
+      });
+    }
   });
 }
 

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -116,10 +116,13 @@ export function main() {
         expect(template.content.children.length).toBe(1);
 
         renderer.insertBefore(template, span, div);
-        expect(template.content.children).toEqual([span, div]);
+        expect(template.content.children.length).toBe(2);
+        expect(template.content.children.item(0)).toBe(span);
+        expect(template.content.children.item(1)).toBe(div);
 
         renderer.removeChild(template, div);
-        expect(template.content.children).toEqual([span])
+        expect(template.content.children.length).toBe(1);
+        expect(template.content.children.item(0)).toBe(span);
       });
     }
   });

--- a/packages/platform-browser/testing/src/browser_util.ts
+++ b/packages/platform-browser/testing/src/browser_util.ts
@@ -57,6 +57,8 @@ export class BrowserDetection {
     return !!(<any>global).Intl && (<any>global).Intl !== (<any>global).IntlPolyfill;
   }
 
+  get supportsHtmlTemplate(): boolean { return 'content' in getDOM().createElement('template'); }
+
   get isChromeDesktop(): boolean {
     return this._ua.indexOf('Chrome') > -1 && this._ua.indexOf('Mobile Safari') == -1 &&
         this._ua.indexOf('Edge') == -1;


### PR DESCRIPTION
Fixes #15557

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
#15557


**What is the new behavior?**
`DefaultDomRenderer2` will append, insert, and remove child nodes from a parent's content attribute if the parent's content is a DocumentFragment.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

