### PR TITLE
docs(router): Change CanDeactivate to CanLoad

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -30,7 +30,7 @@ import {UrlSegment, UrlSegmentGroup} from './url_tree';
  *   {@link CanActivateChild} for more info.
  * - `canDeactivate` is an array of DI tokens used to look up CanDeactivate handlers. See
  *   {@link CanDeactivate} for more info.
- * - `canLoad` is an array of DI tokens used to look up CanDeactivate handlers. See
+ * - `canLoad` is an array of DI tokens used to look up CanLoad handlers. See
  *   {@link CanLoad} for more info.
  * - `data` is additional data provided to the component via `ActivatedRoute`.
  * - `resolve` is a map of DI tokens used to look up data resolvers. See {@link Resolve} for more


### PR DESCRIPTION
fix mistake in docs, CanDeactivate should be CanLoad

**Please check if the PR fulfills these requirements**
- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x ] Other... Please describe:   Documentation Fix
```

**What is the current behavior?** (You can also link to an open issue here)
Docs contain `CanDeactivate` where they should contain `CanLoad`.


**What is the new behavior?**
Docs contain `CanLoad`.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

