### PR TITLE
fix(aio): make autoscroll work & add #top-of-page

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -9,6 +9,7 @@
   <span class="fill-remaining-space"></span>
 </md-toolbar>
 
+<a id="top-of-page"></a>
 <md-sidenav-container class="sidenav-container" role="main">
 
   <md-sidenav [ngClass]="{'collapsed': !isSideBySide }" #sidenav class="sidenav" [opened]="isOpened" [mode]="mode">

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -286,14 +286,14 @@ describe('AppComponent', () => {
       const scrollService: AutoScrollService = fixture.debugElement.injector.get(AutoScrollService);
       spyOn(scrollService, 'scroll');
       locationService.go('some/url#fragment');
-      expect(scrollService.scroll).toHaveBeenCalledWith(jasmine.any(HTMLElement));
+      expect(scrollService.scroll).toHaveBeenCalledWith();
     });
 
     it('should be called when a document has been rendered', () => {
       const scrollService: AutoScrollService = fixture.debugElement.injector.get(AutoScrollService);
       spyOn(scrollService, 'scroll');
       component.onDocRendered();
-      expect(scrollService.scroll).toHaveBeenCalledWith(jasmine.any(HTMLElement));
+      expect(scrollService.scroll).toHaveBeenCalledWith();
     });
   });
 

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -106,7 +106,7 @@ export class AppComponent implements OnInit {
 
   // Scroll to the anchor in the hash fragment.
   autoScroll() {
-    this.autoScrollService.scroll(this.docViewer.nativeElement.offsetParent);
+    this.autoScrollService.scroll();
   }
 
   onDocRendered() {

--- a/aio/src/app/shared/auto-scroll.service.ts
+++ b/aio/src/app/shared/auto-scroll.service.ts
@@ -7,22 +7,23 @@ import { DOCUMENT } from '@angular/platform-browser';
  */
 @Injectable()
 export class AutoScrollService {
-
   constructor(
       @Inject(DOCUMENT) private document: any,
       private location: PlatformLocation) { }
 
   /**
-   * Scroll the contents of the container
-   * to the element with id extracted from the current location hash fragment
+   * Scroll to the element with id extracted from the current location hash fragment
+   * Scroll to top if no hash
+   * Don't scroll if hash not found
    */
-  scroll(container: HTMLElement) {
+  scroll() {
     const hash = this.getCurrentHash();
-    const element: HTMLElement = this.document.getElementById(hash);
+    const element: HTMLElement = hash
+        ? this.document.getElementById(hash)
+        : this.document.getElementById('top-of-page') || this.document.body;
     if (element) {
       element.scrollIntoView();
-    } else {
-      container.scrollTop = 0;
+      if (window && window.scrollBy) { window.scrollBy(0, -80); }
     }
   }
 


### PR DESCRIPTION
Scrolls to hash element or top of page when no hash. Scrolls down a big to account for top menu overhang.

No longer scrolls when the hash element is not found.

Also adds  `<a id="top-of-page"></a>` which will benefit future efforts to navigate there from within a page.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```