### PR TITLE
[WIP] feat(forms): add generic typings to AbstractControl

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -76,13 +76,13 @@ function coerceToAsyncValidator(asyncValidator?: AsyncValidatorFn | AsyncValidat
  *
  * @stable
  */
-export abstract class AbstractControl {
+export abstract class AbstractControl<T = any> {
   /** @internal */
-  _value: any;
+  _value: T|null;
   /** @internal */
   _onCollectionChange = () => {};
 
-  private _valueChanges: EventEmitter<any>;
+  private _valueChanges: EventEmitter<T|null>;
   private _statusChanges: EventEmitter<any>;
   private _status: string;
   private _errors: ValidationErrors|null;
@@ -96,7 +96,7 @@ export abstract class AbstractControl {
   /**
    * The value of the control.
    */
-  get value(): any { return this._value; }
+  get value(): T|null { return this._value; }
 
   /**
    * The parent control.
@@ -198,7 +198,10 @@ export abstract class AbstractControl {
    * Emits an event every time the value of the control changes, in
    * the UI or programmatically.
    */
-  get valueChanges(): Observable<any> { return this._valueChanges; }
+  get valueChanges(): Observable<T|null> {
+    // TODO: fix this cast here
+    return (<any>this._valueChanges);
+  }
 
   /**
    * Emits an event every time the validation status of the control
@@ -356,17 +359,17 @@ export abstract class AbstractControl {
   /**
    * Sets the value of the control. Abstract method (implemented in sub-classes).
    */
-  abstract setValue(value: any, options?: Object): void;
+  abstract setValue(value: T, options?: Object): void;
 
   /**
    * Patches the value of the control. Abstract method (implemented in sub-classes).
    */
-  abstract patchValue(value: any, options?: Object): void;
+  abstract patchValue(value: T, options?: Object): void;
 
   /**
    * Resets the control. Abstract method (implemented in sub-classes).
    */
-  abstract reset(value?: any, options?: Object): void;
+  abstract reset(value?: T, options?: Object): void;
 
   /**
    * Re-calculates the value and validation status of the control.
@@ -466,7 +469,12 @@ export abstract class AbstractControl {
    *
    * * `this.form.get(['person', 'name']);`
    */
-  get(path: Array<string|number>|string): AbstractControl|null { return _find(this, path, '.'); }
+  get<GetT extends{[key: string]: any}|Array<string|number>|string|number = any>(
+      path: Array<string|number>|string): AbstractControl<GetT>|null {
+    // the union types here is the union of the possible types for FormGroup, FormArray and
+    // FormCotrol
+    return _find(this, path, '.');
+  }
 
   /**
    * Returns true if the control with the given path has the error specified. Otherwise
@@ -515,7 +523,7 @@ export abstract class AbstractControl {
 
   /** @internal */
   _initObservables() {
-    this._valueChanges = new EventEmitter();
+    this._valueChanges = new EventEmitter<T|null>();
     this._statusChanges = new EventEmitter();
   }
 
@@ -629,14 +637,22 @@ export abstract class AbstractControl {
  *
  * @stable
  */
-export class FormControl extends AbstractControl {
+export class FormControl<T = any> extends AbstractControl<T> {
   /** @internal */
   _onChange: Function[] = [];
-
   constructor(
-      formState: any = null, validator?: ValidatorFn|ValidatorFn[]|null,
+      validator?: ValidatorFn|ValidatorFn[]|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null)
+  constructor(
+      formState: T, validator?: ValidatorFn|ValidatorFn[]|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null)
+  constructor(
+      formState?: T|null, validator?: ValidatorFn|ValidatorFn[]|null,
       asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null) {
     super(coerceToValidator(validator), coerceToAsyncValidator(asyncValidator));
+    if (formState === undefined) {
+      formState = null;
+    }
     this._applyFormState(formState);
     this.updateValueAndValidity({onlySelf: true, emitEvent: false});
     this._initObservables();
@@ -659,7 +675,7 @@ export class FormControl extends AbstractControl {
    * If `emitViewToModelChange` is `true`, an ngModelChange event will be fired to update the
    * model.  This is the default behavior if `emitViewToModelChange` is not specified.
    */
-  setValue(value: any, options: {
+  setValue(value: T|null, options: {
     onlySelf?: boolean,
     emitEvent?: boolean,
     emitModelToViewChange?: boolean,
@@ -680,7 +696,7 @@ export class FormControl extends AbstractControl {
    * It exists for symmetry with {@link FormGroup#patchValue} on `FormGroups` and `FormArrays`,
    * where it does behave differently.
    */
-  patchValue(value: any, options: {
+  patchValue(value: T|null, options: {
     onlySelf?: boolean,
     emitEvent?: boolean,
     emitModelToViewChange?: boolean,
@@ -717,7 +733,7 @@ export class FormControl extends AbstractControl {
    * console.log(this.control.status);  // 'DISABLED'
    * ```
    */
-  reset(formState: any = null, options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+  reset(formState: T|null = null, options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
     this._applyFormState(formState);
     this.markAsPristine(options);
     this.markAsUntouched(options);
@@ -828,9 +844,9 @@ export class FormControl extends AbstractControl {
  *
  * @stable
  */
-export class FormGroup extends AbstractControl {
+export class FormGroup<T extends{[key: string]: any} = any> extends AbstractControl<T> {
   constructor(
-      public controls: {[key: string]: AbstractControl}, validator?: ValidatorFn|null,
+      public controls: {[key in keyof T]: AbstractControl<T[key]>}, validator?: ValidatorFn|null,
       asyncValidator?: AsyncValidatorFn|null) {
     super(validator || null, asyncValidator || null);
     this._initObservables();
@@ -914,12 +930,16 @@ export class FormGroup extends AbstractControl {
    *
    *  ```
    */
-  setValue(value: {[key: string]: any}, options: {onlySelf?: boolean, emitEvent?: boolean} = {}):
-      void {
+  setValue(value: T, options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+    // when T: any null is allowed through which will casue an exception later on
+    if (value === null) {
+      throw new Error(`Must supply a value`);
+    }
     this._checkAllValuesPresent(value);
     Object.keys(value).forEach(name => {
       this._throwIfControlMissing(name);
-      this.controls[name].setValue(value[name], {onlySelf: true, emitEvent: options.emitEvent});
+      // `value![name]` we know that value isn't null here since it has keys
+      this.controls[name].setValue(value ![name], {onlySelf: true, emitEvent: options.emitEvent});
     });
     this.updateValueAndValidity(options);
   }
@@ -945,11 +965,12 @@ export class FormGroup extends AbstractControl {
    *
    *  ```
    */
-  patchValue(value: {[key: string]: any}, options: {onlySelf?: boolean, emitEvent?: boolean} = {}):
-      void {
+  patchValue(value: T|null, options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
     Object.keys(value).forEach(name => {
       if (this.controls[name]) {
-        this.controls[name].patchValue(value[name], {onlySelf: true, emitEvent: options.emitEvent});
+        // `value![name]` we know that value isn't null here since it has keys
+        this.controls[name].patchValue(
+            value ![name], {onlySelf: true, emitEvent: options.emitEvent});
       }
     });
     this.updateValueAndValidity(options);
@@ -987,7 +1008,8 @@ export class FormGroup extends AbstractControl {
    * console.log(this.form.get('first').status);  // 'DISABLED'
    * ```
    */
-  reset(value: any = {}, options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+  reset(value: T|{[key: string]: any} = {}, options: {onlySelf?: boolean,
+                                                      emitEvent?: boolean} = {}): void {
     this._forEachChild((control: AbstractControl, name: string) => {
       control.reset(value[name], {onlySelf: true, emitEvent: options.emitEvent});
     });
@@ -1002,7 +1024,7 @@ export class FormGroup extends AbstractControl {
    * If you'd like to include all values regardless of disabled status, use this method.
    * Otherwise, the `value` property is the best way to get the value of the group.
    */
-  getRawValue(): any {
+  getRawValue(): T {
     return this._reduceChildren(
         {}, (acc: {[k: string]: AbstractControl}, control: AbstractControl, name: string) => {
           acc[name] = control instanceof FormControl ? control.value : (<any>control).getRawValue();
@@ -1131,9 +1153,9 @@ export class FormGroup extends AbstractControl {
  *
  * @stable
  */
-export class FormArray extends AbstractControl {
+export class FormArray<T = any> extends AbstractControl<T[]|any[]> {
   constructor(
-      public controls: AbstractControl[], validator?: ValidatorFn|null,
+      public controls: AbstractControl<T>[], validator?: ValidatorFn|null,
       asyncValidator?: AsyncValidatorFn|null) {
     super(validator || null, asyncValidator || null);
     this._initObservables();
@@ -1144,12 +1166,12 @@ export class FormArray extends AbstractControl {
   /**
    * Get the {@link AbstractControl} at the given `index` in the array.
    */
-  at(index: number): AbstractControl { return this.controls[index]; }
+  at(index: number): AbstractControl<T> { return this.controls[index]; }
 
   /**
    * Insert a new {@link AbstractControl} at the end of the array.
    */
-  push(control: AbstractControl): void {
+  push(control: AbstractControl<T>): void {
     this.controls.push(control);
     this._registerControl(control);
     this.updateValueAndValidity();
@@ -1159,7 +1181,7 @@ export class FormArray extends AbstractControl {
   /**
    * Insert a new {@link AbstractControl} at the given `index` in the array.
    */
-  insert(index: number, control: AbstractControl): void {
+  insert(index: number, control: AbstractControl<T>): void {
     this.controls.splice(index, 0, control);
 
     this._registerControl(control);
@@ -1180,7 +1202,7 @@ export class FormArray extends AbstractControl {
   /**
    * Replace an existing control.
    */
-  setControl(index: number, control: AbstractControl): void {
+  setControl(index: number, control: AbstractControl<T>): void {
     if (this.controls[index]) this.controls[index]._registerOnCollectionChange(() => {});
     this.controls.splice(index, 1);
 
@@ -1219,7 +1241,7 @@ export class FormArray extends AbstractControl {
    *  console.log(arr.value);   // ['Nancy', 'Drew']
    *  ```
    */
-  setValue(value: any[], options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+  setValue(value: T[], options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
     this._checkAllValuesPresent(value);
     value.forEach((newValue: any, index: number) => {
       this._throwIfControlMissing(index);
@@ -1248,7 +1270,7 @@ export class FormArray extends AbstractControl {
    *  console.log(arr.value);   // ['Nancy', null]
    *  ```
    */
-  patchValue(value: any[], options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+  patchValue(value: T[], options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
     value.forEach((newValue: any, index: number) => {
       if (this.at(index)) {
         this.at(index).patchValue(newValue, {onlySelf: true, emitEvent: options.emitEvent});
@@ -1288,7 +1310,7 @@ export class FormArray extends AbstractControl {
    * console.log(this.arr.get(0).status);  // 'DISABLED'
    * ```
    */
-  reset(value: any = [], options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+  reset(value: T[] = [], options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
     this._forEachChild((control: AbstractControl, index: number) => {
       control.reset(value[index], {onlySelf: true, emitEvent: options.emitEvent});
     });
@@ -1303,7 +1325,7 @@ export class FormArray extends AbstractControl {
    * If you'd like to include all values regardless of disabled status, use this method.
    * Otherwise, the `value` property is the best way to get the value of the array.
    */
-  getRawValue(): any[] {
+  getRawValue(): T[] {
     return this.controls.map((control: AbstractControl) => {
       return control instanceof FormControl ? control.value : (<any>control).getRawValue();
     });
@@ -1330,7 +1352,7 @@ export class FormArray extends AbstractControl {
   /** @internal */
   _updateValue(): void {
     this._value = this.controls.filter((control) => control.enabled || this.disabled)
-                      .map((control) => control.value);
+                      .map((control) => control.value!);
   }
 
   /** @internal */

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -42,6 +42,51 @@ export function main() {
   function syncValidator(_: any /** TODO #9100 */): any /** TODO #9100 */ { return null; }
 
   describe('FormControl', () => {
+    it('should work with generics', () => {
+
+      const c1 = new FormControl(undefined);
+      const c2 = new FormControl(null);
+      const c3 = new FormControl();
+      const c4 = new FormControl<string>();
+      c2.setValue(1);
+      c2.setValue('a');
+
+      c4.setValue('a');
+      c4.setValue(null);
+      c4.patchValue('');
+      c4.patchValue(null);
+      c4.value;
+      c4.valueChanges.subscribe(a => a);
+
+      interface MyInterface {
+        name: string;
+      }
+      const g1 = new FormGroup({'name': new FormControl()});
+      const g2 = new FormGroup<MyInterface>({'name': new FormControl()});
+
+      g1.value;
+      g1.setValue({name: 'b'});
+
+      g2.setValue({name: 'a'});
+      g2.patchValue({name: 'a'});
+      g2.getRawValue();
+      g2.valueChanges.subscribe(a => a);
+
+      const a1 = new FormArray([new FormControl()]);
+      const a2 = new FormArray([new FormControl<number>()]);
+
+      a1.push(new FormControl(''));
+      a1.push(new FormControl(2));
+
+      a2.push(new FormControl(2));
+      a2.insert(2, new FormControl(2));
+      a2.at(2);
+      a2.reset([]);
+      a2.value;
+      a2.valueChanges.subscribe(a => a);
+
+    })
+
     it('should default the value to null', () => {
       const c = new FormControl();
       expect(c.value).toBe(null);

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -209,6 +209,11 @@ export function main() {
         expect(form.value).toEqual({parent: {'one': '', 'two': ''}});
       });
 
+      it('should throw when passed null', () => {
+        const g = new FormGroup({'a': new FormControl()});
+        expect(() => g.setValue(null)).toThrowError(new RegExp('Must supply a value'))
+      });
+
       it('should throw if fields are missing from supplied value (subset)', () => {
         expect(() => g.setValue({
           'one': 'one'

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -1,5 +1,5 @@
 /** @stable */
-export declare abstract class AbstractControl {
+export declare abstract class AbstractControl<T = any> {
     asyncValidator: AsyncValidatorFn | null;
     readonly dirty: boolean;
     readonly disabled: boolean;
@@ -16,8 +16,8 @@ export declare abstract class AbstractControl {
     readonly untouched: boolean;
     readonly valid: boolean;
     validator: ValidatorFn | null;
-    readonly value: any;
-    readonly valueChanges: Observable<any>;
+    readonly value: T;
+    readonly valueChanges: Observable<T>;
     constructor(validator: ValidatorFn | null, asyncValidator: AsyncValidatorFn | null);
     clearAsyncValidators(): void;
     clearValidators(): void;
@@ -29,7 +29,7 @@ export declare abstract class AbstractControl {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
-    get(path: Array<string | number> | string): AbstractControl | null;
+    get<GetT = any>(path: Array<string | number> | string): AbstractControl<GetT> | null;
     getError(errorCode: string, path?: string[]): any;
     hasError(errorCode: string, path?: string[]): boolean;
     markAsDirty({onlySelf}?: {
@@ -47,15 +47,15 @@ export declare abstract class AbstractControl {
     markAsUntouched({onlySelf}?: {
         onlySelf?: boolean;
     }): void;
-    abstract patchValue(value: any, options?: Object): void;
-    abstract reset(value?: any, options?: Object): void;
+    abstract patchValue(value: T, options?: Object): void;
+    abstract reset(value?: T, options?: Object): void;
     setAsyncValidators(newValidator: AsyncValidatorFn | AsyncValidatorFn[]): void;
     setErrors(errors: ValidationErrors | null, {emitEvent}?: {
         emitEvent?: boolean;
     }): void;
     setParent(parent: FormGroup | FormArray): void;
     setValidators(newValidator: ValidatorFn | ValidatorFn[] | null): void;
-    abstract setValue(value: any, options?: Object): void;
+    abstract setValue(value: T, options?: Object): void;
     updateValueAndValidity({onlySelf, emitEvent}?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
@@ -172,25 +172,25 @@ export interface Form {
 }
 
 /** @stable */
-export declare class FormArray extends AbstractControl {
-    controls: AbstractControl[];
+export declare class FormArray<T = any> extends AbstractControl<T[]> {
+    controls: AbstractControl<T>[];
     readonly length: number;
-    constructor(controls: AbstractControl[], validator?: ValidatorFn | null, asyncValidator?: AsyncValidatorFn | null);
-    at(index: number): AbstractControl;
-    getRawValue(): any[];
-    insert(index: number, control: AbstractControl): void;
-    patchValue(value: any[], options?: {
+    constructor(controls: AbstractControl<T>[], validator?: ValidatorFn | null, asyncValidator?: AsyncValidatorFn | null);
+    at(index: number): AbstractControl<T>;
+    getRawValue(): T[];
+    insert(index: number, control: AbstractControl<T>): void;
+    patchValue(value: T[], options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
-    push(control: AbstractControl): void;
+    push(control: AbstractControl<T>): void;
     removeAt(index: number): void;
-    reset(value?: any, options?: {
+    reset(value?: T[], options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
-    setControl(index: number, control: AbstractControl): void;
-    setValue(value: any[], options?: {
+    setControl(index: number, control: AbstractControl<T>): void;
+    setValue(value: T[], options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
@@ -221,9 +221,10 @@ export declare class FormBuilder {
 }
 
 /** @stable */
-export declare class FormControl extends AbstractControl {
-    constructor(formState?: any, validator?: ValidatorFn | ValidatorFn[] | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
-    patchValue(value: any, options?: {
+export declare class FormControl<T = any> extends AbstractControl<T | null> {
+    constructor(formState: T, validator?: ValidatorFn | ValidatorFn[] | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
+    constructor(validator?: ValidatorFn | ValidatorFn[] | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
+    patchValue(value: T | null, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
         emitModelToViewChange?: boolean;
@@ -231,11 +232,11 @@ export declare class FormControl extends AbstractControl {
     }): void;
     registerOnChange(fn: Function): void;
     registerOnDisabledChange(fn: (isDisabled: boolean) => void): void;
-    reset(formState?: any, options?: {
+    reset(formState?: T | null, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
-    setValue(value: any, options?: {
+    setValue(value: T | null, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
         emitModelToViewChange?: boolean;
@@ -277,7 +278,9 @@ export declare class FormControlName extends NgControl implements OnChanges, OnD
 }
 
 /** @stable */
-export declare class FormGroup extends AbstractControl {
+export declare class FormGroup<T extends {
+    [key: string]: any;
+} = any> extends AbstractControl<T> {
     controls: {
         [key: string]: AbstractControl;
     };
@@ -286,23 +289,21 @@ export declare class FormGroup extends AbstractControl {
     }, validator?: ValidatorFn | null, asyncValidator?: AsyncValidatorFn | null);
     addControl(name: string, control: AbstractControl): void;
     contains(controlName: string): boolean;
-    getRawValue(): any;
-    patchValue(value: {
-        [key: string]: any;
-    }, options?: {
+    getRawValue(): T;
+    patchValue(value: T | null, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
     registerControl(name: string, control: AbstractControl): AbstractControl;
     removeControl(name: string): void;
-    reset(value?: any, options?: {
+    reset(value?: T | {
+        [key: string]: any;
+    }, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
     setControl(name: string, control: AbstractControl): void;
-    setValue(value: {
-        [key: string]: any;
-    }, options?: {
+    setValue(value: T, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?**
#13721 Currently there is no generic type support for `AbstractControl`
Therefore `AbstractControl#value` will always return a value with type: `any`

**What is the new behavior?**
Provides type support for `AbstractControl#value` and related fields/methods

For example:
```
const control = new FormControl('Toxicable');
const value = control.value;
const changes = control.valueChanges;
```
In this example `control` will be `control: FormControl<string>`
`value` will be `value: string` 
`changes` will be `changes: Observable<string>`

**Does this PR introduce a breaking change?** (check one with "x")
```
[ x ] Yes
[ ] No
```
The breaking change is the TS2.3 requirement for default generics
With default generics it means we are able to make these changes without breaking the API surface 
For example:
```
const control = new FormControl();
const value = control.value;
```
Here control will be `control: FormControl<any>`
`value` will be `value: any`
Which is the same behavior as the API currently provides

However. If someone is misusing the API like below, then it will indeed break their code
```
const control = new FormControl('Toxicable');
control.value.toFixed(3); //the user might be using the string as a number
```
This will throw with the TS compiler since it will now infer the type and know that `control.value` is a string

closes #13721

cc @kara 