### PR TITLE
aio: search results escape

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -5,10 +5,10 @@
   </button>
   <a class="nav-link home" href="/"><img src="{{ homeImageUrl }}" title="Home" alt="Home"></a>
   <aio-top-menu *ngIf="isSideBySide" [nodes]="topMenuNodes"></aio-top-menu>
-  <aio-search-box class="search-container" #searchBox></aio-search-box>
+  <aio-search-box class="search-container" #searchBox (search)="doSearch($event)"></aio-search-box>
   <span class="fill-remaining-space"></span>
 </md-toolbar>
-<aio-search-results #searchResults></aio-search-results>
+<aio-search-results #searchResults *ngIf="showSearchResults" (resultSelected)="hideSearchResults()"></aio-search-results>
 
 <md-sidenav-container class="sidenav-container" [class.starting]="isStarting" role="main">
 

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -504,6 +504,15 @@ describe('AppComponent', () => {
         fixture.detectChanges();
         expect(searchBox.focus).toHaveBeenCalled();
       });
+
+      it('should set focus back to the search box when the search results are displayed and the escape key is pressed', () => {
+        const searchBox: SearchBoxComponent = fixture.debugElement.query(By.directive(SearchBoxComponent)).componentInstance;
+        spyOn(searchBox, 'focus');
+        component.showSearchResults = true;
+        window.document.dispatchEvent(new KeyboardEvent('keyup', { 'key': 'Escape' }));
+        fixture.detectChanges();
+        expect(searchBox.focus).toHaveBeenCalled();
+      });
     });
 
     describe('showing search results', () => {

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -268,6 +268,7 @@ export class AppComponent implements OnInit {
       // escape key
       if (this.showSearchResults) {
         this.hideSearchResults();
+        this.focusSearchBox();
       }
     }
   }

--- a/aio/src/app/search/search-box/search-box.component.spec.ts
+++ b/aio/src/app/search/search-box/search-box.component.spec.ts
@@ -1,20 +1,27 @@
+import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed, inject } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SearchBoxComponent } from './search-box.component';
-import { SearchService } from '../search.service';
 import { MockSearchService } from 'testing/search.service';
 import { LocationService } from 'app/shared/location.service';
 import { MockLocationService } from 'testing/location.service';
 
+@Component({
+  template: '<aio-search-box (search)="doSearch($event)"></aio-search-box>'
+})
+class HostComponent {
+  doSearch = jasmine.createSpy('doSearch');
+}
+
 describe('SearchBoxComponent', () => {
   let component: SearchBoxComponent;
-  let fixture: ComponentFixture<SearchBoxComponent>;
+  let host: HostComponent;
+  let fixture: ComponentFixture<HostComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SearchBoxComponent ],
+      declarations: [ SearchBoxComponent, HostComponent ],
       providers: [
-        { provide: SearchService, useFactory: () => new MockSearchService() },
         { provide: LocationService, useFactory: () => new MockLocationService('') }
       ]
     })
@@ -22,61 +29,51 @@ describe('SearchBoxComponent', () => {
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(SearchBoxComponent);
-    component = fixture.componentInstance;
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    component = fixture.debugElement.query(By.directive(SearchBoxComponent)).componentInstance;
     fixture.detectChanges();
   });
 
   describe('initialisation', () => {
-    it('should initialize the search worker', inject([SearchService], (searchService: SearchService) => {
-      fixture.detectChanges(); // triggers ngOnInit
-      expect(searchService.initWorker).toHaveBeenCalled();
-      expect(searchService.loadIndex).toHaveBeenCalled();
-    }));
-
     it('should get the current search query from the location service', inject([LocationService], (location: MockLocationService) => {
       location.search.and.returnValue({ search: 'initial search' });
-      spyOn(component, 'onSearch');
       component.ngOnInit();
       expect(location.search).toHaveBeenCalled();
-      expect(component.onSearch).toHaveBeenCalledWith('initial search');
+      expect(host.doSearch).toHaveBeenCalledWith('initial search');
       expect(component.searchBox.nativeElement.value).toEqual('initial search');
     }));
   });
 
   describe('on keyup', () => {
-    it('should call the search service, if it is not triggered by the ESC key', inject([SearchService], (search: MockSearchService) => {
+    it('should trigger the search event', () => {
       const input = fixture.debugElement.query(By.css('input'));
       input.triggerEventHandler('keyup', { target: { value: 'some query' } });
-      expect(search.search).toHaveBeenCalledWith('some query');
-    }));
-
-    it('should not call the search service if it is triggered by the ESC key', inject([SearchService], (search: MockSearchService) => {
-      const input = fixture.debugElement.query(By.css('input'));
-      input.triggerEventHandler('keyup', { target: { value: 'some query' }, which: 27 });
-      expect(search.search).not.toHaveBeenCalled();
-    }));
-
-    it('should grab focus when the / key is pressed', () => {
-      const input = fixture.debugElement.query(By.css('input'));
-      window.document.dispatchEvent(new KeyboardEvent('keyup', { 'key': '/' }));
-      expect(document.activeElement).toBe(input.nativeElement, 'Search box should be active element');
+      expect(host.doSearch).toHaveBeenCalledWith('some query');
     });
   });
 
   describe('on focus', () => {
-    it('should call the search service on focus', inject([SearchService], (search: SearchService) => {
+    it('should trigger the search event', () => {
       const input = fixture.debugElement.query(By.css('input'));
       input.triggerEventHandler('focus', { target: { value: 'some query' } });
-      expect(search.search).toHaveBeenCalledWith('some query');
-    }));
+      expect(host.doSearch).toHaveBeenCalledWith('some query');
+    });
   });
 
   describe('on click', () => {
-    it('should call the search service on click', inject([SearchService], (search: SearchService) => {
+    it('should trigger the search event', () => {
       const input = fixture.debugElement.query(By.css('input'));
       input.triggerEventHandler('click', { target: { value: 'some query'}});
-      expect(search.search).toHaveBeenCalledWith('some query');
-    }));
+      expect(host.doSearch).toHaveBeenCalledWith('some query');
+    });
+  });
+
+  describe('focus', () => {
+    it('should set the focus to the input box', () => {
+      const input = fixture.debugElement.query(By.css('input'));
+      component.focus();
+      expect(document.activeElement).toBe(input.nativeElement);
+    });
   });
 });

--- a/aio/src/app/search/search-results/search-results.component.html
+++ b/aio/src/app/search/search-results/search-results.component.html
@@ -1,6 +1,10 @@
-<div class="search-results" *ngIf="hasAreas | async" >
+<div class="search-results">
+  <div *ngIf="searchAreas.length; then searchResults; else notFound"></div>
+</div>
+
+<ng-template #searchResults>
   <h2 class="visually-hidden">Search Results</h2>
-  <div class="search-area" *ngFor="let area of searchAreas | async">
+  <div class="search-area" *ngFor="let area of searchAreas">
     <h3>{{area.name}} ({{area.pages.length}})</h3>
     <ul class="priority-pages" >
       <li class="search-page" *ngFor="let page of area.priorityPages">
@@ -18,7 +22,8 @@
       </li>
     </ul>
   </div>
-</div>
-<div class="search-results" *ngIf="notFound" >
+</ng-template>
+
+<ng-template #notFound>
   <p>No results found.</p>
-</div>
+</ng-template>

--- a/aio/src/app/search/search.service.ts
+++ b/aio/src/app/search/search.service.ts
@@ -6,7 +6,7 @@ can be found in the LICENSE file at http://angular.io/license
 
 import { NgZone, Injectable, Type } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
 import 'rxjs/add/operator/publishLast';
 import 'rxjs/add/operator/concatMap';
 import { WebWorkerClient } from 'app/shared/web-worker';
@@ -29,7 +29,7 @@ export interface SearchResult {
 export class SearchService {
   private worker: WebWorkerClient;
   private ready: Observable<boolean>;
-  private resultsSubject = new Subject<SearchResults>();
+  private resultsSubject = new ReplaySubject<SearchResults>(1);
   readonly searchResults = this.resultsSubject.asObservable();
 
   constructor(private zone: NgZone) {}

--- a/aio/src/testing/search.service.ts
+++ b/aio/src/testing/search.service.ts
@@ -6,5 +6,4 @@ export class MockSearchService {
   initWorker = jasmine.createSpy('initWorker');
   loadIndex = jasmine.createSpy('loadIndex');
   search = jasmine.createSpy('search');
-  hideResults = jasmine.createSpy('hideResults');
 }


### PR DESCRIPTION
For improved accessibility, the focus should be sent
back to the input box when we are displaying the
search results and the user hits ESC.

See #16005

(This fix is enabled by the refactoring of the search UI management code.)