### PR TITLE
fix: switch ApplicationRef_ to use runGuarded

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -436,7 +436,7 @@ export class ApplicationRef_ extends ApplicationRef {
     this._enforceNoNewChanges = isDevMode();
 
     this._zone.onMicrotaskEmpty.subscribe(
-        {next: () => { this._zone.run(() => { this.tick(); }); }});
+        {next: () => { this._zone.runGuarded(() => { this.tick(); }); }});
 
     const isCurrentlyStable = new Observable<boolean>((observer: Observer<boolean>) => {
       this._stable = this._zone.isStable && !this._zone.hasPendingMacrotasks &&


### PR DESCRIPTION
Before this change, if tick() hit an exception (like when lifecycle hooks throw), ApplicationRef_ would unsubscribe from _zone.onMicrotaskEmpty which would cause change detection to stop working.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

When a lifecycle hook throws, change detection stops working:
https://github.com/angular/angular/issues/2413
https://github.com/angular/angular/issues/9531

**What is the new behavior?**

Change detection keeps working even when lifecycle hooks throw.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

