### PR TITLE
docs(aio): fix broken regions

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -206,7 +206,7 @@ The following example creates four route definitions, configures the router via 
 and adds the result to the `AppModule`'s `imports` array.
 
 
-<code-example path="router/src/app/app.module.0.ts" linenums="false" title="src/app/app.module.ts (excerpt)" region="excerpt">
+<code-example path="router/src/app/app.module.0.ts" linenums="false" title="src/app/app.module.ts (excerpt)">
 
 </code-example>
 
@@ -915,7 +915,7 @@ Instead of adding the `"/sidekicks"` route, define a `wildcard` route instead an
 
 Create the `PageNotFoundComponent` to display when users visit invalid URLs.
 
-<code-example path="router/src/app/not-found.component.ts" linenums="false" title="src/app/not-found.component.ts (404 component)" region="404 component">
+<code-example path="router/src/app/not-found.component.ts" linenums="false" title="src/app/not-found.component.ts (404 component)">
 
 </code-example>
 
@@ -1436,7 +1436,7 @@ Remove the `HeroListComponent` import and the `/heroes` route from the `app-rout
 These are concerns at the top level of the application itself.
 
 
-<code-example path="router/src/app/app-routing.module.2.ts" linenums="false" title="src/app/app-routing.module.ts (v2)" region="v2">
+<code-example path="router/src/app/app-routing.module.2.ts" linenums="false" title="src/app/app-routing.module.ts (v2)">
 
 </code-example>
 
@@ -3138,7 +3138,7 @@ The `redirectUrl` property will store the attempted URL so you can navigate to i
 Revise the `AuthGuard` to call it.
 
 
-<code-example path="router/src/app/auth-guard.service.2.ts" linenums="false" title="src/app/auth-guard.service.ts (v2)" region="v2">
+<code-example path="router/src/app/auth-guard.service.2.ts" linenums="false" title="src/app/auth-guard.service.ts (v2)">
 
 </code-example>
 
@@ -3348,7 +3348,7 @@ wanted to use this guard for this component and needed to get
 the component's properties or confirm whether the router should allow navigation away from it.
 
 
-<code-example path="router/src/app/can-deactivate-guard.service.1.ts" linenums="false" title="src/app/can-deactivate-guard.service.ts (component-specific)" region="component-specific">
+<code-example path="router/src/app/can-deactivate-guard.service.1.ts" linenums="false" title="src/app/can-deactivate-guard.service.ts (component-specific)">
 
 </code-example>
 
@@ -3372,7 +3372,7 @@ to resolve to truthy (navigate) or falsy (stay put).
 Add the `Guard` to the crisis detail route in `crisis-center-routing.module.ts` using the `canDeactivate` array.
 
 
-<code-example path="router/src/app/crisis-center/crisis-center-routing.module.3.ts" linenums="false" title="src/app/crisis-center/crisis-center-routing.module.ts (can deactivate guard)" region="can deactivate guard">
+<code-example path="router/src/app/crisis-center/crisis-center-routing.module.3.ts" linenums="false" title="src/app/crisis-center/crisis-center-routing.module.ts (can deactivate guard)">
 
 </code-example>
 
@@ -3559,7 +3559,7 @@ Add an `anchor` element so you can jump to a certain point on the page.
 Add the `NavigationExtras` object to the `router.navigate` method that navigates you to the `/login` route.
 
 
-<code-example path="router/src/app/auth-guard.service.4.ts" linenums="false" title="src/app/auth-guard.service.ts (v3)" region="v3">
+<code-example path="router/src/app/auth-guard.service.4.ts" linenums="false" title="src/app/auth-guard.service.ts (v3)">
 
 </code-example>
 
@@ -3582,7 +3582,7 @@ Since you'll be navigating to the *Admin Dashboard* route after logging in, you'
 query parameters and fragment.
 
 
-<code-example path="router/src/app/admin/admin-dashboard.component.2.ts" linenums="false" title="src/app/admin/admin-dashboard.component.ts (v2)" region="v2">
+<code-example path="router/src/app/admin/admin-dashboard.component.2.ts" linenums="false" title="src/app/admin/admin-dashboard.component.ts (v2)">
 
 </code-example>
 
@@ -3923,7 +3923,7 @@ Now edit the `AdminDashboardComponent` to display the log of preloaded routes.
 When you're done it looks like this.
 
 
-<code-example path="router/src/app/admin/admin-dashboard.component.ts" linenums="false" title="src/app/admin/admin-dashboard.component.ts (preloaded modules)" region="preloaded modules">
+<code-example path="router/src/app/admin/admin-dashboard.component.ts" linenums="false" title="src/app/admin/admin-dashboard.component.ts (preloaded modules)">
 
 </code-example>
 
@@ -4196,7 +4196,7 @@ providing the `useHash: true` in an object as the second argument of the `Router
 in the `AppModule`.
 
 
-<code-example path="router/src/app/app.module.6.ts" linenums="false" title="src/app/app.module.ts (hash URL strategy)" region="hash URL strategy">
+<code-example path="router/src/app/app.module.6.ts" linenums="false" title="src/app/app.module.ts (hash URL strategy)">
 
 </code-example>
 

--- a/aio/content/guide/template-syntax.md
+++ b/aio/content/guide/template-syntax.md
@@ -1746,7 +1746,7 @@ Learn more about the `FormsModule` and `ngModel` in the
 Here's how to import the `FormsModule` to make `[(ngModel)]` available.
 
 
-<code-example path="template-syntax/src/app/app.module.1.ts" linenums="false" title="src/app/app.module.ts (FormsModule import)" region="FormsModule import">
+<code-example path="template-syntax/src/app/app.module.1.ts" linenums="false" title="src/app/app.module.ts (FormsModule import)">
 
 </code-example>
 

--- a/aio/content/tutorial/toh-pt5.md
+++ b/aio/content/tutorial/toh-pt5.md
@@ -669,7 +669,7 @@ is revised and ready to be navigated to.
 Here's what the `HeroDetailComponent` looks like now:
 
 
-<code-example path="toh-4/src/app/hero-detail.component.ts" title="src/app/hero-detail.component.ts (current)">
+<code-example path="toh-pt4/src/app/hero-detail.component.ts" title="src/app/hero-detail.component.ts (current)">
 
 </code-example>
 
@@ -936,7 +936,7 @@ the current template exhibits a "master/detail" style with the list of heroes
 at the top and details of the selected hero below.
 
 
-<code-example path="toh-4/src/app/app.component.ts" region="template" title="src/app/heroes.component.ts (current template)" linenums="false">
+<code-example path="toh-pt4/src/app/app.component.ts" region="template" title="src/app/heroes.component.ts (current template)" linenums="false">
 
 </code-example>
 
@@ -1200,7 +1200,7 @@ These correspond to the full set of master styles that you installed earlier dur
 Here's an excerpt:
 
 
-<code-example path="toh-pt5/src/styles.css" region="toh" title="src/styles.css (excerpt)">
+<code-example path="toh-pt5/src/styles.css" region="toh"  title="src/styles.css (excerpt)">
 
 </code-example>
 

--- a/aio/content/tutorial/toh-pt6.md
+++ b/aio/content/tutorial/toh-pt6.md
@@ -144,7 +144,7 @@ section of the [HTTP Client](guide/server-communication#in-mem-web-api) page.
 In the current `HeroService` implementation, a Promise resolved with mock heroes is returned.
 
 
-<code-example path="toh-4/src/app/hero.service.ts" region="get-heroes" title="src/app/hero.service.ts (old getHeroes)">
+<code-example path="toh-pt4/src/app/hero.service.ts" region="get-heroes" title="src/app/hero.service.ts (old getHeroes)">
 
 </code-example>
 

--- a/aio/tools/transforms/angular.io-package/index.js
+++ b/aio/tools/transforms/angular.io-package/index.js
@@ -123,9 +123,7 @@ module.exports =
               exclude: [
                 '**/*plnkr.no-link.html',
                 '**/node_modules/**',
-                // _boilerplate files
-                '**/_boilerplate/**',
-                '**/*/src/styles.css',
+                // boilerplate files
                 '**/*/src/systemjs-angular-loader.js',
                 '**/*/src/systemjs.config.js',
                 '**/*/src/tsconfig.json',


### PR DESCRIPTION
This fixes some broken regions that `dgeni` was complaining about. Migration errors (and a few mine).

There are two missing files but they are fixed on the `e2e` pr.