### PR TITLE
fix(upgrade): use correct attribute name for upgraded component's binings

### DIFF
--- a/packages/upgrade/test/dynamic/test_helpers.ts
+++ b/packages/upgrade/test/dynamic/test_helpers.ts
@@ -6,4 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {UpgradeAdapterRef} from '@angular/upgrade';
+import * as angular from '@angular/upgrade/src/common/angular1';
+import {$ROOT_SCOPE} from '@angular/upgrade/src/common/constants';
+
 export * from '../common/test_helpers';
+
+export function $digest(adapter: UpgradeAdapterRef) {
+  const $rootScope = adapter.ng1Injector.get($ROOT_SCOPE) as angular.IRootScopeService;
+  $rootScope.$digest();
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When using a different property/attribute name for an upgraded component's binding (e.g. `bindings: {propName: '<attrName'}`), the property and attribute names are swapped (e.g. using `attrName` as the property name and `propName` as the attribute name). This results in unexpected behavior.
This only affects `upgrade/dynamic`. `upgrade/static` works correctly already.


**What is the new behavior?**
The correct names for properties and attributes are used.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No **(but any apps relying on the previous, broken behavior will be broken)**
```


**Other information**:
Fixes #8856.