### PR TITLE
fix(forms): email validator without required is optional

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -121,7 +121,8 @@ export class Validators {
    * Validator that performs email validation.
    */
   static email(control: AbstractControl): ValidationErrors|null {
-    return EMAIL_REGEXP.test(control.value) ? null : {'email': true};
+    return isEmptyInputValue(control.value) || EMAIL_REGEXP.test(control.value) ? null :
+                                                                                  {'email': true};
   }
 
   /**

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -1264,7 +1264,7 @@ export function main() {
            tick();
 
            expect(input.nativeElement.value).toEqual('');
-           expect(control.hasError('email')).toBe(true);
+           expect(control.hasError('email')).toBe(false);
 
            input.nativeElement.value = 'test@gmail.com';
            dispatchEvent(input.nativeElement, 'input');


### PR DESCRIPTION
if the value is empty and not required the email validator should be skipped

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Input with email validator and empty content creates a email validation error.


**What is the new behavior?**
Input is only validated for email if not empty, otherwise required can be used to generate the error.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

