### PR TITLE
fix(di): mark Inject.token as an external value.

### DIFF
--- a/packages/core/src/di/metadata.ts
+++ b/packages/core/src/di/metadata.ts
@@ -50,7 +50,8 @@ export interface InjectDecorator {
  *
  * @stable
  */
-export interface Inject { token: any; }
+// declare to prevent Closure renaming with tsickle set up to generate externs.
+export declare interface Inject { token: any; }
 
 /**
  * Inject decorator and metadata.


### PR DESCRIPTION
This tells Closure Compiler in combination with tsickle not to rename
`token` when accessed in the application. This is required as token is
accessed in string form via `makeParamDecorator`.