### PR TITLE
fix(http): flatten metadata for @angular/http/testing

### DIFF
--- a/packages/http/testing/public_api.ts
+++ b/packages/http/testing/public_api.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * @module
+ * @description
+ * Entry point for all public APIs of the http testing package.
+ */
+export * from './src/testing';

--- a/packages/http/testing/tsconfig-build.json
+++ b/packages/http/testing/tsconfig-build.json
@@ -8,9 +8,12 @@
     }
   },
   "files": [
-    "index.ts"
+    "public_api.ts"
   ],
   "angularCompilerOptions": {
-    "strictMetadataEmit": true
+    "annotateForClosureCompiler": true,
+    "strictMetadataEmit": true,
+    "flatModuleOutFile": "index.js",
+    "flatModuleId": "@angular/http/testing"
   }
 }


### PR DESCRIPTION
@angular/http/testing used to publish a metadata structure which paralleled
the .d.ts structure. This causes ngc to write incorrect imports for this
bundle when compiling providers using MockBackend and other http testing
classes.

This change restructures the @angular/http/testing build a bit, modeling it
after @angular/platform-browser-animations, and produces a FESM structure
that has flat metadata.

Fixes #15521.