### PR TITLE
docs(di): remove link to non-existent class in `InjectableDecorator`

### DIFF
--- a/packages/core/src/di/metadata.ts
+++ b/packages/core/src/di/metadata.ts
@@ -127,7 +127,7 @@ export interface InjectableDecorator {
    *
    * {@example core/di/ts/metadata_spec.ts region='Injectable'}
    *
-   * {@link Injector} will throw {@link NoAnnotationError} when trying to instantiate a class that
+   * {@link Injector} will throw an error when trying to instantiate a class that
    * does not have `@Injectable` marker, as shown in the example below.
    *
    * {@example core/di/ts/metadata_spec.ts region='InjectableThrows'}


### PR DESCRIPTION
Closes #16640
