### PR TITLE
docs(aio): remove fundamentals/techniques intro pages

### DIFF
--- a/aio/content/guide/fundamentals.md
+++ b/aio/content/guide/fundamentals.md
@@ -1,3 +1,0 @@
-# Fundamentals of Angular
-
-Learn the fundamental features of Angular in this section of the guide.

--- a/aio/content/guide/techniques.md
+++ b/aio/content/guide/techniques.md
@@ -1,3 +1,0 @@
-# Techniques
-
-Learn important Angular application techniques such as how to setup, secure, and deploy your application.

--- a/aio/content/marketing/docs.md
+++ b/aio/content/marketing/docs.md
@@ -21,10 +21,10 @@ Angular is a platform that makes it easy to build applications with the web. Ang
       <p class="card-footer"><a href="guide/tutorial">Tutorial</a></p>-->
   </div>
 
-  <a href="guide/fundamentals" class="card" title="Angular Fundamentals">
+  <a href="guide/architecture" class="card" title="Angular Architecture">
       <section>Fundamentals</section>
-      <p>Get additional information on specific topics in the Fundamentals section.</p>
-      <p class="card-footer">Fundamentals</p>
+      <p>Learn Angular application fundamentals, starting with an architecture overview.</p>
+      <p class="card-footer">Architecture</p>
   </a>
 </div>
 

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -91,12 +91,6 @@
       "children": [
 
         {
-          "url": "guide/fundamentals",
-          "title": "Introduction",
-          "tooltip": "An introduction to the fundamentals of Angular."
-        },
-
-        {
           "url": "guide/animations",
           "title": "Animations",
           "tooltip": "A guide to Angular's animation system."
@@ -266,12 +260,6 @@
       "title": "Techniques",
       "tooltip": "Techniques for putting Angular to work in your environment",
       "children": [
-
-        {
-          "url": "guide/techniques",
-          "title": "Introduction",
-          "tooltip": "An introduction to techniques to use when developing with Angular."
-        },
 
         {
           "url": "guide/security",


### PR DESCRIPTION
Removed fundamentals/techniques intro pages which were placeholders.
Redirected the "Fundamentals" card on the "Docs" page to "architecture".

The essential changes in this PR were requested/approved by @juleskremer. The execution (specifically the new "Fundamentals" card verbiage) needs a look.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
