### PR TITLE
build(aio): make toc heading go to top

### DIFF
--- a/aio/src/app/embedded/toc/toc.component.html
+++ b/aio/src/app/embedded/toc/toc.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="hasToc" [class.closed]="isClosed">
-  <div *ngIf="!hasSecondary" class="toc-heading">Contents</div>
+  <div *ngIf="!hasSecondary" class="toc-heading" (click)="scrollTop()">Contents</div>
   <div *ngIf="hasSecondary" class="toc-heading secondary"
       (click)="toggle(false)"
       title="Expand/collapse contents"

--- a/aio/src/app/embedded/toc/toc.component.spec.ts
+++ b/aio/src/app/embedded/toc/toc.component.spec.ts
@@ -226,12 +226,14 @@ describe('TocComponent', () => {
 
   describe('when in side panel (not embedded))', () => {
     let fixture: ComponentFixture<HostNotEmbeddedTocComponent>;
+    let scrollService: ScrollService;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(HostNotEmbeddedTocComponent);
       tocComponentDe = fixture.debugElement.children[0];
       tocComponent = tocComponentDe.componentInstance;
       tocService = TestBed.get(TocService);
+      scrollService = TestBed.get(ScrollService);
 
       fixture.detectChanges();
       page = setPage();
@@ -239,6 +241,12 @@ describe('TocComponent', () => {
 
     it('should not be in embedded state', () => {
       expect(tocComponent.isEmbedded).toEqual(false);
+    });
+
+    it('should have the header as a link to scroll top', () => {
+      let tocHeading = fixture.debugElement.query(By.css('.toc-heading'));
+      tocHeading.nativeElement.click();
+      expect(scrollService.scrollToTop).toHaveBeenCalled();
     });
 
     it('should display all items', () => {

--- a/aio/src/app/embedded/toc/toc.component.ts
+++ b/aio/src/app/embedded/toc/toc.component.ts
@@ -51,6 +51,10 @@ export class TocComponent implements OnInit, OnDestroy {
     this.onDestroy.next();
   }
 
+  scrollTop() {
+    this.scrollService.scrollToTop();
+  }
+
   toggle(canScroll = true) {
     this.isClosed = !this.isClosed;
     if (canScroll && this.isClosed) { this.scrollService.scrollToTop(); }


### PR DESCRIPTION
This makes the "Contents" header scroll to top as we discused in our sync.

That being said, I don't like the "Contents" being a div anymore. Even if a cheat with a `cursor: pointer` it won't make it more accessible if I am not mistaken.

How could make it a `<a>` and not die in the process? I am not sure if there is any `href` I can use to scroll to top (or maybe the same page url or something).

What do you think?