### PR TITLE
fix(language-service): detect when there isn't a tsconfig.json

### DIFF
--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -1097,7 +1097,9 @@ function findTsConfig(fileName: string): string {
   while (fs.existsSync(dir)) {
     const candidate = path.join(dir, 'tsconfig.json');
     if (fs.existsSync(candidate)) return candidate;
-    dir = path.dirname(dir);
+    const parentDir = path.dirname(dir);
+    if (parentDir === dir) break;
+    dir = parentDir;
   }
 }
 

--- a/packages/language-service/test/test_data.ts
+++ b/packages/language-service/test/test_data.ts
@@ -9,6 +9,7 @@
 import {MockData} from './test_utils';
 
 export const toh = {
+  'foo.ts': `export * from './app/app.component.ts';`,
   app: {
     'app.component.ts': `import { Component } from '@angular/core';
 

--- a/packages/language-service/test/typescript_host_spec.ts
+++ b/packages/language-service/test/typescript_host_spec.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import 'reflect-metadata';
+import * as ts from 'typescript';
+
+import {TypeScriptServiceHost} from '../src/typescript_host';
+
+import {toh} from './test_data';
+import {MockTypescriptHost} from './test_utils';
+
+
+describe('completions', () => {
+  let host: ts.LanguageServiceHost;
+  let service: ts.LanguageService;
+  let ngHost: TypeScriptServiceHost;
+
+  beforeEach(() => {
+    host = new MockTypescriptHost(['/app/main.ts'], toh);
+    service = ts.createLanguageService(host);
+  });
+
+  it('should be able to create a typescript host',
+     () => { expect(() => new TypeScriptServiceHost(host, service)).not.toThrow(); });
+
+  beforeEach(() => { ngHost = new TypeScriptServiceHost(host, service); });
+
+  it('should be able to analyze modules',
+     () => { expect(ngHost.getAnalyzedModules()).toBeDefined(); });
+
+  it('should be able to analyze modules in without a tsconfig.json file', () => {
+    host = new MockTypescriptHost(['foo.ts'], toh);
+    service = ts.createLanguageService(host);
+    ngHost = new TypeScriptServiceHost(host, service);
+    expect(ngHost.getAnalyzedModules()).toBeDefined();
+  });
+});


### PR DESCRIPTION
Fixes #15874

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

The language service is created in a directory that has no `tsconfig.json` file in itself or one of its parents it would infinite loop searching for it.

#15874
https://github.com/angular/vscode-ng-language-service/issues/69

**What is the new behavior?**

It now terminates the loop looking for a tsconfig.json file when it is not found in a parent directory.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
