### PR TITLE
fix(compiler-cli): set default format to xlf for serialize

### DIFF
--- a/packages/compiler-cli/src/extractor.ts
+++ b/packages/compiler-cli/src/extractor.ts
@@ -48,7 +48,7 @@ export class Extractor {
     return this.ngExtractor.extract(files);
   }
 
-  serialize(bundle: compiler.MessageBundle, formatName: string): string {
+  serialize(bundle: compiler.MessageBundle, formatName = 'xlf'): string {
     const format = formatName.toLowerCase();
     let serializer: compiler.Serializer;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
```
[x] Bugfix
```

**What is the current behavior?**
Fixes a regression introduced with the new XLIFF2 format. See #16235.


**What is the new behavior?**
Default format for this function is xlf


**Does this PR introduce a breaking change?**
```
[x] No
```