### PR TITLE
fix(aio): copy button placement fix

### DIFF
--- a/aio/src/styles/1-layouts/_sidenav.scss
+++ b/aio/src/styles/1-layouts/_sidenav.scss
@@ -83,7 +83,7 @@ md-sidenav-container div.mat-sidenav-content {
   width: 100%;
 }
 
-.mat-icon {
+.mat-icon, .material-icons {
   display: inline-block;
   position: absolute;
   top: 6px;


### PR DESCRIPTION
Added material-icons class back in that is used throughout codebase which previously renamed during SVG icon implementation

Closes https://github.com/angular/angular/issues/16292

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

