### PR TITLE
fix(aio): do not display a Toc initially

### DIFF
--- a/aio/src/app/embedded/toc/toc.component.spec.ts
+++ b/aio/src/app/embedded/toc/toc.component.spec.ts
@@ -55,6 +55,10 @@ describe('TocComponent', () => {
       expect(tocComponent.isEmbedded).toEqual(true);
     });
 
+    it('should not display a ToC initially', () => {
+      expect(tocComponent.hasToc).toBe(false);
+    });
+
     it('should not display anything when no TocItems', () => {
       tocService.tocList.next([]);
       fixture.detectChanges();

--- a/aio/src/app/embedded/toc/toc.component.ts
+++ b/aio/src/app/embedded/toc/toc.component.ts
@@ -12,7 +12,7 @@ import { TocItem, TocService } from 'app/shared/toc.service';
 export class TocComponent implements OnInit, OnDestroy {
 
   hasSecondary = false;
-  hasToc = true;
+  hasToc = false;
   isClosed = true;
   isEmbedded = false;
   private primaryMax = 4;


### PR DESCRIPTION
Previously the `hasToc` was initialised to true, which caused a flash of
unwanted "Contents" [sic] even if the page was not going to need a ToC.

Closes #16597