### PR TITLE
docs(aio): Fix broken code-tabs rendering in Tutorial/Routing

### DIFF
--- a/aio/content/tutorial/toh-pt5.md
+++ b/aio/content/tutorial/toh-pt5.md
@@ -922,10 +922,19 @@ Use an ES `import` statement *and* add it to the `NgModule.imports` list.
 
 Here is the revised `AppModule`, compared to its pre-refactor state:
 
+
 <code-tabs>
-  <code-pane path="toh-pt5/src/app/app.module.ts" title="src/app/app.module.ts (after)"></code-pane>
-  <code-pane path="toh-pt5/src/app/app.module.3.ts" title="src/app/app.module.ts (before)"></code-pane>
+
+  <code-pane title="src/app/app.module.ts (after)" path="toh-pt5/src/app/app.module.ts">
+
+  </code-pane>
+
+  <code-pane title="src/app/app.module.ts (before)" path="toh-pt5/src/app/app.module.3.ts">
+
+  </code-pane>
+
 </code-tabs>
+
 
 The revised and simplified `AppModule` is focused on identifying the key pieces of the app.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Other... Please describe: Documentation-only change
```

**What is the current behavior?** (You can also link to an open issue here)

Instead of displaying the file contents, the code-tabs instruction renders this error message:

+makeTabs( toh-5/ts/src/app/app.module.ts, toh-5/ts/src/app/app.module.3.ts, null, src/app/app.module.ts (after), src/app/app.module.ts (before)) :marked

Screenshot:

<img width="844" alt="broken-code-tabs-rendering-screenshot" src="https://cloud.githubusercontent.com/assets/3024544/25275779/41b88340-2697-11e7-8ccb-e9f795e0d0ff.png">


**What is the new behavior?**

I currently have no way of verifying my changes, but I assume that changing the formatting to match the other code-tabs fixes the problem.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

