### PR TITLE
build(aio): update dgeni-packages to 0.17.2

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -61,7 +61,7 @@
     "concurrently": "^3.4.0",
     "cross-spawn": "^5.1.0",
     "dgeni": "^0.4.7",
-    "dgeni-packages": "0.17.0",
+    "dgeni-packages": "^0.17.2",
     "entities": "^1.1.1",
     "eslint": "^3.19.0",
     "eslint-plugin-jasmine": "^2.2.0",

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -1802,9 +1802,9 @@ devtools-timeline-model@1.1.6:
     chrome-devtools-frontend "1.0.401423"
     resolve "1.1.7"
 
-dgeni-packages@0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.17.0.tgz#b2e5117670e99109f664703af26a460a5064d6cc"
+dgeni-packages@^0.17.2:
+  version "0.17.2"
+  resolved "https://registry.yarnpkg.com/dgeni-packages/-/dgeni-packages-0.17.2.tgz#45040d703a9f0497d18d3af1d92964bc042fe6b5"
   dependencies:
     canonical-path "0.0.2"
     catharsis "^0.8.1"


### PR DESCRIPTION
This version has fix for the jsdoc parser, which was
causing false negative warnings and errors in the doc
gen.

Closes #16319
