### PR TITLE
feat(aio): hide side nav in mobile mode

### DIFF
--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -71,35 +71,76 @@ describe('AppComponent', () => {
     });
   });
 
-  describe('shows/hide SideNav based on doc\'s navigation view', () => {
+  describe('SideNav when side-by-side', () => {
+    let hamburger: HTMLButtonElement;
+    let locationService: MockLocationService;
+    let sidenav: Element;
+
+    beforeEach(() => {
+      component.onResize(1033); // side-by-side
+      locationService = fixture.debugElement.injector.get(LocationService) as any;
+      hamburger = fixture.debugElement.query(By.css('.hamburger')).nativeElement;
+      sidenav = fixture.debugElement.query(By.css('md-sidenav')).nativeElement;
+    });
+
+    it('should open when nav to a guide page (guide/pipes)', () => {
+      locationService.urlSubject.next('guide/pipes');
+      fixture.detectChanges();
+      expect(sidenav.className).toMatch(/sidenav-open/);
+    });
+
+    it('should open when nav to an api page', () => {
+      locationService.urlSubject.next('api/a/b/c/d');
+      fixture.detectChanges();
+      expect(sidenav.className).toMatch(/sidenav-open/);
+    });
+
+    it('should be closed when nav to a marketing page (features)', () => {
+      locationService.urlSubject.next('features');
+      fixture.detectChanges();
+      expect(sidenav.className).toMatch(/sidenav-clos/);
+    });
+
+    describe('when manually closed', () => {
+
+      beforeEach(() => {
+        locationService.urlSubject.next('guide/pipes');
+        fixture.detectChanges();
+        hamburger.click();
+        fixture.detectChanges();
+      });
+
+      it('should be closed', () => {
+        expect(sidenav.className).toMatch(/sidenav-clos/);
+      });
+    });
+  });
+
+  describe('SideNav when NOT side-by-side (mobile)', () => {
+    let sidenav: Element;
     let locationService: MockLocationService;
 
     beforeEach(() => {
+      component.onResize(1000); // NOT side-by-side
       locationService = fixture.debugElement.injector.get(LocationService) as any;
-      component.onResize(1000); // side-by-side
+      sidenav = fixture.debugElement.query(By.css('md-sidenav')).nativeElement;
     });
 
-    it('should have sidenav open when doc in the sidenav (guide/pipes)', () => {
+    it('should be closed when nav to a guide page (guide/pipes)', () => {
       locationService.urlSubject.next('guide/pipes');
-
       fixture.detectChanges();
-      const sidenav = fixture.debugElement.query(By.css('md-sidenav')).nativeElement;
-      expect(sidenav.className).toMatch(/sidenav-open/);
+      expect(sidenav.className).toMatch(/sidenav-clos/);
     });
 
-    it('should have sidenav open when doc is an api page', () => {
+    it('should be closed when nav to an api page', () => {
       locationService.urlSubject.next('api/a/b/c/d');
-
       fixture.detectChanges();
-      const sidenav = fixture.debugElement.query(By.css('md-sidenav')).nativeElement;
-      expect(sidenav.className).toMatch(/sidenav-open/);
+      expect(sidenav.className).toMatch(/sidenav-clos/);
     });
 
-    it('should have sidenav closed when doc not in the sidenav (features)', () => {
+    it('should be closed when nav to a marketing page (features)', () => {
       locationService.urlSubject.next('features');
-
       fixture.detectChanges();
-      const sidenav = fixture.debugElement.query(By.css('md-sidenav')).nativeElement;
       expect(sidenav.className).toMatch(/sidenav-clos/);
     });
   });

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -76,11 +76,11 @@ export class AppComponent implements OnInit {
       this.currentNode = currentNode;
       this.pageId = this.currentNode.url.replace('/', '-') || 'home';
 
-      // Toggle the sidenav if the kind of view changed
+      // Toggle the sidenav if side-by-side and the kind of view changed
       if (this.previousNavView === currentNode.view) { return; }
       this.previousNavView = currentNode.view;
       this.isSideNavDoc = currentNode.view === sideNavView;
-      this.sideNavToggle(this.isSideNavDoc);
+      this.sideNavToggle(this.isSideNavDoc && this.isSideBySide);
     });
 
     this.navigationService.navigationViews.subscribe(views => {

--- a/aio/src/app/documents/document.service.spec.ts
+++ b/aio/src/app/documents/document.service.spec.ts
@@ -34,8 +34,8 @@ function getServices(initialUrl: string = '') {
   const injector = createInjector(initialUrl);
   return {
     backend: injector.get(ConnectionBackend) as MockBackend,
-    location: injector.get(LocationService) as MockLocationService,
-    service: injector.get(DocumentService) as DocumentService,
+    locationService: injector.get(LocationService) as MockLocationService,
+    docService: injector.get(DocumentService) as DocumentService,
     logger: injector.get(Logger) as MockLogger
   };
 }
@@ -43,16 +43,16 @@ function getServices(initialUrl: string = '') {
 describe('DocumentService', () => {
 
   it('should be creatable', () => {
-    const { service } = getServices();
-    expect(service).toBeTruthy();
+    const { docService } = getServices();
+    expect(docService).toBeTruthy();
   });
 
   describe('currentDocument', () => {
 
     it('should fetch a document for the initial location url', () => {
-      const { service, backend } = getServices('initial/url');
+      const { docService, backend } = getServices('initial/url');
       const connections = backend.connectionsArray;
-      service.currentDocument.subscribe();
+      docService.currentDocument.subscribe();
 
       expect(connections.length).toEqual(1);
       expect(connections[0].request.url).toEqual(CONTENT_URL_PREFIX + 'initial/url.json');
@@ -63,24 +63,24 @@ describe('DocumentService', () => {
       let latestDocument: DocumentContents;
       const doc0 = { title: 'doc 0' };
       const doc1 = { title: 'doc 1' };
-      const { service, backend, location } = getServices('initial/url');
+      const { docService, backend, locationService } = getServices('initial/url');
       const connections = backend.connectionsArray;
 
-      service.currentDocument.subscribe(doc => latestDocument = doc);
+      docService.currentDocument.subscribe(doc => latestDocument = doc);
       expect(latestDocument).toBeUndefined();
 
       connections[0].mockRespond(createResponse(doc0));
       expect(latestDocument).toEqual(doc0);
 
-      location.urlSubject.next('new/url');
+      locationService.go('new/url');
       connections[1].mockRespond(createResponse(doc1));
       expect(latestDocument).toEqual(doc1);
     });
 
     it('should emit the not-found document if the document is not found on the server', () => {
-      const { service, backend } = getServices('missing/url');
+      const { docService, backend } = getServices('missing/url');
       const connections = backend.connectionsArray;
-      service.currentDocument.subscribe();
+      docService.currentDocument.subscribe();
 
       connections[0].mockError(new Response(new ResponseOptions({ status: 404, statusText: 'NOT FOUND'})) as any);
       expect(connections.length).toEqual(2);
@@ -91,32 +91,32 @@ describe('DocumentService', () => {
       let currentDocument: DocumentContents;
       const notFoundDoc = { title: 'Not Found', contents: 'Document not found' };
       const nextDoc = { title: 'Next Doc' };
-      const { service, backend, location } = getServices('file-not-found');
+      const { docService, backend, locationService } = getServices('file-not-found');
       const connections = backend.connectionsArray;
-      service.currentDocument.subscribe(doc => currentDocument = doc);
+      docService.currentDocument.subscribe(doc => currentDocument = doc);
 
       connections[0].mockError(new Response(new ResponseOptions({ status: 404, statusText: 'NOT FOUND'})) as any);
       expect(connections.length).toEqual(1);
       expect(currentDocument).toEqual(notFoundDoc);
 
       // now check that we haven't killed the currentDocument observable sequence
-      location.urlSubject.next('new/url');
+      locationService.go('new/url');
       connections[1].mockRespond(createResponse(nextDoc));
       expect(currentDocument).toEqual(nextDoc);
     });
 
     it('should not crash the app if the response is not valid JSON', () => {
       let latestDocument: DocumentContents;
-      const { service, backend, location } = getServices('initial/url');
+      const { docService, backend, locationService} = getServices('initial/url');
       const connections = backend.connectionsArray;
 
-      service.currentDocument.subscribe(doc => latestDocument = doc);
+      docService.currentDocument.subscribe(doc => latestDocument = doc);
 
       connections[0].mockRespond(new Response(new ResponseOptions({ body: 'this is invalid JSON' })));
       expect(latestDocument.title).toEqual('Error fetching document');
 
       const doc1 = { title: 'doc 1' };
-      location.urlSubject.next('new/url');
+      locationService.go('new/url');
       connections[1].mockRespond(createResponse(doc1));
       expect(latestDocument).toEqual(doc1);
     });
@@ -127,10 +127,10 @@ describe('DocumentService', () => {
 
       const doc0 = { title: 'doc 0' };
       const doc1 = { title: 'doc 1' };
-      const { service, backend, location } = getServices('url/0');
+      const { docService, backend, locationService} = getServices('url/0');
       const connections = backend.connectionsArray;
 
-      subscription = service.currentDocument.subscribe(doc => latestDocument = doc);
+      subscription = docService.currentDocument.subscribe(doc => latestDocument = doc);
       expect(connections.length).toEqual(1);
       connections[0].mockRespond(createResponse(doc0));
       expect(latestDocument).toEqual(doc0);
@@ -139,8 +139,8 @@ describe('DocumentService', () => {
       // modify the response so we can check that future subscriptions do not trigger another request
       connections[0].response.next(createResponse({ title: 'error 0' }));
 
-      subscription = service.currentDocument.subscribe(doc => latestDocument = doc);
-      location.urlSubject.next('url/1');
+      subscription = docService.currentDocument.subscribe(doc => latestDocument = doc);
+      locationService.go('url/1');
       expect(connections.length).toEqual(2);
       connections[1].mockRespond(createResponse(doc1));
       expect(latestDocument).toEqual(doc1);
@@ -149,14 +149,14 @@ describe('DocumentService', () => {
       // modify the response so we can check that future subscriptions do not trigger another request
       connections[1].response.next(createResponse({ title: 'error 1' }));
 
-      subscription = service.currentDocument.subscribe(doc => latestDocument = doc);
-      location.urlSubject.next('url/0');
+      subscription = docService.currentDocument.subscribe(doc => latestDocument = doc);
+      locationService.go('url/0');
       expect(connections.length).toEqual(2);
       expect(latestDocument).toEqual(doc0);
       subscription.unsubscribe();
 
-      subscription = service.currentDocument.subscribe(doc => latestDocument = doc);
-      location.urlSubject.next('url/1');
+      subscription = docService.currentDocument.subscribe(doc => latestDocument = doc);
+      locationService.go('url/1');
       expect(connections.length).toEqual(2);
       expect(latestDocument).toEqual(doc1);
       subscription.unsubscribe();
@@ -166,15 +166,15 @@ describe('DocumentService', () => {
   describe('computeMap', () => {
     it('should map the "empty" location to the correct document request', () => {
       let latestDocument: DocumentContents;
-      const { service, backend } = getServices();
-      service.currentDocument.subscribe(doc => latestDocument = doc);
+      const { docService, backend } = getServices();
+      docService.currentDocument.subscribe(doc => latestDocument = doc);
 
       expect(backend.connectionsArray[0].request.url).toEqual(CONTENT_URL_PREFIX + 'index.json');
     });
 
     it('should map the "folder" locations to the correct document request', () => {
-      const { service, backend, location } = getServices('guide/');
-      service.currentDocument.subscribe();
+      const { docService, backend, locationService} = getServices('guide/');
+      docService.currentDocument.subscribe();
 
       expect(backend.connectionsArray[0].request.url).toEqual(CONTENT_URL_PREFIX + 'guide.json');
     });

--- a/aio/src/testing/location.service.ts
+++ b/aio/src/testing/location.service.ts
@@ -5,9 +5,11 @@ export class MockLocationService {
   currentUrl = this.urlSubject.asObservable();
   search = jasmine.createSpy('search').and.returnValue({});
   setSearch = jasmine.createSpy('setSearch');
-  go = jasmine.createSpy('Location.go');
+  go = jasmine.createSpy('Location.go').and
+              .callFake((url: string) => this.urlSubject.next(url));
   handleAnchorClick = jasmine.createSpy('Location.handleAnchorClick')
       .and.returnValue(false); // prevent click from causing a browser navigation
+
   constructor(private initialUrl) {}
 }
 


### PR DESCRIPTION
Don’t show the side nav in mobile (not side-by-side) view when arriving or navigating.
Only show it by request.

The side nav should continue to appear in wide mode (side-by-side) when navigating from a marketing page to a guide page.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

