### PR TITLE
fix(aio): create a proper commit link on preview comments

### DIFF
--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/upload-server/upload-server-factory.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/upload-server/upload-server-factory.ts
@@ -58,7 +58,7 @@ class UploadServerFactory {
     const githubPullRequests = new GithubPullRequests(githubToken, repoSlug);
 
     buildCreator.on(CreatedBuildEvent.type, ({pr, sha}: CreatedBuildEvent) => {
-      const body = `The angular.io preview for ${sha.slice(0, 7)} is available [here][1].\n\n` +
+      const body = `The angular.io preview for ${sha} is available [here][1].\n\n` +
                    `[1]: https://pr${pr}-${sha}.${domainName}/`;
 
       githubPullRequests.addComment(pr, body);

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/test/upload-server/upload-server-factory.spec.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/test/upload-server/upload-server-factory.spec.ts
@@ -143,7 +143,7 @@ describe('uploadServerFactory', () => {
 
     it('should post a comment on GitHub on \'build.created\'', () => {
       const prsAddCommentSpy = spyOn(GithubPullRequests.prototype, 'addComment');
-      const commentBody = 'The angular.io preview for 1234567 is available [here][1].\n\n' +
+      const commentBody = 'The angular.io preview for 1234567890 is available [here][1].\n\n' +
                           '[1]: https://pr42-1234567890.domain.name/';
 
       buildCreator.emit(CreatedBuildEvent.type, {pr: 42, sha: '1234567890'});


### PR DESCRIPTION
Previously, only a few characters of the SHA would apepar on the preview link
comment posted on the PR. This was usually enough for GitHub to create a link to
the corresponding commit, but it was possible to have collisions with other
commits with the same first characters (which prevented GitHub from identifying
the correct commit and create a link.)

This commit fixes this issue by explicitly specifying the URL to the commit
(using the full SHA).

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

