### PR TITLE
feat(aio): close other expanded nodes when select node in sidebar 

### DIFF
--- a/aio/e2e/app.e2e-spec.ts
+++ b/aio/e2e/app.e2e-spec.ts
@@ -15,7 +15,7 @@ describe('site App', function() {
     expect(page.getDocViewerText()).toMatch(/Progressive web apps/i);
   });
 
-  it('should show the tutorial index page at `/tutorial/`', () => {
+  it('should show the tutorial index page at `/tutorial/` after jitterbugging through features', () => {
     // check that we can navigate directly to the tutorial page
     page.navigateTo('tutorial/');
     expect(page.getDocViewerText()).toMatch(/Tutorial: Tour of Heroes/i);
@@ -24,8 +24,11 @@ describe('site App', function() {
     page.getLink('features').click();
     expect(page.getDocViewerText()).toMatch(/Features/i);
 
-    // Show the menu; the tutorial section should be fully open from previous visit
+    // Show the menu
     page.docsMenuLink.click();
+
+    // Open the tutorial header
+    page.getNavItem(/tutorial/i).click();
 
     // Navigate to the tutorial introduction via a link in the sidenav
     page.getNavItem(/introduction/i).click();

--- a/aio/src/app/layout/nav-item/nav-item.component.ts
+++ b/aio/src/app/layout/nav-item/nav-item.component.ts
@@ -17,7 +17,7 @@ export class NavItemComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (changes['selectedNodes'] || changes['node']) {
       this.isSelected = this.selectedNodes.indexOf(this.node) !== -1;
-      this.isExpanded = this.isExpanded || this.isSelected;
+      this.isExpanded = this.isSelected;
     }
     this.setClasses();
   }


### PR DESCRIPTION
Closing unselected nodes was the original behavior. We changed so that nodes stay open until explicitly close.

After trying for a while, most folks think this leaves the sidenav feeling cluttered and they prefer that non-selected nodes close when you select a doc.

Let's try it for a while.

I will add tests when people say they really do prefer auto-node-closing and this PR is approved _in principle_.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```