### PR TITLE
feat(router) added method to convert an Url to RouterStateSnapshot

### DIFF
--- a/packages/router/test/router.spec.ts
+++ b/packages/router/test/router.spec.ts
@@ -55,6 +55,36 @@ describe('Router', () => {
        }));
   });
 
+  describe('urlToRouteStateSnapshot', () => {
+    beforeEach(() => { TestBed.configureTestingModule({imports: [RouterTestingModule]}); });
+
+    it('should return snapshot or exception', inject([Router], (r: Router) => {
+         r.resetConfig([
+           {
+             path: 'a',
+             component: ComponentA,
+             data: {state: 'i am A'},
+             children: [{path: 'b', component: ComponentB, data: {state: 'i am B'}}]
+           },
+           {path: 'c', component: ComponentC, data: {state: 'i am C'}}
+         ]);
+
+         r.urlToRouteStateSnapshot('/a').then(
+             (s) => { expect(s.root.firstChild !.data).toEqual({state: 'i am A'}); });
+
+         r.urlToRouteStateSnapshot('/a/b').then(
+             (s) => { expect(s.root.firstChild !.firstChild !.data).toEqual({state: 'i am B'}); });
+
+         r.urlToRouteStateSnapshot('/c').then(
+             (s) => { expect(s.root.firstChild !.data).toEqual({state: 'i am C'}); });
+
+         r.urlToRouteStateSnapshot('/x').catch((s => {
+           expect(s.toString()).toContain('Error: Cannot match any routes. URL Segment: \'x\'');
+         }));
+
+       }));
+  });
+
   describe('PreActivation', () => {
     const serializer = new DefaultUrlSerializer();
     const inj = {get: (token: any) => () => `${token}_value`};
@@ -367,3 +397,7 @@ function checkGuards(
   p.initalize(new ChildrenOutletContexts());
   p.checkGuards().subscribe(check, (e) => { throw e; });
 }
+
+class ComponentA {}
+class ComponentB {}
+class ComponentC {}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

There is no clean way to convert an url to a route.
See #15750

**What is the new behavior?**

You now can convert any url to a routestatesnapshot (if they exist).
This is will allows you to easily generate breadcrumbs or create a directive to check access to a routeLink


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

**Other information**:

I did not include any tests because of the size of the change and the actual logic is in the recognize function which is already has its own tests.