### PR TITLE
fix(compiler-cli): add fallback to xlf format to extractor

### DIFF
--- a/packages/compiler-cli/src/extractor.ts
+++ b/packages/compiler-cli/src/extractor.ts
@@ -49,6 +49,7 @@ export class Extractor {
   }
 
   serialize(bundle: compiler.MessageBundle, formatName: string): string {
+    formatName = formatName || 'xlf';
     const format = formatName.toLowerCase();
     let serializer: compiler.Serializer;
 

--- a/packages/compiler-cli/src/extractor.ts
+++ b/packages/compiler-cli/src/extractor.ts
@@ -49,7 +49,6 @@ export class Extractor {
   }
 
   serialize(bundle: compiler.MessageBundle, formatName: string): string {
-    formatName = formatName || 'xlf';
     const format = formatName.toLowerCase();
     let serializer: compiler.Serializer;
 

--- a/scripts/ci/offline_compiler_test.sh
+++ b/scripts/ci/offline_compiler_test.sh
@@ -57,6 +57,7 @@ cp -v package.json $TMP
 
   ./node_modules/.bin/ngc -p tsconfig-build.json --i18nFile=src/messages.fi.xlf --locale=fi --i18nFormat=xlf
 
+  ./node_modules/.bin/ng-xi18n -p tsconfig-xi18n.json --locale=fr
   ./node_modules/.bin/ng-xi18n -p tsconfig-xi18n.json --i18nFormat=xlf --locale=fr
   ./node_modules/.bin/ng-xi18n -p tsconfig-xi18n.json --i18nFormat=xlf2 --outFile=messages.xliff2.xlf
   ./node_modules/.bin/ng-xi18n -p tsconfig-xi18n.json --i18nFormat=xmb --outFile=custom_file.xmb

--- a/tools/@angular/tsc-wrapped/src/cli_options.ts
+++ b/tools/@angular/tsc-wrapped/src/cli_options.ts
@@ -15,7 +15,7 @@ export class I18nExtractionCliOptions extends CliOptions {
   locale: string|null;
   outFile: string|null;
 
-  constructor({i18nFormat = null, locale = null, outFile = null}: {
+  constructor({i18nFormat = 'xlf', locale = null, outFile = null}: {
     i18nFormat?: string,
     locale?: string,
     outFile?: string,


### PR DESCRIPTION
**What kind of change does this PR introduce?**
```
[x] Bugfix
```

**What is the current behavior?**
Running `./node_modules/.bin/ng-xi18n` to extract messages without the `--i18nFormat` parameter results in 
```
TypeError: Cannot read property 'toLowerCase' of null
    at Extractor.serialize (/.../node_modules/@angular/compiler-cli/src/extractor.js:46:32)
    at /.../node_modules/@angular/compiler-cli/src/extractor.js:32:33
    at process._tickCallback (internal/process/next_tick.js:109:7)
    at Module.runMain (module.js:606:11)
    at run (bootstrap_node.js:393:7)
    at startup (bootstrap_node.js:150:9)
    at bootstrap_node.js:508:3
Extraction failed
```


**What is the new behavior?**
Running `./node_modules/.bin/ng-xi18n` without a format works because it falls back to a default format of `xlf` as described in the Cookbook here: https://angular.io/docs/ts/latest/cookbook/i18n.html#!#ng-xi18n


**Does this PR introduce a breaking change?**
```
[x] No
```