### PR TITLE
docs(aio): correct abbreviation

### DIFF
--- a/aio/content/tutorial/toh-pt5.md
+++ b/aio/content/tutorial/toh-pt5.md
@@ -918,7 +918,7 @@ such as `RouterLink` and `RouterOutlet`.
 ### Update *AppModule*
 
 Delete the routing configuration from `AppModule` and import the `AppRoutingModule`.
-Use an ES `import` statement *and* add it to the `NgModule.imports` list.
+Use an ES2015 `import` statement *and* add it to the `NgModule.imports` list.
 
 Here is the revised `AppModule`, compared to its pre-refactor state:
 


### PR DESCRIPTION
change abbreviation from 'ES' to 'ES2015'. the 'ES2015' abbreviation is used elsewhere in the tutorial.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: Fix to documentation
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

