### PR TITLE
fix(router): Wrap Promise-like instances in native Promises

### DIFF
--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -97,7 +97,10 @@ export function wrapIntoObservable<T>(value: T | NgModuleFactory<T>| Promise<T>|
   }
 
   if (isPromise(value)) {
-    return fromPromise(value);
+    // Use `Promise.resolve()` to wrap promise-like instances.
+    // Required ie when a Resolver returns a AngularJS `$q` promise to correctly trigger the
+    // change detection.
+    return fromPromise(Promise.resolve(value));
   }
 
   return of (value);


### PR DESCRIPTION
Hybrid apps (mix of Angular and AngularJS) might return AngularJS implementation
of Promises that do not play well with the change detection. Wrapping them in
native Promises fix this issue.

This could be the case when a Resolver returns a `$q` promise.

**fixes an issue in g3, validated with @bourey**

presubmit cl/155873380