### PR TITLE
build(aio): IDEs should only parse the `src` files

### DIFF
--- a/aio/tsconfig.json
+++ b/aio/tsconfig.json
@@ -16,5 +16,12 @@
       "es2016",
       "dom"
     ]
-  }
+  },
+  "exclude": [
+    "content",
+    "tools",
+    "aio-builds-setup",
+    "node_modules",
+    "scripts"
+  ]
 }


### PR DESCRIPTION
I found that VS Code was taking an age to bring up the intellisense
for TypeScript source files in the `aio/src` folder.
I believe that this is because it was trying to parse all the files in
the `aio/content/examples` folder as well, which is not relevant to the
web app development.

This change restricts the root `aio/tsconfig.json` to only the `aio/src`
folder.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

