### PR TITLE
feat(aio): should not send in-page navigations to Google Analytics

### DIFF
--- a/aio/src/app/shared/ga.service.spec.ts
+++ b/aio/src/app/shared/ga.service.spec.ts
@@ -84,7 +84,9 @@ describe('GaService', () => {
         expect(gaSpySendCalls()).toEqual(['/testUrl']);
       });
 
-      it('should send twice with same URL, back-to-back, when the hash changes', () => {
+      it('should send twice with same URL, back-to-back, even when the hash changes', () => {
+        // Therefore it is up to caller NOT to call it when hash changes if this is unwanted.
+        // See LocationService and its specs
         gaService.sendPage('testUrl#one');
         gaService.sendPage('testUrl#two');
         expect(gaSpySendCalls()).toEqual([

--- a/aio/src/app/shared/ga.service.ts
+++ b/aio/src/app/shared/ga.service.ts
@@ -27,9 +27,7 @@ export class GaService {
   }
 
   sendPage(url: string) {
-    // Won't re-send if the url (including fragment) hasn't changed.
-    // TODO: Perhaps we don't want to track clicks on in-page links.
-    // Could easily report only when the page (base url) changes.
+    // Won't re-send if the url hasn't changed.
     if (url === this.previousUrl) { return; }
     this.previousUrl = url;
     this.ga('set', 'page', '/' + url);

--- a/aio/src/app/shared/location.service.spec.ts
+++ b/aio/src/app/shared/location.service.spec.ts
@@ -517,6 +517,18 @@ describe('LocationService', () => {
       expect(args[0]).toBe('some-new-url');
     });
 
+    it('should call locationChanged with url stripped of hash or query', () => {
+      // Important to keep GA service from sending tracking event when the doc hasn't changed
+      // e.g., when the user navigates within the page via # fragments.
+      service.go('some-new-url#one');
+      service.go('some-new-url#two');
+      service.go('some-new-url/?foo="true"');
+      expect(gaLocationChanged.calls.count()).toBe(4, 'gaService.locationChanged called');
+      const args = gaLocationChanged.calls.allArgs();
+      expect(args[1]).toEqual(args[2], 'same url for hash calls');
+      expect(args[1]).toEqual(args[3], 'same url for query string call');
+    });
+
     it('should call locationChanged when window history changes', () => {
       location.simulatePopState('/next-url');
 

--- a/aio/src/app/shared/location.service.ts
+++ b/aio/src/app/shared/location.service.ts
@@ -15,11 +15,12 @@ export class LocationService {
   private urlSubject = new Subject<string>();
   currentUrl = this.urlSubject
     .map(url => this.stripSlashes(url))
-    .do(url => this.gaService.locationChanged(url))
     .publishReplay(1);
 
   currentPath = this.currentUrl
-    .map(url => url.match(/[^?#]*/)[0]); // strip query and hash
+    .map(url => url.match(/[^?#]*/)[0]) // strip query and hash
+    .do(url => this.gaService.locationChanged(url))
+    .publishReplay(1);
 
   constructor(
     private gaService: GaService,
@@ -27,6 +28,7 @@ export class LocationService {
     private platformLocation: PlatformLocation) {
 
     this.currentUrl.connect();
+    this.currentPath.connect();
     this.urlSubject.next(location.path(true));
 
     this.location.subscribe(state => {


### PR DESCRIPTION
closes #16521
`LocationService` sends `GaService` a url stripped of fragment and query strings.
`GaService` already guards against re-send of the prior url so it will only report doc changes.

<hr>

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```
