### PR TITLE
fix(aio): preserve space after anchor elements

### DIFF
--- a/aio/transforms/rho-package/services/renderMarkdown.js
+++ b/aio/transforms/rho-package/services/renderMarkdown.js
@@ -63,6 +63,6 @@ module.exports = function renderMarkdown() {
 
   function renderMarkdownImpl(content) {
     const rawHtml = new rho.BlockCompiler(rho.options).toHtml(content);
-    return prettyPrint(rawHtml, { indent_size: 2, unformatted: [...defaultUnformattedTags, ...renderMarkdownImpl.unformattedTags]});
+    return prettyPrint(rawHtml, { indent_size: 2, max_char: 0, unformatted: [...defaultUnformattedTags, ...renderMarkdownImpl.unformattedTags]});
   };
 };

--- a/aio/transforms/rho-package/services/renderMarkdown.spec.js
+++ b/aio/transforms/rho-package/services/renderMarkdown.spec.js
@@ -49,4 +49,17 @@ describe('rho: renderMarkdown service', () => {
     const output = renderMarkdown(content);
     expect(output).toEqual('<code-example>\n  abc\n  def\n</code-example>');
   });
+
+  it('should not remove spaces after anchor tags', () => {
+    var input =
+        'A aa aaa aaaa aaaaa aaaaaa aaaaaaa aaaaaaaa aaaaaaaaa aaaaaaaaaa aaaaaaaaaaa\n' +
+        '[foo](path/to/foo) bbb.';
+    var output =
+        '<p>' +
+        'A aa aaa aaaa aaaaa aaaaaa aaaaaaa aaaaaaaa aaaaaaaaa aaaaaaaaaa aaaaaaaaaaa\n' +
+        '<a href="path/to/foo">foo</a> bbb.' +
+        '</p>';
+
+    expect(renderMarkdown(input)).toEqual(output);
+  });
 });


### PR DESCRIPTION
Sometimes, depending on the length of lines, anchor elements would be formatted
incorrectly by `html.prettyPrint` and the space right after the element was
removed.

This was apparently caused by a bug in `html.prettyPrint` in combination with
its default behavior of wrapping lines at a specific limit (70 chars). Since the
output is only meant to be used as JSON string data, wrapping the lines makes it
less readable by adding unnecessary `\n`.

This commit disables the line wrapping, which effectively avoids the bug that
was responsible for incorrectly formatting anchor elements and surrounding
space.

Related to #15681.
