### PR TITLE
fix(aio): add style for p tags inside of h1 tags

### DIFF
--- a/aio/src/styles/0-base/_typography.scss
+++ b/aio/src/styles/0-base/_typography.scss
@@ -18,6 +18,14 @@
       margin: 8px 0px;
     }
 
+    // Temporary fix
+    h1 p {
+      display:inline-block;
+      font-size: 24px;
+      font-weight: 500;
+      margin: 8px 0px;
+    }
+
     h1:after {
       content: "";
       display: block;


### PR DESCRIPTION
Temporary fix for h1 headings currently populating within p tags inside of an h1 tag
I can condense if needed but kept this as its separate section so it is noticeable for removal

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

