### PR TITLE
feat(aio): add tooltip to nav node if none specified

### DIFF
--- a/aio/src/app/navigation/navigation.service.spec.ts
+++ b/aio/src/app/navigation/navigation.service.spec.ts
@@ -80,20 +80,54 @@ describe('NavigationService', () => {
     it('should do WHAT(?) if the request fails');
   });
 
+  describe('node.tooltip', () => {
+    let view: NavigationNode[];
+
+    const sideNav: NavigationNode[] = [
+      { title: 'a', tooltip: 'a tip' },
+      { title: 'b' },
+      { title: 'c!'},
+      { url: 'foo' }
+    ];
+
+    beforeEach(() => {
+      navService.navigationViews.subscribe(views => view = views.sideNav);
+      backend.connectionsArray[0].mockRespond(createResponse({sideNav}));
+    });
+
+    it('should have the supplied tooltip', () => {
+      expect(view[0].tooltip).toEqual('a tip');
+    });
+
+    it('should create a tooltip from title + period', () => {
+      expect(view[1].tooltip).toEqual('b.');
+    });
+
+    it('should create a tooltip from title, keeping its trailing punctuation', () => {
+      expect(view[2].tooltip).toEqual('c!');
+    });
+
+    it('should not create a tooltip if there is no title', () => {
+      expect(view[3].tooltip).toBeUndefined();
+    });
+  });
+
   describe('currentNode', () => {
     let currentNode: CurrentNode;
     let locationService: MockLocationService;
 
-    const topBarNodes: NavigationNode[] = [{ url: 'features', title: 'Features' }];
+    const topBarNodes: NavigationNode[] = [
+      { url: 'features', title: 'Features', tooltip: 'tip' }
+    ];
     const sideNavNodes: NavigationNode[] = [
-        { title: 'a', children: [
-          { url: 'b', title: 'b', children: [
-            { url: 'c', title: 'c' },
-            { url: 'd', title: 'd' }
+        { title: 'a', tooltip: 'tip', children: [
+          { url: 'b', title: 'b', tooltip: 'tip', children: [
+            { url: 'c', title: 'c', tooltip: 'tip' },
+            { url: 'd', title: 'd', tooltip: 'tip' }
           ] },
-          { url: 'e', title: 'e' }
+          { url: 'e', title: 'e', tooltip: 'tip' }
         ] },
-        { url: 'f', title: 'f' }
+        { url: 'f', title: 'f', tooltip: 'tip' }
       ];
 
     const navJson = {
@@ -199,6 +233,7 @@ describe('NavigationService', () => {
   describe('docVersions', () => {
     let actualDocVersions: NavigationNode[];
     let docVersions: NavigationNode[];
+    let expectedDocVersions: NavigationNode[];
 
     beforeEach(() => {
       actualDocVersions = [];
@@ -207,12 +242,16 @@ describe('NavigationService', () => {
         { title: 'v2', url: 'https://v2.angular.io' }
       ];
 
+      expectedDocVersions = docVersions.map(v => (
+        {...v, ...{ tooltip: v.title + '.'}})
+      );
+
       navService.navigationViews.subscribe(views => actualDocVersions = views.docVersions);
     });
 
     it('should extract the docVersions', () => {
       backend.connectionsArray[0].mockRespond(createResponse({ docVersions }));
-      expect(actualDocVersions).toEqual(docVersions);
+      expect(actualDocVersions).toEqual(expectedDocVersions);
     });
   });
 });


### PR DESCRIPTION
Creating a default tooltip from the node title saves duplicated effort while maintaining `navigation.json` by hand. Discovered the value while splitting Router guide into 9 separate pages.

<hr>

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```