### PR TITLE
docs(aio): add a progress reporter for the webpack guide

### DIFF
--- a/aio/content/examples/webpack/config/karma.conf.js
+++ b/aio/content/examples/webpack/config/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function (config) {
       noInfo: true
     },
 
-    reporters: ['kjhtml'],
+    reporters: ['progress', 'kjhtml'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,


### PR DESCRIPTION
Without this reporter, it seemed that it wasn't running any test.
