### PR TITLE
build(aio): remove "pure" property from pipe template

### DIFF
--- a/aio/tools/transforms/templates/api/pipe.template.html
+++ b/aio/tools/transforms/templates/api/pipe.template.html
@@ -2,7 +2,4 @@
 
 {% block details %}
 {% include "includes/description.html" %}
-<div class="pipe-properties">
-  {% if doc.pipeOptions.pure == "true" %}<label class="pipe-type-label pure">pure</label>{% endif %}
-</div>
 {% endblock %}


### PR DESCRIPTION
This information is not relevant to users, right now.

Closes #16641
