### PR TITLE
ci(aio): create previews for all PRs that touch non-spec files in `aio/` or `packages/`

### DIFF
--- a/aio/scripts/deploy-preview.sh
+++ b/aio/scripts/deploy-preview.sh
@@ -4,21 +4,53 @@
 set +x -eu -o pipefail
 
 
-INPUT_DIR=dist/
-OUTPUT_FILE=/tmp/snapshot.tar.gz
-AIO_BUILDS_DOMAIN=ngbuilds.io
-UPLOAD_URL=https://$AIO_BUILDS_DOMAIN/create-build/$TRAVIS_PULL_REQUEST/$TRAVIS_PULL_REQUEST_SHA
-DEPLOYED_URL=https://pr$TRAVIS_PULL_REQUEST-$TRAVIS_PULL_REQUEST_SHA.$AIO_BUILDS_DOMAIN
+readonly INPUT_DIR=dist/
+readonly OUTPUT_FILE=/tmp/snapshot.tar.gz
+readonly AIO_BUILDS_DOMAIN=ngbuilds.io
+readonly UPLOAD_URL=https://$AIO_BUILDS_DOMAIN/create-build/$TRAVIS_PULL_REQUEST/$TRAVIS_PULL_REQUEST_SHA
+readonly DEPLOYED_URL=https://pr$TRAVIS_PULL_REQUEST-$TRAVIS_PULL_REQUEST_SHA.$AIO_BUILDS_DOMAIN
+readonly skipBuild=$([[ "$1" == "--skip-build" ]] && echo "true" || echo "");
+readonly relevantChangedFilesCount=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -P "^(?:aio|packages)/(?!.*[._]spec\.[jt]s$)" | wc -l)
 
 cd "`dirname $0`/.."
 
+# Do not deploy unless this PR has touched relevant files: `aio/` or `packages/` (except for spec files)
+if [[ $relevantChangedFilesCount -eq 0 ]]; then
+  echo "Skipping deploy because this PR did not touch any relevant files."
+  exit 0
+fi
+
+# Do not deploy unless this PR meets certain preconditions.
+readonly preverifyExitCode=$(./aio-builds-setup/scripts/travis-preverify-pr.sh && echo 0 || echo $?)
+case $preverifyExitCode in
+  0)
+    # Preconditions met: Deploy
+    ;;
+  1)
+    # Preconditions not met: Skip deploy
+    echo "Skipping deploy because this PR did not meet the preconditions."
+    exit 0
+    ;;
+  2)
+    # An error occurred: Fail the script
+    exit 1
+    ;;
+  *)
+    # Unexpected exit code: Fail the script
+    echo "Unexpected preverification exit code: $preverifyExitCode"
+    exit 1
+    ;;
+esac
+
 # Build the app
-yarn build
+if [ "$skipBuild" != "true" ]; then
+  yarn build
+fi
 tar --create --gzip --directory "$INPUT_DIR" --file "$OUTPUT_FILE" .
 
 # Deploy to staging
 exec 3>&1
-httpCode=$(
+readonly httpCode=$(
   curl --include --location --request POST --silent --write-out "\nHTTP_CODE: %{http_code}\n" \
        --header "Authorization: Token $NGBUILDS_IO_KEY" --data-binary "@$OUTPUT_FILE" "$UPLOAD_URL" \
   | sed 's/\r\n/\n/' \

--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -40,9 +40,9 @@ case ${CI_MODE} in
     travisFoldEnd "deploy.packages"
     ;;
   aio)
-    # Don't deploy if this build is not for master or aio-master
-    if [[ ${TRAVIS_BRANCH} != "master" && ${TRAVIS_BRANCH} != "aio-master" ]]; then
-      echo "Skipping deploy because this build is not for master or aio-master."
+    # Don't deploy if this build is not for master
+    if [[ ${TRAVIS_BRANCH} != "master" ]]; then
+      echo "Skipping deploy because this build is not for master."
       exit 0
     fi
 
@@ -51,34 +51,10 @@ case ${CI_MODE} in
       cd ${TRAVIS_BUILD_DIR}/aio
 
       if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
-        # This is a PR: deploy a snapshot for previewing
+        # This is a PR: deploy a snapshot for previewing (if preconditions met)
         travisFoldStart "deploy.aio.pr-preview"
-          # Only deploy if this PR has touched relevant files.
-          readonly AIO_CHANGED_FILES_COUNT=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep ^aio/ | wc -l)
-          if [[ AIO_CHANGED_FILES_COUNT -eq 0 ]]; then
-            echo "Skipping deploy because this PR did not touch any files inside 'aio/'."
-          else
-            # Only deploy if this PR meets certain preconditions.
-            readonly AIO_PREVERIFY_EXIT_CODE=$(./aio-builds-setup/scripts/travis-preverify-pr.sh && echo 0 || echo $?)
-            case $AIO_PREVERIFY_EXIT_CODE in
-              2)
-                # An error occurred: Fail the build
-                exit 1;
-                ;;
-              1)
-                # Preconditions not met: Skip deploy
-                echo "Skipping deploy because this PR did not meet the preconditions."
-                ;;
-              0)
-                # Preconditions met: Deploy
-                yarn deploy-preview
-                ;;
-            esac
-          fi
+          yarn deploy-preview
         travisFoldEnd "deploy.aio.pr-preview"
-      elif [[ ${TRAVIS_BRANCH} == "aio-master" ]]; then
-        # This is upstream aio-master: Don't deploy to staging
-        echo "Skipping deploy to staging because this build is for upstream aio-master."
       else
         # This is upstream master: Deploy to staging
         travisFoldStart "deploy.aio.staging"


### PR DESCRIPTION
Previously, no previews would be deployed for PRs that didn't touch files inside `aio/`. Now, previews will be deployed for PRs that touch non-spec files inside either `aio/` or `packages/` (as long as other preconditions are met).

Partially addresses #16526.