### PR TITLE
[wip/experiment] feat(compiler): ability to add i18n message references

### DIFF
--- a/packages/compiler/src/i18n/i18n_ast.ts
+++ b/packages/compiler/src/i18n/i18n_ast.ts
@@ -18,11 +18,12 @@ export class Message {
    * @param meaning
    * @param description
    * @param id
+   * @param ref a way to reference the message independently of the its id
    */
   constructor(
       public nodes: Node[], public placeholders: {[phName: string]: string},
       public placeholderToMessage: {[phName: string]: Message}, public meaning: string,
-      public description: string, public id: string) {
+      public description: string, public id: string, public ref: string = '') {
     if (nodes.length) {
       this.sources = [{
         filePath: nodes[0].sourceSpan.start.file.url,
@@ -37,7 +38,7 @@ export class Message {
   }
 }
 
-// line and columns indexes are 1 based
+// line and column indexes are 1 based
 export interface MessageSpan {
   filePath: string;
   startLine: number;

--- a/packages/compiler/src/i18n/message_bundle.ts
+++ b/packages/compiler/src/i18n/message_bundle.ts
@@ -67,7 +67,8 @@ export class MessageBundle {
       const mapper = serializer.createNameMapper(messages[id]);
       const src = messages[id];
       const nodes = mapper ? mapperVisitor.convert(src.nodes, mapper) : src.nodes;
-      let transformedMessage = new i18n.Message(nodes, {}, {}, src.meaning, src.description, id);
+      let transformedMessage =
+          new i18n.Message(nodes, {}, {}, src.meaning, src.description, id, src.ref);
       transformedMessage.sources = src.sources;
       if (filterSources) {
         transformedMessage.sources.forEach(

--- a/packages/compiler/src/i18n/serializers/idref_mapping.ts
+++ b/packages/compiler/src/i18n/serializers/idref_mapping.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as i18n from '../i18n_ast';
+
+import {Serializer} from './serializer';
+
+/**
+ * Generates an id to reference mapping (JSON format).
+ *
+ * References are defined using the i18n attributes: `<p i18n="meaning|desc@@id##ref">content</p>`
+ *
+ * References are a way to reference a message. Unlike the message id, the references do not change
+ * when the message content changes.
+ */
+export class IdToRefMapping extends Serializer {
+  constructor(private serializer: Serializer) { super(); };
+
+  write(messages: i18n.Message[], locale: string|null): string {
+    const mapping: {[id: string]: string} = {};
+    messages.forEach(msg => {
+      if (msg.ref) {
+        mapping[this.digest(msg)] = msg.ref;
+      }
+    });
+
+    return JSON.stringify(mapping, null, 2);
+  }
+
+  load(content: string, url: string):
+      {locale: string | null, i18nNodesByMsgId: {[msgId: string]: i18n.Node[]}} {
+    throw new Error('Unsupported');
+  }
+
+  digest(message: i18n.Message): string { return this.serializer.digest(message); }
+}

--- a/packages/compiler/test/i18n/digest_spec.ts
+++ b/packages/compiler/test/i18n/digest_spec.ts
@@ -20,6 +20,7 @@ export function main(): void {
           meaning: '',
           description: '',
           sources: [],
+          ref: 'ref',
         })).toEqual('i');
       });
     });

--- a/packages/compiler/test/i18n/serializers/idref_mapping_spec.ts
+++ b/packages/compiler/test/i18n/serializers/idref_mapping_spec.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {MessageBundle} from '@angular/compiler/src/i18n/message_bundle';
+import {IdToRefMapping} from '@angular/compiler/src/i18n/serializers/idref_mapping';
+import {Xmb} from '@angular/compiler/src/i18n/serializers/xmb';
+import {HtmlParser} from '@angular/compiler/src/ml_parser/html_parser';
+import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/interpolation_config';
+
+export function main(): void {
+  describe('IdToRefMapping', () => {
+
+    it('should generate an id to ref mapping', () => {
+      const HTML = `
+<p i18n="##ref_only">1</p>
+<p i18n="@@i##ref_and_id">2</p>
+<p i18n="m|d##ref_and_md">3</p>
+<p i18n="m|d@@i2##ref_and_md_and_id">4</p>
+<p i18n="m|d@@i3">5</p>`;
+
+      const bundle = new MessageBundle(new HtmlParser, [], {}, 'en');
+      bundle.updateFromTemplate(HTML, 'url', DEFAULT_INTERPOLATION_CONFIG);
+      const refMapping = new IdToRefMapping(new Xmb());
+
+      expect(JSON.parse(bundle.write(refMapping))).toEqual({
+        '4863371103643861248': 'ref_only',
+        'i': 'ref_and_id',
+        '693235761972813932': 'ref_and_md',
+        'i2': 'ref_and_md_and_id',
+      });
+
+    });
+  });
+}


### PR DESCRIPTION
Experiment to add ref to messages.
The goal is to be able to refer to the messages even when their content change (which also means their id change) without setting an explicit id so that the same message is translated in the same way regardless the number of occurrences.