### PR TITLE
build(aio): improve info-bar template

### DIFF
--- a/aio/tools/transforms/templates/includes/_info-bar.html
+++ b/aio/tools/transforms/templates/includes/_info-bar.html
@@ -3,12 +3,14 @@
 <!-- INFO BAR -->
 <div class="info-banner api-info-bar">
   <span class="info-bar-item">
-    npm package: <a href="#">{$ doc.package $}</a>
+    npm package: <code>@angular/{$ doc.moduleDoc.id $}</code>
   </span>
 
+  {% if doc.ngModule %}
   <span class="info-bar-item">
-    NgModule: <a href="#">{$ doc.moduleDoc.name $}</a>
+    NgModule: {@link {$ doc.ngModule $}}
   </span>
+  {% endif %}
 
   <span class="info-bar-item">
     {$ github.githubViewLink(doc, versionInfo) $}


### PR DESCRIPTION
The "npm module" and "NgModule" are now rendered correctly.

Closes #16055
