### PR TITLE
docs(aio): add link to schema for angular-cli.json config file

### DIFF
--- a/aio/content/guide/cli-quickstart.md
+++ b/aio/content/guide/cli-quickstart.md
@@ -647,7 +647,7 @@ These files go in the root folder next to `src/`.
       Configuration for Angular CLI.
       In this file you can set several defaults and also configure what files are included
       when your project is build.
-      Check out the official documentation if you want to know more.
+      Check out the official documentation or [schema](https://github.com/angular/angular-cli/blob/master/docs/documentation/angular-cli.md) if you want to know more.
     </td>
 
   </tr>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
on the quickstart, no link to the schema for the angular-cli.json configuration


**What is the new behavior?**
on the quickstart, a link to the schema for the angular-cli.json configuration


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: none


**Other information**:

I linked to the actual repo readme (on master branch, docs/documentation/anglular-cli.md). This seems brittle but I'm not sure it's exposed anywhere else. I do find it duplicated in the wiki (https://github.com/angular/angular-cli/wiki/angular-cli), but would think the readme is the source of truth. If you like adding a link, please let me know if you would like me to change it to something else.
