### PR TITLE
fix(forms): Prevent accessing FormGroup.value properties with dot notation.

### DIFF
--- a/packages/forms/src/directives/abstract_control_directive.ts
+++ b/packages/forms/src/directives/abstract_control_directive.ts
@@ -20,7 +20,7 @@ import {ValidationErrors} from './validators';
 export abstract class AbstractControlDirective {
   get control(): AbstractControl { throw new Error('unimplemented'); }
 
-  get value(): any { return this.control ? this.control.value : null; }
+  get value(): {[key: string]: any} { return this.control ? this.control.value : null; }
 
   get valid(): boolean { return this.control ? this.control.valid : null; }
 


### PR DESCRIPTION
Only allow properties of form group values to be access with bracket notation. This change prevents accessing the wrong properties when code is minified by the closure compiler.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
With the current behavior,  FormGroup.value has the any type. This is problematic since the formGroupName directive takes a string and that string is used to match up properties on the form group. When code is minified, if properties of FromGroup.value were accessed with dot notation, the property access would be minified (due to the value have the any type). 

**What is the new behavior?**
The new behavior prevents minification of property names of FormGroup.value.


**Does this PR introduce a breaking change?** (check one with "x")
```
[] Yes
[x ] No
```
