### PR TITLE
fix(http): export ContentType

### DIFF
--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -11,7 +11,7 @@ export {JSONPBackend, JSONPConnection} from './backends/jsonp_backend';
 export {CookieXSRFStrategy, XHRBackend, XHRConnection} from './backends/xhr_backend';
 export {BaseRequestOptions, RequestOptions} from './base_request_options';
 export {BaseResponseOptions, ResponseOptions} from './base_response_options';
-export {ReadyState, RequestMethod, ResponseContentType, ResponseType} from './enums';
+export {ContentType, ReadyState, RequestMethod, ResponseContentType, ResponseType} from './enums';
 export {Headers} from './headers';
 export {Http, Jsonp} from './http';
 export {HttpModule, JsonpModule} from './http_module';

--- a/tools/public_api_guard/http/http.d.ts
+++ b/tools/public_api_guard/http/http.d.ts
@@ -27,6 +27,17 @@ export declare abstract class ConnectionBackend {
 }
 
 /** @experimental */
+export declare enum ContentType {
+    NONE = 0,
+    JSON = 1,
+    FORM = 2,
+    FORM_DATA = 3,
+    TEXT = 4,
+    BLOB = 5,
+    ARRAY_BUFFER = 6,
+}
+
+/** @experimental */
 export declare class CookieXSRFStrategy implements XSRFStrategy {
     constructor(_cookieName?: string, _headerName?: string);
     configureRequest(req: Request): void;


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

- as discussed in #13090 it was intended to export ContenType, yet the change never got merged
- [design doc](https://docs.google.com/document/d/1C_wzuuQEjIktJxrTlUTjTCDEZR8YduGTfbpe4WsNfNk/edit#heading=h.xgjl2srtytjt) of http rewrite in 4.1 is not explicity about this part of the API
- it seems to be reasonable to export `ContentType`, e.g. for testing purposes to verify http requests made by the client


**What is the new behavior?**

`ContentType` is exported from `angular/http`


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

