### PR TITLE
fix(aio): strip leading slashes from path (and improve DRY-ness)

### DIFF
--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -76,7 +76,7 @@ export class AppComponent implements OnInit {
     });
 
     // scroll even if only the hash fragment changed
-    this.locationService.currentUrl.subscribe(url => this.autoScroll());
+    this.locationService.currentUrl.subscribe(() => this.autoScroll());
 
     this.navigationService.currentNode.subscribe(currentNode => {
       this.currentNode = currentNode;

--- a/aio/src/app/documents/document.service.ts
+++ b/aio/src/app/documents/document.service.ts
@@ -39,7 +39,7 @@ export class DocumentService {
     private http: Http,
     location: LocationService) {
     // Whenever the URL changes we try to get the appropriate doc
-    this.currentDocument = location.currentUrl.switchMap(() => this.getDocument(location.path()));
+    this.currentDocument = location.currentPath.switchMap(path => this.getDocument(path));
   }
 
   private getDocument(url: string) {

--- a/aio/src/app/embedded/current-location.component.spec.ts
+++ b/aio/src/app/embedded/current-location.component.spec.ts
@@ -1,18 +1,19 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LocationService } from 'app/shared/location.service';
+import { MockLocationService } from 'testing/location.service';
 import { CurrentLocationComponent } from './current-location.component';
 
-let currentPath: string;
-class MockLocation {
-  path() { return currentPath; }
-}
 
 describe('CurrentLocationComponent', () => {
+  let locationService: MockLocationService;
+
   beforeEach(async(() => {
+    locationService = new MockLocationService('initial/url');
+
     TestBed.configureTestingModule({
       declarations: [ CurrentLocationComponent ],
       providers: [
-        { provide: LocationService, useClass: MockLocation }
+        { provide: LocationService, useValue: locationService }
       ]
     });
     TestBed.compileComponents();
@@ -21,8 +22,13 @@ describe('CurrentLocationComponent', () => {
   it('should render the current location', () => {
     const fixture = TestBed.createComponent(CurrentLocationComponent);
     const element: HTMLElement = fixture.nativeElement;
-    currentPath = 'a/b/c';
+
     fixture.detectChanges();
-    expect(element.innerText).toEqual('a/b/c');
+    expect(element.innerText).toEqual('initial/url');
+
+    locationService.urlSubject.next('next/url');
+
+    fixture.detectChanges();
+    expect(element.innerText).toEqual('next/url');
   });
 });

--- a/aio/src/app/embedded/current-location.component.ts
+++ b/aio/src/app/embedded/current-location.component.ts
@@ -7,7 +7,7 @@ import { LocationService } from 'app/shared/location.service';
  */
 @Component({
   selector: 'current-location',
-  template: '{{location.path()}}'
+  template: '{{ location.currentPath | async }}'
 })
 export class CurrentLocationComponent {
   constructor(public location: LocationService) {

--- a/aio/src/app/navigation/navigation.service.spec.ts
+++ b/aio/src/app/navigation/navigation.service.spec.ts
@@ -178,9 +178,6 @@ describe('NavigationService', () => {
       locationService.go('c');
       expect(currentNode).toEqual(cnode, 'location: c');
 
-      locationService.go('c/');
-      expect(currentNode).toEqual(cnode, 'location: c/');
-
       locationService.go('c#foo');
       expect(currentNode).toEqual(cnode, 'location: c#foo');
 

--- a/aio/src/app/navigation/navigation.service.ts
+++ b/aio/src/app/navigation/navigation.service.ts
@@ -16,14 +16,6 @@ export { CurrentNode, NavigationNode, NavigationResponse, NavigationViews, Versi
 
 const navigationPath = 'content/navigation.json';
 
-const urlParser = document.createElement('a');
-function cleanUrl(url: string) {
-  // remove hash (#) and query params (?)
-  urlParser.href = '/' + url;
-  // strip leading and trailing slashes
-  return urlParser.pathname.replace(/^\/+|\/$/g, '');
-}
-
 @Injectable()
 export class NavigationService {
   /**
@@ -91,10 +83,9 @@ export class NavigationService {
   private getCurrentNode(navigationViews: Observable<NavigationViews>): Observable<CurrentNode> {
     const currentNode = combineLatest(
       navigationViews.map(this.computeUrlToNavNodesMap),
-      this.location.currentUrl,
+      this.location.currentPath,
       (navMap, url) => {
-        let urlKey = cleanUrl(url);
-        urlKey = urlKey.startsWith('api/') ? 'api' : urlKey;
+        const urlKey = url.startsWith('api/') ? 'api' : url;
         return navMap[urlKey] || { view: '', url: urlKey, nodes: [] };
       })
       .publishReplay(1);

--- a/aio/src/app/shared/location.service.ts
+++ b/aio/src/app/shared/location.service.ts
@@ -14,8 +14,11 @@ export class LocationService {
   private readonly urlParser = document.createElement('a');
   private urlSubject = new Subject<string>();
   currentUrl = this.urlSubject
+    .map(url => this.stripSlashes(url))
     .do(url => this.gaService.locationChanged(url))
     .publishReplay(1);
+  currentPath = this.currentUrl
+    .map(url => url.match(/[^?#]*/)[0]);   // strip off query and hash
 
   constructor(
     private gaService: GaService,
@@ -23,33 +26,22 @@ export class LocationService {
     private platformLocation: PlatformLocation) {
 
     this.currentUrl.connect();
-    const initialUrl = this.stripLeadingSlashes(location.path(true));
-    this.urlSubject.next(initialUrl);
+    this.urlSubject.next(location.path(true));
 
     this.location.subscribe(state => {
-      const url = this.stripLeadingSlashes(state.url);
-      return this.urlSubject.next(url);
+      return this.urlSubject.next(state.url);
     });
   }
 
   // TODO?: ignore if url-without-hash-or-search matches current location?
   go(url: string) {
+    url = this.stripSlashes(url);
     this.location.go(url);
     this.urlSubject.next(url);
   }
 
-  private stripLeadingSlashes(url: string) {
-    return url.replace(/^\/+/, '');
-  }
-
-  /**
-   * Get the current path, without trailing slash, hash fragment or query params
-   */
-  path(): string {
-    let path = this.location.path(false);
-    path = path.match(/[^?]*/)[0]; // strip off query
-    path = path.replace(/\/$/, ''); // strip off trailing slash
-    return path;
+  private stripSlashes(url: string) {
+    return url.replace(/^\/+/, '').replace(/\/+(\?|#|$)/, '$1');
   }
 
   search(): { [index: string]: string; } {
@@ -122,7 +114,7 @@ export class LocationService {
       return true;
     }
 
-    this.go(this.stripLeadingSlashes(relativeUrl));
+    this.go(relativeUrl);
     return false;
   }
 }

--- a/aio/src/testing/location.service.ts
+++ b/aio/src/testing/location.service.ts
@@ -3,12 +3,11 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 export class MockLocationService {
   urlSubject = new BehaviorSubject<string>(this.initialUrl);
   currentUrl = this.urlSubject.asObservable();
+  currentPath = this.currentUrl.map(url => url.match(/[^?#]*/)[0]);
   search = jasmine.createSpy('search').and.returnValue({});
   setSearch = jasmine.createSpy('setSearch');
   go = jasmine.createSpy('Location.go').and
               .callFake((url: string) => this.urlSubject.next(url));
-  path = jasmine.createSpy('Location.path').and
-              .callFake(() => this.urlSubject.getValue().split('?')[0]);
   handleAnchorClick = jasmine.createSpy('Location.handleAnchorClick')
       .and.returnValue(false); // prevent click from causing a browser navigation
 


### PR DESCRIPTION
Previously, the path returned by `LocationService.path()` preserved leading slashes, which resulted in requests with consequtive slashes in the URL. Such requests would fail (with a 404) on staging.

This commit fixes it, by removing leading slashes from the path. It also refactors `LocationService` a bit, converting path to an observable, `currentPath` (similar to `currentUrl`), and applies certain clean-ups (e.g. stripping slashes, query, hash) in one place, which simplifies consumption.

This is an alternative to #16230.