### PR TITLE
fix(upgrade): initialize all inputs in time for `ngOnChanges()`

### DIFF
--- a/packages/upgrade/src/common/util.ts
+++ b/packages/upgrade/src/common/util.ts
@@ -75,3 +75,10 @@ export function hookupNgModel(ngModel: angular.INgModelController, component: an
     component.registerOnChange(ngModel.$setViewValue.bind(ngModel));
   }
 }
+
+/**
+ * Test two values for strict equality, accounting for the fact that `NaN !== NaN`.
+ */
+export function strictEquals(val1: any, val2: any): boolean {
+  return val1 === val2 || (val1 !== val1 && val2 !== val2);
+}

--- a/packages/upgrade/src/dynamic/upgrade_ng1_adapter.ts
+++ b/packages/upgrade/src/dynamic/upgrade_ng1_adapter.ts
@@ -10,7 +10,7 @@ import {Directive, DoCheck, ElementRef, EventEmitter, Inject, OnChanges, OnInit,
 
 import * as angular from '../common/angular1';
 import {$COMPILE, $CONTROLLER, $HTTP_BACKEND, $SCOPE, $TEMPLATE_CACHE} from '../common/constants';
-import {controllerKey} from '../common/util';
+import {controllerKey, strictEquals} from '../common/util';
 
 
 interface IBindingDestination {
@@ -309,8 +309,7 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
     checkProperties.forEach((propName, i) => {
       const value = destinationObj ![propName];
       const last = lastValues[i];
-      if (value !== last &&
-          (value === value || last === last)) {  // ignore NaN values (NaN !== NaN)
+      if (!strictEquals(last, value)) {
         const eventEmitter: EventEmitter<any> = (this as any)[propOuts[i]];
         eventEmitter.emit(lastValues[i] = value);
       }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Non-bracketed inputs (e.g. `xyz="foo"`) on downgraded components are initialized using `attrs.$observe()` (which uses `$evalAsync()` under the hood), while bracketed inputs (e.g. `[xyz]="'foo'"`) are initialized using `$watch()`. If the downgraded component is created during a `$digest` (e.g. by an `ng-if` watcher), the non-bracketed inputs were not initialized in time for the initial call to `ngOnChanges()` and `ngOnInit()`.


**What is the new behavior?**
`$watch()` is used to initialize all inputs. `$observe()` is still used for subsequent updates on non-bracketed inputs, because it is more performant.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```


**Other information**:
Fixes #16212.