### PR TITLE
docs(aio): remove duplicate `as`

### DIFF
--- a/aio/content/tutorial/toh-pt4.md
+++ b/aio/content/tutorial/toh-pt4.md
@@ -341,7 +341,7 @@ You don't really need a dedicated method to wrap one line.  Write it anyway:
 
  You might be tempted to call the `getHeroes()` method in a constructor, but
 a constructor should not contain complex logic,
-especially a constructor that calls a server, such as as a data access method.
+especially a constructor that calls a server, such as a data access method.
 The constructor is for simple initializations, like wiring constructor parameters to properties.
 
 To have Angular call `getHeroes()`, you can implement the Angular *ngOnInit lifecycle hook*.


### PR DESCRIPTION
the word `as` incorrectly appears consecutively

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: docs
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

