### PR TITLE
docs(aio): hide the copy button for code in StyleGuide tables.

### DIFF
--- a/aio/content/guide/styleguide.md
+++ b/aio/content/guide/styleguide.md
@@ -566,7 +566,7 @@ and reference assets of different types.
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @Component({ ... })
         export class AppComponent { }
       </code-example>
@@ -585,7 +585,7 @@ and reference assets of different types.
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @Component({ ... })
         export class HeroesComponent { }
       </code-example>
@@ -604,7 +604,7 @@ and reference assets of different types.
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @Component({ ... })
         export class HeroListComponent { }
       </code-example>
@@ -623,7 +623,7 @@ and reference assets of different types.
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @Component({ ... })
         export class HeroDetailComponent { }
       </code-example>
@@ -642,7 +642,7 @@ and reference assets of different types.
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @Directive({ ... })
         export class ValidationDirective { }
       </code-example>
@@ -661,7 +661,7 @@ and reference assets of different types.
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @NgModule({ ... })
         export class AppModule
       </code-example>
@@ -680,7 +680,7 @@ and reference assets of different types.
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @Pipe({ name: 'initCaps' })
         export class InitCapsPipe implements PipeTransform { }
       </code-example>
@@ -699,7 +699,7 @@ and reference assets of different types.
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @Injectable()
         export class UserProfileService { }
       </code-example>
@@ -815,7 +815,7 @@ As always, strive for consistency.
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @Injectable()
         export class HeroDataService { }
       </code-example>
@@ -834,7 +834,7 @@ As always, strive for consistency.
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @Injectable()
         export class CreditService { }
       </code-example>
@@ -853,7 +853,7 @@ As always, strive for consistency.
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @Injectable()
         export class Logger { }
       </code-example>
@@ -1207,7 +1207,7 @@ For example, the prefix `toh` represents from **T**our **o**f **H**eroes and the
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @Pipe({ name: 'ellipsis' })
         export class EllipsisPipe implements PipeTransform { }
       </code-example>
@@ -1226,7 +1226,7 @@ For example, the prefix `toh` represents from **T**our **o**f **H**eroes and the
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @Pipe({ name: 'initCaps' })
         export class InitCapsPipe implements PipeTransform { }
       </code-example>
@@ -1605,7 +1605,7 @@ A consistent class and file name convention make these modules easy to spot and 
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @NgModule({ ... })
         export class AppModule { }
       </code-example>
@@ -1624,7 +1624,7 @@ A consistent class and file name convention make these modules easy to spot and 
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @NgModule({ ... })
         export class HeroesModule { }
       </code-example>
@@ -1643,7 +1643,7 @@ A consistent class and file name convention make these modules easy to spot and 
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @NgModule({ ... })
         export class VillainsModule { }
       </code-example>
@@ -1662,7 +1662,7 @@ A consistent class and file name convention make these modules easy to spot and 
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @NgModule({ ... })
         export class AppRoutingModule { }
       </code-example>
@@ -1681,7 +1681,7 @@ A consistent class and file name convention make these modules easy to spot and 
 
     <td>
 
-      <code-example>
+      <code-example hideCopy>
         @NgModule({ ... })
         export class HeroesRoutingModule { }
       </code-example>


### PR DESCRIPTION
The code samples in the tables in the StyleGuides are fragments and shouldn't be copied. 
The copy button also takes up too much space. 
These tables still need formatting work.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
