### PR TITLE
docs(aio): fix broken NgModules link in tutorial

### DIFF
--- a/aio/content/tutorial/toh-pt3.md
+++ b/aio/content/tutorial/toh-pt3.md
@@ -276,7 +276,7 @@ This module declares only the two application components, `AppComponent` and `He
 
 
 
-Read more about Angular modules in the [NgModules](guide/ngmodule "Angular Modules (NgModule)") guide.
+Read more about Angular modules in the [NgModules](guide/ngmodule "Angular Modules") guide.
 
 
 </div>


### PR DESCRIPTION
Brackets included in link title contents were breaking markdown parsing, preventing correct link generation.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Current markdown is being rendered as a link to `https://angular.io/docs/ts/latest/guide/ngmodule.html%20%22Angular%20Modules%20(NgModule`.


**What is the new behavior?**
Markdown will render to a link to `https://angular.io/docs/ts/latest/guide/ngmodule.html` with the title text `Angular Modules`.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

