### PR TITLE
fix(compiler): make I18NHtmlParser provider AoT-compliant (2.4.x)

### DIFF
--- a/modules/@angular/compiler/src/jit/compiler_factory.ts
+++ b/modules/@angular/compiler/src/jit/compiler_factory.ts
@@ -42,6 +42,11 @@ const _NO_RESOURCE_LOADER: ResourceLoader = {
 
 const baseHtmlParser = new OpaqueToken('HtmlParser');
 
+export function i18nHtmlParserFactory(
+    parser: HtmlParser, translations: string, format: string): i18n.I18NHtmlParser {
+  return new i18n.I18NHtmlParser(parser, translations, format);
+}
+
 /**
  * A set of providers that provide `JitCompiler` and its dependencies to use for
  * template compilation.
@@ -60,8 +65,7 @@ export const COMPILER_PROVIDERS: Array<any|Type<any>|{[k: string]: any}|any[]> =
   },
   {
     provide: i18n.I18NHtmlParser,
-    useFactory: (parser: HtmlParser, translations: string, format: string) =>
-                    new i18n.I18NHtmlParser(parser, translations, format),
+    useFactory: i18nHtmlParserFactory,
     deps: [
       baseHtmlParser,
       [new Optional(), new Inject(TRANSLATIONS)],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

```
ERROR in Error encountered resolving symbol values statically. Function calls are not supported. Consider replacing the function or lambda with a reference to an exported function (position 63:17 in the original .ts file), resolving symbol COMPILER_PROVIDERS
```

**What is the new behavior?**

Using ``COMPILER_PROVIDERS`` should work in an app that is compiled for AoT.

```
import { COMPILER_PROVIDERS } from '@angular/compiler';

@NgModule({
  providers: [ ...COMPILER_PROVIDERS ]
})
```

Allows apps to use AoT compilation while still being able to dynamically create components as [demonstrated in this plunkr](http://plnkr.co/edit/wh4VJG?p=preview).

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

