### PR TITLE
fix(language-service): infer correct type of `?.` expressions

### DIFF
--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -649,8 +649,14 @@ class TypeScriptSymbolQuery implements SymbolQuery {
   }
 
   getNonNullableType(symbol: Symbol): Symbol {
-    // TODO: Replace with typeChecker API when available;
-    return symbol;
+    if (symbol instanceof TypeWrapper && (typeof this.checker.getNonNullableType == 'function')) {
+      const tsType = symbol.tsType;
+      const nonNullableType = this.checker.getNonNullableType(tsType);
+      if (nonNullableType != tsType) {
+        return new TypeWrapper(nonNullableType, symbol.context);
+      }
+    }
+    return this.getBuiltinType(BuiltinType.Any);
   }
 
   getPipes(): SymbolTable {

--- a/packages/language-service/test/test_utils.ts
+++ b/packages/language-service/test/test_utils.ts
@@ -68,6 +68,7 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
   private scriptVersion = new Map<string, number>();
   private overrides = new Map<string, string>();
   private projectVersion = 0;
+  private options: ts.CompilerOptions;
 
   constructor(private scriptNames: string[], private data: MockData) {
     const moduleFilename = module.filename.replace(/\\/g, '/');
@@ -77,6 +78,16 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
     let distIndex = moduleFilename.indexOf('/dist/all');
     if (distIndex >= 0)
       this.nodeModulesPath = path.join(moduleFilename.substr(0, distIndex), 'node_modules');
+    this.options = {
+      target: ts.ScriptTarget.ES5,
+      module: ts.ModuleKind.CommonJS,
+      moduleResolution: ts.ModuleResolutionKind.NodeJs,
+      emitDecoratorMetadata: true,
+      experimentalDecorators: true,
+      removeComments: false,
+      noImplicitAny: false,
+      lib: ['lib.es2015.d.ts', 'lib.dom.d.ts'],
+    };
   }
 
   override(fileName: string, content: string) {
@@ -99,18 +110,12 @@ export class MockTypescriptHost implements ts.LanguageServiceHost {
 
   forgetAngular() { this.angularPath = undefined; }
 
-  getCompilationSettings(): ts.CompilerOptions {
-    return {
-      target: ts.ScriptTarget.ES5,
-      module: ts.ModuleKind.CommonJS,
-      moduleResolution: ts.ModuleResolutionKind.NodeJs,
-      emitDecoratorMetadata: true,
-      experimentalDecorators: true,
-      removeComments: false,
-      noImplicitAny: false,
-      lib: ['lib.es2015.d.ts', 'lib.dom.d.ts'],
-    };
+  overrideOptions(cb: (options: ts.CompilerOptions) => ts.CompilerOptions) {
+    this.options = cb(this.options);
+    this.projectVersion++;
   }
+
+  getCompilationSettings(): ts.CompilerOptions { return this.options; }
 
   getProjectVersion(): string { return this.projectVersion.toString(); }
 


### PR DESCRIPTION
Fixes #15885

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

The language service would not infer the correct type for `?.` operators.

#15885 

**What is the new behavior?**

The language service now correctly strips null and undefined from the type before looking for type members.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
