### PR TITLE
fix(forms): update form control disabled state

### DIFF
--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -57,6 +57,7 @@ export function setUpControl(control: FormControl, dir: NgControl): void {
   });
 
   if (dir.valueAccessor !.setDisabledState) {
+    dir.valueAccessor !.setDisabledState !(control.disabled);
     control.registerOnDisabledChange(
         (isDisabled: boolean) => { dir.valueAccessor !.setDisabledState !(isDisabled); });
   }


### PR DESCRIPTION
When you recreate FormGroup only value and validators are being updated on formControlName directive but not the state.

Fixes #15206 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

When you create a new FormGroup the HTML element state (disabled/enabled) is not updated.

**What is the new behavior?**

The HTML element state is updated.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
