### PR TITLE
build(aio): throw an error if a code-example tag is not closed

### DIFF
--- a/aio/tools/transforms/remark-package/services/renderMarkdown.spec.js
+++ b/aio/tools/transforms/remark-package/services/renderMarkdown.spec.js
@@ -49,6 +49,17 @@ describe('remark: renderMarkdown service', () => {
     expect(output).toEqual('<code-example>\n\n  **abc**\n\n  def\n</code-example>\n<code-tabs><code-pane>\n\n  **abc**\n\n  def\n</code-pane></code-tabs>\n');
   });
 
+  it('should handle recursive tags marked as unformatted', () => {
+    const content = '<code-example>\n\n  <code-example>\n\n  **abc**\n\n  def\n\n</code-example>\n\n</code-example>\n\nhij\n\n<code-example>\n\nklm</code-example>';
+    const output = renderMarkdown(content);
+    expect(output).toEqual('<code-example>\n\n  <code-example>\n\n  **abc**\n\n  def\n\n</code-example>\n\n</code-example>\n<p>hij</p>\n<code-example>\n\nklm</code-example>\n');
+  });
+
+  it('should raise an error if a tag marked as unformatted is not closed', () => {
+    const content = '<code-example path="xxx">\n\n  **abc**\n\n  def\n<code-example>\n\n\n\n  **abc**\n\n  def\n</code-example>';
+    expect(() => renderMarkdown(content)).toThrowError('Unmatched plain HTML block tag <code-example path="xxx">');
+  });
+
   it('should not remove spaces after anchor tags', () => {
     var input =
         'A aa aaa aaaa aaaaa aaaaaa aaaaaaa aaaaaaaa aaaaaaaaa aaaaaaaaaa aaaaaaaaaaa\n' +


### PR DESCRIPTION
Previously, if a tag like `<code-example>` or `<code-tabs>` had no matching closing tag then the `yarn docs` got into an infinite loop and hung.
Now we get a nice error message containing the offending tag.