### PR TITLE
feat(aio): search results - show top 5 results and API icons

### DIFF
--- a/aio/src/app/search/search-results/search-results.component.html
+++ b/aio/src/app/search/search-results/search-results.component.html
@@ -2,13 +2,19 @@
   <h2 class="visually-hidden">Search Results</h2>
   <div class="search-area" *ngFor="let area of searchAreas | async">
     <h3>{{area.name}} ({{area.pages.length}})</h3>
-    <ul>
+    <ul class="priority-pages" >
       <li class="search-page" *ngFor="let page of area.priorityPages">
-        <a class="search-result-item" href="{{ page.path }}" (click)="onResultSelected(page)">{{ page.title }}</a>
+        <a class="search-result-item" href="{{ page.path }}" (click)="onResultSelected(page)">
+          <span class="symbol {{page.type}}" *ngIf="area.name === 'api'"></span>{{ page.title }}
+        </a>
       </li>
-      <li *ngIf="area.priorityPages.length"><hr></li>
+    </ul>
+    <div class="more-items material-icons" *ngIf="area.priorityPages.length > 0">more_horiz</div>
+    <ul>
       <li class="search-page" *ngFor="let page of area.pages">
-        <a class="search-result-item" href="{{ page.path }}" (click)="onResultSelected(page)">{{ page.title }}</a>
+        <a class="search-result-item" href="{{ page.path }}" (click)="onResultSelected(page)">
+          <span class="symbol {{page.type}}" *ngIf="area.name === 'api'"></span>{{ page.title }}
+        </a>
       </li>
     </ul>
   </div>

--- a/aio/src/app/search/search-results/search-results.component.html
+++ b/aio/src/app/search/search-results/search-results.component.html
@@ -1,8 +1,12 @@
 <div class="search-results" *ngIf="hasAreas | async" >
   <h2 class="visually-hidden">Search Results</h2>
   <div class="search-area" *ngFor="let area of searchAreas | async">
-    <h3>{{area.name}}</h3>
+    <h3>{{area.name}} ({{area.pages.length}})</h3>
     <ul>
+      <li class="search-page" *ngFor="let page of area.priorityPages">
+        <a class="search-result-item" href="{{ page.path }}" (click)="onResultSelected(page)">{{ page.title }}</a>
+      </li>
+      <li *ngIf="area.priorityPages.length"><hr></li>
       <li class="search-page" *ngFor="let page of area.pages">
         <a class="search-result-item" href="{{ page.path }}" (click)="onResultSelected(page)">{{ page.title }}</a>
       </li>

--- a/aio/src/app/search/search-results/search-results.component.spec.ts
+++ b/aio/src/app/search/search-results/search-results.component.spec.ts
@@ -19,10 +19,10 @@ describe('SearchResultsComponent', () => {
   /** Get a full set of test results. "Take" what you need */
   function getTestResults(take?: number) {
     const results: SearchResult[] = [
-      { path: 'guide/a', title: 'Guide A'},
-      { path: 'api/d', title: 'API D'},
+      { path: 'guide/a', title: 'Guide A' },
+      { path: 'api/d', title: 'API D' },
       { path: 'guide/b', title: 'Guide B' },
-      { path: 'guide/a/c', title: 'Guide A - C'},
+      { path: 'guide/a/c', title: 'Guide A - C' },
       { path: 'api/c', title: 'API C' }
     ]
     // fill it out to exceed 10 guide pages
@@ -30,7 +30,7 @@ describe('SearchResultsComponent', () => {
       return { path: 'guide/' + l, title: 'Guide ' + l};
     }))
     // add these empty fields to satisfy interface
-    .map(r => ({...r, ...{ keywords: '', titleWords: '', type: '' }}));
+    .map(r => ({...{ keywords: '', titleWords: '', type: '' }, ...r }));
 
     return take === undefined ? results : results.slice(0, take);
   }
@@ -75,13 +75,13 @@ describe('SearchResultsComponent', () => {
 
     expect(currentAreas).toEqual([
       { name: 'api', pages: [
-        {path: 'api/c', title: 'API C', type: '', keywords: '', titleWords: '' },
-        {path: 'api/d', title: 'API D', type: '', keywords: '', titleWords: '' },
+        { path: 'api/c', title: 'API C', type: '', keywords: '', titleWords: '' },
+        { path: 'api/d', title: 'API D', type: '', keywords: '', titleWords: '' },
       ], priorityPages: [] },
       { name: 'guide', pages: [
-        {path: 'guide/a', title: 'Guide A',       type: '', keywords: '', titleWords: '' },
-        {path: 'guide/a/c', title: 'Guide A - C', type: '', keywords: '', titleWords: '' },
-        {path: 'guide/b', title: 'Guide B',       type: '', keywords: '', titleWords: '' },
+        { path: 'guide/a', title: 'Guide A',       type: '', keywords: '', titleWords: '' },
+        { path: 'guide/a/c', title: 'Guide A - C', type: '', keywords: '', titleWords: '' },
+        { path: 'guide/b', title: 'Guide B',       type: '', keywords: '', titleWords: '' },
       ], priorityPages: [] }
     ]);
   });
@@ -108,7 +108,7 @@ describe('SearchResultsComponent', () => {
 
   it('should put search results with no containing folder into the default area (other)', () => {
     const results = [
-      {path: 'news', title: 'News', type: 'marketing', keywords: '', titleWords: '' }
+      { path: 'news', title: 'News', type: 'marketing', keywords: '', titleWords: '' }
     ];
 
     searchResults.next({ query: '', results: results });
@@ -121,7 +121,7 @@ describe('SearchResultsComponent', () => {
 
   it('should omit search results with no title', () => {
     const results = [
-      {path: 'news', title: undefined, type: 'marketing', keywords: '', titleWords: '' }
+      { path: 'news', title: undefined, type: 'marketing', keywords: '', titleWords: '' }
     ];
 
     searchResults.next({ query: '', results: results });
@@ -132,7 +132,7 @@ describe('SearchResultsComponent', () => {
     let selectedResult: SearchResult;
     component.resultSelected.subscribe((result: SearchResult) => selectedResult = result);
     const results = [
-      {path: 'news', title: 'News', type: 'marketing', keywords: '', titleWords: '' }
+      { path: 'news', title: 'News', type: 'marketing', keywords: '', titleWords: '' }
     ];
 
     searchResults.next({ query: '', results: results });
@@ -140,12 +140,12 @@ describe('SearchResultsComponent', () => {
     const anchor = fixture.debugElement.query(By.css('a'));
 
     anchor.triggerEventHandler('click', {});
-    expect(selectedResult).toEqual({path: 'news', title: 'News', type: 'marketing', keywords: '', titleWords: '' });
+    expect(selectedResult).toEqual({ path: 'news', title: 'News', type: 'marketing', keywords: '', titleWords: '' });
   });
 
   it('should clear the results when a search result is clicked', () => {
     const results = [
-      {path: 'news', title: 'News', type: 'marketing', keywords: '', titleWords: '' }
+      { path: 'news', title: 'News', type: 'marketing', keywords: '', titleWords: '' }
     ];
 
     searchResults.next({ query: '', results: results });
@@ -160,7 +160,7 @@ describe('SearchResultsComponent', () => {
   describe('hideResults', () => {
     it('should clear the results', () => {
       const results = [
-        {path: 'news', title: 'News', type: 'marketing', keywords: '', titleWords: '' }
+        { path: 'news', title: 'News', type: 'marketing', keywords: '', titleWords: '' }
       ];
 
       searchResults.next({ query: '', results: results });

--- a/aio/src/app/search/search-results/search-results.component.ts
+++ b/aio/src/app/search/search-results/search-results.component.ts
@@ -6,6 +6,7 @@ import { SearchResult, SearchResults, SearchService } from '../search.service';
 export interface SearchArea {
   name: string;
   pages: SearchResult[];
+  priorityPages: SearchResult[];
 }
 
 /**
@@ -65,10 +66,12 @@ export class SearchResultsComponent implements OnInit {
       area.push(result);
     });
     const keys = Object.keys(searchAreaMap).sort((l, r) => l > r ? 1 : -1);
-    return keys.map(name => ({
-      name,
-      pages: searchAreaMap[name].sort(compareResults)
-    }));
+    return keys.map(name => {
+      let pages = searchAreaMap[name];
+      const priorityPages = pages.length > 10 ? searchAreaMap[name].slice(0, 5) : [];
+      pages = pages.sort(compareResults);
+      return { name, pages, priorityPages };
+  });
   }
 
   // Split the search result path and use the top level folder, if there is one, as the area name.

--- a/aio/src/styles/1-layouts/_layouts-dir.scss
+++ b/aio/src/styles/1-layouts/_layouts-dir.scss
@@ -4,7 +4,6 @@
 
 @import 'sidenav';
 @import 'content-layout';
-@import 'search-results';
 @import 'top-menu';
 @import 'marketing-layout';
 @import 'footer';

--- a/aio/src/styles/2-modules/_modules-dir.scss
+++ b/aio/src/styles/2-modules/_modules-dir.scss
@@ -17,6 +17,7 @@
    @import 'hero';
    @import 'announcement-bar';
    @import 'banner';
+   @import 'search-results';
    @import 'api-list';
    @import 'hr';
    @import 'live-example';

--- a/aio/src/styles/2-modules/_search-results.scss
+++ b/aio/src/styles/2-modules/_search-results.scss
@@ -61,8 +61,19 @@ aio-search-results {
             color: $white;
         }
         &:visited {
-        text-decoration: none;
+          text-decoration: none;
         }
+
+        span.symbol {
+          margin-right: 8px;
+        }
+    }
+
+    .more-items {
+      content: 'more_horiz';
+      font-size: 20px;
+      color: $mediumgray;
+      padding: 0;
     }
 
     @include bp(tiny) {

--- a/aio/src/styles/_constants.scss
+++ b/aio/src/styles/_constants.scss
@@ -95,6 +95,14 @@ $api-symbols: (
     content: 'K',
     background: $purple-600
   ),
+  let: (
+    content: 'K',
+    background: $purple-600
+  ),
+  var: (
+    content: 'K',
+    background: $purple-600
+  ),
   type-alias: (
     content: 'T',
     background: $light-green-600


### PR DESCRIPTION
Separate commits in this PR tackle **two usability issues** with search results.

This is independent of PR #16443 which handles the "no search results" case. Depending on how these PRs are merged, we may have a small conflict to resolve.

### 1. List the top weighted search results

Search results (which arrive weighted) are shown sorted by title within area.
The alpha sort was easier on readers than the weighted.

But at least one reviewer pointed out a usability problem. When you look for a word/word-fragment that appears frequently, a word such as "component", there are too many matching pages. The most likely match page (by weight) sorts deep into the area results and requires considerable scrolling. That isn't intuitive.

This PR offers a solution. When the number of match pages in an area exceeds 10, the top 5 weighted results are shown _above_ the others, followed by a line, followed by the complete alpha list.

This PR also displays the number of matches in each area next to the area name.

Coincidentally DRYed up some tests

### 2. Add API Icons

@StephenFluin or @IgorMinar a while ago asked to see the same icons displayed for API results as on the API page.  

It was easy to add while making the first change and including it reduced probability of tiresome merge conflicts if it was in a separate PR. Added as a separate commit. 

<hr>

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
