### PR TITLE
ci(aio): deploy previews early (right after build)

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -41,7 +41,18 @@ travisFoldEnd "tsc a bunch of useless stuff"
 if [[ ${CI_MODE:-} == "aio" ]]; then
   travisFoldStart "build.aio"
     cd "`dirname $0`/../../aio"
-    yarn run build
+    yarn build
+
+    # If this is a PR for angular/angular@master, deploy a snapshot for previewing early
+    # (if preconditions are met) regardless of the test outcome.
+    if [[ ${TRAVIS_REPO_SLUG} == "angular/angular" ]] &&
+       [[ ${TRAVIS_BRANCH} == "master" ]] &&
+       [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
+      travisFoldStart "deploy.aio.pr-preview"
+        yarn deploy-preview -- --skip-build
+      travisFoldEnd "deploy.aio.pr-preview"
+    fi
+
     cd -
   travisFoldEnd "build.aio"
 fi

--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -51,10 +51,7 @@ case ${CI_MODE} in
       cd ${TRAVIS_BUILD_DIR}/aio
 
       if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
-        # This is a PR: deploy a snapshot for previewing (if preconditions met)
-        travisFoldStart "deploy.aio.pr-preview"
-          yarn deploy-preview
-        travisFoldEnd "deploy.aio.pr-preview"
+        # This is a PR: It has already been deployed in `build.sh`.
       else
         # This is upstream master: Deploy to staging
         travisFoldStart "deploy.aio.staging"


### PR DESCRIPTION
Previously, PR previews were deployed after successfully running all tests. While this makes sense for staging/production deployments, previews should be available as soon as possible (and regardless of the outcome of tests).

Fixes #16705.