### PR TITLE
feat(aio): boilerplate:add cleans (removes) before adding

### DIFF
--- a/aio/tools/examples/add-example-boilerplate.js
+++ b/aio/tools/examples/add-example-boilerplate.js
@@ -30,6 +30,7 @@ const files = {
 
 // requires admin access because it adds symlinks
 function add() {
+  remove();
   const realPath = path.join(SHARED_PATH, '/node_modules');
   const nodeModulesPaths = getNodeModulesPaths(EXAMPLES_PATH);
 


### PR DESCRIPTION
`yarn boilerplate:add` cleans the example folders (as in `yarn boilerplate:remove`) before adding the boilerplate files and symlinks.

Small tool change. 