### PR TITLE
fix(aio): replace headers on the temporary marketing home page

### DIFF
--- a/aio/content/marketing/index.html
+++ b/aio/content/marketing/index.html
@@ -3,7 +3,7 @@
   <div class="hero background-superhero-paper is-large">
 
     <img src="assets/images/logos/angular/angular.svg" class="hero-logo"/>
-    <h1 class="text-headline no-toc">One framework.<br>Mobile &amp; desktop.</h1>
+    <title class="text-headline">One framework. Mobile &amp; desktop.</title>
     <a href="guide/quickstart" md-button="md-button" class="hero-cta mat-raised button button-large button-plain">Get Started</a>
 
     <announcement-bar class="announcement-bar">
@@ -30,7 +30,7 @@
 
       <div class="text-container">
         <div class="text-block promo-1-desc l-pad-top-2">
-          <h2 class="text-headline">Develop Across All Platforms</h2>
+          <section class="text-headline">Develop Across All Platforms</section>
           <p class="text-body">Learn one way to build applications with Angular and reuse your code and abilities to build apps for any deployment target. For web, mobile web, native mobile and native desktop.
           </p>
         </div>
@@ -40,7 +40,7 @@
     <div layout="row" layout-xs="column" class="home-row">
       <div class="text-container">
         <div class="text-block">
-          <h2 class="text-headline">Speed & Performance</h2>
+          <section class="text-headline">Speed & Performance</section>
           <p class="text-body">Achieve the maximum speed possible on the Web Platform today, and take it further, via Web Workers and server-side rendering.</p>
           <p class="text-body">Angular puts you in control over scalability. Meet huge data requirements by building data models on RxJS, Immutable.js or another push-model.</p>
         </div>
@@ -60,7 +60,7 @@
 
       <div class="text-container">
         <div class="text-block promo-3-desc">
-          <h2 class="text-headline">Incredible Tooling</h2>
+          <section class="text-headline">Incredible Tooling</section>
           <p class="text-body">Build features quickly with simple, declarative templates. Extend the template language with your own components and use a wide array of existing components. Get immediate Angular-specific help and feedback with nearly every IDE and editor. All this comes together so you can focus on building amazing apps rather than trying to make the code work.
           </p>
         </div>
@@ -71,7 +71,7 @@
 
       <div class="text-container">
         <div class="text-block l-pad-top-2">
-          <h2 class="text-headline">Loved by Millions</h2>
+          <section class="text-headline">Loved by Millions</section>
           <p class="text-body">From prototype through global deployment, Angular delivers the productivity and scalable infrastructure that supports Google's largest applications.</p>
         </div>
       </div>

--- a/aio/src/styles/0-base/_typography.scss
+++ b/aio/src/styles/0-base/_typography.scss
@@ -11,7 +11,7 @@
       -moz-osx-font-smoothing: grayscale;
     }
 
-    h1 {
+    h1, title {
       display:inline-block;
       font-size: 24px;
       font-weight: 500;
@@ -28,14 +28,14 @@
       clear: both;
     }
 
-    h2 {
+    h2, section {
       font-size: 22px;
       font-weight: 500;
       margin: 32px 0px 24px;
       clear: both;
     }
 
-    h3 {
+    h3, article {
       font-size: 20px;
       font-weight: 400;
       margin: 24px 0px;


### PR DESCRIPTION
closes #16824
Although this page is being replaced (#16228), current page has annoying anchor headers. Remove them, replacing h1/h2/h3 with title/section/article and applying the respective header styles to these semantic tags.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```
