### PR TITLE
feat(aio): add log rotation in preview server

### DIFF
--- a/aio/aio-builds-setup/dockerbuild/Dockerfile
+++ b/aio/aio-builds-setup/dockerbuild/Dockerfile
@@ -79,6 +79,11 @@ RUN apt-get update -y && apt-get install -y \
 RUN yarn global add pm2@2
 
 
+# Set up log rotation
+COPY logrotate/* /etc/logrotate.d/
+RUN chmod 0644 /etc/logrotate.d/*
+
+
 # Set up cronjobs
 COPY cronjobs/aio-builds-cleanup /etc/cron.d/
 RUN chmod 0744 /etc/cron.d/aio-builds-cleanup

--- a/aio/aio-builds-setup/dockerbuild/logrotate/aio-misc
+++ b/aio/aio-builds-setup/dockerbuild/logrotate/aio-misc
@@ -1,0 +1,9 @@
+/var/log/aio/clean-up.log /var/log/aio/init.log /var/log/aio/verify-setup.log {
+  compress
+  create
+  delaycompress
+  missingok
+  monthly
+  notifempty
+  rotate 6
+}

--- a/aio/aio-builds-setup/dockerbuild/logrotate/aio-nginx
+++ b/aio/aio-builds-setup/dockerbuild/logrotate/aio-nginx
@@ -1,0 +1,13 @@
+/var/log/aio/nginx/*.log /var/log/aio/nginx-test/*.log {
+  compress
+  create
+  delaycompress
+  missingok
+  monthly
+  notifempty
+  rotate 6
+  sharedscripts
+  postrotate
+    service nginx rotate >/dev/null 2>&1
+  endscript
+}

--- a/aio/aio-builds-setup/dockerbuild/logrotate/aio-upload-server
+++ b/aio/aio-builds-setup/dockerbuild/logrotate/aio-upload-server
@@ -1,0 +1,9 @@
+/var/log/aio/upload-server-*.log {
+  compress
+  copytruncate
+  delaycompress
+  missingok
+  monthly
+  notifempty
+  rotate 6
+}

--- a/aio/aio-builds-setup/docs/vm-setup--create-host-dirs-and-files.md
+++ b/aio/aio-builds-setup/docs/vm-setup--create-host-dirs-and-files.md
@@ -41,9 +41,10 @@ certificate covering both the domain and subdomains.
 ## Create directory for logs (Optional)
 Optionally, a logs directory can pe passed to the docker container for storing non-system-related
 logs. If not provided, the logs are kept locally on the container and will be lost whenever the
-container is replaced (e.g. when updating to use a newer version of the docker image).
+container is replaced (e.g. when updating to use a newer version of the docker image). Log files are
+rotated and retained for 6 months.
 
-The following files log files are kept in this directory:
+The following log files are kept in this directory:
 
 - `clean-up.log`:
   Output of the `aio-clean-up` command, run as a cronjob for cleaning up the build artifacts of


### PR DESCRIPTION
Since logs can be kept on the host machine (so they outlive each container), it is good to have rotation (and also discard older files).