### PR TITLE
fix(tsc-wrapped): collect new expressions with no arguments

### DIFF
--- a/tools/@angular/tsc-wrapped/test/evaluator.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/evaluator.spec.ts
@@ -215,7 +215,20 @@ describe('Evaluator', () => {
       0, {__symbolic: 'spread', expression: {__symbolic: 'reference', name: 'arrImport'}}, 5
     ]);
   });
+
+  it('should be able to handle a new expression with no arguments', () => {
+    const source = sourceFileOf(`
+      export var a = new f;
+    `);
+    const expr = findVar(source, 'a');
+    expect(evaluator.evaluateNode(expr.initializer))
+        .toEqual({__symbolic: 'new', expression: {__symbolic: 'reference', name: 'f'}});
+  });
 });
+
+function sourceFileOf(text: string): ts.SourceFile {
+  return ts.createSourceFile('test.ts', text, ts.ScriptTarget.Latest, true);
+}
 
 const FILES: Directory = {
   'directives.ts': `


### PR DESCRIPTION
Fixes #15906

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)
The expression `new f` causes the collector to throw.

#15906

**What is the new behavior?**

The collector treats this as if it was `new f()`. Also guard against other kinds of expressions that might have similarly leave the `arguments` field of the node `undefined`.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```