### PR TITLE
fix(http): introduce encodingHint for text() for better ArrayBuffer support

### DIFF
--- a/packages/http/src/http_utils.ts
+++ b/packages/http/src/http_utils.ts
@@ -42,6 +42,15 @@ export function getResponseURL(xhr: any): string|null {
   return null;
 }
 
+export function stringToArrayBuffer8(input: String): ArrayBuffer {
+  const view = new Uint8Array(input.length);
+  for (let i = 0, strLen = input.length; i < strLen; i++) {
+    view[i] = input.charCodeAt(i);
+  }
+  return view.buffer;
+}
+
+
 export function stringToArrayBuffer(input: String): ArrayBuffer {
   const view = new Uint16Array(input.length);
   for (let i = 0, strLen = input.length; i < strLen; i++) {

--- a/packages/http/src/static_request.ts
+++ b/packages/http/src/static_request.ts
@@ -167,4 +167,5 @@ const noop = function() {};
 const w = typeof window == 'object' ? window : noop;
 const FormData = (w as any /** TODO #9100 */)['FormData'] || noop;
 const Blob = (w as any /** TODO #9100 */)['Blob'] || noop;
-export const ArrayBuffer = (w as any /** TODO #9100 */)['ArrayBuffer'] || noop;
+export const ArrayBuffer: ArrayBufferConstructor =
+    (w as any /** TODO #9100 */)['ArrayBuffer'] || noop;

--- a/packages/http/test/static_request_spec.ts
+++ b/packages/http/test/static_request_spec.ts
@@ -7,10 +7,12 @@
  */
 
 import {describe, expect, it} from '@angular/core/testing/src/testing_internal';
+import {ɵgetDOM as getDOM} from '@angular/platform-browser';
 
 import {RequestOptions} from '../src/base_request_options';
 import {ContentType} from '../src/enums';
 import {Headers} from '../src/headers';
+import {stringToArrayBuffer, stringToArrayBuffer8} from '../src/http_utils';
 import {ArrayBuffer, Request} from '../src/static_request';
 
 export function main() {
@@ -109,5 +111,18 @@ export function main() {
 
       expect(req.text()).toEqual('');
     });
+
+    if (getDOM().supportsWebAnimation()) {
+      it('should serialize an ArrayBuffer to string via legacy encoding', () => {
+        const str = '\u89d2\u5ea6';
+        expect(new Request({body: stringToArrayBuffer(str), url: '/'}).text()).toEqual(str);
+      });
+
+      it('should serialize an ArrayBuffer to string via iso-8859 encoding', () => {
+        const str = 'abcd';
+        expect(new Request({body: stringToArrayBuffer8(str), url: '/'}).text('iso-8859'))
+            .toEqual(str);
+      });
+    }
   });
 }


### PR DESCRIPTION
Currently, if a Response has an ArrayBuffer body and text() is called, Angular
attempts to convert the ArrayBuffer to a string. Doing this requires knowing
the encoding of the bytes in the buffer, which is context that we don't have.

Instead, we assume that the buffer is encoded in UTF-16, and attempt to process
it that way. Unfortunately the approach chosen (interpret buffer as Uint16Array and
create a Javascript string from each entry using String.fromCharCode) is incorrect
as it does not handle UTF-16 surrogate pairs. What Angular actually implements, then,
is UCS-2 decoding, which is equivalent to UTF-16 with characters restricted to the
base plane.

No standard way of decoding UTF-8 or UTF-16 exists in the browser today. APIs like
TextDecoder are only supported in a few browsers, and although hacks like using the
FileReader API with a Blob to force browsers to do content encoding detection and
decoding exist, they're slow and not compatible with the synchronous text() API.

Thus, this bug is fixed by introducing an encodingHint parameter to text(). The
default value of this parameter is 'legacy', indicating that the existing broken
behavior should be used - this prevents breaking existing apps. The only other
possible value of the hint is 'iso-8859' which interprets each byte of the buffer
with String.fromCharCode. UTF-8 and UTF-16 are not supported - it is up to the
consumer to get the ArrayBuffer and decode it themselves.

The parameter is a hint, as it's not always used (for example, if the conversion
to text doesn't involve an ArrayBuffer source). Additionally, this leaves the door
open for future implementations to perform more sophisticated encoding detection
and ignore the user-provided value if it can be proven to be incorrect.

Fixes #15932.