### PR TITLE
fix(router): Named route and lazyloading

### DIFF
--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -393,9 +393,10 @@ function validateNode(route: Route, fullPath: string): void {
   if (Array.isArray(route)) {
     throw new Error(`Invalid configuration of route '${fullPath}': Array cannot be specified`);
   }
-  if (!route.component && (route.outlet && route.outlet !== PRIMARY_OUTLET)) {
+  if (!route.component && !route.loadChildren &&
+      (route.outlet && route.outlet !== PRIMARY_OUTLET)) {
     throw new Error(
-        `Invalid configuration of route '${fullPath}': a componentless route cannot have a named outlet set`);
+        `Invalid configuration of route '${fullPath}': a named outlet should wether have component or loadChildren`);
   }
   if (route.redirectTo && route.children) {
     throw new Error(

--- a/packages/router/test/config.spec.ts
+++ b/packages/router/test/config.spec.ts
@@ -132,8 +132,10 @@ describe('config', () => {
     it('should throw when pathPatch is invalid', () => {
       expect(() => { validateConfig([{path: 'a', outlet: 'aux', children: []}]); })
           .toThrowError(
-              /Invalid configuration of route 'a': a componentless route cannot have a named outlet set/);
+              /Invalid configuration of route 'a': a named outlet should wether have component or loadChildren/);
 
+      expect(() => validateConfig([{path: 'a', outlet: 'aux', loadChildren: 'value'}]))
+          .not.toThrow();
       expect(() => validateConfig([{path: 'a', outlet: '', children: []}])).not.toThrow();
       expect(() => validateConfig([{path: 'a', outlet: PRIMARY_OUTLET, children: []}]))
           .not.toThrow();


### PR DESCRIPTION
a small patch to be able to lazyload a module in a named router-outlet with one restriction is to specify the lazyloaded named outlet first in the routing.

#12842

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
LazyLoading in a named router-outled was throwing an error, and not supported.
see #12842


**What is the new behavior?**
lazyloading in named router-outlet is working fine if the lazyloaded modules are specified first in the routing. (Can be improved).


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: