### PR TITLE
feat(compiler-cli): add param to set MissingTranslationStrategy on ngc

### DIFF
--- a/packages/compiler-cli/src/ngtools_api.ts
+++ b/packages/compiler-cli/src/ngtools_api.ts
@@ -35,6 +35,7 @@ export interface NgTools_InternalApi_NG2_CodeGen_Options {
   i18nFormat?: string;
   i18nFile?: string;
   locale?: string;
+  missingTranslation?: string;
 
   readResource: (fileName: string) => Promise<string>;
 
@@ -95,6 +96,7 @@ export class NgTools_InternalApi_NG_2 {
       i18nFormat: options.i18nFormat !,
       i18nFile: options.i18nFile !,
       locale: options.locale !,
+      missingTranslation: options.missingTranslation !,
       basePath: options.basePath
     };
 

--- a/packages/compiler/src/aot/compiler_factory.ts
+++ b/packages/compiler/src/aot/compiler_factory.ts
@@ -51,12 +51,12 @@ export function createAotCompiler(compilerHost: AotCompilerHost, options: AotCom
   StaticAndDynamicReflectionCapabilities.install(staticReflector);
   const console = new Console();
   const htmlParser = new I18NHtmlParser(
-      new HtmlParser(), translations, options.i18nFormat, MissingTranslationStrategy.Warning,
-      console);
+      new HtmlParser(), translations, options.i18nFormat, options.missingTranslation, console);
   const config = new CompilerConfig({
     defaultEncapsulation: ViewEncapsulation.Emulated,
     useJit: false,
     enableLegacyTemplate: options.enableLegacyTemplate !== false,
+    missingTranslation: options.missingTranslation,
   });
   const normalizer = new DirectiveNormalizer(
       {get: (url: string) => compilerHost.loadResource(url)}, urlResolver, htmlParser, config);

--- a/packages/compiler/src/aot/compiler_options.ts
+++ b/packages/compiler/src/aot/compiler_options.ts
@@ -6,10 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {MissingTranslationStrategy} from '@angular/core';
+
 export interface AotCompilerOptions {
   locale?: string;
   i18nFormat?: string;
   translations?: string;
+  missingTranslation?: MissingTranslationStrategy;
   enableLegacyTemplate?: boolean;
   /** preamble for all generated source files */
   genFilePreamble?: string;

--- a/tools/@angular/tsc-wrapped/src/cli_options.ts
+++ b/tools/@angular/tsc-wrapped/src/cli_options.ts
@@ -31,12 +31,20 @@ export class NgcCliOptions extends CliOptions {
   public i18nFormat: string;
   public i18nFile: string;
   public locale: string;
+  public missingTranslation: string;
 
-  constructor({i18nFormat = null, i18nFile = null, locale = null, basePath = null}:
-                  {i18nFormat?: string, i18nFile?: string, locale?: string, basePath?: string}) {
+  constructor({i18nFormat = null, i18nFile = null, locale = null, missingTranslation = null,
+               basePath = null}: {
+    i18nFormat?: string,
+    i18nFile?: string,
+    locale?: string,
+    missingTranslation?: string,
+    basePath?: string
+  }) {
     super({basePath: basePath});
     this.i18nFormat = i18nFormat;
     this.i18nFile = i18nFile;
     this.locale = locale;
+    this.missingTranslation = missingTranslation;
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
```
[x] Bugfix
[x] Feature
```

**What is the current behavior?**
See issue #15808. We were unable to set the MissingTranslationStrategy for AOT (it only worked in JIT) because of a recent refactoring of the functionality.


**What is the new behavior?**
Added a new cli parameter `missingTranslation` for ngc that you can use to set the MissingTranslationStrategy. It takes the values `error`, `warning` or `ignore`. The internal APIs still use the enum MissingTranslationStrategy (the string parameters are converted to numbers, for consistency).


**Does this PR introduce a breaking change?**
```
[x] No
```


**Other information**:
I didn't add any test yet, not really sure how to test this?