### PR TITLE
fix(i18n): avoid a `...null` spread in extraction

### DIFF
--- a/packages/compiler/src/i18n/message_bundle.ts
+++ b/packages/compiler/src/i18n/message_bundle.ts
@@ -26,7 +26,7 @@ export class MessageBundle {
       private _implicitAttrs: {[k: string]: string[]}, private _locale: string|null = null) {}
 
   updateFromTemplate(html: string, url: string, interpolationConfig: InterpolationConfig):
-      ParseError[]|null {
+      ParseError[] {
     const htmlParserResult = this._htmlParser.parse(html, url, true, interpolationConfig);
 
     if (htmlParserResult.errors.length) {
@@ -41,7 +41,7 @@ export class MessageBundle {
     }
 
     this._messages.push(...i18nParserResult.messages);
-    return null;
+    return [];
   }
 
   // Return the message in the internal format


### PR DESCRIPTION
This code only runs in ES5 mode in the test suite, so this is difficult to test. However `updateFromTemplate` is being called with a spread operator, as `...updateFromTemplate(...)`. The spread operator should fail on `null` values. This change avoids the problem by always returning a (possibly empty) array.