### PR TITLE
fix(compiler): ignore errors when evaluating base classes

### DIFF
--- a/packages/compiler/src/aot/static_reflector.ts
+++ b/packages/compiler/src/aot/static_reflector.ts
@@ -118,7 +118,7 @@ export class StaticReflector implements ɵReflectorReader {
       const classMetadata = this.getTypeMetadata(type);
       propMetadata = {};
       if (classMetadata['extends']) {
-        const parentType = this.simplify(type, classMetadata['extends']);
+        const parentType = this.trySimplify(type, classMetadata['extends']);
         if (parentType instanceof StaticSymbol) {
           const parentPropMetadata = this.propMetadata(parentType);
           Object.keys(parentPropMetadata).forEach((parentProp) => {
@@ -176,7 +176,7 @@ export class StaticReflector implements ɵReflectorReader {
             parameters.push(nestedResult);
           });
         } else if (classMetadata['extends']) {
-          const parentType = this.simplify(type, classMetadata['extends']);
+          const parentType = this.trySimplify(type, classMetadata['extends']);
           if (parentType instanceof StaticSymbol) {
             parameters = this.parameters(parentType);
           }
@@ -199,7 +199,7 @@ export class StaticReflector implements ɵReflectorReader {
       const classMetadata = this.getTypeMetadata(type);
       methodNames = {};
       if (classMetadata['extends']) {
-        const parentType = this.simplify(type, classMetadata['extends']);
+        const parentType = this.trySimplify(type, classMetadata['extends']);
         if (parentType instanceof StaticSymbol) {
           const parentMethodNames = this._methodNames(parentType);
           Object.keys(parentMethodNames).forEach((parentProp) => {

--- a/packages/compiler/test/aot/static_reflector_spec.ts
+++ b/packages/compiler/test/aot/static_reflector_spec.ts
@@ -495,6 +495,31 @@ describe('StaticReflector', () => {
     expect(() => reflector.propMetadata(appComponent)).not.toThrow();
   });
 
+  it('should not throw with an invalid extends', () => {
+    const data = Object.create(DEFAULT_TEST_DATA);
+    const file = '/tmp/src/invalid-component.ts';
+    data[file] = `
+        import {Component} from '@angular/core';
+
+        function InvalidParent() {
+          return InvalidParent;
+        }
+
+        @Component({
+          selector: 'tmp',
+          template: '',
+        })
+        export class BadComponent extends InvalidParent() {
+
+        }
+      `;
+    init(data);
+    const badComponent = reflector.getStaticSymbol(file, 'BadComponent');
+    expect(reflector.propMetadata(badComponent)).toEqual({});
+    expect(reflector.parameters(badComponent)).toEqual([]);
+    expect(reflector.hasLifecycleHook(badComponent, 'onDestroy')).toEqual(false);
+  });
+
   it('should produce a annotation even if it contains errors', () => {
     const data = Object.create(DEFAULT_TEST_DATA);
     const file = '/tmp/src/invalid-component.ts';


### PR DESCRIPTION
Fixes #15536

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

#15536

The static reflector emits errors for base classes it doesn't understand. It should just ignore them.

**What is the new behavior?**

The static reflector now ignores base classes it doesn't understand in more cases.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```