### PR TITLE
feat(compiler-cli): add i18n parameters to tsconfig

### DIFF
--- a/packages/compiler-cli/src/extract_i18n.ts
+++ b/packages/compiler-cli/src/extract_i18n.ts
@@ -22,8 +22,9 @@ import {Extractor} from './extractor';
 function extract(
     ngOptions: tsc.AngularCompilerOptions, cliOptions: tsc.I18nExtractionCliOptions,
     program: ts.Program, host: ts.CompilerHost): Promise<void> {
-  return Extractor.create(ngOptions, program, host, cliOptions.locale)
-      .extract(cliOptions.i18nFormat !, cliOptions.outFile);
+  const format = cliOptions.i18nFormat || ngOptions.i18nFormat || 'xlf';
+  const outFile = cliOptions.outFile || ngOptions.outFile || null;
+  return Extractor.create(ngOptions, program, host, cliOptions.locale).extract(format, outFile);
 }
 
 // Entry point

--- a/packages/compiler-cli/src/extractor.ts
+++ b/packages/compiler-cli/src/extractor.ts
@@ -49,7 +49,7 @@ export class Extractor {
   }
 
   serialize(bundle: compiler.MessageBundle, formatName: string): string {
-    const format = formatName.toLowerCase();
+    const format = (formatName || 'xlf').toLowerCase();
     let serializer: compiler.Serializer;
 
     switch (format) {
@@ -98,7 +98,8 @@ export class Extractor {
                                         new CompilerHost(program, options, context);
     }
 
-    const {extractor: ngExtractor} = compiler.Extractor.create(ngCompilerHost, locale || null);
+    const {extractor: ngExtractor} =
+        compiler.Extractor.create(ngCompilerHost, locale || options.locale || null);
 
     return new Extractor(options, ngExtractor, tsCompilerHost, ngCompilerHost, program);
   }

--- a/packages/compiler-cli/src/ngtools_api.ts
+++ b/packages/compiler-cli/src/ngtools_api.ts
@@ -150,6 +150,6 @@ export class NgTools_InternalApi_NG_2 {
     const extractor = Extractor.create(
         options.angularCompilerOptions, options.program, options.host, locale, hostContext);
 
-    return extractor.extract(options.i18nFormat !, options.outFile || null);
+    return extractor.extract(options.i18nFormat || 'xlf', options.outFile || null);
   }
 }

--- a/tools/@angular/tsc-wrapped/src/options.ts
+++ b/tools/@angular/tsc-wrapped/src/options.ts
@@ -81,6 +81,27 @@ interface Options extends ts.CompilerOptions {
 
   // Whether to enable support for <template> and the template attribute (true by default)
   enableLegacyTemplate?: boolean;
+
+  // format for extracted messages file (xlf, xlf2, xmb)
+  i18nFormat?: string;
+
+  // locale of your application for extracted messages file
+  locale?: string;
+
+  // path & name for the extracted messages file
+  outFile?: string;
+
+  // format for imported translation files (xlf, xlf2, xtb)
+  i18nTranslationFormat?: string;
+
+  // locale for imported translation files
+  translationLocale?: string;
+
+  // path & name of your translations file
+  i18nFile?: string;
+
+  // strategy to use for missing translations (error, warning or ignore)
+  missingTranslation?: string;
 }
 
 export default Options;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
```
[x] Feature
```

**What is the current behavior?** (You can also link to an open issue here)
Right now you cannot add existing i18n parameters to tsconfig, see issue #16232


**What is the new behavior?**
You can now add parameters to your tsconfig that will be used when you don't provide cli parameters. It works with ng-xi18n and ngc. Since they both have some parameters with a similar name, those options in tsconfig have a slightly different name compared to the cli parameters (with the prefix source for ng-xi18n and the prefix target for ngc).


**Does this PR introduce a breaking change?** (check one with "x")
```
[x] No
```