### PR TITLE
fix(tsc-wrapped): resolve short-hand literal values to locals

### DIFF
--- a/tools/@angular/tsc-wrapped/test/collector.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/collector.spec.ts
@@ -721,6 +721,21 @@ describe('Collector', () => {
     });
   });
 
+  describe('regerssion', () => {
+    it('should be able to collect a short-hand property value', () => {
+      const source = ts.createSourceFile(
+          '', `
+        const children = { f1: 1 };
+        export const r = [
+          {path: ':locale', children}
+        ];
+      `,
+          ts.ScriptTarget.Latest, true);
+      const metadata = collector.getMetadata(source);
+      expect(metadata.metadata).toEqual({r: [{path: ':locale', children: {f1: 1}}]});
+    });
+  });
+
   function override(fileName: string, content: string) {
     host.overrideFile(fileName, content);
     host.addFile(fileName);


### PR DESCRIPTION
Fixes: #16872

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
```

**What is the current behavior?** (You can also link to an open issue here)

Collector generates a global reference where it should resolve local references in a short hand object literal assignment.
#16872 

**What is the new behavior?**

Collector correctly resolves local references.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
