### PR TITLE
docs(aio): Fix reference to the right example

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -223,7 +223,7 @@ There are _no leading slashes_ in the _path_.
 The router parses and builds the final URL for you,
 allowing you to use both relative and absolute paths when navigating between application views.
 
-The `:id` in the first route is a token for a route parameter. In a URL such as `/hero/42`, "42"
+The `:id` in the second route is a token for a route parameter. In a URL such as `/hero/42`, "42"
 is the value of the `id` parameter. The corresponding `HeroDetailComponent`
 will use that value to find and present the hero whose `id` is 42.
 You'll learn more about route parameters later in this guide.


### PR DESCRIPTION
Fix reference to the right example (it's the second route in the example the one showing the route parameter, not the first one)

See https://angular.io/docs/ts/latest/guide/router.html#basics-config
![screen shot 2017-04-19 at 11 33 47](https://cloud.githubusercontent.com/assets/747646/25173352/0b640976-24f4-11e7-95a5-6c509f0fbed8.png)
