### PR TITLE
fix(language-service): parse extended i18n forms

### DIFF
--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -110,7 +110,7 @@ class LanguageServiceImpl implements LanguageService {
         const config = new CompilerConfig();
         const parser = new TemplateParser(
             config, expressionParser, new DomElementSchemaRegistry(), htmlParser, null, []);
-        const htmlResult = htmlParser.parse(template.source, '');
+        const htmlResult = htmlParser.parse(template.source, '', true);
         const analyzedModules = this.host.getAnalyzedModules();
         let errors: Diagnostic[] = undefined;
         let ngModule = analyzedModules.ngModuleByPipeOrDirective.get(template.type);

--- a/packages/language-service/test/diagnostics_spec.ts
+++ b/packages/language-service/test/diagnostics_spec.ts
@@ -236,6 +236,28 @@ describe('diagnostics', () => {
           fileName => onlyModuleDiagnostics(ngService.getDiagnostics(fileName)));
     });
 
+    // Issue #15625
+    it('should not report errors for localization syntax', () => {
+      addCode(
+          `
+          @Component({
+            selector: 'my-component',
+            template: \`
+            <div>
+                {fieldCount, plural, =0 {no fields} =1 {1 field} other {{{fieldCount}} fields}}
+            </div>
+            \`
+          })
+          export class MyComponent {
+            fieldCount: number;
+          }
+      `,
+          fileName => {
+            const diagnostics = ngService.getDiagnostics(fileName);
+            onlyModuleDiagnostics(diagnostics);
+          });
+    });
+
     function addCode(code: string, cb: (fileName: string, content?: string) => void) {
       const fileName = '/app/app.component.ts';
       const originalContent = mockHost.getFileContent(fileName);
@@ -255,7 +277,7 @@ describe('diagnostics', () => {
       if (diagnostics.length > 1) {
         for (const diagnostic of diagnostics) {
           if (diagnostic.message.indexOf('MyComponent') >= 0) continue;
-          console.error(`(${diagnostic.span.start}:${diagnostic.span.end}): ${diagnostic.message}`);
+          fail(`(${diagnostic.span.start}:${diagnostic.span.end}): ${diagnostic.message}`);
         }
         return;
       }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

The language service reports i18n extended forms as errors.

**What is the new behavior?**

It correctly parses them.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```