### PR TITLE
feat(compiler): support a non-null postfix assert

### DIFF
--- a/packages/compiler-cli/src/diagnostics/expression_type.ts
+++ b/packages/compiler-cli/src/diagnostics/expression_type.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, AstVisitor, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead, visitAstChildren} from '@angular/compiler';
+import {AST, AstVisitor, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead, visitAstChildren} from '@angular/compiler';
 
 import {BuiltinType, Signature, Span, Symbol, SymbolQuery, SymbolTable} from './symbols';
 
@@ -281,6 +281,11 @@ export class AstType implements AstVisitor {
   visitPrefixNot(ast: PrefixNot) {
     // The type of a prefix ! is always boolean.
     return this.query.getBuiltinType(BuiltinType.Boolean);
+  }
+
+  visitNonNullAssert(ast: NonNullAssert) {
+    const expressionType = this.getType(ast.expression);
+    return this.query.getNonNullableType(expressionType);
   }
 
   visitPropertyRead(ast: PropertyRead) {

--- a/packages/compiler-cli/test/diagnostics/expression_diagnostics_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/expression_diagnostics_spec.ts
@@ -135,6 +135,8 @@ describe('expression diagnostics', () => {
      () => reject(`<div>{{maybe_person.name.first}}`, 'The expression might be null'));
   it('should accept a safe accss to an undefined field',
      () => accept(`<div>{{maybe_person?.name.first}}</div>`));
+  it('should accept a type assert to an undefined field',
+     () => accept(`<div>{{maybe_person!.name.first}}</div>`));
   it('should accept a # reference', () => accept(`
           <form #f="ngForm" novalidate>
             <input name="first" ngModel required #first="ngModel">

--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -348,6 +348,11 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
     return convertToStatementIfNeeded(mode, o.not(this._visit(ast.expression, _Mode.Expression)));
   }
 
+  visitNonNullAssert(ast: cdAst.NonNullAssert, mode: _Mode): any {
+    return convertToStatementIfNeeded(
+        mode, o.assertNotNull(this._visit(ast.expression, _Mode.Expression)));
+  }
+
   visitPropertyRead(ast: cdAst.PropertyRead, mode: _Mode): any {
     const leftMostSafe = this.leftMostSafeNode(ast);
     if (leftMostSafe) {
@@ -509,6 +514,7 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
       visitMethodCall(ast: cdAst.MethodCall) { return visit(this, ast.receiver); },
       visitPipe(ast: cdAst.BindingPipe) { return null; },
       visitPrefixNot(ast: cdAst.PrefixNot) { return null; },
+      visitNonNullAssert(ast: cdAst.NonNullAssert) { return null; },
       visitPropertyRead(ast: cdAst.PropertyRead) { return visit(this, ast.receiver); },
       visitPropertyWrite(ast: cdAst.PropertyWrite) { return null; },
       visitQuote(ast: cdAst.Quote) { return null; },
@@ -547,6 +553,7 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
       visitMethodCall(ast: cdAst.MethodCall) { return true; },
       visitPipe(ast: cdAst.BindingPipe) { return true; },
       visitPrefixNot(ast: cdAst.PrefixNot) { return visit(this, ast.expression); },
+      visitNonNullAssert(ast: cdAst.PrefixNot) { return visit(this, ast.expression); },
       visitPropertyRead(ast: cdAst.PropertyRead) { return false; },
       visitPropertyWrite(ast: cdAst.PropertyWrite) { return false; },
       visitQuote(ast: cdAst.Quote) { return false; },

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -10,7 +10,8 @@ import * as chars from '../chars';
 import {CompilerInjectable} from '../injectable';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../ml_parser/interpolation_config';
 import {escapeRegExp} from '../util';
-import {AST, ASTWithSource, AstVisitor, Binary, BindingPipe, Chain, Conditional, EmptyExpr, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, ParseSpan, ParserError, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead, TemplateBinding} from './ast';
+
+import {AST, ASTWithSource, AstVisitor, Binary, BindingPipe, Chain, Conditional, EmptyExpr, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, NonNullAssert, ParseSpan, ParserError, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead, TemplateBinding} from './ast';
 import {EOF, Lexer, Token, TokenType, isIdentifier, isQuote} from './lexer';
 
 
@@ -523,6 +524,9 @@ export class _ParseAST {
         this.expectCharacter(chars.$RPAREN);
         result = new FunctionCall(this.span(result.span.start), result, args);
 
+      } else if (this.optionalOperator('!')) {
+        result = new NonNullAssert(this.span(result.span.start), result);
+
       } else {
         return result;
       }
@@ -810,6 +814,8 @@ class SimpleExpressionChecker implements AstVisitor {
   visitBinary(ast: Binary, context: any) {}
 
   visitPrefixNot(ast: PrefixNot, context: any) {}
+
+  visitNonNullAssert(ast: NonNullAssert, context: any) {}
 
   visitConditional(ast: Conditional, context: any) {}
 

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -344,6 +344,10 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     ast.condition.visitExpression(this, ctx);
     return null;
   }
+  visitAssertNotNullExpr(ast: o.AssertNotNull, ctx: EmitterVisitorContext): any {
+    ast.condition.visitExpression(this, ctx);
+    return null;
+  }
   abstract visitFunctionExpr(ast: o.FunctionExpr, ctx: EmitterVisitorContext): any;
   abstract visitDeclareFunctionStmt(stmt: o.DeclareFunctionStmt, context: any): any;
 

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -377,6 +377,15 @@ export class NotExpr extends Expression {
   }
 }
 
+export class AssertNotNull extends Expression {
+  constructor(public condition: Expression, sourceSpan?: ParseSourceSpan|null) {
+    super(condition.type, sourceSpan);
+  }
+  visitExpression(visitor: ExpressionVisitor, context: any): any {
+    return visitor.visitAssertNotNullExpr(this, context);
+  }
+}
+
 export class CastExpr extends Expression {
   constructor(public value: Expression, type?: Type|null, sourceSpan?: ParseSourceSpan|null) {
     super(type, sourceSpan);
@@ -503,6 +512,7 @@ export interface ExpressionVisitor {
   visitExternalExpr(ast: ExternalExpr, context: any): any;
   visitConditionalExpr(ast: ConditionalExpr, context: any): any;
   visitNotExpr(ast: NotExpr, context: any): any;
+  visitAssertNotNullExpr(ast: AssertNotNull, context: any): any;
   visitCastExpr(ast: CastExpr, context: any): any;
   visitFunctionExpr(ast: FunctionExpr, context: any): any;
   visitBinaryOperatorExpr(ast: BinaryOperatorExpr, context: any): any;
@@ -768,6 +778,11 @@ export class AstTransformer implements StatementVisitor, ExpressionVisitor {
         new NotExpr(ast.condition.visitExpression(this, context), ast.sourceSpan), context);
   }
 
+  visitAssertNotNullExpr(ast: AssertNotNull, context: any): any {
+    return this.transformExpr(
+        new AssertNotNull(ast.condition.visitExpression(this, context), ast.sourceSpan), context);
+  }
+
   visitCastExpr(ast: CastExpr, context: any): any {
     return this.transformExpr(
         new CastExpr(ast.value.visitExpression(this, context), ast.type, ast.sourceSpan), context);
@@ -945,6 +960,10 @@ export class RecursiveAstVisitor implements StatementVisitor, ExpressionVisitor 
     return ast;
   }
   visitNotExpr(ast: NotExpr, context: any): any {
+    ast.condition.visitExpression(this, context);
+    return ast;
+  }
+  visitAssertNotNullExpr(ast: AssertNotNull, context: any): any {
     ast.condition.visitExpression(this, context);
     return ast;
   }
@@ -1137,6 +1156,11 @@ export function literalMap(
 
 export function not(expr: Expression, sourceSpan?: ParseSourceSpan | null): NotExpr {
   return new NotExpr(expr, sourceSpan);
+}
+
+export function assertNotNull(
+    expr: Expression, sourceSpan?: ParseSourceSpan | null): AssertNotNull {
+  return new AssertNotNull(expr, sourceSpan);
 }
 
 export function fn(

--- a/packages/compiler/src/output/output_interpreter.ts
+++ b/packages/compiler/src/output/output_interpreter.ts
@@ -233,6 +233,9 @@ class StatementInterpreter implements o.StatementVisitor, o.ExpressionVisitor {
   visitNotExpr(ast: o.NotExpr, ctx: _ExecutionContext): any {
     return !ast.condition.visitExpression(this, ctx);
   }
+  visitAssertNotNullExpr(ast: o.AssertNotNull, ctx: _ExecutionContext): any {
+    return ast.condition.visitExpression(this, ctx);
+  }
   visitCastExpr(ast: o.CastExpr, ctx: _ExecutionContext): any {
     return ast.value.visitExpression(this, ctx);
   }

--- a/packages/compiler/src/output/ts_emitter.ts
+++ b/packages/compiler/src/output/ts_emitter.ts
@@ -129,6 +129,12 @@ class _TsEmitterVisitor extends AbstractEmitterVisitor implements o.TypeVisitor 
     return null;
   }
 
+  visitAssertNotNullExpr(ast: o.AssertNotNull, ctx: EmitterVisitorContext): any {
+    const result = super.visitAssertNotNullExpr(ast, ctx);
+    ctx.print(ast, '!');
+    return result;
+  }
+
   visitDeclareVarStmt(stmt: o.DeclareVarStmt, ctx: EmitterVisitorContext): any {
     if (ctx.isExportedVar(stmt.name) && stmt.value instanceof o.ExternalExpr && !stmt.type) {
       // check for a reexport

--- a/packages/compiler/test/aot/compiler_spec.ts
+++ b/packages/compiler/test/aot/compiler_spec.ts
@@ -14,7 +14,7 @@ import * as ts from 'typescript';
 
 import {extractSourceMap, originalPositionFor} from '../output/source_map_util';
 
-import {EmittingCompilerHost, MockData, MockDirectory, MockMetadataBundlerHost, arrayToMockDir, arrayToMockMap, compile, settings, setup, toMockFileArray} from './test_util';
+import {EmittingCompilerHost, MockData, MockDirectory, MockMetadataBundlerHost, arrayToMockDir, arrayToMockMap, compile, expectNoDiagnostics, settings, setup, toMockFileArray} from './test_util';
 
 describe('compiler (unbundled Angular)', () => {
   let angularFiles = setup();
@@ -214,6 +214,32 @@ describe('compiler (unbundled Angular)', () => {
                `Warning: Can't resolve all parameters for MyService in /app/app.ts: (?). This will become an error in Angular v5.x`);
          });
 
+       }));
+
+    it('should be able to supress a null access', async(() => {
+         const FILES: MockDirectory = {
+           app: {
+             'app.ts': `
+                import {Component, NgModule} from '@angular/core';
+
+                interface Person { name: string; }
+
+                @Component({
+                  selector: 'my-comp',
+                  template: '{{maybe_person!.name}}'
+                })
+                export class MyComp {
+                  maybe_person?: Person;
+                }
+
+                @NgModule({
+                  declarations: [MyComp]
+                })
+                export class MyModule {}
+              `
+           }
+         };
+         compile([FILES, angularFiles], {postCompile: expectNoDiagnostics});
        }));
   });
 

--- a/packages/compiler/test/aot/test_util.ts
+++ b/packages/compiler/test/aot/test_util.ts
@@ -44,6 +44,7 @@ export const settings: ts.CompilerOptions = {
   removeComments: false,
   noImplicitAny: false,
   skipLibCheck: true,
+  strictNullChecks: true,
   lib: ['lib.es2015.d.ts', 'lib.dom.d.ts'],
   types: []
 };

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -112,6 +112,12 @@ export function main() {
         checkAction('!!!true');
       });
 
+      it('should parse postfix ! expression', () => {
+        checkAction('true!');
+        checkAction('a!.b');
+        checkAction('a!!!!.b');
+      });
+
       it('should parse multiplicative expressions',
          () => { checkAction('3*4/2%5', '3 * 4 / 2 % 5'); });
 

--- a/packages/compiler/test/expression_parser/unparser.ts
+++ b/packages/compiler/test/expression_parser/unparser.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, AstVisitor, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead} from '../../src/expression_parser/ast';
+import {AST, AstVisitor, Binary, BindingPipe, Chain, Conditional, FunctionCall, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, MethodCall, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeMethodCall, SafePropertyRead} from '../../src/expression_parser/ast';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../src/ml_parser/interpolation_config';
 
 class Unparser implements AstVisitor {
@@ -154,6 +154,11 @@ class Unparser implements AstVisitor {
   visitPrefixNot(ast: PrefixNot, context: any) {
     this._expression += '!';
     this._visit(ast.expression);
+  }
+
+  visitNonNullAssert(ast: NonNullAssert, context: any) {
+    this._visit(ast.expression);
+    this._expression += '!';
   }
 
   visitSafePropertyRead(ast: SafePropertyRead, context: any) {

--- a/packages/compiler/test/output/js_emitter_spec.ts
+++ b/packages/compiler/test/output/js_emitter_spec.ts
@@ -146,6 +146,7 @@ export function main() {
       const lhs = o.variable('lhs');
       const rhs = o.variable('rhs');
       expect(emitStmt(o.not(someVar).toStmt())).toEqual('!someVar;');
+      expect(emitStmt(o.assertNotNull(someVar).toStmt())).toEqual('someVar;');
       expect(
           emitStmt(someVar.conditional(o.variable('trueCase'), o.variable('falseCase')).toStmt()))
           .toEqual('(someVar? trueCase: falseCase);');

--- a/packages/compiler/test/output/ts_emitter_spec.ts
+++ b/packages/compiler/test/output/ts_emitter_spec.ts
@@ -232,6 +232,7 @@ export function main() {
       const rhs = o.variable('rhs');
       expect(emitStmt(someVar.cast(o.INT_TYPE).toStmt())).toEqual('(<number>someVar);');
       expect(emitStmt(o.not(someVar).toStmt())).toEqual('!someVar;');
+      expect(emitStmt(o.assertNotNull(someVar).toStmt())).toEqual('someVar!;');
       expect(
           emitStmt(someVar.conditional(o.variable('trueCase'), o.variable('falseCase')).toStmt()))
           .toEqual('(someVar? trueCase: falseCase);');

--- a/packages/language-service/src/expressions.ts
+++ b/packages/language-service/src/expressions.ts
@@ -69,6 +69,7 @@ export function getExpressionCompletions(
       }
     },
     visitPrefixNot(ast) {},
+    visitNonNullAssert(ast) {},
     visitPropertyRead(ast) {
       const receiverType = getType(ast.receiver);
       result = receiverType ? receiverType.members() : scope;
@@ -138,6 +139,7 @@ export function getExpressionSymbol(
       }
     },
     visitPrefixNot(ast) {},
+    visitNonNullAssert(ast) {},
     visitPropertyRead(ast) {
       const receiverType = getType(ast.receiver);
       symbol = receiverType && receiverType.members().get(ast.name);


### PR DESCRIPTION
Template expressions can now use a post-fix `!` operator
that asserts the target of the operator is not null. This is
similar to the TypeScript non-null assert operator. Expressions
generated in factories will be generated with the non-null assert
operator.

Closes: #10855

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Feature
```

**What is the new behavior?**

Discussed in the commit message above.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
