### PR TITLE
fix(aio): make `aio-top-menu .nav-link` cover the whole `<li>`

### DIFF
--- a/aio/src/styles/1-layouts/_top-menu.scss
+++ b/aio/src/styles/1-layouts/_top-menu.scss
@@ -4,7 +4,8 @@
 }
 
 aio-top-menu a.nav-link {
-  margin: 0 16px;
+  margin: 0;
+  padding: 24px 16px;
   cursor: pointer;
 
   &:focus {

--- a/aio/src/styles/1-layouts/_top-menu.scss
+++ b/aio/src/styles/1-layouts/_top-menu.scss
@@ -6,11 +6,9 @@
 aio-top-menu a.nav-link {
   margin: 0 16px;
   cursor: pointer;
-  
+
   &:focus {
-    background-color: $accentblue;
     outline: none;
-    padding: 21px 16px;
   }
 }
 
@@ -60,6 +58,11 @@ aio-top-menu {
 
       &:hover {
         background-color: $accentblue;
+      }
+
+      &:focus {
+        background-color: $accentblue;
+        outline: none;
       }
     }
   }


### PR DESCRIPTION
Discussed in https://github.com/angular/angular/pull/16513/files#r114630560.
Builds on top of #16513.