### PR TITLE
build(aio): render titles correctly in content pages

### DIFF
--- a/aio/e2e/app.e2e-spec.ts
+++ b/aio/e2e/app.e2e-spec.ts
@@ -49,6 +49,13 @@ describe('site App', function() {
     });
   });
 
+  describe('tutorial docs', () => {
+    it('should not render a paragraph element inside the h1 element', () => {
+      page.navigateTo('tutorial/toh-pt1');
+      expect(element(by.css('h1 p')).isPresent()).toBeFalsy();
+    });
+  });
+
   describe('google analytics', () => {
     beforeEach(done => page.gaReady.then(done));
 

--- a/aio/tools/transforms/templates/content.template.html
+++ b/aio/tools/transforms/templates/content.template.html
@@ -1,4 +1,4 @@
-{% if doc.title %}<h1>{$ doc.title | marked $}</h1>{% endif %}
+{% if doc.title %}{$ ('# ' + doc.title.trim()) | marked $}{% endif %}
 <div class="content">
 {$ doc.description | marked $}
 </div>


### PR DESCRIPTION
If a document provided a title jsdoc tag then its h1
element was being rendered incorrectly as a markdown
paragraph.

This change renders the title as a markdown h1 tag
directly.

Fixes #16099
Closes #16136 (making it unnecessary)
