### PR TITLE
fix(core): use presence of Symbol.observable to detect observables (rxjs 5.3.0+)

### DIFF
--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -18,6 +18,7 @@ export default {
     'rxjs/Observer': 'Rx',
     'rxjs/Subscription': 'Rx',
     'rxjs/observable/merge': 'Rx.Observable',
-    'rxjs/operator/share': 'Rx.Observable.prototype'
+    'rxjs/operator/share': 'Rx.Observable.prototype',
+    'rxjs/symbol/observable': 'Rx.Symbol'
   }
 };

--- a/packages/core/src/util/lang.ts
+++ b/packages/core/src/util/lang.ts
@@ -7,6 +7,7 @@
  */
 
 import {Observable} from 'rxjs/Observable';
+import {observable as Symbol_observable} from 'rxjs/symbol/observable';
 
 /**
  * Determine if the argument is shaped like a Promise
@@ -21,6 +22,5 @@ export function isPromise(obj: any): obj is Promise<any> {
  * Determine if the argument is an Observable
  */
 export function isObservable(obj: any | Observable<any>): obj is Observable<any> {
-  // TODO use Symbol.observable when https://github.com/ReactiveX/rxjs/issues/2415 will be resolved
-  return !!obj && typeof obj.subscribe === 'function';
+  return !!(obj && obj[Symbol_observable]);
 }

--- a/packages/core/test/util/lang_spec.ts
+++ b/packages/core/test/util/lang_spec.ts
@@ -30,9 +30,6 @@ export function main() {
   describe('isObservable', () => {
     it('should be true for an Observable', () => expect(isObservable(of (true))).toEqual(true));
 
-    it('should be true if the argument is the object with subscribe function',
-       () => expect(isObservable({subscribe: () => {}})).toEqual(true));
-
     it('should be false if the argument is undefined',
        () => expect(isObservable(undefined)).toEqual(false));
 
@@ -43,5 +40,8 @@ export function main() {
 
     it('should be false if the argument is a function',
        () => expect(isObservable(() => {})).toEqual(false));
+
+    it('should be false if the argument is the object with subscribe function',
+       () => expect(isObservable({subscribe: () => {}})).toEqual(false));
   });
 }


### PR DESCRIPTION
https://github.com/ReactiveX/rxjs/issues/2415 was resolved so we can now use `Symbol.observable`

The minimal rxjs version is `5.3.0`

cc @jasonaden 