### PR TITLE
feat(aio): fixed sidenav, moved footer inside of sidenav container

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -21,10 +21,12 @@
     <aio-dt [on]="dtOn" [(doc)]="currentDocument"></aio-dt>
   </section>
 
+  <footer>
+    <aio-footer [nodes]="footerNodes" [versionInfo]="versionInfo" ></aio-footer>
+  </footer>
+
 </md-sidenav-container>
 
 <aio-search-results #searchResults></aio-search-results>
 
-<footer>
-  <aio-footer [nodes]="footerNodes" [versionInfo]="versionInfo" ></aio-footer>
-</footer>
+

--- a/aio/src/styles/1-layouts/_sidenav.scss
+++ b/aio/src/styles/1-layouts/_sidenav.scss
@@ -3,11 +3,13 @@ aio-nav-menu.top-menu .vertical-menu-item  {
   text-transform: uppercase;
 }
 
-.mat-sidenav.sidenav {
-  box-shadow: 6px 0 6px rgba(0,0,0,0.10);
-  background-color: $offwhite;
+md-sidenav.mat-sidenav.sidenav {
+  position: fixed;
+  bottom: 0;
   padding: 80px 0px 0px;
   min-width: 260px;
+  background-color: $offwhite;
+  box-shadow: 6px 0 6px rgba(0,0,0,0.10);
 }
 
 md-sidenav.mat-sidenav.sidenav.collapsed {


### PR DESCRIPTION
When content pages were short, the footer would take up a large part
of the display area and the side nav would look like it was shorter than
it really was.

This change moves the footer into the main content area so that the
nav always extends to the full length the browser.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

