### PR TITLE
fix(aio): fix URL redirection for API pages

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -24,7 +24,7 @@
       {"type": 301, "source": "/docs/ts/latest/cookbook/:cookbook.html", "destination": "/guide/:cookbook"},
 
       // docs/ts/latest/api/*/index/*-type.html
-      {"type": 301, "source": "/docs/ts/latest/api/:package/index/:api-type.html", "destination": "/api/:package/:api"},
+      {"type": 301, "source": "/docs/ts/latest/api/:package/index/:api-*.html", "destination": "/api/:package/:api"},
 
       // guide/*, tutorial/*, **/*
       {"type": 301, "source": "/docs/ts/latest/:any*", "destination": "/:any*"}


### PR DESCRIPTION
I thought that the old API docs had a literal `-type` suffix, but it turns out `<type>` is actually a placeholder (can be `class`/`pipe`/`directive` etc).