### PR TITLE
feat(aio): don't set query params during search #16125

### DIFF
--- a/aio/src/app/search/search-box/search-box.component.spec.ts
+++ b/aio/src/app/search/search-box/search-box.component.spec.ts
@@ -56,12 +56,6 @@ describe('SearchBoxComponent', () => {
       input.triggerEventHandler('keyup', { target: { value: 'some query' }, which: 27 });
       expect(search.search).not.toHaveBeenCalled();
     }));
-
-    it('should set the search part of the browser location', inject([LocationService], (location: MockLocationService) => {
-      const input = fixture.debugElement.query(By.css('input'));
-      input.triggerEventHandler('keyup', { target: { value: 'some query' } });
-      expect(location.setSearch).toHaveBeenCalledWith('Full Text Search', { search: 'some query' });
-    }));
   });
 
   describe('on focus', () => {

--- a/aio/src/app/search/search-box/search-box.component.ts
+++ b/aio/src/app/search/search-box/search-box.component.ts
@@ -41,11 +41,9 @@ export class SearchBoxComponent implements OnInit {
   }
 
   onSearch(query: string, keyCode?: number) {
-    if (keyCode === 27) {
-      // Ignore escape key
+    if (keyCode === 27) { // ignore escape key
       return;
     }
-    this.locationService.setSearch('Full Text Search', { search: query });
     this.searchService.search(query);
   }
 }


### PR DESCRIPTION
closes #16125

While typing in the search box no longer updates the URL in the addr bar, you can still create a link like `~/?search=animations` and it will open the search dialog and profile the search box as it may be useful to email such a thing to someone.

API search still updates query params as sending someone a pre-filtered API search link is  handy.