### PR TITLE
fix(language-service): remove asserts for non-null expressions

### DIFF
--- a/packages/language-service/src/ast_path.ts
+++ b/packages/language-service/src/ast_path.ts
@@ -13,7 +13,9 @@ export class AstPath<T> {
   get head(): T|undefined { return this.path[0]; }
   get tail(): T|undefined { return this.path[this.path.length - 1]; }
 
-  parentOf(node: T): T|undefined { return this.path[this.path.indexOf(node) - 1]; }
+  parentOf(node: T|undefined): T|undefined {
+    return node && this.path[this.path.indexOf(node) - 1];
+  }
   childOf(node: T): T|undefined { return this.path[this.path.indexOf(node) + 1]; }
 
   first<N extends T>(ctor: {new (...args: any[]): N}): N|undefined {

--- a/packages/language-service/src/reflector_host.ts
+++ b/packages/language-service/src/reflector_host.ts
@@ -22,18 +22,24 @@ class ReflectorModuleModuleResolutionHost implements ts.ModuleResolutionHost {
     if (snapshot) {
       return snapshot.getText(0, snapshot.getLength());
     }
+
+    // Typescript readFile() declaration should be `readFile(fileName: string): string | undefined
     return undefined !;
   }
 
   directoryExists: (directoryName: string) => boolean;
 }
 
+// This reflector host's purpose is to first set verboseInvalidExpressions to true so the
+// reflector will collect errors instead of throwing, and second to all deferring the creation
+// of the program until it is actually needed.
 export class ReflectorHost extends CompilerHost {
   constructor(
       private getProgram: () => ts.Program, serviceHost: ts.LanguageServiceHost,
       options: AngularCompilerOptions) {
     super(
-        null !, options,
+        // The ancestor value for program is overridden below so passing null here is safe.
+        /* program */ null !, options,
         new ModuleResolutionHostAdapter(new ReflectorModuleModuleResolutionHost(serviceHost)),
         {verboseInvalidExpression: true});
   }

--- a/packages/language-service/src/template_path.ts
+++ b/packages/language-service/src/template_path.ts
@@ -104,10 +104,10 @@ class TemplateAstPathBuilder extends TemplateAstChildVisitor {
   constructor(private position: number, private allowWidening: boolean) { super(); }
 
   visit(ast: TemplateAst, context: any): any {
-    let span = spanOf(ast) !;
+    let span = spanOf(ast);
     if (inSpan(this.position, span)) {
       const len = this.path.length;
-      if (!len || this.allowWidening || isNarrower(span, spanOf(this.path[len - 1]) !)) {
+      if (!len || this.allowWidening || isNarrower(span, spanOf(this.path[len - 1]))) {
         this.path.push(ast);
       }
     } else {

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -25,14 +25,16 @@ export function create(info: any /* ts.server.PluginCreateInfo */): ts.LanguageS
   }
 
   function diagnosticToDiagnostic(d: Diagnostic, file: ts.SourceFile): ts.Diagnostic {
-    return {
+    const result = {
       file,
       start: d.span.start,
       length: d.span.end - d.span.start,
       messageText: d.message,
       category: ts.DiagnosticCategory.Error,
-      code: 0
+      code: 0,
+      source: 'ng'
     };
+    return result;
   }
 
   function tryOperation(attempting: string, callback: () => void) {
@@ -78,7 +80,7 @@ export function create(info: any /* ts.server.PluginCreateInfo */): ts.LanguageS
       if (ours) {
         const displayParts: typeof base.displayParts = [];
         for (const part of ours.text) {
-          displayParts.push({kind: part.language !, text: part.text});
+          displayParts.push({kind: part.language || 'angular', text: part.text});
         }
         base = <any>{
           displayParts,

--- a/packages/language-service/src/types.ts
+++ b/packages/language-service/src/types.ts
@@ -8,8 +8,6 @@
 
 import {CompileDirectiveMetadata, CompileMetadataResolver, NgAnalyzedModules, StaticSymbol} from '@angular/compiler';
 
-
-
 /**
  * The range of a span of text in a source file.
  *
@@ -455,7 +453,7 @@ export interface LanguageServiceHost {
    * refers to a template file then the `position` should be ignored. If the `position` is not in a
    * template literal string then this method should return `undefined`.
    */
-  getTemplateAt(fileName: string, position: number): TemplateSource /* |undefined */;
+  getTemplateAt(fileName: string, position: number): TemplateSource|undefined;
 
   /**
    * Return the template source information for all templates in `fileName` or for `fileName` if it

--- a/packages/language-service/src/utils.ts
+++ b/packages/language-service/src/utils.ts
@@ -21,6 +21,9 @@ export function isParseSourceSpan(value: any): value is ParseSourceSpan {
   return value && !!value.start;
 }
 
+export function spanOf(span: SpanHolder): Span;
+export function spanOf(span: ParseSourceSpan): Span;
+export function spanOf(span: SpanHolder | ParseSourceSpan | undefined): Span|undefined;
 export function spanOf(span?: SpanHolder | ParseSourceSpan): Span|undefined {
   if (!span) return undefined;
   if (isParseSourceSpan(span)) {
@@ -39,8 +42,8 @@ export function spanOf(span?: SpanHolder | ParseSourceSpan): Span|undefined {
 }
 
 export function inSpan(position: number, span?: Span, exclusive?: boolean): boolean {
-  return span && exclusive ? position >= span.start && position < span.end :
-                             position >= span !.start && position <= span !.end;
+  return span != null && (exclusive ? position >= span.start && position < span.end :
+                                      position >= span.start && position <= span.end);
 }
 
 export function offsetSpan(span: Span, amount: number): Span {
@@ -54,7 +57,8 @@ export function isNarrower(spanA: Span, spanB: Span): boolean {
 export function hasTemplateReference(type: CompileTypeMetadata): boolean {
   if (type.diDeps) {
     for (let diDep of type.diDeps) {
-      if (diDep.token !.identifier && identifierName(diDep.token !.identifier !) == 'TemplateRef')
+      if (diDep.token && diDep.token.identifier &&
+          identifierName(diDep.token !.identifier !) == 'TemplateRef')
         return true;
     }
   }


### PR DESCRIPTION
Reworked some of the code so asserts are no longer necessary.
Added additional and potentially redundant checks
Added checks where the null checker found real problems.


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

Language service used postfix '!' to avoid struct null checking errors.

**What is the new behavior?**

Removed most of the postfix '!' as described above.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
