### PR TITLE
docs(animation-callbacks): remove duplicate word

### DIFF
--- a/aio/content/guide/animations.md
+++ b/aio/content/guide/animations.md
@@ -496,7 +496,7 @@ those callbacks like this:
 
 
 
-The callbacks receive an `AnimationEvent` that contains contains useful properties such as
+The callbacks receive an `AnimationEvent` that contains useful properties such as
 `fromState`, `toState` and `totalTime`.
 
 Those callbacks will fire whether or not an animation is picked up.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: documentation correction
```

**What is the current behavior?** (You can also link to an open issue here)
Currently the documentation [here](https://angular.io/docs/ts/latest/guide/animations.html#!#animation-callbacks) states `AnimationEvent` that contains contains useful


**What is the new behavior?**
Should say `AnimationEvent` that contains useful


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

