### PR TITLE
fix(language-service): look for type constructors on canonical symbol

### DIFF
--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -694,8 +694,9 @@ class TypeScriptSymbolQuery implements SymbolQuery {
     return spanAt(this.source, line, column);
   }
 
-  private getTemplateRefContextType(type: ts.Symbol): ts.Symbol|undefined {
-    const constructor = type.members && type.members !['__constructor'];
+  private getTemplateRefContextType(typeSymbol: ts.Symbol): ts.Symbol|undefined {
+    const type = this.checker.getTypeOfSymbolAtLocation(typeSymbol, this.source);
+    const constructor = type.symbol && type.symbol.members && type.symbol.members['__constructor'];
     if (constructor) {
       const constructorDeclaration = constructor.declarations ![0] as ts.ConstructorTypeNode;
       for (const parameter of constructorDeclaration.parameters) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

In some cases the compiler could not find the constructor of directives, such as `NgForOf`, to get its template reference type. This causes it to fail to infer types for `*ngFor`.

See https://github.com/angular/vscode-ng-language-service/issues/67

**What is the new behavior?**

The type constructors are now found.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```