### PR TITLE
docs(aio): grammatical fix. remove duplicate word 'our'

### DIFF
--- a/aio/content/guide/upgrade.md
+++ b/aio/content/guide/upgrade.md
@@ -1816,7 +1816,7 @@ load every file in our AngularJS app to use ES6 modules in order to ensure Angul
 loaded correctly.
 
 This is a considerable effort and it often isn't worth it, especially since we are in the
-process of moving our our to Angular already.
+process of moving our code to Angular.
 Instead we declare `angular` as `angular.IAngularStatic` to indicate it is a global variable
 and still have full typing support.
 


### PR DESCRIPTION
I messed up #16345 while rebasing (and now that it is closed, I can't force-push any more).
Re-applying the changes here.