### PR TITLE
fix(upgrade): Prevent renaming of $inject property

### DIFF
--- a/packages/upgrade/src/common/downgrade_injectable.ts
+++ b/packages/upgrade/src/common/downgrade_injectable.ts
@@ -53,7 +53,7 @@ import {INJECTOR_KEY} from './constants';
  */
 export function downgradeInjectable(token: any): Function {
   const factory = function(i: Injector) { return i.get(token); };
-  (factory as any).$inject = [INJECTOR_KEY];
+  (factory as any)['$inject'] = [INJECTOR_KEY];
 
   return factory;
 }


### PR DESCRIPTION
Use bracket notation to access $inject in downgradeInjectable to
support property renaming. Since the return type is any, Closure compiler renames $inject.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When downgrading an Angular injectable, the `$inject` property is renamed by Closure Compiler in the resulting AngularJS factory. See [PR#14441](https://github.com/angular/angular/pull/14441) for a similar issue in downgradeComponent.



**What is the new behavior?**
The `$inject` property is no longer renamed because it is accessed using brackets and a string.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

