### PR TITLE
fix(language-service): initialize static reflector correctly

### DIFF
--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AotSummaryResolver, CompileDirectiveMetadata, CompileMetadataResolver, CompilerConfig, DEFAULT_INTERPOLATION_CONFIG, DirectiveNormalizer, DirectiveResolver, DomElementSchemaRegistry, HtmlParser, InterpolationConfig, NgAnalyzedModules, NgModuleResolver, ParseTreeResult, Parser, PipeResolver, ResourceLoader, StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, SummaryResolver, UrlResolver, analyzeNgModules, componentModuleUrl, createOfflineCompileUrlResolver, extractProgramSymbols} from '@angular/compiler';
+import {AotSummaryResolver, CompileDirectiveMetadata, CompileMetadataResolver, CompilerConfig, DEFAULT_INTERPOLATION_CONFIG, DirectiveNormalizer, DirectiveResolver, DomElementSchemaRegistry, HtmlParser, InterpolationConfig, NgAnalyzedModules, NgModuleResolver, ParseTreeResult, Parser, PipeResolver, ResourceLoader, StaticAndDynamicReflectionCapabilities, StaticReflector, StaticSymbol, StaticSymbolCache, StaticSymbolResolver, SummaryResolver, UrlResolver, analyzeNgModules, componentModuleUrl, createOfflineCompileUrlResolver, extractProgramSymbols} from '@angular/compiler';
 import {Type, ViewEncapsulation, ɵConsole as Console} from '@angular/core';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -428,6 +428,7 @@ export class TypeScriptServiceHost implements LanguageServiceHost {
       const ssr = this.staticSymbolResolver;
       result = this._reflector = new StaticReflector(
           this._summaryResolver, ssr, [], [], (e, filePath) => this.collectError(e, filePath));
+      StaticAndDynamicReflectionCapabilities.install(result);
     }
     return result;
   }

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -201,7 +201,6 @@ describe('diagnostics', () => {
       expect(diagnostic).toEqual([]);
     });
 
-
     it('should report an error for invalid providers', () => {
       addCode(
           `
@@ -218,6 +217,23 @@ describe('diagnostics', () => {
             expect(expected).toBeDefined();
             expect(notExpected).toBeUndefined();
           });
+    });
+
+    // Issue #15768
+    it('should be able to parse a template reference', () => {
+      addCode(
+          `
+        @Component({
+          selector: 'my-component',
+          template: \`
+            <div *ngIf="comps | async; let comps; else loading">
+            </div>
+            <ng-template #loading>Loading comps...</ng-template>            
+          \`
+        })
+        export class MyComponent {}
+      `,
+          fileName => onlyModuleDiagnostics(ngService.getDiagnostics(fileName)));
     });
 
     function addCode(code: string, cb: (fileName: string, content?: string) => void) {


### PR DESCRIPTION
Fixes #15768

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

#15768 

**What is the new behavior?**

Using `else` no longer causes the language service to crash.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
