### PR TITLE
refactor(aio): remove redundant test

### DIFF
--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -353,14 +353,6 @@ describe('AppComponent', () => {
     });
   });
 
-  describe('search worker', () => {
-    it('should initialize the search worker', inject([SearchService], (searchService: SearchService) => {
-      fixture.detectChanges(); // triggers ngOnInit
-      expect(searchService.initWorker).toHaveBeenCalled();
-      expect(searchService.loadIndex).toHaveBeenCalled();
-    }));
-  });
-
   describe('initial rendering', () => {
     beforeEach(async(() => {
       createTestingModule('a/b');


### PR DESCRIPTION
The search worker is now initialised from the `SearchBoxComponent`, which
has its own tests for this.

Closes #15593
