### PR TITLE
feat(aio): redirect old URLs to new ones

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -5,6 +5,29 @@
   "hosting": {
     "public": "dist",
     "cleanUrls": true,
+    "redirects": [
+      // cli-quickstart.html glossary.html, quickstart.html
+      {"type": 301, "source": "/docs/ts/latest/cli-quickstart.html", "destination": "/guide/cli-quickstart"},
+      {"type": 301, "source": "/docs/ts/latest/glossary.html",       "destination": "/guide/glossary"},
+      {"type": 301, "source": "/docs/ts/latest/quickstart.html",     "destination": "/guide/quickstart"},
+
+      // cookbook, cookbook/, cookbook/index.html
+      {"type": 301, "source": "/docs/ts/latest/cookbook",            "destination": "/guide/cb-index"},
+      {"type": 301, "source": "/docs/ts/latest/cookbook/",           "destination": "/guide/cb-index"},
+      {"type": 301, "source": "/docs/ts/latest/cookbook/index.html", "destination": "/guide/cb-index"},
+
+      // cookbook/dependency-injection.html
+      {"type": 301, "source": "/docs/ts/latest/cookbook/dependency-injection.html", "destination": "/guide/cb-dependency-injection"},
+
+      // cookbook/*.html
+      {"type": 301, "source": "/docs/ts/latest/cookbook/:cookbook.html", "destination": "/guide/:cookbook"},
+
+      // docs/ts/latest/api/*/index/*-type.html
+      {"type": 301, "source": "/docs/ts/latest/api/:package/index/:api-type.html", "destination": "/api/:package/:api"},
+
+      // guide/*, tutorial/*, **/*
+      {"type": 301, "source": "/docs/ts/latest/:any*", "destination": "/:any*"}
+    ],
     "rewrites": [
       {
         "source": "**/!(*.*)",


### PR DESCRIPTION
There are external resources that link to the old URLs. In order to avoid
breaking them, the old URLs are redirected to the new ones.

Fixes #15795
Closes #16133