### PR TITLE
fix(compiler-cli):the type of moduleMetadata.imports is ModuleWithPro…

### DIFF
--- a/packages/compiler-cli/src/ngtools_impl.ts
+++ b/packages/compiler-cli/src/ngtools_impl.ts
@@ -150,7 +150,11 @@ function _extractLazyRoutesFromStaticModule(
       }, []);
 
   const importedSymbols = ((moduleMetadata.imports || []) as any[])
-                              .filter(i => i instanceof StaticSymbol) as StaticSymbol[];
+                              .filter(i => i instanceof StaticSymbol || i.ngModule instanceof StaticSymbol)
+                              .map(i => {
+                                if(i instanceof StaticSymbol) return i;
+                                if(i.ngModule instanceof StaticSymbol) return i.ngModule;
+                              }) as StaticSymbol[];
 
   return importedSymbols
       .reduce(


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

if use forRoot with AppRoutingModule like this, it can't generate lazy routes chunks when building:
```
@NgModule({
  imports: [
    BrowserModule,
    AppRoutingModule.forRoot()
  ],
  declarations: [AppComponent],
  bootstrap: [AppComponent]
})
export class AppModule {
}
```
**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[*] No
```

