### PR TITLE
ci(aio): do not fail when re-deploying preview for the same PR/SHA

### DIFF
--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/upload-server/build-creator.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/upload-server/build-creator.ts
@@ -26,7 +26,7 @@ export class BuildCreator extends EventEmitter {
       all([this.exists(prDir), this.exists(shaDir)]).
       then(([prDirExisted, shaDirExisted]) => {
         if (shaDirExisted) {
-          throw new UploadError(403, `Request to overwrite existing directory: ${shaDir}`);
+          throw new UploadError(409, `Request to overwrite existing directory: ${shaDir}`);
         }
 
         dirToRemoveOnError = prDirExisted ? shaDir : prDir;

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/server-integration.e2e.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/server-integration.e2e.ts
@@ -73,7 +73,7 @@ h.runForAllSupportedSchemes((scheme, port) => describe(`integration (on ${scheme
     h.createDummyArchive(pr9, sha9, archivePath);
 
     uploadBuild(pr9, sha9, archivePath).
-      then(h.verifyResponse(403)).
+      then(h.verifyResponse(409)).
       then(() => Promise.all([
         getFile(pr9, sha9, 'index.html').then(h.verifyResponse(200, idxContentRegex9)),
         getFile(pr9, sha9, 'foo/bar.js').then(h.verifyResponse(200, barContentRegex9)),

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/upload-server.e2e.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/verify-setup/upload-server.e2e.ts
@@ -101,7 +101,7 @@ describe('upload-server (on HTTP)', () => {
       expect(h.readBuildFile(pr, sha9, 'index.html')).toBe('My content');
 
       h.runCmd(`${curl} http://${host}/create-build/${pr}/${sha9}`).
-        then(h.verifyResponse(403, /^Request to overwrite existing directory/)).
+        then(h.verifyResponse(409, /^Request to overwrite existing directory/)).
         then(() => expect(h.readBuildFile(pr, sha9, 'index.html')).toBe('My content')).
         then(done);
     });

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/test/upload-server/build-creator.spec.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/test/upload-server/build-creator.spec.ts
@@ -66,7 +66,7 @@ describe('BuildCreator', () => {
     it('should throw if the build does already exist', done => {
       bcExistsSpy.and.returnValue(true);
       bc.create(pr, sha, archive).catch(err => {
-        expectToBeUploadError(err, 403, `Request to overwrite existing directory: ${shaDir}`);
+        expectToBeUploadError(err, 409, `Request to overwrite existing directory: ${shaDir}`);
         done();
       });
     });

--- a/aio/scripts/deploy-preview.sh
+++ b/aio/scripts/deploy-preview.sh
@@ -24,8 +24,9 @@ httpCode=$(
   | sed 's/HTTP_CODE: //'
 )
 
-# Exit with an error if the request failed
-if [ $httpCode -lt 200 ] || [ $httpCode -ge 400 ]; then
+# Exit with an error if the request failed.
+# (Ignore 409 failures, which mean trying to re-deploy for the same PR/SHA.)
+if [ $httpCode -lt 200 ] || ([ $httpCode -ge 400 ] && [ $httpCode -ne 409 ]); then
   exit 1
 fi
 


### PR DESCRIPTION
Previously, when trying to upload the build artifacts for a PR/SHA that was
already successfully deployed (e.g. when re-running a Travis job), the preview
server would return a 403 and the build would fail.

Since we have other mechanisms to verify that the PR author is trusted and the
artifacts do indeed come from the specified PR and since the new artifacts
should be the same with the already deployed ones (same SHA), there is no reason
to fail the build. The preview server will reject the request with a special
HTTP status code (409 - Conflict), which the `deploy-preview` script will
recognize and exit with 0.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

