### PR TITLE
fix(router): the preloader use the module from the loaded config

### DIFF
--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -105,7 +105,7 @@ export class RouterPreloader {
       // we already have the config loaded, just recurse
       if (route.loadChildren && !route.canLoad && route._loadedConfig) {
         const childConfig = route._loadedConfig;
-        res.push(this.processRoutes(ngModule, childConfig.routes));
+        res.push(this.processRoutes(childConfig.module, childConfig.routes));
 
         // no config loaded, fetch the config
       } else if (route.loadChildren && !route.canLoad) {

--- a/packages/router/test/router_preloader.spec.ts
+++ b/packages/router/test/router_preloader.spec.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, NgModule, NgModuleFactoryLoader} from '@angular/core';
+import {Compiler, Component, NgModule, NgModuleFactoryLoader, NgModuleRef} from '@angular/core';
 import {TestBed, fakeAsync, inject, tick} from '@angular/core/testing';
 
-import {RouteConfigLoadEnd, RouteConfigLoadStart, Router, RouterModule} from '../index';
+import {Route, RouteConfigLoadEnd, RouteConfigLoadStart, Router, RouterModule} from '../index';
+import {LoadedRouterConfig} from '../src/router_config_loader';
 import {PreloadAllModules, PreloadingStrategy, RouterPreloader} from '../src/router_preloader';
 import {RouterTestingModule, SpyNgModuleFactoryLoader} from '../testing';
 
@@ -17,65 +18,6 @@ describe('RouterPreloader', () => {
   @Component({template: ''})
   class LazyLoadedCmp {
   }
-
-  describe('should preload configurations', () => {
-    @NgModule({
-      declarations: [LazyLoadedCmp],
-      imports: [RouterModule.forChild([{path: 'LoadedModule2', component: LazyLoadedCmp}])]
-    })
-    class LoadedModule2 {
-    }
-
-    @NgModule(
-        {imports: [RouterModule.forChild([{path: 'LoadedModule1', loadChildren: 'expected2'}])]})
-    class LoadedModule1 {
-    }
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule.withRoutes([{path: 'lazy', loadChildren: 'expected'}])],
-        providers: [{provide: PreloadingStrategy, useExisting: PreloadAllModules}]
-      });
-    });
-
-    it('should work',
-       fakeAsync(inject(
-           [NgModuleFactoryLoader, RouterPreloader, Router],
-           (loader: SpyNgModuleFactoryLoader, preloader: RouterPreloader, router: Router) => {
-             const events: Array<RouteConfigLoadStart|RouteConfigLoadEnd> = [];
-
-             router.events.subscribe(e => {
-               if (e instanceof RouteConfigLoadEnd || e instanceof RouteConfigLoadStart) {
-                 events.push(e);
-               }
-             });
-
-             loader.stubbedModules = {
-               expected: LoadedModule1,
-               expected2: LoadedModule2,
-             };
-
-             preloader.preload().subscribe(() => {});
-
-             tick();
-
-             const c = router.config;
-             expect(c[0].loadChildren).toEqual('expected');
-
-             const loaded: any = (<any>c[0])._loadedConfig.routes;
-             expect(loaded[0].path).toEqual('LoadedModule1');
-
-             const loaded2: any = (<any>loaded[0])._loadedConfig.routes;
-             expect(loaded2[0].path).toEqual('LoadedModule2');
-
-             expect(events.map(e => e.toString())).toEqual([
-               'RouteConfigLoadStart(path: lazy)',
-               'RouteConfigLoadEnd(path: lazy)',
-               'RouteConfigLoadStart(path: LoadedModule1)',
-               'RouteConfigLoadEnd(path: LoadedModule1)',
-             ]);
-           })));
-  });
 
   describe('should not load configurations with canLoad guard', () => {
     @NgModule({
@@ -105,6 +47,132 @@ describe('RouterPreloader', () => {
 
              const c = router.config;
              expect(!!((<any>c[0])._loadedConfig)).toBe(false);
+           })));
+  });
+
+  describe('should preload configurations', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [RouterTestingModule.withRoutes([{path: 'lazy', loadChildren: 'expected'}])],
+        providers: [{provide: PreloadingStrategy, useExisting: PreloadAllModules}]
+      });
+    });
+
+    it('should work',
+       fakeAsync(inject(
+           [NgModuleFactoryLoader, RouterPreloader, Router, NgModuleRef],
+           (loader: SpyNgModuleFactoryLoader, preloader: RouterPreloader, router: Router,
+            testModule: NgModuleRef<any>) => {
+             const events: Array<RouteConfigLoadStart|RouteConfigLoadEnd> = [];
+             @NgModule({
+               declarations: [LazyLoadedCmp],
+               imports:
+                   [RouterModule.forChild([{path: 'LoadedModule2', component: LazyLoadedCmp}])]
+             })
+             class LoadedModule2 {
+             }
+
+             @NgModule({
+               imports:
+                   [RouterModule.forChild([{path: 'LoadedModule1', loadChildren: 'expected2'}])]
+             })
+             class LoadedModule1 {
+             }
+
+             router.events.subscribe(e => {
+               if (e instanceof RouteConfigLoadEnd || e instanceof RouteConfigLoadStart) {
+                 events.push(e);
+               }
+             });
+
+             loader.stubbedModules = {
+               expected: LoadedModule1,
+               expected2: LoadedModule2,
+             };
+
+             preloader.preload().subscribe(() => {});
+
+             tick();
+
+             const c = router.config;
+             expect(c[0].loadChildren).toEqual('expected');
+
+             const loadedConfig: LoadedRouterConfig = (<any>c[0])._loadedConfig;
+             const module: any = loadedConfig.module;
+             expect(loadedConfig.routes[0].path).toEqual('LoadedModule1');
+             expect(module.parent).toBe(testModule);
+
+             const loadedConfig2: LoadedRouterConfig = (<any>loadedConfig.routes[0])._loadedConfig;
+             const module2: any = loadedConfig2.module;
+             expect(loadedConfig2.routes[0].path).toEqual('LoadedModule2');
+             expect(module2.parent).toBe(module);
+
+             expect(events.map(e => e.toString())).toEqual([
+               'RouteConfigLoadStart(path: lazy)',
+               'RouteConfigLoadEnd(path: lazy)',
+               'RouteConfigLoadStart(path: LoadedModule1)',
+               'RouteConfigLoadEnd(path: LoadedModule1)',
+             ]);
+           })));
+  });
+
+  describe('should support modules that have already been loaded', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [RouterTestingModule.withRoutes([{path: 'lazy', loadChildren: 'expected'}])],
+        providers: [{provide: PreloadingStrategy, useExisting: PreloadAllModules}]
+      });
+    });
+
+    it('should work',
+       fakeAsync(inject(
+           [NgModuleFactoryLoader, RouterPreloader, Router, NgModuleRef, Compiler],
+           (loader: SpyNgModuleFactoryLoader, preloader: RouterPreloader, router: Router,
+            testModule: NgModuleRef<any>, compiler: Compiler) => {
+             @NgModule()
+             class LoadedModule2 {
+             }
+
+             const module2 = compiler.compileModuleSync(LoadedModule2).create(null);
+
+             @NgModule({
+               imports: [RouterModule.forChild([
+                 <Route>{
+                   path: 'LoadedModule2',
+                   loadChildren: 'no',
+                   _loadedConfig: {
+                     routes: [{path: 'LoadedModule3', loadChildren: 'expected3'}],
+                     module: module2,
+                   }
+                 },
+               ])]
+             })
+             class LoadedModule1 {
+             }
+
+             @NgModule({imports: [RouterModule.forChild([])]})
+             class LoadedModule3 {
+             }
+
+             loader.stubbedModules = {
+               expected: LoadedModule1,
+               expected3: LoadedModule3,
+             };
+
+             preloader.preload().subscribe(() => {});
+
+             tick();
+
+             const c = router.config;
+
+             const loadedConfig: LoadedRouterConfig = (<any>c[0])._loadedConfig;
+             const module: any = loadedConfig.module;
+             expect(module.parent).toBe(testModule);
+
+             const loadedConfig2: LoadedRouterConfig = (<any>loadedConfig.routes[0])._loadedConfig;
+             const loadedConfig3: LoadedRouterConfig = (<any>loadedConfig2.routes[0])._loadedConfig;
+             const module3: any = loadedConfig3.module;
+             expect(module3.parent).toBe(module2);
            })));
   });
 


### PR DESCRIPTION
Before the change we used a wrong module in the preloader when the module was already loaded.

/cc @DzmitryShylovich who came with the fix

fixes #15626