### PR TITLE
docs(aio): fix bad cookbook URL references for aot-compiler

### DIFF
--- a/aio/content/guide/change-log.md
+++ b/aio/content/guide/change-log.md
@@ -170,7 +170,7 @@ Docs and code samples updated and tested with Angular v.2.1.0.
 
 ## NEW "Ahead of time (AOT) Compilation" cookbook (2016-10-11)
 
-The NEW [Ahead of time (AOT) Compilation](cookbook/aot-compiler) cookbook
+The NEW [Ahead of time (AOT) Compilation](guide/aot-compiler) cookbook
 explains what AOT compilation is and why you'd want it.
 It demonstrates the basics with a QuickStart app
 followed by the more advanced considerations of compiling and bundling the Tour of Heroes.

--- a/aio/content/guide/deployment.md
+++ b/aio/content/guide/deployment.md
@@ -45,7 +45,7 @@ The techniques progress from _easy but suboptimal_ to _more optimal and more inv
 
 * [_Ahead of Time_ compilation (AOT)](guide/deployment#aot "AOT Compilation") is the first of
 [several optimization strategies](guide/deployment#optimize).
-You'll also want to read the [detailed instructions in the AOT Cookbook](cookbook/aot-compiler "AOT Cookbook").
+You'll also want to read the [detailed instructions in the AOT Cookbook](guide/aot-compiler "AOT Cookbook").
 
 * [Webpack](guide/deployment#webpack "Webpack Optimization") is a popular general purpose packaging tool with a rich ecosystem, including plugins for AOT.
 The Angular [webpack guide](guide/webpack "Webpack: an introduction") can get you started and
@@ -280,7 +280,7 @@ Apps compiled with AOT launch faster for several reasons.
 * You don't download the Angular compiler, which is pretty big on its own.
 * The compiler discards unused Angular directives that a tree-shaking tool can then exclude.
 
-Learn more about AOT Compilation in the [AOT Cookbook](cookbook/aot-compiler "AOT Cookbook")
+Learn more about AOT Compilation in the [AOT Cookbook](guide/aot-compiler "AOT Cookbook")
 which describes running the AOT compiler from the command line
 and using [_rollup_](guide/deployment#rollup) for bundling, minification, uglification and tree shaking.
 
@@ -628,4 +628,4 @@ Read about how to enable CORS for specific servers at
 
 ## Next steps
  If you want to go beyond the [simple _copy-deploy_](guide/deployment#dev-deploy "Simplest deployment possible") approach,
- read the [AOT Cookbook](cookbook/aot-compiler "AOT Cookbook") next.
+ read the [AOT Cookbook](guide/aot-compiler "AOT Cookbook") next.

--- a/aio/content/guide/upgrade.md
+++ b/aio/content/guide/upgrade.md
@@ -1141,7 +1141,7 @@ After this, the service is injectable anywhere in our AngularJS code:
 We can take advantage of Ahead-of-time (AoT) compilation on hybrid apps just like on any other
 Angular application.
 The setup for an hybrid app is mostly the same as described in 
-[the Ahead-of-time Compilation chapter](cookbook/aot-compiler)
+[the Ahead-of-time Compilation chapter](guide/aot-compiler)
 save for differences in `index.html` and `main-aot.ts`
 
 Our `index.html` will likely have script tags loading AngularJS files, so the `index.html` we
@@ -2152,7 +2152,7 @@ remove the filter &lt;script&gt; tag from `index.html`:
 ## AoT compile the hybrid app
 
 To use AoT with our hybrid app we have to first set it up like any other Angular application,
-as shown in [the Ahead-of-time Compilation chapter](cookbook/aot-compiler).
+as shown in [the Ahead-of-time Compilation chapter](guide/aot-compiler).
 
 Then we have to change `main-aot.ts` bootstrap also bootstrap the AngularJS app 
 via `UpgradeModule`:


### PR DESCRIPTION
@petebacondarwin Fixes from https://github.com/angular/angular/pull/16077