### PR TITLE
fix(compiler,tsc-wapped): fixing various metadata issues

### DIFF
--- a/packages/compiler/src/aot/static_reflector.ts
+++ b/packages/compiler/src/aot/static_reflector.ts
@@ -203,7 +203,6 @@ export class StaticReflector implements ɵReflectorReader {
             if (paramType) nestedResult.push(paramType);
             const decorators = parameterDecorators ? parameterDecorators[index] : null;
             if (decorators) {
-              if (paramType) nestedResult.push(paramType);
               nestedResult.push(...decorators);
             }
             parameters !.push(nestedResult);

--- a/packages/compiler/src/aot/static_reflector.ts
+++ b/packages/compiler/src/aot/static_reflector.ts
@@ -194,16 +194,16 @@ export class StaticReflector implements ɵReflectorReader {
         const ctorData = members ? members['__ctor__'] : null;
         if (ctorData) {
           const ctor = (<any[]>ctorData).find(a => a['__symbolic'] == 'constructor');
-          const parameterTypes = <any[]>this.simplify(type, ctor['parameters'] || []);
+          const rawParameterTypes = <any[]>ctor['parameters'] || [];
           const parameterDecorators = <any[]>this.simplify(type, ctor['parameterDecorators'] || []);
           parameters = [];
-          parameterTypes.forEach((paramType, index) => {
+          rawParameterTypes.forEach((rawParamType, index) => {
             const nestedResult: any[] = [];
-            if (paramType) {
-              nestedResult.push(paramType);
-            }
+            const paramType = this.trySimplify(type, rawParamType);
+            if (paramType) nestedResult.push(paramType);
             const decorators = parameterDecorators ? parameterDecorators[index] : null;
             if (decorators) {
+              if (paramType) nestedResult.push(paramType);
               nestedResult.push(...decorators);
             }
             parameters !.push(nestedResult);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

If a injectable class has a `@Inject()` on one of the constructor parameters the static reflector will report if any of the types cannot be used as a token; these types should be ignored.

**What is the new behavior?**

The types of constructor parameters with `@Inject()` are ignored. Types with `|null` or `|undefined` are equivalent to the non-nullable types matching what TypeScript generates for JIT.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
