### PR TITLE
docs(aio): remove redundant tutorial instruction

### DIFF
--- a/aio/content/tutorial/toh-pt5.md
+++ b/aio/content/tutorial/toh-pt5.md
@@ -923,8 +923,15 @@ Use an ES2015 `import` statement *and* add it to the `NgModule.imports` list.
 Here is the revised `AppModule`, compared to its pre-refactor state:
 
 <code-tabs>
-  <code-pane path="toh-pt5/src/app/app.module.ts" title="src/app/app.module.ts (after)"></code-pane>
-  <code-pane path="toh-pt5/src/app/app.module.3.ts" title="src/app/app.module.ts (before)"></code-pane>
+
+  <code-pane title="src/app/app.module.ts (after)" path="toh-pt5/src/app/app.module.ts">
+  
+  </code-pane>
+  
+  <code-pane title="src/app/app.module.ts (before)" path="toh-pt5/src/app/app.module.3.ts">
+  
+  </code-pane>
+  
 </code-tabs>
 
 The revised and simplified `AppModule` is focused on identifying the key pieces of the app.
@@ -941,8 +948,6 @@ at the top and details of the selected hero below.
 </code-example>
 
 
-
-Delete the `<h1>` at the top.
 
 Delete the last line of the template with the `<hero-detail>` tags.
 


### PR DESCRIPTION
docs(aio): remove redundant tutorial instruction

this step was already completed earlier in this tutorial (line 214)

no breaking change

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: docs
```

**What is the current behavior?** (You can also link to an open issue here)
Instructions to do a step that was already done on line 214


**What is the new behavior?**
Deleted that redundant instruction.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Also reformatted a block of code-tabs to be the standard format. (just added spacing and swapped title and src tags. for some reason this component is not working on the live website: https://angular.io/docs/ts/latest/tutorial/toh-pt5.html but it looks like it may have been fixed already, so I just added the standard spacing.)