### PR TITLE
WIP: Enable type checking 

### DIFF
--- a/packages/compiler-cli/integrationtest/src/features.ts
+++ b/packages/compiler-cli/integrationtest/src/features.ts
@@ -41,6 +41,7 @@ export class CompWithReferences {
 
 @Component({selector: 'cmp-pipes', template: `<div *ngIf>{{test | somePipe}}</div>`})
 export class CompUsingPipes {
+  test: string;
 }
 
 @Component({

--- a/packages/compiler-cli/integrationtest/tsconfig-build.json
+++ b/packages/compiler-cli/integrationtest/tsconfig-build.json
@@ -3,7 +3,8 @@
     // For TypeScript 1.8, we have to lay out generated files
     // in the same source directory with your code.
     "genDir": ".",
-    "debug": true
+    "debug": true,
+    "expressionDiagnostics": "error"
   },
 
   "compilerOptions": {

--- a/packages/compiler-cli/src/diagnostics/typescript_symbols.ts
+++ b/packages/compiler-cli/src/diagnostics/typescript_symbols.ts
@@ -191,8 +191,8 @@ class TypeScriptSymbolQuery implements SymbolQuery {
     if (constructor) {
       const constructorDeclaration = constructor.declarations ![0] as ts.ConstructorTypeNode;
       for (const parameter of constructorDeclaration.parameters) {
-        const type = this.checker.getTypeAtLocation(parameter.type !);
-        if (type.symbol !.name == 'TemplateRef' && isReferenceType(type)) {
+        const type = parameter.type && this.checker.getTypeAtLocation(parameter.type);
+        if (type && type.symbol && type.symbol.name == 'TemplateRef' && isReferenceType(type)) {
           const typeReference = type as ts.TypeReference;
           if (typeReference.typeArguments.length === 1) {
             return typeReference.typeArguments[0].symbol;

--- a/packages/compiler/src/aot/compiler.ts
+++ b/packages/compiler/src/aot/compiler.ts
@@ -225,9 +225,16 @@ export class AotCompiler {
     const pipes = ngModule.transitiveModule.pipes.map(
         pipe => this._metadataResolver.getPipeSummary(pipe.reference));
 
-    const {template: parsedTemplate, pipes: usedPipes} = this._templateParser.parse(
+    const {template: parsedTemplate, htmlAst, pipes: usedPipes} = this._templateParser.parse(
         compMeta, compMeta.template !.template !, directives, pipes, ngModule.schemas,
         templateSourceUrl(ngModule.type, compMeta, compMeta.template !));
+
+    if (this._host.checkTemplate) {
+      const diagnostics =
+          this._host.checkTemplate(compMeta.type.reference, htmlAst, parsedTemplate, pipes);
+      this._templateParser.reportDiagnostics(diagnostics);
+    }
+
     const stylesExpr = componentStyles ? o.variable(componentStyles.stylesVar) : o.literalArr([]);
     const viewResult =
         this._viewCompiler.compileComponent(compMeta, parsedTemplate, stylesExpr, usedPipes);

--- a/packages/compiler/src/aot/compiler_host.ts
+++ b/packages/compiler/src/aot/compiler_host.ts
@@ -6,6 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {CompilePipeSummary} from '../compile_metadata';
+import {Node} from '../ml_parser/ast';
+import {ParseError} from '../parse_util';
+import {TemplateAst} from '../template_parser/template_ast';
+
+import {StaticSymbol} from './static_symbol';
 import {StaticSymbolResolverHost} from './static_symbol_resolver';
 import {AotSummaryResolverHost} from './summary_resolver';
 
@@ -18,4 +24,11 @@ export interface AotCompilerHost extends StaticSymbolResolverHost, AotSummaryRes
    * Loads a resource (e.g. html / css)
    */
   loadResource(path: string): Promise<string>;
+
+  /**
+   * Optionally check the given template for additional diagnostic errors.
+   */
+  checkTemplate?
+      (component: StaticSymbol, htmlAst: Node[], templateAst: TemplateAst[],
+       pipes: CompilePipeSummary[]): ParseError[];
 }

--- a/packages/compiler/src/ast_path.ts
+++ b/packages/compiler/src/ast_path.ts
@@ -35,8 +35,9 @@ export class AstPath<T> {
   }
   childOf(node: T): T|undefined { return this.path[this.path.indexOf(node) + 1]; }
 
-  first<N extends T>(ctor: {new (...args: any[]): N}): N|undefined {
-    for (let i = this.path.length - 1; i >= 0; i--) {
+  first<N extends T>(ctor: {new (...args: any[]): N}, after?: T): N|undefined {
+    const s = after ? this.path.indexOf(after) - 1 : this.path.length - 1;
+    for (let i = s; i >= 0; i--) {
       let item = this.path[i];
       if (item instanceof ctor) return <N>item;
     }

--- a/tools/@angular/tsc-wrapped/src/options.ts
+++ b/tools/@angular/tsc-wrapped/src/options.ts
@@ -81,6 +81,13 @@ interface Options extends ts.CompilerOptions {
 
   // Whether to enable support for <template> and the template attribute (true by default)
   enableLegacyTemplate?: boolean;
+
+  // Binding expression diagnostics
+  // error:   Errors detected in binding expressions trigger an error and the compilation is
+  //          stopped.
+  // warning: Errors detecetd in binding expressions are reported as warnings.
+  // off:     Binding expressions are not examined for errors.
+  expressionDiagnostics?: 'error'|'warning'|'off';
 }
 
 export default Options;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Feature
```

**What is the current behavior?** (You can also link to an open issue here)

The compiler relies on the generated TypeScript to report type errors in templates. Due to the use of the `any` type when generating let variables, of this left many type errors undetected.  Also, due changes in the code generation in 4.0 the number of problems discoverable using this approach has been significantly reduced.

**What is the new behavior?**

The compiler will invoke the language service type checker to catch many of the errors are left undetected in the current model.

To avoid being a breaking change, this additional checking is optional. It can be enabled by adding `"expressionDiagnostics": "error"` to the `"angularCompilerOpitons"` section of the project's `tsconfig.json` file. Alternately, a project can use `"expressionDiagnostics": "warning"` to report newly detected errors as warning

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
