### PR TITLE
fix(tsc-wrapped): ensure valid path separators in metadata

### DIFF
--- a/tools/@angular/tsc-wrapped/src/bundler.ts
+++ b/tools/@angular/tsc-wrapped/src/bundler.ts
@@ -522,12 +522,14 @@ export class CompilerHostAdapter implements MetadataBundlerHost {
 
 function resolveModule(importName: string, from: string): string {
   if (importName.startsWith('.') && from) {
-    const normalPath = path.normalize(path.join(path.dirname(from), importName));
+    let normalPath = path.normalize(path.join(path.dirname(from), importName));
     if (!normalPath.startsWith('.') && from.startsWith('.')) {
       // path.normalize() preserves leading '../' but not './'. This adds it back.
-      return `.${path.sep}${normalPath}`;
+      normalPath = `.${path.sep}${normalPath}`;
     }
-    return normalPath;
+    // Replace windows path delimiters with forward-slashes. Otherwise the paths are not
+    // TypeScript compatible when building the bundle.
+    return normalPath.replace(/\\/g, '/');
   }
   return importName;
 }

--- a/tools/@angular/tsc-wrapped/test/bundler_spec.ts
+++ b/tools/@angular/tsc-wrapped/test/bundler_spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
@@ -82,6 +81,19 @@ describe('metadata bundler', () => {
       {privateName: 'ɵa', name: 'PrivateOne', module: './src/one'},
       {privateName: 'ɵb', name: 'PrivateTwo', module: './src/two/index'}
     ]);
+  });
+
+  it('should not output windows paths in metadata', () => {
+    const host = new MockStringBundlerHost('/', {
+      'index.ts': `
+        export * from './exports/test';
+      `,
+      'exports': {'test.ts': `export class TestExport {}`}
+    });
+    const bundler = new MetadataBundler('/index', undefined, host);
+    const result = bundler.getMetadataBundle();
+
+    expect(result.metadata.origins).toEqual({'TestExport': './exports/test'});
   });
 
   it('should convert re-exported to the export', () => {

--- a/tools/@angular/tsc-wrapped/test/typescript.mocks.ts
+++ b/tools/@angular/tsc-wrapped/test/typescript.mocks.ts
@@ -54,7 +54,9 @@ export class Host implements ts.LanguageServiceHost {
 }
 
 export function open(directory: Directory, fileName: string): Directory|string|undefined {
-  const names = fileName.split('/');
+  // Path might be normalized by the current node environment. But it could also happen that this
+  // path directly comes from the compiler in POSIX format. Support both separators for development.
+  const names = fileName.split(/[\\/]/);
   let current: Directory|string = directory;
   if (names.length && names[0] === '') names.shift();
   for (const name of names) {


### PR DESCRIPTION
* Fixes that `tsc-wrapped` stores invalid path separators in the bundled metadata files. Previous errors could have been: `Cannot find module '.corecoordinationnique-selection-dispatcher'.` (See https://github.com/angular/material2/issues/3834)

* Fixes failing tests on Windows. Now all tooling tests are green on Windows.

**Note**: Also updated my old reproduction repository ([see here](https://github.com/DevVersion/ng-compiler-cli-test)). Basically the issues appear if something is inside of the `origins` metadata and will be used by the bundler.

Related to #15403