### PR TITLE
fix(upgrade): use quote to prevent ClosureCompiler obfuscating $event.

### DIFF
--- a/packages/upgrade/src/common/downgrade_component_adapter.ts
+++ b/packages/upgrade/src/common/downgrade_component_adapter.ts
@@ -165,7 +165,7 @@ export class DowngradeComponentAdapter {
             next: assignExpr ?
                 ((setter: any) => (v: any /** TODO #9100 */) => setter(this.scope, v))(setter) :
                 ((getter: any) => (v: any /** TODO #9100 */) =>
-                     getter(this.scope, {$event: v}))(getter)
+                     getter(this.scope, {'$event': v}))(getter)
           });
         } else {
           throw new Error(


### PR DESCRIPTION
This is critical for AngularJS to get the $event object in template when using ClosureCompiler.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
ClosureCompiler will obfuscated $event, which makes AngularJS template unable to pass event object from Angular component.


**What is the new behavior?**
ClosureCompiler won't obfuscated $event. 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

