### PR TITLE
refactor(aio): remove redundant styles

### DIFF
--- a/aio/src/styles/2-modules/_live-example.scss
+++ b/aio/src/styles/2-modules/_live-example.scss
@@ -1,3 +1,0 @@
-live-example > div:first-child {
-    max-width: 600px;
-}

--- a/aio/src/styles/2-modules/_modules-dir.scss
+++ b/aio/src/styles/2-modules/_modules-dir.scss
@@ -20,7 +20,6 @@
    @import 'search-results';
    @import 'api-list';
    @import 'hr';
-   @import 'live-example';
    @import 'scrollbar';
    @import 'callout';
    @import 'resources';


### PR DESCRIPTION
Due to the new structure of `live-example`, the only style in `_live-example.scss` was not applied. This is OK according to https://github.com/angular/angular/issues/15935#issuecomment-295482503, since we want it to take the full width.

Fixes #15935