### PR TITLE
fix(language-service): don't require `reflect-metadata` module to be provided

### DIFF
--- a/packages/language-service/rollup.config.js
+++ b/packages/language-service/rollup.config.js
@@ -49,13 +49,15 @@ function resolve(id, from) {
 }
 
 var banner = `
+var $reflect = {defineMetadata: function() {}, getOwnMetadata: function(){}};
+((typeof global !== 'undefined' && global)||{})['Reflect'] = $reflect;
 var $deferred, $resolved, $provided;
 function $getModule(name) { return $provided[name] || require(name); }
 function define(modules, cb) { $deferred = { modules: modules, cb: cb }; }
 module.exports = function(provided) {
   if ($resolved) return $resolved;
   var result = {};
-  $provided = Object.assign({}, provided || {}, { exports: result });
+  $provided = Object.assign({'reflect-metadata': $reflect}, provided || {}, { exports: result });
   $deferred.cb.apply(this, $deferred.modules.map($getModule));
   $resolved = result;
   return result;


### PR DESCRIPTION
Fixes #15568

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

The language service requires `reflect-metadata` to be findable when the language service module is loaded. Depending on how the module is loaded that might be challenging to to provide.

**What is the new behavior?**

The `reflect-metadata` module is faked inside the language service. It can be provided by to the module factory function but a fake is created instead of trying to load one.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```