### PR TITLE
feat(http): add toString method for request class

### DIFF
--- a/packages/http/src/static_request.ts
+++ b/packages/http/src/static_request.ts
@@ -161,6 +161,10 @@ export class Request extends Body {
         return null;
     }
   }
+
+  toString(): string {
+    return `Request for URL: ${this.url} using method: ${RequestMethod[this.action]}`;
+  }
 }
 
 const noop = function() {};


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
There is no toString method for Request, which results into `[object Object]`.

**What is the new behavior?**
It returns `Request for URL: http://localhost:8080/api using method: Get`.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

