### PR TITLE
feat(aio): add prettier network fail page

### DIFF
--- a/aio/content/marketing/test.html
+++ b/aio/content/marketing/test.html
@@ -1,5 +1,7 @@
 <h1>Test Code Page</h1>
 
+<p>Current location is <current-location></current-location></p>
+
 <h2>&lt;code-tabs&gt;</h2>
 
 <p>No linenums at code-tabs level</p>

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -72,12 +72,7 @@ export class AppComponent implements OnInit {
     this.documentService.currentDocument.subscribe(doc => {
       this.currentDocument = doc;
       this.setDocumentTitle(doc.title);
-      this.pageId = this.currentDocument.url.replace('/', '-');
-
-      // Special case the home page
-      if (this.pageId === 'index') {
-        this.pageId = 'home';
-      }
+      this.setPageId(doc.id);
     });
 
     // scroll even if only the hash fragment changed
@@ -151,11 +146,16 @@ export class AppComponent implements OnInit {
     this.sidenav.toggle(value);
   }
 
-  setDocumentTitle(title) {
+  setDocumentTitle(title: string) {
     if (title.trim()) {
       this.titleService.setTitle(`Angular - ${title}`);
     } else {
       this.titleService.setTitle('Angular');
     }
+  }
+
+  setPageId(id: string) {
+    // Special case the home page
+    this.pageId = (id === 'index') ? 'home' : id.replace('/', '-');
   }
 }

--- a/aio/src/app/documents/document-contents.ts
+++ b/aio/src/app/documents/document-contents.ts
@@ -1,5 +1,8 @@
 export interface DocumentContents {
-  url: string;
+  /** The unique identifier for this document */
+  id: string;
+  /** The string to display in the browser tab when this document is being viewed */
   title: string;
+  /** The HTML to display in the doc viewer */
   contents: string;
 }

--- a/aio/src/app/documents/document.service.spec.ts
+++ b/aio/src/app/documents/document.service.spec.ts
@@ -86,15 +86,14 @@ describe('DocumentService', () => {
       connections[0].mockError(new Response(new ResponseOptions({ status: 404, statusText: 'NOT FOUND'})) as any);
       expect(connections.length).toEqual(2);
       expect(connections[1].request.url).toEqual(CONTENT_URL_PREFIX + 'file-not-found.json');
-      const fileNotFoundDoc = { title: 'File Not Found' };
+      const fileNotFoundDoc = { id: 'file-not-found', title: 'Page Not Found', contents: '<h1>Page Not Found</h1>' };
       connections[1].mockRespond(createResponse(fileNotFoundDoc));
-      expect(currentDocument).toEqual(jasmine.objectContaining(fileNotFoundDoc));
-      expect(currentDocument.url).toEqual('file-not-found');
+      expect(currentDocument).toEqual(fileNotFoundDoc);
     });
 
     it('should emit a hard-coded not-found document if the not-found document is not found on the server', () => {
       let currentDocument: DocumentContents;
-      const notFoundDoc: DocumentContents = { title: 'Not Found', contents: 'Document not found', url: 'file-not-found' };
+      const notFoundDoc: DocumentContents = { title: 'Not Found', contents: 'Document not found', id: 'file-not-found' };
       const nextDoc = { title: 'Next Doc', url: 'new/url' };
       const { docService, backend, locationService } = getServices('file-not-found');
       const connections = backend.connectionsArray;
@@ -178,7 +177,7 @@ describe('DocumentService', () => {
     });
 
     it('should map the "folder" locations to the correct document request', () => {
-      const { docService, backend, locationService} = getServices('guide/');
+      const { docService, backend, locationService} = getServices('guide');
       docService.currentDocument.subscribe();
 
       expect(backend.connectionsArray[0].request.url).toEqual(CONTENT_URL_PREFIX + 'guide.json');

--- a/aio/src/app/embedded/current-location.component.spec.ts
+++ b/aio/src/app/embedded/current-location.component.spec.ts
@@ -1,0 +1,28 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { LocationService } from 'app/shared/location.service';
+import { CurrentLocationComponent } from './current-location.component';
+
+let currentPath: string;
+class MockLocation {
+  path() { return currentPath; }
+}
+
+describe('CurrentLocationComponent', () => {
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CurrentLocationComponent ],
+      providers: [
+        { provide: LocationService, useClass: MockLocation }
+      ]
+    });
+    TestBed.compileComponents();
+  }));
+
+  it('should render the current location', () => {
+    const fixture = TestBed.createComponent(CurrentLocationComponent);
+    const element: HTMLElement = fixture.nativeElement;
+    currentPath = 'a/b/c';
+    fixture.detectChanges();
+    expect(element.innerText).toEqual('a/b/c');
+  });
+});

--- a/aio/src/app/embedded/current-location.component.ts
+++ b/aio/src/app/embedded/current-location.component.ts
@@ -1,0 +1,15 @@
+/* tslint:disable component-selector */
+import { Component } from '@angular/core';
+import { LocationService } from 'app/shared/location.service';
+
+/**
+ * A simple embedded component that displays the current location path
+ */
+@Component({
+  selector: 'current-location',
+  template: '{{location.path()}}'
+})
+export class CurrentLocationComponent {
+  constructor(public location: LocationService) {
+  }
+}

--- a/aio/src/app/embedded/embedded.module.ts
+++ b/aio/src/app/embedded/embedded.module.ts
@@ -19,6 +19,7 @@ import { CodeTabsComponent } from './code/code-tabs.component';
 import { ContributorListComponent } from './contributor/contributor-list.component';
 import { ContributorComponent } from './contributor/contributor.component';
 import { DocTitleComponent } from './doc-title.component';
+import { CurrentLocationComponent } from './current-location.component';
 import { LiveExampleComponent, EmbeddedPlunkerComponent } from './live-example/live-example.component';
 import { ResourceListComponent } from './resource/resource-list.component';
 import { ResourceService } from './resource/resource.service';
@@ -27,8 +28,8 @@ import { ResourceService } from './resource/resource.service';
  * such as CodeExampleComponent, LiveExampleComponent,...
  */
 export const embeddedComponents: any[] = [
-  ApiListComponent, CodeExampleComponent, CodeTabsComponent,
-  ContributorListComponent, DocTitleComponent, LiveExampleComponent, ResourceListComponent
+  ApiListComponent, CodeExampleComponent, CodeTabsComponent, ContributorListComponent,
+  CurrentLocationComponent, DocTitleComponent, LiveExampleComponent, ResourceListComponent
 ];
 
 /** Injectable class w/ property returning components that can be embedded in docs */

--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
@@ -122,23 +122,23 @@ describe('DocViewerComponent', () => {
   });
 
   it(('should display nothing when set currentDoc has no content'), () => {
-    component.currentDoc = { title: 'fake title', contents: '', url: 'a/b' };
+    component.currentDoc = { title: 'fake title', contents: '', id: 'a/b' };
     fixture.detectChanges();
     expect(docViewerEl.innerHTML).toBe('');
   });
 
   it(('should display simple static content doc'), () => {
     const contents = '<p>Howdy, doc viewer</p>';
-    component.currentDoc = { title: 'fake title', contents, url: 'a/b' };
+    component.currentDoc = { title: 'fake title', contents, id: 'a/b' };
     fixture.detectChanges();
     expect(docViewerEl.innerHTML).toEqual(contents);
   });
 
   it(('should display nothing after reset static content doc'), () => {
     const contents = '<p>Howdy, doc viewer</p>';
-    component.currentDoc = { title: 'fake title', contents, url: 'a/b' };
+    component.currentDoc = { title: 'fake title', contents, id: 'a/b' };
     fixture.detectChanges();
-    component.currentDoc = { title: 'fake title', contents: '', url: 'a/c' };
+    component.currentDoc = { title: 'fake title', contents: '', id: 'a/c' };
     fixture.detectChanges();
     expect(docViewerEl.innerHTML).toEqual('');
   });
@@ -149,7 +149,7 @@ describe('DocViewerComponent', () => {
       <p><aio-foo></aio-foo></p>
       <p>Below Foo</p>
     `;
-    component.currentDoc = { title: 'fake title', contents, url: 'a/b' };
+    component.currentDoc = { title: 'fake title', contents, id: 'a/b' };
     fixture.detectChanges();
     const fooHtml = docViewerEl.querySelector('aio-foo').innerHTML;
     expect(fooHtml).toContain('Foo Component');
@@ -165,7 +165,7 @@ describe('DocViewerComponent', () => {
       </div>
       <p>Below Foo</p>
     `;
-    component.currentDoc = { title: 'fake title', contents, url: 'a/b' };
+    component.currentDoc = { title: 'fake title', contents, id: 'a/b' };
     fixture.detectChanges();
     const foos = docViewerEl.querySelectorAll('aio-foo');
     expect(foos.length).toBe(2);
@@ -177,7 +177,7 @@ describe('DocViewerComponent', () => {
       <aio-bar></aio-bar>
       <p>Below Bar</p>
     `;
-    component.currentDoc = { title: 'fake title', contents, url: 'a/b' };
+    component.currentDoc = { title: 'fake title', contents, id: 'a/b' };
     fixture.detectChanges();
     const barHtml = docViewerEl.querySelector('aio-bar').innerHTML;
     expect(barHtml).toContain('Bar Component');
@@ -189,7 +189,7 @@ describe('DocViewerComponent', () => {
       <aio-bar>###bar content###</aio-bar>
       <p>Below Bar</p>
     `;
-    component.currentDoc = { title: 'fake title', contents, url: 'a/b' };
+    component.currentDoc = { title: 'fake title', contents, id: 'a/b' };
 
     // necessary to trigger projection within ngOnInit
     fixture.detectChanges();
@@ -207,7 +207,7 @@ describe('DocViewerComponent', () => {
       <p><aio-foo></aio-foo></p>
       <p>Bottom</p>
     `;
-    component.currentDoc = { title: 'fake title', contents, url: 'a/b' };
+    component.currentDoc = { title: 'fake title', contents, id: 'a/b' };
 
     // necessary to trigger Bar's projection within ngOnInit
     fixture.detectChanges();
@@ -230,7 +230,7 @@ describe('DocViewerComponent', () => {
       <p><aio-foo></aio-foo><p>
       <p>Bottom</p>
     `;
-    component.currentDoc = { title: 'fake title', contents, url: 'a/b' };
+    component.currentDoc = { title: 'fake title', contents, id: 'a/b' };
 
     // necessary to trigger Bar's projection within ngOnInit
     fixture.detectChanges();
@@ -254,7 +254,7 @@ describe('DocViewerComponent', () => {
       <p><aio-foo></aio-foo></p>
       <p>Bottom</p>
     `;
-    component.currentDoc = { title: 'fake title', contents, url: 'a/b' };
+    component.currentDoc = { title: 'fake title', contents, id: 'a/b' };
 
     // necessary to trigger Bar's projection within ngOnInit
     fixture.detectChanges();
@@ -282,7 +282,7 @@ describe('DocViewerComponent', () => {
       <p><aio-baz>---More baz--</aio-baz></p>
       <p>Bottom</p>
     `;
-    component.currentDoc = { title: 'fake title', contents, url: 'a/b' };
+    component.currentDoc = { title: 'fake title', contents, id: 'a/b' };
 
     // necessary to trigger Bar's projection within ngOnInit
     fixture.detectChanges();

--- a/aio/src/app/shared/location.service.spec.ts
+++ b/aio/src/app/shared/location.service.spec.ts
@@ -124,6 +124,37 @@ describe('LocationService', () => {
     });
   });
 
+  describe('path', () => {
+    it('should ask Location for the current path without the hash', () => {
+      const location: MockLocationStrategy = injector.get(LocationStrategy);
+      const service: LocationService = injector.get(LocationService);
+
+      // We cannot test this directly in the following test because the `MockLocationStrategy`
+      // does not remove the hash from the path, even if we do pass `false`.
+
+      spyOn(location, 'path').and.callThrough();
+      service.path();
+      expect(location.path).toHaveBeenCalledWith(false);
+    });
+
+    it('should return the current location.path, with the query and trailing slash stripped off', () => {
+      const location: MockLocationStrategy = injector.get(LocationStrategy);
+      const service: LocationService = injector.get(LocationService);
+
+      location.simulatePopState('a/b/c?foo=bar&moo=car');
+      expect(service.path()).toEqual('a/b/c');
+
+      location.simulatePopState('c/d/e');
+      expect(service.path()).toEqual('c/d/e');
+
+      location.simulatePopState('a/b/c/?foo=bar&moo=car');
+      expect(service.path()).toEqual('a/b/c');
+
+      location.simulatePopState('c/d/e/');
+      expect(service.path()).toEqual('c/d/e');
+    });
+  });
+
   describe('search', () => {
     it('should read the query from the current location.path', () => {
       const location: MockLocationStrategy = injector.get(LocationStrategy);

--- a/aio/src/app/shared/location.service.ts
+++ b/aio/src/app/shared/location.service.ts
@@ -42,6 +42,16 @@ export class LocationService {
     return url.replace(/^\/+/, '');
   }
 
+  /**
+   * Get the current path, without trailing slash, hash fragment or query params
+   */
+  path(): string {
+    let path = this.location.path(false);
+    path = path.match(/[^?]*/)[0]; // strip off query
+    path = path.replace(/\/$/, ''); // strip off trailing slash
+    return path;
+  }
+
   search(): { [index: string]: string; } {
     const search = {};
     const path = this.location.path();

--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -27,6 +27,9 @@
   <link rel="manifest" href="pwa-manifest.json">
   <meta name="theme-color" content="#1976d2">
 
+  <!-- loading this image here so we will have it already if the network fails -->
+  <img src="assets/images/support/net-crash.svg" width="0px;" height="0px;">
+
   <!-- Google Analytics -->
   <script>
   window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;

--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -27,9 +27,6 @@
   <link rel="manifest" href="pwa-manifest.json">
   <meta name="theme-color" content="#1976d2">
 
-  <!-- loading this image here so we will have it already if the network fails -->
-  <img src="assets/images/support/net-crash.svg" width="0px;" height="0px;">
-
   <!-- Google Analytics -->
   <script>
   window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;

--- a/aio/src/styles/1-layouts/_not-found.scss
+++ b/aio/src/styles/1-layouts/_not-found.scss
@@ -1,6 +1,6 @@
 #file-not-found {
     padding: 3rem 3rem 3rem;
-} 
+}
 
 .nf-container {
     align-items: center;
@@ -18,4 +18,10 @@
         text-transform: uppercase;
         margin: 8px 0;
     }
+}
+
+.nf-icon.material-icons {
+    color: $blue;
+    font-size: 100px;
+    position: static;
 }

--- a/aio/src/testing/location.service.ts
+++ b/aio/src/testing/location.service.ts
@@ -7,6 +7,8 @@ export class MockLocationService {
   setSearch = jasmine.createSpy('setSearch');
   go = jasmine.createSpy('Location.go').and
               .callFake((url: string) => this.urlSubject.next(url));
+  path = jasmine.createSpy('Location.path').and
+              .callFake(() => this.urlSubject.getValue().split('?')[0]);
   handleAnchorClick = jasmine.createSpy('Location.handleAnchorClick')
       .and.returnValue(false); // prevent click from causing a browser navigation
 

--- a/aio/tools/transforms/angular.io-package/processors/convertToJson.js
+++ b/aio/tools/transforms/angular.io-package/processors/convertToJson.js
@@ -31,7 +31,7 @@ module.exports = function convertToJsonProcessor(log, createDocMessage) {
             log.warn(createDocMessage('Title property expected', doc));
           }
 
-          doc.renderedContent = JSON.stringify({ title, contents }, null, 2);
+          doc.renderedContent = JSON.stringify({ id: doc.path, title, contents }, null, 2);
         }
       });
     }

--- a/aio/tools/transforms/angular.io-package/processors/convertToJson.spec.js
+++ b/aio/tools/transforms/angular.io-package/processors/convertToJson.spec.js
@@ -21,9 +21,11 @@ describe('convertToJson processor', () => {
       docType: 'test-doc',
       title: 'The Title',
       name: 'The Name',
+      path: 'test/doc',
       renderedContent: 'Some Content'
     }];
     processor.$process(docs);
+    expect(JSON.parse(docs[0].renderedContent).id).toEqual('test/doc');
     expect(JSON.parse(docs[0].renderedContent).title).toEqual('The Title');
     expect(JSON.parse(docs[0].renderedContent).contents).toEqual('Some Content');
   });


### PR DESCRIPTION
closes #16112.

When server or network goes down, we serve a canned page. Current ugly page is described in issue #16112.

This PR provides a prettier page along the lines of the better looking 404 page.
It does NOT cache the page so that, once connectivity is restored, it will try again to get that page.

I found a free “network crashed” svg that’s tiny. I’m loading it in `index.html` for the obvious reason that it needs to exist when you crash.  It should go in the service worker `pwa-manifest.json` too but I don’t know how to do that.

I would have just put it inline but I don’t know how to position and scale an svg. Maybe this is much ado about too little and we should just use a Material Design Icon.

### Update (2nd commit)
- fixed `DocumentService` test I broke (refactored for clarity)
- switched from svg to Material Design icon for lighter weight and fewer complications
- generalized for non-network fetch error causes.

**See it work**

1. Open the Mary Poppins preview
2. Nav to Docs
3. Pick a guide doc
4. Open dev tools, network tab
5. Click "offline"
6. Nav to a different guide page; should see the new error page
7. Nav back to prev. page; it should still display perfectly
8. Go back online
9. Nav to the formerly-failed guide page; it loads this time.

**Todo**
- [ ] @sjtrimble to fix styling.
