### PR TITLE
fix(animations): check for keyframes before adding previousStyleProps

### DIFF
--- a/packages/animations/browser/src/render/web_animations/web_animations_player.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_player.ts
@@ -67,7 +67,7 @@ export class WebAnimationsPlayer implements AnimationPlayer {
     });
 
     const previousStyleProps = Object.keys(this.previousStyles);
-    if (previousStyleProps.length) {
+    if (previousStyleProps.length && keyframes.length) {
       let startingKeyframe = keyframes[0];
       let missingStyleProps: string[] = [];
       previousStyleProps.forEach(prop => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Under certain circumstances, repeated playback of an animation might result in an error caused by WebAnimationPlayer attempting to apply previous styles to an unexisting first keyframe. 


**What is the new behavior?**
This small PR fixes the issue by making sure there are keyframes in the animation before executing said code.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

