### PR TITLE
test(router): enable running the campaign in non-ES6 browsers

### DIFF
--- a/packages/router/karma-test-shim.js
+++ b/packages/router/karma-test-shim.js
@@ -71,4 +71,4 @@ Promise
       return Promise.all(
           allSpecFiles.map(function(moduleName) { return System.import(moduleName); }));
     })
-    .then(__karma__.start, (v) => console.error(v));
+    .then(__karma__.start, function(v) { console.error(v) });


### PR DESCRIPTION
Running the router tests in no-ES6 browsers (e.g Internet Explorer) fails with a syntax error.
