### PR TITLE
fix(aio): fix PWA testing in cases where `atob`/`btoa` is necessary

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -85,7 +85,7 @@
     "karma-coverage-istanbul-reporter": "^0.2.0",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "lighthouse": "^1.6.3",
+    "lighthouse": "1.6.3",
     "lodash": "^4.17.4",
     "protractor": "~5.1.0",
     "rehype": "^4.0.0",

--- a/aio/scripts/deploy-preview.sh
+++ b/aio/scripts/deploy-preview.sh
@@ -69,5 +69,5 @@ readonly relevantChangedFilesCount=$(git diff --name-only $TRAVIS_COMMIT_RANGE |
   fi
 
   # Run PWA-score tests
-  yarn test-pwa-score -- "$DEPLOYED_URL" "$MIN_PWA_SCORE"
+  yarn test-pwa-score -- "$DEPLOYED_URL" "$MIN_PWA_SCORE" "$PWA_RESULTS_LOG"
 )

--- a/aio/scripts/deploy-staging.sh
+++ b/aio/scripts/deploy-staging.sh
@@ -20,5 +20,5 @@ DEPLOYED_URL=https://$FIREBASE_PROJECT_ID.firebaseapp.com
   # Run PWA-score tests
   # TODO(gkalpak): Figure out why this fails and re-enable.
   sleep 10
-  yarn test-pwa-score -- "$DEPLOYED_URL" "$MIN_PWA_SCORE" || true
+  yarn test-pwa-score -- "$DEPLOYED_URL" "$MIN_PWA_SCORE" "$PWA_RESULTS_LOG" || true
 )

--- a/aio/scripts/test-pwa-score.js
+++ b/aio/scripts/test-pwa-score.js
@@ -20,6 +20,10 @@ const config = require('lighthouse/lighthouse-core/config/default.json');
 // Constants
 const FLAGS = {output: 'json'};
 
+// Work-around traceviewer-js bug.
+global.atob = str => new Buffer(str, 'base64').toString('binary');
+global.btoa = str => new Buffer(str, 'binary').toString('base64');
+
 // Specify the path to Chrome on Travis
 if (process.env.TRAVIS) {
   process.env.LIGHTHOUSE_CHROMIUM_PATH = process.env.CHROME_BIN;

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -4086,7 +4086,7 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lighthouse@^1.6.3:
+lighthouse@1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/lighthouse/-/lighthouse-1.6.3.tgz#099ef484d94d844fab7189ef105e1f33464326b6"
   dependencies:

--- a/scripts/ci/env.sh
+++ b/scripts/ci/env.sh
@@ -120,6 +120,9 @@ setEnvVar PATH $HOME/.yarn/bin:$PATH
 setEnvVar NODE_PATH ${NODE_PATH:-}:${PROJECT_ROOT}/dist/all:${PROJECT_ROOT}/dist/tools
 setEnvVar LOGS_DIR /tmp/angular-build/logs
 
+# Log file for full PWA testing results
+setEnvVar PWA_RESULTS_LOG $LOGS_DIR/pwa-results.json
+
 # strip leading "/home/travis/build/angular/angular/" or "./" path. Could this be done in one shot?
 CURRENT_SHELL_SOURCE_FILE=${BASH_SOURCE#${PROJECT_ROOT}/}
 export CURRENT_SHELL_SOURCE_FILE=${CURRENT_SHELL_SOURCE_FILE#./}


### PR DESCRIPTION
In some cases (unclear when), traceviewer-js, used by Lighthouse under the hood, assumes `atob`/`btoa` are defined in the global scope. This is true for browser environments, but not on node.

As a result, some aggregations that required access to model-tracing failed to produce results, dropping the overall PWA score.

This affected #16665 (e.g. commit 0de6eec).

##
This PR also includes a commit to enable logging the full PWA testing results. This will (hopefully) help diagnose errors or regressions in PWA scores.