### PR TITLE
build(aio): add setup script

### DIFF
--- a/aio/README.md
+++ b/aio/README.md
@@ -13,6 +13,7 @@ You should run all these tasks from the `angular/aio` folder.
 Here are the most important tasks you might need to use:
 
 * `yarn` - install all the dependencies.
+* `yarn setup` - Install all the dependencies, boilerplate, plunkers, zips and runs dgeni on the docs.
 
 * `yarn start` - run a development web server that watches the files; then builds the doc-viewer and reloads the page, as necessary.
 * `yarn lint` - check that the doc-viewer code follows our style rules.

--- a/aio/package.json
+++ b/aio/package.json
@@ -8,11 +8,12 @@
   "scripts": {
     "ng": "yarn check-env && ng",
     "start": "yarn check-env && ng serve",
-    "build": "yarn check-env && yarn docs && ng build -prod -sm",
+    "build": "yarn check-env && yarn setup && ng build -prod -sm",
     "lint": "yarn check-env && yarn docs-lint && ng lint",
     "test": "yarn check-env && ng test --sourcemap=false",
     "pree2e": "yarn ~~update-webdriver",
     "e2e": "yarn check-env && ng e2e --no-webdriver-update",
+    "setup": "yarn && yarn boilerplate:add && yarn docs &&  yarn generate-plunkers && yarn generate-zips",
     "pretest-pwa-score-local": "yarn build",
     "test-pwa-score-local": "concurrently --kill-others --success first \"http-server dist -p 4200 --silent\" \"yarn test-pwa-score -- http://localhost:4200 90\"",
     "test-pwa-score": "node scripts/test-pwa-score",


### PR DESCRIPTION
This makes easier to setup the project. Generates boilerplate, zips, plunkers, the docs... Everything in one command so you can clone, run `yarn setup` and start working on it.

Fixes #16121 
