### PR TITLE
build(aio): update rho to new version

### DIFF
--- a/aio/transforms/rho-package/services/renderMarkdown.spec.js
+++ b/aio/transforms/rho-package/services/renderMarkdown.spec.js
@@ -9,7 +9,7 @@ describe('rho: renderMarkdown service', () => {
   it('should convert markdown to HTML', () => {
     const content = '# heading 1\n' +
         '\n' +
-        'A paragraph with *bold* and _italic_.\n' +
+        'A paragraph with **bold** and _italic_.\n' +
         '\n' +
         '* List item 1\n' +
         '* List item 2';

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -4935,7 +4935,7 @@ restore-cursor@^2.0.0:
 
 "rho@https://github.com/petebacondarwin/rho#master":
   version "0.4.0"
-  resolved "https://github.com/petebacondarwin/rho#0ad228a47ceb598648504ca8f57eba14aa0fc5e1"
+  resolved "https://github.com/petebacondarwin/rho#c7dbd35fce17111de5131b8035b70e4f8c966362"
   dependencies:
     html "*"
     nomnom "*"


### PR DESCRIPTION
This version changes the expected syntax for emphasis.
The original Rho renderer uses `*` for strong an `_` for em.
But it is more standard in markdown to use `**` or `__` for bold
and `*` or `_` for em.