### PR TITLE
fix(upgrade): prevent $digest from being called if it is already in progress

### DIFF
--- a/packages/upgrade/src/common/angular1.ts
+++ b/packages/upgrade/src/common/angular1.ts
@@ -54,6 +54,7 @@ export interface IRootScopeService {
   $$childTail: IScope;
   $$childHead: IScope;
   $$nextSibling: IScope;
+  $$phase: string;
   [key: string]: any;
 }
 export interface IScope extends IRootScopeService {}

--- a/packages/upgrade/src/dynamic/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_adapter.ts
@@ -579,7 +579,11 @@ export class UpgradeAdapter {
                   .then(() => this.ng2BootstrapDeferred.resolve(ng1Injector), onError)
                   .then(() => {
                     let subscription =
-                        this.ngZone.onMicrotaskEmpty.subscribe({next: () => rootScope.$digest()});
+                        this.ngZone.onMicrotaskEmpty.subscribe({next: () => {
+                          if(rootScope.$$phase !== '$digest') {
+                            rootScope.$digest();
+                          }
+                        }});
                     rootScope.$on('$destroy', () => { subscription.unsubscribe(); });
                   });
             })

--- a/packages/upgrade/src/dynamic/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_adapter.ts
@@ -578,12 +578,13 @@ export class UpgradeAdapter {
                   })
                   .then(() => this.ng2BootstrapDeferred.resolve(ng1Injector), onError)
                   .then(() => {
-                    let subscription =
-                        this.ngZone.onMicrotaskEmpty.subscribe({next: () => {
-                          if(rootScope.$$phase !== '$digest') {
-                            rootScope.$digest();
-                          }
-                        }});
+                    let subscription = this.ngZone.onMicrotaskEmpty.subscribe({
+                      next: () => {
+                        if (rootScope.$$phase !== '$digest') {
+                          rootScope.$digest();
+                        }
+                      }
+                    });
                     rootScope.$on('$destroy', () => { subscription.unsubscribe(); });
                   });
             })


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Calling rootScope.$digest causes a `$digest is already in progress` error when using upgrade along with @angular/flex-layout.


**What is the new behavior?**
`$digest` is not being called if it is already in progress.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
In a hybrid application, we are using @angular/flex-layout on different pages and when transitioning from a page to a new page the flex-layout invokes a zone.run which then triggers a digest, thus throwing this error.
