### PR TITLE
fix(aio): constrain header-link styles

### DIFF
--- a/aio/src/styles/2-modules/_heading-anchors.scss
+++ b/aio/src/styles/2-modules/_heading-anchors.scss
@@ -14,7 +14,7 @@
       }
     }
 
-    a {
+    a.header-link {
       text-decoration: none;
       padding-left: 8px;
       margin-left: -50px;


### PR DESCRIPTION
The CSS rule for positioning the automated header links was too general,
causing other links inside headings to be positioned incorrectly.

Closes #16573
