### PR TITLE
fix(compiler): ignore calls to unresolved symbols in metadata

### DIFF
--- a/packages/compiler/src/aot/static_reflector.ts
+++ b/packages/compiler/src/aot/static_reflector.ts
@@ -584,7 +584,7 @@ export class StaticReflector implements ɵReflectorReader {
                     return simplifyCall(staticSymbol, targetFunction, argExpressions);
                   }
                 }
-                break;
+                return IGNORE;
               case 'error':
                 let message = produceErrorMessage(expression);
                 if (expression['line']) {

--- a/packages/compiler/test/aot/static_reflector_spec.ts
+++ b/packages/compiler/test/aot/static_reflector_spec.ts
@@ -546,6 +546,30 @@ describe('StaticReflector', () => {
     expect(annotation.providers).toEqual([1, 2, 3, 4, 5, 6, 7]);
   });
 
+  it('should ignore unresolved calls', () => {
+    const data = Object.create(DEFAULT_TEST_DATA);
+    const file = '/tmp/src/invalid-component.ts';
+    data[file] = `
+        import {Component} from '@angular/core';
+        import {unknown} from 'unresolved';
+
+        @Component({
+          selector: 'tmp',
+          template: () => {},
+          providers: [triggers()]
+        })
+        export class BadComponent {
+
+        }
+      `;
+    init(data, [], () => {}, {verboseInvalidExpression: true});
+
+    const badComponent = reflector.getStaticSymbol(file, 'BadComponent');
+    const annotations = reflector.annotations(badComponent);
+    const annotation = annotations[0];
+    expect(annotation.providers).toEqual([]);
+  });
+
   describe('inheritance', () => {
     class ClassDecorator {
       constructor(public value: any) {}

--- a/packages/compiler/test/aot/static_symbol_resolver_spec.ts
+++ b/packages/compiler/test/aot/static_symbol_resolver_spec.ts
@@ -436,6 +436,9 @@ export class MockStaticSymbolResolverHost implements StaticSymbolResolverHost {
       }
       return baseName + '.d.ts';
     }
+    if (modulePath == 'unresolved') {
+      return undefined;
+    }
     return '/tmp/' + modulePath + '.d.ts';
   }
 


### PR DESCRIPTION
This only shows up in the language service. Calls to symbols
that are not resolve resulted in null instead of being resolved
causing the language service to see exceptions when the null
was not expected such as in the animations array.

Fixes #15969


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```
**What is the current behavior?** (You can also link to an open issue here)

The language service produces spurious errors as described in #15969

**What is the new behavior?**

The spurious errors are not generated.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
