### PR TITLE
fix(language-service): only use canonical symbols

### DIFF
--- a/packages/language-service/src/typescript_host.ts
+++ b/packages/language-service/src/typescript_host.ts
@@ -811,10 +811,15 @@ class TypeWrapper implements Symbol {
 }
 
 class SymbolWrapper implements Symbol {
+  private symbol: ts.Symbol;
   private _tsType: ts.Type;
   private _members: SymbolTable;
 
-  constructor(private symbol: ts.Symbol, private context: TypeContext) {}
+  constructor(symbol: ts.Symbol, private context: TypeContext) {
+    this.symbol = symbol && context && (symbol.flags & ts.SymbolFlags.Alias) ?
+        context.checker.getAliasedSymbol(symbol) :
+        symbol;
+  }
 
   get name(): string { return this.symbol.name; }
 


### PR DESCRIPTION
Language service was treating some alias TypeScript symbols as if
they where the canonical symbol. If the symbol in scope is an alias
of another symbol the symbol should be converted to the canonical
symbol.

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

The language service was incorrectly handling alias symbol which produces spurious errors.

See https://github.com/angular/vscode-ng-language-service/issues/81

**What is the new behavior?**

The language service now converts alias symbols into the canonical symbol.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
