### PR TITLE
fix(aio): no white band below toolbar when mobile

### DIFF
--- a/aio/src/styles/0-base/_typography.scss
+++ b/aio/src/styles/0-base/_typography.scss
@@ -64,13 +64,13 @@
       clear: both;
     }
 
-    h1, h2 {
+    h1 {
       @media screen and (max-width: 600px) {
-        margin: 16px 0;
+        margin: 0;
       }
     }
 
-    h3, h4, h5, h6 {
+    h1:after, h2, h3, h4, h5, h6 {
       @media screen and (max-width: 600px) {
         margin: 8px 0;
       }

--- a/aio/src/styles/1-layouts/_sidenav.scss
+++ b/aio/src/styles/1-layouts/_sidenav.scss
@@ -39,6 +39,9 @@ md-sidenav-container.sidenav-container {
     @media (max-width: 800px) {
       max-width: 100%;
     }
+    @media (max-width: 600px) {
+      padding-top: 56px;
+    }
 }
 
 md-sidenav-container div.mat-sidenav-content {


### PR DESCRIPTION
At 600px wide, the buttons on toolbar shrank from 64 to 56px, leaving an 8px white band between the toolbar and the main content.

This fix shrinks the content’s top padding from 64 to 56 as well.

<hr>

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```