### PR TITLE
ci(language-service): update ci tests to official 2.3 build

### DIFF
--- a/integration/language_service_plugin/typescripts/2.3/package.json
+++ b/integration/language_service_plugin/typescripts/2.3/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "typescript": "2.3.0-dev.20170223"
+    "typescript": "2.3.0"
   }
 }

--- a/integration/language_service_plugin/typescripts/2.3/yarn.lock
+++ b/integration/language_service_plugin/typescripts/2.3/yarn.lock
@@ -2,6 +2,6 @@
 # yarn lockfile v1
 
 
-typescript@2.3.0-dev.20170223:
-  version "2.3.0-dev.20170223"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.0-dev.20170223.tgz#286494c36625ea2eb26f963ed205cd9ca5c41447"
+typescript@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.0.tgz#2e63e09284392bc8158a2444c33e2093795c0418"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] CI related changes
```

**What is the current behavior?** (You can also link to an open issue here)

The language service integration test tests against TypeScript 2.3.0-dev.20170223

**What is the new behavior?**

The language service integration test tests against the released 2.3.0 of TypeScript.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
