### PR TITLE
fix(aio): correct position of sidenav icons

### DIFF
--- a/aio/src/styles/1-layouts/_sidenav.scss
+++ b/aio/src/styles/1-layouts/_sidenav.scss
@@ -68,6 +68,7 @@ md-sidenav-container div.mat-sidenav-content {
   &:hover {
     text-shadow: 0 0 5px #ffffff;
     background-color: $lightgray;
+
   }
 
   //icons _within_ nav
@@ -146,10 +147,12 @@ a.selected.level-1,
 
 .level-1.expanded .mat-icon, .level-2.expanded .mat-icon {
   @include rotate(90deg);
+  top: 10px;
 }
 
 .level-1:not(.expanded) .mat-icon, .level-2:not(.expanded) .mat-icon {
   @include rotate(0deg);
+  margin: 4px;
 }
 
 .promo-img-container img {


### PR DESCRIPTION
Positioned md-icons so that they correctly align horizontally with text and don't move vertically when the vertical-menu-items are hovered upon in the sidenav

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

