### PR TITLE
feat(forms): add better type support for AbstractControl#status

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -83,8 +83,8 @@ export abstract class AbstractControl {
   _onCollectionChange = () => {};
 
   private _valueChanges: EventEmitter<any>;
-  private _statusChanges: EventEmitter<any>;
-  private _status: string;
+  private _statusChanges: EventEmitter<'VALID'|'INVALID'|'PENDING'|'DISABLED'>;
+  private _status: 'VALID'|'INVALID'|'PENDING'|'DISABLED';
   private _errors: ValidationErrors|null;
   private _pristine: boolean = true;
   private _touched: boolean = false;
@@ -115,7 +115,7 @@ export abstract class AbstractControl {
    * These statuses are mutually exclusive, so a control cannot be
    * both valid AND invalid or invalid AND disabled.
    */
-  get status(): string { return this._status; }
+  get status(): 'VALID'|'INVALID'|'PENDING'|'DISABLED' { return this._status; }
 
   /**
    * A control is `valid` when its `status === VALID`.
@@ -204,7 +204,9 @@ export abstract class AbstractControl {
    * Emits an event every time the validation status of the control
    * is re-calculated.
    */
-  get statusChanges(): Observable<any> { return this._statusChanges; }
+  get statusChanges(): Observable<'VALID'|'INVALID'|'PENDING'|'DISABLED'> {
+    return <EventEmitter<any>>this._statusChanges;
+  }
 
   /**
    * Sets the synchronous validators that are active on this control.  Calling
@@ -520,7 +522,7 @@ export abstract class AbstractControl {
   }
 
 
-  private _calculateStatus(): string {
+  private _calculateStatus(): 'VALID'|'INVALID'|'PENDING'|'DISABLED' {
     if (this._allControlsDisabled()) return DISABLED;
     if (this._errors) return INVALID;
     if (this._anyControlsHaveStatus(PENDING)) return PENDING;

--- a/tools/public_api_guard/forms/forms.d.ts
+++ b/tools/public_api_guard/forms/forms.d.ts
@@ -10,8 +10,8 @@ export declare abstract class AbstractControl {
     readonly pending: boolean;
     readonly pristine: boolean;
     readonly root: AbstractControl;
-    readonly status: string;
-    readonly statusChanges: Observable<any>;
+    readonly status: 'VALID' | 'INVALID' | 'PENDING' | 'DISABLED';
+    readonly statusChanges: Observable<'VALID' | 'INVALID' | 'PENDING' | 'DISABLED'>;
     readonly touched: boolean;
     readonly untouched: boolean;
     readonly valid: boolean;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: 
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Feature
```

**What is the current behavior?** (You can also link to an open issue here)
`Abstract#status` is currently typed to `string` where as it has four distinct cases of it's value

**What is the new behavior?**
`Abstract#status` now is of type `'VALID' | 'INVALID' | 'PENDING' | 'DISABLED' ` giving slightly better support for the developer


**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```
Im not 100% certain if this is valid, but if someone is comparing `Abstract#status` to a string other than the ones it can possibly be then after this change TS will throw an error at compile time

cc @kara 