### PR TITLE
Fix/14376

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -148,11 +148,15 @@ export class FormGroupDirective extends ControlContainer implements Form,
   /** @internal */
   _updateDomValue() {
     this.directives.forEach(dir => {
-      const newCtrl: any = this.form.get(dir.path);
+      const newCtrl = this.form.get(dir.path);
       if (dir._control !== newCtrl) {
         cleanUpControl(dir._control, dir);
-        if (newCtrl) setUpControl(newCtrl, dir);
-        dir._control = newCtrl;
+        if (newCtrl && newCtrl instanceof FormControl) {
+          setUpControl(newCtrl, dir);
+          dir._control = newCtrl;
+        } else {
+          dir._control = null;
+        }
       }
     });
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

- [x] Bugfix

This should fix #14376 and is the solution proposed here: https://github.com/angular/angular/issues/14376#issuecomment-291873349

I must say I'm not sure of all the implication of that change but seems pretty safe.
`Form.get()` returns an `AbstractControl` and `setUpControl()` expects a `FormControl` as argument so we check the `AbstractControl` is of type `FormControl`. That type check was not causing any error because of an `any` typecast.

**Does this PR introduce a breaking change?**
[ ] Yes
[x] No

