### PR TITLE
fix(expression): Inform user where Quoted error was thrown

### DIFF
--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -388,7 +388,8 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
   visitAll(asts: cdAst.AST[], mode: _Mode): any { return asts.map(ast => this.visit(ast, mode)); }
 
   visitQuote(ast: cdAst.Quote, mode: _Mode): any {
-    throw new Error('Quotes are not supported for evaluation!');
+    throw new Error(`Quotes are not supported for evaluation!
+        Statement: ${ast.uninterpretedExpression} located at ${ast.location}`);
   }
 
   private visit(ast: cdAst.AST, mode: _Mode): any {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Better error message
```

**What is the current behavior?** (You can also link to an open issue here)
Static error with no hint as to where the error occurred when there some shenanigans with quoting in a template.


**What is the new behavior?**
Let user know exact expression and template that threw the error


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: N/A


**Other information**:

