### PR TITLE
feat(aio): TOC max height

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -33,7 +33,9 @@
 
 
 
-<div *ngIf="isSideBySide" class="toc-container"></div>
+<div class="toc-container" [style.max-height.px]="tocMaxHeight">
+  <aio-toc></aio-toc>
+</div>
 
 <footer>
   <aio-footer [nodes]="footerNodes" [versionInfo]="versionInfo" ></aio-footer>

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -1,4 +1,4 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NO_ERRORS_SCHEMA, DebugElement } from '@angular/core';
 import { async, inject, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Title } from '@angular/platform-browser';
 import { APP_BASE_HREF } from '@angular/common';
@@ -10,20 +10,21 @@ import { of } from 'rxjs/observable/of';
 
 import { AppComponent } from './app.component';
 import { AppModule } from './app.module';
-import { AutoScrollService } from 'app/shared/auto-scroll.service';
+import { TocComponent } from 'app/embedded/toc/toc.component';
 import { DocViewerComponent } from 'app/layout/doc-viewer/doc-viewer.component';
+import { NavigationNode } from 'app/navigation/navigation.service';
+import { SearchService } from 'app/search/search.service';
+import { SearchBoxComponent } from 'app/search/search-box/search-box.component';
+import { SearchResultsComponent } from 'app/search/search-results/search-results.component';
+import { AutoScrollService } from 'app/shared/auto-scroll.service';
 import { GaService } from 'app/shared/ga.service';
 import { LocationService } from 'app/shared/location.service';
 import { Logger } from 'app/shared/logger.service';
+import { SwUpdateNotificationsService } from 'app/sw-updates/sw-update-notifications.service';
 import { MockLocationService } from 'testing/location.service';
 import { MockLogger } from 'testing/logger.service';
 import { MockSearchService } from 'testing/search.service';
 import { MockSwUpdateNotificationsService } from 'testing/sw-update-notifications.service';
-import { NavigationNode } from 'app/navigation/navigation.service';
-import { SearchBoxComponent } from 'app/search/search-box/search-box.component';
-import { SearchResultsComponent } from 'app/search/search-results/search-results.component';
-import { SearchService } from 'app/search/search.service';
-import { SwUpdateNotificationsService } from 'app/sw-updates/sw-update-notifications.service';
 
 describe('AppComponent', () => {
   let component: AppComponent;
@@ -68,6 +69,15 @@ describe('AppComponent', () => {
       expect(component.isSideBySide).toBe(true);
       component.onResize(500);
       expect(component.isSideBySide).toBe(false);
+    });
+  });
+
+  describe('onScroll', () => {
+    it('should update `tocMaxHeight` accordingly', () => {
+      expect(component.tocMaxHeight).toBeUndefined();
+
+      component.onScroll();
+      expect(component.tocMaxHeight).toBeGreaterThan(0);
     });
   });
 
@@ -431,6 +441,31 @@ describe('AppComponent', () => {
 
       searchBox.nativeElement.click();
       expect(searchResultsComponent.hideResults).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('aio-toc', () => {
+    let tocDebugElement: DebugElement;
+    let tocContainer: DebugElement;
+
+    beforeEach(() => {
+      tocDebugElement = fixture.debugElement.query(By.directive(TocComponent));
+      tocContainer = tocDebugElement.parent;
+    });
+
+
+    it('should have a non-embedded `<aio-toc>` element', () => {
+      expect(tocDebugElement).toBeDefined();
+      expect(tocDebugElement.classes.embedded).toBeFalsy();
+    });
+
+    it('should update the TOC container\'s `maxHeight` based on `tocMaxHeight`', () => {
+      expect(tocContainer.styles['max-height']).toBeNull();
+
+      component.tocMaxHeight = '100';
+      fixture.detectChanges();
+
+      expect(tocContainer.styles['max-height']).toBe('100px');
     });
   });
 

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -19,9 +19,13 @@ const sideNavView = 'SideNav';
 })
 export class AppComponent implements OnInit {
 
+  currentDocument: DocumentContents;
+  currentDocVersion: NavigationNode;
   currentNode: CurrentNode;
   currentPath: string;
+  docVersions: NavigationNode[];
   dtOn = false;
+  footerNodes: NavigationNode[];
 
   /**
    * An HTML friendly identifier for the currently displayed page.
@@ -46,9 +50,6 @@ export class AppComponent implements OnInit {
   @HostBinding('class')
   hostClasses = '';
 
-  currentDocument: DocumentContents;
-  footerNodes: NavigationNode[];
-
   isStarting = true;
   isSideBySide = false;
   private isSideNavDoc = false;
@@ -57,9 +58,8 @@ export class AppComponent implements OnInit {
   private sideBySideWidth = 1032;
   sideNavNodes: NavigationNode[];
   topMenuNodes: NavigationNode[];
-
-  currentDocVersion: NavigationNode;
-  docVersions: NavigationNode[];
+  tocMaxHeight: string;
+  private tocMaxHeightOffset = 0;
   versionInfo: VersionInfo;
 
   get homeImageUrl() {
@@ -86,10 +86,11 @@ export class AppComponent implements OnInit {
   constructor(
     private autoScrollService: AutoScrollService,
     private documentService: DocumentService,
+    private hostElement: ElementRef,
     private locationService: LocationService,
     private navigationService: NavigationService,
     private swUpdateNotifications: SwUpdateNotificationsService
-  ) { }
+  ) {  }
 
   ngOnInit() {
     this.onResize(window.innerWidth);
@@ -208,5 +209,20 @@ export class AppComponent implements OnInit {
     const viewClass = `view-${this.currentNode && this.currentNode.view}`;
 
     this.hostClasses = `${pageClass} ${folderClass} ${viewClass}`;
+  }
+
+  // Dynamically change height of table of contents container
+  @HostListener('window:scroll')
+  onScroll() {
+    if (!this.tocMaxHeightOffset) {
+      // Must wait until now for md-toolbar to be measurable.
+      const el = this.hostElement.nativeElement as Element;
+      this.tocMaxHeightOffset =
+          el.querySelector('footer').clientHeight +
+          el.querySelector('md-toolbar.app-toolbar').clientHeight +
+          44; //  margin
+    }
+
+    this.tocMaxHeight = (document.body.scrollHeight - window.pageYOffset - this.tocMaxHeightOffset).toFixed(2);
   }
 }

--- a/aio/src/app/embedded/embedded.module.ts
+++ b/aio/src/app/embedded/embedded.module.ts
@@ -45,6 +45,9 @@ export class EmbeddedComponents {
     ContributorComponent,
     EmbeddedPlunkerComponent
   ],
+  exports: [
+    TocComponent
+  ],
   providers: [
     ContributorService,
     CopierService,

--- a/aio/src/app/embedded/toc/toc.component.html
+++ b/aio/src/app/embedded/toc/toc.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="hasToc" [class.closed]="isClosed">
   <div *ngIf="!hasSecondary" class="toc-heading">Contents</div>
-  <div *ngIf="hasSecondary"  class="toc-heading secondary"
+  <div *ngIf="hasSecondary" class="toc-heading secondary"
       (click)="toggle()"
       title="Expand/collapse contents"
       aria-label="Expand/collapse contents">

--- a/aio/src/styles/2-modules/_toc.scss
+++ b/aio/src/styles/2-modules/_toc.scss
@@ -1,9 +1,9 @@
 .toc-container {
     width: 18%;
     position: fixed;
-    top: 84px;
+    top: 96px;
     right: 0;
-    bottom: 18px;
+    bottom: 32px;
     overflow-y: auto;
     overflow-x: hidden;
 
@@ -11,6 +11,20 @@
       display: none;
       width: 0;
     }
+}
+
+aio-toc {
+  &.embedded {
+    @media (min-width: 801px) {
+      display: none;
+    }
+  }
+
+  &:not(.embedded) {
+    @media (max-width: 800px) {
+      display: none;
+    }
+  }
 }
 
 aio-toc > div {
@@ -87,7 +101,7 @@ aio-toc > div {
     @media (max-width: 800px) {
       width: auto;
     }
-  
+
   }
 
   ul.toc-list li {
@@ -141,6 +155,6 @@ aio-toc > div {
   }
 }
 
-aio-toc > div.closed li.secondary {
+aio-toc.embedded > div.closed li.secondary {
     display: none;
 }


### PR DESCRIPTION
Dynamically change the max-height of the TOC (table of contents) container so that it collapses nicely once a user is at the bottom of the page once the footer appears.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior?**

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

