### PR TITLE
WIP fix(forms): email validator should be usable on optional fields

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -80,6 +80,9 @@ export class Validators {
    * Validator that performs email validation.
    */
   static email(control: AbstractControl): ValidationErrors|null {
+    if (isEmptyInputValue(control.value)) {
+      return null;  // don't validate empty values to allow optional controls
+    }
     return EMAIL_REGEXP.test(control.value) ? null : {'email': true};
   }
 

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -917,13 +917,14 @@ export function main() {
 
       it('should validate email', fakeAsync(() => {
            const fixture = initTest(NgModelEmailValidator);
+           const input = fixture.debugElement.query(By.css('input'));
+           input.nativeElement.value = 'invalid-email';
            fixture.detectChanges();
            tick();
 
            const control =
                fixture.debugElement.children[0].injector.get(NgForm).control.get('email') !;
 
-           const input = fixture.debugElement.query(By.css('input'));
            expect(control.hasError('email')).toBe(false);
 
            fixture.componentInstance.validatorEnabled = true;

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -72,6 +72,12 @@ export function main() {
     });
 
     describe('email', () => {
+      it('should not error on an empty string',
+         () => { expect(Validators.email(new FormControl(''))).toBeNull(); });
+
+      it('should not error on null',
+         () => { expect(Validators.email(new FormControl(null))).toBeNull(); });
+
       it('should error on invalid email',
          () => expect(Validators.email(new FormControl('some text'))).toEqual({'email': true}));
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Validation with an email validator will fail if the field is left empty. It is not possible to use it on an optional email field.

**What is the new behavior?**

An empty email field will successfully pass the validation done by the email validator.

**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

**If this PR contains a breaking change, please describe the impact and migration path for existing applications:**

For email fields which are supposed to be mandatory, the required validator should be added in addition to the email validator.

**Other information**:

I am opening this PR to add consistency with other validators (minLength, pattern) which do a similar call to `isEmptyInputValue` before doing their own check so that it is possible to use them on optional fields.