### PR TITLE
fix(router): prevent routerOutlet from extra changeDetections

### DIFF
--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -76,7 +76,7 @@ export class RouterOutlet implements OnDestroy {
     return r;
   }
 
-  attach(ref: ComponentRef<any>, activatedRoute: ActivatedRoute) {
+  attach(ref: ComponentRef<any>, activatedRoute: ActivatedRoute): void {
     this.activated = ref;
     this._activatedRoute = activatedRoute;
     this.location.insert(ref.hostView);
@@ -117,7 +117,7 @@ export class RouterOutlet implements OnDestroy {
 
   activateWith(
       activatedRoute: ActivatedRoute, resolver: ComponentFactoryResolver|null,
-      outletMap: RouterOutletMap) {
+      outletMap: RouterOutletMap): void {
     if (this.isActivated) {
       throw new Error('Cannot activate an already activated outlet');
     }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -25,12 +25,11 @@ import {applyRedirects} from './apply_redirects';
 import {LoadedRouterConfig, QueryParamsHandling, ResolveData, Route, Routes, RunGuardsAndResolvers, validateConfig} from './config';
 import {createRouterState} from './create_router_state';
 import {createUrlTree} from './create_url_tree';
-import {RouterOutlet} from './directives/router_outlet';
 import {Event, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, RouteConfigLoadEnd, RouteConfigLoadStart, RoutesRecognized} from './events';
 import {recognize} from './recognize';
 import {DetachedRouteHandle, DetachedRouteHandleInternal, RouteReuseStrategy} from './route_reuse_strategy';
 import {RouterConfigLoader} from './router_config_loader';
-import {RouterOutletMap} from './router_outlet_map';
+import {RouterOutletMap, IRouterOutlet} from './router_outlet_map';
 import {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot, advanceActivatedRoute, createEmptyState, equalParamsAndUrlSegments, inheritedParamsDataResolve} from './router_state';
 import {PRIMARY_OUTLET, Params, isNavigationCancelingError} from './shared';
 import {DefaultUrlHandlingStrategy, UrlHandlingStrategy} from './url_handling_strategy';
@@ -880,7 +879,7 @@ export class PreActivation {
   }
 
   private deactiveRouteAndItsChildren(
-      route: TreeNode<ActivatedRouteSnapshot>, outlet: RouterOutlet|null): void {
+      route: TreeNode<ActivatedRouteSnapshot>, outlet: IRouterOutlet|null): void {
     const prevChildren = nodeChildrenAsMap(route);
     const r = route.value;
 
@@ -1111,7 +1110,7 @@ class ActivateRoutes {
   }
 
   private placeComponentIntoOutlet(
-      outletMap: RouterOutletMap, future: ActivatedRoute, outlet: RouterOutlet): void {
+      outletMap: RouterOutletMap, future: ActivatedRoute, outlet: IRouterOutlet): void {
     const config = parentLoadedConfig(future.snapshot);
     const cmpFactoryResolver = config ? config.module.componentFactoryResolver : null;
 
@@ -1137,7 +1136,7 @@ class ActivateRoutes {
   private deactiveRouteAndOutlet(route: TreeNode<ActivatedRoute>, parentOutletMap: RouterOutletMap):
       void {
     const prevChildren: {[key: string]: any} = nodeChildrenAsMap(route);
-    let outlet: RouterOutlet|null = null;
+    let outlet: IRouterOutlet|null = null;
 
     // getOutlet throws when cannot find the right outlet,
     // which can happen if an outlet was in an NgIf and was removed
@@ -1198,17 +1197,8 @@ function nodeChildrenAsMap<T extends{outlet: string}>(node: TreeNode<T>| null) {
   return map;
 }
 
-function getOutlet(outletMap: RouterOutletMap, route: ActivatedRoute): RouterOutlet {
-  const outlet = outletMap._outlets[route.outlet];
-  if (!outlet) {
-    const componentName = (<any>route.component).name;
-    if (route.outlet === PRIMARY_OUTLET) {
-      throw new Error(`Cannot find primary outlet to load '${componentName}'`);
-    } else {
-      throw new Error(`Cannot find the outlet ${route.outlet} to load '${componentName}'`);
-    }
-  }
-  return outlet;
+function getOutlet(outletMap: RouterOutletMap, route: ActivatedRoute): IRouterOutlet {
+  return outletMap._getOutlet(route.outlet);
 }
 
 function validateCommands(commands: string[]): void {

--- a/packages/router/src/router_outlet_map.ts
+++ b/packages/router/src/router_outlet_map.ts
@@ -6,7 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ComponentRef, ComponentFactoryResolver} from '@angular/core';
 import {RouterOutlet} from './directives/router_outlet';
+import {ActivatedRoute} from './router_state';
+
 
 /**
  * @whatItDoes Contains all the router outlets created in a component.
@@ -15,15 +18,86 @@ import {RouterOutlet} from './directives/router_outlet';
  */
 export class RouterOutletMap {
   /** @internal */
-  _outlets: {[name: string]: RouterOutlet} = {};
+  _outlets: {[name: string]: ProxyRouterOutlet} = {};
 
   /**
    * Adds an outlet to this map.
    */
-  registerOutlet(name: string, outlet: RouterOutlet): void { this._outlets[name] = outlet; }
+  registerOutlet(name: string, outlet: RouterOutlet): void {
+    let proxyOutlet = this._outlets[name];
+    if (proxyOutlet) {
+      proxyOutlet.setOutlet(outlet);
+    } else {
+      this._outlets[name] = new ProxyRouterOutlet(name, this, outlet);
+    }
+  }
 
   /**
    * Removes an outlet from this map.
    */
   removeOutlet(name: string): void { this._outlets[name] = undefined !; }
+
+  /** @internal */
+  _getOutlet(name: string): IRouterOutlet {
+    let outlet = this._outlets[name];
+    if (!outlet) {
+      outlet = this._outlets[name] = new ProxyRouterOutlet(name, this, null);
+    }
+    return outlet;
+  }
+}
+
+export interface IRouterOutlet {
+  readonly isActivated: boolean;
+  readonly component: any;
+  readonly outletMap: RouterOutletMap;
+
+  activateWith(
+    activatedRoute: ActivatedRoute, resolver: ComponentFactoryResolver|null,
+    outletMap: RouterOutletMap): void;
+  deactivate(): void;
+  attach(ref: ComponentRef<any>, activatedRoute: ActivatedRoute): void;
+  detach(): ComponentRef<any>;
+}
+
+export class ProxyRouterOutlet implements IRouterOutlet {
+  delayApplys: Array<(delegate: IRouterOutlet) => void> = [];
+
+  get isActivated(): boolean {
+    return this.delegate!.isActivated;
+  };
+  get component(): any {
+    return this.delegate!.component;
+  }
+
+  constructor(public name: string, public outletMap: RouterOutletMap, private delegate: IRouterOutlet|null) {
+  }
+
+  setOutlet(delegate: IRouterOutlet): void {
+    this.delegate = delegate;
+    this.delayApplys.forEach((fn) => fn(delegate));
+  }
+
+  apply(applyFn: (delegate: IRouterOutlet) => void) {
+    this.delegate ? applyFn(this.delegate) : this.delayApplys.push(applyFn);
+  }
+
+  activateWith(
+    activatedRoute: ActivatedRoute, resolver: ComponentFactoryResolver|null,
+    outletMap: RouterOutletMap): void {
+    this.apply((delegate: IRouterOutlet) => delegate.activateWith(activatedRoute, resolver, outletMap));
+  }
+
+  deactivate(): void {
+    this.apply((delegate: IRouterOutlet) => delegate.deactivate());
+  }
+
+  attach(ref: ComponentRef<any>, activatedRoute: ActivatedRoute): void {
+    return this.delegate!.attach(ref, activatedRoute);
+  }
+
+  detach(): ComponentRef<any> {
+    return this.delegate!.detach();
+  }
+
 }


### PR DESCRIPTION
Currently router performs change detection eagerly on component when the component is assigned to RouterOutlet. Another change detection is than performed globally. This double change detection presents a problem for animations.