### PR TITLE
fix(upgrade): call setInterval outside the Angular zone

### DIFF
--- a/packages/upgrade/src/common/angular1.ts
+++ b/packages/upgrade/src/common/angular1.ts
@@ -158,6 +158,12 @@ export interface IInjectorService {
   has(key: string): boolean;
 }
 
+export interface IIntervalService {
+  (func: Function, delay: number, count?: number, invokeApply?: boolean,
+   ...args: any[]): Promise<any>;
+  cancel(promise: Promise<any>): boolean;
+}
+
 export interface ITestabilityService {
   findBindings(element: Element, expression: string, opt_exactMatch?: boolean): Element[];
   findModels(element: Element, expression: string, opt_exactMatch?: boolean): Element[];

--- a/packages/upgrade/src/common/constants.ts
+++ b/packages/upgrade/src/common/constants.ts
@@ -11,6 +11,7 @@ export const $CONTROLLER = '$controller';
 export const $DELEGATE = '$delegate';
 export const $HTTP_BACKEND = '$httpBackend';
 export const $INJECTOR = '$injector';
+export const $INTERVAL = '$interval';
 export const $PARSE = '$parse';
 export const $PROVIDE = '$provide';
 export const $ROOT_SCOPE = '$rootScope';


### PR DESCRIPTION
This wraps the $interval service when using upgrade to run the
$interval() call outside the Angular zone. However, the callback is
invoked within the Angular zone, so changes still propagate to
downgraded components. Fixes #16349.

**Please check if the PR fulfills these requirements**
- [X ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

In AngularJS, the `$interval` service wraps setTimeout so that `$digest` will be called after the interval fires. Because `$interval` does not block stability in AngularJS, we recommended that Protractor users use it instead of `$timeout` for long running or polling tasks.

Upon upgrading, those user's tests start failing, because the `$interval` service will block stability for the Angular zone, whereas it didn't in AngularJS.

**What is the new behavior?**

This wraps the `$interval` service so that `setTimeout` is called outside the Angular zone. However, the callback is still run within the Angular zone, so that changes still propagate (ie, this does not address #6385 at all). 

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
[X] I don't know?
```

I think it technically might be a breaking change, but the previous behavior was not what people would expect when upgrading from AngularJS.