### PR TITLE
fix(http): types for MockBackend

### DIFF
--- a/packages/http/testing/src/mock_backend.ts
+++ b/packages/http/testing/src/mock_backend.ts
@@ -195,9 +195,9 @@ export class MockConnection implements Connection {
 @Injectable()
 export class MockBackend implements ConnectionBackend {
   /**
-   * {@link EventEmitter}
-   * of {@link MockConnection} instances that have been created by this backend. Can be subscribed
-   * to in order to respond to connections.
+   * {@link Subject} emitting {@link MockConnection} instances that have been created by this
+   * backend.
+   * Can be subscribed to in order to respond to connections.
    *
    * ### Example
    *
@@ -230,7 +230,7 @@ export class MockBackend implements ConnectionBackend {
    *
    * This property only exists in the mock implementation, not in real Backends.
    */
-  connections: any;  //<MockConnection>
+  connections: Subject<MockConnection>;
 
   /**
    * An array representation of `connections`. This array will be updated with each connection that
@@ -240,14 +240,14 @@ export class MockBackend implements ConnectionBackend {
    */
   connectionsArray: MockConnection[];
   /**
-   * {@link EventEmitter} of {@link MockConnection} instances that haven't yet been resolved (i.e.
+   * {@link Subject} emitting {@link MockConnection} instances that haven't yet been resolved (i.e.
    * with a `readyState`
    * less than 4). Used internally to verify that no connections are pending via the
    * `verifyNoPendingRequests` method.
    *
    * This property only exists in the mock implementation, not in real Backends.
    */
-  pendingConnections: any;  // Subject<MockConnection>
+  pendingConnections: Subject<MockConnection>;
   constructor() {
     this.connectionsArray = [];
     this.connections = new Subject();

--- a/tools/public_api_guard/http/testing.d.ts
+++ b/tools/public_api_guard/http/testing.d.ts
@@ -1,8 +1,8 @@
 /** @experimental */
 export declare class MockBackend implements ConnectionBackend {
-    connections: any;
+    connections: Subject<MockConnection>;
     connectionsArray: MockConnection[];
-    pendingConnections: any;
+    pendingConnections: Subject<MockConnection>;
     constructor();
     createConnection(req: Request): MockConnection;
     resolveAllConnections(): void;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

`connections` and `pendingConnections` are documented as "EventEmitter of MockConnection", but declared as `any`


**What is the new behavior?**

declaring as `Subject<MockConnection>` gives better coding experience when writing tests

![mock-backkend](https://cloud.githubusercontent.com/assets/901354/24644930/4d9d912a-1916-11e7-8956-31e94aaf6f7a.png)

**Does this PR introduce a breaking change?**
```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: changes the API of `MockBackend`. Could cause ts compilation errors. Existing applications need to honor `Subject<MockConnection>`. Since narrowing down from `any` and not changing actual implementation, existing applications should already conform to the type implicitly at run-time. Thus, chances of breaking a build should be low. Impact should be low.


**Other information**:

