### PR TITLE
fix(aio): remove leading slashes from the Location path

### DIFF
--- a/aio/src/app/shared/location.service.spec.ts
+++ b/aio/src/app/shared/location.service.spec.ts
@@ -137,7 +137,7 @@ describe('LocationService', () => {
       expect(location.path).toHaveBeenCalledWith(false);
     });
 
-    it('should return the current location.path, with the query and trailing slash stripped off', () => {
+    it('should return the current location.path, with the query, leading slash and trailing slash stripped off', () => {
       const location: MockLocationStrategy = injector.get(LocationStrategy);
       const service: LocationService = injector.get(LocationService);
 
@@ -147,10 +147,10 @@ describe('LocationService', () => {
       location.simulatePopState('c/d/e');
       expect(service.path()).toEqual('c/d/e');
 
-      location.simulatePopState('a/b/c/?foo=bar&moo=car');
+      location.simulatePopState('/a/b/c/?foo=bar&moo=car');
       expect(service.path()).toEqual('a/b/c');
 
-      location.simulatePopState('c/d/e/');
+      location.simulatePopState('/c/d/e/');
       expect(service.path()).toEqual('c/d/e');
     });
   });

--- a/aio/src/app/shared/location.service.ts
+++ b/aio/src/app/shared/location.service.ts
@@ -43,10 +43,11 @@ export class LocationService {
   }
 
   /**
-   * Get the current path, without trailing slash, hash fragment or query params
+   * Get the current path, without leading or trailing slash, hash fragment or query params
    */
   path(): string {
     let path = this.location.path(false);
+    path = path.replace(/^\/+/, ''); // strip off leading slashes
     path = path.match(/[^?]*/)[0]; // strip off query
     path = path.replace(/\/$/, ''); // strip off trailing slash
     return path;


### PR DESCRIPTION
The leading slash was causing the staging server to break
