### PR TITLE
fix(compiler): don't throw on source elements in xtb files

### DIFF
--- a/packages/compiler/src/i18n/serializers/xtb.ts
+++ b/packages/compiler/src/i18n/serializers/xtb.ts
@@ -17,6 +17,7 @@ import {digest, toPublicName} from './xmb';
 const _TRANSLATIONS_TAG = 'translationbundle';
 const _TRANSLATION_TAG = 'translation';
 const _PLACEHOLDER_TAG = 'ph';
+const _SOURCE_TAG = 'source';
 
 export class Xtb extends Serializer {
   write(messages: i18n.Message[], locale: string|null): string { throw new Error('Unsupported'); }
@@ -195,7 +196,7 @@ class XmlToI18n implements ml.Visitor {
       }
 
       this._addError(el, `<${_PLACEHOLDER_TAG}> misses the "name" attribute`);
-    } else {
+    } else if (el.name !== _SOURCE_TAG) {
       this._addError(el, `Unexpected tag`);
     }
     return null;

--- a/packages/compiler/test/i18n/integration_xmb_xtb_spec.ts
+++ b/packages/compiler/test/i18n/integration_xmb_xtb_spec.ts
@@ -57,10 +57,10 @@ export function main() {
 
 const XTB = `
 <translationbundle>
-  <translation id="615790887472569365">attributs i18n sur les balises</translation>
+  <translation id="615790887472569365"><source>file.ts:3</source>attributs i18n sur les balises</translation>
   <translation id="3707494640264351337">imbriqué</translation>
-  <translation id="5539162898278769904">imbriqué</translation>
-  <translation id="3780349238193953556"><ph name="START_ITALIC_TEXT"/>avec des espaces réservés<ph name="CLOSE_ITALIC_TEXT"/></translation>
+  <translation id="5539162898278769904"><source>file.ts:7</source>imbriqué</translation>
+  <translation id="3780349238193953556"><source>file.ts:9</source><source>file.ts:10</source><ph name="START_ITALIC_TEXT"/>avec des espaces réservés<ph name="CLOSE_ITALIC_TEXT"/></translation>
   <translation id="5525133077318024839">sur des balises non traductibles</translation>
   <translation id="8670732454866344690">sur des balises traductibles</translation>
   <translation id="4593805537723189714">{VAR_PLURAL, plural, =0 {zero} =1 {un} =2 {deux} other {<ph name="START_BOLD_TEXT"/>beaucoup<ph name="CLOSE_BOLD_TEXT"/>}}</translation>

--- a/packages/compiler/test/i18n/serializers/xtb_spec.ts
+++ b/packages/compiler/test/i18n/serializers/xtb_spec.ts
@@ -73,6 +73,15 @@ export function main(): void {
         });
       });
 
+      it('should load XTB files with source elements', () => {
+        const XTB = `<?xml version="1.0" encoding="UTF-8"?>
+<translationbundle>
+  <translation id="8841459487341224498"><source>file.ts:1</source>rab</translation>
+</translationbundle>`;
+
+        expect(loadAsMap(XTB)).toEqual({'8841459487341224498': 'rab'});
+      });
+
       it('should replace ICU placeholders with their translations', () => {
         const XTB = `<?xml version="1.0" encoding="UTF-8" ?>
 <translationbundle>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)
When we extract xmb we add source elements to the translation file. If these elements stay in the xtb file, the parser will throw.
See #16638.


**What is the new behavior?**
The xtb parser ignores source elements


**Does this PR introduce a breaking change?**
```
[x] No
```