### PR TITLE
fix(aio): remove searchbox shrink animation

### DIFF
--- a/aio/src/styles/1-layouts/_top-menu.scss
+++ b/aio/src/styles/1-layouts/_top-menu.scss
@@ -95,18 +95,10 @@ aio-search-box input {
   background-color: $offwhite;
   padding: 5px 10px;
   margin-left: 8px;
-  width:150px;
+  width: 200px;
   height: 40%;
-   @include bp(big) {
-    transition: width 0.4s ease-in-out;
-    &:focus {
-      width: 50%;
-    }
-  }
+
   @media (max-width: 480px) {
-    transition: width 0.4s ease-in-out;
-    &:focus {
-      width: 50%;
-    }
+    width: 180px;
   }
 }


### PR DESCRIPTION
In mobile mode, the search box animated to a smaller size when you typed in the box, presumably to make more room to type a longer search term. The animation is both distracting and unnecessary.

This PR has a wide and narrower searchbox but does not animate. Even the narrower width for mobile is wide enough to accommodate the longest typical search term (e.g., "ahead-of-time compilation").

<hr>

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```