### PR TITLE
feat(tsc-wrapped): always convert index shorthand imports

### DIFF
--- a/tools/@angular/tsc-wrapped/src/main.ts
+++ b/tools/@angular/tsc-wrapped/src/main.ts
@@ -86,12 +86,8 @@ export function main(
       parsed.fileNames.push(name);
     }
 
-    const tsickleCompilerHostOptions: tsickle.Options = {
-      googmodule: false,
-      untyped: true,
-      convertIndexImportShorthand:
-          ngOptions.target === ts.ScriptTarget.ES2015,  // This covers ES6 too
-    };
+    const tsickleCompilerHostOptions:
+        tsickle.Options = {googmodule: false, untyped: true, convertIndexImportShorthand: true};
 
     const tsickleHost: tsickle.TsickleHost = {
       shouldSkipTsickleProcessing: (fileName) => /\.d\.ts$/.test(fileName),

--- a/tools/@angular/tsc-wrapped/test/main.spec.ts
+++ b/tools/@angular/tsc-wrapped/test/main.spec.ts
@@ -366,4 +366,57 @@ describe('tsc-wrapped', () => {
         })
         .catch(e => done.fail(e));
   });
+
+  it('should expand shorthand imports for ES2015 modules', (done) => {
+    write('tsconfig.json', `{
+      "compilerOptions": {
+        "experimentalDecorators": true,
+        "types": [],
+        "outDir": "built",
+        "declaration": true,
+        "moduleResolution": "node",
+        "target": "es2015",
+        "module": "es2015"
+      },
+      "angularCompilerOptions": {
+        "annotateForClosureCompiler": true
+      },
+      "files": ["test.ts"]
+    }`);
+
+    main(basePath, {basePath})
+        .then(() => {
+          const fileOutput = readOut('js');
+          expect(fileOutput).toContain(`export { A, B } from './dep/index'`);
+          done();
+        })
+        .catch(e => done.fail(e));
+  });
+
+  it('should expand shorthand imports for ES5 CommonJS modules', (done) => {
+    write('tsconfig.json', `{
+      "compilerOptions": {
+        "experimentalDecorators": true,
+        "types": [],
+        "outDir": "built",
+        "declaration": true,
+        "moduleResolution": "node",
+        "target": "es5",
+        "module": "commonjs"
+      },
+      "angularCompilerOptions": {
+        "annotateForClosureCompiler": true
+      },
+      "files": ["test.ts"]
+    }`);
+
+    main(basePath, {basePath})
+        .then(() => {
+          const fileOutput = readOut('js');
+          expect(fileOutput).toContain(`var index_1 = require("./dep/index");`);
+          done();
+        })
+        .catch(e => done.fail(e));
+  });
+
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[X] Feature
```

**What is the current behavior?** (You can also link to an open issue here)

Index shorthand imports are currently only converted when targeting ES2015

**What is the new behavior?**

Index shorthand imports will be converted always. 

**Does this PR introduce a breaking change?** (check one with "x")
- You **may** consider this as breaking.

----
Now converts shorthand imports for every TypeScript target. Tsickle is able to expand index shorthand imports for every TypeScript target and module possibility.

Expanding shorthand imports for CommonJS modules is also helpful when testing in the browser. Module loaders like SystemJS are not able to understand directory imports (or index shorthand imports)

cc. @alexeagle @jelbourn 