### PR TITLE
fix(aio): AppComponent should scroll only once when location changes

### DIFF
--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -21,6 +21,7 @@ const sideNavView = 'SideNav';
 export class AppComponent implements OnInit {
 
   currentNode: CurrentNode;
+  currentPath: string;
   dtOn = false;
   pageId: string;
   currentDocument: DocumentContents;
@@ -76,8 +77,15 @@ export class AppComponent implements OnInit {
       this.setPageId(doc.id);
     });
 
-    // scroll even if only the hash fragment changed
-    this.locationService.currentUrl.subscribe(() => this.autoScroll());
+    this.locationService.currentPath.subscribe(path => {
+        if (this.currentPath && path === this.currentPath) {
+          // scroll only if on same page (most likely a change to the hash)
+          this.autoScroll();
+        } else {
+          // don't scroll; leave that to `onDocRendered`
+          this.currentPath = path;
+        }
+      });
 
     this.navigationService.currentNode.subscribe(currentNode => {
       this.currentNode = currentNode;
@@ -100,7 +108,7 @@ export class AppComponent implements OnInit {
     this.swUpdateNotifications.enable();
   }
 
-  // Scroll to the anchor in the hash fragment.
+  // Scroll to the anchor in the hash fragment or top of doc.
   autoScroll() {
     this.autoScrollService.scroll();
   }

--- a/aio/src/app/shared/location.service.ts
+++ b/aio/src/app/shared/location.service.ts
@@ -17,8 +17,9 @@ export class LocationService {
     .map(url => this.stripSlashes(url))
     .do(url => this.gaService.locationChanged(url))
     .publishReplay(1);
+
   currentPath = this.currentUrl
-    .map(url => url.match(/[^?#]*/)[0]);   // strip off query and hash
+    .map(url => url.match(/[^?#]*/)[0]); // strip query and hash
 
   constructor(
     private gaService: GaService,

--- a/aio/src/testing/location.service.ts
+++ b/aio/src/testing/location.service.ts
@@ -2,7 +2,8 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 export class MockLocationService {
   urlSubject = new BehaviorSubject<string>(this.initialUrl);
-  currentUrl = this.urlSubject.asObservable();
+  currentUrl = this.urlSubject.asObservable().map(url => this.stripSlashes(url));
+  // strip off query and hash
   currentPath = this.currentUrl.map(url => url.match(/[^?#]*/)[0]);
   search = jasmine.createSpy('search').and.returnValue({});
   setSearch = jasmine.createSpy('setSearch');
@@ -12,5 +13,9 @@ export class MockLocationService {
       .and.returnValue(false); // prevent click from causing a browser navigation
 
   constructor(private initialUrl) {}
+
+  private stripSlashes(url: string) {
+    return url.replace(/^\/+/, '').replace(/\/+(\?|#|$)/, '$1');
+  }
 }
 


### PR DESCRIPTION
Should scroll _either_ when the current page hash frag changes _or_ the page changes and the new doc has loaded ... _but not both_.

Was scrolling both times causing a noticeable and jarring jitter on doc page changes.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```
