### PR TITLE
docs(aio): move links from nav groups to items

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -87,9 +87,14 @@
 
     {
       "title": "Fundamentals",
-      "url": "guide/fundamentals",
       "tooltip": "The fundamentals of Angular",
       "children": [
+
+        {
+          "url": "guide/fundamentals",
+          "title": "Introduction",
+          "tooltip": "An introduction to the fundamentals of Angular."
+        },
 
         {
           "url": "guide/animations",
@@ -259,9 +264,14 @@
 
     {
       "title": "Techniques",
-      "url": "guide/techniques",
       "tooltip": "Techniques for putting Angular to work in your environment",
       "children": [
+
+        {
+          "url": "guide/techniques",
+          "title": "Introduction",
+          "tooltip": "An introduction to techniques to use when developing with Angular."
+        },
 
         {
           "url": "guide/security",


### PR DESCRIPTION
Fundamentals and Techniques nav groups we also links to pages. This caused
counterintuitive behaviour when clicking on them.

This commit moves each link from the group item to a children item, called
Introduction.

Closes #16604

