### PR TITLE
build: do not create the bundles when updating the public API

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,9 +29,10 @@ function loadTask(fileName, taskName) {
 
 gulp.task('format:enforce', loadTask('format', 'enforce'));
 gulp.task('format', loadTask('format', 'format'));
-gulp.task('build.sh', loadTask('build'));
+gulp.task('build.sh', loadTask('build', 'all'));
+gulp.task('build.sh:no-bundle', loadTask('build', 'no-bundle'));
 gulp.task('public-api:enforce', loadTask('public-api', 'enforce'));
-gulp.task('public-api:update', ['build.sh'], loadTask('public-api', 'update'));
+gulp.task('public-api:update', ['build.sh:no-bundle'], loadTask('public-api', 'update'));
 gulp.task('lint', ['format:enforce', 'validate-commit-messages', 'tslint']);
 gulp.task('tslint', ['tools:build'], loadTask('lint'));
 gulp.task('validate-commit-messages', loadTask('validate-commit-message'));

--- a/tools/gulp-tasks/build.js
+++ b/tools/gulp-tasks/build.js
@@ -1,7 +1,14 @@
 
-module.exports = (gulp) => (done) => {
+module.exports = {
+  // build everything and generate bundles
+  'all': (gulp) => (done) => execBuild(done),
+  // same as all without the bundling part - faster / lower memory usage
+  'no-bundle': (gulp) => (done) => execBuild(done, '--bundle=false'),
+};
+
+function execBuild(done, args = '') {
   const path = require('path');
   const childProcess = require('child_process');
   // increase maxbuffer to address out of memory exception when running certain tasks
-  childProcess.exec(path.join(__dirname, '../../build.sh'), {maxBuffer: 300 * 1024}, done);
-};
+  childProcess.exec(path.join(__dirname, `../../build.sh ${args}`), {maxBuffer: 300 * 1024}, done);
+}


### PR DESCRIPTION
- 1.7x faster on my machine (2.7 vs 4.6 min)
- should solve the memory issue

/cc @ocombe 