### PR TITLE
fix(aio): allow empty titles for contents pages

### DIFF
--- a/aio/content/file-not-found.md
+++ b/aio/content/file-not-found.md
@@ -1,3 +1,3 @@
-@title Document not found
+@title
 @description
 <h3>Document not found</h3>

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -272,6 +272,14 @@ describe('AppComponent', () => {
       fixture.detectChanges();
       expect(titleService.setTitle).toHaveBeenCalledWith('Angular - Pipes');
     });
+
+    it('should update the document title, with a default value if the document has no title', () => {
+      const titleService = TestBed.get(Title);
+      spyOn(titleService, 'setTitle');
+      locationService.go('file-not-found');
+      fixture.detectChanges();
+      expect(titleService.setTitle).toHaveBeenCalledWith('Angular');
+    });
   });
 
   describe('autoScrolling', () => {
@@ -424,12 +432,18 @@ class TestHttp {
     "contents": "<h1>Test Doc</h1>"
   };
 
+  fileNotFoundDoc = {
+    "title": "",
+    "contents": "Page not found"
+  };
+
   // get = jasmine.createSpy('get').and.callFake((url: string) => { ... });
   get(url: string) {
     const json =
       /navigation.json/.test(url) ? this.navJson :
       /api/.test(url) ? this.apiDoc :
       /pipes/.test(url) ? this.pipesDoc :
+      /file-not-found/.test(url) ? this.fileNotFoundDoc :
       this.testDoc;
     return of({ json: () => json });
   }

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -150,6 +150,10 @@ export class AppComponent implements OnInit {
   }
 
   setDocumentTitle(title) {
-    this.titleService.setTitle(`Angular - ${title}`);
+    if (title.trim()) {
+      this.titleService.setTitle(`Angular - ${title}`);
+    } else {
+      this.titleService.setTitle('Angular');
+    }
   }
 }

--- a/aio/tools/transforms/angular.io-package/processors/convertToJson.js
+++ b/aio/tools/transforms/angular.io-package/processors/convertToJson.js
@@ -8,8 +8,14 @@ module.exports = function convertToJsonProcessor(log, createDocMessage) {
       const docTypes = this.docTypes;
       docs.forEach((doc) => {
         if (docTypes.indexOf(doc.docType) !== -1) {
-          let title = doc.title || doc.name;
           let contents = doc.renderedContent || '';
+
+          let title = doc.title;
+
+          // We do allow an empty `title` but resort to `name` if it is not even defined
+          if (title === undefined) {
+            title = doc.name;
+          }
 
           // If there is no title then try to extract it from the first h1 in the renderedContent
           if (title === undefined) {

--- a/aio/tools/transforms/angular.io-package/processors/convertToJson.spec.js
+++ b/aio/tools/transforms/angular.io-package/processors/convertToJson.spec.js
@@ -4,7 +4,7 @@ var Dgeni = require('dgeni');
 describe('convertToJson processor', () => {
   var dgeni, injector, processor, log;
 
-  beforeEach(function() {
+  beforeAll(function() {
     dgeni = new Dgeni([testPackage('angular.io-package')]);
     injector = dgeni.configureInjector();
     processor = injector.get('convertToJsonProcessor');
@@ -32,6 +32,20 @@ describe('convertToJson processor', () => {
     const docs = [{ docType: 'test-doc', name: 'The Name' }];
     processor.$process(docs);
     expect(JSON.parse(docs[0].renderedContent).title).toEqual('The Name');
+  });
+
+  it('should accept an empty title', () => {
+    const docs = [{ docType: 'test-doc', title: '' }];
+    processor.$process(docs);
+    expect(JSON.parse(docs[0].renderedContent).title).toEqual('');
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('should accept an empty name if title is not provided', () => {
+    const docs = [{ docType: 'test-doc', name: '' }];
+    processor.$process(docs);
+    expect(JSON.parse(docs[0].renderedContent).title).toEqual('');
+    expect(log.warn).not.toHaveBeenCalled();
   });
 
   it('should get the title from the first `h1` if no title nor name is specified', () => {


### PR DESCRIPTION
Now if you specifically provide an empty `@title` tag
for a contents file, the doc-gen will not complain and
the browser will just display a reasonable default.

See https://github.com/angular/angular/pull/16089#discussion_r112143410