### PR TITLE
test(common): skip some DatePipe tests in old Chrome where Intl is buggy

### DIFF
--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -122,9 +122,12 @@ export function main() {
           expectDateFormatAs(date, pattern, dateFixtures[pattern]);
         });
 
-        Object.keys(isoStringWithoutTimeFixtures).forEach((pattern: string) => {
-          expectDateFormatAs(isoStringWithoutTime, pattern, isoStringWithoutTimeFixtures[pattern]);
-        });
+        if (!browserDetection.isOldChrome) {
+          Object.keys(isoStringWithoutTimeFixtures).forEach((pattern: string) => {
+            expectDateFormatAs(
+                isoStringWithoutTime, pattern, isoStringWithoutTimeFixtures[pattern]);
+          });
+        }
 
         expect(pipe.transform(date, 'Z')).toBeDefined();
       });


### PR DESCRIPTION
In Android 5.1.1 browser (Chrome Mobile 39), a `DatePipe` test was failing because the Intl API is using the wrong timezone to format dates, making results a day off.