### PR TITLE
feat(aio): each doc can add/remove class to aio-shell with <aio-context>

### DIFF
--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -26,9 +26,6 @@ export class AppComponent implements OnInit {
   currentDocument: DocumentContents;
   footerNodes: NavigationNode[];
 
-  @HostBinding('class.marketing')
-  isMarketing = false;
-
   isStarting = true;
   isSideBySide = false;
   private isSideNavDoc = false;
@@ -60,6 +57,9 @@ export class AppComponent implements OnInit {
   @ViewChild(SearchResultsComponent)
   searchResults: SearchResultsComponent;
 
+  @HostBinding('class')
+  shellClasses = '';
+
   @ViewChild(MdSidenav)
   sidenav: MdSidenav;
 
@@ -79,6 +79,7 @@ export class AppComponent implements OnInit {
     this.documentService.currentDocument.subscribe(doc => {
       this.currentDocument = doc;
       this.setPageId(doc.id);
+      this.shellClasses = this.getShellClasses(doc);
     });
 
     this.locationService.currentPath.subscribe(path => {
@@ -98,7 +99,6 @@ export class AppComponent implements OnInit {
       if (this.previousNavView === currentNode.view) { return; }
       this.previousNavView = currentNode.view;
       this.isSideNavDoc = currentNode.view === sideNavView;
-      this.isMarketing = !this.isSideNavDoc;
       this.sideNavToggle(this.isSideNavDoc && this.isSideBySide);
     });
 
@@ -173,5 +173,18 @@ export class AppComponent implements OnInit {
   setPageId(id: string) {
     // Special case the home page
     this.pageId = (id === 'index') ? 'home' : id.replace('/', '-');
+  }
+
+  private getShellClasses(doc: DocumentContents) {
+    let shellClasses = /^(guide|tutorial)\//.test(doc.id) ? '' : 'marketing ';
+
+    const contents = doc.contents || '';
+    // extract the classes from `<aio-context>`
+    const contextMatch = contents.match(/<aio-context.*class="([^"]*)/);
+    if (contextMatch) {
+      shellClasses += contextMatch[1] || '';
+    }
+
+    return shellClasses;
   }
 }


### PR DESCRIPTION
closes #16549
Supports doc-specific styling of the entire shell based on the context of the current document.
Also adds the “marketing” class if the docId indicates the doc is neither a guide nor tutorial page.

Add something like the following near the top (or at the top) of the `.md` (or `.html`) file.

```
<aio-context class="foo bar"></aio-context>
```

If it’s a guide or tutorial page ('guide/...' or 'tutorial/...'), this PR's changes will copy the classes up and you’ll see `<aio-shell class="foo bar">`.  Otherwise you'll see `<aio-shell class="marketing foo bar">`.

<hr>

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
