### PR TITLE
docs(aio): fix sizing of marketing doc images

### DIFF
--- a/aio/content/marketing/index.html
+++ b/aio/content/marketing/index.html
@@ -24,7 +24,7 @@
 
       <div class="promo-img-container promo-1">
         <div>
-          <img src="assets/images/home/responsive-framework.svg" alt="responsive framework">
+          <img height="222" src="assets/images/home/responsive-framework.svg" alt="responsive framework">
         </div>
       </div>
 
@@ -48,7 +48,7 @@
 
       <div class="promo-img-container promo-2">
         <div>
-          <img src="assets/images/home/speed-performance.svg" alt="speed and performance">
+          <img height="222" src="assets/images/home/speed-performance.svg" alt="speed and performance">
         </div>
       </div>
     </div><!-- Group 3-->

--- a/aio/content/marketing/presskit.html
+++ b/aio/content/marketing/presskit.html
@@ -129,7 +129,7 @@
           <a href="assets/images/logos/angularjs/AngularJS-Shield.svg" title="AngularJS logo">
           original AngularJS logo</a> / icon, and not the Angular icon.</p>
 
-          <img src="assets/images/logos/angularjs/AngularJS-Shield.svg" alt="AngularJS Logo" style="margin-left:20px;" >
+          <img src="assets/images/logos/angularjs/AngularJS-Shield.svg" alt="AngularJS Logo" style="margin-left:20px;" height="128" width="128">
 
           <h3>Angular Material</h3>
 

--- a/aio/src/styles/2-modules/_presskit.scss
+++ b/aio/src/styles/2-modules/_presskit.scss
@@ -39,6 +39,7 @@
         margin-top: 10px;
         border-radius: 4px;
         width: 128px;
+        height: 128px;
         background-color: #34474F;
       }
 
@@ -65,6 +66,7 @@
 
       img {
         width: 128px;
+        height: 128px;
         margin-bottom: $unit * 2;
       }
     }


### PR DESCRIPTION
This commit ensures that all the images in the marketing docs are correcly
sized.

Related to #16600