### PR TITLE
feat(http): Add support to HTTP service to subscribe to chunk streaming

### DIFF
--- a/packages/http/src/backends/xhr_backend.ts
+++ b/packages/http/src/backends/xhr_backend.ts
@@ -145,7 +145,7 @@ export class XHRConnection implements Connection {
         let chunkReceived = _xhr.responseText.substring(lastIndex, currentIndex);
         lastIndex = currentIndex;
         if (chunkStream$) chunkStream$.next(chunkReceived);
-      }
+      };
 
       _xhr.addEventListener('load', onLoad);
       _xhr.addEventListener('progress', onChunkReceived);

--- a/packages/http/src/backends/xhr_backend.ts
+++ b/packages/http/src/backends/xhr_backend.ts
@@ -141,11 +141,10 @@ export class XHRConnection implements Connection {
 
       const onChunkReceived = () => {
         let currentIndex = _xhr.responseText.length;
-        if(lastIndex === currentIndex) return;
+        if (lastIndex === currentIndex) return;
         let chunkReceived = _xhr.responseText.substring(lastIndex, currentIndex);
         lastIndex = currentIndex;
-        if(chunkStream$) 
-          chunkStream$.next(chunkReceived);
+        if (chunkStream$) chunkStream$.next(chunkReceived);
       }
 
       _xhr.addEventListener('load', onLoad);

--- a/packages/http/src/base_request_options.ts
+++ b/packages/http/src/base_request_options.ts
@@ -13,7 +13,7 @@ import {Headers} from './headers';
 import {normalizeMethodName} from './http_utils';
 import {RequestOptionsArgs} from './interfaces';
 import {URLSearchParams} from './url_search_params';
-
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 /**
  * Creates a request options object to be optionally provided when instantiating a
@@ -77,11 +77,15 @@ export class RequestOptions {
    * Select a buffer to store the response, such as ArrayBuffer, Blob, Json (or Document)
    */
   responseType: ResponseContentType|null;
+  /**
+   * BehaviorSubject observable for HTTP chunk stream
+   */
+  chunks$?: BehaviorSubject<string>|null;
 
   // TODO(Dzmitry): remove search when this.search is removed
   constructor(
       {method, headers, body, url, search, params, withCredentials,
-       responseType}: RequestOptionsArgs = {}) {
+       responseType, chunks$}: RequestOptionsArgs = {}) {
     this.method = method != null ? normalizeMethodName(method) : null;
     this.headers = headers != null ? headers : null;
     this.body = body != null ? body : null;
@@ -89,6 +93,7 @@ export class RequestOptions {
     this.params = this._mergeSearchParams(params || search);
     this.withCredentials = withCredentials != null ? withCredentials : null;
     this.responseType = responseType != null ? responseType : null;
+    this.chunks$ = chunks$ != null ? chunks$ : null;
   }
 
   /**
@@ -124,7 +129,8 @@ export class RequestOptions {
       withCredentials: options && options.withCredentials != null ? options.withCredentials :
                                                                     this.withCredentials,
       responseType: options && options.responseType != null ? options.responseType :
-                                                              this.responseType
+                                                              this.responseType,
+      chunks$: options && options.chunks$ != null ? options.chunks$ : this.chunks$
     });
   }
 

--- a/packages/http/src/base_request_options.ts
+++ b/packages/http/src/base_request_options.ts
@@ -7,13 +7,14 @@
  */
 
 import {Injectable} from '@angular/core';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 import {RequestMethod, ResponseContentType} from './enums';
 import {Headers} from './headers';
 import {normalizeMethodName} from './http_utils';
 import {RequestOptionsArgs} from './interfaces';
 import {URLSearchParams} from './url_search_params';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+
 
 /**
  * Creates a request options object to be optionally provided when instantiating a
@@ -84,8 +85,8 @@ export class RequestOptions {
 
   // TODO(Dzmitry): remove search when this.search is removed
   constructor(
-      {method, headers, body, url, search, params, withCredentials,
-       responseType, chunks$}: RequestOptionsArgs = {}) {
+      {method, headers, body, url, search, params, withCredentials, responseType, 
+       chunks$}: RequestOptionsArgs = {}) {
     this.method = method != null ? normalizeMethodName(method) : null;
     this.headers = headers != null ? headers : null;
     this.body = body != null ? body : null;

--- a/packages/http/src/base_request_options.ts
+++ b/packages/http/src/base_request_options.ts
@@ -85,7 +85,7 @@ export class RequestOptions {
 
   // TODO(Dzmitry): remove search when this.search is removed
   constructor(
-      {method, headers, body, url, search, params, withCredentials, responseType, 
+      {method, headers, body, url, search, params, withCredentials, responseType,
        chunks$}: RequestOptionsArgs = {}) {
     this.method = method != null ? normalizeMethodName(method) : null;
     this.headers = headers != null ? headers : null;

--- a/packages/http/src/http.ts
+++ b/packages/http/src/http.ts
@@ -138,8 +138,8 @@ export class Http {
    */
   post(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
     return this.request(new Request(mergeOptions(
-        this._defaultOptions.merge(new RequestOptions({
-            body: body, chunks$: options && options.chunks$ ? options.chunks$ : null})),
+        this._defaultOptions.merge(new RequestOptions(
+            {body: body, chunks$: options && options.chunks$ ? options.chunks$ : null})),
         options, RequestMethod.Post, url)));
   }
 

--- a/packages/http/src/http.ts
+++ b/packages/http/src/http.ts
@@ -139,9 +139,8 @@ export class Http {
   post(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
     return this.request(new Request(mergeOptions(
         this._defaultOptions.merge(new RequestOptions({
-            body: body,
-            chunks$: options && options.chunks$ ? options.chunks$ : null
-        })), options, RequestMethod.Post, url)));
+            body: body, chunks$: options && options.chunks$ ? options.chunks$ : null})),
+        options, RequestMethod.Post, url)));
   }
 
   /**

--- a/packages/http/src/http.ts
+++ b/packages/http/src/http.ts
@@ -33,7 +33,8 @@ function mergeOptions(
       headers: providedOpts.headers,
       body: providedOpts.body,
       withCredentials: providedOpts.withCredentials,
-      responseType: providedOpts.responseType
+      responseType: providedOpts.responseType,
+      chunks$: providedOpts.chunks$
     })) as RequestArgs;
   }
 
@@ -137,8 +138,10 @@ export class Http {
    */
   post(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
     return this.request(new Request(mergeOptions(
-        this._defaultOptions.merge(new RequestOptions({body: body})), options, RequestMethod.Post,
-        url)));
+        this._defaultOptions.merge(new RequestOptions({
+            body: body,
+            chunks$: options && options.chunks$ ? options.chunks$ : null
+        })), options, RequestMethod.Post, url)));
   }
 
   /**

--- a/packages/http/src/interfaces.ts
+++ b/packages/http/src/interfaces.ts
@@ -6,11 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+
 import {ReadyState, RequestMethod, ResponseContentType, ResponseType} from './enums';
 import {Headers} from './headers';
 import {Request} from './static_request';
 import {URLSearchParams} from './url_search_params';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+
 
 /**
  * Abstract class from which real backends are derived.

--- a/packages/http/src/interfaces.ts
+++ b/packages/http/src/interfaces.ts
@@ -10,6 +10,7 @@ import {ReadyState, RequestMethod, ResponseContentType, ResponseType} from './en
 import {Headers} from './headers';
 import {Request} from './static_request';
 import {URLSearchParams} from './url_search_params';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 /**
  * Abstract class from which real backends are derived.
@@ -55,6 +56,7 @@ export interface RequestOptionsArgs {
   body?: any;
   withCredentials?: boolean|null;
   responseType?: ResponseContentType|null;
+  chunks$?: BehaviorSubject<string>|null;
 }
 
 /**

--- a/packages/http/src/static_request.ts
+++ b/packages/http/src/static_request.ts
@@ -6,13 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+
 import {Body} from './body';
 import {ContentType, RequestMethod, ResponseContentType} from './enums';
 import {Headers} from './headers';
 import {normalizeMethodName} from './http_utils';
 import {RequestArgs} from './interfaces';
 import {URLSearchParams} from './url_search_params';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+
 
 
 // TODO(jeffbcross): properly implement body accessors

--- a/packages/http/src/static_request.ts
+++ b/packages/http/src/static_request.ts
@@ -12,6 +12,7 @@ import {Headers} from './headers';
 import {normalizeMethodName} from './http_utils';
 import {RequestArgs} from './interfaces';
 import {URLSearchParams} from './url_search_params';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 
 // TODO(jeffbcross): properly implement body accessors
@@ -71,6 +72,8 @@ export class Request extends Body {
   withCredentials: boolean;
   /** Buffer to store the response */
   responseType: ResponseContentType;
+  /** BehaviorSubject observable for HTTP chunk stream */
+  chunks$: BehaviorSubject<string>|null;
   constructor(requestOptions: RequestArgs) {
     super();
     // TODO: assert that url is present
@@ -95,6 +98,7 @@ export class Request extends Body {
     this.contentType = this.detectContentType();
     this.withCredentials = requestOptions.withCredentials !;
     this.responseType = requestOptions.responseType !;
+    this.chunks$ = requestOptions.chunks$ !;
   }
 
   /**

--- a/packages/http/test/backends/xhr_backend_spec.ts
+++ b/packages/http/test/backends/xhr_backend_spec.ts
@@ -9,6 +9,8 @@
 import {Injectable} from '@angular/core';
 import {AsyncTestCompleter, SpyObject, afterEach, beforeEach, beforeEachProviders, describe, expect, inject, it} from '@angular/core/testing/src/testing_internal';
 import {ɵgetDOM as getDOM} from '@angular/platform-browser';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+
 import {BrowserXhr} from '../../src/backends/browser_xhr';
 import {CookieXSRFStrategy, XHRBackend, XHRConnection} from '../../src/backends/xhr_backend';
 import {BaseRequestOptions, RequestOptions} from '../../src/base_request_options';
@@ -19,7 +21,6 @@ import {XSRFStrategy} from '../../src/interfaces';
 import {Request} from '../../src/static_request';
 import {Response} from '../../src/static_response';
 import {URLSearchParams} from '../../src/url_search_params';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 let abortSpy: any;
 let sendSpy: any;
@@ -765,9 +766,7 @@ Connection: keep-alive`;
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
            const base = new BaseRequestOptions();
            const connection = new XHRConnection(
-               new Request(
-                   base.merge(new RequestOptions({chunks$:null}))),
-               new MockBrowserXHR());
+               new Request(base.merge(new RequestOptions({chunks$:null}))), new MockBrowserXHR());
            connection.response.subscribe((res: Response) => {
              expect(res.json()).toBe(null);
              expect(connection.request.chunks$).toBeFalsy();
@@ -783,9 +782,7 @@ Connection: keep-alive`;
            const base = new BaseRequestOptions();
            let chunkObs = new BehaviorSubject<string>('');
            const connection = new XHRConnection(
-               new Request(
-                   base.merge(new RequestOptions({chunks$:chunkObs}))),
-               new MockBrowserXHR());
+               new Request(base.merge(new RequestOptions({chunks$:chunkObs}))), new MockBrowserXHR());
            connection.response.subscribe((res: Response) => {
              expect(res.json()).toBe(null);
              expect(connection.request.chunks$).toBeTruthy();
@@ -797,18 +794,17 @@ Connection: keep-alive`;
            existingXHRs[0].dispatchEvent('load');
          }));
 
-      it('should complete a request', 
-        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+      it('should complete a request', inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
            sampleRequest.chunks$ = null;
            const connection = new XHRConnection(
                sampleRequest, new MockBrowserXHR(),
                new ResponseOptions({type: ResponseType.Error}));
            connection.response.subscribe(
-               (res: Response) => { 
+               (res: Response) => {
                  expect(res.type).toBe(ResponseType.Error); 
                  expect(connection.request.chunks$).toBeFalsy();
-               }, null !,
-               () => { async.done(); });
+               },
+               null !, () => { async.done(); });
            existingXHRs[0].setStatusCode(200);
            existingXHRs[0].dispatchEvent('load');
          }));

--- a/packages/http/test/backends/xhr_backend_spec.ts
+++ b/packages/http/test/backends/xhr_backend_spec.ts
@@ -766,7 +766,7 @@ Connection: keep-alive`;
          inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
            const base = new BaseRequestOptions();
            const connection = new XHRConnection(
-               new Request(base.merge(new RequestOptions({chunks$:null}))), new MockBrowserXHR());
+               new Request(base.merge(new RequestOptions({chunks$: null}))), new MockBrowserXHR());
            connection.response.subscribe((res: Response) => {
              expect(res.json()).toBe(null);
              expect(connection.request.chunks$).toBeFalsy();
@@ -782,7 +782,8 @@ Connection: keep-alive`;
            const base = new BaseRequestOptions();
            let chunkObs = new BehaviorSubject<string>('');
            const connection = new XHRConnection(
-               new Request(base.merge(new RequestOptions({chunks$:chunkObs}))), new MockBrowserXHR());
+               new Request(base.merge(new RequestOptions({chunks$: chunkObs}))),
+               new MockBrowserXHR());
            connection.response.subscribe((res: Response) => {
              expect(res.json()).toBe(null);
              expect(connection.request.chunks$).toBeTruthy();
@@ -801,7 +802,7 @@ Connection: keep-alive`;
                new ResponseOptions({type: ResponseType.Error}));
            connection.response.subscribe(
                (res: Response) => {
-                 expect(res.type).toBe(ResponseType.Error); 
+                 expect(res.type).toBe(ResponseType.Error);
                  expect(connection.request.chunks$).toBeFalsy();
                },
                null !, () => { async.done(); });

--- a/packages/http/test/backends/xhr_backend_spec.ts
+++ b/packages/http/test/backends/xhr_backend_spec.ts
@@ -19,6 +19,7 @@ import {XSRFStrategy} from '../../src/interfaces';
 import {Request} from '../../src/static_request';
 import {Response} from '../../src/static_response';
 import {URLSearchParams} from '../../src/url_search_params';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 
 let abortSpy: any;
 let sendSpy: any;
@@ -757,6 +758,58 @@ Connection: keep-alive`;
            });
 
            existingXHRs[0].setStatusCode(204);
+           existingXHRs[0].dispatchEvent('load');
+         }));
+
+      it('should create a valid connection with null stream observable',
+         inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+           const base = new BaseRequestOptions();
+           const connection = new XHRConnection(
+               new Request(
+                   base.merge(new RequestOptions({chunks$:null}))),
+               new MockBrowserXHR());
+           connection.response.subscribe((res: Response) => {
+             expect(res.json()).toBe(null);
+             expect(connection.request.chunks$).toBeFalsy();
+             async.done();
+           });
+
+           existingXHRs[0].setStatusCode(204);
+           existingXHRs[0].dispatchEvent('load');
+         }));
+
+      it('should create a connection with a observable passed as parameter in the request',
+         inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+           const base = new BaseRequestOptions();
+           let chunkObs = new BehaviorSubject<string>('');
+           const connection = new XHRConnection(
+               new Request(
+                   base.merge(new RequestOptions({chunks$:chunkObs}))),
+               new MockBrowserXHR());
+           connection.response.subscribe((res: Response) => {
+             expect(res.json()).toBe(null);
+             expect(connection.request.chunks$).toBeTruthy();
+             expect(connection.request.chunks$).toEqual(chunkObs);
+             async.done();
+           });
+
+           existingXHRs[0].setStatusCode(204);
+           existingXHRs[0].dispatchEvent('load');
+         }));
+
+      it('should complete a request', 
+        inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+           sampleRequest.chunks$ = null;
+           const connection = new XHRConnection(
+               sampleRequest, new MockBrowserXHR(),
+               new ResponseOptions({type: ResponseType.Error}));
+           connection.response.subscribe(
+               (res: Response) => { 
+                 expect(res.type).toBe(ResponseType.Error); 
+                 expect(connection.request.chunks$).toBeFalsy();
+               }, null !,
+               () => { async.done(); });
+           existingXHRs[0].setStatusCode(200);
            existingXHRs[0].dispatchEvent('load');
          }));
     });

--- a/packages/http/test/http_spec.ts
+++ b/packages/http/test/http_spec.ts
@@ -10,8 +10,8 @@ import {Injector, ReflectiveInjector} from '@angular/core';
 import {TestBed, getTestBed} from '@angular/core/testing';
 import {AsyncTestCompleter, afterEach, beforeEach, describe, inject, it} from '@angular/core/testing/src/testing_internal';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {Observable} from 'rxjs/Observable';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+import {Observable} from 'rxjs/Observable';
 import {zip} from 'rxjs/observable/zip';
 
 import {BaseRequestOptions, ConnectionBackend, Http, HttpModule, JSONPBackend, Jsonp, JsonpModule, Request, RequestMethod, RequestOptions, Response, ResponseContentType, ResponseOptions, URLSearchParams, XHRBackend} from '../index';
@@ -224,7 +224,7 @@ export function main() {
                async.done();
              });
              expect(http.request).not.toHaveBeenCalled();
-             http.get(url, { chunks$:null }).subscribe((res: Response) => {});
+             http.get(url, {chunks$:null}).subscribe((res: Response) => {});
            }));
 
         it('should perform a get request with valid chunk BehaviorSubject',
@@ -239,7 +239,7 @@ export function main() {
              });
              expect(http.request).not.toHaveBeenCalled();
              let chunkStreamObs = new BehaviorSubject<string>('');
-             http.get(url, { chunks$:chunkStreamObs }).subscribe((res: Response) => {});
+             http.get(url, {chunks$:chunkStreamObs}).subscribe((res: Response) => {});
            }));
       });
 
@@ -279,7 +279,7 @@ export function main() {
                async.done();
              });
              expect(http.request).not.toHaveBeenCalled();
-             http.post(url, 'post me', { chunks$:null }).subscribe((res: Response) => {});
+             http.post(url, 'post me', {chunks$:null}).subscribe((res: Response) => {});
            }));
 
         it('should perform a post request with a valid BehaviorSubject (an instance)',
@@ -294,7 +294,7 @@ export function main() {
              });
              expect(http.request).not.toHaveBeenCalled();
              let chunkStreamObs = new BehaviorSubject<string>('');
-             http.post(url, 'post me', { chunks$:chunkStreamObs }).subscribe((res: Response) => {});
+             http.post(url, 'post me', {chunks$:chunkStreamObs}).subscribe((res: Response) => {});
            }));
       });
 

--- a/packages/http/test/http_spec.ts
+++ b/packages/http/test/http_spec.ts
@@ -11,6 +11,7 @@ import {TestBed, getTestBed} from '@angular/core/testing';
 import {AsyncTestCompleter, afterEach, beforeEach, describe, inject, it} from '@angular/core/testing/src/testing_internal';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {Observable} from 'rxjs/Observable';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {zip} from 'rxjs/observable/zip';
 
 import {BaseRequestOptions, ConnectionBackend, Http, HttpModule, JSONPBackend, Jsonp, JsonpModule, Request, RequestMethod, RequestOptions, Response, ResponseContentType, ResponseOptions, URLSearchParams, XHRBackend} from '../index';
@@ -212,6 +213,34 @@ export function main() {
              expect(http.request).not.toHaveBeenCalled();
              http.get(url).subscribe((res: Response) => {});
            }));
+
+        it('should perform a get request with null chunk BehaviorSubject',
+           inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+             backend.connections.subscribe((c: MockConnection) => {
+               expect(c.request.method).toBe(RequestMethod.Get);
+               expect(c.request.chunks$).toBeFalsy();
+               expect(http.request).toHaveBeenCalled();
+               backend.resolveAllConnections();
+               async.done();
+             });
+             expect(http.request).not.toHaveBeenCalled();
+             http.get(url, { chunks$:null }).subscribe((res: Response) => {});
+           }));
+
+        it('should perform a get request with valid chunk BehaviorSubject',
+           inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+             backend.connections.subscribe((c: MockConnection) => {
+               expect(c.request.method).toBe(RequestMethod.Get);
+               expect(c.request.chunks$).toBeTruthy();
+               expect(c.request.chunks$).toBeAnInstanceOf(BehaviorSubject);
+               expect(http.request).toHaveBeenCalled();
+               backend.resolveAllConnections();
+               async.done();
+             });
+             expect(http.request).not.toHaveBeenCalled();
+             let chunkStreamObs = new BehaviorSubject<string>('');
+             http.get(url, { chunks$:chunkStreamObs }).subscribe((res: Response) => {});
+           }));
       });
 
 
@@ -238,6 +267,34 @@ export function main() {
                async.done();
              });
              http.post(url, body).subscribe((res: Response) => {});
+           }));
+
+        it('should perform a post request with explicit null BehaviorSubject parameter',
+           inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+             backend.connections.subscribe((c: MockConnection) => {
+               expect(c.request.method).toBe(RequestMethod.Post);
+               expect(c.request.chunks$).toBeFalsy();
+               expect(http.request).toHaveBeenCalled();
+               backend.resolveAllConnections();
+               async.done();
+             });
+             expect(http.request).not.toHaveBeenCalled();
+             http.post(url, 'post me', { chunks$:null }).subscribe((res: Response) => {});
+           }));
+
+        it('should perform a post request with a valid BehaviorSubject (an instance)',
+           inject([AsyncTestCompleter], (async: AsyncTestCompleter) => {
+             backend.connections.subscribe((c: MockConnection) => {
+               expect(c.request.method).toBe(RequestMethod.Post);
+               expect(c.request.chunks$).toBeTruthy;
+               expect(c.request.chunks$).toBeAnInstanceOf(BehaviorSubject);
+               expect(http.request).toHaveBeenCalled();
+               backend.resolveAllConnections();
+               async.done();
+             });
+             expect(http.request).not.toHaveBeenCalled();
+             let chunkStreamObs = new BehaviorSubject<string>('');
+             http.post(url, 'post me', { chunks$:chunkStreamObs }).subscribe((res: Response) => {});
            }));
       });
 

--- a/packages/http/test/http_spec.ts
+++ b/packages/http/test/http_spec.ts
@@ -224,7 +224,7 @@ export function main() {
                async.done();
              });
              expect(http.request).not.toHaveBeenCalled();
-             http.get(url, {chunks$:null}).subscribe((res: Response) => {});
+             http.get(url, {chunks$: null}).subscribe((res: Response) => {});
            }));
 
         it('should perform a get request with valid chunk BehaviorSubject',
@@ -239,7 +239,7 @@ export function main() {
              });
              expect(http.request).not.toHaveBeenCalled();
              let chunkStreamObs = new BehaviorSubject<string>('');
-             http.get(url, {chunks$:chunkStreamObs}).subscribe((res: Response) => {});
+             http.get(url, {chunks$: chunkStreamObs}).subscribe((res: Response) => {});
            }));
       });
 
@@ -279,7 +279,7 @@ export function main() {
                async.done();
              });
              expect(http.request).not.toHaveBeenCalled();
-             http.post(url, 'post me', {chunks$:null}).subscribe((res: Response) => {});
+             http.post(url, 'post me', {chunks$: null}).subscribe((res: Response) => {});
            }));
 
         it('should perform a post request with a valid BehaviorSubject (an instance)',
@@ -294,7 +294,7 @@ export function main() {
              });
              expect(http.request).not.toHaveBeenCalled();
              let chunkStreamObs = new BehaviorSubject<string>('');
-             http.post(url, 'post me', {chunks$:chunkStreamObs}).subscribe((res: Response) => {});
+             http.post(url, 'post me', {chunks$: chunkStreamObs}).subscribe((res: Response) => {});
            }));
       });
 

--- a/tools/public_api_guard/http/http.d.ts
+++ b/tools/public_api_guard/http/http.d.ts
@@ -112,6 +112,7 @@ export declare enum ReadyState {
 
 /** @experimental */
 export declare class Request extends Body {
+    chunks$: BehaviorSubject<string> | null;
     headers: Headers;
     method: RequestMethod;
     responseType: ResponseContentType;
@@ -137,6 +138,7 @@ export declare enum RequestMethod {
 /** @experimental */
 export declare class RequestOptions {
     body: any;
+    chunks$?: BehaviorSubject<string> | null;
     headers: Headers | null;
     method: RequestMethod | string | null;
     params: URLSearchParams;
@@ -144,13 +146,14 @@ export declare class RequestOptions {
     /** @deprecated */ search: URLSearchParams;
     url: string | null;
     withCredentials: boolean | null;
-    constructor({method, headers, body, url, search, params, withCredentials, responseType}?: RequestOptionsArgs);
+    constructor({method, headers, body, url, search, params, withCredentials, responseType, chunks$}?: RequestOptionsArgs);
     merge(options?: RequestOptionsArgs): RequestOptions;
 }
 
 /** @experimental */
 export interface RequestOptionsArgs {
     body?: any;
+    chunks$?: BehaviorSubject<string> | null;
     headers?: Headers | null;
     method?: string | RequestMethod | null;
     params?: string | URLSearchParams | {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## Current behavior
The HTTP service in Angular returns, by default, an observable for the requests. It could be 
enough for the most of needs or scenarios. That is because we interact with the backend 
through a pair or request-response, we ask for an action or data to the server and it will 
reply accordingly to that request. However, if we need a continuos stream of data, usually
another approach is taken in account (for instance, websockets, but there are situations
where a WebSocket does not completely fit).

## Needed behavior
It would be helpful if the HTTP service (usually GET / POST verbs) can receive an observable
which we would subscribe to. When we would be subscribed to that observable, we will be
notified for a new incoming chunk of data. Why those two verbs? Reasons:
* GET: to start an streaming data passing optional parameters in the URL.
* POST: to start an streaming data passing complex data in the body of the request.

Typically, as the chunks are strings, the Observable can be specified as BehaviorSubject; it
needs to specify the type (generic), so, it finally would be a BehaviorSubject<string>.

## Real example / implementation of this feature
But... Is out there a real use case of this? Yes, there is. I am currently working in a 
homemade IoT platform, composed by a dashboard that receives different values from multiple
sensors provided by a raspberry PI and an Intel Edison boards. The data gathered is sent to
either an app developed in Angular or to Chrome extension app. In both case, it is a fact 
that WebSocket could cover the real-time requirement, but an HTTP streaming can do it 
perfectly too (avoiding to add another library in both sides, client and backend).

## Related issues about that
There are some issues related to this one, but a little differences.

### [Request/Upload progress handling via http](https://github.com/angular/angular/issues/10424)
This issue has a lot of comments and positive feedback for other users to be covered as a new
feature in the HTTP service. However, there are three reasons to close it: 
* http does not care how backend get the data.
* users of http don't care about how http gets the data.
* XHR becomes deprecated, XHR using backend becomes deprecated, everything remains clean. 

### [streaming ndjson response for http package](https://github.com/angular/angular/issues/15892)
This issue says that could be interesing support streaming for ndjson responses, but it is not
planned, needing investigation and the feature request is moved to the backlog. Probably, this
issue can cover this investigation step/work.

### [download/upload progress handling](https://github.com/angular/angular/pull/13036)
This issue talks about file management (upload/download process), which is not related to HTTP 
streaming and it is a different situation (this proposal is focused in receive valid and useful 
data in chunks and make it avaiable as soon as possible for the user). Another comment on the
issue refers to not to be tied to XHR in a long-term.

## Discussion about XHR & fetch
I agree with the fact that HTTP service and the users don't care about the source of the data,
but, whatever would be the origin of it, the developer could be interested in being notified
when each chunk of data arrives, to process it and show it in that moment. No files, no
uploads/downloads... just take the piece of information and manage it in real-time.

But, what about fetch? Don't worry, because I've also extracted into small PoC/repo where I 
establish a connection with an continuos (infinite) stream of data simulating the values
read from three sensors. I suscribe to that endpoint and for each chunk I refresh the
dashboard updating the information in real-time without WebSockets. The fetch object has
not been modified at all.

The repo mentioned are:
* [IoT Platform repo (evidence to avoid websockets)]
(https://github.com/semagarcia/t3chfest2017-iot-platform)
* [PoC with HTTP proposal modification and fetch implementation (app.service.ts)]
(https://github.com/semagarcia/angular-http-streaming)



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```


**Other information**:
The doc is not updated yet; I'd like to wait to feedback before to write the changes.
