### PR TITLE
test: add script to check embedded source-maps correctness

### DIFF
--- a/check-embedded-sourcemaps.js
+++ b/check-embedded-sourcemaps.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+const sourceMapFilePath = process.argv[2];
+const sourceMapFileDir  = path.dirname(sourceMapFilePath);
+
+if (sourceMapFilePath) {
+    const sourceMapContents = fs.readFileSync(sourceMapFilePath, 'UTF-8');
+
+    const sourceMapObject = JSON.parse(sourceMapContents);
+
+    if (sourceMapObject.sourcesContent) {
+        sourceMapObject.sources.forEach(function(relativePath, index) {
+            const shortPath = path.relative('.', path.resolve(sourceMapFileDir, relativePath));
+
+            const embeddedSource = sourceMapObject.sourcesContent[index];
+            const actualSource   = fs.readFileSync(shortPath, 'UTF-8');
+
+            const same = embeddedSource === actualSource;
+
+            console.log(`${sourceMapFilePath} -> ${shortPath}: ${same ? 'same': 'different'}`);
+        }, this);
+    }
+}

--- a/check-embedded-sourcemaps.sh
+++ b/check-embedded-sourcemaps.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+find dist/packages-dist -name '*.js.map' -exec node check-embedded-sourcemaps.js {} \;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Output JS files have embedded sourcemaps that don't map to sources correctly. Probably they map to some intermediate TS source. And they even don't map correctly to those intermediate TS files. This breaks in-browser stack traces and makes debugging and NG source exploration impossible.


**What is the new behavior?**
`check-embedded-sourcemaps.sh` shows reports for each source reference. I'm not sure where to correctly integrate it in build/CI process.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

