### PR TITLE
fix(router): Preloader should use the module injector from a route

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -9,6 +9,7 @@
 import {NgModuleFactory, Type} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 
+import {LoadedRouterConfig} from './router_config_loader';
 import {PRIMARY_OUTLET} from './shared';
 import {UrlSegment, UrlSegmentGroup} from './url_tree';
 
@@ -363,7 +364,7 @@ export interface Route {
 
 export interface InternalRoute extends Route {
   // `LoadedRouterConfig` loaded via a Route `loadChildren`
-  _loadedConfig?: any;
+  _loadedConfig?: LoadedRouterConfig|undefined;
 }
 
 export function validateConfig(config: Routes, parentPath: string = ''): void {

--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -6,7 +6,7 @@
 *found in the LICENSE file at https://angular.io/license
 */
 
-import {Compiler, Injectable, Injector, NgModuleFactoryLoader, NgModuleRef} from '@angular/core';
+import {Compiler, Injectable, Injector, NgModuleFactoryLoader, NgModuleRef, OnDestroy} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {Subscription} from 'rxjs/Subscription';
 import {from} from 'rxjs/observable/from';
@@ -17,9 +17,9 @@ import {filter} from 'rxjs/operator/filter';
 import {mergeAll} from 'rxjs/operator/mergeAll';
 import {mergeMap} from 'rxjs/operator/mergeMap';
 import {InternalRoute, Route, Routes} from './config';
-import {NavigationEnd, RouteConfigLoadEnd, RouteConfigLoadStart} from './events';
+import {Event, NavigationEnd, RouteConfigLoadEnd, RouteConfigLoadStart} from './events';
 import {Router} from './router';
-import {RouterConfigLoader} from './router_config_loader';
+import {LoadedRouterConfig, RouterConfigLoader} from './router_config_loader';
 
 /**
  * @whatItDoes Provides a preloading strategy.
@@ -73,7 +73,7 @@ export class NoPreloading implements PreloadingStrategy {
  * @stable
  */
 @Injectable()
-export class RouterPreloader {
+export class RouterPreloader implements OnDestroy {
   private loader: RouterConfigLoader;
   private subscription: Subscription;
 
@@ -87,8 +87,8 @@ export class RouterPreloader {
   };
 
   setUpPreloading(): void {
-    const navigations = filter.call(this.router.events, (e: any) => e instanceof NavigationEnd);
-    this.subscription = concatMap.call(navigations, () => this.preload()).subscribe(() => {});
+    const navigations$ = filter.call(this.router.events, (e: Event) => e instanceof NavigationEnd);
+    this.subscription = concatMap.call(navigations$, () => this.preload()).subscribe(() => {});
   }
 
   preload(): Observable<any> {
@@ -121,8 +121,8 @@ export class RouterPreloader {
 
   private preloadConfig(ngModule: NgModuleRef<any>, route: InternalRoute): Observable<void> {
     return this.preloadingStrategy.preload(route, () => {
-      const loaded = this.loader.load(ngModule.injector, route);
-      return mergeMap.call(loaded, (config: any): any => {
+      const loaded$ = this.loader.load(ngModule.injector, route);
+      return mergeMap.call(loaded$, (config: LoadedRouterConfig) => {
         route._loadedConfig = config;
         return this.processRoutes(config.module, config.routes);
       });

--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -105,7 +105,7 @@ export class RouterPreloader implements OnDestroy {
       // we already have the config loaded, just recurse
       if (route.loadChildren && !route.canLoad && route._loadedConfig) {
         const childConfig = route._loadedConfig;
-        res.push(this.processRoutes(ngModule, childConfig.routes));
+        res.push(this.processRoutes(childConfig.module, childConfig.routes));
 
         // no config loaded, fetch the config
       } else if (route.loadChildren && !route.canLoad) {

--- a/tools/public_api_guard/router/router.d.ts
+++ b/tools/public_api_guard/router/router.d.ts
@@ -354,7 +354,7 @@ export declare class RouterOutletMap {
 }
 
 /** @stable */
-export declare class RouterPreloader {
+export declare class RouterPreloader implements OnDestroy {
     constructor(router: Router, moduleLoader: NgModuleFactoryLoader, compiler: Compiler, injector: Injector, preloadingStrategy: PreloadingStrategy);
     ngOnDestroy(): void;
     preload(): Observable<any>;


### PR DESCRIPTION
Fixes regression introduced by https://github.com/angular/angular/commit/23bf34853c83b2131991e11da1c8dcc75ee3d731#diff-86faca9d9f6af67bf4abf6c3f6ab380bR108

Closes #15626