### PR TITLE
refactor(aio): simplify/clarify some observables

### DIFF
--- a/aio/src/app/navigation/navigation.service.ts
+++ b/aio/src/app/navigation/navigation.service.ts
@@ -59,26 +59,30 @@ export class NavigationService {
    */
   private fetchNavigationInfo(): Observable<NavigationResponse> {
     const navigationInfo = this.http.get(navigationPath)
-             .map(res => res.json() as NavigationResponse)
-             .publishLast();
+      .map(res => res.json() as NavigationResponse)
+      .publishLast();
     navigationInfo.connect();
     return navigationInfo;
   }
 
   private getVersionInfo(navigationInfo: Observable<NavigationResponse>) {
-    const versionInfo = navigationInfo.map(response => response.__versionInfo).publishReplay(1);
+    const versionInfo = navigationInfo
+      .map(response => response.__versionInfo)
+      .publishLast();
     versionInfo.connect();
     return versionInfo;
   }
 
   private getNavigationViews(navigationInfo: Observable<NavigationResponse>): Observable<NavigationViews> {
-    const navigationViews = navigationInfo.map(response => {
-      const views: NavigationViews = Object.assign({}, response);
-      Object.keys(views).forEach(key => {
-        if (key[0] === '_') { delete views[key]; }
-      });
-      return views;
-    }).publishReplay(1);
+    const navigationViews = navigationInfo
+      .map(response => {
+        const views = Object.assign({}, response);
+        Object.keys(views).forEach(key => {
+          if (key[0] === '_') { delete views[key]; }
+        });
+        return views as NavigationViews;
+      })
+      .publishLast();
     navigationViews.connect();
     return navigationViews;
   }
@@ -93,6 +97,7 @@ export class NavigationService {
     const currentNode = combineLatest(
       navigationViews.map(views => this.computeUrlToNavNodesMap(views)),
       this.location.currentPath,
+
       (navMap, url) => {
         const urlKey = url.startsWith('api/') ? 'api' : url;
         return navMap[urlKey] || { view: '', url: urlKey, nodes: [] };

--- a/aio/src/app/search/search.service.ts
+++ b/aio/src/app/search/search.service.ts
@@ -30,7 +30,7 @@ export class SearchService {
   private worker: WebWorkerClient;
   private ready: Observable<boolean>;
   private resultsSubject = new Subject<SearchResults>();
-  get searchResults() { return this.resultsSubject.asObservable(); }
+  readonly searchResults = this.resultsSubject.asObservable();
 
   constructor(private zone: NgZone) {}
 

--- a/aio/src/app/shared/location.service.spec.ts
+++ b/aio/src/app/shared/location.service.spec.ts
@@ -500,6 +500,8 @@ describe('LocationService', () => {
     beforeEach(() => {
       const gaService = injector.get(GaService);
       gaLocationChanged = gaService.locationChanged;
+      // execute currentPath observable so that gaLocationChanged is called
+      service.currentPath.subscribe();
     });
 
     it('should call locationChanged with initial URL', () => {

--- a/aio/src/app/shared/location.service.ts
+++ b/aio/src/app/shared/location.service.ts
@@ -2,9 +2,8 @@ import { Injectable } from '@angular/core';
 import { Location, PlatformLocation } from '@angular/common';
 
 import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
 import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/publishReplay';
 
 import { GaService } from 'app/shared/ga.service';
 
@@ -12,23 +11,19 @@ import { GaService } from 'app/shared/ga.service';
 export class LocationService {
 
   private readonly urlParser = document.createElement('a');
-  private urlSubject = new Subject<string>();
+  private urlSubject = new ReplaySubject<string>(1);
   currentUrl = this.urlSubject
-    .map(url => this.stripSlashes(url))
-    .publishReplay(1);
+    .map(url => this.stripSlashes(url));
 
   currentPath = this.currentUrl
     .map(url => url.match(/[^?#]*/)[0]) // strip query and hash
-    .do(url => this.gaService.locationChanged(url))
-    .publishReplay(1);
+    .do(url => this.gaService.locationChanged(url));
 
   constructor(
     private gaService: GaService,
     private location: Location,
     private platformLocation: PlatformLocation) {
 
-    this.currentUrl.connect();
-    this.currentPath.connect();
     this.urlSubject.next(location.path(true));
 
     this.location.subscribe(state => {


### PR DESCRIPTION
Reformatted some observables to improve clarity.
Removed superfluous `publishReplay` and `connect` calls in `LocationService`.
Replace `publishReplay(1)` with `publishLast()` in `NavigationService` for observables derived from a single `http.get` call.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```
