### PR TITLE
fix(common): Location should strip trailing slash ignoring query and…

### DIFF
--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -170,7 +170,7 @@ export class Location {
   /**
    * If url has a trailing slash, remove it, otherwise return url as is.
    */
-  public static stripTrailingSlash(url: string): string { return url.replace(/\/$/, ''); }
+  public static stripTrailingSlash(url: string): string { return url.replace(/\/(?=$|\?|#)/, ''); }
 }
 
 function _stripBaseHref(baseHref: string, url: string): string {

--- a/packages/common/test/localization_spec.ts
+++ b/packages/common/test/localization_spec.ts
@@ -10,6 +10,7 @@ import {LOCALE_ID} from '@angular/core';
 import {TestBed, inject} from '@angular/core/testing';
 
 import {NgLocaleLocalization, NgLocalization, getPluralCategory} from '../src/localization';
+import {Location} from '../src/location/location';
 
 export function main() {
   describe('l10n', () => {
@@ -154,6 +155,23 @@ export function main() {
             getPluralCategory(2, ['one'], l10n);
           }).toThrowError('No plural message found for value "2"');
         });
+      });
+    });
+  });
+
+  describe('Location', () => {
+    describe('stripTrailingSlash', () => {
+      describe('should strip trailing slash when url contains', () => {
+        it('no params', () => {
+          expect(Location.stripTrailingSlash('/test')).toBe('/test');
+          expect(Location.stripTrailingSlash('/test/')).toBe('/test');
+        });
+
+        it('query params',
+           () => { expect(Location.stripTrailingSlash('/test/?a=b')).toBe('/test?a=b'); });
+
+        it('hash path',
+           () => { expect(Location.stripTrailingSlash('/test/#ab')).toBe('/test#ab'); });
       });
     });
   });


### PR DESCRIPTION
… hash

Closes #14905

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)
Trailing slash are only being removed when there's not query string or hashes in the URL


**What is the new behavior?**
Trailing slash should always be removed, no matter if query or hash in URL


**Does this PR introduce a breaking change?** (check one with "x")
```
[x] No
```