### PR TITLE
fix(compiler-cli): allow '==' to compare nullable types

### DIFF
--- a/packages/compiler-cli/test/diagnostics/expression_diagnostics_spec.ts
+++ b/packages/compiler-cli/test/diagnostics/expression_diagnostics_spec.ts
@@ -175,7 +175,16 @@ describe('expression diagnostics', () => {
   it('should reject an uncalled event handler',
      () => reject(
          '<div (click)="click">{{person.name.first}}</div>', 'Unexpected callable expression'));
-
+  describe('with comparisions between nullable and non-nullable', () => {
+    it('should accept ==', () => accept(`<div>{{e == 1 ? 'a' : 'b'}}</div>`));
+    it('should accept ===', () => accept(`<div>{{e === 1 ? 'a' : 'b'}}</div>`));
+    it('should accept !=', () => accept(`<div>{{e != 1 ? 'a' : 'b'}}</div>`));
+    it('should accept !==', () => accept(`<div>{{e !== 1 ? 'a' : 'b'}}</div>`));
+    it('should accept &&', () => accept(`<div>{{e && 1 ? 'a' : 'b'}}</div>`));
+    it('should accept ||', () => accept(`<div>{{e || 1 ? 'a' : 'b'}}</div>`));
+    it('should reject >',
+       () => reject(`<div>{{e > 1 ? 'a' : 'b'}}</div>`, 'The expression might be null'));
+  });
 });
 
 const FILES: Directory = {
@@ -216,6 +225,7 @@ const FILES: Directory = {
           promised_people: Promise<Person[]>;
           private private_person: Person;
           private private_people: Person[];
+          e?: number;
 
           getPerson(): Person { return this.person; }
           click() {}


### PR DESCRIPTION
Fixes: #16729

* fix(compiler-cli): diagnose issues in conditional of ternary

Fixes: #16730

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

Comparing a nullable type with a non-nullable type produces an error.

**What is the new behavior?**

No error is reported.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
