### PR TITLE
build(aio): give intellisense to the examples

### DIFF
--- a/aio/content/examples/tsconfig.json
+++ b/aio/content/examples/tsconfig.json
@@ -1,0 +1,21 @@
+// this tsconfig is used to give intellisense to
+// all the examples in this folder
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "lib": ["es2015", "dom"],
+    "noImplicitAny": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "typeRoots": [
+      "../../tools/examples/shared/node_modules/@types"
+    ]
+  },
+  "include": [
+    "*/e2e-spec.ts"
+  ]
+}


### PR DESCRIPTION
Currently, intellisense doesn't work in the `/content/examples` folder because VsCode is looking for a tsconfig that doesn't exist. I provide a dummy one just for the sake of intellisense.