### PR TITLE
feat(platform-browser): add prefix and suffix to page title

### DIFF
--- a/packages/platform-browser/src/browser/title.ts
+++ b/packages/platform-browser/src/browser/title.ts
@@ -26,6 +26,18 @@ import {DOCUMENT} from '../dom/dom_tokens';
 export class Title {
   constructor(@Inject(DOCUMENT) private _doc: any) {}
   /**
+   * Text before the title
+   * @type {string}
+   * @memberOf Title
+   */
+  suffix: string = '';
+  /**
+   * Text after the title
+   * @type {string}
+   * @memberOf Title
+   */
+  prefix: string = '';
+  /**
    * Get the title of the current HTML document.
    * @returns {string}
    */
@@ -35,5 +47,7 @@ export class Title {
    * Set the title of the current HTML document.
    * @param newTitle
    */
-  setTitle(newTitle: string) { getDOM().setTitle(this._doc, newTitle); }
+  setTitle(newTitle: string) {
+    getDOM().setTitle(this._doc, newTitle ? this.prefix + newTitle + this.suffix : '');
+  }
 }

--- a/packages/platform-browser/test/browser/title_spec.ts
+++ b/packages/platform-browser/test/browser/title_spec.ts
@@ -18,7 +18,11 @@ export function main() {
     const initialTitle = getDOM().getTitle(doc);
     const titleService = new Title(doc);
 
-    afterEach(() => { getDOM().setTitle(doc, initialTitle); });
+    afterEach(() => {
+      getDOM().setTitle(doc, initialTitle);
+      titleService.prefix = '';
+      titleService.suffix = '';
+    });
 
     it('should allow reading initial title',
        () => { expect(titleService.getTitle()).toEqual(initialTitle); });
@@ -27,6 +31,14 @@ export function main() {
       titleService.setTitle('test title');
       expect(getDOM().getTitle(doc)).toEqual('test title');
       expect(titleService.getTitle()).toEqual('test title');
+    });
+
+    it('should set a title with prefix- and suffixes on the injected document', () => {
+      titleService.prefix = 'Prefix-';
+      titleService.suffix = '-Suffix';
+      titleService.setTitle('test title');
+      expect(getDOM().getTitle(doc)).toEqual('Prefix-test title-Suffix');
+      expect(titleService.getTitle()).toEqual('Prefix-test title-Suffix');
     });
 
     it('should reset title to empty string if title not provided', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** 
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** 
If you want to have a prefix- or suffix-text in your page-title, you need to write them every time the title is getting set.

```
titleService.setTitle('Home - My Fancy Tool');
...
titleService.setTitle('Detail Page - My Fancy Tool');
```


**What is the new behavior?**
You define your pre- and suffixes only once (e.g. at the application start) and they were added automatically every time the title is changed.

```
titleService.suffix = ' - My Fancy Tool';
titleService.setTitle('Home');
```

Your page-title now would be look like this: **Home - My Fancy Tool**


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

