### PR TITLE
fix(aio): trim unnecessary whitespace from retrieved example regions

### DIFF
--- a/aio/transforms/angular.io-package/processors/copyContentAssets.spec.js
+++ b/aio/transforms/angular.io-package/processors/copyContentAssets.spec.js
@@ -2,7 +2,7 @@ const testPackage = require('../../helpers/test-package');
 const Dgeni = require('dgeni');
 const factory = require('./copyContentAssets');
 
-fdescribe('extractDecoratedClasses processor', function() {
+describe('extractDecoratedClasses processor', function() {
   let dgeni, injector, processor;
 
   beforeEach(function() {

--- a/aio/transforms/examples-package/services/getExampleRegion.js
+++ b/aio/transforms/examples-package/services/getExampleRegion.js
@@ -26,6 +26,6 @@ module.exports = function getExampleRegion(exampleMap, createDocMessage, log, co
       return '';
     }
 
-    return sourceCodeDoc.renderedContent;
+    return sourceCodeDoc.renderedContent.trim();
   };
 };

--- a/aio/transforms/examples-package/services/getExampleRegion.spec.js
+++ b/aio/transforms/examples-package/services/getExampleRegion.spec.js
@@ -12,10 +12,18 @@ describe('getExampleRegion', () => {
     exampleMap = injector.get('exampleMap');
     collectExamples.exampleFolders = ['examples'];
     exampleMap['examples'] = {
-      'test/url': { regions: {
-        '': { renderedContent: 'whole file' },
-        'region-1': { renderedContent: 'region 1 contents' }
-      } }
+      'test/url': {
+        regions: {
+          '': { renderedContent: 'whole file' },
+          'region-1': { renderedContent: 'region 1 contents' }
+        }
+      },
+      'test/url2': {
+        regions: {
+          '': { renderedContent: ' \n \n whole file with whitespace \n \n ' },
+          'region-2': { renderedContent: ' \n \n region 2 contents \n \n ' }
+        }
+      }
     };
   });
 
@@ -25,5 +33,10 @@ describe('getExampleRegion', () => {
 
   it('should contain the region contents from the example file if a region is specified', () => {
     expect(getExampleRegion({}, 'test/url', 'region-1')).toEqual('region 1 contents');
+  });
+
+  it('should trim whitespace from retrieved contents', () => {
+    expect(getExampleRegion({}, 'test/url2')).toEqual('whole file with whitespace');
+    expect(getExampleRegion({}, 'test/url2', 'region-2')).toEqual('region 2 contents');
   });
 });


### PR DESCRIPTION
The extra `\n` at the end were causing extra empty lines in `<code-example>`s.

Related to #15681.