### PR TITLE
build(aio): fail the doc-gen if there is an invalid `{@link ...}` tag

### DIFF
--- a/aio/tools/transforms/angular.io-package/index.js
+++ b/aio/tools/transforms/angular.io-package/index.js
@@ -25,7 +25,11 @@ module.exports = new Package('angular.io', [gitPackage, apiPackage, contentPacka
     renderDocsProcessor.extraData.versionInfo = versionInfo;
   })
 
-  .config(function(checkAnchorLinksProcessor) {
+  .config(function(checkAnchorLinksProcessor, linkInlineTagDef) {
+
+    // Fail the processing if there is an invalid link
+    linkInlineTagDef.failOnBadLink = true;
+
     checkAnchorLinksProcessor.$enabled = true;
     // since we encode the HTML to JSON we need to ensure that this processor runs before that encoding happens.
     checkAnchorLinksProcessor.$runBefore = ['convertToJsonProcessor'];


### PR DESCRIPTION
This fail behaviour is only turned on for `yarn docs`;
in `yarn docs-watch` you only receive a warning.
This is because you can get false errors when watching
since we don't parse all the docs in that case.

Closes #15199